### PR TITLE
SPE-1496: Bounded post-contract debrief + next-intent flow

### DIFF
--- a/docs/contract-debrief-next-intent-audit.md
+++ b/docs/contract-debrief-next-intent-audit.md
@@ -1,0 +1,174 @@
+# Contract Debrief & Next-Intent Audit (SPE-1496)
+
+> Design note and architectural reference for the bounded post-contract debrief
+> flow and the captured next-intent that biases later contract suggestions.
+>
+> Sources of truth: `src/domain/contracts.ts`, `src/domain/models.ts`,
+> `src/features/report/operationsReportView.ts`,
+> `src/features/dashboard/OperationsReportPanel.tsx`,
+> `src/features/operations/frontDeskView.ts`.
+
+---
+
+## 1. Goal
+
+Completed contract operations should not silently drop the player back into
+passive browsing. The debrief slice emits a deterministic, compact record per
+completed contract operation surfaced from the latest weekly report, and lets
+the player capture a single bounded "next intent" choice that nudges later
+contract offer ordering. No prose recap generator, no planner, no system-pushed
+next contract.
+
+---
+
+## 2. Data shapes
+
+### `ContractDebriefRecord` (`src/domain/models.ts`)
+
+Compact deterministic record emitted per completed contract operation.
+
+- `caseId`, `caseTitle`
+- `contractTemplateId`, `factionId?`, `factionLabel?`
+- `outcome: MissionResolutionKind`
+- `week: number`
+- `summary: string` — single sentence stitched from outcome + faction channel
+- `changedEntities: ContractDebriefChangedEntity[]` — bounded list of
+  staff / subject / route / evidence / faction state shifts
+- `unresolvedClocks: ContractDebriefUnresolvedClock[]` — recovery pressure
+  and any spawned follow-up consequences
+- `strategicOptions: ContractDebriefStrategicOption[]` — bounded
+  `ContractNextIntent` suggestions with a short reason
+
+### `ContractNextIntent` (`src/domain/models.ts`)
+
+Bounded closed union:
+
+- `chase-lead`
+- `stabilize-staff`
+- `repair-agency`
+- `pursue-faction`
+- `prepare-equipment`
+- `answer-emergency`
+
+Add new values sparingly — they all need a label
+(`getContractNextIntentLabel`) and a bias branch in
+`getNextIntentSelectionBias`.
+
+### `ContractSystemState` additions
+
+- `nextIntent?: ContractNextIntent | null`
+- `nextIntentCapturedWeek?: number`
+
+Both are persisted through `sanitizeContractSystemState` and survive
+`refreshContractBoard` regeneration so the bias term keeps applying until the
+player clears it.
+
+---
+
+## 3. Pipelines
+
+### Debrief record generation (pure derivation)
+
+`getRecentContractDebriefRecords(game)`:
+
+1. Reads the latest entry of `game.reports`.
+2. Filters `caseSnapshots` to those with a terminal `MissionResult`.
+3. For each snapshot, calls `buildContractDebriefRecord(snapshot, week, caseInstance?)`.
+4. Returns records ordered by `caseId` for stable UI output.
+
+`buildContractDebriefRecord` is a pure function over a single
+`WeeklyReportCaseSnapshot` plus an optional live `CaseInstance`. It pulls the
+contract template id and faction id from the case-instance contract first,
+then falls back to a safe extraction from the snapshot via
+`extractContractRuntimeFromSnapshot`. Returns `null` if no
+`MissionResult` or no contract template id is available.
+
+Helpers used to populate `changedEntities`:
+
+- `describeSubject` (hidden state / outcome on the subject case)
+- `describeFatalities`, `describeInjuries`, `describeFatigueShifts`
+- `describeFactionShifts`, `describeEvidenceGains`
+- `describeRoute`
+
+Helpers used to populate `unresolvedClocks`:
+
+- `describeUnresolvedClocks` — recovery pressure band + spawned consequences
+
+Helpers used to populate `strategicOptions`:
+
+- `buildStrategicOptions` + `dedupeStrategicOptions` — bounded mapping from
+  observed deltas to `ContractNextIntent` suggestions
+
+All helpers are pure, take only mission-result and snapshot data, and emit no
+freeform prose.
+
+### Next-intent capture
+
+`setContractNextIntent(state, intent)` writes the chosen intent into
+`state.contracts` along with `state.week` as `nextIntentCapturedWeek`.
+`clearContractNextIntent(state)` removes both fields. `getContractNextIntent`
+reads the sanitized value. The Zustand store exposes `setContractNextIntent`
+and `clearContractNextIntent` actions in `src/app/store/gameStore.ts`.
+
+### Contract suggestion bias
+
+`buildSelectionScore` adds `getNextIntentSelectionBias(state, definition)` as
+an additive term. Each `ContractNextIntent` has a deterministic mapping to a
+bounded bias derived from:
+
+- `definition.strategyTag` (`income`, `materials`, `research`, `progression`)
+- `definition.factionId` + the resolved `factionTier`
+- whether the chain has a `completed_contract` unlock condition
+- the cumulative risk modifier (`difficulty_flat` / `death_risk`)
+
+Bias values are bounded so the term never overrides unlock conditions; it only
+nudges ordering. `refreshContractBoard` preserves the captured next intent
+across regeneration so the bias keeps applying.
+
+---
+
+## 4. UI surfaces
+
+- **Operations report panel** (`OperationsReportPanel.tsx`) renders a
+  "Post-contract debrief" article that lists each record's summary, changed
+  entities, and unresolved clocks. Below the list, a bounded pill-set lets the
+  player capture or clear the next intent.
+- **Front desk attention list** (`frontDeskView.ts`) inserts a single compact
+  "Post-contract debrief" attention item built from
+  `contractDebrief.attentionSummary` whenever there are debrief records, with
+  tone derived from the lead record's outcome / unresolved clocks / captured
+  intent. The item links to the operations report.
+- The operations report view exposes `getContractDebriefView(game)` and
+  `OperationsReportView.contractDebrief` for any future surface that wants the
+  same digest without re-deriving it.
+
+---
+
+## 5. Save/load and determinism
+
+- `nextIntent` and `nextIntentCapturedWeek` are persisted via
+  `sanitizeContractSystemState`, so they round-trip through saves.
+- Debrief records are pure derivations from the weekly report and current
+  cases — they are not persisted, and recomputing them after load matches the
+  pre-save output.
+- All helpers are deterministic; tests in `src/test/contractsDebrief.test.ts`
+  exercise debrief generation, next-intent capture, and the bias path.
+
+---
+
+## 6. Out of scope (intentional)
+
+- No prose recap generation or freeform journaling.
+- No "system pushes the next contract" path.
+- No multi-step planner; bias is a single additive term.
+- No new event-queue interception or broad narrative pipeline.
+- No expansion of report-note types — the debrief layer sits beside the report
+  rather than rewriting it.
+
+Future work that would extend (but not violate) this boundary:
+
+- Persistent debrief history across multiple weeks (currently just the latest
+  report).
+- Richer strategic options for as-yet-unlisted `ContractNextIntent` values.
+- Surfacing the captured intent on the contract board UI as a "current focus"
+  pill so the bias is legible at the point of decision.

--- a/docs/contract-debrief-next-intent-audit.md
+++ b/docs/contract-debrief-next-intent-audit.md
@@ -74,14 +74,19 @@ player clears it.
 1. Reads the latest entry of `game.reports`.
 2. Filters `caseSnapshots` to those with a terminal `MissionResult`.
 3. For each snapshot, calls `buildContractDebriefRecord(snapshot, week, caseInstance?)`.
-4. Returns records ordered by `caseId` for stable UI output.
+4. Returns records ordered by **urgency** — `fail` > `unresolved` > `partial`
+   > `success`, with ties broken by unresolved-clock count (more clocks first)
+   > and finally by `caseId` ascending. `records[0]` therefore represents the
+   > most pressing signal of the week, which is what the front-desk attention
+   > tone reads.
 
 `buildContractDebriefRecord` is a pure function over a single
-`WeeklyReportCaseSnapshot` plus an optional live `CaseInstance`. It pulls the
-contract template id and faction id from the case-instance contract first,
-then falls back to a safe extraction from the snapshot via
-`extractContractRuntimeFromSnapshot`. Returns `null` if no
-`MissionResult` or no contract template id is available.
+`WeeklyReportCaseSnapshot` plus an optional live `CaseInstance`. It merges the
+contract template id and faction id from both sources per field — the
+case-instance contract takes precedence when it actually carries a value, but
+missing fields fall back to the snapshot so an empty case-instance contract
+object cannot suppress a valid snapshot contract. Returns `null` if no
+`MissionResult` or no contract template id is available from either source.
 
 Helpers used to populate `changedEntities`:
 
@@ -97,7 +102,9 @@ Helpers used to populate `unresolvedClocks`:
 Helpers used to populate `strategicOptions`:
 
 - `buildStrategicOptions` + `dedupeStrategicOptions` — bounded mapping from
-  observed deltas to `ContractNextIntent` suggestions
+  observed structured deltas to `ContractNextIntent` suggestions. The
+  faction-improved branch reads `MissionResult.rewards.factionStanding` numeric
+  deltas directly rather than parsing human-readable copy.
 
 All helpers are pure, take only mission-result and snapshot data, and emit no
 freeform prose.
@@ -109,6 +116,11 @@ freeform prose.
 `clearContractNextIntent(state)` removes both fields. `getContractNextIntent`
 reads the sanitized value. The Zustand store exposes `setContractNextIntent`
 and `clearContractNextIntent` actions in `src/app/store/gameStore.ts`.
+
+`sanitizeContractSystemState` only carries `nextIntentCapturedWeek` forward
+when a valid `nextIntent` is also present. A corrupted save with a captured
+week but no captured intent normalizes to "no intent, no captured week" rather
+than leaving a dangling timestamp.
 
 ### Contract suggestion bias
 

--- a/docs/report-notes-audit.md
+++ b/docs/report-notes-audit.md
@@ -13,6 +13,13 @@ Report notes (`ReportNote[]`) populate the weekly debrief log. Two systems produ
 
 Both are pure functions. Neither writes to `GameState` directly.
 
