### PR TITLE
Include root validation tests in standard test script

### DIFF
--- a/app.vite.config.ts
+++ b/app.vite.config.ts
@@ -63,7 +63,7 @@ export default defineConfig({
       },
     },
     setupFiles: ['src/test/setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'test/**/*.test.{ts,tsx}'],
     exclude: ['docs/**', '**/docs/**'],
     coverage: {
       exclude: ['docs/**', '**/docs/**'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Extends the shared Vitest include pattern so `npm run test:run` discovers root-level validation tests under `test/` in addition to source tests under `src/`.

### Validation
- `npm run test:run -- test/boundary-enforcement.test.ts` passes and confirms the root validation test is now discoverable.
- `npm run test:run` passes with 303 test files and 2704 tests.
- `git diff --check` passes.

### Known baseline blockers
- `npm run lint` currently fails on unrelated existing unused-variable errors in `src/domain/squadKitAssignment.test.ts`.
- `npm run build` currently fails on unrelated existing TypeScript errors across fatigue, site generation, event feed coverage, and squad kit tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f67bceb6-f7a1-4420-8912-15fc6be935e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f67bceb6-f7a1-4420-8912-15fc6be935e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

