### PR TITLE
SPE-1302: squad configuration summary panel

### DIFF
--- a/src/features/teams/SquadConfigurationSummaryPanel.test.tsx
+++ b/src/features/teams/SquadConfigurationSummaryPanel.test.tsx
@@ -1,0 +1,117 @@
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { SquadConfigurationSummaryPanel } from './SquadConfigurationSummaryPanel'
+import type { SquadConfigurationSummary } from '../../domain/squadConfigurationSummary'
+
+function makeMetadata() {
+  return {
+    squadId: 'sq-001',
+    name: 'Night Watch',
+    role: 'enforcement',
+    doctrine: 'aggressive',
+    shift: 'nights',
+    assignedZone: 'district-3',
+    designatedLeaderId: 'a_mina',
+  }
+}
+
+function makeOccupancy() {
+  return {
+    slots: [
+      { slotId: 'slot-1', role: 'lead', occupantId: 'a_mina', occupied: true, order: 1 },
+      { slotId: 'slot-2', role: 'support', occupantId: null, occupied: false, order: 2 },
+    ],
+    totalSlots: 2,
+    occupiedSlots: 1,
+    vacantSlots: 1,
+  }
+}
+
+describe('SquadConfigurationSummaryPanel', () => {
+  it('renders a placeholder when summary is null', () => {
+    render(<SquadConfigurationSummaryPanel summary={null} />)
+
+    expect(screen.getByRole('region', { name: /squad configuration/i })).toBeInTheDocument()
+    expect(screen.getByText(/no squad configuration available/i)).toBeInTheDocument()
+  })
+
+  it('renders metadata and slot occupancy', () => {
+    const summary: SquadConfigurationSummary = {
+      metadata: makeMetadata(),
+      occupancy: makeOccupancy(),
+      kit: { state: 'unassigned', assignment: null, validation: null },
+    }
+
+    render(<SquadConfigurationSummaryPanel summary={summary} />)
+
+    expect(screen.getByText('Night Watch')).toBeInTheDocument()
+    expect(screen.getByText('enforcement')).toBeInTheDocument()
+    expect(screen.getByText('aggressive')).toBeInTheDocument()
+    expect(screen.getByText('nights')).toBeInTheDocument()
+    expect(screen.getByText('district-3')).toBeInTheDocument()
+    expect(screen.getAllByText('a_mina').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText(/1\/2 occupied/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/vacant/i).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders unassigned kit state', () => {
+    const summary: SquadConfigurationSummary = {
+      metadata: makeMetadata(),
+      occupancy: makeOccupancy(),
+      kit: { state: 'unassigned', assignment: null, validation: null },
+    }
+
+    render(<SquadConfigurationSummaryPanel summary={summary} />)
+
+    expect(screen.getByText(/no kit assigned/i)).toBeInTheDocument()
+  })
+
+  it('renders assigned-valid kit state with covered tags', () => {
+    const summary: SquadConfigurationSummary = {
+      metadata: makeMetadata(),
+      occupancy: makeOccupancy(),
+      kit: {
+        state: 'assigned-valid',
+        assignment: { kitTemplateId: 'kt-01', kitTemplateLabel: 'Urban Response Kit' },
+        validation: {
+          status: 'valid',
+          coveredTags: ['breaching', 'medical'],
+          coverage: 1,
+        },
+      },
+    }
+
+    render(<SquadConfigurationSummaryPanel summary={summary} />)
+
+    expect(screen.getByText('Urban Response Kit')).toBeInTheDocument()
+    expect(screen.getByText(/valid/i)).toBeInTheDocument()
+    expect(screen.getByText(/breaching/i)).toBeInTheDocument()
+    expect(screen.getByText(/medical/i)).toBeInTheDocument()
+  })
+
+  it('renders assigned-mismatch kit state with missing tags and shortfall', () => {
+    const summary: SquadConfigurationSummary = {
+      metadata: makeMetadata(),
+      occupancy: makeOccupancy(),
+      kit: {
+        state: 'assigned-mismatch',
+        assignment: { kitTemplateId: 'kt-02', kitTemplateLabel: 'Recon Kit' },
+        validation: {
+          status: 'mismatch',
+          coveredTags: ['surveillance'],
+          missingTags: ['breaching', 'medical'],
+          shortfall: 2,
+        },
+      },
+    }
+
+    render(<SquadConfigurationSummaryPanel summary={summary} />)
+
+    expect(screen.getByText('Recon Kit')).toBeInTheDocument()
+    expect(screen.getByText(/mismatch/i)).toBeInTheDocument()
+    expect(screen.getByText(/breaching/i)).toBeInTheDocument()
+    expect(screen.getByText(/medical/i)).toBeInTheDocument()
+    expect(screen.getByText(/shortfall:?\s*2/i)).toBeInTheDocument()
+  })
+})

--- a/src/features/teams/SquadConfigurationSummaryPanel.tsx
+++ b/src/features/teams/SquadConfigurationSummaryPanel.tsx
@@ -1,0 +1,98 @@
+import type { SquadConfigurationSummary } from '../../domain/squadConfigurationSummary'
+
+interface SquadConfigurationSummaryPanelProps {
+  summary: SquadConfigurationSummary | null
+}
+
+export function SquadConfigurationSummaryPanel({
+  summary,
+}: SquadConfigurationSummaryPanelProps) {
+  return (
+    <article
+      className="panel panel-support space-y-3"
+      role="region"
+      aria-label="Squad configuration"
+    >
+      <h3 className="text-lg font-semibold">Squad configuration</h3>
+
+      {summary === null ? (
+        <p className="text-sm opacity-50">No squad configuration available.</p>
+      ) : (
+        <SquadConfigurationContent summary={summary} />
+      )}
+    </article>
+  )
+}
+
+function SquadConfigurationContent({ summary }: { summary: SquadConfigurationSummary }) {
+  const { metadata, occupancy, kit } = summary
+
+  return (
+    <>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <LabeledValue label="Name" value={metadata.name} />
+        <LabeledValue label="Role" value={metadata.role} />
+        <LabeledValue label="Doctrine" value={metadata.doctrine} />
+        <LabeledValue label="Shift" value={metadata.shift} />
+        {metadata.assignedZone ? (
+          <LabeledValue label="Zone" value={metadata.assignedZone} />
+        ) : null}
+        {metadata.designatedLeaderId ? (
+          <LabeledValue label="Leader ID" value={metadata.designatedLeaderId} />
+        ) : null}
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] opacity-50">
+          Slots — {occupancy.occupiedSlots}/{occupancy.totalSlots} occupied, {occupancy.vacantSlots}{' '}
+          vacant
+        </p>
+        <ul className="space-y-1">
+          {occupancy.slots.map((slot) => (
+            <li key={slot.slotId} className="flex items-center gap-2 text-sm">
+              <span className="min-w-24 opacity-60">{slot.role}</span>
+              {slot.occupied ? (
+                <span className="opacity-90">{slot.occupantId}</span>
+              ) : (
+                <span className="italic opacity-40">vacant</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] opacity-50">
+          Assigned kit
+        </p>
+        {kit.state === 'unassigned' ? (
+          <p className="text-sm opacity-50">No kit assigned</p>
+        ) : kit.state === 'assigned-valid' ? (
+          <div className="space-y-1">
+            <p className="text-sm font-medium">{kit.assignment.kitTemplateLabel}</p>
+            <p className="text-xs text-green-300/80">
+              Valid — covers: {kit.validation.coveredTags.join(', ')}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            <p className="text-sm font-medium">{kit.assignment.kitTemplateLabel}</p>
+            <p className="text-xs text-amber-300/80">
+              Mismatch — missing: {kit.validation.missingTags.join(', ')} (shortfall:{' '}
+              {kit.validation.shortfall})
+            </p>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+function LabeledValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-sm font-medium">{value}</p>
+    </div>
+  )
+}

--- a/src/features/teams/TeamDetailPage.tsx
+++ b/src/features/teams/TeamDetailPage.tsx
@@ -7,6 +7,7 @@ import { type Agent, type AgentRole, type PerformanceMetricSummary } from '../..
 import { getTeamAssignedCaseId, getTeamMemberIds } from '../../domain/teamSimulation'
 import { getTeamDeploymentHistory } from '../deployment/deploymentEventSelectors'
 import { getCoverageRolesForAgents } from '../../domain/validateTeam'
+import { SquadConfigurationSummaryPanel } from './SquadConfigurationSummaryPanel'
 import {
   AGENCY_LABELS,
   CASE_UI_LABELS,
@@ -185,6 +186,8 @@ export default function TeamDetailPage() {
               />
             </div>
           </article>
+
+          <SquadConfigurationSummaryPanel summary={null} />
 
           <article
             className="panel panel-support space-y-3"


### PR DESCRIPTION
## SPE-1302 — Squad configuration summary panel

Smallest honest UI consumer for the landed squad configuration summary read model (SPE-1301).

### What this adds

- **SquadConfigurationSummaryPanel** — prop-driven panel component rendering:
  - Squad metadata: name, role, doctrine, shift, assigned zone, designated leader ID
  - Ordered slot occupancy with per-slot occupied/vacant state
  - Assigned kit identity or "No kit assigned"
  - Valid state with covered tags
  - Mismatch state with exact missing tags and shortfall count
- Wired into **TeamDetailPage** below the capability summary article
  - Passes 
ull for now (store does not yet carry squad kit data — follow-up store extension)
- 5 focused component tests covering: null placeholder, metadata+slots, unassigned, valid, mismatch
- TeamDetailPage regression: 4/4 pass
- 
px tsc --noEmit clean

### Constraints respected

- No editing controls, no schedule switching, no staging assignment
- No patrol/alert/leader-dependence/command-routing/responder-readiness logic
- No models.ts widening
- Tailwind-only styling; no store imports inside the panel itself

### Stacking chain

**#1314** (this) → stacked on **#1313** (SPE-1301) → stacked on **#1310** (SPE-1299) → main

> ⚠️ Merge in order: #1310 → #1313 → #1314
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jamesjedi420/containment-protocol/pull/1315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->