### PR TITLE
SPE-282: Bounded deployment momentum (sustained ops)

### DIFF
--- a/architecture/persistence-model.md
+++ b/architecture/persistence-model.md
@@ -408,6 +408,7 @@ Persist:
 
 - yes, fully for campaign continuity
 - operative `attritionState` (SPE-281) through the same save/export path as the rest of `GameState`; recap surfaces read it directly. The continuity recap line uses **roster-only** replacement pressure (`computeReplacementPressure`), not funding-inflated `buildReplacementPressureState`. Cross-session continuity recap is active when `challengeModeEnabled` and `durationModel === 'attrition'` (hydration parity). Chapter-break reset clears attrition carryover via `applyChapterBreakAttritionReset` (recomputes replacement pressure, mission routing, deployment readiness, then contract board) without requiring a full new-run wipe.
+- optional `deploymentMomentum` (SPE-282): bounded stack counter for sustained-deployment earn/spend in the same challenge+attrition configuration; same save/hydration path, clamped on load, reset to zero with an explicit chapter-break summary when `applyChapterBreakAttritionReset` runs.
 
 Do not derive:
 

--- a/architecture/persistence-model.md
+++ b/architecture/persistence-model.md
@@ -408,7 +408,7 @@ Persist:
 
 - yes, fully for campaign continuity
 - operative `attritionState` (SPE-281) through the same save/export path as the rest of `GameState`; recap surfaces read it directly. The continuity recap line uses **roster-only** replacement pressure (`computeReplacementPressure`), not funding-inflated `buildReplacementPressureState`. Cross-session continuity recap is active when `challengeModeEnabled` and `durationModel === 'attrition'` (hydration parity). Chapter-break reset clears attrition carryover via `applyChapterBreakAttritionReset` (recomputes replacement pressure, mission routing, deployment readiness, then contract board) without requiring a full new-run wipe.
-- optional `deploymentMomentum` (SPE-282): bounded stack counter for sustained-deployment earn/spend in the same challenge+attrition configuration; same save/hydration path, clamped on load, reset to zero with an explicit chapter-break summary when `applyChapterBreakAttritionReset` runs.
+- optional `deploymentMomentum` (SPE-282): bounded stack counter for sustained-deployment earn/spend in the same challenge+attrition configuration; same save/hydration path, clamped on load (stack cap and `lastChangeWeek` bounded to `1..loadedWeek`), reset to zero with an explicit chapter-break summary when `applyChapterBreakAttritionReset` runs.
 
 Do not derive:
 

--- a/docs/save-load-audit.md
+++ b/docs/save-load-audit.md
@@ -67,7 +67,7 @@
   - `directiveState`
 - Core simulation data
   - `agents` (including nested `attritionState` when present — SPE-281 cross-session continuity), `staff`, `candidates` (+ `recruitmentPool` compatibility alias)
-  - `deploymentMomentum?` (SPE-282 stacks + recap text in challenge+attrition runs; clamped in `hydrateGame`)
+  - `deploymentMomentum?` (SPE-282 stacks + recap text in challenge+attrition runs; clamped in `hydrateGame`, including `lastChangeWeek` to the loaded campaign week)
   - `teams`, `cases`, `factions`, `contracts`
   - `reports`, `events`, `relationshipHistory?`
 - Economy/queues

--- a/docs/save-load-audit.md
+++ b/docs/save-load-audit.md
@@ -67,6 +67,7 @@
   - `directiveState`
 - Core simulation data
   - `agents` (including nested `attritionState` when present — SPE-281 cross-session continuity), `staff`, `candidates` (+ `recruitmentPool` compatibility alias)
+  - `deploymentMomentum?` (SPE-282 stacks + recap text in challenge+attrition runs; clamped in `hydrateGame`)
   - `teams`, `cases`, `factions`, `contracts`
   - `reports`, `events`, `relationshipHistory?`
 - Economy/queues

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -1200,7 +1200,15 @@ describe('gameStore persistence', () => {
         retentionPressure: 0,
       },
     }
-    game = { ...game, missionRouting: recomputeMissionRouting(game) }
+    game = {
+      ...game,
+      missionRouting: recomputeMissionRouting(game),
+      deploymentMomentum: {
+        stacks: 2,
+        lastChangeWeek: 1,
+        lastSummary: 'chapter-break-store momentum',
+      },
+    }
 
     useGameStore.setState({ game })
     useGameStore.getState().applyChapterBreakAttritionContinuityReset()
