### PR TITLE
feat(spe-820): canonical incident-impact schema with deep-clone fix

### DIFF
--- a/src/domain/templates/__tests__/hazardIncident.test.ts
+++ b/src/domain/templates/__tests__/hazardIncident.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import { hazardIncidentTemplates } from '../hazardIncidentTemplates'
 import { resolveIncident } from '../hazardIncidentRuntime'
+import type { IncidentImpact } from '../incidentImpact'
 
 describe('HazardIncidentTemplate deterministic escalation', () => {
   const template = hazardIncidentTemplates[0]
@@ -21,5 +22,75 @@ describe('HazardIncidentTemplate deterministic escalation', () => {
     const state = { escalationStep: 2, risk: 4, resolved: false }
     const result = resolveIncident(template, state, 'stabilize anomaly')
     expect(result.resolved).toBe(true)
+  })
+
+  it('carries canonical typed impact with explicit denominator semantics', () => {
+    const state = { escalationStep: 0, risk: 2, resolved: false }
+    const result = resolveIncident(template, state, 'seal breach')
+
+    expect(result.impact?.schemaVersion).toBe('spe-820.v1')
+    expect(result.impact?.affectedPopulation?.denominator?.kind).toBe('people')
+    expect(result.impact?.facilityImpact?.denominator?.kind).toBe('facilities')
+    expect(result.impact?.outages?.denominator?.kind).toBe('customers')
+  })
+
+  it('keeps uncertainty visible in standard fields', () => {
+    const state = { escalationStep: 0, risk: 2, resolved: false }
+    const result = resolveIncident(template, state, 'seal breach')
+
+    expect(result.impact?.affectedPopulation?.uncertainty?.level).toBe('medium')
+    expect(result.impact?.fatalities?.uncertainty?.level).toBe('high')
+  })
+
+  it('supports local extension fields without affecting canonical fields', () => {
+    const state = { escalationStep: 0, risk: 2, resolved: false }
+    const result = resolveIncident(template, state, 'seal breach')
+
+    expect(result.impact?.extensions?.transit_evacuations?.metric.value).toBe(12)
+    expect(result.impact?.extensions?.transit_evacuations?.metric.denominator?.kind).toBe(
+      'services'
+    )
+    expect(result.impact?.rescueDemand?.value).toBe(44)
+  })
+
+  it('returns deterministic impact snapshots and does not alias mutable extension objects', () => {
+    const state = { escalationStep: 0, risk: 2, resolved: false }
+    const first = resolveIncident(template, state, 'seal breach')
+    const second = resolveIncident(template, state, 'seal breach')
+
+    expect(first.impact).toEqual(second.impact)
+    expect(first.impact).not.toBe(second.impact)
+
+    if (first.impact?.extensions?.transit_evacuations?.metric) {
+      first.impact.extensions.transit_evacuations.metric.value = 999
+    }
+
+    const third = resolveIncident(template, state, 'seal breach')
+    expect(third.impact?.extensions?.transit_evacuations?.metric.value).toBe(12)
+  })
+
+  it('does not alias canonical metric fields from the original impact', () => {
+    const state = { escalationStep: 0, risk: 2, resolved: false }
+    const result1 = resolveIncident(template, state, 'seal breach')
+    const result2 = resolveIncident(template, state, 'seal breach')
+    if (result1.impact?.affectedPopulation) {
+      result1.impact.affectedPopulation.value = 9999
+    }
+    expect(result2.impact?.affectedPopulation?.value).toBe(480)
+    expect(template.impact?.affectedPopulation?.value).toBe(480)
+  })
+
+  it('clones state.impact fallback path when template has no impact', () => {
+    const noImpactTemplate = { ...hazardIncidentTemplates[0], impact: undefined }
+    const stateImpact: IncidentImpact = {
+      schemaVersion: 'spe-820.v1',
+      fatalities: { value: 7, denominator: { kind: 'people' } },
+    }
+    const state = { escalationStep: 0, risk: 2, resolved: false, impact: stateImpact }
+    const result = resolveIncident(noImpactTemplate, state, 'seal breach')
+    expect(result.impact?.fatalities?.value).toBe(7)
+    expect(result.impact).not.toBe(stateImpact)
+    if (result.impact?.fatalities) result.impact.fatalities.value = 999
+    expect(stateImpact.fatalities?.value).toBe(7)
   })
 })

