### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/JamesJedi420/containment-protocol/security/code-scanning/1](https://github.com/JamesJedi420/containment-protocol/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/test.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the best minimal setting is:

- `contents: read`

This preserves current functionality (checkout and read operations) while preventing accidental write-capable token usage. No imports, methods, or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