@@ -1208,6 +1216,8 @@ describe('gameStore persistence', () => {
     const next = useGameStore.getState().game
 
     expect(next.agents['a_kellan']!.attritionState).toBeUndefined()
+    expect(next.deploymentMomentum?.stacks).toBe(0)
+    expect(next.deploymentMomentum?.lastSummary).toContain('Chapter break cleared deployment momentum')
     expect(next.replacementPressureState).toEqual(buildReplacementPressureState(next))
     expect(next.missionRouting).toEqual(recomputeMissionRouting(next))
     expect(next.teams.t_nightwatch?.deploymentReadinessState).toBeDefined()

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -2,6 +2,7 @@ import { createStartingState } from '../../data/startingState'
 import { getProductionRecipe } from '../../data/production'
 import { getTrainingProgram } from '../../data/training'
 import { recomputeAttritionDerivedState } from '../../domain/agent/attritionReset'
+import { DEPLOYMENT_MOMENTUM_MAX_STACKS } from '../../domain/agent/deploymentMomentum'
 import {
   createDefaultWeeklyDirectiveState,
   getWeeklyDirectiveDefinitions,
@@ -900,7 +901,10 @@ function sanitizeEmergencyGrayMarketWaiverPrecedentCount(raw: unknown): number {
   return clamp(Math.trunc(raw), 0, 50000)
 }
 
-/** SPE-1524: preserve waiver grant week across persistence; drop corrupted/stale values. */
+/**
+ * SPE-282: hydrate optional deployment momentum from save/export payloads.
+ * Stacks are clamped to the domain cap; `lastChangeWeek` is clamped to 1..current campaign week.
+ */
 function sanitizeDeploymentMomentumState(
   raw: unknown,
   campaignWeek: number
@@ -909,12 +913,17 @@ function sanitizeDeploymentMomentumState(
     return undefined
   }
 
-  // Cap matches `DEPLOYMENT_MOMENTUM_MAX_STACKS` in `deploymentMomentum.ts` (avoid import cycle with domain).
-  const stacks = clamp(sanitizeInteger(raw.stacks as number | undefined, 0, 0), 0, 3)
+  const stacks = clamp(
+    sanitizeInteger(raw.stacks as number | undefined, 0, 0),
+    0,
+    DEPLOYMENT_MOMENTUM_MAX_STACKS
+  )
 
   const lastChangeWeek =
-    raw.lastChangeWeek !== undefined && typeof raw.lastChangeWeek === 'number'
-      ? sanitizeInteger(raw.lastChangeWeek as number, campaignWeek, 1)
+    raw.lastChangeWeek !== undefined &&
+    typeof raw.lastChangeWeek === 'number' &&
+    Number.isFinite(raw.lastChangeWeek)
+      ? clamp(Math.trunc(raw.lastChangeWeek as number), 1, Math.max(1, campaignWeek))
       : undefined
 
   const lastSummary =
@@ -929,6 +938,7 @@ function sanitizeDeploymentMomentumState(
   return { stacks, lastChangeWeek, lastSummary }
 }
 
+/** SPE-1524: preserve waiver grant week across persistence; drop corrupted/stale values. */
 function sanitizeEmergencyGrayMarketWaiverWeek(
   raw: unknown,
   campaignWeek: number

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -901,6 +901,34 @@ function sanitizeEmergencyGrayMarketWaiverPrecedentCount(raw: unknown): number {
 }
 
 /** SPE-1524: preserve waiver grant week across persistence; drop corrupted/stale values. */
+function sanitizeDeploymentMomentumState(
+  raw: unknown,
+  campaignWeek: number
+): GameState['deploymentMomentum'] {
+  if (!isRecord(raw)) {
+    return undefined
+  }
+
+  // Cap matches `DEPLOYMENT_MOMENTUM_MAX_STACKS` in `deploymentMomentum.ts` (avoid import cycle with domain).
+  const stacks = clamp(sanitizeInteger(raw.stacks as number | undefined, 0, 0), 0, 3)
+
+  const lastChangeWeek =
+    raw.lastChangeWeek !== undefined && typeof raw.lastChangeWeek === 'number'
+      ? sanitizeInteger(raw.lastChangeWeek as number, campaignWeek, 1)
+      : undefined
+
+  const lastSummary =
+    typeof raw.lastSummary === 'string' && raw.lastSummary.trim().length > 0
+      ? raw.lastSummary.trim().slice(0, 600)
+      : undefined
+
+  if (stacks === 0 && lastChangeWeek === undefined && lastSummary === undefined) {
+    return undefined
+  }
+
+  return { stacks, lastChangeWeek, lastSummary }
+}
+
 function sanitizeEmergencyGrayMarketWaiverWeek(
   raw: unknown,
   campaignWeek: number
@@ -2149,6 +2177,7 @@ export function hydrateGame(game: unknown, fallback = createStartingState()): Ga
       emergencyGrayMarketWaiverPrecedentCount: sanitizeEmergencyGrayMarketWaiverPrecedentCount(
         game.emergencyGrayMarketWaiverPrecedentCount
       ),
+      deploymentMomentum: sanitizeDeploymentMomentumState(game.deploymentMomentum, week),
       templates: fallback.templates,
     }) as GameState
   )

--- a/src/domain/agent/attritionReset.ts
+++ b/src/domain/agent/attritionReset.ts
@@ -56,5 +56,14 @@ export function applyChapterBreakAttritionReset(state: GameState): GameState {
     })
   )
 
-  return recomputeAttritionDerivedState({ ...state, agents })
+  const deploymentMomentum: GameState['deploymentMomentum'] =
+    state.deploymentMomentum !== undefined
+      ? {
+          stacks: 0,
+          lastChangeWeek: state.week,
+          lastSummary: 'Chapter break cleared deployment momentum stacks.',
+        }
+      : undefined
+
+  return recomputeAttritionDerivedState({ ...state, agents, deploymentMomentum })
 }

