### PR TITLE
[codex] Implement behavior-weighted disguise validation

### DIFF
--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -4,6 +4,11 @@ import { buildFactionMissionContext } from './factions'
 import { buildTeamCompositionProfile, getTeamMemberIds, getUniqueTeamMembers } from './teamSimulation'
 import { buildTeamCohesionSummary } from './teamComposition'
 import { buildAgentLoadoutReadinessSummary } from './equipment'
+import {
+  applyBehaviorWeightedDisguiseValidationToCase,
+  evaluateBehaviorWeightedDisguiseValidation,
+  type BehaviorWeightedDisguiseValidationResult,
+} from './disguiseValidation'
 import { buildAgencyProtocolState } from './protocols'
 import { computeTeamScore, computeRequiredScore } from './sim/scoring'
 import { resolveWeakestLinkMission } from './weakestLinkResolution'
@@ -17,6 +22,7 @@ export interface WeeklyCaseResolutionStrategy {
   assignedAgentLeaderBonuses: Record<string, LeaderBonus>
   activeTeamStressModifiers: Record<string, number>
   outcome: ResolutionOutcome
+  behaviorValidation?: BehaviorWeightedDisguiseValidationResult
   weakestLinkResult?: import('./weakestLinkResolution').WeakestLinkMissionResolutionResult
 }
 