+A separate, narrower surface — the post-contract debrief — sits beside the report
+notes. It does **not** add new `ReportNote` types; instead it derives a compact
+record from the latest `WeeklyReport.caseSnapshots` and surfaces it through the
+operations report and front-desk attention list. See
+[`contract-debrief-next-intent-audit.md`](./contract-debrief-next-intent-audit.md)
+for shapes and pipeline details.
+
 ---
 
 ## 2. Note Identity and Timestamps

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -60,6 +60,7 @@ import {
 } from '../../domain/hiddenCombatResolver'
 import type { ScreenRouteContext } from '../../domain/screenRouting'
 import {
+  type ContractNextIntent,
   type DeveloperLogEvent,
   type GameConfig,
   type GameFlagValue,
@@ -121,8 +122,10 @@ import { recomputeMissionRouting, routeMissionToTeam } from '../../domain/missio
 import { evaluateDeploymentEligibility } from '../../domain/deploymentReadiness'
 import { reconcileAgents } from '../../domain/sim/reconciliation'
 import {
+  clearContractNextIntent,
   launchContract as launchContractDomain,
   refreshContractBoard,
+  setContractNextIntent,
 } from '../../domain/contracts'
 import {
   createRunFromCurrentConfig,
@@ -200,6 +203,9 @@ interface GameStore {
     agentId: Id
   ) => ReturnType<typeof refreshPreparedSupportProcedureState>
   launchContract: (contractId: Id, teamId: Id) => void
+  /** SPE-1496: capture or clear the player's bounded post-contract next intent. */
+  setContractNextIntent: (intent: ContractNextIntent | null) => void
+  clearContractNextIntent: () => void
   launchMajorIncident: (
     caseId: Id,
     teamIds: Id[],
@@ -1091,6 +1097,12 @@ export const useGameStore = create<GameStore>()(
 
       launchContract: (contractId, teamId) =>
         set((s) => ({ game: launchContractDomain(s.game, contractId, teamId) })),
+
+      setContractNextIntent: (intent) =>
+        set((s) => ({ game: setContractNextIntent(s.game, intent) })),
+
+      clearContractNextIntent: () =>
+        set((s) => ({ game: clearContractNextIntent(s.game) })),
 
       launchMajorIncident: (caseId, teamIds, strategy = 'balanced', provisions = []) =>
         set((s) => ({

--- a/src/domain/contracts.ts
+++ b/src/domain/contracts.ts
@@ -19,9 +19,14 @@ import type {
   CaseInstance,
   CaseTemplate,
   ContractChainDefinition,
+  ContractDebriefChangedEntity,
+  ContractDebriefRecord,
+  ContractDebriefStrategicOption,
+  ContractDebriefUnresolvedClock,
   ContractHistoryRecord,
   ContractMaterialDrop,
   ContractModifier,
+  ContractNextIntent,
   ContractOffer,
   ContractResearchUnlock,
   ContractRewardPackage,
@@ -29,10 +34,14 @@ import type {
   ContractStrategyTag,
   ContractSystemState,
   GameState,
+  MissionInjuryRecord,
   MissionResolutionKind,
+  MissionResult,
   ReputationTier,
   StatBlock,
   Team,
+  WeeklyReport,
+  WeeklyReportCaseSnapshot,
 } from './models'
 import { previewResolutionForTeamIds } from './sim/resolve'
 import { assignTeam } from './sim/assign'
@@ -1270,6 +1279,7 @@ function buildSelectionScore(
   })
     ? 0.85
     : 0
+  const nextIntentBias = getNextIntentSelectionBias(state, definition)
 
   return (
     rng.next() +
@@ -1277,9 +1287,88 @@ function buildSelectionScore(
     powerFactor * 0.2 +
     factionBias +
     progressionUnlockBias +
-    recentChainCompletionBias -
+    recentChainCompletionBias +
+    nextIntentBias -
     freshnessPenalty
   )
+}
+
+/**
+ * SPE-1496: deterministic bias term used by `buildSelectionScore` to align contract
+ * ordering with the player's captured next intent. Bias is bounded and additive —
+ * it never overrides unlock conditions and only nudges ordering.
+ */
+export function getNextIntentSelectionBias(
+  state: GameState,
+  definition: ContractTemplateDefinition
+): number {
+  const contracts = sanitizeContractSystemState(state.contracts)
+  const intent = contracts.nextIntent ?? null
+
+  if (!intent) {
+    return 0
+  }
+
+  const factionTier = getFactionTier(state, definition.factionId)
+  const hasChainContinuation = (definition.chain.unlockConditions ?? []).some(
+    (condition) => condition.type === 'completed_contract'
+  )
+  const strategy = definition.strategyTag
+  const riskBoost =
+    definition.modifiers
+      .filter((modifier) => modifier.effect === 'difficulty_flat' || modifier.effect === 'death_risk')
+      .reduce((sum, modifier) => sum + (modifier.value ?? 0), 0)
+
+  switch (intent) {
+    case 'chase-lead':
+      // Boost contracts that continue an unlocked chain (closes the open lead the
+      // player just surfaced) and progression-tagged work that depends on prior runs.
+      return (hasChainContinuation ? 0.55 : 0) + (strategy === 'progression' ? 0.18 : 0)
+
+    case 'stabilize-staff':
+      // Prefer lower-risk income and materials work; downrank high lethality contracts.
+      return (
+        (strategy === 'income' ? 0.32 : 0) +
+        (strategy === 'materials' ? 0.18 : 0) -
+        Math.min(0.55, riskBoost * 0.04)
+      )
+
+    case 'repair-agency':
+      // Bias toward research/progression work and faction-friendly channels that lift standing.
+      return (
+        (strategy === 'research' ? 0.28 : 0) +
+        (strategy === 'progression' ? 0.2 : 0) +
+        (factionTier === 'friendly' || factionTier === 'allied' ? 0.18 : 0)
+      )
+
+    case 'pursue-faction':
+      // Boost contracts attached to the player's strongest cooperative faction.
+      if (!definition.factionId) {
+        return -0.12
+      }
+      return (
+        (factionTier === 'allied' ? 0.55 : 0) +
+        (factionTier === 'friendly' ? 0.32 : 0) +
+        (factionTier === 'hostile' ? -0.18 : 0)
+      )
+
+    case 'prepare-equipment':
+      // Bias toward materials-focused contracts that refill the supply chain.
+      return strategy === 'materials' ? 0.42 : strategy === 'income' ? 0.12 : 0
+
+    case 'answer-emergency':
+      // Bias toward income/progression work with elevated pressure (emergency posture).
+      return (
+        (strategy === 'income' ? 0.28 : 0) +
+        (strategy === 'progression' ? 0.2 : 0) +
+        Math.min(0.35, riskBoost * 0.03)
+      )
+
+    default: {
+      const _exhaustive: never = intent
+      return _exhaustive
+    }
+  }
 }
 
 function meetsUnlockCondition(
@@ -1734,6 +1823,12 @@ export function sanitizeContractSystemState(
         )
       : { ...fallback.history }
 
+  const nextIntent = normalizeContractNextIntent(raw.nextIntent ?? fallback.nextIntent)
+  const nextIntentCapturedWeek =
+    typeof raw.nextIntentCapturedWeek === 'number' && Number.isFinite(raw.nextIntentCapturedWeek)
+      ? Math.max(0, Math.round(raw.nextIntentCapturedWeek))
+      : fallback.nextIntentCapturedWeek
+
   return {
     generatedWeek:
       typeof raw.generatedWeek === 'number' && Number.isFinite(raw.generatedWeek)
@@ -1744,7 +1839,92 @@ export function sanitizeContractSystemState(
     unlockedResearchIds: Array.isArray(raw.unlockedResearchIds)
       ? raw.unlockedResearchIds.filter((entry): entry is string => typeof entry === 'string')
       : [...fallback.unlockedResearchIds],
+    ...(nextIntent ? { nextIntent } : {}),
+    ...(typeof nextIntentCapturedWeek === 'number' ? { nextIntentCapturedWeek } : {}),
   }
+}
+
+const CONTRACT_NEXT_INTENT_VALUES: readonly ContractNextIntent[] = [
+  'chase-lead',
+  'stabilize-staff',
+  'repair-agency',
+  'pursue-faction',
+  'prepare-equipment',
+  'answer-emergency',
+] as const
+
+function normalizeContractNextIntent(value: unknown): ContractNextIntent | null {
+  if (
+    typeof value === 'string' &&
+    (CONTRACT_NEXT_INTENT_VALUES as readonly string[]).includes(value)
+  ) {
+    return value as ContractNextIntent
+  }
+  return null
+}
+
+/** Bounded canonical list for UI surfaces and tests. */
+export function getContractNextIntentValues(): readonly ContractNextIntent[] {
+  return CONTRACT_NEXT_INTENT_VALUES
+}
+
+/** Player-facing label for an intent value. Pure derivation. */
+export function getContractNextIntentLabel(intent: ContractNextIntent): string {
+  switch (intent) {
+    case 'chase-lead':
+      return 'Chase the open lead'
+    case 'stabilize-staff':
+      return 'Stabilize staff'
+    case 'repair-agency':
+      return 'Repair agency standing'
+    case 'pursue-faction':
+      return 'Pursue faction channel'
+    case 'prepare-equipment':
+      return 'Prepare equipment'
+    case 'answer-emergency':
+      return 'Answer emergency pressure'
+    default: {
+      // Exhaustiveness guard; ContractNextIntent is a closed union.
+      const _exhaustive: never = intent
+      return _exhaustive
+    }
+  }
+}
+
+export function getContractNextIntent(state: GameState): ContractNextIntent | null {
+  return sanitizeContractSystemState(state.contracts).nextIntent ?? null
+}
+
+/** Capture a bounded post-contract next intent. Pass `null` to clear. */
+export function setContractNextIntent(
+  state: GameState,
+  intent: ContractNextIntent | null
+): GameState {
+  const contracts = sanitizeContractSystemState(state.contracts)
+  const normalized = intent ? normalizeContractNextIntent(intent) : null
+
+  if ((contracts.nextIntent ?? null) === normalized) {
+    return state
+  }
+
+  const nextContracts: ContractSystemState = {
+    ...contracts,
+    nextIntent: normalized,
+    ...(normalized ? { nextIntentCapturedWeek: state.week } : {}),
+  }
+
+  if (!normalized) {
+    delete (nextContracts as { nextIntentCapturedWeek?: number }).nextIntentCapturedWeek
+  }
+
+  return {
+    ...state,
+    contracts: nextContracts,
+  }
+}
+
+export function clearContractNextIntent(state: GameState): GameState {
+  return setContractNextIntent(state, null)
 }
 
 export function refreshContractBoard(state: GameState): GameState {
@@ -1767,6 +1947,13 @@ export function refreshContractBoard(state: GameState): GameState {
       }),
       history: contracts.history,
       unlockedResearchIds: [...contracts.unlockedResearchIds],
+      // SPE-1496: preserve the bounded next-intent capture across board regeneration
+      // so the bias term in `buildSelectionScore` reflects player intent until
+      // the player clears it.
+      ...(contracts.nextIntent ? { nextIntent: contracts.nextIntent } : {}),
+      ...(typeof contracts.nextIntentCapturedWeek === 'number'
+        ? { nextIntentCapturedWeek: contracts.nextIntentCapturedWeek }
+        : {}),
     },
   }
 }
@@ -2118,4 +2305,343 @@ export function getContractChainLabels(offer: Pick<ContractOffer, 'chain'>) {
 
 export function getContractMaterialLabel(material: Pick<ContractMaterialDrop, 'itemId' | 'label'>) {
   return material.label || inventoryItemLabels[material.itemId] || material.itemId
+}
+
+// ---------------------------------------------------------------------------
+// SPE-1496: post-contract debrief surface (deterministic; no prose recap)
+// ---------------------------------------------------------------------------
+
+function mapOutcomeLabel(outcome: MissionResolutionKind): string {
+  switch (outcome) {
+    case 'success':
+      return 'resolved cleanly'
+    case 'partial':
+      return 'partially contained'
+    case 'fail':
+      return 'failed in the field'
+    case 'unresolved':
+    default:
+      return 'lapsed without resolution'
+  }
+}
+
+function describeFatalities(missionResult: MissionResult): ContractDebriefChangedEntity[] {
+  return (missionResult.fatalities ?? []).map((fatality) => ({
+    kind: 'staff' as const,
+    id: `fatality:${fatality.agentId}`,
+    label: fatality.agentName ?? fatality.agentId,
+    detail: `Lost in the field${fatality.reason ? ` (${fatality.reason})` : ''}.`,
+  }))
+}
+
+function describeInjuries(injuries: readonly MissionInjuryRecord[]): ContractDebriefChangedEntity[] {
+  return injuries.map((injury) => ({
+    kind: 'staff' as const,
+    id: `injury:${injury.agentId}`,
+    label: injury.agentName,
+    detail: `${injury.severity} injury${injury.damage > 0 ? ` / ${injury.damage} damage` : ''}.`,
+  }))
+}
+
+function describeFatigueShifts(missionResult: MissionResult): ContractDebriefChangedEntity[] {
+  return missionResult.fatigueChanges
+    .filter((change) => Math.abs(change.delta) >= 3)
+    .map((change) => ({
+      kind: 'staff' as const,
+      id: `fatigue:${change.teamId}`,
+      label: change.teamName ?? change.teamId,
+      detail: `Fatigue ${change.before} -> ${change.after} (${change.delta >= 0 ? '+' : ''}${change.delta}).`,
+    }))
+}
+
+function describeFactionShifts(missionResult: MissionResult): ContractDebriefChangedEntity[] {
+  return missionResult.rewards.factionStanding
+    .filter((standing) => standing.delta !== 0)
+    .map((standing) => ({
+      kind: 'faction' as const,
+      id: `faction:${standing.factionId}`,
+      label: standing.label,
+      detail: `Standing ${standing.delta > 0 ? '+' : ''}${standing.delta}.`,
+    }))
+}
+
+function describeEvidenceGains(missionResult: MissionResult): ContractDebriefChangedEntity[] {
+  return missionResult.rewards.inventoryRewards
+    .filter((grant) => grant.quantity > 0)
+    .map((grant) => ({
+      kind: 'evidence' as const,
+      id: `inventory:${grant.itemId}`,
+      label: grant.label,
+      detail: `${grant.quantity}x recovered (${grant.kind}).`,
+    }))
+}
+
+function describeRoute(
+  missionResult: MissionResult,
+  snapshot: WeeklyReportCaseSnapshot
+): ContractDebriefChangedEntity | null {
+  const route = missionResult.route
+  if (!route) {
+    return null
+  }
+  return {
+    kind: 'route',
+    id: `route:${snapshot.caseId}`,
+    label: 'Route confirmed',
+    detail: `Operational route ${route}.`,
+  }
+}
+
+function extractContractRuntimeFromSnapshot(
+  snapshot: WeeklyReportCaseSnapshot
+): ActiveContractRuntime | undefined {
+  const raw = (snapshot as { contract?: unknown }).contract
+  if (raw && typeof raw === 'object') {
+    return raw as ActiveContractRuntime
+  }
+  return undefined
+}
+
+function describeSubject(
+  missionResult: MissionResult,
+  snapshot: WeeklyReportCaseSnapshot
+): ContractDebriefChangedEntity {
+  const hidden = missionResult.hiddenState
+  const detail = hidden
+    ? `Subject state ${hidden} after the operation.`
+    : `Operation ${mapOutcomeLabel(missionResult.outcome)}.`
+
+  return {
+    kind: 'subject',
+    id: `subject:${snapshot.caseId}`,
+    label: snapshot.title,
+    detail,
+  }
+}
+
+function describeUnresolvedClocks(missionResult: MissionResult): ContractDebriefUnresolvedClock[] {
+  const clocks: ContractDebriefUnresolvedClock[] = []
+  const weakestLink = missionResult.weakestLink
+
+  if (weakestLink?.recoveryPressureBand) {
+    clocks.push({
+      id: `recovery:${missionResult.caseId}`,
+      label: 'Recovery pressure',
+      detail: `Weakest-link recovery pressure ${weakestLink.recoveryPressureBand}.`,
+    })
+  }
+
+  for (const consequence of missionResult.spawnedConsequences) {
+    clocks.push({
+      id: `consequence:${consequence.caseId}`,
+      label:
+        consequence.type === 'stage_escalation'
+          ? 'Escalation clock'
+          : consequence.type === 'queued_follow_up'
+            ? 'Queued follow-up'
+            : 'Follow-up case',
+      detail: consequence.detail,
+    })
+  }
+
+  return clocks
+}
+
+function buildStrategicOptions(
+  record: Pick<
+    ContractDebriefRecord,
+    'outcome' | 'changedEntities' | 'unresolvedClocks' | 'factionId'
+  >
+): ContractDebriefStrategicOption[] {
+  const options: ContractDebriefStrategicOption[] = []
+  const staffChanges = record.changedEntities.filter((entity) => entity.kind === 'staff')
+  const factionChanges = record.changedEntities.filter((entity) => entity.kind === 'faction')
+  const evidenceChanges = record.changedEntities.filter((entity) => entity.kind === 'evidence')
+
+  if (record.unresolvedClocks.some((clock) => clock.id.startsWith('consequence:'))) {
+    options.push({
+      intent: 'chase-lead',
+      label: getContractNextIntentLabel('chase-lead'),
+      reason: 'A follow-up case is queued from this operation.',
+    })
+  }
+
+  if (
+    staffChanges.some((entity) => entity.id.startsWith('fatality:')) ||
+    staffChanges.filter((entity) => entity.id.startsWith('injury:')).length >= 2 ||
+    record.unresolvedClocks.some((clock) => clock.id.startsWith('recovery:'))
+  ) {
+    options.push({
+      intent: 'stabilize-staff',
+      label: getContractNextIntentLabel('stabilize-staff'),
+      reason: 'Staff impact and recovery pressure need to be cleared before redeployment.',
+    })
+  }
+
+  if (record.outcome === 'fail' || record.outcome === 'unresolved') {
+    options.push({
+      intent: 'repair-agency',
+      label: getContractNextIntentLabel('repair-agency'),
+      reason: 'Agency standing slipped from this operation.',
+    })
+  }
+
+  if (record.factionId && factionChanges.some((entity) => entity.detail.includes('+'))) {
+    options.push({
+      intent: 'pursue-faction',
+      label: getContractNextIntentLabel('pursue-faction'),
+      reason: 'Faction standing improved — keep the channel hot.',
+    })
+  }
+
+  if (evidenceChanges.length > 0) {
+    options.push({
+      intent: 'prepare-equipment',
+      label: getContractNextIntentLabel('prepare-equipment'),
+      reason: 'Recovered evidence/materials are ready for fabrication or supply.',
+    })
+  }
+
+  if (
+    record.outcome !== 'success' ||
+    record.unresolvedClocks.some((clock) => clock.id.startsWith('recovery:'))
+  ) {
+    options.push({
+      intent: 'answer-emergency',
+      label: getContractNextIntentLabel('answer-emergency'),
+      reason: 'Active pressure is still elevated; surge response is available.',
+    })
+  }
+
+  return dedupeStrategicOptions(options)
+}
+
+function dedupeStrategicOptions(
+  options: ContractDebriefStrategicOption[]
+): ContractDebriefStrategicOption[] {
+  const seen = new Set<ContractNextIntent>()
+  const deduped: ContractDebriefStrategicOption[] = []
+
+  for (const option of options) {
+    if (seen.has(option.intent)) {
+      continue
+    }
+    seen.add(option.intent)
+    deduped.push(option)
+  }
+
+  return deduped
+}
+
+/**
+ * SPE-1496: deterministic per-contract debrief record. Pure derivation from the
+ * supplied mission result and snapshot — no game-state side effects. Surfaces a
+ * compact digest of changed entities, unresolved clocks, and a bounded set of
+ * strategic options that map directly onto `ContractNextIntent` values.
+ */
+export function buildContractDebriefRecord(
+  snapshot: WeeklyReportCaseSnapshot,
+  reportWeek: number,
+  caseInstance?: CaseInstance
+): ContractDebriefRecord | null {
+  const missionResult = snapshot.missionResult
+  if (!missionResult) {
+    return null
+  }
+
+  const contractRuntime: ActiveContractRuntime | undefined =
+    (caseInstance?.contract as ActiveContractRuntime | undefined) ??
+    extractContractRuntimeFromSnapshot(snapshot)
+  const templateId =
+    contractRuntime?.templateId ??
+    contractRuntime?.contractId ??
+    contractRuntime?.offerId ??
+    null
+
+  if (!templateId) {
+    return null
+  }
+
+  const factionId = contractRuntime?.factionId ?? caseInstance?.factionId
+  const factionLabel = factionId ? getFactionDefinition(factionId)?.label ?? factionId : undefined
+
+  const changedEntities: ContractDebriefChangedEntity[] = [
+    describeSubject(missionResult, snapshot),
+    ...describeFatalities(missionResult),
+    ...describeInjuries(missionResult.injuries),
+    ...describeFatigueShifts(missionResult),
+    ...describeFactionShifts(missionResult),
+    ...describeEvidenceGains(missionResult),
+  ]
+  const routeEntity = describeRoute(missionResult, snapshot)
+  if (routeEntity) {
+    changedEntities.push(routeEntity)
+  }
+
+  const unresolvedClocks = describeUnresolvedClocks(missionResult)
+
+  const factionSummary = factionLabel ? `${factionLabel} channel` : 'Open channel'
+  const summary = `${snapshot.title} ${mapOutcomeLabel(missionResult.outcome)} via ${factionSummary}.`
+
+  const strategicOptions = buildStrategicOptions({
+    outcome: missionResult.outcome,
+    changedEntities,
+    unresolvedClocks,
+    ...(factionId ? { factionId } : {}),
+  })
+
+  return {
+    caseId: snapshot.caseId,
+    caseTitle: snapshot.title,
+    contractTemplateId: templateId,
+    ...(factionId ? { factionId } : {}),
+    ...(factionLabel ? { factionLabel } : {}),
+    outcome: missionResult.outcome,
+    week: reportWeek,
+    summary,
+    changedEntities,
+    unresolvedClocks,
+    strategicOptions,
+  }
+}
+
+/**
+ * SPE-1496: scan the most recent weekly report for completed contract operations
+ * and emit their structured debrief records. Returns most-recent-first, ordered
+ * by case id for determinism.
+ */
+export function getRecentContractDebriefRecords(
+  game: Pick<GameState, 'reports' | 'cases'>,
+  limit = 3
+): ContractDebriefRecord[] {
+  const latest: WeeklyReport | undefined = game.reports.at(-1)
+  if (!latest) {
+    return []
+  }
+
+  const snapshots = Object.values(latest.caseSnapshots ?? {})
+    .filter(
+      (snapshot): snapshot is WeeklyReportCaseSnapshot =>
+        Boolean(snapshot?.missionResult) &&
+        // A case-snapshot represents a completed contract operation when the
+        // mission result reports a terminal outcome and the snapshot's case
+        // still has contract runtime data (or carried it in the snapshot).
+        (snapshot.missionResult?.outcome === 'success' ||
+          snapshot.missionResult?.outcome === 'partial' ||
+          snapshot.missionResult?.outcome === 'fail' ||
+          snapshot.missionResult?.outcome === 'unresolved')
+    )
+    .sort((left, right) => left.caseId.localeCompare(right.caseId))
+
+  const records: ContractDebriefRecord[] = []
+
+  for (const snapshot of snapshots) {
+    const caseInstance = game.cases[snapshot.caseId]
+    const record = buildContractDebriefRecord(snapshot, latest.week, caseInstance)
+    if (record) {
+      records.push(record)
+    }
+  }
+
+  return records.slice(0, Math.max(0, limit))
 }

--- a/src/domain/contracts.ts
+++ b/src/domain/contracts.ts
@@ -1,9 +1,6 @@
 import { inventoryItemLabels } from '../data/production'
 import { appendOperationEventDrafts } from './events'
-import {
-  getAgencyProgressionUnlockLabel,
-  hasAgencyProgressionUnlock,
-} from './agencyProgression'
+import { getAgencyProgressionUnlockLabel, hasAgencyProgressionUnlock } from './agencyProgression'
 import { getFactionDefinition, inferFactionIdFromCaseTags } from './factions'
 import { createMissionIntelState } from './intel'
 import { clamp, createSeededRng, normalizeSeed } from './math'
@@ -155,7 +152,8 @@ const CONTRACT_RESEARCH_UNLOCKS: Record<string, ContractResearchUnlock> = {
   'liturgic-containment-index': {
     id: 'liturgic-containment-index',
     label: 'Liturgic Containment Index',
-    description: 'Recovered rite indices that open deeper occult-response catalog and containment work.',
+    description:
+      'Recovered rite indices that open deeper occult-response catalog and containment work.',
   },
 } as const
 
@@ -839,7 +837,8 @@ const CONTRACT_TEMPLATES: readonly ContractTemplateDefinition[] = [
       {
         id: 'stormgrid-relay-chaos',
         label: 'Relay instability',
-        description: 'Unstable relay cutovers make the operation harsher than normal intercept work.',
+        description:
+          'Unstable relay cutovers make the operation harsher than normal intercept work.',
         effect: 'injury_risk',
         value: 6,
       },
@@ -1038,11 +1037,7 @@ function cloneRewards(rewards: ContractRewardPackage): ContractRewardPackage {
   }
 }
 
-function scaleDifficultyProfile(
-  baseDifficulty: StatBlock,
-  scalar: number,
-  difficultyFlat: number
-) {
+function scaleDifficultyProfile(baseDifficulty: StatBlock, scalar: number, difficultyFlat: number) {
   const flatPerAxis = difficultyFlat / 4
 
   return {
@@ -1146,7 +1141,9 @@ export const CONTRACT_ARCHIVE_INSTABILITY_MODIFIER_ID = 'archive-instability' as
  * Returns a stable human-readable clause description when the case's contract template
  * includes the archive-instability modifier; otherwise null.
  */
-export function describeContractArchiveInstabilityClause(caseInstance: CaseInstance): string | null {
+export function describeContractArchiveInstabilityClause(
+  caseInstance: CaseInstance
+): string | null {
   const templateId = caseInstance.contract?.templateId
   if (!templateId || typeof templateId !== 'string') {
     return null
@@ -1165,9 +1162,7 @@ function getContractDisplayLabel(templateId: string) {
   return getContractDefinition(templateId)?.name ?? templateId
 }
 
-function formatContractResolutionLabel(
-  value: MissionResolutionKind | 'none' | undefined
-) {
+function formatContractResolutionLabel(value: MissionResolutionKind | 'none' | undefined) {
   switch (value) {
     case 'success':
       return 'success'
@@ -1216,7 +1211,8 @@ function buildContractPreviewOffer(
         social: 1,
       },
       riskLevel: 'low' as const,
-      durationWeeks: definition.durationWeeks ?? state.templates[definition.caseTemplateId]?.durationWeeks ?? 1,
+      durationWeeks:
+        definition.durationWeeks ?? state.templates[definition.caseTemplateId]?.durationWeeks ?? 1,
       rewards: buildRewardPackage(state, definition),
       requirements: {
         recommendedClasses: [...definition.requirements.recommendedClasses],
@@ -1224,10 +1220,14 @@ function buildContractPreviewOffer(
       },
       modifiers: definition.modifiers.map((modifier) => ({ ...modifier })),
       chain: {
-        ...(definition.chain.nextContracts ? { nextContracts: [...definition.chain.nextContracts] } : {}),
+        ...(definition.chain.nextContracts
+          ? { nextContracts: [...definition.chain.nextContracts] }
+          : {}),
         ...(definition.chain.unlockConditions
           ? {
-              unlockConditions: definition.chain.unlockConditions.map((condition) => ({ ...condition })),
+              unlockConditions: definition.chain.unlockConditions.map((condition) => ({
+                ...condition,
+              })),
             }
           : {}),
       },
@@ -1314,10 +1314,9 @@ export function getNextIntentSelectionBias(
     (condition) => condition.type === 'completed_contract'
   )
   const strategy = definition.strategyTag
-  const riskBoost =
-    definition.modifiers
-      .filter((modifier) => modifier.effect === 'difficulty_flat' || modifier.effect === 'death_risk')
-      .reduce((sum, modifier) => sum + (modifier.value ?? 0), 0)
+  const riskBoost = definition.modifiers
+    .filter((modifier) => modifier.effect === 'difficulty_flat' || modifier.effect === 'death_risk')
+    .reduce((sum, modifier) => sum + (modifier.value ?? 0), 0)
 
   switch (intent) {
     case 'chase-lead':
@@ -1384,7 +1383,10 @@ function meetsUnlockCondition(
   switch (condition.type) {
     case 'completed_contract': {
       const record = contracts.history[condition.contractTemplateId ?? '']
-      return getOutcomeMeetsMinimum(record?.bestOutcome ?? 'none', condition.minimumOutcome ?? 'success')
+      return getOutcomeMeetsMinimum(
+        record?.bestOutcome ?? 'none',
+        condition.minimumOutcome ?? 'success'
+      )
     }
     case 'research_unlocked':
       return completedResearchUnlockIds.has(condition.researchId ?? '')
@@ -1400,10 +1402,7 @@ function meetsUnlockCondition(
   }
 }
 
-function getContractAvailabilityBlockers(
-  state: GameState,
-  definition: ContractTemplateDefinition
-) {
+function getContractAvailabilityBlockers(state: GameState, definition: ContractTemplateDefinition) {
   const contracts = sanitizeContractSystemState(state.contracts)
   const blockers: Array<{ code: string; detail: string }> = []
   const template = state.templates[definition.caseTemplateId]
@@ -1668,9 +1667,15 @@ function buildOfferFromDefinition(
     },
     modifiers: definition.modifiers.map((modifier) => ({ ...modifier })),
     chain: {
-      ...(definition.chain.nextContracts ? { nextContracts: [...definition.chain.nextContracts] } : {}),
+      ...(definition.chain.nextContracts
+        ? { nextContracts: [...definition.chain.nextContracts] }
+        : {}),
       ...(definition.chain.unlockConditions
-        ? { unlockConditions: definition.chain.unlockConditions.map((condition) => ({ ...condition })) }
+        ? {
+            unlockConditions: definition.chain.unlockConditions.map((condition) => ({
+              ...condition,
+            })),
+          }
         : {}),
     },
     strategyTag: definition.strategyTag,
@@ -1681,7 +1686,9 @@ function buildOfferFromDefinition(
 function generateContractOffers(state: GameState) {
   const progressionFactor = getCurrentProgressionFactor(state)
   const powerFactor = getAvailablePowerFactor(state)
-  const eligible = CONTRACT_TEMPLATES.filter((definition) => isDefinitionEligible(state, definition))
+  const eligible = CONTRACT_TEMPLATES.filter((definition) =>
+    isDefinitionEligible(state, definition)
+  )
   const ranked = eligible
     .map((definition) => ({
       definition,
@@ -1749,7 +1756,10 @@ export function sanitizeContractSystemState(
               1,
               Math.round(offer.caseDifficulty?.investigation ?? offer.difficulty ?? 1)
             ),
-            utility: Math.max(1, Math.round(offer.caseDifficulty?.utility ?? offer.difficulty ?? 1)),
+            utility: Math.max(
+              1,
+              Math.round(offer.caseDifficulty?.utility ?? offer.difficulty ?? 1)
+            ),
             social: Math.max(1, Math.round(offer.caseDifficulty?.social ?? offer.difficulty ?? 1)),
           },
           requirements: {
@@ -1824,10 +1834,15 @@ export function sanitizeContractSystemState(
       : { ...fallback.history }
 
   const nextIntent = normalizeContractNextIntent(raw.nextIntent ?? fallback.nextIntent)
-  const nextIntentCapturedWeek =
+  // SPE-1496 (PR #1621 review fix): only carry `nextIntentCapturedWeek` forward
+  // when a valid `nextIntent` is present. This keeps corrupted / partial save
+  // data from leaving a captured-week value without a captured intent, which is
+  // inconsistent with `clearContractNextIntent` and with the field's meaning.
+  const rawCapturedWeek =
     typeof raw.nextIntentCapturedWeek === 'number' && Number.isFinite(raw.nextIntentCapturedWeek)
       ? Math.max(0, Math.round(raw.nextIntentCapturedWeek))
       : fallback.nextIntentCapturedWeek
+  const nextIntentCapturedWeek = nextIntent ? rawCapturedWeek : undefined
 
   return {
     generatedWeek:
@@ -1978,7 +1993,8 @@ export function getContractCatalogEntries(state: GameState): ContractCatalogEntr
   return CONTRACT_TEMPLATES.map((definition, index) => {
     const offer = offersByTemplateId.get(definition.id)
     const caseTemplate = state.templates[definition.caseTemplateId]
-    const preview = offer ?? buildContractPreviewOffer(state, definition, index, progressionFactor, powerFactor)
+    const preview =
+      offer ?? buildContractPreviewOffer(state, definition, index, progressionFactor, powerFactor)
     const blockers =
       offer !== undefined
         ? []
@@ -2018,7 +2034,11 @@ export function getContractCatalogEntries(state: GameState): ContractCatalogEntr
       chain: {
         ...(preview.chain.nextContracts ? { nextContracts: [...preview.chain.nextContracts] } : {}),
         ...(preview.chain.unlockConditions
-          ? { unlockConditions: preview.chain.unlockConditions.map((condition) => ({ ...condition })) }
+          ? {
+              unlockConditions: preview.chain.unlockConditions.map((condition) => ({
+                ...condition,
+              })),
+            }
           : {}),
       },
       availabilityState,
@@ -2224,7 +2244,12 @@ export function recordContractOutcome(
     return nextContracts
   }
 
-  const templateId = activeContract.templateId ?? activeContract.contractId ?? activeContract.offerId ?? activeContract.caseId ?? ''
+  const templateId =
+    activeContract.templateId ??
+    activeContract.contractId ??
+    activeContract.offerId ??
+    activeContract.caseId ??
+    ''
   const currentRecord = nextContracts.history[templateId] ?? {
     completions: 0,
     bestOutcome: 'none',
@@ -2293,7 +2318,9 @@ export function getContractStrategyLabel(strategyTag: ContractStrategyTag) {
 }
 
 export function getContractFactionLabel(offer: Pick<ContractOffer, 'factionId'>) {
-  return offer.factionId ? getFactionDefinition(offer.factionId)?.label ?? offer.factionId : 'Open channel'
+  return offer.factionId
+    ? (getFactionDefinition(offer.factionId)?.label ?? offer.factionId)
+    : 'Open channel'
 }
 
 export function getContractChainLabels(offer: Pick<ContractOffer, 'chain'>) {
@@ -2334,7 +2361,9 @@ function describeFatalities(missionResult: MissionResult): ContractDebriefChange
   }))
 }
 
-function describeInjuries(injuries: readonly MissionInjuryRecord[]): ContractDebriefChangedEntity[] {
+function describeInjuries(
+  injuries: readonly MissionInjuryRecord[]
+): ContractDebriefChangedEntity[] {
   return injuries.map((injury) => ({
     kind: 'staff' as const,
     id: `injury:${injury.agentId}`,
@@ -2392,12 +2421,53 @@ function describeRoute(
   }
 }
 
-function extractContractRuntimeFromSnapshot(
-  snapshot: WeeklyReportCaseSnapshot
-): ActiveContractRuntime | undefined {
-  const raw = (snapshot as { contract?: unknown }).contract
-  if (raw && typeof raw === 'object') {
-    return raw as ActiveContractRuntime
+/**
+ * Loosely-typed extraction of contract runtime data from either source. Both
+ * `WeeklyReportCaseSnapshot` and `CaseInstance.contract` only formally guarantee
+ * `templateId` plus an index signature, so we read the fields we care about
+ * through optional access rather than casting the whole object to
+ * `ActiveContractRuntime`.
+ */
+type ContractRuntimeBag = {
+  templateId?: unknown
+  contractId?: unknown
+  offerId?: unknown
+  factionId?: unknown
+}
+
+function readContractRuntimeBag(value: unknown): ContractRuntimeBag | undefined {
+  if (value && typeof value === 'object') {
+    return value as ContractRuntimeBag
+  }
+  return undefined
+}
+
+function pickContractStringField(
+  ...candidates: Array<ContractRuntimeBag | undefined>
+): string | null {
+  for (const bag of candidates) {
+    if (!bag) {
+      continue
+    }
+    for (const field of ['templateId', 'contractId', 'offerId'] as const) {
+      const value = bag[field]
+      if (typeof value === 'string' && value.length > 0) {
+        return value
+      }
+    }
+  }
+  return null
+}
+
+function pickFactionId(...candidates: Array<ContractRuntimeBag | undefined>): string | undefined {
+  for (const bag of candidates) {
+    if (!bag) {
+      continue
+    }
+    const value = bag.factionId
+    if (typeof value === 'string' && value.length > 0) {
+      return value
+    }
   }
   return undefined
 }
@@ -2447,15 +2517,24 @@ function describeUnresolvedClocks(missionResult: MissionResult): ContractDebrief
   return clocks
 }
 
+/**
+ * SPE-1496 (PR #1621 review fix): `buildStrategicOptions` accepts the
+ * structured numeric `factionStanding` array from `MissionResult.rewards`
+ * directly so the "faction standing improved" inference no longer depends on
+ * parsing the human-readable `detail` string of a faction changed-entity. The
+ * `changedEntities` / `unresolvedClocks` inputs are still used for the other
+ * inferences because those already key off id prefixes, not free-form copy.
+ */
 function buildStrategicOptions(
   record: Pick<
     ContractDebriefRecord,
     'outcome' | 'changedEntities' | 'unresolvedClocks' | 'factionId'
-  >
+  > & {
+    factionStanding: MissionResult['rewards']['factionStanding']
+  }
 ): ContractDebriefStrategicOption[] {
   const options: ContractDebriefStrategicOption[] = []
   const staffChanges = record.changedEntities.filter((entity) => entity.kind === 'staff')
-  const factionChanges = record.changedEntities.filter((entity) => entity.kind === 'faction')
   const evidenceChanges = record.changedEntities.filter((entity) => entity.kind === 'evidence')
 
   if (record.unresolvedClocks.some((clock) => clock.id.startsWith('consequence:'))) {
@@ -2486,7 +2565,8 @@ function buildStrategicOptions(
     })
   }
 
-  if (record.factionId && factionChanges.some((entity) => entity.detail.includes('+'))) {
+  const factionImproved = record.factionStanding.some((standing) => standing.delta > 0)
+  if (record.factionId && factionImproved) {
     options.push({
       intent: 'pursue-faction',
       label: getContractNextIntentLabel('pursue-faction'),
@@ -2549,21 +2629,22 @@ export function buildContractDebriefRecord(
     return null
   }
 
-  const contractRuntime: ActiveContractRuntime | undefined =
-    (caseInstance?.contract as ActiveContractRuntime | undefined) ??
-    extractContractRuntimeFromSnapshot(snapshot)
-  const templateId =
-    contractRuntime?.templateId ??
-    contractRuntime?.contractId ??
-    contractRuntime?.offerId ??
-    null
+  // SPE-1496 (PR #1621 review fix): merge contract runtime fields from both the
+  // live `CaseInstance` and the `WeeklyReportCaseSnapshot` per field, instead of
+  // picking one source wholesale. The case-instance contract takes precedence
+  // when it actually carries a value for the field, but missing fields fall
+  // back to the snapshot so an empty case-instance contract object can never
+  // suppress a valid snapshot contract.
+  const caseBag = readContractRuntimeBag(caseInstance?.contract)
+  const snapshotBag = readContractRuntimeBag((snapshot as { contract?: unknown }).contract)
+  const templateId = pickContractStringField(caseBag, snapshotBag)
 
   if (!templateId) {
     return null
   }
 
-  const factionId = contractRuntime?.factionId ?? caseInstance?.factionId
-  const factionLabel = factionId ? getFactionDefinition(factionId)?.label ?? factionId : undefined
+  const factionId = pickFactionId(caseBag, snapshotBag) ?? caseInstance?.factionId
+  const factionLabel = factionId ? (getFactionDefinition(factionId)?.label ?? factionId) : undefined
 
   const changedEntities: ContractDebriefChangedEntity[] = [
     describeSubject(missionResult, snapshot),
@@ -2587,6 +2668,7 @@ export function buildContractDebriefRecord(
     outcome: missionResult.outcome,
     changedEntities,
     unresolvedClocks,
+    factionStanding: missionResult.rewards.factionStanding,
     ...(factionId ? { factionId } : {}),
   })
 
@@ -2606,9 +2688,45 @@ export function buildContractDebriefRecord(
 }
 
 /**
+ * SPE-1496 (PR #1621 review fix): bounded urgency ranking for the latest-report
+ * debrief records. Lower number = more urgent, which sorts first.
+ *
+ * The order is intentionally compact and deterministic — failure and unresolved
+ * outcomes lead so the front-desk attention tone derived from `records[0]`
+ * surfaces the most pressing signal in a week that mixes outcomes.
+ */
+const DEBRIEF_OUTCOME_URGENCY_RANK: Record<MissionResolutionKind, number> = {
+  fail: 0,
+  unresolved: 1,
+  partial: 2,
+  success: 3,
+}
+
+function compareDebriefRecordsByUrgency(
+  left: ContractDebriefRecord,
+  right: ContractDebriefRecord
+): number {
+  const outcomeDelta =
+    DEBRIEF_OUTCOME_URGENCY_RANK[left.outcome] - DEBRIEF_OUTCOME_URGENCY_RANK[right.outcome]
+  if (outcomeDelta !== 0) {
+    return outcomeDelta
+  }
+  const clockDelta = right.unresolvedClocks.length - left.unresolvedClocks.length
+  if (clockDelta !== 0) {
+    return clockDelta
+  }
+  return left.caseId.localeCompare(right.caseId)
+}
+
+/**
  * SPE-1496: scan the most recent weekly report for completed contract operations
- * and emit their structured debrief records. Returns most-recent-first, ordered
- * by case id for determinism.
+ * and emit their structured debrief records.
+ *
+ * Records are ordered by urgency (`fail` > `unresolved` > `partial` > `success`),
+ * with ties broken by unresolved-clock count (more clocks first) and finally by
+ * `caseId` ascending for full determinism. This lets downstream surfaces such
+ * as the front-desk attention item read `records[0]` and trust it represents
+ * the most pressing signal in the week, not just the alphabetic first case.
  */
 export function getRecentContractDebriefRecords(
   game: Pick<GameState, 'reports' | 'cases'>,
@@ -2619,6 +2737,8 @@ export function getRecentContractDebriefRecords(
     return []
   }
 
+  // Iterate snapshots in caseId order first so record construction itself is
+  // deterministic; the final `sort` below then re-orders by urgency.
   const snapshots = Object.values(latest.caseSnapshots ?? {})
     .filter(
       (snapshot): snapshot is WeeklyReportCaseSnapshot =>
@@ -2643,5 +2763,6 @@ export function getRecentContractDebriefRecords(
     }
   }
 
+  records.sort(compareDebriefRecordsByUrgency)
   return records.slice(0, Math.max(0, limit))
 }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -904,6 +904,65 @@ export interface ContractHistoryRecord {
   lastCompletedWeek?: number
 }
 
+/**
+ * SPE-1496: bounded enum of post-contract player intents.
+ * Values are deliberately small and deterministic — they bias later contract
+ * suggestion/order through `getNextIntentSelectionBias` and never trigger a
+ * planner or freeform recap. Add cases sparingly.
+ */
+export type ContractNextIntent =
+  | 'chase-lead'
+  | 'stabilize-staff'
+  | 'repair-agency'
+  | 'pursue-faction'
+  | 'prepare-equipment'
+  | 'answer-emergency'
+
+export type ContractDebriefChangedEntityKind =
+  | 'staff'
+  | 'subject'
+  | 'route'
+  | 'evidence'
+  | 'faction'
+
+export interface ContractDebriefChangedEntity {
+  kind: ContractDebriefChangedEntityKind
+  id: string
+  label: string
+  detail: string
+}
+
+export interface ContractDebriefUnresolvedClock {
+  id: string
+  label: string
+  detail: string
+}
+
+export interface ContractDebriefStrategicOption {
+  intent: ContractNextIntent
+  label: string
+  reason: string
+}
+
+/**
+ * SPE-1496: compact deterministic record emitted for one completed contract operation.
+ * Surfaces the changed entities, unresolved clocks, and bounded strategic options the
+ * player needs to set a next intent — without a freeform prose recap layer.
+ */
+export interface ContractDebriefRecord {
+  caseId: Id
+  caseTitle: string
+  contractTemplateId: Id
+  factionId?: Id
+  factionLabel?: string
+  outcome: MissionResolutionKind
+  week: number
+  summary: string
+  changedEntities: ContractDebriefChangedEntity[]
+  unresolvedClocks: ContractDebriefUnresolvedClock[]
+  strategicOptions: ContractDebriefStrategicOption[]
+}
+
 export interface ActiveContractRuntime {
   contractId?: Id
   offerId?: Id
@@ -930,6 +989,14 @@ export interface ContractSystemState {
   history: Record<string, ContractHistoryRecord>
   unlockedResearchIds: string[]
   active?: Record<string, ActiveContractRuntime>
+  /**
+   * SPE-1496: bounded post-contract player intent. When set, `buildSelectionScore`
+   * applies a deterministic bias to align next contract offers with the chosen
+   * direction. `null`/absent means no bias.
+   */
+  nextIntent?: ContractNextIntent | null
+  /** SPE-1496: campaign week the next intent was captured (informational/debug). */
+  nextIntentCapturedWeek?: number
 }
 
 export interface Contact {

--- a/src/features/dashboard/OperationsReportPanel.tsx
+++ b/src/features/dashboard/OperationsReportPanel.tsx
@@ -6,8 +6,9 @@ import { useGameStore } from '../../app/store/gameStore'
 import { getOperationsReportView } from '../report/operationsReportView'
 
 export function OperationsReportPanel() {
-  const { game } = useGameStore()
+  const { game, setContractNextIntent, clearContractNextIntent } = useGameStore()
   const view = useMemo(() => getOperationsReportView(game), [game])
+  const debrief = view.contractDebrief
 
   return (
     <section className="panel panel-support space-y-4" aria-label="Operations report">
@@ -189,6 +190,126 @@ export function OperationsReportPanel() {
           ) : (
             <p className="mt-3 text-sm opacity-60">No deployment readiness pairings are available.</p>
           )}
+        </article>
+
+        <article
+          className="rounded border border-white/10 px-3 py-3"
+          aria-label="Post-contract debrief"
+        >
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">Post-contract debrief</h3>
+            <p className="text-sm opacity-60">
+              Compact deterministic digest of completed contracts and the captured next-intent
+              focus.
+            </p>
+          </div>
+
+          {debrief.records.length > 0 ? (
+            <ul className="mt-3 space-y-3">
+              {debrief.records.map((record) => (
+                <li
+                  key={`${record.week}:${record.caseId}`}
+                  className="rounded border border-white/10 px-3 py-3"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium">
+                        <Link
+                          to={APP_ROUTES.caseDetail(record.caseId)}
+                          className="hover:underline"
+                        >
+                          {record.caseTitle}
+                        </Link>
+                      </p>
+                      <p className="text-xs opacity-50">
+                        Week{' '}
+                        <Link
+                          to={APP_ROUTES.reportDetail(record.week)}
+                          className="hover:underline"
+                        >
+                          {record.week}
+                        </Link>{' '}
+                        / {record.outcomeLabel}
+                        {record.factionLabel ? ` / ${record.factionLabel}` : null}
+                      </p>
+                    </div>
+                    <Tag
+                      tone={
+                        record.outcomeLabel === 'Fail'
+                          ? 'danger'
+                          : record.outcomeLabel === 'Partial' || record.outcomeLabel === 'Unresolved'
+                            ? 'warning'
+                            : 'info'
+                      }
+                    >
+                      {record.outcomeLabel}
+                    </Tag>
+                  </div>
+                  <p className="mt-2 text-sm opacity-75">{record.summary}</p>
+
+                  {record.changedEntities.length > 0 ? (
+                    <ul className="mt-2 space-y-1 text-sm opacity-70">
+                      {record.changedEntities.map((entity) => (
+                        <li key={entity.id}>
+                          <span className="font-medium">{entity.label}:</span> {entity.detail}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+
+                  {record.unresolvedClocks.length > 0 ? (
+                    <ul className="mt-2 space-y-1 text-sm opacity-65">
+                      {record.unresolvedClocks.map((clock) => (
+                        <li key={clock.id}>
+                          <span className="font-medium">Clock:</span> {clock.label} — {clock.detail}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-3 text-sm opacity-60">
+              No completed contracts in the latest report. Captured next intent applies to the next
+              board refresh.
+            </p>
+          )}
+
+          <div className="mt-3 space-y-2" aria-label="Next-intent picker">
+            <p className="text-sm font-medium opacity-80">
+              Captured next intent:{' '}
+              {debrief.selectedIntent
+                ? debrief.intentChoices.find((choice) => choice.selected)?.label
+                : 'None'}
+            </p>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {debrief.intentChoices.map((choice) => (
+                <button
+                  key={choice.intent}
+                  type="button"
+                  onClick={() => setContractNextIntent(choice.intent)}
+                  className={`rounded-full border px-2 py-1 transition ${
+                    choice.selected
+                      ? 'border-cyan-300/60 bg-cyan-500/20 text-cyan-50'
+                      : 'border-white/10 bg-white/5 text-white/80 hover:bg-white/10'
+                  }`}
+                  title={choice.reason ?? 'Bias next contract suggestion ordering.'}
+                  aria-pressed={choice.selected}
+                >
+                  {choice.label}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => clearContractNextIntent()}
+                className="rounded-full border border-white/10 bg-white/5 px-2 py-1 text-white/80 hover:bg-white/10"
+                aria-pressed={debrief.selectedIntent === null}
+              >
+                Clear
+              </button>
+            </div>
+          </div>
         </article>
 
         <article className="rounded border border-white/10 px-3 py-3" aria-label="Recent outcome report">

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -923,6 +923,32 @@ function buildAttentionItems(
     ...(notice.actionTarget ? { href: getFrontDeskNoticeActionHref(notice.actionTarget) } : {}),
   }))
 
+  const debriefAttention =
+    operationsReport.contractDebrief.attentionSummary && operationsReport.contractDebrief.records.length > 0
+      ? [
+          {
+            id: 'debrief:latest',
+            title: 'Post-contract debrief',
+            summary: operationsReport.contractDebrief.attentionSummary,
+            tone: ((): FrontDeskNoticeTone => {
+              const lead = operationsReport.contractDebrief.records[0]!
+              if (lead.outcomeLabel === 'Fail' || lead.outcomeLabel === 'Unresolved') {
+                return 'danger'
+              }
+              if (
+                lead.outcomeLabel === 'Partial' ||
+                lead.unresolvedClocks.length > 0 ||
+                operationsReport.contractDebrief.selectedIntent === null
+              ) {
+                return 'warning'
+              }
+              return 'info'
+            })(),
+            href: APP_ROUTES.report,
+          } as const,
+        ]
+      : []
+
   const signalItems = shell.signals
     .filter((signal) => signal.tone !== 'neutral')
     .map((signal) => ({
@@ -953,7 +979,7 @@ function buildAttentionItems(
       href: APP_ROUTES.teamDetail(entry.teamId),
     }))
 
-  return [...noticeItems, ...signalItems, ...routingItems, ...readinessItems]
+  return [...noticeItems, ...debriefAttention, ...signalItems, ...routingItems, ...readinessItems]
     .sort((left, right) => {
       const priorityDelta = getAttentionPriority(right.tone) - getAttentionPriority(left.tone)
 

--- a/src/features/report/operationsReportView.ts
+++ b/src/features/report/operationsReportView.ts
@@ -1,5 +1,18 @@
-import type { GameState, Id, MissionPriorityBand, MissionRoutingStateKind } from '../../domain/models'
+import type {
+  ContractDebriefRecord,
+  ContractNextIntent,
+  GameState,
+  Id,
+  MissionPriorityBand,
+  MissionRoutingStateKind,
+} from '../../domain/models'
 import { buildTeamDeploymentReadinessState } from '../../domain/deploymentReadiness'
+import {
+  getContractNextIntent,
+  getContractNextIntentLabel,
+  getContractNextIntentValues,
+  getRecentContractDebriefRecords,
+} from '../../domain/contracts'
 import { normalizeMissionRoutingState } from '../../domain/missionIntakeRouting'
 import {
   EXECUTION_INSTABILITY_SHARED_CLOCK_SUMMARY,
@@ -109,11 +122,42 @@ export interface WeeklyOperationsSummaryView {
   deploymentMomentumSummary?: string
 }
 
+export interface ContractDebriefIntentChoiceView {
+  intent: ContractNextIntent
+  label: string
+  selected: boolean
+  /** Reason text when the option appeared as a strategic option on a recent debrief. */
+  reason?: string
+}
+
+export interface ContractDebriefRecordView {
+  caseId: Id
+  caseTitle: string
+  contractTemplateId: Id
+  factionLabel?: string
+  outcomeLabel: string
+  week: number
+  summary: string
+  changedEntities: ContractDebriefRecord['changedEntities']
+  unresolvedClocks: ContractDebriefRecord['unresolvedClocks']
+}
+
+export interface ContractDebriefView {
+  records: ContractDebriefRecordView[]
+  /** Bounded list of all possible next-intent choices, ordered for stable UI. */
+  intentChoices: ContractDebriefIntentChoiceView[]
+  /** Currently captured intent, if any. */
+  selectedIntent: ContractNextIntent | null
+  /** Compact attention line for surfaces that only have room for one summary. */
+  attentionSummary: string | null
+}
+
 export interface OperationsReportView {
   missionRouting: MissionRoutingReportItemView[]
   deploymentReadiness: DeploymentReadinessReportItemView[]
   recentOutcomes: WeakestLinkOutcomeReportItemView[]
   weeklySummary: WeeklyOperationsSummaryView
+  contractDebrief: ContractDebriefView
 }
 
 function capitalizeLabel(value: string) {
@@ -424,11 +468,68 @@ function buildRotatingRosterContinuityRecapLine(game: GameState): string | undef
   return formatRotatingRosterContinuitySummary(counts)
 }
 
+export function getContractDebriefView(game: GameState): ContractDebriefView {
+  const records = getRecentContractDebriefRecords(game)
+  const selectedIntent = getContractNextIntent(game)
+
+  const reasonByIntent = new Map<ContractNextIntent, string>()
+  for (const record of records) {
+    for (const option of record.strategicOptions) {
+      if (!reasonByIntent.has(option.intent)) {
+        reasonByIntent.set(option.intent, option.reason)
+      }
+    }
+  }
+
+  const intentChoices: ContractDebriefIntentChoiceView[] = getContractNextIntentValues().map(
+    (intent) => ({
+      intent,
+      label: getContractNextIntentLabel(intent),
+      selected: selectedIntent === intent,
+      ...(reasonByIntent.get(intent) ? { reason: reasonByIntent.get(intent)! } : {}),
+    })
+  )
+
+  const recordViews: ContractDebriefRecordView[] = records.map((record) => ({
+    caseId: record.caseId,
+    caseTitle: record.caseTitle,
+    contractTemplateId: record.contractTemplateId,
+    ...(record.factionLabel ? { factionLabel: record.factionLabel } : {}),
+    outcomeLabel: formatOutcomeLabel(record.outcome),
+    week: record.week,
+    summary: record.summary,
+    changedEntities: [...record.changedEntities],
+    unresolvedClocks: [...record.unresolvedClocks],
+  }))
+
+  const attentionSummary = (() => {
+    if (recordViews.length === 0) {
+      return selectedIntent
+        ? `Next intent: ${getContractNextIntentLabel(selectedIntent)}.`
+        : null
+    }
+
+    const lead = recordViews[0]!
+    const intentSuffix = selectedIntent
+      ? ` Next intent: ${getContractNextIntentLabel(selectedIntent)}.`
+      : ' Next intent unset.'
+    return `${lead.summary}${intentSuffix}`
+  })()
+
+  return {
+    records: recordViews,
+    intentChoices,
+    selectedIntent,
+    attentionSummary,
+  }
+}
+
 export function getOperationsReportView(game: GameState): OperationsReportView {
   return {
     missionRouting: getMissionRoutingReportView(game),
     deploymentReadiness: getDeploymentReadinessReportView(game),
     recentOutcomes: getWeakestLinkOutcomeReportView(game),
     weeklySummary: getWeeklyOperationsSummaryView(game),
+    contractDebrief: getContractDebriefView(game),
   }
 }

--- a/src/test/contractsDebrief.test.ts
+++ b/src/test/contractsDebrief.test.ts
@@ -1,0 +1,344 @@
+/**
+ * SPE-1496: targeted coverage for the bounded post-contract debrief flow.
+ *
+ * Validates three legs of the slice in isolation:
+ *   1. Deterministic debrief record generation from a `WeeklyReportCaseSnapshot`.
+ *   2. Bounded next-intent capture round-trips through pure state helpers.
+ *   3. Next-intent ordering bias deterministically nudges later contract offers
+ *      without overriding unlock conditions.
+ */
+import { describe, expect, it } from 'vitest'
+import '../test/setup'
+
+import { createStartingState } from '../data/startingState'
+import {
+  buildContractDebriefRecord,
+  clearContractNextIntent,
+  getContractNextIntent,
+  getContractNextIntentLabel,
+  getContractNextIntentValues,
+  getContractOffers,
+  getNextIntentSelectionBias,
+  getRecentContractDebriefRecords,
+  refreshContractBoard,
+  setContractNextIntent,
+} from '../domain/contracts'
+import type {
+  ActiveContractRuntime,
+  CaseInstance,
+  MissionResult,
+  WeeklyReport,
+  WeeklyReportCaseSnapshot,
+} from '../domain/models'
+
+function buildSnapshot(): WeeklyReportCaseSnapshot {
+  const missionResult: MissionResult = {
+    caseId: 'case-debrief',
+    caseTitle: 'Vault Sweep',
+    teamsUsed: [{ teamId: 't_nightwatch' }],
+    outcome: 'partial',
+    hiddenState: 'revealed',
+    route: 'transition',
+    weakestLink: {
+      caseId: 'case-debrief',
+      resultKind: 'partial',
+      outcomeCategory: 'mixed_resolution',
+      recoveryPressureBand: 'elevated',
+      contributors: [],
+      details: [],
+      expectedRecoveryWeeksDelta: 1,
+    } as unknown as MissionResult['weakestLink'],
+    performanceSummary: {} as MissionResult['performanceSummary'],
+    rewards: {
+      outcome: 'partial',
+      caseType: 'sweep',
+      caseTypeLabel: 'Sweep',
+      operationValue: 0,
+      factors: [],
+      fundingDelta: 0,
+      containmentDelta: 0,
+      strategicValueDelta: 0,
+      reputationDelta: 0,
+      inventoryRewards: [
+        { kind: 'material', itemId: 'shard-fragment', label: 'Shard Fragment', quantity: 2, tags: [] },
+      ],
+      factionStanding: [
+        { factionId: 'oversight', label: 'Oversight Bureau', delta: 2, overlapTags: [] },
+      ],
+      label: 'Vault Sweep',
+      reasons: [],
+    },
+    penalties: { fundingLoss: 0, containmentLoss: 0, reputationLoss: 0, strategicLoss: 0 },
+    fatigueChanges: [
+      {
+        teamId: 't_nightwatch',
+        teamName: 'Nightwatch',
+        before: 1,
+        after: 6,
+        delta: 5,
+        stressModifier: 0,
+      },
+    ],
+    injuries: [{ agentId: 'a_ava', agentName: 'Ava', severity: 'moderate', damage: 3 }],
+    fatalities: [],
+    spawnedConsequences: [
+      {
+        type: 'queued_follow_up',
+        caseId: 'case-followup',
+        detail: 'Faction lead surfaced for follow-up.',
+      },
+    ],
+    explanationNotes: [],
+  }
+
+  const snapshot = {
+    caseId: 'case-debrief',
+    title: 'Vault Sweep',
+    kind: 'standard',
+    mode: 'deterministic',
+    status: 'completed',
+    stage: 1,
+    deadlineRemaining: 0,
+    durationWeeks: 1,
+    assignedTeamIds: ['t_nightwatch'],
+    missionResult,
+    contract: {
+      templateId: 'oversight-lockdown-retainer',
+      factionId: 'oversight',
+    } satisfies ActiveContractRuntime,
+  } as unknown as WeeklyReportCaseSnapshot
+  return snapshot
+}
+
+describe('SPE-1496 contract debrief record', () => {
+  it('builds a deterministic record capturing changed entities and unresolved clocks', () => {
+    const snapshot = buildSnapshot()
+
+    const first = buildContractDebriefRecord(snapshot, 5)
+    const second = buildContractDebriefRecord(snapshot, 5)
+
+    expect(first).not.toBeNull()
+    expect(second).toEqual(first)
+
+    expect(first!.caseId).toBe('case-debrief')
+    expect(first!.contractTemplateId).toBe('oversight-lockdown-retainer')
+    expect(first!.factionId).toBe('oversight')
+    expect(first!.outcome).toBe('partial')
+    expect(first!.week).toBe(5)
+
+    // Subject + injury + fatigue + faction shift + evidence + route should all surface.
+    const kinds = new Set(first!.changedEntities.map((entity) => entity.kind))
+    expect(kinds.has('subject')).toBe(true)
+    expect(kinds.has('staff')).toBe(true)
+    expect(kinds.has('faction')).toBe(true)
+    expect(kinds.has('evidence')).toBe(true)
+    expect(kinds.has('route')).toBe(true)
+
+    // Unresolved clocks: recovery pressure + spawned follow-up consequence.
+    expect(first!.unresolvedClocks.map((clock) => clock.id).sort()).toEqual(
+      ['consequence:case-followup', 'recovery:case-debrief'].sort()
+    )
+
+    // Strategic options are bounded subset of ContractNextIntent.
+    const intentSet = new Set(getContractNextIntentValues())
+    for (const option of first!.strategicOptions) {
+      expect(intentSet.has(option.intent)).toBe(true)
+      expect(option.label).toBe(getContractNextIntentLabel(option.intent))
+    }
+
+    // Each suggested intent appears at most once.
+    const intents = first!.strategicOptions.map((option) => option.intent)
+    expect(new Set(intents).size).toBe(intents.length)
+  })
+
+  it('returns null when the snapshot has no completed mission result', () => {
+    const snapshot = {
+      caseId: 'case-blank',
+      title: 'Empty',
+      kind: 'standard',
+      mode: 'deterministic',
+      status: 'in_progress',
+      stage: 1,
+      deadlineRemaining: 0,
+      durationWeeks: 1,
+      assignedTeamIds: [],
+    } as unknown as WeeklyReportCaseSnapshot
+
+    expect(buildContractDebriefRecord(snapshot, 1)).toBeNull()
+  })
+
+  it('falls back to the case instance contract runtime when the snapshot lacks one', () => {
+    const snapshot = buildSnapshot()
+    // Strip the snapshot-side contract to force the case-instance fallback.
+    delete (snapshot as { contract?: unknown }).contract
+
+    const caseInstance = {
+      id: 'case-debrief',
+      contract: { templateId: 'institutions-ritual-archive', factionId: 'institutions' },
+    } as unknown as CaseInstance
+
+    const record = buildContractDebriefRecord(snapshot, 7, caseInstance)
+    expect(record).not.toBeNull()
+    expect(record!.contractTemplateId).toBe('institutions-ritual-archive')
+    expect(record!.factionId).toBe('institutions')
+  })
+
+  it('reads the latest weekly report and emits debrief records ordered by case id', () => {
+    const baseSnapshot = buildSnapshot()
+    const secondSnapshot = {
+      ...baseSnapshot,
+      caseId: 'aaa-case',
+      title: 'Aaa Case',
+    } as WeeklyReportCaseSnapshot
+    Object.defineProperty(secondSnapshot, 'caseId', { value: 'aaa-case', enumerable: true })
+
+    const report: WeeklyReport = {
+      week: 12,
+      summary: '',
+      events: [],
+      caseSnapshots: {
+        [baseSnapshot.caseId]: baseSnapshot,
+        [secondSnapshot.caseId]: secondSnapshot,
+      },
+    } as unknown as WeeklyReport
+
+    const state = {
+      reports: [report],
+      cases: {},
+    }
+
+    const records = getRecentContractDebriefRecords(state)
+    expect(records.length).toBe(2)
+    expect(records[0]!.caseId).toBe('aaa-case')
+    expect(records[1]!.caseId).toBe('case-debrief')
+  })
+})
+
+describe('SPE-1496 next-intent capture', () => {
+  it('captures the canonical bounded set and clears cleanly', () => {
+    const state = createStartingState()
+
+    expect(getContractNextIntent(state)).toBeNull()
+
+    const captured = setContractNextIntent(state, 'pursue-faction')
+    expect(getContractNextIntent(captured)).toBe('pursue-faction')
+    expect(captured.contracts?.nextIntentCapturedWeek).toBe(state.week)
+
+    const cleared = clearContractNextIntent(captured)
+    expect(getContractNextIntent(cleared)).toBeNull()
+    expect(cleared.contracts?.nextIntentCapturedWeek).toBeUndefined()
+  })
+
+  it('exposes a stable enum surface for UI iteration', () => {
+    const values = getContractNextIntentValues()
+    expect(values.length).toBeGreaterThan(0)
+    for (const value of values) {
+      const label = getContractNextIntentLabel(value)
+      expect(typeof label).toBe('string')
+      expect(label.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+function regenerateBoard(state: ReturnType<typeof createStartingState>) {
+  // Bump week to force `refreshContractBoard` past its `generatedWeek === week`
+  // early-return without dropping the captured next intent.
+  return refreshContractBoard({ ...state, week: state.week + 1 })
+}
+
+describe('SPE-1496 next-intent contract suggestion bias', () => {
+  it('returns zero bias when no intent is captured and non-zero when one is', () => {
+    const state = createStartingState()
+    // Use a real definition surfaced on the board.
+    const definition = {
+      id: 'oversight-lockdown-retainer',
+      caseTemplateId: 'institutions-ritual-archive',
+      name: 'Oversight Lockdown Retainer',
+      description: '',
+      strategyTag: 'income',
+      durationWeeks: 1,
+      factionId: 'oversight',
+      requirements: { recommendedClasses: [], discouragedClasses: [] },
+      modifiers: [],
+      chain: {},
+    } as unknown as Parameters<typeof getNextIntentSelectionBias>[1]
+
+    expect(getNextIntentSelectionBias(state, definition)).toBe(0)
+
+    const stabilizing = setContractNextIntent(state, 'stabilize-staff')
+    expect(getNextIntentSelectionBias(stabilizing, definition)).toBeGreaterThan(0)
+  })
+
+  it('produces distinct bias magnitudes for different intents on the same definition', () => {
+    const state = createStartingState()
+    const incomeDefinition = {
+      id: 'income-test',
+      caseTemplateId: 'income-test-case',
+      name: 'Income Test',
+      description: '',
+      strategyTag: 'income',
+      durationWeeks: 1,
+      requirements: { recommendedClasses: [], discouragedClasses: [] },
+      modifiers: [],
+      chain: {},
+    } as unknown as Parameters<typeof getNextIntentSelectionBias>[1]
+    const materialsDefinition = {
+      ...incomeDefinition,
+      id: 'materials-test',
+      name: 'Materials Test',
+      strategyTag: 'materials',
+    } as unknown as Parameters<typeof getNextIntentSelectionBias>[1]
+
+    const stabilizing = setContractNextIntent(state, 'stabilize-staff')
+    const equipping = setContractNextIntent(state, 'prepare-equipment')
+
+    expect(getNextIntentSelectionBias(stabilizing, incomeDefinition)).toBeGreaterThan(
+      getNextIntentSelectionBias(stabilizing, materialsDefinition)
+    )
+    expect(getNextIntentSelectionBias(equipping, materialsDefinition)).toBeGreaterThan(
+      getNextIntentSelectionBias(equipping, incomeDefinition)
+    )
+  })
+
+  it('preserves the captured next intent across `refreshContractBoard`', () => {
+    const base = createStartingState()
+    const captured = setContractNextIntent(base, 'chase-lead')
+    const regenerated = regenerateBoard(captured)
+    expect(regenerated.contracts?.nextIntent).toBe('chase-lead')
+    expect(regenerated.contracts?.nextIntentCapturedWeek).toBe(base.week)
+  })
+
+  it('keeps board generation deterministic for a fixed captured intent', () => {
+    const base = createStartingState()
+    const stabilizingA = regenerateBoard(setContractNextIntent(base, 'stabilize-staff'))
+    const stabilizingB = regenerateBoard(setContractNextIntent(base, 'stabilize-staff'))
+    expect(getContractOffers(stabilizingA).map((offer) => offer.templateId)).toEqual(
+      getContractOffers(stabilizingB).map((offer) => offer.templateId)
+    )
+  })
+
+  it('keeps the bias bounded so it cannot override unlock conditions', () => {
+    const state = createStartingState()
+    const definition = {
+      id: 'oversight-lockdown-retainer',
+      caseTemplateId: 'institutions-ritual-archive',
+      name: 'Oversight Lockdown Retainer',
+      description: '',
+      strategyTag: 'income',
+      durationWeeks: 1,
+      factionId: 'oversight',
+      requirements: { recommendedClasses: [], discouragedClasses: [] },
+      modifiers: [],
+      chain: {},
+    } as unknown as Parameters<typeof getNextIntentSelectionBias>[1]
+
+    for (const intent of getContractNextIntentValues()) {
+      const captured = setContractNextIntent(state, intent)
+      const bias = getNextIntentSelectionBias(captured, definition)
+      // Total bias is always bounded — the largest single positive lever is the
+      // `chase-lead` chain continuation case at +0.55, and the cap on any
+      // composite term stays under ~1.0 by construction.
+      expect(Math.abs(bias)).toBeLessThan(1)
+    }
+  })
+})

--- a/src/test/contractsDebrief.test.ts
+++ b/src/test/contractsDebrief.test.ts
@@ -21,6 +21,7 @@ import {
   getNextIntentSelectionBias,
   getRecentContractDebriefRecords,
   refreshContractBoard,
+  sanitizeContractSystemState,
   setContractNextIntent,
 } from '../domain/contracts'
 import type {
@@ -60,7 +61,13 @@ function buildSnapshot(): WeeklyReportCaseSnapshot {
       strategicValueDelta: 0,
       reputationDelta: 0,
       inventoryRewards: [
-        { kind: 'material', itemId: 'shard-fragment', label: 'Shard Fragment', quantity: 2, tags: [] },
+        {
+          kind: 'material',
+          itemId: 'shard-fragment',
+          label: 'Shard Fragment',
+          quantity: 2,
+          tags: [],
+        },
       ],
       factionStanding: [
         { factionId: 'oversight', label: 'Oversight Bureau', delta: 2, overlapTags: [] },
@@ -183,7 +190,75 @@ describe('SPE-1496 contract debrief record', () => {
     expect(record!.factionId).toBe('institutions')
   })
 
-  it('reads the latest weekly report and emits debrief records ordered by case id', () => {
+  it('SPE-1496 (PR #1621 review fix): empty case-instance contract does not block a valid snapshot contract', () => {
+    const snapshot = buildSnapshot()
+    // The case-instance contract object exists but carries no templateId,
+    // which used to short-circuit the snapshot fallback. After the fix it
+    // should merge per-field and still resolve to the snapshot's templateId.
+    const caseInstance = {
+      id: 'case-debrief',
+      contract: {},
+    } as unknown as CaseInstance
+
+    const record = buildContractDebriefRecord(snapshot, 9, caseInstance)
+    expect(record).not.toBeNull()
+    expect(record!.contractTemplateId).toBe('oversight-lockdown-retainer')
+    expect(record!.factionId).toBe('oversight')
+  })
+
+  it('SPE-1496 (PR #1621 review fix): per-field merge prefers case-instance fields when present', () => {
+    const snapshot = buildSnapshot()
+    // Snapshot side has both templateId + factionId. The case-instance side
+    // only supplies a templateId — factionId must still fall back to snapshot.
+    const caseInstance = {
+      id: 'case-debrief',
+      contract: { templateId: 'institutions-ritual-archive' },
+    } as unknown as CaseInstance
+
+    const record = buildContractDebriefRecord(snapshot, 9, caseInstance)
+    expect(record).not.toBeNull()
+    expect(record!.contractTemplateId).toBe('institutions-ritual-archive')
+    expect(record!.factionId).toBe('oversight')
+  })
+
+  it('SPE-1496 (PR #1621 review fix): infers pursue-faction from numeric standing delta, not detail text', () => {
+    const snapshot = buildSnapshot()
+    const record = buildContractDebriefRecord(snapshot, 11)
+    expect(record).not.toBeNull()
+    // The base snapshot has a faction standing delta of +2 for the bound
+    // faction. The pursue-faction option must surface based on the structured
+    // numeric delta, not because the changed-entity detail string contains '+'.
+    const intents = record!.strategicOptions.map((option) => option.intent)
+    expect(intents).toContain('pursue-faction')
+  })
+
+  it('SPE-1496 (PR #1621 review fix): no pursue-faction when all faction-standing deltas are non-positive', () => {
+    const base = buildSnapshot()
+    const negativeStanding = {
+      ...base,
+      missionResult: {
+        ...base.missionResult!,
+        rewards: {
+          ...base.missionResult!.rewards,
+          factionStanding: [
+            {
+              factionId: 'oversight',
+              label: 'Oversight Bureau',
+              delta: -3,
+              overlapTags: [],
+            },
+          ],
+        },
+      },
+    } as unknown as WeeklyReportCaseSnapshot
+
+    const record = buildContractDebriefRecord(negativeStanding, 11)
+    expect(record).not.toBeNull()
+    const intents = record!.strategicOptions.map((option) => option.intent)
+    expect(intents).not.toContain('pursue-faction')
+  })
+
+  it('reads the latest weekly report and emits debrief records', () => {
     const baseSnapshot = buildSnapshot()
     const secondSnapshot = {
       ...baseSnapshot,
@@ -208,9 +283,111 @@ describe('SPE-1496 contract debrief record', () => {
     }
 
     const records = getRecentContractDebriefRecords(state)
+    // Both snapshots share the same `partial` outcome, so urgency-ranked
+    // ordering falls through to the caseId tiebreak.
     expect(records.length).toBe(2)
     expect(records[0]!.caseId).toBe('aaa-case')
     expect(records[1]!.caseId).toBe('case-debrief')
+  })
+
+  it('SPE-1496 (PR #1621 review fix): ranks records by urgency so fail/unresolved lead success', () => {
+    const partial = buildSnapshot()
+    const fail = {
+      ...buildSnapshot(),
+      caseId: 'zzz-fail',
+      title: 'Zeta Failure',
+      missionResult: {
+        ...buildSnapshot().missionResult!,
+        caseId: 'zzz-fail',
+        outcome: 'fail' as const,
+      },
+    } as unknown as WeeklyReportCaseSnapshot
+    Object.defineProperty(fail, 'caseId', { value: 'zzz-fail', enumerable: true })
+    const success = {
+      ...buildSnapshot(),
+      caseId: 'aaa-success',
+      title: 'Alpha Win',
+      missionResult: {
+        ...buildSnapshot().missionResult!,
+        caseId: 'aaa-success',
+        outcome: 'success' as const,
+        // No unresolved consequences for the success record so its rank stays
+        // last on the urgency axis.
+        spawnedConsequences: [],
+        weakestLink: undefined,
+      },
+    } as unknown as WeeklyReportCaseSnapshot
+    Object.defineProperty(success, 'caseId', { value: 'aaa-success', enumerable: true })
+
+    const report: WeeklyReport = {
+      week: 14,
+      summary: '',
+      events: [],
+      caseSnapshots: {
+        [partial.caseId]: partial,
+        [fail.caseId]: fail,
+        [success.caseId]: success,
+      },
+    } as unknown as WeeklyReport
+
+    const records = getRecentContractDebriefRecords({ reports: [report], cases: {} })
+    expect(records.map((record) => record.outcome)).toEqual(['fail', 'partial', 'success'])
+    // The alphabetic-first success case must not become `records[0]` and hide
+    // the failure signal from front-desk attention tone derivation.
+    expect(records[0]!.caseId).toBe('zzz-fail')
+  })
+
+  it('SPE-1496 (PR #1621 review fix): same-urgency records tiebreak on unresolved clock count then caseId', () => {
+    const heavyClocks = {
+      ...buildSnapshot(),
+      caseId: 'mmm-heavy',
+      title: 'Heavy Clocks',
+      missionResult: {
+        ...buildSnapshot().missionResult!,
+        caseId: 'mmm-heavy',
+        outcome: 'partial' as const,
+        spawnedConsequences: [
+          {
+            type: 'queued_follow_up' as const,
+            caseId: 'follow-1',
+            detail: 'First follow-up.',
+          },
+          {
+            type: 'queued_follow_up' as const,
+            caseId: 'follow-2',
+            detail: 'Second follow-up.',
+          },
+        ],
+      },
+    } as unknown as WeeklyReportCaseSnapshot
+    Object.defineProperty(heavyClocks, 'caseId', { value: 'mmm-heavy', enumerable: true })
+    const lightClocks = {
+      ...buildSnapshot(),
+      caseId: 'aaa-light',
+      title: 'Light Clocks',
+      missionResult: {
+        ...buildSnapshot().missionResult!,
+        caseId: 'aaa-light',
+        outcome: 'partial' as const,
+        spawnedConsequences: [],
+        weakestLink: undefined,
+      },
+    } as unknown as WeeklyReportCaseSnapshot
+    Object.defineProperty(lightClocks, 'caseId', { value: 'aaa-light', enumerable: true })
+
+    const report: WeeklyReport = {
+      week: 15,
+      summary: '',
+      events: [],
+      caseSnapshots: {
+        [heavyClocks.caseId]: heavyClocks,
+        [lightClocks.caseId]: lightClocks,
+      },
+    } as unknown as WeeklyReport
+
+    const records = getRecentContractDebriefRecords({ reports: [report], cases: {} })
+    expect(records[0]!.caseId).toBe('mmm-heavy')
+    expect(records[1]!.caseId).toBe('aaa-light')
   })
 })
 
@@ -237,6 +414,37 @@ describe('SPE-1496 next-intent capture', () => {
       expect(typeof label).toBe('string')
       expect(label.length).toBeGreaterThan(0)
     }
+  })
+
+  it('SPE-1496 (PR #1621 review fix): sanitize drops capturedWeek when intent is missing', () => {
+    const state = createStartingState()
+    // Simulate corrupted save data: captured week present, intent absent.
+    const captured = sanitizeContractSystemState(
+      {
+        ...state.contracts,
+        nextIntent: undefined,
+        nextIntentCapturedWeek: 4,
+      },
+      state.contracts
+    )
+
+    expect(captured.nextIntent).toBeUndefined()
+    expect(captured.nextIntentCapturedWeek).toBeUndefined()
+  })
+
+  it('SPE-1496 (PR #1621 review fix): sanitize preserves capturedWeek when intent is valid', () => {
+    const state = createStartingState()
+    const captured = sanitizeContractSystemState(
+      {
+        ...state.contracts,
+        nextIntent: 'chase-lead',
+        nextIntentCapturedWeek: 8,
+      },
+      state.contracts
+    )
+
+    expect(captured.nextIntent).toBe('chase-lead')
+    expect(captured.nextIntentCapturedWeek).toBe(8)
   })
 })
 


### PR DESCRIPTION
## Summary
- Implements the smallest coherent slice of [SPE-1496](https://linear.app/.../SPE-1496) — a bounded post-contract debrief + next-intent flow.
- Adds a deterministic `ContractDebriefRecord` per completed contract operation (latest weekly report) and a bounded `ContractNextIntent` enum the player captures from a compact pill picker.
- Captured next-intent feeds a single additive bias term in `buildSelectionScore` so later contract offer ordering reflects player intent without overriding any unlock conditions or pushing the next contract automatically.
- Surfaces the digest in the Operations Report panel and via a single compact "Post-contract debrief" attention item on the Front Desk.
- No prose recap generator, no planner, no new narrative pipeline.

## Boundary fit
- Reuses `WeeklyReport.caseSnapshots` + `CaseInstance.contract` as the only data sources; no new persistence beyond two fields on `ContractSystemState`.
- Reuses existing operations report and front-desk attention surfaces — no parallel summary system.
- All derivations are pure functions; no side effects, no event-queue interception.
- Bias is bounded (every total stays under 1.0) so it nudges only.

## Files
- `src/domain/models.ts` — `ContractNextIntent`, `ContractDebriefRecord` (+ supporting types), `ContractSystemState.{nextIntent,nextIntentCapturedWeek}`.
- `src/domain/contracts.ts` — debrief helpers (`buildContractDebriefRecord`, `getRecentContractDebriefRecords`), next-intent helpers, `getNextIntentSelectionBias`, preservation across `refreshContractBoard`.
- `src/app/store/gameStore.ts` — `setContractNextIntent` / `clearContractNextIntent` actions.
- `src/features/report/operationsReportView.ts` — `ContractDebriefView` on `OperationsReportView`.
- `src/features/dashboard/OperationsReportPanel.tsx` — debrief article + intent pill set.
- `src/features/operations/frontDeskView.ts` — single bounded debrief attention item.
- `docs/contract-debrief-next-intent-audit.md` — new audit doc covering shapes, pipelines, UI surfaces, and out-of-scope choices.
- `docs/report-notes-audit.md` — cross-reference paragraph.
- `src/test/contractsDebrief.test.ts` — 11 targeted tests.

## Test plan
- [x] `npx vitest run src/test/contractsDebrief.test.ts` — 11 new tests pass.
- [x] `npx vitest run src/test/contracts.test.ts` — 9 existing contract tests still pass.
- [x] `npx vitest run src/features/report/operationsReportView.test.ts` — 8 existing tests still pass.
- [x] `npx vitest run src/test/frontDeskView.test.ts` — 9 existing tests still pass.
- [x] `npx vitest run src/test/sim.validation.test.ts` — 7 deterministic long-run validation tests still pass.
- [x] `npx vitest run src/test/reportNotes.test.ts` — 15 existing tests still pass.
- [x] `npx eslint` on every changed file — clean.
- [x] `npx tsc --build` — no new TS errors; the remaining baseline errors are pre-existing and called out in `AGENTS.md`.

## Out of scope (deliberately)
- Persistent multi-week debrief history (only the latest weekly report is surfaced).
- Richer per-intent UI rationale beyond the strategic-option reasons we already emit.
- A "current focus" pill on the contract board itself.
- Any change to event-queue routing or report-note types.
