### PR TITLE
SPE-1301: squad configuration summary read model (domain-only)

### DIFF
--- a/src/domain/squadConfigurationSummary.ts
+++ b/src/domain/squadConfigurationSummary.ts
@@ -1,0 +1,189 @@
+import type { SquadMetadata } from './squadMetadata'
+import type { SquadKitAssignment } from './squadKitAssignment'
+import type { SquadKitTemplate } from './squadKitTemplate'
+import { validateSquadKitAssignment } from './squadKitAssignment'
+
+export interface SquadConfigurationSlotInput {
+  readonly slotId: string
+  readonly role: string
+  readonly occupantId: string | null
+  readonly order: number
+}
+
+export interface SquadConfigurationSlotSummary {
+  readonly slotId: string
+  readonly role: string
+  readonly occupantId: string | null
+  readonly occupied: boolean
+  readonly order: number
+}
+
+export interface SquadConfigurationOccupancySummary {
+  readonly slots: readonly SquadConfigurationSlotSummary[]
+  readonly totalSlots: number
+  readonly occupiedSlots: number
+  readonly vacantSlots: number
+}
+
+export type SquadConfigurationKitSummary =
+  | {
+      readonly state: 'unassigned'
+      readonly assignment: null
+      readonly validation: null
+    }
+  | {
+      readonly state: 'assigned-valid'
+      readonly assignment: {
+        readonly kitTemplateId: string
+        readonly kitTemplateLabel: string
+      }
+      readonly validation: {
+        readonly status: 'valid'
+        readonly coveredTags: readonly string[]
+        readonly coverage: number
+      }
+    }
+  | {
+      readonly state: 'assigned-mismatch'
+      readonly assignment: {
+        readonly kitTemplateId: string
+        readonly kitTemplateLabel: string
+      }
+      readonly validation: {
+        readonly status: 'mismatch'
+        readonly coveredTags: readonly string[]
+        readonly missingTags: readonly string[]
+        readonly shortfall: number
+      }
+    }
+
+export interface SquadConfigurationSummary {
+  readonly metadata: SquadMetadata
+  readonly occupancy: SquadConfigurationOccupancySummary
+  readonly kit: SquadConfigurationKitSummary
+}
+
+export type SquadConfigurationSummaryFailure = 'invalid_squad_id' | 'assigned_kit_template_not_found'
+
+export type SquadConfigurationSummaryResult =
+  | { readonly ok: true; readonly summary: SquadConfigurationSummary }
+  | { readonly ok: false; readonly error: SquadConfigurationSummaryFailure }
+
+export interface BuildSquadConfigurationSummaryInput {
+  readonly metadata: SquadMetadata
+  readonly slots: readonly SquadConfigurationSlotInput[]
+  readonly assignment: SquadKitAssignment | null
+  readonly kitTemplatesById: Readonly<Record<string, SquadKitTemplate>>
+  readonly squadItemTags: readonly string[]
+}
+
+function buildOccupancySummary(
+  slots: readonly SquadConfigurationSlotInput[]
+): SquadConfigurationOccupancySummary {
+  const orderedSlots = [...slots]
+    .map((slot) => ({
+      slotId: slot.slotId,
+      role: slot.role,
+      occupantId: slot.occupantId,
+      occupied: slot.occupantId !== null,
+      order: slot.order,
+    }))
+    .sort((left, right) => {
+      if (left.order !== right.order) {
+        return left.order - right.order
+      }
+
+      if (left.slotId < right.slotId) {
+        return -1
+      }
+
+      if (left.slotId > right.slotId) {
+        return 1
+      }
+
+      return 0
+    })
+
+  const occupiedSlots = orderedSlots.filter((slot) => slot.occupied).length
+
+  return {
+    slots: orderedSlots,
+    totalSlots: orderedSlots.length,
+    occupiedSlots,
+    vacantSlots: orderedSlots.length - occupiedSlots,
+  }
+}
+
+export function buildSquadConfigurationSummary(
+  input: BuildSquadConfigurationSummaryInput
+): SquadConfigurationSummaryResult {
+  if (!input.metadata?.squadId) {
+    return { ok: false, error: 'invalid_squad_id' }
+  }
+
+  const occupancy = buildOccupancySummary(input.slots)
+
+  if (!input.assignment?.kitTemplateId) {
+    return {
+      ok: true,
+      summary: {
+        metadata: input.metadata,
+        occupancy,
+        kit: {
+          state: 'unassigned',
+          assignment: null,
+          validation: null,
+        },
+      },
+    }
+  }
+
+  const assignedTemplate = input.kitTemplatesById[input.assignment.kitTemplateId]
+  if (!assignedTemplate) {
+    return { ok: false, error: 'assigned_kit_template_not_found' }
+  }
+
+  const validation = validateSquadKitAssignment(assignedTemplate, input.squadItemTags)
+  if (validation.status === 'valid') {
+    return {
+      ok: true,
+      summary: {
+        metadata: input.metadata,
+        occupancy,
+        kit: {
+          state: 'assigned-valid',
+          assignment: {
+            kitTemplateId: assignedTemplate.id,
+            kitTemplateLabel: assignedTemplate.label,
+          },
+          validation: {
+            status: 'valid',
+            coveredTags: validation.result.coveredTags,
+            coverage: validation.result.coverage,
+          },
+        },
+      },
+    }
+  }
+
+  return {
+    ok: true,
+    summary: {
+      metadata: input.metadata,
+      occupancy,
+      kit: {
+        state: 'assigned-mismatch',
+        assignment: {
+          kitTemplateId: assignedTemplate.id,
+          kitTemplateLabel: assignedTemplate.label,
+        },
+        validation: {
+          status: 'mismatch',
+          coveredTags: validation.result.coveredTags,
+          missingTags: validation.result.missingTags,
+          shortfall: validation.result.shortfall,
+        },
+      },
+    },
+  }
+}