@@ -68,11 +74,38 @@ export function resolveAssignedCaseForWeek(
   const assignedAgents = [
     ...getUniqueTeamMembers(currentCase.assignedTeamIds, state.teams, state.agents),
   ]
+  const supportTags = [
+    ...new Set(currentCase.assignedTeamIds.flatMap((teamId) => state.teams[teamId]?.tags ?? [])),
+  ]
+  const leaderId =
+    currentCase.assignedTeamIds.length === 1
+      ? (state.teams[currentCase.assignedTeamIds[0]]?.leaderId ?? null)
+      : null
+  const behaviorValidation = evaluateBehaviorWeightedDisguiseValidation(
+    effectiveCase,
+    assignedAgents,
+    {
+      supportTags,
+      teamTags: supportTags,
+      leaderId,
+    }
+  )
+  const resolvedEffectiveCase = applyBehaviorWeightedDisguiseValidationToCase(
+    effectiveCase,
+    behaviorValidation
+  )
+  const scoreAdjustment = factionContext.scoreAdjustment + behaviorValidation.scoreAdjustment
+  const scoreAdjustmentReason = [
+    ...factionContext.reasons,
+    behaviorValidation.scoreAdjustmentReason,
+  ]
+    .filter(Boolean)
+    .join(' / ')
   const invalidMajorIncidentOutcome: ResolutionOutcome = {
     caseId: currentCase.id,
     mode: 'probability',
     kind: 'raid',
-    delta: -effectiveCase.durationWeeks,
+    delta: -resolvedEffectiveCase.durationWeeks,
     successChance: 0,
     result: 'fail',
     reasons: ['Major incident launch state was invalid at resolution time.'],
@@ -85,26 +118,19 @@ export function resolveAssignedCaseForWeek(
     const assignedTeamId = currentCase.assignedTeamIds[0]
     const team = state.teams[assignedTeamId]
     const agentsById = state.agents
-    const supportTags = [
-      ...new Set(currentCase.assignedTeamIds.flatMap((teamId) => state.teams[teamId]?.tags ?? [])),
-    ]
-    const leaderId =
-      currentCase.assignedTeamIds.length === 1
-        ? (state.teams[currentCase.assignedTeamIds[0]]?.leaderId ?? null)
-        : null
-    const baseScore = computeTeamScore(assignedAgents, effectiveCase, {
+    const baseScore = computeTeamScore(assignedAgents, resolvedEffectiveCase, {
       inventory: state.inventory,
       protocolState: buildAgencyProtocolState(state),
       supportTags,
       teamTags: supportTags,
       leaderId,
-      scoreAdjustment: factionContext.scoreAdjustment,
-      scoreAdjustmentReason: factionContext.reasons.join(' / '),
+      scoreAdjustment,
+      scoreAdjustmentReason,
       partyCardScoreBonus: cardBonus?.scoreAdjustment,
       partyCardReasons: cardBonus?.reasons,
       config: state.config,
     }).score
-    const requiredScore = computeRequiredScore(effectiveCase, state.config)
+    const requiredScore = computeRequiredScore(resolvedEffectiveCase, state.config)
     const readiness = buildTeamDeploymentReadinessState(state, assignedTeamId)
     const cohesion = buildTeamCohesionSummary(team, agentsById)
     const members = team.memberIds || team.agentIds || []
@@ -119,8 +145,8 @@ export function resolveAssignedCaseForWeek(
       week: state.week,
       baseScore,
       requiredScore,
-      intelConfidence: effectiveCase.intelConfidence,
-      intelUncertainty: effectiveCase.intelUncertainty,
+      intelConfidence: resolvedEffectiveCase.intelConfidence,
+      intelUncertainty: resolvedEffectiveCase.intelUncertainty,
       teamReadiness: readiness,
       teamCohesion: cohesion,
       loadoutSummaries,
@@ -137,6 +163,9 @@ export function resolveAssignedCaseForWeek(
       successChance: undefined,
       result: weakestLinkResult.resultKind,
       reasons: [
+        ...(behaviorValidation.scoreAdjustmentReason
+          ? [behaviorValidation.scoreAdjustmentReason]
+          : []),
         `Weakest-link outcome: ${weakestLinkResult.outcomeCategory}`,
         ...weakestLinkResult.weakestLinkNarrativeReasonCodes,
       ],
@@ -148,7 +177,7 @@ export function resolveAssignedCaseForWeek(
           invalidMajorIncidentOutcome
         : currentCase.kind === 'raid'
         ? resolveRaid(
-            effectiveCase,
+            resolvedEffectiveCase,
             currentCase.assignedTeamIds.map((id) => state.teams[id]).filter(Boolean),
             state.agents,
             state.config,
@@ -156,34 +185,28 @@ export function resolveAssignedCaseForWeek(
             state.inventory,
             {
               protocolState: buildAgencyProtocolState(state),
-              scoreAdjustment: factionContext.scoreAdjustment,
-              scoreAdjustmentReason: factionContext.reasons.join(' / '),
+              scoreAdjustment,
+              scoreAdjustmentReason,
             }
           )
-        : resolveCase(currentCase, assignedAgents, state.config, rng, {
+        : resolveCase(resolvedEffectiveCase, assignedAgents, state.config, rng, {
             inventory: state.inventory,
             protocolState: buildAgencyProtocolState(state),
-            supportTags: [
-              ...new Set(
-                currentCase.assignedTeamIds.flatMap((teamId) => state.teams[teamId]?.tags ?? [])
-              ),
-            ],
-            leaderId:
-              currentCase.assignedTeamIds.length === 1
-                ? (state.teams[currentCase.assignedTeamIds[0]]?.leaderId ?? null)
-                : null,
-            scoreAdjustment: factionContext.scoreAdjustment,
-            scoreAdjustmentReason: factionContext.reasons.join(' / '),
+            supportTags,
+            leaderId,
+            scoreAdjustment,
+            scoreAdjustmentReason,
             partyCardScoreBonus: cardBonus?.scoreAdjustment,
             partyCardReasons: cardBonus?.reasons,
           })
   }
   return {
-    effectiveCase,
+    effectiveCase: resolvedEffectiveCase,
     assignedAgents,
     assignedAgentLeaderBonuses,
     activeTeamStressModifiers,
     outcome,
+    behaviorValidation,
     weakestLinkResult,
   }
 }

--- a/src/domain/disguiseValidation.ts
+++ b/src/domain/disguiseValidation.ts
@@ -1,0 +1,193 @@
+import { clamp } from './math'
+import type { Agent, CaseInstance, Id } from './models'
+import { hasEffectiveCountermeasure } from './resistances'
+
+const AUTHORITY_SCRUTINY_TAGS = ['public', 'media', 'court']
+const PROCEDURAL_SCRUTINY_TAGS = ['witness', 'interview', 'civilian', 'court']
+const HIERARCHY_READER_TAGS = ['liaison', 'negotiation']
+const PROCEDURAL_READER_TAGS = ['investigator', 'forensics', 'field-kit', 'analyst']
+
+export interface BehaviorWeightedDisguiseValidationContext {
+  supportTags?: string[]
+  teamTags?: string[]
+  leaderId?: Id | null
+}
+
+export interface BehaviorWeightedDisguiseValidationResult {
+  active: boolean
+  level: 'none' | 'meaningful' | 'strong'
+  scoreAdjustment: number
+  scoreAdjustmentReason?: string
+  evidenceSignals: string[]
+  detectionConfidence?: number
+  counterDetection: boolean
+  shouldDegradeSuccessToPartial: boolean
+  degradeSuccessReason?: string
+}
+
+const INACTIVE_BEHAVIOR_VALIDATION: BehaviorWeightedDisguiseValidationResult = {
+  active: false,
+  level: 'none',
+  scoreAdjustment: 0,
+  evidenceSignals: [],
+  counterDetection: false,
+  shouldDegradeSuccessToPartial: false,
+}
+
+function hasAnyTag(tags: readonly string[], candidates: readonly string[]) {
+  return candidates.some((candidate) => tags.includes(candidate))
+}
+
+function roundTo(value: number, digits = 1) {
+  const factor = 10 ** digits
+  return Math.round(value * factor) / factor
+}
+
+function collectCaseTags(caseData: CaseInstance) {
+  return [...new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])]
+}
+
+function collectObserverTags(
+  agents: Agent[],
+  context: BehaviorWeightedDisguiseValidationContext
+) {
+  return [
+    ...new Set([
+      ...(context.supportTags ?? []),
+      ...(context.teamTags ?? []),
+      ...agents.flatMap((agent) => [agent.role, ...agent.tags]),
+    ]),
+  ]
+}
+
+function averageStat(agents: Agent[], stat: 'social' | 'investigation') {
+  if (agents.length === 0) {
+    return 0
+  }
+
+  const total = agents.reduce((sum, agent) => sum + (agent.baseStats?.[stat] ?? 0), 0)
+  return total / agents.length
+}
+
+function formatSignals(signals: string[]) {
+  return signals.join(', ')
+}
+
+export function evaluateBehaviorWeightedDisguiseValidation(
+  caseData: CaseInstance,
+  agents: Agent[],
+  context: BehaviorWeightedDisguiseValidationContext = {}
+): BehaviorWeightedDisguiseValidationResult {
+  if (caseData.hiddenState !== 'hidden' || agents.length === 0) {
+    return INACTIVE_BEHAVIOR_VALIDATION
+  }
+
+  const caseTags = collectCaseTags(caseData)
+  const authorityScrutiny = hasAnyTag(caseTags, AUTHORITY_SCRUTINY_TAGS)
+  const proceduralScrutiny = hasAnyTag(caseTags, PROCEDURAL_SCRUTINY_TAGS)
+  const silenceScrutiny = authorityScrutiny || caseData.weights.social >= 0.55
+
+  if (!authorityScrutiny && !proceduralScrutiny && !silenceScrutiny) {
+    return INACTIVE_BEHAVIOR_VALIDATION
+  }
+
+  const observerTags = collectObserverTags(agents, context)
+  const averageSocial = averageStat(agents, 'social')
+  const averageInvestigation = averageStat(agents, 'investigation')
+  const evidenceSignals: string[] = []
+  let validationScore = 0
+
+  const hierarchyRead = hasAnyTag(observerTags, HIERARCHY_READER_TAGS) ? 1 : 0
+  const silenceRead = averageSocial >= 55 ? 1 : averageSocial >= 45 ? 0.5 : 0
+  const procedureRead = hasAnyTag(observerTags, PROCEDURAL_READER_TAGS)
+    ? 1
+    : averageInvestigation >= 55
+      ? 1
+      : averageInvestigation >= 45
+        ? 0.5
+        : 0
+
+  if (authorityScrutiny && hierarchyRead > 0) {
+    validationScore += hierarchyRead
+    evidenceSignals.push('hierarchy fit')
+  }
+
+  if (silenceScrutiny && silenceRead > 0) {
+    validationScore += silenceRead
+    evidenceSignals.push('silence')
+  }
+
+  if (proceduralScrutiny && procedureRead > 0) {
+    validationScore += procedureRead
+    evidenceSignals.push('procedural compliance')
+  }
+
+  const priorDetectionConfidence =
+    typeof caseData.detectionConfidence === 'number'
+      ? clamp(caseData.detectionConfidence, 0, 1)
+      : 0
+  const counterDetectionPressure =
+    (caseData.counterDetection ? 1 : 0) +
+    (priorDetectionConfidence >= 0.45 ? 1 : 0) +
+    (hasEffectiveCountermeasure({ family: 'deception', presentTags: observerTags }) ? 0.5 : 0)
+
+  if (validationScore < 1) {
+    return {
+      ...INACTIVE_BEHAVIOR_VALIDATION,
+      active: true,
+      evidenceSignals,
+    }
+  }
+
+  const level =
+    validationScore >= 2 || (validationScore >= 1 && counterDetectionPressure >= 1)
+      ? 'strong'
+      : 'meaningful'
+  const scoreAdjustment = level === 'strong' ? 4.5 : 2.5
+  const scoreAdjustmentReason = `Behavior validation: +${scoreAdjustment.toFixed(1)} (${formatSignals(evidenceSignals)})`
+  const detectionConfidence =
+    level === 'strong'
+      ? 1
+      : Math.max(priorDetectionConfidence, 0.6)
+
+  return {
+    active: true,
+    level,
+    scoreAdjustment: roundTo(scoreAdjustment),
+    scoreAdjustmentReason,
+    evidenceSignals,
+    detectionConfidence,
+    counterDetection: level === 'strong' || caseData.counterDetection === true,
+    shouldDegradeSuccessToPartial: level === 'strong' && authorityScrutiny,
+    degradeSuccessReason:
+      level === 'strong' && authorityScrutiny
+        ? 'Behavior mismatch triggered visible authority scrutiny and prevented a clean resolution.'
+        : undefined,
+  }
+}
+
+export function applyBehaviorWeightedDisguiseValidationToCase(
+  caseData: CaseInstance,
+  validation: BehaviorWeightedDisguiseValidationResult | undefined
+): CaseInstance {
+  if (!validation?.active || validation.level === 'none') {
+    return caseData
+  }
+
+  const nextDetectionConfidence =
+    typeof validation.detectionConfidence === 'number'
+      ? clamp(
+          Math.max(caseData.detectionConfidence ?? 0, validation.detectionConfidence),
+          0,
+          1
+        )
+      : caseData.detectionConfidence
+
+  return {
+    ...caseData,
+    ...(typeof nextDetectionConfidence === 'number'
+      ? { detectionConfidence: nextDetectionConfidence }
+      : {}),
+    ...(validation.counterDetection ? { counterDetection: true } : {}),
+  }
+}

--- a/src/domain/disguiseValidation.ts
+++ b/src/domain/disguiseValidation.ts
@@ -6,6 +6,19 @@ const AUTHORITY_SCRUTINY_TAGS = ['public', 'media', 'court']
 const PROCEDURAL_SCRUTINY_TAGS = ['witness', 'interview', 'civilian', 'court']
 const HIERARCHY_READER_TAGS = ['liaison', 'negotiation']
 const PROCEDURAL_READER_TAGS = ['investigator', 'forensics', 'field-kit', 'analyst']
+const SOCIAL_SCRUTINY_WEIGHT_THRESHOLD = 0.55
+const STAT_READ_STRONG_THRESHOLD = 55
+const STAT_READ_MEANINGFUL_THRESHOLD = 45
+const DETECTION_CONFIDENCE_PRESSURE_THRESHOLD = 0.45
+const STRONG_VALIDATION_SCORE_THRESHOLD = 2
+const ESCALATION_VALIDATION_SCORE_THRESHOLD = 1
+const ESCALATION_COUNTER_PRESSURE_THRESHOLD = 1
+const STRONG_VALIDATION_SCORE_ADJUSTMENT = 4.5
+const MEANINGFUL_VALIDATION_SCORE_ADJUSTMENT = 2.5
+const MEANINGFUL_DETECTION_CONFIDENCE_FLOOR = 0.6
+const FULL_DETECTION_CONFIDENCE = 1
+const PARTIAL_BEHAVIOR_SIGNAL = 0.5
+const FULL_BEHAVIOR_SIGNAL = 1
 
 export interface BehaviorWeightedDisguiseValidationContext {
   supportTags?: string[]
@@ -85,7 +98,8 @@ export function evaluateBehaviorWeightedDisguiseValidation(
   const caseTags = collectCaseTags(caseData)
   const authorityScrutiny = hasAnyTag(caseTags, AUTHORITY_SCRUTINY_TAGS)
   const proceduralScrutiny = hasAnyTag(caseTags, PROCEDURAL_SCRUTINY_TAGS)
-  const silenceScrutiny = authorityScrutiny || caseData.weights.social >= 0.55
+  const silenceScrutiny =
+    authorityScrutiny || caseData.weights.social >= SOCIAL_SCRUTINY_WEIGHT_THRESHOLD
 
   if (!authorityScrutiny && !proceduralScrutiny && !silenceScrutiny) {
     return INACTIVE_BEHAVIOR_VALIDATION
@@ -97,14 +111,21 @@ export function evaluateBehaviorWeightedDisguiseValidation(
   const evidenceSignals: string[] = []
   let validationScore = 0
 
-  const hierarchyRead = hasAnyTag(observerTags, HIERARCHY_READER_TAGS) ? 1 : 0
-  const silenceRead = averageSocial >= 55 ? 1 : averageSocial >= 45 ? 0.5 : 0
+  const hierarchyRead = hasAnyTag(observerTags, HIERARCHY_READER_TAGS)
+    ? FULL_BEHAVIOR_SIGNAL
+    : 0
+  const silenceRead =
+    averageSocial >= STAT_READ_STRONG_THRESHOLD
+      ? FULL_BEHAVIOR_SIGNAL
+      : averageSocial >= STAT_READ_MEANINGFUL_THRESHOLD
+        ? PARTIAL_BEHAVIOR_SIGNAL
+        : 0
   const procedureRead = hasAnyTag(observerTags, PROCEDURAL_READER_TAGS)
-    ? 1
-    : averageInvestigation >= 55
-      ? 1
-      : averageInvestigation >= 45
-        ? 0.5
+    ? FULL_BEHAVIOR_SIGNAL
+    : averageInvestigation >= STAT_READ_STRONG_THRESHOLD
+      ? FULL_BEHAVIOR_SIGNAL
+      : averageInvestigation >= STAT_READ_MEANINGFUL_THRESHOLD
+        ? PARTIAL_BEHAVIOR_SIGNAL
         : 0
 
   if (authorityScrutiny && hierarchyRead > 0) {
@@ -128,10 +149,10 @@ export function evaluateBehaviorWeightedDisguiseValidation(
       : 0
   const counterDetectionPressure =
     (caseData.counterDetection ? 1 : 0) +
-    (priorDetectionConfidence >= 0.45 ? 1 : 0) +
+    (priorDetectionConfidence >= DETECTION_CONFIDENCE_PRESSURE_THRESHOLD ? 1 : 0) +
     (hasEffectiveCountermeasure({ family: 'deception', presentTags: observerTags }) ? 0.5 : 0)
 
-  if (validationScore < 1) {
+  if (validationScore < ESCALATION_VALIDATION_SCORE_THRESHOLD) {
     return {
       ...INACTIVE_BEHAVIOR_VALIDATION,
       active: true,
@@ -140,15 +161,20 @@ export function evaluateBehaviorWeightedDisguiseValidation(
   }
 
   const level =
-    validationScore >= 2 || (validationScore >= 1 && counterDetectionPressure >= 1)
+    validationScore >= STRONG_VALIDATION_SCORE_THRESHOLD ||
+    (validationScore >= ESCALATION_VALIDATION_SCORE_THRESHOLD &&
+      counterDetectionPressure >= ESCALATION_COUNTER_PRESSURE_THRESHOLD)
       ? 'strong'
       : 'meaningful'
-  const scoreAdjustment = level === 'strong' ? 4.5 : 2.5
+  const scoreAdjustment =
+    level === 'strong'
+      ? STRONG_VALIDATION_SCORE_ADJUSTMENT
+      : MEANINGFUL_VALIDATION_SCORE_ADJUSTMENT
   const scoreAdjustmentReason = `Behavior validation: +${scoreAdjustment.toFixed(1)} (${formatSignals(evidenceSignals)})`
   const detectionConfidence =
     level === 'strong'
-      ? 1
-      : Math.max(priorDetectionConfidence, 0.6)
+      ? FULL_DETECTION_CONFIDENCE
+      : Math.max(priorDetectionConfidence, MEANINGFUL_DETECTION_CONFIDENCE_FLOOR)
 
   return {
     active: true,

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -1136,11 +1136,13 @@ function buildAggregateBattleEventDraft(
 }
 
 interface WeeklyCaseResolutionStrategy {
+  effectiveCase: CaseInstance
   assignedAgents: NonNullable<GameState['agents'][string]>[]
   assignedAgentLeaderBonuses: Record<string, LeaderBonus>
   activeTeamStressModifiers: Record<string, number>
   outcome: ResolutionOutcomeWithDetails
   aggregateBattleSummary?: AggregateBattleCampaignSummary
+  behaviorValidation?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['behaviorValidation']
   weakestLinkResult?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['weakestLinkResult']
 }
 
@@ -1263,11 +1265,13 @@ function resolveAssignedCaseForWeek(
 
   // Return the original outcome object for downstream consumers, but attach the explicit contracts for testability
   return {
+    effectiveCase: canonicalResolution.effectiveCase,
     assignedAgents: canonicalResolution.assignedAgents,
     assignedAgentLeaderBonuses: canonicalResolution.assignedAgentLeaderBonuses,
     activeTeamStressModifiers: canonicalResolution.activeTeamStressModifiers,
     outcome,
     aggregateBattleSummary,
+    behaviorValidation: canonicalResolution.behaviorValidation,
     weakestLinkResult: canonicalResolution.weakestLinkResult,
     campaignToIncident,
     incidentToCampaign,
@@ -1795,16 +1799,14 @@ function resolveAssignments(
       supportShortfall: isSupportShortfall,
     }
     const {
+      effectiveCase,
       assignedAgentLeaderBonuses,
       activeTeamStressModifiers,
       outcome,
       aggregateBattleSummary,
+      behaviorValidation,
       weakestLinkResult,
     } = weeklyResolution
-    const effectiveCase = {
-      ...currentCase,
-      assignedTeamIds: existingAssignedTeamIds,
-    }
 
     Object.assign(context.activeTeamStressModifiers, activeTeamStressModifiers)
     context.nextState.teams = releaseTeams(context.nextState.teams, existingAssignedTeamIds)
@@ -2032,7 +2034,7 @@ function resolveAssignments(
 
       recordCaseOutcome(context, caseId, 'resolved')
       context.nextState.cases[caseId] = {
-        ...currentCase,
+        ...effectiveCase,
         assignedTeamIds: [],
         status: 'resolved',
         weeksRemaining: 0,
@@ -2056,10 +2058,13 @@ function resolveAssignments(
           )
         )
       }
+      if (behaviorValidation?.shouldDegradeSuccessToPartial && behaviorValidation.degradeSuccessReason) {
+        downgradeResolvedCaseToPartial(context, caseId, behaviorValidation.degradeSuccessReason)
+      }
       continue
     }
 
-    const resolutionEscalation = createResolutionEscalationTransition(currentCase, outcome.result)
+    const resolutionEscalation = createResolutionEscalationTransition(effectiveCase, outcome.result)
     const escalatedCase = {
       ...resolutionEscalation.nextCase,
       status: 'open' as const,
@@ -2205,6 +2210,7 @@ function downgradeResolvedCaseToPartial(
   note: string
 ) {
   const sourceCase = context.sourceState.cases[caseId]
+  const resolvedCase = context.nextState.cases[caseId] ?? sourceCase
   const mission = context.missionResultDraftByCaseId[caseId]
 
   if (!sourceCase || !mission || mission.outcome !== 'success') {
@@ -2214,7 +2220,7 @@ function downgradeResolvedCaseToPartial(
   const existingAssignedTeamIds = sourceCase.assignedTeamIds.filter((teamId) =>
     Boolean(context.sourceState.teams[teamId])
   )
-  const resolutionEscalation = createResolutionEscalationTransition(sourceCase, 'partial')
+  const resolutionEscalation = createResolutionEscalationTransition(resolvedCase, 'partial')
   const downgradedCase = {
     ...resolutionEscalation.nextCase,
     status: 'open' as const,

--- a/src/domain/sim/resolve.ts
+++ b/src/domain/sim/resolve.ts
@@ -15,6 +15,7 @@ import { previewResolutionPartyCards } from '../partyCards/engine'
 import { buildAgencyProtocolState } from '../protocols'
 import { buildFactionMissionContext } from '../factions'
 import { evaluateContractRoleFit } from '../contractsRuntime'
+import { evaluateBehaviorWeightedDisguiseValidation } from '../disguiseValidation'
 import {
   buildAggregatedLeaderBonus,
   createDefaultPerformanceMetricSummary,
@@ -77,6 +78,8 @@ function buildTeamScoreContextForTeamIds(
   const normalizedTeamIds = [...new Set(teamIds)].filter((teamId) => Boolean(state.teams[teamId]))
   const teams = normalizedTeamIds.map((teamId) => state.teams[teamId]).filter(Boolean)
   const agents = getUniqueTeamMembers(normalizedTeamIds, state.teams, state.agents)
+  const supportTags = getSupportTags(state, normalizedTeamIds)
+  const protocolState = buildAgencyProtocolState(state)
 
   const coordination =
     c.kind === 'raid' && normalizedTeamIds.length > 1
@@ -99,13 +102,33 @@ function buildTeamScoreContextForTeamIds(
   const factionContext = buildFactionMissionContext(c, state)
   const contractFit =
     c.contract && hasContractRoleFitInput(c.contract) ? evaluateContractRoleFit(c.contract, agents) : null
+  const behaviorValidation = evaluateBehaviorWeightedDisguiseValidation(c, agents, {
+    supportTags,
+    teamTags: supportTags,
+    leaderId:
+      normalizedTeamIds.length === 1
+        ? (state.teams[normalizedTeamIds[0]]?.leaderId ?? null)
+        : null,
+  })
+  const baseScoreAdjustment =
+    (coordination?.scoreAdjustment ?? 0) +
+    factionContext.scoreAdjustment +
+    (contractFit?.scoreAdjustment ?? 0)
+  const scoreAdjustmentReason = [
+    coordination?.reason,
+    ...factionContext.reasons,
+    ...(contractFit?.reasons ?? []),
+    behaviorValidation.scoreAdjustmentReason,
+  ]
+    .filter(Boolean)
+    .join(' / ')
 
   return {
     teamIds: normalizedTeamIds,
     agents,
     context: {
       inventory: state.inventory,
-      supportTags: getSupportTags(state, normalizedTeamIds),
+      supportTags,
       preflight: {
         selectedTeamCount: normalizedTeamIds.length,
         minTeamCount: c.kind === 'raid' ? (c.raid?.minTeams ?? 2) : undefined,
@@ -114,16 +137,11 @@ function buildTeamScoreContextForTeamIds(
         normalizedTeamIds.length === 1
           ? (state.teams[normalizedTeamIds[0]]?.leaderId ?? null)
           : null,
-      scoreAdjustment:
-        (coordination?.scoreAdjustment ?? 0) +
-        factionContext.scoreAdjustment +
-        (contractFit?.scoreAdjustment ?? 0),
-      scoreAdjustmentReason: [coordination?.reason, ...factionContext.reasons, ...(contractFit?.reasons ?? [])]
-        .filter(Boolean)
-        .join(' / '),
+      scoreAdjustment: baseScoreAdjustment + behaviorValidation.scoreAdjustment,
+      scoreAdjustmentReason,
       partyCardScoreBonus: partyCardBonus?.scoreAdjustment,
       partyCardReasons: partyCardReason,
-      protocolState: buildAgencyProtocolState(state),
+      protocolState,
       leaderBonusOverride:
         normalizedTeamIds.length > 1 && teams.some((team) => getTeamMemberIds(team).length > 1)
           ? buildAggregatedLeaderBonus(teams, state.agents)

--- a/src/test/advanceWeek.behaviorValidation.test.ts
+++ b/src/test/advanceWeek.behaviorValidation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createAuthorityReader(id: string) {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation: 55,
+      utility: 40,
+      social: 70,
+    },
+    tags: ['medium', 'liaison'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  } satisfies Agent
+}
+
+function createAuthorityTeam(id: string, agentId: string) {
+  return {
+    id,
+    name: id,
+    agentIds: [agentId],
+    tags: [],
+  } satisfies Team
+}
+
+function createAuthorityScrutinyCase(teamId: string): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-001',
+      templateId: 'ops-004',
+    }),
+    mode: 'deterministic',
+    status: 'in_progress',
+    weeksRemaining: 1,
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    requiredTags: ['medium'],
+    preferredTags: [],
+    assignedTeamIds: [teamId],
+  }
+}
+
+function tuneAuthoritySuccessCase(state: ReturnType<typeof createStartingState>, teamId: string) {
+  const baseCase = createAuthorityScrutinyCase(teamId)
+
+  for (let socialDifficulty = 8; socialDifficulty <= 140; socialDifficulty += 1) {
+    const candidate: CaseInstance = {
+      ...baseCase,
+      difficulty: {
+        combat: 0,
+        investigation: 0,
+        utility: 0,
+        social: socialDifficulty,
+      },
+      weights: {
+        combat: 0,
+        investigation: 0,
+        utility: 0,
+        social: 1,
+      },
+    }
+    const resolution = resolveAssignedCaseForWeek(candidate, state, () => 0.5)
+
+    if (resolution.outcome.result === 'success' && resolution.behaviorValidation?.level === 'strong') {
+      return candidate
+    }
+  }
+
+  throw new Error('Unable to tune a strong authority-scrutiny success case.')
+}
+
+describe('advanceWeek behavior-weighted disguise validation', () => {
+  it('reveals a hidden public disguise and downgrades the outcome under authority scrutiny', () => {
+    const state = createStartingState()
+    const authorityReader = createAuthorityReader('a_authority_reader')
+    const authorityTeam = createAuthorityTeam('t_authority_reader', authorityReader.id)
+    state.agents[authorityReader.id] = authorityReader
+    state.teams[authorityTeam.id] = authorityTeam
+
+    state.reports = []
+    state.agency!.supportAvailable = 2
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-001'] = tuneAuthoritySuccessCase(state, authorityTeam.id)
+
+    const preAdvanceResolution = resolveAssignedCaseForWeek(state.cases['case-001'], state, () => 0.5)
+    expect(preAdvanceResolution.outcome.result).toBe('success')
+    expect(preAdvanceResolution.behaviorValidation?.level).toBe('strong')
+    expect(
+      preAdvanceResolution.outcome.reasons.some((reason) => reason.includes('Behavior validation:'))
+    ).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const missionResult = lastReport.caseSnapshots?.['case-001']?.missionResult
+
+    expect(missionResult?.outcome).toBe('partial')
+    expect(missionResult?.hiddenState).toBe('revealed')
+    expect(missionResult?.counterDetection).toBe(true)
+    expect(missionResult?.detectionConfidence).toBe(1)
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes('Behavior validation:'))
+    ).toBe(true)
+    expect(
+      missionResult?.explanationNotes.some((note) =>
+        note.includes('Behavior mismatch triggered visible authority scrutiny')
+      )
+    ).toBe(true)
+    expect(nextState.cases['case-001'].status).toBe('open')
+  })
+})

--- a/src/test/behaviorDisguiseValidation.test.ts
+++ b/src/test/behaviorDisguiseValidation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
+import type { Agent, CaseInstance, GameState, Team } from '../domain/models'
+import { previewResolutionForTeamIds } from '../domain/sim/resolve'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createBehaviorObserver(id: string, tags: string[], social: number) {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation: 50,
+      utility: 40,
+      social,
+    },
+    tags: ['medium', ...tags],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  } satisfies Agent
+}
+
+function createObserverTeam(id: string, agentId: string) {
+  return {
+    id,
+    name: id,
+    agentIds: [agentId],
+    tags: [],
+  } satisfies Team
+}
+
+function createHiddenBriefingCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-behavior',
+      templateId: 'ops-004',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    requiredTags: ['medium'],
+    preferredTags: [],
+    assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+function tuneBehaviorGateCase(
+  state: GameState,
+  hiddenCase: CaseInstance,
+  teamId: string
+): CaseInstance {
+  for (let socialDifficulty = 8; socialDifficulty <= 120; socialDifficulty += 1) {
+    const candidate: CaseInstance = {
+      ...hiddenCase,
+      difficulty: {
+        combat: 0,
+        investigation: 0,
+        utility: 0,
+        social: socialDifficulty,
+      },
+      weights: {
+        combat: 0,
+        investigation: 0,
+        utility: 0,
+        social: 1,
+      },
+    }
+    const hiddenPreview = previewResolutionForTeamIds(candidate, state, [teamId])
+    const visiblePreview = previewResolutionForTeamIds(
+      {
+        ...candidate,
+        hiddenState: undefined,
+        detectionConfidence: undefined,
+        counterDetection: undefined,
+      },
+      state,
+      [teamId]
+    )
+
+    if (hiddenPreview.odds.success === 1 && visiblePreview.odds.success === 0) {
+      return candidate
+    }
+  }
+
+  throw new Error('Unable to tune a hidden behavior-validation threshold case.')
+}
+
+describe('behavior-weighted disguise validation', () => {
+  it('stays inactive on hidden cases without behavior-scrutiny context', () => {
+    const state = createStartingState()
+    const observer = state.agents.a_mina
+    const hiddenCase: CaseInstance = {
+      ...state.cases['case-001'],
+      hiddenState: 'hidden',
+      detectionConfidence: 0.2,
+      counterDetection: false,
+    }
+
+    const result = evaluateBehaviorWeightedDisguiseValidation(hiddenCase, [observer])
+
+    expect(result.active).toBe(false)
+    expect(result.level).toBe('none')
+    expect(result.scoreAdjustment).toBe(0)
+    expect(result.counterDetection).toBe(false)
+  })
+
+  it('uses the same behavior gate in preview and live threshold resolution', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('a_behavior_reader', ['liaison'], 30)
+    const team = createObserverTeam('t_behavior_reader', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    const hiddenCase = tuneBehaviorGateCase(
+      state,
+      createHiddenBriefingCase(),
+      team.id
+    )
+    const hiddenPreview = previewResolutionForTeamIds(hiddenCase, state, [team.id])
+    const visiblePreview = previewResolutionForTeamIds(
+      {
+        ...hiddenCase,
+        hiddenState: undefined,
+        detectionConfidence: undefined,
+        counterDetection: undefined,
+      },
+      state,
+      [team.id]
+    )
+    const live = resolveAssignedCaseForWeek(
+      {
+        ...hiddenCase,
+        assignedTeamIds: [team.id],
+      },
+      state,
+      () => 0.5
+    )
+
+    expect(hiddenPreview.odds.success).toBe(1)
+    expect(visiblePreview.odds.success).toBe(0)
+    expect(live.outcome.result).toBe('success')
+    expect(live.behaviorValidation?.level).toBe('meaningful')
+    expect(live.behaviorValidation?.scoreAdjustment).toBeGreaterThan(0)
+    expect(live.outcome.reasons.some((reason) => reason.includes('Behavior validation:'))).toBe(
+      true
+    )
+  })
+})


### PR DESCRIPTION
## What changed

This adds a bounded behavior-weighted disguise validation layer on top of the existing hidden-state pipeline.

- adds one shared deterministic behavior-validation evaluator for already-hidden cases
- feeds preview and live resolution through the existing `scoreAdjustment` / `scoreAdjustmentReason` path
- raises `detectionConfidence` on meaningful mismatch
- sets `counterDetection` on strong mismatch so the existing reveal flow emits `revealed`
- reuses the existing downgrade-to-partial path when strong authority/public scrutiny should spoil an otherwise clean success
- reports through existing mission-result hidden-state fields and `explanationNotes`
- adds focused tests for preview/live parity and deterministic reporting

## Why it changed

SPE-285 / GitHub issue #286 asks for disguise validation to depend on behavior, silence, hierarchy fit, and procedural compliance rather than visible presentation alone, while staying deterministic and bounded.

## Root cause

The hidden-state layer from SPE-70 already supported reveal and counter-detection, but it did not have a compact behavior-validation pass that could invalidate a plausible presentation based on conduct mismatch.

## Review stabilization

During review, one production fix was applied:

- deterministic live scrutiny now carries its behavior-validation reason through the mission-result explanation path so reveal/degrade outcomes stay inspectable in `explanationNotes`

## Impact

- hidden cases can now be validated separately from appearance
- at least one authority/public response can change because of conduct mismatch alone
- scope remains intentionally bounded to cases that already enter the hidden-state pipeline
- no new disguise framework, patrol simulation, escort simulation, covert-access subsystem, or broad authored activation rollout was added in this pass

## Validation

- `cmd /c npx vitest --config app.vite.config.ts run src/test/advanceWeek.hiddenState.integration.test.ts src/test/advanceWeek.hiddenState.downstream.test.ts src/features/report/ReportFeature.hiddenState.test.tsx src/test/behaviorDisguiseValidation.test.ts src/test/advanceWeek.behaviorValidation.test.ts`
- `cmd /c npx vitest --config app.vite.config.ts run src/test/sim.resolve.test.ts src/test/sim.advanceWeek.test.ts`
- `cmd /c npx tsc -b --pretty false`

Closes #286