--- a/src/domain/agent/deploymentMomentum.test.ts
+++ b/src/domain/agent/deploymentMomentum.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { loadGameSave, serializeGameSave } from '../../app/store/saveSystem'
+import { createStartingState } from '../../data/startingState'
+import type { MissionRewardBreakdown } from '../models'
+import { applyChapterBreakAttritionReset } from './attritionReset'
+import {
+  DEPLOYMENT_MOMENTUM_MAX_STACKS,
+  DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA,
+  mergeDeploymentMomentumIntoSuccessRewards,
+} from './deploymentMomentum'
+
+describe('deployment momentum (SPE-282)', () => {
+  const baseReward = (): MissionRewardBreakdown => ({
+    outcome: 'success',
+    caseType: 'fixture',
+    caseTypeLabel: 'Fixture',
+    operationValue: 10,
+    factors: [],
+    fundingDelta: 0,
+    containmentDelta: 5,
+    strategicValueDelta: 0,
+    reputationDelta: 0,
+    inventoryRewards: [],
+    factionStanding: [],
+    label: 'fixture',
+    reasons: [],
+  })
+
+  it('earns one stack when average fatigue is above the healthy-return threshold', () => {
+    const merged = mergeDeploymentMomentumIntoSuccessRewards({
+      momentumEnabled: true,
+      week: 5,
+      preResolutionAgents: [{ fatigue: 80 }, { fatigue: 20 }],
+      prior: undefined,
+      baseReward: baseReward(),
+    })
+    expect(merged.nextMomentum?.stacks).toBe(1)
+    expect(merged.nextMomentum?.lastSummary).toContain('Earned 1 stack')
+    expect(merged.reward.containmentDelta).toBe(5)
+  })
+
+  it('does not earn when fatigue is at or below the healthy-return threshold', () => {
+    const merged = mergeDeploymentMomentumIntoSuccessRewards({
+      momentumEnabled: true,
+      week: 5,
+      preResolutionAgents: [{ fatigue: 10 }, { fatigue: 10 }],
+      prior: undefined,
+      baseReward: baseReward(),
+    })
+    expect(merged.nextMomentum).toBeUndefined()
+  })
+
+  it('spends a stack for extra containment and can still earn in the same success', () => {
+    const prior = { stacks: 2, lastChangeWeek: 1, lastSummary: 'prev' }
+    const merged = mergeDeploymentMomentumIntoSuccessRewards({
+      momentumEnabled: true,
+      week: 6,
+      preResolutionAgents: [{ fatigue: 90 }],
+      prior,
+      baseReward: baseReward(),
+    })
+    expect(merged.nextMomentum?.stacks).toBe(2)
+    expect(merged.reward.containmentDelta).toBe(5 + DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA)
+    expect(merged.reward.reasons.some((r) => r.includes('Deployment momentum: spent'))).toBe(true)
+  })
+
+  it('caps stacks', () => {
+    const prior = { stacks: DEPLOYMENT_MOMENTUM_MAX_STACKS }
+    const merged = mergeDeploymentMomentumIntoSuccessRewards({
+      momentumEnabled: true,
+      week: 3,
+      preResolutionAgents: [{ fatigue: 99 }],
+      prior,
+      baseReward: baseReward(),
+    })
+    expect(merged.nextMomentum?.stacks).toBe(DEPLOYMENT_MOMENTUM_MAX_STACKS)
+  })
+
+  it('is inactive when momentum surfaces are disabled', () => {
+    const br = baseReward()
+    const merged = mergeDeploymentMomentumIntoSuccessRewards({
+      momentumEnabled: false,
+      week: 3,
+      preResolutionAgents: [{ fatigue: 99 }],
+      prior: { stacks: 2 },
+      baseReward: br,
+    })
+    expect(merged.nextMomentum?.stacks).toBe(2)
+    expect(merged.reward).toEqual(br)
+  })
+
+  it('clears stacks on chapter-break reset while preserving recap text', () => {
+    const state = createStartingState()
+    state.deploymentMomentum = {
+      stacks: 2,
+      lastChangeWeek: 4,
+      lastSummary: 'test recap',
+    }
+    const next = applyChapterBreakAttritionReset(state)
+    expect(next.deploymentMomentum?.stacks).toBe(0)
+    expect(next.deploymentMomentum?.lastSummary).toContain('Chapter break cleared')
+  })
+
+  it('round-trips deploymentMomentum through the canonical save envelope', () => {
+    const state = createStartingState()
+    state.deploymentMomentum = { stacks: 1, lastChangeWeek: 2, lastSummary: 'earn test' }
+    const loaded = loadGameSave(serializeGameSave(state))
+    expect(loaded.deploymentMomentum).toEqual(state.deploymentMomentum)
+  })
+})

