### PR TITLE
Add AGENTS.md and fix Vite dev server type-import issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Containment Protocol — Agent Instructions
+
+## Cursor Cloud specific instructions
+
+This is a client-side-only React/TypeScript SPA (no backend, no database, no external services).
+All simulation logic is pure TypeScript; state is managed via Zustand with `localStorage` persistence.
+
+### Running services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| Dev server | `npm run dev` | Vite on http://localhost:5173 with HMR |
+| Lint | `npm run lint` | ESLint 9 |
+| Tests | `npm run test:run` | Vitest (302 files, ~2700 tests, ~55s) |
+| Format check | `npm run format:check` | Prettier |
+
+### Non-obvious caveats
+
+- **`npm run build` has pre-existing TS errors** in test files (`squadKitAssignment.test.ts`, `siteGeneration.pipeline.test.ts`, `supportLoadout.test.ts`). These do not affect tests or the dev server. The Vite dev server transpiles TypeScript without strict type checking.
+- **Vite 8 / Rolldown** strips type-only exports at the ESM boundary. If you import an `interface` or `type` alias as a value import, the dev server will throw `SyntaxError: does not provide an export named '...'`. Always use `import type { ... }` for type-only imports in source files that the Vite dev server loads.
+- **Tests use `--pool vmThreads`** and the `jsdom` environment. The full suite runs in ~55s.
+- **No environment variables or secrets** are required. The only optional env var is `STRICT_TEST_CONSOLE=1` (used in CI to fail on console warnings in tests).
+- **Node.js 22** is required (matches CI configuration in `.github/workflows/test.yml`).
+
+### Standard scripts reference
+
+All scripts are documented in `README.md` under the **Scripts** section and in `package.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,17 @@ All simulation logic is pure TypeScript; state is managed via Zustand with `loca
 
 ### Running services
 
-| Service | Command | Notes |
-|---------|---------|-------|
-| Dev server | `npm run dev` | Vite on http://localhost:5173 with HMR |
-| Lint | `npm run lint` | ESLint 9 |
-| Tests | `npm run test:run` | Vitest (302 files, ~2700 tests, ~55s) |
-| Format check | `npm run format:check` | Prettier |
+| Service      | Command                | Notes                                  |
+| ------------ | ---------------------- | -------------------------------------- |
+| Dev server   | `npm run dev`          | Vite on http://localhost:5173 with HMR |
+| Lint         | `npm run lint`         | ESLint 9                               |
+| Tests        | `npm run test:run`     | Vitest (302 files, ~2700 tests, ~55s)  |
+| Format check | `npm run format:check` | Prettier                               |
 
 ### Non-obvious caveats
 
-- **`npm run build` has pre-existing TS errors** in test files (`squadKitAssignment.test.ts`, `siteGeneration.pipeline.test.ts`, `supportLoadout.test.ts`). These do not affect tests or the dev server. The Vite dev server transpiles TypeScript without strict type checking.
-- **Vite 8 / Rolldown** strips type-only exports at the ESM boundary. If you import an `interface` or `type` alias as a value import, the dev server will throw `SyntaxError: does not provide an export named '...'`. Always use `import type { ... }` for type-only imports in source files that the Vite dev server loads.
+- **`npm run build` currently has baseline TS errors outside dev-environment setup.** Treat those as known type-contract drift, not as production-ignored failures; fix them in scoped follow-up changes before using `build` as a deployment gate. They do not block tests or the dev server because Vite transpiles TypeScript without strict type checking.
+- **This repo is pinned to Vite 8 (`vite` `^8.0.1`) with the native config loader.** Type-only exports are stripped at the ESM boundary. If you import an `interface` or `type` alias as a value import, the dev server will throw `SyntaxError: does not provide an export named '...'`. Always use `import type { ... }` for type-only imports in source files that the Vite dev server loads.
 - **Tests use `--pool vmThreads`** and the `jsdom` environment. The full suite runs in ~55s.
 - **No environment variables or secrets** are required. The only optional env var is `STRICT_TEST_CONSOLE=1` (used in CI to fail on console warnings in tests).
 - **Node.js 22** is required (matches CI configuration in `.github/workflows/test.yml`).

--- a/src/domain/squadKitAssignment.test.ts
+++ b/src/domain/squadKitAssignment.test.ts
@@ -1,16 +1,13 @@
 // Squad kit assignment and validation seam tests (SPE-1025 child)
 // Covers assign, reassign, clear, valid, mismatch paths deterministically
 import { describe, it, expect } from 'vitest'
