### PR TITLE
Add licensed handling procurement allocation

### DIFF
--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -22,7 +22,10 @@ export type ProcurementMarketBoundary = 'agency-supplier-roster' | 'settlement-g
 export type ProcurementLegalityAccessMode = 'licensed' | 'covert'
 export type ProcurementParticipantChannelType = 'quartermaster' | 'broker'
 export type ProcurementLiquidityProfile = 'stable' | 'thin'
-export type ProcurementResourceClass = 'supplier_attention_slot' | 'reagent_stock'
+export type ProcurementResourceClass =
+  | 'supplier_attention_slot'
+  | 'reagent_stock'
+  | 'licensed_handling_capacity'
 export type ProcurementAllocationUrgency = 'standard' | 'contingency'
 export type ProcurementSubstitutionStatus = 'none' | 'degraded_substitute'
 
@@ -161,6 +164,10 @@ const REAGENT_STOCK_MATERIAL_ID = 'occult_reagents'
 const REAGENT_STOCK_CAPACITY = 1
 const DEGRADED_REAGENT_SUBSTITUTE_PRICE_MULTIPLIER = 1.25
 const DEGRADED_REAGENT_SUBSTITUTE_DELAY_WEEKS = 1
+const LICENSED_HANDLING_SOURCE_ID = 'licensed_handling_desk'
+const LICENSED_HANDLING_SOURCE_LABEL = 'Licensed handling desk'
+const LICENSED_HANDLING_CAPACITY = 1
+const LICENSED_HANDLING_LISTING_IDS = new Set(['gear:combat_stims', 'gear:hazmat_suit'])
 
 interface ProcurementMarketPacketDefinition extends Omit<
   ProcurementMarketPacket,
@@ -506,6 +513,7 @@ export function getProcurementAllocations(game: GameState, marketWeek = game.mar
   return [
     ...getCurrentSupplierAttentionAllocations(game, marketWeek),
     ...getCurrentReagentStockAllocations(game, REAGENT_STOCK_MATERIAL_ID, marketWeek),
+    ...getCurrentLicensedHandlingAllocations(game, marketWeek),
   ].sort((left, right) => left.allocationId.localeCompare(right.allocationId))
 }
 
@@ -656,6 +664,60 @@ function createReagentAllocationStatus(
   }
 }
 