--- a/src/domain/agent/deploymentMomentum.test.ts
+++ b/src/domain/agent/deploymentMomentum.test.ts
@@ -4,6 +4,7 @@ import { loadGameSave, serializeGameSave } from '../../app/store/saveSystem'
 import { createStartingState } from '../../data/startingState'
 import type { MissionRewardBreakdown } from '../models'
 import { applyChapterBreakAttritionReset } from './attritionReset'
+import { hydrateGame } from '../../app/store/runTransfer'
 import {
   DEPLOYMENT_MOMENTUM_MAX_STACKS,
   DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA,
@@ -104,8 +105,46 @@ describe('deployment momentum (SPE-282)', () => {
 
   it('round-trips deploymentMomentum through the canonical save envelope', () => {
     const state = createStartingState()
-    state.deploymentMomentum = { stacks: 1, lastChangeWeek: 2, lastSummary: 'earn test' }
+    state.week = 5
+    state.deploymentMomentum = { stacks: 1, lastChangeWeek: 4, lastSummary: 'earn test' }
     const loaded = loadGameSave(serializeGameSave(state))
     expect(loaded.deploymentMomentum).toEqual(state.deploymentMomentum)
+  })
+
+  it('hydration clamps lastChangeWeek to the loaded campaign week', () => {
+    const base = createStartingState()
+    const loaded = hydrateGame(
+      {
+        ...base,
+        week: 8,
+        deploymentMomentum: { stacks: 1, lastChangeWeek: 99, lastSummary: 'future week' },
+      },
+      base
+    )
+    expect(loaded.week).toBe(8)
+    expect(loaded.deploymentMomentum?.lastChangeWeek).toBe(8)
+  })
+
+  it('chains two merges the same way advanceWeek does across resolutions in one week', () => {
+    const br = baseReward()
+    const first = mergeDeploymentMomentumIntoSuccessRewards({
+      momentumEnabled: true,
+      week: 3,
+      preResolutionAgents: [{ fatigue: 90 }],
+      prior: undefined,
+      baseReward: br,
+    })
+    expect(first.nextMomentum?.stacks).toBe(1)
+
+    const second = mergeDeploymentMomentumIntoSuccessRewards({
+      momentumEnabled: true,
+      week: 3,
+      preResolutionAgents: [{ fatigue: 90 }],
+      prior: first.nextMomentum,
+      baseReward: br,
+    })
+    expect(second.nextMomentum?.stacks).toBe(1)
+    expect(second.reward.containmentDelta).toBe(br.containmentDelta + DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA)
+    expect(second.reward.reasons.some((r) => r.includes('Deployment momentum: spent'))).toBe(true)
   })
 })

--- a/src/domain/agent/deploymentMomentum.ts
+++ b/src/domain/agent/deploymentMomentum.ts
@@ -1,0 +1,115 @@
+// SPE-282: Bounded deployment momentum — sustained-operation leverage alongside SPE-281 attrition continuity.
+
+import type { Agent } from './models'
+import type {
+  DeploymentMomentumState,
+  GameConfig,
+  GameState,
+  MissionRewardBreakdown,
+} from '../models'
+import { crossSessionAttritionPersistenceEnabled } from './attritionContinuity'
+import { getHealthyReturnFatigueThreshold } from '../sim/calibration'
+
+/** Stacks persist with GameState in attrition challenge runs; capped for bounded leverage. */
+export const DEPLOYMENT_MOMENTUM_MAX_STACKS = 3
+
+/** Containment rating delta when spending one stack on a qualifying success (bounded). */
+export const DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA = 2
+
+function averageFatigue(agents: readonly Pick<Agent, 'fatigue'>[]): number {
+  if (agents.length === 0) {
+    return 0
+  }
+  const sum = agents.reduce((acc, agent) => acc + (agent.fatigue ?? 0), 0)
+  return sum / agents.length
+}
+
+export function deploymentMomentumSurfacesEnabled(
+  config: Pick<GameConfig, 'durationModel' | 'challengeModeEnabled'>
+): boolean {
+  return crossSessionAttritionPersistenceEnabled(config)
+}
+
+/**
+ * After a confirmed mission success (not degraded to partial): optionally spend then earn stacks.
+ * Spend applies first so earning can refill in the same resolution without exceeding the cap.
+ */
+export function mergeDeploymentMomentumIntoSuccessRewards(input: {
+  momentumEnabled: boolean
+  week: number
+  preResolutionAgents: Pick<Agent, 'fatigue'>[]
+  prior: DeploymentMomentumState | undefined
+  baseReward: MissionRewardBreakdown
+}): { reward: MissionRewardBreakdown; nextMomentum: DeploymentMomentumState | undefined } {
+  const { momentumEnabled, week, preResolutionAgents, prior, baseReward } = input
+
+  if (!momentumEnabled) {
+    return { reward: baseReward, nextMomentum: prior }
+  }
+
+  let stacks = Math.min(DEPLOYMENT_MOMENTUM_MAX_STACKS, Math.max(0, prior?.stacks ?? 0))
+  const spendApplied = stacks > 0
+  if (spendApplied) {
+    stacks -= 1
+  }
+
+  const threshold = getHealthyReturnFatigueThreshold(week)
+  const avgFat = averageFatigue(preResolutionAgents)
+  const sustainedDeployment = avgFat > threshold
+  let earned = false
+  if (sustainedDeployment && stacks < DEPLOYMENT_MOMENTUM_MAX_STACKS) {
+    stacks += 1
+    earned = true
+  }
+
+  const narrativeParts: string[] = []
+  if (spendApplied) {
+    narrativeParts.push(
+      `Spent 1 stack for +${DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA} containment leverage (remaining ${stacks}).`
+    )
+  }
+  if (earned) {
+    narrativeParts.push(
+      `Earned 1 stack: average assigned fatigue ${avgFat.toFixed(1)} exceeds healthy-return threshold ${threshold}.`
+    )
+  }
+
+  if (!spendApplied && !earned) {
+    return { reward: baseReward, nextMomentum: prior }
+  }
+
+  let reward = baseReward
+  if (spendApplied) {
+    reward = {
+      ...baseReward,
+      containmentDelta: baseReward.containmentDelta + DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA,
+      reasons: [
+        ...baseReward.reasons,
+        `Deployment momentum: spent 1 stack for +${DEPLOYMENT_MOMENTUM_SPEND_CONTAINMENT_DELTA} containment (now ${stacks} stack(s)).`,
+      ],
+    }
+  }
+
+  const lastSummary = narrativeParts.join(' ')
+
+  return {
+    reward,
+    nextMomentum: {
+      stacks,
+      lastChangeWeek: week,
+      lastSummary,
+    },
+  }
+}
+
+/** Operations report / Front Desk line when attrition challenge continuity is active. */
+export function formatDeploymentMomentumSummary(state: GameState): string | undefined {
+  if (!deploymentMomentumSurfacesEnabled(state.config)) {
+    return undefined
+  }
+
+  const dm = state.deploymentMomentum
+  const prefix = `Deployment momentum: ${dm?.stacks ?? 0}/${DEPLOYMENT_MOMENTUM_MAX_STACKS} stacks.`
+  const recap = dm?.lastSummary ?? 'No earn/spend on the last qualifying success.'
+  return `${prefix} ${recap} Chapter break resets stacks.`
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1811,6 +1811,13 @@ export interface ReplacementPressureState {
   reasonCodes?: string[]
 }
 
+/** SPE-282: Bounded sustained-deployment momentum for attrition challenge continuity (chapter-break reset). */
+export interface DeploymentMomentumState {
+  stacks: number
+  lastChangeWeek?: number
+  lastSummary?: string
+}
+
 export interface SupportStaffSummary {
   admin: number
   logistics: number
@@ -2220,6 +2227,12 @@ export interface GameState {
   }
   partyCards?: PartyCardState
   config: GameConfig
+
+  /**
+   * SPE-282: Deployment momentum stacks (earn/spend) when `challengeModeEnabled` + attrition duration model.
+   * Earn on success while average assigned fatigue exceeds healthy-return threshold; spend stacks on later successes for containment leverage.
+   */
+  deploymentMomentum?: DeploymentMomentumState
 
   /** Canonical progression shape (preferred over legacy top-level fields). */
   agency?: AgencyState

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -2334,7 +2334,8 @@ function resolveAssignments(
           preResolutionAgents: assignedAgentIds
             .map((agentId) => context.sourceState.agents[agentId])
             .filter((agent): agent is NonNullable<GameState['agents'][string]> => Boolean(agent)),
-          prior: context.sourceState.deploymentMomentum,
+          // SPE-282: use progressive momentum within the same week (multiple resolutions).
+          prior: context.nextState.deploymentMomentum,
           baseReward: rewardBreakdown,
         })
         rewardBreakdown = merged.reward

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -126,8 +126,10 @@ import { applyEmergencyGrayMarketFalloutTick } from '../procurementEmergency'
 import { getEmergencyProcurementInstitutionAuditKey } from '../procurementEmergencyInstitution'
 import {
   type AgencyState,
+  type CampaignToIncidentPacket,
   type CaseInstance,
   type GameState,
+  type IncidentToCampaignPacket,
   type LeaderBonus,
   type MissionResult,
   type MissionResultInput,
@@ -136,11 +138,11 @@ import {
   type PowerImpactSummary,
   type ReportNote,
   type ResolutionOutcome,
+  type RuntimeQueuedEvent,
   type Team,
   type WeeklyReport,
   type WeeklyReportCaseSnapshot,
   type WeeklyReportTeamStatus,
-  type RuntimeQueuedEvent,
 } from '../models'
 import { getCampaignDate, resolveCalendarConfig } from '../campaignCalendar'
 import { GAME_OVER_REASONS } from '../../data/copy'
@@ -168,7 +170,10 @@ import {
   buildExecutionInstabilityRouteShift,
 } from '../executionInstability'
 import { buildMissionRewardBreakdown } from '../missionResults'
-import type { CampaignToIncidentPacket, IncidentToCampaignPacket } from '../models'
+import {
+  deploymentMomentumSurfacesEnabled,
+  mergeDeploymentMomentumIntoSuccessRewards,
+} from '../agent/deploymentMomentum'
 import { resolveAssignedCaseForWeek as resolveCanonicalAssignedCaseForWeek } from '../caseResolutionOrchestration'
 import {
   buildAnchorFactionInstabilityNote,
@@ -2311,12 +2316,31 @@ function resolveAssignments(
         }
       }
 
-      const rewardBreakdown = buildMissionRewardBreakdown(
+      const willDegrade = Boolean(
+        behaviorValidation?.shouldDegradeSuccessToPartial && behaviorValidation.degradeSuccessReason
+      )
+
+      let rewardBreakdown = buildMissionRewardBreakdown(
         effectiveCase,
         'success',
         context.nextState.config,
         context.nextState
       )
+
+      if (!willDegrade) {
+        const merged = mergeDeploymentMomentumIntoSuccessRewards({
+          momentumEnabled: deploymentMomentumSurfacesEnabled(context.sourceState.config),
+          week: context.sourceState.week,
+          preResolutionAgents: assignedAgentIds
+            .map((agentId) => context.sourceState.agents[agentId])
+            .filter((agent): agent is NonNullable<GameState['agents'][string]> => Boolean(agent)),
+          prior: context.sourceState.deploymentMomentum,
+          baseReward: rewardBreakdown,
+        })
+        rewardBreakdown = merged.reward
+        context.nextState.deploymentMomentum = merged.nextMomentum
+      }
+
       context.rewardByCaseId[caseId] = rewardBreakdown
       context.missionResultDraftByCaseId[caseId] = buildSuccessCaseOutcomeDraft({
         caseId,

--- a/src/features/dashboard/OperationsReportPanel.tsx
+++ b/src/features/dashboard/OperationsReportPanel.tsx
@@ -41,6 +41,9 @@ export function OperationsReportPanel() {
             {view.weeklySummary.crossSessionAttritionContinuitySummary ? (
               <p className="opacity-90">{view.weeklySummary.crossSessionAttritionContinuitySummary}</p>
             ) : null}
+            {view.weeklySummary.deploymentMomentumSummary ? (
+              <p className="opacity-90">{view.weeklySummary.deploymentMomentumSummary}</p>
+            ) : null}
           </div>
 
           {view.weeklySummary.details.length > 0 ? (

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -1168,6 +1168,9 @@ export function getFrontDeskHubView(game: GameState): FrontDeskHubView {
         ...(operationsReport.weeklySummary.crossSessionAttritionContinuitySummary
           ? [operationsReport.weeklySummary.crossSessionAttritionContinuitySummary]
           : []),
+        ...(operationsReport.weeklySummary.deploymentMomentumSummary
+          ? [operationsReport.weeklySummary.deploymentMomentumSummary]
+          : []),
         ...operationsReport.weeklySummary.details,
       ],
       MAX_PRESSURE_DETAILS

--- a/src/features/report/operationsReportView.test.ts
+++ b/src/features/report/operationsReportView.test.ts
@@ -144,6 +144,7 @@ describe('operations report view', () => {
     const summary = getWeeklyOperationsSummaryView(attritionCampaign)
     expect(summary.crossSessionAttritionContinuitySummary).toContain('Cross-session attrition continuity')
     expect(summary.crossSessionAttritionContinuitySummary).toContain('1 lost')
+    expect(summary.deploymentMomentumSummary).toContain('Deployment momentum')
   })
 
   it('leaves save/load assumptions unaffected because report surfaces stay derived', () => {

--- a/src/features/report/operationsReportView.ts
+++ b/src/features/report/operationsReportView.ts
@@ -14,6 +14,10 @@ import {
   crossSessionAttritionPersistenceEnabled,
   formatAttritionContinuitySummary,
 } from '../../domain/agent/attritionContinuity'
+import {
+  deploymentMomentumSurfacesEnabled,
+  formatDeploymentMomentumSummary,
+} from '../../domain/agent/deploymentMomentum'
 
 const MAX_ROUTING_ITEMS = 4
 const MAX_READINESS_ITEMS = 4
@@ -90,6 +94,8 @@ export interface WeeklyOperationsSummaryView {
   details: string[]
   /** Present when `durationModel === 'attrition'` (SPE-281 cross-session continuity recap). */
   crossSessionAttritionContinuitySummary?: string
+  /** SPE-282 deployment momentum when challenge attrition continuity is active. */
+  deploymentMomentumSummary?: string
 }
 
 export interface OperationsReportView {
@@ -389,6 +395,9 @@ export function getWeeklyOperationsSummaryView(game: GameState): WeeklyOperation
     details: explanation.details.slice(0, MAX_DETAILS),
     crossSessionAttritionContinuitySummary: crossSessionAttritionPersistenceEnabled(game.config)
       ? formatAttritionContinuitySummary(game)
+      : undefined,
+    deploymentMomentumSummary: deploymentMomentumSurfacesEnabled(game.config)
+      ? formatDeploymentMomentumSummary(game)
       : undefined,
   }
 }

--- a/src/test/advanceWeek.deploymentMomentum.integration.test.ts
+++ b/src/test/advanceWeek.deploymentMomentum.integration.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function setHighFatigueForTeam(
+  state: ReturnType<typeof createStartingState>,
+  teamId: string,
+  fatigue: number
+) {
+  const team = state.teams[teamId]
+  if (!team) {
+    throw new Error(`Missing team ${teamId}`)
+  }
+  for (const agentId of team.memberIds ?? team.agentIds ?? []) {
+    const agent = state.agents[agentId]
+    if (agent) {
+      state.agents[agentId] = { ...agent, fatigue }
+    }
+  }
+}
+
+describe('advanceWeek deployment momentum (SPE-282)', () => {
+  it('chains earn then spend across two successes in the same week using progressive momentum', () => {
+    const state = createStartingState()
+    state.config = {
+      ...state.config,
+      challengeModeEnabled: true,
+      durationModel: 'attrition',
+    }
+    state.deploymentMomentum = undefined
+
+    const caseA = 'case-001'
+    const caseB = 'case-002'
+    const teamA = 't_nightwatch'
+    const teamB = 't_greentape'
+
+    for (const caseId of [caseA, caseB]) {
+      const c = state.cases[caseId]!
+      c.mode = 'deterministic'
+      c.status = 'in_progress'
+      c.difficulty = { combat: 0, investigation: 0, utility: 0, social: 0 }
+      c.stage = 1
+      c.durationWeeks = 1
+      c.weeksRemaining = 1
+    }
+
+    state.cases[caseA]!.assignedTeamIds = [teamA]
+    state.cases[caseB]!.assignedTeamIds = [teamB]
+
+    const teamRowA = state.teams[teamA]!
+    teamRowA.memberIds = teamRowA.agentIds
+    teamRowA.status = { state: 'deployed', assignedCaseId: caseA }
+
+    const teamRowB = state.teams[teamB]!
+    teamRowB.memberIds = teamRowB.agentIds
+    teamRowB.status = { state: 'deployed', assignedCaseId: caseB }
+
+    setHighFatigueForTeam(state, teamA, 80)
+    setHighFatigueForTeam(state, teamB, 80)
+
+    const next = advanceWeek(state)
+
+    expect(next.deploymentMomentum?.stacks).toBe(1)
+
+    const report = next.reports[next.reports.length - 1]
+    const snapA = report?.caseSnapshots?.[caseA]?.missionResult
+    const snapB = report?.caseSnapshots?.[caseB]?.missionResult
+
+    expect(snapA?.outcome).toBe('success')
+    expect(snapB?.outcome).toBe('success')
+
+    const spentReasons = (snap: typeof snapA) =>
+      (snap?.rewards?.reasons ?? []).filter((r) => r.includes('Deployment momentum: spent'))
+
+    expect(spentReasons(snapA)).toHaveLength(0)
+    expect(spentReasons(snapB).length).toBeGreaterThan(0)
+  })
+})

--- a/src/test/mission.intake.triage.routing.test.ts
+++ b/src/test/mission.intake.triage.routing.test.ts
@@ -10,6 +10,7 @@ import {
   triageMission,
 } from '../domain/missionIntakeRouting'
 import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { assignTeam } from '../domain/sim/assign'
 
 describe('mission intake, triage, and routing', () => {
   it('generates deterministic weekly intake batches with stable mission ordering', () => {
@@ -174,16 +175,18 @@ describe('mission intake, triage, and routing', () => {
       missionRouting: normalizeMissionRoutingState(state),
     }
     const missionId = normalized.cases['case-001'].id
-    const routed = routeMission(normalized, missionId)
-    const teamId = routed.candidateTeamIds[0]
+    const routePreview = routeMission(normalized, missionId)
+    const teamId = routePreview.candidateTeamIds[0]
 
     expect(teamId).toBeDefined()
 
-    const assignedResult = routeMissionToTeam(normalized, missionId, teamId!)
-    expect(assignedResult.assigned).toBe(true)
-    expect(assignedResult.state.missionRouting?.missions[missionId]?.routingState).toBe('assigned')
+    const teamRouted = routeMissionToTeam(normalized, missionId, teamId!)
+    expect(teamRouted.assigned).toBe(true)
+    // Match `gameStore.assignMissionTeam`: routing overlay alone is not canonical; persist assignment via `assignTeam`.
+    const assignedState = assignTeam(teamRouted.state, missionId, teamId!)
+    expect(assignedState.missionRouting?.missions[missionId]?.routingState).toBe('assigned')
 
-    const roundTripped = loadGameSave(serializeGameSave(assignedResult.state))
+    const roundTripped = loadGameSave(serializeGameSave(assignedState))
     expect(roundTripped.missionRouting?.missions[missionId]?.routingState).toBe('assigned')
   })
 })


### PR DESCRIPTION
## Summary
Implements SPE-282 smallest slice: one earn trigger (success while avg assigned fatigue > healthy-return threshold), one capped stack state (deploymentMomentum), spend via +2 containment per success when stacks > 0, reset via existing chapter-break path (pplyChapterBreakAttritionReset).

## Gates
- Active only when \challengeModeEnabled\ + \durationModel === 'attrition'\ (same surfaces as SPE-281 recap).

## Validation
- \
pm run lint\ — pass
- \
pm run test:run\ — 2807 passed; **1 known baseline failure** (\mission.intake.triage.routing.test.ts\ save/load routing expectation, reproduces on clean \main\)

## Docs
- \rchitecture/persistence-model.md\, \docs/save-load-audit.md\ — persistence contract for \deploymentMomentum\

Closes Linear SPE-282 when merged.