-import { SquadMetadata } from './squadMetadata'
-import {
-  SquadKitTemplate,
-  createSquadKitTemplate,
-} from './squadKitTemplate'
+import type { SquadMetadata } from './squadMetadata'
+import { createSquadKitTemplate } from './squadKitTemplate'
+import type { SquadKitTemplate } from './squadKitTemplate'
 import {
   assignSquadKit,
   clearSquadKitAssignment,
   validateSquadKitAssignment,
-  SquadKitAssignment,
 } from './squadKitAssignment'
 
 const validSquad: SquadMetadata = {
@@ -41,19 +38,35 @@ describe('Squad kit assignment seam', () => {
   it('assigns a valid kit template to a squad', () => {
     const result = assignSquadKit(validSquad, validKitTemplate)
     expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error('Expected successful kit assignment')
+    }
     expect(result.assignment).toEqual({ squadId: 'S1', kitTemplateId: 'kit1' })
   })
 
   it('reassigns a different kit template deterministically', () => {
     const first = assignSquadKit(validSquad, validKitTemplate)
     const second = assignSquadKit(validSquad, partialKitTemplate)
+    expect(first.ok).toBe(true)
+    if (!first.ok) {
+      throw new Error('Expected initial kit assignment')
+    }
+    expect(first.assignment).toEqual({ squadId: 'S1', kitTemplateId: 'kit1' })
     expect(second.ok).toBe(true)
+    if (!second.ok) {
+      throw new Error('Expected replacement kit assignment')
+    }
     expect(second.assignment).toEqual({ squadId: 'S1', kitTemplateId: 'kit2' })
   })
 
   it('clears an assigned kit template', () => {
-    const cleared = clearSquadKitAssignment(validSquad, { currentAssignment: { squadId: 'S1', kitTemplateId: 'kit1' } })
+    const cleared = clearSquadKitAssignment(validSquad, {
+      currentAssignment: { squadId: 'S1', kitTemplateId: 'kit1' },
+    })
     expect(cleared.ok).toBe(true)
+    if (!cleared.ok) {
+      throw new Error('Expected successful kit assignment clear')
+    }
     expect(cleared.assignment).toEqual({ squadId: 'S1', kitTemplateId: null })
   })
 
@@ -65,8 +78,13 @@ describe('Squad kit assignment seam', () => {
   })
 
   it('returns error for clearing with no assignment', () => {
-    const result = clearSquadKitAssignment(validSquad, { currentAssignment: { squadId: 'S1', kitTemplateId: null } })
+    const result = clearSquadKitAssignment(validSquad, {
+      currentAssignment: { squadId: 'S1', kitTemplateId: null },
+    })
     expect(result.ok).toBe(false)
+    if (result.ok) {
+      throw new Error('Expected no-assignment clear failure')
+    }
     expect(result.error).toBe('no_assignment_to_clear')
   })
 
@@ -75,12 +93,18 @@ describe('Squad kit assignment seam', () => {
       currentAssignment: { squadId: 'S2', kitTemplateId: 'kit1' },
     })
     expect(result.ok).toBe(false)
+    if (result.ok) {
+      throw new Error('Expected assignment squad mismatch failure')
+    }
     expect(result.error).toBe('assignment_squad_mismatch')
   })
 
   it('returns deterministic clear payload when currentAssignment is missing', () => {
     const result = clearSquadKitAssignment(validSquad)
     expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error('Expected deterministic clear payload')
+    }
     expect(result.assignment).toEqual({ squadId: 'S1', kitTemplateId: null })
   })
 
@@ -106,10 +130,8 @@ describe('Squad kit assignment seam', () => {
   })
 
   it('returns typed invalid_input error for invalid validation inputs', () => {
-    const invalidTemplate =
-      null as unknown as Parameters<typeof validateSquadKitAssignment>[0]
-    const invalidTags =
-      null as unknown as Parameters<typeof validateSquadKitAssignment>[1]
+    const invalidTemplate = null as unknown as Parameters<typeof validateSquadKitAssignment>[0]
+    const invalidTags = null as unknown as Parameters<typeof validateSquadKitAssignment>[1]
     const validation = validateSquadKitAssignment(invalidTemplate, invalidTags)
     expect(validation).toEqual({ status: 'error', error: 'invalid_input' })
   })

--- a/src/domain/squadKitAssignment.ts
+++ b/src/domain/squadKitAssignment.ts
@@ -1,12 +1,8 @@
 // Squad kit assignment and validation seam (SPE-1025 child)
 // Domain-only, deterministic, no model widening unless unavoidable
 import type { SquadMetadata } from './squadMetadata'
-import {
-  SquadKitTemplate,
-  KitMatchResult,
-  KitMismatchResult,
-  evaluateSquadKitMatch,
-} from './squadKitTemplate'
+import type { KitMatchResult, KitMismatchResult, SquadKitTemplate } from './squadKitTemplate'
+import { evaluateSquadKitMatch } from './squadKitTemplate'
 
 export interface SquadKitAssignment {
   squadId: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cloud Agents and fixes a Vite 8 dev server compatibility issue.

### Changes

1. **`AGENTS.md`** — Added Cursor Cloud specific instructions documenting:
   - How to run the dev server, lint, tests, and format checks
   - Non-obvious caveats: baseline TypeScript build drift, package-pinned Vite 8/native loader type-import behavior, test pool configuration
   - Node.js 22 requirement

2. **`src/domain/squadKitAssignment.ts`** — Separated type-only imports (`KitMatchResult`, `KitMismatchResult`, `SquadKitTemplate`) from value imports (`evaluateSquadKitMatch`) using `import type` syntax. Vite 8's native-loader/Rolldown path strips interface/type exports at the ESM boundary, causing `SyntaxError: does not provide an export named '...'` when type-only exports are imported as values in the dev server.

3. **`src/domain/squadKitAssignment.test.ts`** — Removed the CI lint failure by converting type-only imports and making assignment/error result branches explicit for TypeScript and ESLint.

### Evidence

- `npm run lint` passes.
- `npm run test:run -- src/domain/squadKitAssignment.test.ts` passes: 12 tests.
- `npm run test:run` passes: 302 test files, 2703 tests.
- `npm run build` still fails on documented baseline TypeScript errors outside this dev-environment setup slice; `AGENTS.md` now states those must be fixed before using build as a deployment gate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aca46ba7-24a4-4f21-90f6-90ba660057a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aca46ba7-24a4-4f21-90f6-90ba660057a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

