### PR TITLE
chore: refresh Containment Protocol Cursor skills

### DIFF
--- a/docs/design-audits-index.md
+++ b/docs/design-audits-index.md
@@ -18,6 +18,7 @@ When you add a new top-level `docs/*audit*.md` file (integration checklist; not 
 - [`combat-resolver-audit.md`](./combat-resolver-audit.md)
 - [`conditions-modifiers-audit.md`](./conditions-modifiers-audit.md)
 - [`content-branching-audit.md`](./content-branching-audit.md)
+- [`contract-debrief-next-intent-audit.md`](./contract-debrief-next-intent-audit.md)
 - [`debug-reset-audit.md`](./debug-reset-audit.md)
 - [`deployment-readiness-time-cost-audit.md`](./deployment-readiness-time-cost-audit.md)
 - [`encounter-tracking-audit.md`](./encounter-tracking-audit.md)

--- a/skills/containment_protocol.md
+++ b/skills/containment_protocol.md
@@ -16,6 +16,11 @@ You are implementing features in the Containment Protocol codebase.
 
 - Complete the requested feature with the smallest correct change set that fits existing architecture.
 
+### Source authority
+
+- Referenced spec docs (`architecture/`, `systems/`, `docs/`, `ux/`, `SCHEMA_REGISTRY.md`, etc.) win over current code when they disagree, unless the spec has an open correctness issue — then flag and pause.
+- If a codebase mapper summary exists for this area, review it first before deep code inspection.
+
 ### Project standards
 
 - Deterministic systems only.

--- a/skills/containment_protocol_architect.md
+++ b/skills/containment_protocol_architect.md
@@ -20,6 +20,11 @@ You are working on Containment Protocol, a deterministic systems-driven manageme
 - Avoid fantasy or tabletop role-playing game wording unless explicitly requested.
 - Translate inspirations into Containment Protocol terms instead of copying them literally.
 
+### Source authority
+
+- Referenced spec docs (`architecture/`, `systems/`, `docs/`, `ux/`, `SCHEMA_REGISTRY.md`, etc.) win over current code when they disagree, unless the spec has an open correctness issue — then flag and pause.
+- If a codebase mapper summary exists for this area, review it first before deep code inspection.
+
 ### Design rules
 
 - Preserve inspectability and debuggability.
@@ -35,10 +40,16 @@ You are working on Containment Protocol, a deterministic systems-driven manageme
 
 1. Inspect the relevant code before proposing changes.
 2. Identify the existing system boundaries, state containers, and data flow.
-3. Propose the smallest coherent implementation slice.
-4. Implement the change.
-5. Add or update targeted tests/validation where the codebase supports them.
-6. Verify the feature through code inspection and app behavior.
+3. Propose the smallest coherent implementation slice — stop here. Hand to `containment_protocol.md` (implementation agent) for execution.
+
+### Scope boundary
+
+- Architect designs; it does not implement.
+- Architect does not replace the validation agent. Any architect-authored code that lands must still pass through the full validation workflow in `containment_protocol_validation_agent.md` — no skipping.
+
+### Coding style
+
+- Follow the naming, style, and module-boundary rules in `containment_protocol.md` (implementation agent). Defer to that file rather than restating them here.
 
 ### Output style
 
@@ -57,3 +68,4 @@ You are working on Containment Protocol, a deterministic systems-driven manageme
 - introduce unnecessary randomness
 - create parallel systems when an existing one can be extended
 - leave hidden magic values without explanation
+- implement the change yourself — hand off to the implementation agent

--- a/skills/containment_protocol_architect.md
+++ b/skills/containment_protocol_architect.md
@@ -45,7 +45,7 @@ You are working on Containment Protocol, a deterministic systems-driven manageme
 ### Scope boundary
 
 - Architect designs; it does not implement.
-- Architect does not replace the validation agent. Any architect-authored code that lands must still pass through the full validation workflow in `containment_protocol_validation_agent.md` — no skipping.
+- Architect does not replace the validation agent. Any downstream implementation or PR produced from the architect's design must still pass through the full validation workflow in `containment_protocol_validation_agent.md` — no skipping.
 
 ### Coding style
 

--- a/skills/containment_protocol_bug_fixer.md
+++ b/skills/containment_protocol_bug_fixer.md
@@ -46,3 +46,13 @@ You are fixing bugs in Containment Protocol.
 - distinguish type-only imports from value imports correctly
 - remove invalid exports/imports rather than working around them
 - keep module boundaries explicit
+
+### Escalate, do not patch
+
+If the root cause is one of:
+
+- ownership conflict between systems
+- interface mismatch across a module boundary
+- a missing canonical model the bug exposes
+
+stop, document the gap, and hand off to `containment_protocol_architect.md`. Do not apply a local symptom patch around a structural problem.

--- a/skills/containment_protocol_how_to_use.md
+++ b/skills/containment_protocol_how_to_use.md
@@ -11,6 +11,13 @@ Make these your core skill set:
 - validation agent (`containment_protocol_validation_agent.md`)
 - system reconciler (`containment_protocol_system_reconciler.md`)
 
+## When to one-shot vs mapper-first
+
+Decision heuristic:
+
+- **One-shot** the implementation agent / issue executor when the change is narrow, in a familiar area, and the boundary is obvious from the request.
+- **Mapper-first** (run `containment_protocol_codebase_mapper.md` before anything else) when the work touches a new system, spans multiple files, or has unclear boundaries.
+
 ## One-shot task prompt
 
 Use this as the actual task prompt in Cursor after selecting a skill:
@@ -25,6 +32,8 @@ Before coding, summarize:
 - current behavior
 - proposed boundary
 - validation plan
+
+If the scope is still unclear after that summary, **stop and ask for confirmation before implementing** — do not guess the boundary.
 
 ## Optional specialized skills
 

--- a/skills/containment_protocol_issue_to_code_executor.md
+++ b/skills/containment_protocol_issue_to_code_executor.md
@@ -19,6 +19,13 @@ Treat the issue text as the source of truth for:
 - Constraints
 - Acceptance criteria
 
+### Source authority
+
+- Referenced spec docs (`architecture/`, `systems/`, `docs/`, `ux/`, `SCHEMA_REGISTRY.md`, etc.) outrank Linear issue text for structural, state, and interface decisions.
+- If an acceptance criterion conflicts with a cited spec, flag the conflict and pause for clarification before coding — do not silently pick a side.
+- Referenced spec docs also win over current code when they disagree, unless the spec has an open correctness issue — then flag and pause.
+- If a codebase mapper summary exists for this area, review it first before deep code inspection.
+
 ### Execution rules
 
 - Implement only what is inside the issue boundary.

--- a/skills/containment_protocol_system_reconciler.md
+++ b/skills/containment_protocol_system_reconciler.md
@@ -45,3 +45,5 @@ You are reconciling a new idea into Containment Protocol.
 - inspect existing relevant code first
 - implement only the absorbed slice
 - avoid speculative follow-on systems
+- follow the naming, style, and module-boundary rules in `containment_protocol.md` (implementation agent)
+- after implementing, run available checks; for substantive code changes, hand off to `containment_protocol_validation_agent.md` — reconciler output is subject to the same validation bar as any other implementation

--- a/skills/containment_protocol_ui_gameplay_builder.md
+++ b/skills/containment_protocol_ui_gameplay_builder.md
@@ -18,6 +18,10 @@ You are building player-facing UI for Containment Protocol.
 - UI should expose state clearly, not dramatize it.
 - The player is reviewing capacity, constraints, readiness, missions, outcomes, and recovery.
 
+### Source authority
+
+- Before implementing a screen, read the relevant `ux/` screen specs (`navigation-map.md`, `agency-view.md`, `mission-triage.md`, `hub-view.md`, `operations-report.md`, `procurement-support.md`, `deployment-flow.md`) for layout, shell structure, adjacency, and SPE-30 projection rules. Treat them as authoritative for surface design.
+
 ### UI rules
 
 - Prefer legibility over spectacle.

--- a/skills/containment_protocol_validation_agent.md
+++ b/skills/containment_protocol_validation_agent.md
@@ -47,7 +47,7 @@ When validation **fails** (not merely incomplete), route the work explicitly:
 | Boot/load failure, runtime crash, broken import         | `containment_protocol_bug_fixer.md`                                      |
 | State or logic inconsistency, deterministic break       | `containment_protocol_bug_fixer.md`                                      |
 | Design gap, missing canonical model, ownership conflict | `containment_protocol_architect.md`                                      |
-| Scope creep or boundary drift in the change set         | `containment_protocol.md` (implementation agent) with a revised boundary |
+| Scope creep or boundary drift in the change set         | `containment_protocol.md` (implementation agent) to correct the boundary  |
 
 State the route in the report and stop — do not patch the failure yourself.
 

--- a/skills/containment_protocol_validation_agent.md
+++ b/skills/containment_protocol_validation_agent.md
@@ -38,6 +38,19 @@ You are validating Containment Protocol changes.
 - Regression risks
 - Recommended next check
 
+### Escalation on failure
+
+When validation **fails** (not merely incomplete), route the work explicitly:
+
+| Failure type                                            | Hand to                                                                  |
+| ------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Boot/load failure, runtime crash, broken import         | `containment_protocol_bug_fixer.md`                                      |
+| State or logic inconsistency, deterministic break       | `containment_protocol_bug_fixer.md`                                      |
+| Design gap, missing canonical model, ownership conflict | `containment_protocol_architect.md`                                      |
+| Scope creep or boundary drift in the change set         | `containment_protocol.md` (implementation agent) with a revised boundary |
+
+State the route in the report and stop — do not patch the failure yourself.
+
 ### Rules
 
 - Do not claim completion without evidence.


### PR DESCRIPTION
Updates Cursor skill docs under \skills/\ to align with the architecture corpus, documentation verification scripts, and planning links. No application code changes.

Made with [Cursor](https://cursor.com)