--- a/src/domain/squadConfigurationSummary.ts
+++ b/src/domain/squadConfigurationSummary.ts
@@ -123,6 +123,10 @@ export function buildSquadConfigurationSummary(
 
   const occupancy = buildOccupancySummary(input.slots)
 
+  if (input.assignment && input.assignment.squadId !== input.metadata.squadId) {
+    return { ok: false, error: 'invalid_squad_id' }
+  }
+
   if (!input.assignment?.kitTemplateId) {
     return {
       ok: true,

--- a/src/test/squadConfigurationSummary.test.ts
+++ b/src/test/squadConfigurationSummary.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import { createSquadMetadata } from '../domain/squadMetadata'
+import { assignSquadKit } from '../domain/squadKitAssignment'
+import { createSquadKitTemplate } from '../domain/squadKitTemplate'
+import {
+  buildSquadConfigurationSummary,
+  type SquadConfigurationSlotInput,
+} from '../domain/squadConfigurationSummary'
+
+function createMetadataFixture() {
+  const created = createSquadMetadata({
+    squadId: 'squad-alpha',
+    name: 'Alpha Squad',
+    role: 'rapid_response',
+    doctrine: 'containment',
+    shift: 'night',
+    assignedZone: 'zone-north',
+    designatedLeaderId: 'agent-alpha',
+  })
+
+  if (!created.ok) {
+    throw new Error(`Failed to create squad metadata fixture: ${created.code}`)
+  }
+
+  return created.metadata
+}
+
+function createTemplateFixture() {
+  const created = createSquadKitTemplate({
+    id: 'kit-breach',
+    label: 'Breach Kit',
+    requiredItemTags: ['breach', 'combat', 'protection'],
+    minCoveredCount: 2,
+  })
+
+  if (!created.ok) {
+    throw new Error(`Failed to create kit template fixture: ${created.error}`)
+  }
+
+  return created.template
+}
+
+function createOrderedSlotsFixture(): readonly SquadConfigurationSlotInput[] {
+  return [
+    { slotId: 'slot-3', role: 'support', occupantId: null, order: 3 },
+    { slotId: 'slot-1', role: 'lead', occupantId: 'agent-alpha', order: 1 },
+    { slotId: 'slot-2', role: 'breacher', occupantId: 'agent-bravo', order: 2 },
+  ]
+}
+
+describe('squadConfigurationSummary', () => {
+  it('builds a summary with deterministic vacancy and unassigned kit state', () => {
+    const metadata = createMetadataFixture()
+    const summary = buildSquadConfigurationSummary({
+      metadata,
+      slots: createOrderedSlotsFixture(),
+      assignment: null,
+      kitTemplatesById: {},
+      squadItemTags: [],
+    })
+
+    expect(summary.ok).toBe(true)
+    if (!summary.ok) {
+      throw new Error('Expected summary ok=true')
+    }
+
+    expect(summary.summary.metadata).toEqual(metadata)
+    expect(summary.summary.occupancy.totalSlots).toBe(3)
+    expect(summary.summary.occupancy.occupiedSlots).toBe(2)
+    expect(summary.summary.occupancy.vacantSlots).toBe(1)
+    expect(summary.summary.occupancy.slots.map((slot) => slot.slotId)).toEqual([
+      'slot-1',
+      'slot-2',
+      'slot-3',
+    ])
+    expect(summary.summary.kit).toEqual({
+      state: 'unassigned',
+      assignment: null,
+      validation: null,
+    })
+  })
+
+  it('builds a summary for assigned + valid kit state', () => {
+    const metadata = createMetadataFixture()
+    const template = createTemplateFixture()
+    const assignmentResult = assignSquadKit(metadata, template)
+    expect(assignmentResult.ok).toBe(true)
+    if (!assignmentResult.ok) {
+      throw new Error('Expected assignment ok=true')
+    }
+
+    const summary = buildSquadConfigurationSummary({
+      metadata,
+      slots: createOrderedSlotsFixture(),
+      assignment: assignmentResult.assignment,
+      kitTemplatesById: { [template.id]: template },
+      squadItemTags: ['breach', 'combat'],
+    })
+
+    expect(summary.ok).toBe(true)
+    if (!summary.ok) {
+      throw new Error('Expected summary ok=true')
+    }
+
+    expect(summary.summary.kit).toEqual({
+      state: 'assigned-valid',
+      assignment: {
+        kitTemplateId: 'kit-breach',
+        kitTemplateLabel: 'Breach Kit',
+      },
+      validation: {
+        status: 'valid',
+        coveredTags: ['breach', 'combat'],
+        coverage: 2,
+      },
+    })
+  })
+
+  it('builds a summary for assigned + mismatch with exact reasons', () => {
+    const metadata = createMetadataFixture()
+    const template = createTemplateFixture()
+    const assignmentResult = assignSquadKit(metadata, template)
+    expect(assignmentResult.ok).toBe(true)
+    if (!assignmentResult.ok) {
+      throw new Error('Expected assignment ok=true')
+    }
+
+    const summary = buildSquadConfigurationSummary({
+      metadata,
+      slots: createOrderedSlotsFixture(),
+      assignment: assignmentResult.assignment,
+      kitTemplatesById: { [template.id]: template },
+      squadItemTags: ['breach'],
+    })
+
+    expect(summary.ok).toBe(true)
+    if (!summary.ok) {
+      throw new Error('Expected summary ok=true')
+    }
+
+    expect(summary.summary.kit).toEqual({
+      state: 'assigned-mismatch',
+      assignment: {
+        kitTemplateId: 'kit-breach',
+        kitTemplateLabel: 'Breach Kit',
+      },
+      validation: {
+        status: 'mismatch',
+        coveredTags: ['breach'],
+        missingTags: ['combat', 'protection'],
+        shortfall: 1,
+      },
+    })
+  })
+
+  it('returns typed failure when assignment points to a missing template', () => {
+    const metadata = createMetadataFixture()
+
+    const summary = buildSquadConfigurationSummary({
+      metadata,
+      slots: createOrderedSlotsFixture(),
+      assignment: {
+        squadId: metadata.squadId,
+        kitTemplateId: 'missing-template',
+      },
+      kitTemplatesById: {},
+      squadItemTags: ['breach'],
+    })
+
+    expect(summary).toEqual({
+      ok: false,
+      error: 'assigned_kit_template_not_found',
+    })
+  })
+})

--- a/src/test/squadConfigurationSummary.test.ts
+++ b/src/test/squadConfigurationSummary.test.ts
@@ -172,4 +172,51 @@ describe('squadConfigurationSummary', () => {
       error: 'assigned_kit_template_not_found',
     })
   })
+
+  it('returns typed failure when assignment belongs to a different squad', () => {
+    const metadata = createMetadataFixture()
+    const template = createTemplateFixture()
+
+    const summary = buildSquadConfigurationSummary({
+      metadata,
+      slots: createOrderedSlotsFixture(),
+      assignment: {
+        squadId: 'squad-other',
+        kitTemplateId: template.id,
+      },
+      kitTemplatesById: { [template.id]: template },
+      squadItemTags: ['breach', 'combat'],
+    })
+
+    expect(summary).toEqual({
+      ok: false,
+      error: 'invalid_squad_id',
+    })
+  })
+
+  it('treats cleared assignment (kitTemplateId=null) as unassigned', () => {
+    const metadata = createMetadataFixture()
+
+    const summary = buildSquadConfigurationSummary({
+      metadata,
+      slots: createOrderedSlotsFixture(),
+      assignment: {
+        squadId: metadata.squadId,
+        kitTemplateId: null,
+      },
+      kitTemplatesById: {},
+      squadItemTags: [],
+    })
+
+    expect(summary.ok).toBe(true)
+    if (!summary.ok) {
+      throw new Error('Expected summary ok=true')
+    }
+
+    expect(summary.summary.kit).toEqual({
+      state: 'unassigned',
+      assignment: null,
+      validation: null,
+    })
+  })
 })


### PR DESCRIPTION
## Squad configuration summary read model (SPE-1301, child of SPE-1025)

**Scope note:** domain/read-model only; no UI. Builds on prior squad seams (SPE-1290/SPE-1291/SPE-1295/SPE-1299).

**What changed:**
- Added src/domain/squadConfigurationSummary.ts with a pure deterministic summary builder
- Summary includes metadata, ordered slot occupancy/vacancy, assigned kit state, and kit validation state
- Reuses existing alidateSquadKitAssignment (no duplicate kit validation logic)
- Added focused tests in src/test/squadConfigurationSummary.test.ts for no-kit, assigned-valid, assigned-mismatch, and partial occupancy

**Out of scope:** no scheduling, staging, patrol/alert behavior, leader-dependence, command routing, responder readiness math, or facility doctrine/loadout logic.

**Focused validation:**

pm run test:run -- src/test/squadConfigurationSummary.test.ts
Result: 4 tests passed, 0 failed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jamesjedi420/containment-protocol/pull/1313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

**Stacking note:** This PR is intentionally stacked on **#1310** (jamesdyedbq/spe-1025-squad-kit-assignment-seam). Merge #1310 first; then retarget/rebase this PR to main if needed.