### PR TITLE
Add procurement access gating

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -58,13 +58,7 @@ const ContainmentSiteRoute = createRouteComponent(() =>
     },
   }))
 )
-const MarketsSuppliersRoute = createRouteComponent(() =>
-  import('../features/divisions/SystemBoundaryPage').then((module) => ({
-    default: function MarketsSuppliersRoute() {
-      return <module.SystemBoundaryPage boundary="marketsSuppliers" />
-    },
-  }))
-)
+const MarketsSuppliersRoute = createRouteComponent(() => import('../features/market/MarketPage'))
 const FactionsPage = createRouteComponent(() => import('../features/factions/FactionsPage'))
 const RankingsRoute = createRouteComponent(() =>
   import('../features/divisions/SystemBoundaryPage').then((module) => ({

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -406,6 +406,21 @@ export interface OperationEventPayloadMap {
     unitPrice: number
     totalPrice: number
     remainingAvailability: number
+    allocation?: {
+      allocationId: string
+      resourceClass: 'supplier_attention_slot'
+      source: 'agency_supplier_roster' | 'gray_market_broker'
+      sourceLabel: string
+      destinationUse: string
+      destinationLabel: string
+      urgency: 'standard' | 'contingency'
+      expectedBenefit: string
+      priority: number
+      delayWeeks: number
+      displacedAlternativeUse?: string
+      substitutionStatus: 'none' | 'degraded_substitute'
+      substitutionSummary?: string
+    }
   }
   'faction.standing_changed': {
     week: number

--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -14,6 +14,8 @@ import type { GameState, OperationEvent } from './models'
 
 export type ProcurementTransactionAction = 'buy' | 'sell'
 export type ProcurementListingSource = 'recipe' | 'material' | 'direct_equipment'
+export type ProcurementAcquisitionClass = 'standard' | 'restricted'
+export type ProcurementAccessChannel = 'open_exchange' | 'directorate_special_channel'
 
 export interface ProcurementListing {
   id: string
@@ -31,6 +33,12 @@ export interface ProcurementListing {
   buyPrice: number
   sellPrice: number
   pressureLabel: string
+  acquisitionClass: ProcurementAcquisitionClass
+  accessChannel: ProcurementAccessChannel
+  accessLabel: string
+  accessDetails: string[]
+  accessAvailable: boolean
+  accessBlockedReason?: string
   totalAvailability: number
   remainingAvailability: number
   availableBundles: number
@@ -69,6 +77,34 @@ interface ProcurementListingDefinition {
 }
 
 type MarketTransactionEvent = Extract<OperationEvent, { type: 'market.transaction_recorded' }>
+
+interface ProcurementAccessRule {
+  acquisitionClass: ProcurementAcquisitionClass
+  accessChannel: ProcurementAccessChannel
+  accessLabel: string
+  details: string[]
+  requiredClearanceLevel?: number
+}
+
+const DEFAULT_PROCUREMENT_ACCESS = {
+  acquisitionClass: 'standard',
+  accessChannel: 'open_exchange',
+  accessLabel: 'Open exchange',
+  details: ['Standard supplier access.'],
+} as const satisfies Omit<ProcurementAccessRule, 'requiredClearanceLevel'>
+
+const PROCUREMENT_ACCESS_RULES: Record<string, ProcurementAccessRule> = {
+  'gear:advanced_recon_suite': {
+    acquisitionClass: 'restricted',
+    accessChannel: 'directorate_special_channel',
+    accessLabel: 'Directorate special channel',
+    details: [
+      'Restricted acquisition class.',
+      'Requires directorate clearance before supplier release.',
+    ],
+    requiredClearanceLevel: 2,
+  },
+}
 
 const MATERIAL_BASE_UNIT_PRICES: Record<string, number> = {
   electronic_parts: 7,
@@ -146,6 +182,34 @@ function getDirectEquipmentBasePrice(
   const premiumCount = definition.tags.filter((tag) => premiumTags.includes(tag)).length
 
   return EQUIPMENT_SLOT_BASE_PRICES[definition.slot] + definition.quality * 4 + premiumCount * 2
+}
+
+function getClearanceLevel(game: Pick<GameState, 'agency' | 'clearanceLevel'>) {
+  return Math.max(1, Math.trunc(game.agency?.clearanceLevel ?? game.clearanceLevel ?? 1))
+}
+
+function assessProcurementAccess(definition: ProcurementListingDefinition, game: GameState) {
+  const rule = PROCUREMENT_ACCESS_RULES[definition.id] ?? DEFAULT_PROCUREMENT_ACCESS
+  const clearanceLevel = getClearanceLevel(game)
+  const accessDetails = [...rule.details]
+
+  if (typeof rule.requiredClearanceLevel === 'number') {
+    accessDetails.push(`Clearance ${rule.requiredClearanceLevel}+ required.`)
+  }
+
+  const accessBlockedReason =
+    typeof rule.requiredClearanceLevel === 'number' && clearanceLevel < rule.requiredClearanceLevel
+      ? `${rule.accessLabel} locked: requires clearance ${rule.requiredClearanceLevel}; current clearance ${clearanceLevel}.`
+      : undefined
+
+  return {
+    acquisitionClass: rule.acquisitionClass,
+    accessChannel: rule.accessChannel,
+    accessLabel: rule.accessLabel,
+    accessDetails,
+    accessAvailable: accessBlockedReason === undefined,
+    ...(accessBlockedReason ? { accessBlockedReason } : {}),
+  }
 }
 
 function getListingDefinitions() {
@@ -299,6 +363,7 @@ function buildListing(
       getSoldQuantityForListing(game, definition.id)
   )
   const sellPrice = Math.max(1, Math.round(buyPrice * getSellRatio(game.market.pressure, featured)))
+  const access = assessProcurementAccess(definition, game)
 
   return {
     ...definition,
@@ -307,6 +372,7 @@ function buildListing(
     buyPrice,
     sellPrice,
     pressureLabel: getMarketPressureLabel(game.market.pressure),
+    ...access,
     totalAvailability,
     remainingAvailability,
     availableBundles: Math.floor(remainingAvailability / definition.bundleQuantity),

--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -301,7 +301,7 @@ function getMarketPacketIdForDefinition(
 export function getProcurementMarketPackets(game: Pick<GameState, 'legitimacy'>) {
   return (Object.keys(PROCUREMENT_MARKET_PACKET_DEFINITIONS) as ProcurementMarketPacketId[])
     .map((packetId) => buildMarketPacket(packetId, game))
-    .sort((left, right) => left.label.localeCompare(right.label))
+    .sort((left, right) => left.id.localeCompare(right.id))
 }
 
 export function getProcurementMarketPacket(

--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -21,6 +21,51 @@ export type ProcurementMarketBoundary = 'agency-supplier-roster' | 'settlement-g
 export type ProcurementLegalityAccessMode = 'licensed' | 'covert'
 export type ProcurementParticipantChannelType = 'quartermaster' | 'broker'
 export type ProcurementLiquidityProfile = 'stable' | 'thin'
+export type ProcurementResourceClass = 'supplier_attention_slot'
+export type ProcurementAllocationUrgency = 'standard' | 'contingency'
+export type ProcurementSubstitutionStatus = 'none' | 'degraded_substitute'
+
+export interface ProcurementAllocationPacket {
+  allocationId: string
+  resourceClass: ProcurementResourceClass
+  source: ProcurementMarketPacketId
+  sourceLabel: string
+  destinationUse: string
+  destinationLabel: string
+  urgency: ProcurementAllocationUrgency
+  expectedBenefit: string
+  priority: number
+  delayWeeks: number
+  displacedAlternativeUse?: string
+  substitutionStatus: ProcurementSubstitutionStatus
+  substitutionSummary?: string
+}
+
+export interface ProcurementSubstitutionOption {
+  status: 'available'
+  source: ProcurementMarketPacketId
+  sourceLabel: string
+  delayWeeks: number
+  priceMultiplier: number
+  unitPrice: number
+  summary: string
+}
+
+export interface ProcurementAllocationStatus {
+  resourceClass: ProcurementResourceClass
+  source: ProcurementMarketPacketId
+  sourceLabel: string
+  capacity: number
+  committed: number
+  available: number
+  required: number
+  purchaseAvailable: boolean
+  state: 'available' | 'committed_elsewhere' | 'substituted'
+  allocations: ProcurementAllocationPacket[]
+  displacedAlternativeUse?: string
+  blockerReason?: string
+  substitution?: ProcurementSubstitutionOption
+}
 
 export interface ProcurementMarketPacket {
   id: ProcurementMarketPacketId
@@ -53,6 +98,7 @@ export interface ProcurementListing {
   sellPrice: number
   pressureLabel: string
   marketPacket: ProcurementMarketPacket
+  allocationStatus: ProcurementAllocationStatus
   acquisitionClass: ProcurementAcquisitionClass
   accessChannel: ProcurementAccessChannel
   accessLabel: string
@@ -80,6 +126,7 @@ export interface ProcurementTransactionView {
   unitPrice: number
   totalPrice: number
   remainingAvailability: number
+  allocation?: ProcurementAllocationPacket
   timestamp: string
 }
 
@@ -98,6 +145,14 @@ interface ProcurementListingDefinition {
 
 type MarketTransactionEvent = Extract<OperationEvent, { type: 'market.transaction_recorded' }>
 type SanctionLevel = NonNullable<GameState['legitimacy']>['sanctionLevel']
+
+const SUPPLIER_ATTENTION_CAPACITY: Record<ProcurementMarketPacketId, number> = {
+  agency_supplier_roster: 1,
+  gray_market_broker: 1,
+}
+
+const DEGRADED_SUBSTITUTE_PRICE_MULTIPLIER = 1.35
+const DEGRADED_SUBSTITUTE_DELAY_WEEKS = 1
 
 interface ProcurementMarketPacketDefinition extends Omit<
   ProcurementMarketPacket,
@@ -426,6 +481,121 @@ function getSoldQuantityForListing(
     .reduce((sum, event) => sum + event.payload.quantity, 0)
 }
 
+function getCurrentSupplierAttentionAllocations(
+  game: GameState,
+  marketWeek = game.market.week
+): ProcurementAllocationPacket[] {
+  return game.events
+    .filter((event) => isMarketTransactionEvent(event))
+    .filter(
+      (event) =>
+        event.payload.action === 'buy' &&
+        event.payload.marketWeek === marketWeek &&
+        event.payload.allocation?.resourceClass === 'supplier_attention_slot'
+    )
+    .map((event) => event.payload.allocation!)
+    .sort((left, right) => left.allocationId.localeCompare(right.allocationId))
+}
+
+export function getProcurementAllocations(game: GameState, marketWeek = game.market.week) {
+  return getCurrentSupplierAttentionAllocations(game, marketWeek)
+}
+
+function getSupplierAttentionCapacity(packetId: ProcurementMarketPacketId) {
+  return SUPPLIER_ATTENTION_CAPACITY[packetId] ?? 0
+}
+
+function createOpenAllocationStatus(
+  packet: ProcurementMarketPacket,
+  allocations: ProcurementAllocationPacket[]
+): ProcurementAllocationStatus {
+  const packetAllocations = allocations.filter((allocation) => allocation.source === packet.id)
+  const capacity = getSupplierAttentionCapacity(packet.id)
+  const available = Math.max(0, capacity - packetAllocations.length)
+
+  return {
+    resourceClass: 'supplier_attention_slot',
+    source: packet.id,
+    sourceLabel: packet.label,
+    capacity,
+    committed: packetAllocations.length,
+    available,
+    required: 1,
+    purchaseAvailable: packet.available && available >= 1,
+    state: packet.available && available >= 1 ? 'available' : 'committed_elsewhere',
+    allocations: packetAllocations,
+    ...(available < 1
+      ? {
+          displacedAlternativeUse: packetAllocations[0]?.destinationLabel ?? packet.label,
+          blockerReason: `${packet.label} attention committed to ${packetAllocations[0]?.destinationLabel ?? 'another request'} this market week.`,
+        }
+      : {}),
+  }
+}
+
+function getDegradedSubstitutionOption(
+  definition: ProcurementListingDefinition,
+  game: GameState,
+  baseBuyPrice: number,
+  displacedAlternativeUse: string | undefined,
+  allocations: ProcurementAllocationPacket[]
+): ProcurementSubstitutionOption | undefined {
+  if (definition.source !== 'direct_equipment') {
+    return undefined
+  }
+
+  const substitutePacket = buildMarketPacket('gray_market_broker', game)
+  const substituteStatus = createOpenAllocationStatus(substitutePacket, allocations)
+
+  if (!substitutePacket.available || substituteStatus.available < 1) {
+    return undefined
+  }
+
+  return {
+    status: 'available',
+    source: substitutePacket.id,
+    sourceLabel: substitutePacket.label,
+    delayWeeks: DEGRADED_SUBSTITUTE_DELAY_WEEKS,
+    priceMultiplier: DEGRADED_SUBSTITUTE_PRICE_MULTIPLIER,
+    unitPrice: Math.max(1, Math.round(baseBuyPrice * DEGRADED_SUBSTITUTE_PRICE_MULTIPLIER)),
+    summary: `${substitutePacket.label} can cover ${definition.itemName} after ${displacedAlternativeUse ?? 'the roster slot'} displaced the roster request; +${Math.round((DEGRADED_SUBSTITUTE_PRICE_MULTIPLIER - 1) * 100)}% cost and ${DEGRADED_SUBSTITUTE_DELAY_WEEKS}w handling delay.`,
+  }
+}
+
+function buildAllocationStatus(
+  definition: ProcurementListingDefinition,
+  game: GameState,
+  packet: ProcurementMarketPacket,
+  baseBuyPrice: number
+): ProcurementAllocationStatus {
+  const allocations = getCurrentSupplierAttentionAllocations(game)
+  const status = createOpenAllocationStatus(packet, allocations)
+
+  if (status.purchaseAvailable || !packet.available || packet.id !== 'agency_supplier_roster') {
+    return status
+  }
+
+  const substitution = getDegradedSubstitutionOption(
+    definition,
+    game,
+    baseBuyPrice,
+    status.displacedAlternativeUse,
+    allocations
+  )
+
+  if (!substitution) {
+    return status
+  }
+
+  return {
+    ...status,
+    purchaseAvailable: true,
+    state: 'substituted',
+    blockerReason: undefined,
+    substitution,
+  }
+}
+
 function getBaseAvailability(
   definition: ProcurementListingDefinition,
   game: GameState,
@@ -492,7 +662,9 @@ function buildListing(
   game: GameState
 ): ProcurementListing {
   const marketPacket = buildMarketPacket(getMarketPacketIdForDefinition(definition), game)
-  const buyPrice = getBuyPrice(definition, game, marketPacket)
+  const baseBuyPrice = getBuyPrice(definition, game, marketPacket)
+  const allocationStatus = buildAllocationStatus(definition, game, marketPacket, baseBuyPrice)
+  const buyPrice = allocationStatus.substitution?.unitPrice ?? baseBuyPrice
   const fabricationCost =
     definition.recipeId !== undefined
       ? getProductionRecipe(definition.recipeId)
@@ -518,11 +690,39 @@ function buildListing(
     sellPrice,
     pressureLabel: getMarketPressureLabel(game.market.pressure),
     marketPacket,
+    allocationStatus,
     ...access,
     totalAvailability,
     remainingAvailability,
     availableBundles: Math.floor(remainingAvailability / definition.bundleQuantity),
     inventoryStock: game.inventory[definition.itemId] ?? 0,
+  }
+}
+
+export function buildProcurementAllocationPacket(input: {
+  listing: ProcurementListing
+  transactionId: string
+  quantity: number
+}): ProcurementAllocationPacket {
+  const substitution = input.listing.allocationStatus.substitution
+  const source = substitution?.source ?? input.listing.marketPacket.id
+  const sourceLabel = substitution?.sourceLabel ?? input.listing.marketPacket.label
+  const displacedAlternativeUse = input.listing.allocationStatus.displacedAlternativeUse
+
+  return {
+    allocationId: `${input.transactionId}:supplier-attention`,
+    resourceClass: 'supplier_attention_slot',
+    source,
+    sourceLabel,
+    destinationUse: input.listing.id,
+    destinationLabel: input.listing.itemName,
+    urgency: substitution ? 'contingency' : 'standard',
+    expectedBenefit: `${input.quantity}x ${input.listing.itemName}`,
+    priority: input.listing.featured ? 2 : 1,
+    delayWeeks: substitution?.delayWeeks ?? 0,
+    ...(displacedAlternativeUse ? { displacedAlternativeUse } : {}),
+    substitutionStatus: substitution ? 'degraded_substitute' : 'none',
+    ...(substitution ? { substitutionSummary: substitution.summary } : {}),
   }
 }
 
@@ -556,6 +756,7 @@ export function getCurrentMarketTransactions(
       unitPrice: event.payload.unitPrice,
       totalPrice: event.payload.totalPrice,
       remainingAvailability: event.payload.remainingAvailability,
+      ...(event.payload.allocation ? { allocation: event.payload.allocation } : {}),
       timestamp: event.timestamp,
     }))
     .sort(

--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -16,6 +16,25 @@ export type ProcurementTransactionAction = 'buy' | 'sell'
 export type ProcurementListingSource = 'recipe' | 'material' | 'direct_equipment'
 export type ProcurementAcquisitionClass = 'standard' | 'restricted'
 export type ProcurementAccessChannel = 'open_exchange' | 'directorate_special_channel'
+export type ProcurementMarketPacketId = 'agency_supplier_roster' | 'gray_market_broker'
+export type ProcurementMarketBoundary = 'agency-supplier-roster' | 'settlement-gray-market'
+export type ProcurementLegalityAccessMode = 'licensed' | 'covert'
+export type ProcurementParticipantChannelType = 'quartermaster' | 'broker'
+export type ProcurementLiquidityProfile = 'stable' | 'thin'
+
+export interface ProcurementMarketPacket {
+  id: ProcurementMarketPacketId
+  label: string
+  marketBoundary: ProcurementMarketBoundary
+  legalityAccessMode: ProcurementLegalityAccessMode
+  participantChannelType: ProcurementParticipantChannelType
+  liquidityProfile: ProcurementLiquidityProfile
+  availabilityMultiplier: number
+  priceMultiplier: number
+  knownDistortions: string[]
+  available: boolean
+  blockedReason?: string
+}
 
 export interface ProcurementListing {
   id: string
@@ -33,6 +52,7 @@ export interface ProcurementListing {
   buyPrice: number
   sellPrice: number
   pressureLabel: string
+  marketPacket: ProcurementMarketPacket
   acquisitionClass: ProcurementAcquisitionClass
   accessChannel: ProcurementAccessChannel
   accessLabel: string
@@ -77,6 +97,15 @@ interface ProcurementListingDefinition {
 }
 
 type MarketTransactionEvent = Extract<OperationEvent, { type: 'market.transaction_recorded' }>
+type SanctionLevel = NonNullable<GameState['legitimacy']>['sanctionLevel']
+
+interface ProcurementMarketPacketDefinition extends Omit<
+  ProcurementMarketPacket,
+  'available' | 'blockedReason'
+> {
+  blockedSanctionLevels?: SanctionLevel[]
+  blockedReasonTemplate?: string
+}
 
 interface ProcurementAccessRule {
   acquisitionClass: ProcurementAcquisitionClass
@@ -84,6 +113,44 @@ interface ProcurementAccessRule {
   accessLabel: string
   details: string[]
   requiredClearanceLevel?: number
+}
+
+const PROCUREMENT_MARKET_PACKET_DEFINITIONS: Record<
+  ProcurementMarketPacketId,
+  ProcurementMarketPacketDefinition
+> = {
+  agency_supplier_roster: {
+    id: 'agency_supplier_roster',
+    label: 'Agency supplier roster',
+    marketBoundary: 'agency-supplier-roster',
+    legalityAccessMode: 'licensed',
+    participantChannelType: 'quartermaster',
+    liquidityProfile: 'stable',
+    availabilityMultiplier: 1,
+    priceMultiplier: 1,
+    knownDistortions: ['Standard weekly supplier pressure only.'],
+  },
+  gray_market_broker: {
+    id: 'gray_market_broker',
+    label: 'Gray-market broker',
+    marketBoundary: 'settlement-gray-market',
+    legalityAccessMode: 'covert',
+    participantChannelType: 'broker',
+    liquidityProfile: 'thin',
+    availabilityMultiplier: 0.65,
+    priceMultiplier: 1.25,
+    knownDistortions: [
+      'Thin covert inventory.',
+      'Broker premium applied before weekly exchange pressure.',
+    ],
+    blockedSanctionLevels: ['sanctioned'],
+    blockedReasonTemplate:
+      'Gray-market broker blocked: sanctioned audit posture prevents covert exchange.',
+  },
+}
+
+const DIRECT_EQUIPMENT_MARKET_PACKETS: Partial<Record<string, ProcurementMarketPacketId>> = {
+  combat_stims: 'gray_market_broker',
 }
 
 const DEFAULT_PROCUREMENT_ACCESS = {
@@ -188,26 +255,87 @@ function getClearanceLevel(game: Pick<GameState, 'agency' | 'clearanceLevel'>) {
   return Math.max(1, Math.trunc(game.agency?.clearanceLevel ?? game.clearanceLevel ?? 1))
 }
 
-function assessProcurementAccess(definition: ProcurementListingDefinition, game: GameState) {
+function getSanctionLevel(game: Pick<GameState, 'legitimacy'>): SanctionLevel {
+  return game.legitimacy?.sanctionLevel ?? 'tolerated'
+}
+
+function buildMarketPacket(
+  packetId: ProcurementMarketPacketId,
+  game: Pick<GameState, 'legitimacy'>
+): ProcurementMarketPacket {
+  const definition = PROCUREMENT_MARKET_PACKET_DEFINITIONS[packetId]
+  const sanctionLevel = getSanctionLevel(game)
+  const blocked = definition.blockedSanctionLevels?.includes(sanctionLevel) ?? false
+
+  return {
+    id: definition.id,
+    label: definition.label,
+    marketBoundary: definition.marketBoundary,
+    legalityAccessMode: definition.legalityAccessMode,
+    participantChannelType: definition.participantChannelType,
+    liquidityProfile: definition.liquidityProfile,
+    availabilityMultiplier: definition.availabilityMultiplier,
+    priceMultiplier: definition.priceMultiplier,
+    knownDistortions: [...definition.knownDistortions],
+    available: !blocked,
+    ...(blocked
+      ? {
+          blockedReason:
+            definition.blockedReasonTemplate ??
+            `${definition.label} blocked by current access posture.`,
+        }
+      : {}),
+  }
+}
+
+function getMarketPacketIdForDefinition(
+  definition: ProcurementListingDefinition
+): ProcurementMarketPacketId {
+  if (definition.source === 'direct_equipment') {
+    return DIRECT_EQUIPMENT_MARKET_PACKETS[definition.itemId] ?? 'agency_supplier_roster'
+  }
+
+  return 'agency_supplier_roster'
+}
+
+export function getProcurementMarketPackets(game: Pick<GameState, 'legitimacy'>) {
+  return (Object.keys(PROCUREMENT_MARKET_PACKET_DEFINITIONS) as ProcurementMarketPacketId[])
+    .map((packetId) => buildMarketPacket(packetId, game))
+    .sort((left, right) => left.label.localeCompare(right.label))
+}
+
+export function getProcurementMarketPacket(
+  game: Pick<GameState, 'legitimacy'>,
+  packetId: ProcurementMarketPacketId
+) {
+  return buildMarketPacket(packetId, game)
+}
+
+function assessProcurementAccess(
+  definition: ProcurementListingDefinition,
+  game: GameState,
+  marketPacket: ProcurementMarketPacket
+) {
   const rule = PROCUREMENT_ACCESS_RULES[definition.id] ?? DEFAULT_PROCUREMENT_ACCESS
   const clearanceLevel = getClearanceLevel(game)
-  const accessDetails = [...rule.details]
+  const accessDetails = [...marketPacket.knownDistortions, ...rule.details]
 
   if (typeof rule.requiredClearanceLevel === 'number') {
     accessDetails.push(`Clearance ${rule.requiredClearanceLevel}+ required.`)
   }
 
-  const accessBlockedReason =
+  const ruleBlockedReason =
     typeof rule.requiredClearanceLevel === 'number' && clearanceLevel < rule.requiredClearanceLevel
       ? `${rule.accessLabel} locked: requires clearance ${rule.requiredClearanceLevel}; current clearance ${clearanceLevel}.`
       : undefined
+  const accessBlockedReason = marketPacket.blockedReason ?? ruleBlockedReason
 
   return {
     acquisitionClass: rule.acquisitionClass,
     accessChannel: rule.accessChannel,
     accessLabel: rule.accessLabel,
     accessDetails,
-    accessAvailable: accessBlockedReason === undefined,
+    accessAvailable: marketPacket.available && accessBlockedReason === undefined,
     ...(accessBlockedReason ? { accessBlockedReason } : {}),
   }
 }
@@ -298,7 +426,11 @@ function getSoldQuantityForListing(
     .reduce((sum, event) => sum + event.payload.quantity, 0)
 }
 
-function getBaseAvailability(definition: ProcurementListingDefinition, game: GameState) {
+function getBaseAvailability(
+  definition: ProcurementListingDefinition,
+  game: GameState,
+  marketPacket: ProcurementMarketPacket
+) {
   const rng = createListingRng(game, definition.id)
   const profile = getAvailabilityProfile(definition.source)
   const featuredBonus =
@@ -313,22 +445,35 @@ function getBaseAvailability(definition: ProcurementListingDefinition, game: Gam
       featuredBonus
   )
 
-  return bundleAvailability * definition.bundleQuantity
+  const adjustedBundleAvailability = marketPacket.available
+    ? Math.max(0, Math.floor(bundleAvailability * marketPacket.availabilityMultiplier))
+    : 0
+
+  return adjustedBundleAvailability * definition.bundleQuantity
 }
 
-function getBuyPrice(definition: ProcurementListingDefinition, game: GameState) {
+function getBuyPrice(
+  definition: ProcurementListingDefinition,
+  game: GameState,
+  marketPacket: ProcurementMarketPacket
+) {
+  const applyPacketPrice = (basePrice: number) =>
+    Math.max(1, Math.round(basePrice * marketPacket.priceMultiplier))
+
   if (definition.recipeId) {
     const recipe = getProductionRecipe(definition.recipeId)
     if (recipe) {
-      return getRecipeMarketBuyCost(recipe, game.market)
+      return applyPacketPrice(getRecipeMarketBuyCost(recipe, game.market))
     }
   }
 
   if (definition.materialId) {
     const baseUnitPrice = MATERIAL_BASE_UNIT_PRICES[definition.materialId] ?? 6
-    return Math.max(
-      1,
-      Math.round(baseUnitPrice * definition.bundleQuantity * game.market.costMultiplier)
+    return applyPacketPrice(
+      Math.max(
+        1,
+        Math.round(baseUnitPrice * definition.bundleQuantity * game.market.costMultiplier)
+      )
     )
   }
 
@@ -337,9 +482,8 @@ function getBuyPrice(definition: ProcurementListingDefinition, game: GameState) 
   )
   const baseUnitPrice = equipmentDefinition ? getDirectEquipmentBasePrice(equipmentDefinition) : 20
 
-  return Math.max(
-    1,
-    Math.round(baseUnitPrice * definition.bundleQuantity * game.market.costMultiplier)
+  return applyPacketPrice(
+    Math.max(1, Math.round(baseUnitPrice * definition.bundleQuantity * game.market.costMultiplier))
   )
 }
 
@@ -347,7 +491,8 @@ function buildListing(
   definition: ProcurementListingDefinition,
   game: GameState
 ): ProcurementListing {
-  const buyPrice = getBuyPrice(definition, game)
+  const marketPacket = buildMarketPacket(getMarketPacketIdForDefinition(definition), game)
+  const buyPrice = getBuyPrice(definition, game, marketPacket)
   const fabricationCost =
     definition.recipeId !== undefined
       ? getProductionRecipe(definition.recipeId)
@@ -355,7 +500,7 @@ function buildListing(
         : undefined
       : undefined
   const featured = definition.recipeId === game.market.featuredRecipeId
-  const totalAvailability = getBaseAvailability(definition, game)
+  const totalAvailability = getBaseAvailability(definition, game, marketPacket)
   const remainingAvailability = Math.max(
     0,
     totalAvailability -
@@ -363,7 +508,7 @@ function buildListing(
       getSoldQuantityForListing(game, definition.id)
   )
   const sellPrice = Math.max(1, Math.round(buyPrice * getSellRatio(game.market.pressure, featured)))
-  const access = assessProcurementAccess(definition, game)
+  const access = assessProcurementAccess(definition, game, marketPacket)
 
   return {
     ...definition,
@@ -372,6 +517,7 @@ function buildListing(
     buyPrice,
     sellPrice,
     pressureLabel: getMarketPressureLabel(game.market.pressure),
+    marketPacket,
     ...access,
     totalAvailability,
     remainingAvailability,

--- a/src/domain/reportNotes.ts
+++ b/src/domain/reportNotes.ts
@@ -480,6 +480,7 @@ function buildReflectedReportNote(draft: AnyOperationEventDraft): {
           unitPrice: draft.payload.unitPrice,
           totalPrice: draft.payload.totalPrice,
           remainingAvailability: draft.payload.remainingAvailability,
+          allocation: draft.payload.allocation,
         },
       }
 

--- a/src/domain/sim/market.ts
+++ b/src/domain/sim/market.ts
@@ -1,6 +1,6 @@
 import { appendOperationEventDrafts } from '../events'
 import type { GameState } from '../models'
-import { getProcurementListing } from '../market'
+import { buildProcurementAllocationPacket, getProcurementListing } from '../market'
 import { ensureNormalizedGameState, normalizeGameState } from '../teamSimulation'
 
 function getNextMarketTransactionSequence(state: GameState) {
@@ -33,6 +33,8 @@ export function purchaseMarketInventory(
 
   if (
     !listing.accessAvailable ||
+    !listing.allocationStatus.purchaseAvailable ||
+    (listing.allocationStatus.substitution && normalizedBundles > 1) ||
     normalizedBundles > listing.availableBundles ||
     state.funding < totalPrice
   ) {
@@ -43,6 +45,7 @@ export function purchaseMarketInventory(
     ...state.inventory,
     [listing.itemId]: (state.inventory[listing.itemId] ?? 0) + quantity,
   }
+  const transactionId = nextTransactionId(state)
 
   return normalizeGameState(
     appendOperationEventDrafts(
@@ -58,7 +61,7 @@ export function purchaseMarketInventory(
           payload: {
             week: state.week,
             marketWeek: state.market.week,
-            transactionId: nextTransactionId(state),
+            transactionId,
             action: 'buy',
             listingId: listing.id,
             itemId: listing.itemId,
@@ -69,6 +72,11 @@ export function purchaseMarketInventory(
             unitPrice: Math.round((listing.buyPrice / listing.bundleQuantity) * 100) / 100,
             totalPrice,
             remainingAvailability: Math.max(0, listing.remainingAvailability - quantity),
+            allocation: buildProcurementAllocationPacket({
+              listing,
+              transactionId,
+              quantity,
+            }),
           },
         },
       ]

--- a/src/domain/sim/market.ts
+++ b/src/domain/sim/market.ts
@@ -31,7 +31,11 @@ export function purchaseMarketInventory(
   const quantity = normalizedBundles * listing.bundleQuantity
   const totalPrice = normalizedBundles * listing.buyPrice
 
-  if (normalizedBundles > listing.availableBundles || state.funding < totalPrice) {
+  if (
+    !listing.accessAvailable ||
+    normalizedBundles > listing.availableBundles ||
+    state.funding < totalPrice
+  ) {
     return ensureNormalizedGameState(state)
   }
 

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -5,8 +5,9 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createStartingState } from '../../data/startingState'
+import { purchaseMarketInventory } from '../../domain/sim/market'
 import { useGameStore } from '../../app/store/gameStore'
-import { DEFAULT_MARKET_FILTERS, getFilteredMarketListings } from './marketView'
+import { DEFAULT_MARKET_FILTERS, getFilteredMarketListings, getMarketListings } from './marketView'
 import MarketPage from './MarketPage'
 
 function LocationProbe() {
@@ -280,6 +281,31 @@ describe('MarketPage', () => {
         .length
     ).toBeGreaterThan(0)
     expect(within(grayMarketRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeDisabled()
+  })
+
+  it('shows degraded substitution when supplier attention is committed elsewhere', () => {
+    const game = createStartingState()
+    const fieldPlate = getMarketListings(game).find(
+      (candidate) => candidate.itemId === 'field_plate'
+    )
+
+    expect(fieldPlate).toBeDefined()
+
+    useGameStore.setState({ game: purchaseMarketInventory(game, fieldPlate!.id, 1) })
+
+    renderMarketPage(['/markets-suppliers?q=hazmat%20suit'])
+
+    const hazmatRow = screen.getAllByText(/^hazmat suit$/i)[0]?.closest('li')
+
+    expect(hazmatRow).toBeTruthy()
+    expect(within(hazmatRow!).getByText(/supplier attention: 0\/1 open/i)).toBeInTheDocument()
+    expect(within(hazmatRow!).getByText(/allocation state: substituted/i)).toBeInTheDocument()
+    expect(within(hazmatRow!).getByText(/displaced use: field plate/i)).toBeInTheDocument()
+    expect(within(hazmatRow!).getByText(/degraded substitute:/i)).toHaveTextContent(
+      /gray-market broker/i
+    )
+    expect(within(hazmatRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeEnabled()
+    expect(within(hazmatRow!).getByRole('button', { name: /buy 3 bundles/i })).toBeDisabled()
   })
 
   it('disables sell actions and shows sell-blocked reason when stock is unavailable', () => {

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -230,7 +230,7 @@ describe('MarketPage', () => {
 
     renderMarketPage()
 
-    const restrictedRow = screen.getByText(/advanced recon suite/i).closest('li')
+    const restrictedRow = screen.getAllByText(/^advanced recon suite$/i)[0]?.closest('li')
 
     expect(restrictedRow).toBeTruthy()
     expect(

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -238,8 +238,8 @@ describe('MarketPage', () => {
     ).toBeInTheDocument()
     expect(within(restrictedRow!).getByText(/funding: affordable/i)).toBeInTheDocument()
     expect(
-      within(restrictedRow!).getByText(/directorate special channel locked/i)
-    ).toBeInTheDocument()
+      within(restrictedRow!).getAllByText(/directorate special channel locked/i).length
+    ).toBeGreaterThan(0)
     expect(within(restrictedRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeDisabled()
   })
 

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -276,8 +276,9 @@ describe('MarketPage', () => {
 
     expect(grayMarketRow).toBeTruthy()
     expect(
-      within(grayMarketRow!).getByText(/gray-market broker blocked: sanctioned audit posture/i)
-    ).toBeInTheDocument()
+      within(grayMarketRow!).getAllByText(/gray-market broker blocked: sanctioned audit posture/i)
+        .length
+    ).toBeGreaterThan(0)
     expect(within(grayMarketRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeDisabled()
   })
 

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -243,6 +243,44 @@ describe('MarketPage', () => {
     expect(within(restrictedRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeDisabled()
   })
 
+  it('shows market packet boundaries on procurement listings', () => {
+    const game = createStartingState()
+    useGameStore.setState({ game })
+
+    renderMarketPage(['/markets-suppliers?q=combat%20stims'])
+
+    const grayMarketRow = screen.getAllByText(/^combat stims$/i)[0]?.closest('li')
+
+    expect(grayMarketRow).toBeTruthy()
+    expect(within(grayMarketRow!).getByText(/exchange: gray-market broker/i)).toBeInTheDocument()
+    expect(
+      within(grayMarketRow!).getByText(/boundary: settlement-gray-market/i)
+    ).toBeInTheDocument()
+    expect(within(grayMarketRow!).getByText(/legality: covert/i)).toBeInTheDocument()
+    expect(within(grayMarketRow!).getByText(/liquidity: thin/i)).toBeInTheDocument()
+    expect(within(grayMarketRow!).getByText(/thin covert inventory/i)).toBeInTheDocument()
+  })
+
+  it('shows packet access blockers when a boundary forbids trade', () => {
+    const game = createStartingState()
+    game.legitimacy = {
+      sanctionLevel: 'sanctioned',
+      accessReason: 'audit posture',
+      falloutRisk: 'none',
+    }
+    useGameStore.setState({ game })
+
+    renderMarketPage(['/markets-suppliers?q=combat%20stims'])
+
+    const grayMarketRow = screen.getAllByText(/^combat stims$/i)[0]?.closest('li')
+
+    expect(grayMarketRow).toBeTruthy()
+    expect(
+      within(grayMarketRow!).getByText(/gray-market broker blocked: sanctioned audit posture/i)
+    ).toBeInTheDocument()
+    expect(within(grayMarketRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeDisabled()
+  })
+
   it('disables sell actions and shows sell-blocked reason when stock is unavailable', () => {
     const game = createStartingState()
     game.inventory = Object.fromEntries(Object.keys(game.inventory).map((itemId) => [itemId, 0]))

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '../../test/setup'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -222,6 +222,25 @@ describe('MarketPage', () => {
     expect(buyButtons.length).toBeGreaterThan(0)
     expect(buyButtons[0]).toBeDisabled()
     expect(screen.getAllByText(/need \+\$\d+/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows access-class blockers separately from affordable funding', () => {
+    const game = createStartingState()
+    useGameStore.setState({ game })
+
+    renderMarketPage()
+
+    const restrictedRow = screen.getByText(/advanced recon suite/i).closest('li')
+
+    expect(restrictedRow).toBeTruthy()
+    expect(
+      within(restrictedRow!).getByText(/access: directorate special channel/i)
+    ).toBeInTheDocument()
+    expect(within(restrictedRow!).getByText(/funding: affordable/i)).toBeInTheDocument()
+    expect(
+      within(restrictedRow!).getByText(/directorate special channel locked/i)
+    ).toBeInTheDocument()
+    expect(within(restrictedRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeDisabled()
   })
 
   it('disables sell actions and shows sell-blocked reason when stock is unavailable', () => {

--- a/src/features/market/MarketPage.tsx
+++ b/src/features/market/MarketPage.tsx
@@ -103,9 +103,9 @@ export default function MarketPage() {
         <h3 className="text-base font-semibold">Procurement model</h3>
         <p className="text-sm opacity-60">
           Listings are derived deterministically from the current market week, supply pressure,
-          featured fabrication output, and seeded availability. Procurement reduces weekly channel
-          availability. Selling returns stock to the exchange at a lower recovery price for the same
-          week.
+          featured fabrication output, seeded availability, and explicit access classes. Procurement
+          reduces weekly channel availability. Selling returns stock to the exchange at a lower
+          recovery price for the same week.
         </p>
         <div className="grid gap-3 md:grid-cols-4">
           <Metric label="Market week" value={String(game.market.week)} />
@@ -244,11 +244,30 @@ export default function MarketPage() {
                 </div>
               </div>
 
-              <div className="grid gap-2 text-sm opacity-75 md:grid-cols-4">
+              <div className="grid gap-2 text-sm opacity-75 md:grid-cols-5">
                 <p>Bundle qty: {listing.bundleQuantity}</p>
                 <p>Buy: ${listing.buyPrice}</p>
                 <p>Sell: ${listing.sellPrice}</p>
                 <p>Pressure: {listing.pressureLabel}</p>
+                <p>Access: {listing.accessLabel}</p>
+              </div>
+
+              <div className="grid gap-2 text-xs opacity-70 md:grid-cols-3">
+                <p>Acquisition: {listing.acquisitionClass}</p>
+                <p>
+                  Funding:{' '}
+                  {listing.canAffordOne
+                    ? `Affordable with $${game.funding} on hand`
+                    : (listing.budgetBlockedReason ?? 'Budget blocked')}
+                </p>
+                <p>
+                  Availability:{' '}
+                  {listing.accessAvailable
+                    ? listing.availableBundles > 0
+                      ? `${listing.availableBundles} bundle(s) open`
+                      : (listing.availabilityBlockedReason ?? 'Channel exhausted')
+                    : (listing.accessBlockedReason ?? 'Access blocked')}
+                </p>
               </div>
 
               {listing.tags.length > 0 ? (

--- a/src/features/market/MarketPage.tsx
+++ b/src/features/market/MarketPage.tsx
@@ -277,6 +277,24 @@ export default function MarketPage() {
                 <p>Liquidity: {listing.marketPacket.liquidityProfile}</p>
               </div>
 
+              <div className="grid gap-2 text-xs opacity-70 md:grid-cols-3">
+                <p>
+                  Supplier attention: {listing.allocationStatus.available}/
+                  {listing.allocationStatus.capacity} open
+                </p>
+                <p>Allocation state: {listing.allocationStatus.state.replace(/_/g, ' ')}</p>
+                <p>
+                  Displaced use:{' '}
+                  {listing.allocationStatus.displacedAlternativeUse ?? 'None this market week'}
+                </p>
+              </div>
+
+              {listing.allocationStatus.substitution ? (
+                <p className="text-xs text-amber-200">
+                  Degraded substitute: {listing.allocationStatus.substitution.summary}
+                </p>
+              ) : null}
+
               {listing.marketPacket.knownDistortions.length > 0 ? (
                 <div className="flex flex-wrap gap-2 text-xs opacity-65">
                   {listing.marketPacket.knownDistortions.map((distortion) => (
@@ -380,6 +398,15 @@ export default function MarketPage() {
                     <p className="text-sm opacity-60">
                       Week {transaction.week} / Market week {transaction.marketWeek}
                     </p>
+                    {transaction.allocation ? (
+                      <p className="text-xs opacity-60">
+                        Allocation: {transaction.allocation.sourceLabel} /{' '}
+                        {transaction.allocation.substitutionStatus.replace(/_/g, ' ')}
+                        {transaction.allocation.delayWeeks > 0
+                          ? ` / ${transaction.allocation.delayWeeks}w delay`
+                          : ''}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="text-right text-sm opacity-70">
                     <p>

--- a/src/features/market/MarketPage.tsx
+++ b/src/features/market/MarketPage.tsx
@@ -103,9 +103,9 @@ export default function MarketPage() {
         <h3 className="text-base font-semibold">Procurement model</h3>
         <p className="text-sm opacity-60">
           Listings are derived deterministically from the current market week, supply pressure,
-          featured fabrication output, seeded availability, and explicit access classes. Procurement
-          reduces weekly channel availability. Selling returns stock to the exchange at a lower
-          recovery price for the same week.
+          featured fabrication output, market packets, seeded availability, and explicit access
+          classes. Procurement reduces weekly channel availability. Selling returns stock to the
+          exchange at a lower recovery price for the same week.
         </p>
         <div className="grid gap-3 md:grid-cols-4">
           <Metric label="Market week" value={String(game.market.week)} />
@@ -269,6 +269,26 @@ export default function MarketPage() {
                     : (listing.accessBlockedReason ?? 'Access blocked')}
                 </p>
               </div>
+
+              <div className="grid gap-2 text-xs opacity-70 md:grid-cols-4">
+                <p>Exchange: {listing.marketPacket.label}</p>
+                <p>Boundary: {listing.marketPacket.marketBoundary}</p>
+                <p>Legality: {listing.marketPacket.legalityAccessMode}</p>
+                <p>Liquidity: {listing.marketPacket.liquidityProfile}</p>
+              </div>
+
+              {listing.marketPacket.knownDistortions.length > 0 ? (
+                <div className="flex flex-wrap gap-2 text-xs opacity-65">
+                  {listing.marketPacket.knownDistortions.map((distortion) => (
+                    <span
+                      key={`${listing.id}-${distortion}`}
+                      className="rounded border border-white/10 px-2 py-1"
+                    >
+                      {distortion}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
 
               {listing.tags.length > 0 ? (
                 <div className="flex flex-wrap gap-2 text-xs opacity-65">

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -79,11 +79,27 @@ describe('marketView', () => {
       funding: 0,
     }
 
-    const listing = getMarketListings(game).find((candidate) => candidate.buyPrice > 0)
+    const listing = getMarketListings(game).find(
+      (candidate) => candidate.accessAvailable && candidate.buyPrice > 0
+    )
 
     expect(listing).toBeDefined()
     expect(listing!.canBuyOne).toBe(false)
     expect(listing!.buyBlockedReason).toMatch(/need \+\$\d+/i)
+  })
+
+  it('surfaces access blockers when budget can cover a restricted listing', () => {
+    const game = createStartingState()
+    const listing = getMarketListings(game).find(
+      (candidate) => candidate.itemId === 'advanced_recon_suite'
+    )
+
+    expect(listing).toBeDefined()
+    expect(listing!.canAffordOne).toBe(true)
+    expect(listing!.accessAvailable).toBe(false)
+    expect(listing!.canBuyOne).toBe(false)
+    expect(listing!.budgetBlockedReason).toBeUndefined()
+    expect(listing!.buyBlockedReason).toMatch(/directorate special channel locked/i)
   })
 
   it('normalizes invalid market query params to defaults', () => {

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -58,7 +58,9 @@ describe('marketView', () => {
 
   it('reflects current-week transaction history from domain events', () => {
     const game = createStartingState()
-    const listing = getMarketListings(game)[0]
+    const listing = getMarketListings(game).find(
+      (candidate) => candidate.accessAvailable && candidate.availableBundles > 0
+    )
 
     expect(listing).toBeDefined()
 

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -104,6 +104,21 @@ describe('marketView', () => {
     expect(listing!.buyBlockedReason).toMatch(/directorate special channel locked/i)
   })
 
+  it('surfaces market packet boundary data on listings', () => {
+    const game = createStartingState()
+    const listing = getMarketListings(game).find((candidate) => candidate.itemId === 'combat_stims')
+
+    expect(listing).toBeDefined()
+    expect(listing!.marketPacket).toMatchObject({
+      id: 'gray_market_broker',
+      marketBoundary: 'settlement-gray-market',
+      legalityAccessMode: 'covert',
+      participantChannelType: 'broker',
+      liquidityProfile: 'thin',
+    })
+    expect(listing!.marketPacket.knownDistortions).toContain('Thin covert inventory.')
+  })
+
   it('normalizes invalid market query params to defaults', () => {
     const params = new URLSearchParams('q=%20%20%20&category=invalid&sort=broken')
     const filters = readMarketFilters(params)

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -119,6 +119,34 @@ describe('marketView', () => {
     expect(listing!.marketPacket.knownDistortions).toContain('Thin covert inventory.')
   })
 
+  it('surfaces supplier attention substitution after a competing use commits the slot', () => {
+    const game = createStartingState()
+    const fieldPlate = getMarketListings(game).find(
+      (candidate) => candidate.itemId === 'field_plate'
+    )
+
+    expect(fieldPlate).toBeDefined()
+
+    const afterFieldPlate = purchaseMarketInventory(game, fieldPlate!.id, 1)
+    const hazmatSuit = getMarketListings(afterFieldPlate).find(
+      (candidate) => candidate.itemId === 'hazmat_suit'
+    )
+    const wardSeals = getMarketListings(afterFieldPlate).find(
+      (candidate) => candidate.id === 'ward-seals'
+    )
+
+    expect(hazmatSuit).toBeDefined()
+    expect(hazmatSuit!.allocationStatus.state).toBe('substituted')
+    expect(hazmatSuit!.allocationStatus.substitution?.summary).toMatch(/gray-market broker/i)
+    expect(hazmatSuit!.canBuyOne).toBe(true)
+    expect(hazmatSuit!.canBuyThree).toBe(false)
+
+    expect(wardSeals).toBeDefined()
+    expect(wardSeals!.allocationStatus.state).toBe('committed_elsewhere')
+    expect(wardSeals!.canBuyOne).toBe(false)
+    expect(wardSeals!.buyBlockedReason).toMatch(/attention committed/i)
+  })
+
   it('normalizes invalid market query params to defaults', () => {
     const params = new URLSearchParams('q=%20%20%20&category=invalid&sort=broken')
     const filters = readMarketFilters(params)

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -220,8 +220,17 @@ export function getProcurementScreenView(
 function buildListingView(listing: ProcurementListing, game: GameState): MarketListingView {
   const canAffordOne = game.funding >= listing.buyPrice
   const canAffordThree = game.funding >= listing.buyPrice * 3
-  const canBuyOne = listing.accessAvailable && listing.availableBundles >= 1 && canAffordOne
-  const canBuyThree = listing.accessAvailable && listing.availableBundles >= 3 && canAffordThree
+  const canBuyOne =
+    listing.accessAvailable &&
+    listing.allocationStatus.purchaseAvailable &&
+    listing.availableBundles >= 1 &&
+    canAffordOne
+  const canBuyThree =
+    listing.accessAvailable &&
+    listing.allocationStatus.purchaseAvailable &&
+    !listing.allocationStatus.substitution &&
+    listing.availableBundles >= 3 &&
+    canAffordThree
   const canSellOne = listing.inventoryStock >= listing.bundleQuantity
   const canSellThree = listing.inventoryStock >= listing.bundleQuantity * 3
 
@@ -236,6 +245,8 @@ function buildListingView(listing: ProcurementListing, game: GameState): MarketL
   let buyBlockedReason: string | undefined
   if (!listing.accessAvailable) {
     buyBlockedReason = listing.accessBlockedReason
+  } else if (!listing.allocationStatus.purchaseAvailable) {
+    buyBlockedReason = listing.allocationStatus.blockerReason
   } else if (availabilityBlockedReason) {
     buyBlockedReason = availabilityBlockedReason
   } else if (budgetBlockedReason) {
@@ -279,7 +290,11 @@ function getListingTone(listing: MarketListingView): ProcurementOptionListItemVi
     return 'danger'
   }
 
-  if (!listing.accessAvailable || !listing.canBuyOne) {
+  if (
+    !listing.accessAvailable ||
+    !listing.allocationStatus.purchaseAvailable ||
+    !listing.canBuyOne
+  ) {
     return 'warning'
   }
 
@@ -339,6 +354,20 @@ function buildBudgetPreview(
           : 'Access is blocked before budget can authorize this procurement action.',
       affordable: false,
       blockedReason: listing.accessBlockedReason,
+    }
+  }
+
+  if (!listing.allocationStatus.purchaseAvailable) {
+    return {
+      label: `Buy ${bundles}`,
+      totalCostLabel: formatCurrency(totalCost),
+      fundingAfterLabel: formatCurrency(game.funding),
+      pressureAfterLabel: `${assessFundingPressure(game).budgetPressure}/4`,
+      consequenceSummary:
+        listing.allocationStatus.blockerReason ??
+        'Supplier attention is already committed to another procurement use.',
+      affordable: false,
+      blockedReason: listing.allocationStatus.blockerReason,
     }
   }
 
@@ -432,6 +461,10 @@ function buildProcurementDetailView(
         `Legality: ${listing.marketPacket.legalityAccessMode} / ${listing.marketPacket.participantChannelType}.`,
         `Liquidity: ${listing.marketPacket.liquidityProfile} / availability ${listing.marketPacket.availabilityMultiplier.toFixed(2)}x / price ${listing.marketPacket.priceMultiplier.toFixed(2)}x.`,
         `Access: ${listing.accessLabel} / ${listing.acquisitionClass}.`,
+        `Allocation: ${listing.allocationStatus.sourceLabel} supplier attention ${listing.allocationStatus.available}/${listing.allocationStatus.capacity} open.`,
+        listing.allocationStatus.substitution
+          ? `Substitution: ${listing.allocationStatus.substitution.summary}`
+          : '',
         `Current stock on hand: ${listing.inventoryStock}.`,
         `Market pressure: ${listing.pressureLabel}.`,
         selectedTransactions.length > 0
@@ -443,12 +476,14 @@ function buildProcurementDetailView(
               .join('; ')}.`
           : 'No current-week transaction has hit this line yet.',
       ],
-      4
+      8
     ),
     blockerDetails: uniqueBounded(
       [
         listing.accessBlockedReason ?? '',
         listing.marketPacket.blockedReason ?? '',
+        listing.allocationStatus.blockerReason ?? '',
+        listing.allocationStatus.substitution?.summary ?? '',
         listing.buyBlockedReason ?? '',
         listing.sellBlockedReason ?? '',
         listing.availableBundles < 1
@@ -458,7 +493,7 @@ function buildProcurementDetailView(
           ? 'Fabrication remains the slower but stable fallback if supplier stock collapses.'
           : '',
       ],
-      4
+      6
     ),
     budgetPreviews: [buildBudgetPreview(game, listing, 1), buildBudgetPreview(game, listing, 3)],
     backlogImpactSummary:

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -443,7 +443,7 @@ function buildProcurementDetailView(
               .join('; ')}.`
           : 'No current-week transaction has hit this line yet.',
       ],
-      4
+      8
     ),
     blockerDetails: uniqueBounded(
       [

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -333,9 +333,10 @@ function buildBudgetPreview(
       totalCostLabel: formatCurrency(totalCost),
       fundingAfterLabel: formatCurrency(game.funding),
       pressureAfterLabel: `${assessFundingPressure(game).budgetPressure}/4`,
-      consequenceSummary: listing.canAffordOne
-        ? 'Budget can cover this request, but the acquisition class is not available through the current channel.'
-        : 'Access is blocked before budget can authorize this procurement action.',
+      consequenceSummary:
+        game.funding >= totalCost
+          ? 'Budget can cover this request, but the acquisition class is not available through the current channel.'
+          : 'Access is blocked before budget can authorize this procurement action.',
       affordable: false,
       blockedReason: listing.accessBlockedReason,
     }

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -422,11 +422,14 @@ function buildProcurementDetailView(
           ? `Fabrication alternative: ${formatCurrency(listing.fabricationCost)}.`
           : 'No fabrication alternative is exposed for this line.',
       ],
-      4
+      6
     ),
     acquisitionDetails: uniqueBounded(
       [
         `Source: ${listing.featured ? 'featured ' : ''}${listing.source.replace(/_/g, ' ')} / ${listing.category}.`,
+        `Exchange: ${listing.marketPacket.label} / ${listing.marketPacket.marketBoundary}.`,
+        `Legality: ${listing.marketPacket.legalityAccessMode} / ${listing.marketPacket.participantChannelType}.`,
+        `Liquidity: ${listing.marketPacket.liquidityProfile} / availability ${listing.marketPacket.availabilityMultiplier.toFixed(2)}x / price ${listing.marketPacket.priceMultiplier.toFixed(2)}x.`,
         `Access: ${listing.accessLabel} / ${listing.acquisitionClass}.`,
         `Current stock on hand: ${listing.inventoryStock}.`,
         `Market pressure: ${listing.pressureLabel}.`,
@@ -444,6 +447,7 @@ function buildProcurementDetailView(
     blockerDetails: uniqueBounded(
       [
         listing.accessBlockedReason ?? '',
+        listing.marketPacket.blockedReason ?? '',
         listing.buyBlockedReason ?? '',
         listing.sellBlockedReason ?? '',
         listing.availableBundles < 1
@@ -526,6 +530,12 @@ function matchesFilters(listing: MarketListingView, filters: MarketFilters) {
     listing.description,
     listing.category,
     listing.source,
+    listing.marketPacket.label,
+    listing.marketPacket.marketBoundary,
+    listing.marketPacket.legalityAccessMode,
+    listing.marketPacket.participantChannelType,
+    listing.marketPacket.liquidityProfile,
+    ...listing.marketPacket.knownDistortions,
     ...listing.tags,
     listing.featured ? 'featured' : '',
   ]

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -229,7 +229,7 @@ function buildListingView(listing: ProcurementListing, game: GameState): MarketL
     ? undefined
     : MARKET_UI_TEXT.insufficientFundingBy.replace(
         '{amount}',
-        `$${Math.max(0, listing.buyPrice - game.funding)}`
+        formatCurrency(Math.max(0, listing.buyPrice - game.funding))
       )
   const availabilityBlockedReason =
     listing.availableBundles < 1 ? MARKET_UI_TEXT.exhaustedListing : undefined

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -406,7 +406,7 @@ function buildProcurementDetailView(
     description: listing.description,
     sourceLabel: listing.source.replace(/_/g, ' '),
     availabilityLabel: !listing.accessAvailable
-      ? listing.accessBlockedReason
+      ? (listing.accessBlockedReason ?? 'Access blocked')
       : listing.availableBundles > 0
         ? `${pluralize(listing.availableBundles, 'bundle')} open this week`
         : 'Supplier channel exhausted this week',

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -40,8 +40,12 @@ export interface MarketFilters {
 export interface MarketListingView extends ProcurementListing {
   canBuyOne: boolean
   canBuyThree: boolean
+  canAffordOne: boolean
+  canAffordThree: boolean
   canSellOne: boolean
   canSellThree: boolean
+  budgetBlockedReason?: string
+  availabilityBlockedReason?: string
   buyBlockedReason?: string
   sellBlockedReason?: string
 }
@@ -172,8 +176,11 @@ export function getProcurementScreenView(
   const listings = getFilteredMarketListings(game, filters)
   const fundingState = getCanonicalFundingState(game)
   const fundingPressure = assessFundingPressure(game)
-  const selectedListing = listings.find((listing) => listing.id === selectedListingId) ?? listings[0] ?? null
-  const pendingBacklog = fundingState.procurementBacklog.filter((entry) => entry.status === 'pending')
+  const selectedListing =
+    listings.find((listing) => listing.id === selectedListingId) ?? listings[0] ?? null
+  const pendingBacklog = fundingState.procurementBacklog.filter(
+    (entry) => entry.status === 'pending'
+  )
   const staleRequestIds = new Set(fundingPressure.staleProcurementRequestIds)
   const transactions = getCurrentWeekMarketTransactions(game).slice(0, 5)
 
@@ -185,7 +192,12 @@ export function getProcurementScreenView(
     listings: listings.map((listing) => buildProcurementOptionListItem(listing, game)),
     selectedListingId: selectedListing?.id ?? null,
     selectedDetail: selectedListing ? buildProcurementDetailView(selectedListing, game) : null,
-    budgetSummary: buildProcurementBudgetSummary(game, fundingState, fundingPressure, pendingBacklog.length),
+    budgetSummary: buildProcurementBudgetSummary(
+      game,
+      fundingState,
+      fundingPressure,
+      pendingBacklog.length
+    ),
     backlogRows: pendingBacklog.slice(0, 5).map((entry, index) => {
       const listingLabel =
         listings.find((listing) => listing.itemId === entry.itemId)?.itemName ??
@@ -206,17 +218,28 @@ export function getProcurementScreenView(
 }
 
 function buildListingView(listing: ProcurementListing, game: GameState): MarketListingView {
-  const canBuyOne = listing.availableBundles >= 1 && game.funding >= listing.buyPrice
-  const canBuyThree = listing.availableBundles >= 3 && game.funding >= listing.buyPrice * 3
+  const canAffordOne = game.funding >= listing.buyPrice
+  const canAffordThree = game.funding >= listing.buyPrice * 3
+  const canBuyOne = listing.accessAvailable && listing.availableBundles >= 1 && canAffordOne
+  const canBuyThree = listing.accessAvailable && listing.availableBundles >= 3 && canAffordThree
   const canSellOne = listing.inventoryStock >= listing.bundleQuantity
   const canSellThree = listing.inventoryStock >= listing.bundleQuantity * 3
 
+  const budgetBlockedReason = canAffordOne
+    ? undefined
+    : MARKET_UI_TEXT.insufficientFundingBy.replace(
+        '{amount}',
+        `$${Math.max(0, listing.buyPrice - game.funding)}`
+      )
+  const availabilityBlockedReason =
+    listing.availableBundles < 1 ? MARKET_UI_TEXT.exhaustedListing : undefined
   let buyBlockedReason: string | undefined
-  if (listing.availableBundles < 1) {
-    buyBlockedReason = MARKET_UI_TEXT.exhaustedListing
-  } else if (game.funding < listing.buyPrice) {
-    const shortfall = Math.max(0, listing.buyPrice - game.funding)
-    buyBlockedReason = MARKET_UI_TEXT.insufficientFundingBy.replace('{amount}', `$${shortfall}`)
+  if (!listing.accessAvailable) {
+    buyBlockedReason = listing.accessBlockedReason
+  } else if (availabilityBlockedReason) {
+    buyBlockedReason = availabilityBlockedReason
+  } else if (budgetBlockedReason) {
+    buyBlockedReason = budgetBlockedReason
   }
 
   let sellBlockedReason: string | undefined
@@ -228,8 +251,12 @@ function buildListingView(listing: ProcurementListing, game: GameState): MarketL
     ...listing,
     canBuyOne,
     canBuyThree,
+    canAffordOne,
+    canAffordThree,
     canSellOne,
     canSellThree,
+    ...(budgetBlockedReason ? { budgetBlockedReason } : {}),
+    ...(availabilityBlockedReason ? { availabilityBlockedReason } : {}),
     buyBlockedReason,
     sellBlockedReason,
   }
@@ -252,7 +279,7 @@ function getListingTone(listing: MarketListingView): ProcurementOptionListItemVi
     return 'danger'
   }
 
-  if (!listing.canBuyOne) {
+  if (!listing.accessAvailable || !listing.canBuyOne) {
     return 'warning'
   }
 
@@ -279,13 +306,13 @@ function buildProcurementOptionListItem(
       listing.availableBundles > 0
         ? `${pluralize(listing.availableBundles, 'bundle')} open`
         : 'Channel exhausted',
-    affordabilityLabel:
-      game.funding >= listing.buyPrice
-        ? `Affordable now (${formatCurrency(game.funding)} on hand)`
-        : MARKET_UI_TEXT.insufficientFundingBy.replace(
-            '{amount}',
-            formatCurrency(Math.max(0, listing.buyPrice - game.funding))
-          ),
+    affordabilityLabel: listing.canAffordOne
+      ? `Affordable now (${formatCurrency(game.funding)} on hand)`
+      : (listing.budgetBlockedReason ??
+        MARKET_UI_TEXT.insufficientFundingBy.replace(
+          '{amount}',
+          formatCurrency(Math.max(0, listing.buyPrice - game.funding))
+        )),
     tone,
     ...(listing.buyBlockedReason || listing.sellBlockedReason
       ? { blockerSummary: listing.buyBlockedReason ?? listing.sellBlockedReason }
@@ -299,6 +326,20 @@ function buildBudgetPreview(
   bundles: number
 ): ProcurementBudgetPreviewView {
   const totalCost = listing.buyPrice * bundles
+
+  if (!listing.accessAvailable) {
+    return {
+      label: `Buy ${bundles}`,
+      totalCostLabel: formatCurrency(totalCost),
+      fundingAfterLabel: formatCurrency(game.funding),
+      pressureAfterLabel: `${assessFundingPressure(game).budgetPressure}/4`,
+      consequenceSummary: listing.canAffordOne
+        ? 'Budget can cover this request, but the acquisition class is not available through the current channel.'
+        : 'Access is blocked before budget can authorize this procurement action.',
+      affordable: false,
+      blockedReason: listing.accessBlockedReason,
+    }
+  }
 
   if (listing.availableBundles < bundles) {
     return {
@@ -351,7 +392,10 @@ function buildBudgetPreview(
   }
 }
 
-function buildProcurementDetailView(listing: MarketListingView, game: GameState): ProcurementDetailView {
+function buildProcurementDetailView(
+  listing: MarketListingView,
+  game: GameState
+): ProcurementDetailView {
   const selectedTransactions = getCurrentWeekMarketTransactions(game)
     .filter((entry) => entry.listingId === listing.id)
     .slice(0, 2)
@@ -361,14 +405,14 @@ function buildProcurementDetailView(listing: MarketListingView, game: GameState)
     title: listing.itemName,
     description: listing.description,
     sourceLabel: listing.source.replace(/_/g, ' '),
-    availabilityLabel:
-      listing.availableBundles > 0
+    availabilityLabel: !listing.accessAvailable
+      ? listing.accessBlockedReason
+      : listing.availableBundles > 0
         ? `${pluralize(listing.availableBundles, 'bundle')} open this week`
         : 'Supplier channel exhausted this week',
-    affordabilityLabel:
-      listing.canBuyOne
-        ? `Affordable now at ${formatCurrency(listing.buyPrice)} per bundle`
-        : listing.buyBlockedReason ?? 'Current funding does not cover this procurement action.',
+    affordabilityLabel: listing.canAffordOne
+      ? `Affordable now at ${formatCurrency(listing.buyPrice)} per bundle`
+      : (listing.budgetBlockedReason ?? 'Current funding does not cover this procurement action.'),
     costDetails: uniqueBounded(
       [
         `Buy 1 bundle: ${formatCurrency(listing.buyPrice)} for ${listing.bundleQuantity} unit${listing.bundleQuantity === 1 ? '' : 's'}.`,
@@ -383,6 +427,7 @@ function buildProcurementDetailView(listing: MarketListingView, game: GameState)
     acquisitionDetails: uniqueBounded(
       [
         `Source: ${listing.featured ? 'featured ' : ''}${listing.source.replace(/_/g, ' ')} / ${listing.category}.`,
+        `Access: ${listing.accessLabel} / ${listing.acquisitionClass}.`,
         `Current stock on hand: ${listing.inventoryStock}.`,
         `Market pressure: ${listing.pressureLabel}.`,
         selectedTransactions.length > 0
@@ -398,6 +443,7 @@ function buildProcurementDetailView(listing: MarketListingView, game: GameState)
     ),
     blockerDetails: uniqueBounded(
       [
+        listing.accessBlockedReason ?? '',
         listing.buyBlockedReason ?? '',
         listing.sellBlockedReason ?? '',
         listing.availableBundles < 1

--- a/src/test/economy.test.ts
+++ b/src/test/economy.test.ts
@@ -8,7 +8,9 @@ import { purchaseMarketInventory, sellMarketInventory } from '../domain/sim/mark
 describe('economy', () => {
   it('summarizes deterministic procurement, fabrication edge, and reward flow in one loop view', () => {
     const initial = createStartingState()
-    const listing = getProcurementListings(initial).find((entry) => entry.availableBundles > 0)
+    const listing = getProcurementListings(initial).find(
+      (entry) => entry.accessAvailable && entry.availableBundles > 0
+    )
 
     expect(listing).toBeDefined()
 

--- a/src/test/sim.market.test.ts
+++ b/src/test/sim.market.test.ts
@@ -78,6 +78,44 @@ describe('market procurement simulation', () => {
     expect(result).toBe(state)
   })
 
+  it('blocks restricted acquisition classes separately from budget', () => {
+    const state = createStartingState()
+    const restrictedListing = getProcurementListings(state).find(
+      (candidate) => candidate.itemId === 'advanced_recon_suite'
+    )
+
+    expect(restrictedListing).toBeDefined()
+    expect(state.funding).toBeGreaterThanOrEqual(restrictedListing!.buyPrice)
+    expect(restrictedListing!.accessAvailable).toBe(false)
+    expect(restrictedListing!.accessBlockedReason).toMatch(/directorate special channel locked/i)
+
+    const result = purchaseMarketInventory(state, restrictedListing!.id, 1)
+
+    expect(result).toBe(state)
+  })
+
+  it('allows a restricted acquisition class after clearance unlocks its channel', () => {
+    const state = createStartingState()
+    const clearedState = {
+      ...state,
+      clearanceLevel: 2,
+      agency: state.agency ? { ...state.agency, clearanceLevel: 2 } : state.agency,
+    }
+    const restrictedListing = getProcurementListings(clearedState).find(
+      (candidate) => candidate.itemId === 'advanced_recon_suite'
+    )
+
+    expect(restrictedListing).toBeDefined()
+    expect(restrictedListing!.accessAvailable).toBe(true)
+
+    const result = purchaseMarketInventory(clearedState, restrictedListing!.id, 1)
+
+    expect(result.funding).toBe(clearedState.funding - restrictedListing!.buyPrice)
+    expect(result.inventory.advanced_recon_suite).toBe(
+      (clearedState.inventory.advanced_recon_suite ?? 0) + restrictedListing!.bundleQuantity
+    )
+  })
+
   it('weekly market refresh resets availability tracking to the new market week', () => {
     const state = createStartingState()
     const listing = getProcurementListings(state)[0]

--- a/src/test/sim.market.test.ts
+++ b/src/test/sim.market.test.ts
@@ -13,7 +13,9 @@ describe('market procurement simulation', () => {
 
   it('purchase deducts funding, increases inventory, records a transaction event, and reduces availability', () => {
     const state = createStartingState()
-    const listing = getProcurementListings(state)[0]
+    const listing = getProcurementListings(state).find(
+      (candidate) => candidate.accessAvailable && candidate.availableBundles > 0
+    )
 
     expect(listing).toBeDefined()
 
@@ -136,7 +138,9 @@ describe('market procurement simulation', () => {
 
   it('generates unique market transaction IDs within the same week', () => {
     const state = createStartingState()
-    const listing = getProcurementListings(state)[0]
+    const listing = getProcurementListings(state).find(
+      (candidate) => candidate.accessAvailable && candidate.availableBundles > 0
+    )
 
     expect(listing).toBeDefined()
 

--- a/src/test/sim.market.test.ts
+++ b/src/test/sim.market.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
-import { getProcurementListing, getProcurementListings } from '../domain/market'
+import {
+  getProcurementListing,
+  getProcurementListings,
+  getProcurementMarketPackets,
+} from '../domain/market'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { purchaseMarketInventory, sellMarketInventory } from '../domain/sim/market'
 
@@ -9,6 +13,29 @@ describe('market procurement simulation', () => {
     const state = createStartingState()
 
     expect(getProcurementListings(state)).toEqual(getProcurementListings(state))
+  })
+
+  it('builds deterministic market packets for exchange boundaries', () => {
+    const state = createStartingState()
+    const packets = getProcurementMarketPackets(state)
+
+    expect(packets).toEqual(getProcurementMarketPackets(state))
+    expect(packets.map((packet) => packet.id)).toEqual([
+      'agency_supplier_roster',
+      'gray_market_broker',
+    ])
+    expect(packets.find((packet) => packet.id === 'agency_supplier_roster')).toMatchObject({
+      marketBoundary: 'agency-supplier-roster',
+      legalityAccessMode: 'licensed',
+      liquidityProfile: 'stable',
+      available: true,
+    })
+    expect(packets.find((packet) => packet.id === 'gray_market_broker')).toMatchObject({
+      marketBoundary: 'settlement-gray-market',
+      legalityAccessMode: 'covert',
+      liquidityProfile: 'thin',
+      available: true,
+    })
   })
 
   it('purchase deducts funding, increases inventory, records a transaction event, and reduces availability', () => {
@@ -116,6 +143,63 @@ describe('market procurement simulation', () => {
     expect(result.inventory.advanced_recon_suite).toBe(
       (clearedState.inventory.advanced_recon_suite ?? 0) + restrictedListing!.bundleQuantity
     )
+  })
+
+  it('applies market packet boundary effects to equipment listings', () => {
+    const state = createStartingState()
+    const grayMarketEquipment = getProcurementListings(state).find(
+      (candidate) => candidate.itemId === 'combat_stims'
+    )
+    const rosterEquipment = getProcurementListings(state).find(
+      (candidate) => candidate.itemId === 'field_plate'
+    )
+
+    expect(grayMarketEquipment).toBeDefined()
+    expect(rosterEquipment).toBeDefined()
+    expect(grayMarketEquipment!.category).toBe('equipment')
+    expect(rosterEquipment!.category).toBe('equipment')
+    expect(grayMarketEquipment!.marketPacket).toMatchObject({
+      id: 'gray_market_broker',
+      marketBoundary: 'settlement-gray-market',
+      legalityAccessMode: 'covert',
+    })
+    expect(rosterEquipment!.marketPacket).toMatchObject({
+      id: 'agency_supplier_roster',
+      marketBoundary: 'agency-supplier-roster',
+      legalityAccessMode: 'licensed',
+    })
+    expect(grayMarketEquipment!.marketPacket.priceMultiplier).toBeGreaterThan(
+      rosterEquipment!.marketPacket.priceMultiplier
+    )
+    expect(grayMarketEquipment!.marketPacket.availabilityMultiplier).toBeLessThan(
+      rosterEquipment!.marketPacket.availabilityMultiplier
+    )
+  })
+
+  it('uses packet access rules to block covert exchange under sanctioned posture', () => {
+    const state = createStartingState()
+    const sanctionedState = {
+      ...state,
+      legitimacy: {
+        sanctionLevel: 'sanctioned' as const,
+        accessReason: 'audit posture',
+        falloutRisk: 'none' as const,
+      },
+    }
+    const grayMarketEquipment = getProcurementListings(sanctionedState).find(
+      (candidate) => candidate.itemId === 'combat_stims'
+    )
+
+    expect(grayMarketEquipment).toBeDefined()
+    expect(state.funding).toBeGreaterThanOrEqual(grayMarketEquipment!.buyPrice)
+    expect(grayMarketEquipment!.marketPacket.available).toBe(false)
+    expect(grayMarketEquipment!.totalAvailability).toBe(0)
+    expect(grayMarketEquipment!.accessAvailable).toBe(false)
+    expect(grayMarketEquipment!.accessBlockedReason).toMatch(/sanctioned audit posture/i)
+
+    const result = purchaseMarketInventory(sanctionedState, grayMarketEquipment!.id, 1)
+
+    expect(result).toBe(sanctionedState)
   })
 
   it('weekly market refresh resets availability tracking to the new market week', () => {

--- a/src/test/sim.market.test.ts
+++ b/src/test/sim.market.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import {
+  getProcurementAllocations,
   getProcurementListing,
   getProcurementListings,
   getProcurementMarketPackets,
@@ -59,11 +60,46 @@ describe('market procurement simulation', () => {
         action: 'buy',
         listingId: listing!.id,
         quantity: listing!.bundleQuantity,
+        allocation: {
+          resourceClass: 'supplier_attention_slot',
+          source: listing!.marketPacket.id,
+          destinationUse: listing!.id,
+          substitutionStatus: 'none',
+        },
       },
     })
     expect(nextListing?.remainingAvailability).toBe(
       Math.max(0, listing!.remainingAvailability - listing!.bundleQuantity)
     )
+  })
+
+  it('records supplier attention allocation packets deterministically', () => {
+    const state = createStartingState()
+    const listing = getProcurementListings(state).find(
+      (candidate) =>
+        candidate.itemId === 'field_plate' &&
+        candidate.allocationStatus.purchaseAvailable &&
+        candidate.availableBundles > 0
+    )
+
+    expect(listing).toBeDefined()
+
+    const result = purchaseMarketInventory(state, listing!.id, 1)
+    const allocations = getProcurementAllocations(result)
+
+    expect(allocations).toEqual(getProcurementAllocations(result))
+    expect(allocations).toHaveLength(1)
+    expect(allocations[0]).toMatchObject({
+      resourceClass: 'supplier_attention_slot',
+      source: 'agency_supplier_roster',
+      sourceLabel: 'Agency supplier roster',
+      destinationUse: listing!.id,
+      destinationLabel: listing!.itemName,
+      urgency: 'standard',
+      expectedBenefit: `${listing!.bundleQuantity}x ${listing!.itemName}`,
+      delayWeeks: 0,
+      substitutionStatus: 'none',
+    })
   })
 
   it('sell adds funding, removes inventory, records a transaction event, and increases availability', () => {
@@ -200,6 +236,75 @@ describe('market procurement simulation', () => {
     const result = purchaseMarketInventory(sanctionedState, grayMarketEquipment!.id, 1)
 
     expect(result).toBe(sanctionedState)
+  })
+
+  it('makes one procurement use unavailable when supplier attention is committed elsewhere', () => {
+    const state = createStartingState()
+    const fieldPlate = getProcurementListings(state).find(
+      (candidate) => candidate.itemId === 'field_plate'
+    )
+
+    expect(fieldPlate).toBeDefined()
+
+    const afterFieldPlate = purchaseMarketInventory(state, fieldPlate!.id, 1)
+    const wardSealBatch = getProcurementListings(afterFieldPlate).find(
+      (candidate) => candidate.id === 'ward-seals'
+    )
+
+    expect(wardSealBatch).toBeDefined()
+    expect(wardSealBatch!.allocationStatus.state).toBe('committed_elsewhere')
+    expect(wardSealBatch!.allocationStatus.purchaseAvailable).toBe(false)
+    expect(wardSealBatch!.allocationStatus.displacedAlternativeUse).toBe(fieldPlate!.itemName)
+
+    const blocked = purchaseMarketInventory(afterFieldPlate, wardSealBatch!.id, 1)
+
+    expect(blocked).toBe(afterFieldPlate)
+  })
+
+  it('uses a degraded substitute when agency supplier attention is displaced', () => {
+    const state = createStartingState()
+    const fieldPlate = getProcurementListings(state).find(
+      (candidate) => candidate.itemId === 'field_plate'
+    )
+
+    expect(fieldPlate).toBeDefined()
+
+    const afterFieldPlate = purchaseMarketInventory(state, fieldPlate!.id, 1)
+    const substitutedHazmat = getProcurementListings(afterFieldPlate).find(
+      (candidate) => candidate.itemId === 'hazmat_suit'
+    )
+
+    expect(substitutedHazmat).toBeDefined()
+    expect(substitutedHazmat!.allocationStatus.state).toBe('substituted')
+    expect(substitutedHazmat!.allocationStatus.substitution).toMatchObject({
+      source: 'gray_market_broker',
+      sourceLabel: 'Gray-market broker',
+      delayWeeks: 1,
+      priceMultiplier: 1.35,
+    })
+    expect(substitutedHazmat!.buyPrice).toBe(
+      substitutedHazmat!.allocationStatus.substitution!.unitPrice
+    )
+
+    const afterSubstitution = purchaseMarketInventory(afterFieldPlate, substitutedHazmat!.id, 1)
+    const substitutionEvent = afterSubstitution.events.at(-1)
+
+    expect(afterSubstitution.inventory.hazmat_suit).toBe(
+      (afterFieldPlate.inventory.hazmat_suit ?? 0) + substitutedHazmat!.bundleQuantity
+    )
+    expect(substitutionEvent).toMatchObject({
+      type: 'market.transaction_recorded',
+      payload: {
+        listingId: substitutedHazmat!.id,
+        totalPrice: substitutedHazmat!.buyPrice,
+        allocation: {
+          source: 'gray_market_broker',
+          displacedAlternativeUse: fieldPlate!.itemName,
+          substitutionStatus: 'degraded_substitute',
+          delayWeeks: 1,
+        },
+      },
+    })
   })
 
   it('weekly market refresh resets availability tracking to the new market week', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changes made
- Added deterministic procurement access-class metadata to market listings.
- Added reusable market packets for licensed agency supplier roster and covert gray-market broker exchange boundaries.
- Added supplier-attention allocation packets for market buys.
- Agency supplier roster now has a bounded weekly attention slot that can be committed to one procurement use and displace competing uses.
- Direct-equipment needs displaced by agency roster attention can use a degraded gray-market substitute with premium cost and handling delay metadata.
- Surfaced access, funding, availability, exchange boundary, legality, liquidity, allocation state, displaced use, and substitution outcome in the market UI.
- Mounted the real market/procurement page on the Markets / Suppliers route.
- Added domain, view-model, page, and economy-loop coverage for access gating, market-packet boundary effects, and allocation/substitution behavior.

### Why this belongs in SPE-1189
- This slice adds one compact scarce resource class: supplier attention slots.
- It stays procurement-side and reuses existing market packets, access gates, purchase events, and UI cards.
- It records competing use and degraded substitution without adding a broad planner, optimizer, staffing sim, or global economy layer.

### Validation performed
- Targeted market/procurement tests pass locally.
- ESLint passes locally.
- Changed-file Prettier check passes locally.
- Full Vitest suite passes locally.
- Repo-wide Prettier check still reports pre-existing formatting drift across unrelated files.
- Manual UI walkthrough confirms Field Plate commits agency supplier attention, Hazmat Suit receives degraded gray-market substitute, and Ward Seals is blocked by the displaced supplier attention.

### Acceptance criteria satisfied
- Supplier attention can become unavailable to one task because it was committed elsewhere.
- Allocation packets record displaced alternative use.
- Degraded gray-market substitute can fill a direct-equipment need with premium cost and 1w handling delay metadata.
- Targeted tests cover deterministic scarcity updates, competing use, substitution, and downstream purchase behavior.
- UI exposes allocation state, displaced use, substitution summary, and disabled blocked actions.

### Remaining SPE-1189 follow-up
- Add more procurement-side scarce resource classes or additional packet-specific allocation rules only after this bounded supplier-attention slice is reviewed.

[spe_1189_supplier_attention_allocation_walkthrough.mp4](https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspe_1189_supplier_attention_allocation_walkthrough.mp4)
[SPE-1189 supplier attention blocked Ward Seals](https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspe_1189_supplier_attention_ward_seals.webp)
[spe_1189_ward_seals_blocked_action.mp4](https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspe_1189_ward_seals_blocked_action.mp4)
[SPE-1189 Ward Seals disabled action](https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspe_1189_ward_seals_blocked_action.webp)

[spe_1186_market_packet_ui_search_walkthrough.mp4](https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspe_1186_market_packet_ui_search_walkthrough.mp4)
[SPE-1186 Combat Stims market packet](https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspe_1186_market_packet_combat_stims.webp)
[SPE-1186 Field Plate market packet](https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspe_1186_market_packet_field_plate.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d27ea43-44c9-45a3-84dd-2a9ff03548db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