+function getCurrentLicensedHandlingAllocations(
+  game: GameState,
+  marketWeek = game.market.week
+): ProcurementAllocationPacket[] {
+  return game.events
+    .filter((event) => isMarketTransactionEvent(event))
+    .filter((event) => event.payload.action === 'buy' && event.payload.marketWeek === marketWeek)
+    .flatMap((event) => getMarketTransactionAllocationPackets(event))
+    .filter(
+      (allocation) =>
+        allocation.resourceClass === 'licensed_handling_capacity' &&
+        allocation.source === LICENSED_HANDLING_SOURCE_ID
+    )
+    .sort((left, right) => left.allocationId.localeCompare(right.allocationId))
+}
+
+function getLicensedHandlingRequirement(definition: ProcurementListingDefinition) {
+  return LICENSED_HANDLING_LISTING_IDS.has(definition.id) ? 1 : 0
+}
+
+function createLicensedHandlingAllocationStatus(
+  definition: ProcurementListingDefinition,
+  game: GameState
+): ProcurementAllocationStatus | undefined {
+  const required = getLicensedHandlingRequirement(definition)
+
+  if (required <= 0) {
+    return undefined
+  }
+
+  const allocations = getCurrentLicensedHandlingAllocations(game)
+  const available = Math.max(0, LICENSED_HANDLING_CAPACITY - allocations.length)
+
+  return {
+    resourceClass: 'licensed_handling_capacity',
+    source: LICENSED_HANDLING_SOURCE_ID,
+    sourceLabel: LICENSED_HANDLING_SOURCE_LABEL,
+    capacity: LICENSED_HANDLING_CAPACITY,
+    committed: allocations.length,
+    available,
+    required,
+    purchaseAvailable: available >= required,
+    state: available >= required ? 'available' : 'committed_elsewhere',
+    allocations,
+    ...(available < required
+      ? {
+          displacedAlternativeUse:
+            allocations[0]?.destinationLabel ?? LICENSED_HANDLING_SOURCE_LABEL,
+          blockerReason: `${LICENSED_HANDLING_SOURCE_LABEL} capacity committed to ${allocations[0]?.destinationLabel ?? 'another controlled procurement'} this market week.`,
+        }
+      : {}),
+  }
+}
+
 function getDegradedSubstitutionOption(
   definition: ProcurementListingDefinition,
   game: GameState,
@@ -792,9 +854,11 @@ function buildListing(
     game,
     allocationStatus.substitution?.unitPrice ?? baseBuyPrice
   )
+  const licensedHandlingStatus = createLicensedHandlingAllocationStatus(definition, game)
   const resourceStatuses = [
     allocationStatus,
     ...(reagentAllocationStatus ? [reagentAllocationStatus] : []),
+    ...(licensedHandlingStatus ? [licensedHandlingStatus] : []),
   ]
   const buyPrice =
     reagentAllocationStatus?.substitution?.unitPrice ??

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -346,6 +346,32 @@ describe('MarketPage', () => {
     expect(within(emfRow!).getByRole('button', { name: /buy 3 bundles/i })).toBeDisabled()
   })
 
+  it('shows licensed handling capacity blocking after a controlled purchase', () => {
+    const game = createStartingState()
+    const combatStims = getMarketListings(game).find(
+      (candidate) => candidate.itemId === 'combat_stims'
+    )
+
+    expect(combatStims).toBeDefined()
+
+    useGameStore.setState({ game: purchaseMarketInventory(game, combatStims!.id, 1) })
+
+    renderMarketPage(['/markets-suppliers?q=hazmat%20suit'])
+
+    const hazmatListings = screen.getByRole('list', { name: /market listings/i })
+    const hazmatRow = within(hazmatListings)
+      .getAllByText(/^hazmat suit$/i)[0]
+      ?.closest('li')
+
+    expect(hazmatRow).toBeTruthy()
+    expect(within(hazmatRow!).getByText(/licensed handling desk: 0\/1 open/i)).toBeInTheDocument()
+    expect(
+      within(hazmatRow!).getByText(/licensed handling capacity: committed elsewhere/i)
+    ).toBeInTheDocument()
+    expect(within(hazmatRow!).getByText(/displaced use: combat stims/i)).toBeInTheDocument()
+    expect(within(hazmatRow!).getByRole('button', { name: /buy 1 bundle/i })).toBeDisabled()
+  })
+
   it('disables sell actions and shows sell-blocked reason when stock is unavailable', () => {
     const game = createStartingState()
     game.inventory = Object.fromEntries(Object.keys(game.inventory).map((itemId) => [itemId, 0]))

--- a/src/features/market/MarketPage.test.tsx
+++ b/src/features/market/MarketPage.test.tsx
@@ -61,6 +61,18 @@ function renderMarketPage(initialEntries = ['/markets-suppliers'], initialIndex?
   )
 }
 
+function createDiscountedMarketState() {
+  const game = createStartingState()
+
+  return {
+    ...game,
+    market: {
+      ...game.market,
+      pressure: 'discounted' as const,
+    },
+  }
+}
+
 beforeEach(() => {
   useGameStore.persist.clearStorage()
   useGameStore.setState({ game: createStartingState() })
@@ -347,7 +359,7 @@ describe('MarketPage', () => {
   })
 
   it('shows licensed handling capacity blocking after a controlled purchase', () => {
-    const game = createStartingState()
+    const game = createDiscountedMarketState()
     const combatStims = getMarketListings(game).find(
       (candidate) => candidate.itemId === 'combat_stims'
     )

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -185,6 +185,33 @@ describe('marketView', () => {
     expect(emfSensors!.canBuyThree).toBe(false)
   })
 
+  it('surfaces licensed handling blocking after a controlled purchase commits capacity', () => {
+    const game = createStartingState()
+    const combatStims = getMarketListings(game).find(
+      (candidate) => candidate.itemId === 'combat_stims'
+    )
+
+    expect(combatStims).toBeDefined()
+
+    const afterCombatStims = purchaseMarketInventory(game, combatStims!.id, 1)
+    const hazmatSuit = getMarketListings(afterCombatStims).find(
+      (candidate) => candidate.itemId === 'hazmat_suit'
+    )
+
+    expect(hazmatSuit).toBeDefined()
+    expect(hazmatSuit!.resourceStatuses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceClass: 'licensed_handling_capacity',
+          state: 'committed_elsewhere',
+          displacedAlternativeUse: combatStims!.itemName,
+        }),
+      ])
+    )
+    expect(hazmatSuit!.canBuyOne).toBe(false)
+    expect(hazmatSuit!.buyBlockedReason).toMatch(/Licensed handling desk capacity committed/i)
+  })
+
   it('normalizes invalid market query params to defaults', () => {
     const params = new URLSearchParams('q=%20%20%20&category=invalid&sort=broken')
     const filters = readMarketFilters(params)

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -11,6 +11,18 @@ import {
 } from './marketView'
 
 describe('marketView', () => {
+  function createDiscountedMarketState() {
+    const game = createStartingState()
+
+    return {
+      ...game,
+      market: {
+        ...game.market,
+        pressure: 'discounted' as const,
+      },
+    }
+  }
+
   it('builds deterministic procurement listings with weekly availability and pricing', () => {
     const game = createStartingState()
     const listings = getMarketListings(game)
@@ -186,7 +198,7 @@ describe('marketView', () => {
   })
 
   it('surfaces licensed handling blocking after a controlled purchase commits capacity', () => {
-    const game = createStartingState()
+    const game = createDiscountedMarketState()
     const combatStims = getMarketListings(game).find(
       (candidate) => candidate.itemId === 'combat_stims'
     )

--- a/src/test/sim.market.test.ts
+++ b/src/test/sim.market.test.ts
@@ -11,6 +11,18 @@ import { purchaseMarketInventory, sellMarketInventory } from '../domain/sim/mark
 import { queueFabrication } from '../domain/sim/production'
 
 describe('market procurement simulation', () => {
+  function createDiscountedMarketState() {
+    const state = createStartingState()
+
+    return {
+      ...state,
+      market: {
+        ...state.market,
+        pressure: 'discounted' as const,
+      },
+    }
+  }
+
   it('builds deterministic listings from the same state', () => {
     const state = createStartingState()
 
@@ -104,7 +116,7 @@ describe('market procurement simulation', () => {
   })
 
   it('records licensed handling allocation packets for controlled purchases', () => {
-    const state = createStartingState()
+    const state = createDiscountedMarketState()
     const listing = getProcurementListings(state).find(
       (candidate) =>
         candidate.itemId === 'combat_stims' &&
@@ -431,7 +443,7 @@ describe('market procurement simulation', () => {
   })
 
   it('makes controlled procurement unavailable when licensed handling is committed elsewhere', () => {
-    const state = createStartingState()
+    const state = createDiscountedMarketState()
     const combatStims = getProcurementListings(state).find(
       (candidate) => candidate.itemId === 'combat_stims'
     )

--- a/src/test/sim.market.test.ts
+++ b/src/test/sim.market.test.ts
@@ -103,6 +103,52 @@ describe('market procurement simulation', () => {
     })
   })
 
+  it('records licensed handling allocation packets for controlled purchases', () => {
+    const state = createStartingState()
+    const listing = getProcurementListings(state).find(
+      (candidate) =>
+        candidate.itemId === 'combat_stims' &&
+        candidate.resourceStatuses.some(
+          (status) =>
+            status.resourceClass === 'licensed_handling_capacity' && status.purchaseAvailable
+        ) &&
+        candidate.availableBundles > 0
+    )
+
+    expect(listing).toBeDefined()
+
+    const result = purchaseMarketInventory(state, listing!.id, 1)
+    const allocations = getProcurementAllocations(result)
+
+    expect(allocations).toEqual(getProcurementAllocations(result))
+    expect(allocations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceClass: 'licensed_handling_capacity',
+          source: 'licensed_handling_desk',
+          sourceLabel: 'Licensed handling desk',
+          destinationUse: listing!.id,
+          destinationLabel: listing!.itemName,
+          urgency: 'standard',
+          expectedBenefit: `${listing!.bundleQuantity}x ${listing!.itemName}`,
+          delayWeeks: 0,
+          substitutionStatus: 'none',
+        }),
+      ])
+    )
+    expect(result.events.at(-1)).toMatchObject({
+      type: 'market.transaction_recorded',
+      payload: {
+        allocations: expect.arrayContaining([
+          expect.objectContaining({
+            resourceClass: 'licensed_handling_capacity',
+            source: 'licensed_handling_desk',
+          }),
+        ]),
+      },
+    })
+  })
+
   it('sell adds funding, removes inventory, records a transaction event, and increases availability', () => {
     const state = createStartingState()
     const listing = getProcurementListings(state).find(
@@ -382,6 +428,38 @@ describe('market procurement simulation', () => {
         ]),
       },
     })
+  })
+
+  it('makes controlled procurement unavailable when licensed handling is committed elsewhere', () => {
+    const state = createStartingState()
+    const combatStims = getProcurementListings(state).find(
+      (candidate) => candidate.itemId === 'combat_stims'
+    )
+
+    expect(combatStims).toBeDefined()
+
+    const afterCombatStims = purchaseMarketInventory(state, combatStims!.id, 1)
+    const hazmatSuit = getProcurementListings(afterCombatStims).find(
+      (candidate) => candidate.itemId === 'hazmat_suit'
+    )
+
+    expect(hazmatSuit).toBeDefined()
+
+    const handlingStatus = hazmatSuit!.resourceStatuses.find(
+      (status) => status.resourceClass === 'licensed_handling_capacity'
+    )
+
+    expect(handlingStatus).toMatchObject({
+      source: 'licensed_handling_desk',
+      sourceLabel: 'Licensed handling desk',
+      state: 'committed_elsewhere',
+      purchaseAvailable: false,
+      displacedAlternativeUse: combatStims!.itemName,
+    })
+
+    const blocked = purchaseMarketInventory(afterCombatStims, hazmatSuit!.id, 1)
+
+    expect(blocked).toBe(afterCombatStims)
   })
 
   it('weekly market refresh resets availability tracking to the new market week', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `licensed_handling_capacity` as a compact procurement-side scarce resource class.
- Apply the weekly licensed handling slot only to controlled/hazardous procurement lines: Combat Stims and Hazmat Suit.
- Reuse existing allocation packet/resource status flow so controlled purchases record handling allocations and later controlled listings show committed capacity plus displaced alternative use.
- Surface handling capacity through existing market view/UI resource status rendering with blocker state; no staffing, facility logistics, global planning, or broader legality simulation added.

### Validation performed
- Targeted market/domain/view/UI tests pass: `npm run test:run -- src/test/sim.market.test.ts src/features/market/marketView.test.ts src/features/market/MarketPage.test.tsx`.
- ESLint passes: `npm run lint`.
- Changed-file Prettier check passes: `npx prettier --check "src/domain/market.ts" "src/test/sim.market.test.ts" "src/features/market/marketView.test.ts" "src/features/market/MarketPage.test.tsx"`.
- Full Vitest suite passes: `npm run test:run` — 303 files, 2727 tests.

### Notes
- The implementation intentionally does not add a degraded handling substitute path. The blocker-only behavior is the smallest deterministic procurement slice and avoids broader logistics/legality mechanics.
- Tests use a discounted market week for the Combat Stims setup because the default stable seed has no available gray-market Combat Stims bundles.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c7b65c2-0805-4144-8a7c-6c52e88bc805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c7b65c2-0805-4144-8a7c-6c52e88bc805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