--- a/src/domain/templates/hazardIncidentRuntime.ts
+++ b/src/domain/templates/hazardIncidentRuntime.ts
@@ -1,10 +1,13 @@
 // Deterministic runtime logic for hazard/incident templates (SPE-48)
 import type { HazardIncidentTemplate } from './hazardIncidentTemplates'
+import { cloneIncidentImpact, type IncidentImpact } from './incidentImpact'
 
 export type IncidentState = {
   escalationStep: number
   risk: number
   resolved: boolean
+  /** SPE-820: Canonical typed impact snapshot currently attached to this incident. */
+  impact?: IncidentImpact
 }
 
 export function resolveIncident(
@@ -25,9 +28,17 @@ export function resolveIncident(
     nextStep >= template.escalation.steps.length ||
     (nextStep === template.escalation.steps.length - 1 &&
       template.resolution.requiredActions.includes(action));
+
+  const impact = template.impact
+    ? cloneIncidentImpact(template.impact)
+    : state.impact
+      ? cloneIncidentImpact(state.impact)
+      : undefined
+
   return {
     escalationStep: nextStep,
     risk: state.risk,
     resolved,
+    impact,
   };
 }

--- a/src/domain/templates/hazardIncidentTemplates.ts
+++ b/src/domain/templates/hazardIncidentTemplates.ts
@@ -1,5 +1,6 @@
 // Hazard/Incident Templates (SPE-48)
 import type { ContentTemplateKernel } from './contentTemplateKernel'
+import type { IncidentImpact } from './incidentImpact'
 
 export type HazardIncidentTemplate = ContentTemplateKernel & {
   hazardType: 'containment-breach' | 'exposure' | 'environmental' | 'rival-action'
@@ -12,6 +13,8 @@ export type HazardIncidentTemplate = ContentTemplateKernel & {
     requiredActions: string[]
     fallback: string
   }
+  /** SPE-820: Canonical typed incident-impact vocabulary. */
+  impact?: IncidentImpact
   rewards?: RewardEntry[]
   backlash?: BacklashEntry[]
 }
@@ -41,6 +44,62 @@ export const hazardIncidentTemplates: HazardIncidentTemplate[] = [
     resolution: {
       requiredActions: ['seal breach', 'stabilize anomaly'],
       fallback: 'Evacuate site',
+    },
+    impact: {
+      schemaVersion: 'spe-820.v1',
+      affectedPopulation: {
+        value: 480,
+        denominator: { kind: 'people', total: 1200, label: 'Sector Delta residents' },
+        uncertainty: { level: 'medium', basis: 'partial evac telemetry' },
+      },
+      fatalities: {
+        value: 3,
+        denominator: { kind: 'people', total: 1200 },
+        uncertainty: { level: 'high', basis: 'unverified field reports' },
+      },
+      rescueDemand: {
+        value: 44,
+        denominator: { kind: 'people' },
+      },
+      shelterDemand: {
+        value: 62,
+        denominator: { kind: 'households', total: 410 },
+      },
+      outages: {
+        value: 310,
+        denominator: { kind: 'customers', total: 910 },
+      },
+      facilityImpact: {
+        value: 4,
+        denominator: { kind: 'facilities', total: 11 },
+      },
+      serviceDisruption: {
+        value: 2,
+        denominator: { kind: 'services', total: 6 },
+      },
+      hazmatExposure: {
+        value: 1.8,
+        denominator: { kind: 'distance_km', label: 'plume radius' },
+      },
+      organizationImpact: {
+        value: 2,
+        denominator: { kind: 'organizations', total: 5 },
+      },
+      jurisdictionImpact: {
+        value: 1,
+        denominator: { kind: 'jurisdictions', total: 3 },
+      },
+      extensions: {
+        transit_evacuations: {
+          label: 'Transit evacuation burden',
+          category: 'coordination',
+          metric: {
+            value: 12,
+            denominator: { kind: 'services', total: 20, label: 'transit lines' },
+            uncertainty: { level: 'medium' },
+          },
+        },
+      },
     },
     rewards: [{ rewardType: 'intel', value: 2 }],
     backlash: [

--- a/src/domain/templates/incidentImpact.ts
+++ b/src/domain/templates/incidentImpact.ts
@@ -100,15 +100,7 @@ export function cloneIncidentImpact(impact: IncidentImpact): IncidentImpact {
               key,
               {
                 ...value,
-                metric: {
-                  ...value.metric,
-                  ...(value.metric.denominator
-                    ? { denominator: { ...value.metric.denominator } }
-                    : {}),
-                  ...(value.metric.uncertainty
-                    ? { uncertainty: { ...value.metric.uncertainty } }
-                    : {}),
-                },
+                metric: cloneMetric(value.metric)!,
               },
             ])
           ),

--- a/src/domain/templates/incidentImpact.ts
+++ b/src/domain/templates/incidentImpact.ts
@@ -1,0 +1,118 @@
+// Canonical incident-impact vocabulary (SPE-820)
+
+export type IncidentImpactDenominatorKind =
+  | 'people'
+  | 'households'
+  | 'customers'
+  | 'facilities'
+  | 'organizations'
+  | 'jurisdictions'
+  | 'services'
+  | 'distance_km'
+
+export type IncidentImpactUncertaintyLevel = 'low' | 'medium' | 'high'
+
+export interface IncidentImpactUncertainty {
+  level: IncidentImpactUncertaintyLevel
+  basis?: string
+}
+
+export interface IncidentImpactDenominator<K extends IncidentImpactDenominatorKind = IncidentImpactDenominatorKind> {
+  kind: K
+  total?: number
+  label?: string
+}
+
+export interface IncidentImpactMetric<
+  K extends IncidentImpactDenominatorKind = IncidentImpactDenominatorKind,
+> {
+  value: number
+  denominator?: IncidentImpactDenominator<K>
+  uncertainty?: IncidentImpactUncertainty
+  note?: string
+}
+
+export interface IncidentImpactExtensionField {
+  metric: IncidentImpactMetric
+  category?:
+    | 'people'
+    | 'facilities'
+    | 'services'
+    | 'infrastructure'
+    | 'environment'
+    | 'coordination'
+  label?: string
+}
+
+/**
+ * Canonical typed impact object for incident consequence comparison.
+ *
+ * - Explicit denominator semantics via IncidentImpactMetric.denominator.kind
+ * - Uncertainty remains visible per field
+ * - Extensions are isolated under `extensions` and do not break standard fields
+ */
+export interface IncidentImpact {
+  schemaVersion: 'spe-820.v1'
+  affectedPopulation?: IncidentImpactMetric<'people'>
+  fatalities?: IncidentImpactMetric<'people'>
+  rescueDemand?: IncidentImpactMetric<'people'>
+  shelterDemand?: IncidentImpactMetric<'people' | 'households'>
+  outages?: IncidentImpactMetric<'customers' | 'households' | 'services'>
+  facilityImpact?: IncidentImpactMetric<'facilities'>
+  serviceDisruption?: IncidentImpactMetric<'customers' | 'services' | 'organizations'>
+  hazmatExposure?: IncidentImpactMetric<'people' | 'distance_km'>
+  organizationImpact?: IncidentImpactMetric<'organizations'>
+  jurisdictionImpact?: IncidentImpactMetric<'jurisdictions'>
+  extensions?: Record<string, IncidentImpactExtensionField>
+}
+
+function cloneMetric<K extends IncidentImpactDenominatorKind>(
+  metric: IncidentImpactMetric<K> | undefined
+): IncidentImpactMetric<K> | undefined {
+  if (!metric) return undefined
+  return {
+    ...metric,
+    ...(metric.denominator ? { denominator: { ...metric.denominator } } : {}),
+    ...(metric.uncertainty ? { uncertainty: { ...metric.uncertainty } } : {}),
+  }
+}
+
+/**
+ * Deterministic clone/normalization helper for runtime safety.
+ */
+export function cloneIncidentImpact(impact: IncidentImpact): IncidentImpact {
+  return {
+    schemaVersion: impact.schemaVersion,
+    ...(impact.affectedPopulation ? { affectedPopulation: cloneMetric(impact.affectedPopulation) } : {}),
+    ...(impact.fatalities ? { fatalities: cloneMetric(impact.fatalities) } : {}),
+    ...(impact.rescueDemand ? { rescueDemand: cloneMetric(impact.rescueDemand) } : {}),
+    ...(impact.shelterDemand ? { shelterDemand: cloneMetric(impact.shelterDemand) } : {}),
+    ...(impact.outages ? { outages: cloneMetric(impact.outages) } : {}),
+    ...(impact.facilityImpact ? { facilityImpact: cloneMetric(impact.facilityImpact) } : {}),
+    ...(impact.serviceDisruption ? { serviceDisruption: cloneMetric(impact.serviceDisruption) } : {}),
+    ...(impact.hazmatExposure ? { hazmatExposure: cloneMetric(impact.hazmatExposure) } : {}),
+    ...(impact.organizationImpact ? { organizationImpact: cloneMetric(impact.organizationImpact) } : {}),
+    ...(impact.jurisdictionImpact ? { jurisdictionImpact: cloneMetric(impact.jurisdictionImpact) } : {}),
+    ...(impact.extensions
+      ? {
+          extensions: Object.fromEntries(
+            Object.entries(impact.extensions).map(([key, value]) => [
+              key,
+              {
+                ...value,
+                metric: {
+                  ...value.metric,
+                  ...(value.metric.denominator
+                    ? { denominator: { ...value.metric.denominator } }
+                    : {}),
+                  ...(value.metric.uncertainty
+                    ? { uncertainty: { ...value.metric.uncertainty } }
+                    : {}),
+                },
+              },
+            ])
+          ),
+        }
+      : {}),
+  }
+}


### PR DESCRIPTION
## SPE-820 — Bounded Incident-Impact Schema

### Closure Blocker Fixed
`cloneIncidentImpact()` was shallow-copying all canonical metric fields via object spread (`{...impact}`), allowing runtime mutations to leak back into the authored template or state data and break determinism.

### What Changed

**`src/domain/templates/incidentImpact.ts`** (new file)
- Canonical `IncidentImpact` typed vocabulary with 10 standard metric fields and open `extensions` map
- Private `cloneMetric<K>()` helper deep-clones each metric's `denominator` and `uncertainty`
- `cloneIncidentImpact()` builds return value field-by-field via `cloneMetric()` — no object spread over whole impact

**`src/domain/templates/hazardIncidentTemplates.ts`**
- `HazardIncidentTemplate.impact?: IncidentImpact` authoring seam
- Sample template `hz-001` exercises all 10 canonical fields + 1 extension

**`src/domain/templates/hazardIncidentRuntime.ts`**
- `IncidentState.impact?: IncidentImpact` runtime seam
- `resolveIncident()` clones impact (prefers `template.impact`, falls back to `state.impact`)

**`src/domain/templates/__tests__/hazardIncident.test.ts`**
- New test: canonical metric fields not aliased across `resolveIncident()` calls
- New test: `state.impact` fallback clone path is independent of source

### Test Results
Focused suite: **9/9 passing** (was 7/9 before this fix)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jamesjedi420/containment-protocol/pull/927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
