### PR TITLE
SPE-99: fieldBase recovery validity + deployed fatigue scaling

### DIFF
--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -6,6 +6,12 @@
 - **Trauma Recovery:** Long-term effects from critical failures, fatalities, or mission trauma.
 - **Downtime Recovery:** General rest, recuperation, and non-mission activities (training, therapy, R&R).
 
+## 1b. Expedition field staging & recovery validity (SPE-99 / SPE-1654)
+
+- Contracts may attach an optional `fieldBase` packet on `contract.fieldBase` with compact bands `medical`, `safety`, and `sustenance` (each 0..2) for an **in-progress** expedition case.
+- `expeditionRecoveryNode` deterministically maps those bands to recovery modes (`unsafe_pause`, `ordinary_rest`, `active_recovery`, `sanctuary_recovery`) and scales **deployed** scalar mission fatigue accumulation in the main `advanceWeek` weekly pass: protected staging lowers weekly strain versus unsecured operations; exposed staging (`safety` 0) applies a bounded surcharge instead of a universal off-map reset.
+- Broader human energy budgeting and appetite-linked demand stay on **SPE-1107**; impairment gates that block recovery stay on **SPE-1653**.
+
 ## 2. Recommended Canonical State Fields
 - `agent.recoveryStatus`: { state: 'healthy' | 'recovering' | 'traumatized' | 'incapacitated', detail?: string, sinceWeek: number }
 - `agent.trauma`: { traumaLevel: number, traumaTags: string[], lastEventWeek: number }

--- a/src/domain/contracts.ts
+++ b/src/domain/contracts.ts
@@ -21,6 +21,7 @@ import type {
   ContractDebriefStrategicOption,
   ContractDebriefUnresolvedClock,
   ContractHistoryRecord,
+  FieldBaseQualityBands,
   ContractMaterialDrop,
   ContractModifier,
   ContractNextIntent,
@@ -127,6 +128,8 @@ interface ContractTemplateDefinition {
   requirements: ContractOffer['requirements']
   modifiers: ContractModifier[]
   chain: ContractChainDefinition
+  /** SPE-99 / SPE-1654: optional expedition staging packet carried onto offers and cases. */
+  fieldBase?: FieldBaseQualityBands
   availability?: {
     minFactionTier?: ReputationTier
     maxFactionTier?: ReputationTier
@@ -727,6 +730,7 @@ const CONTRACT_TEMPLATES: readonly ContractTemplateDefinition[] = [
         value: 2.2,
       },
     ],
+    fieldBase: { medical: 2, safety: 2, sustenance: 1 },
     chain: {
       unlockConditions: [{ type: 'progression_unlock', unlockId: 'containment-liturgy' }],
     },
@@ -1066,6 +1070,7 @@ function buildContractCaseSkeleton(
     | 'requirements'
     | 'modifiers'
     | 'chain'
+    | 'fieldBase'
   >,
   template: CaseTemplate,
   caseId: string,
@@ -1100,6 +1105,7 @@ function buildContractCaseSkeleton(
             }
           : {}),
       },
+      ...(offer.fieldBase ? { fieldBase: { ...offer.fieldBase } } : {}),
     } satisfies ActiveContractRuntime,
     // Contracts always use probabilistic resolution so preview bands and live results
     // share the same continuous success model regardless of the source template mode.
@@ -1641,6 +1647,7 @@ function buildOfferFromDefinition(
       requirements: definition.requirements,
       modifiers: definition.modifiers.map((modifier) => ({ ...modifier })),
       chain: definition.chain,
+      ...(definition.fieldBase ? { fieldBase: definition.fieldBase } : {}),
     },
     template,
     `contract-preview-${definition.id}`,
@@ -1680,6 +1687,7 @@ function buildOfferFromDefinition(
     },
     strategyTag: definition.strategyTag,
     generatedWeek: state.week,
+    ...(definition.fieldBase ? { fieldBase: { ...definition.fieldBase } } : {}),
   }
 }
 

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -876,6 +876,16 @@ export interface ContractChainDefinition {
   }>
 }
 
+/**
+ * SPE-99 / SPE-1654: compact field-staging quality for expedition recovery validity
+ * (0 harsh .. 2 secured). Used only where a contract authors an explicit staging packet.
+ */
+export interface FieldBaseQualityBands {
+  medical: 0 | 1 | 2
+  safety: 0 | 1 | 2
+  sustenance: 0 | 1 | 2
+}
+
 export interface ContractOffer {
   id: Id
   templateId: Id
@@ -895,6 +905,8 @@ export interface ContractOffer {
   chain: ContractChainDefinition
   lootTableId?: string
   generatedWeek?: number
+  /** Optional expedition staging packet; see `expeditionRecoveryNode`. */
+  fieldBase?: FieldBaseQualityBands
 }
 
 export interface ContractHistoryRecord {
@@ -981,6 +993,7 @@ export interface ActiveContractRuntime {
   requirements?: ContractRequirements
   modifiers?: ContractModifier[]
   chain?: ContractChainDefinition
+  fieldBase?: FieldBaseQualityBands
 }
 
 export interface ContractSystemState {

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -680,7 +680,9 @@ function applyAgentFatigue(
   config: GameState['config'],
   activeTeamIds: string[],
   cases: GameState['cases'],
-  activeTeamStressModifiers: Record<string, number> = {}
+  activeTeamStressModifiers: Record<string, number> = {},
+  /** SPE-99: week-close fatigue runs after assignment release; use pre-resolution snapshot for fieldBase modes. */
+  deployedRecoveryLookup?: { teams: GameState['teams']; cases: GameState['cases'] }
 ) {
   const activeAgentStressById = new Map<string, number>()
   const activeAgentIds = new Set(
@@ -703,7 +705,13 @@ function applyAgentFatigue(
   )
   const missionFatigue = getMissionFatigue(config)
   const recoveryFatigue = getRecoveryFatigue(config)
-  const recoveryModeByAgent = buildDeployedRecoveryModeByAgentId(teams, cases, activeTeamIds)
+  const recoveryTeams = deployedRecoveryLookup?.teams ?? teams
+  const recoveryCases = deployedRecoveryLookup?.cases ?? cases
+  const recoveryModeByAgent = buildDeployedRecoveryModeByAgentId(
+    recoveryTeams,
+    recoveryCases,
+    activeTeamIds
+  )
 
   return Object.fromEntries(
     Object.entries(agents).map(([id, agent]) => {
@@ -3160,7 +3168,8 @@ function settleWeekState(context: WeeklyExecutionContext, rng: SeededRng) {
     context.sourceState.config,
     [...context.activeTeamIds],
     context.nextState.cases,
-    context.activeTeamStressModifiers
+    context.activeTeamStressModifiers,
+    { teams: context.sourceState.teams, cases: context.sourceState.cases }
   )
   const directiveAdjustedAgents =
     context.selectedDirectiveId === 'recovery-rotation'

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -201,6 +201,10 @@ import {
   decrementOpenDeadline,
 } from './escalation'
 import {
+  buildDeployedRecoveryModeByAgentId,
+  scaleDeployedMissionFatigueDelta,
+} from './expeditionRecoveryNode'
+import {
   buildRecruitmentGenerationState,
   generateCandidates,
   removeExpiredCandidates,
@@ -673,6 +677,7 @@ function applyAgentFatigue(
   teams: GameState['teams'],
   config: GameState['config'],
   activeTeamIds: string[],
+  cases: GameState['cases'],
   activeTeamStressModifiers: Record<string, number> = {}
 ) {
   const activeAgentStressById = new Map<string, number>()
@@ -696,14 +701,23 @@ function applyAgentFatigue(
   )
   const missionFatigue = getMissionFatigue(config)
   const recoveryFatigue = getRecoveryFatigue(config)
+  const recoveryModeByAgent = buildDeployedRecoveryModeByAgentId(teams, cases, activeTeamIds)
 
   return Object.fromEntries(
     Object.entries(agents).map(([id, agent]) => {
-      const delta = activeAgentIds.has(id)
-        ? Math.max(1, Math.round(missionFatigue * (1 + (activeAgentStressById.get(id) ?? 0))))
-        : trainingAgentIds.has(id)
-          ? -(agent.recoveryRateBonus ?? 0)
-          : -(recoveryFatigue + (agent.recoveryRateBonus ?? 0))
+      let delta: number
+      if (activeAgentIds.has(id)) {
+        const rawDelta = Math.max(
+          1,
+          Math.round(missionFatigue * (1 + (activeAgentStressById.get(id) ?? 0)))
+        )
+        const mode = recoveryModeByAgent.get(id) ?? 'ordinary_rest'
+        delta = scaleDeployedMissionFatigueDelta(rawDelta, mode)
+      } else if (trainingAgentIds.has(id)) {
+        delta = -(agent.recoveryRateBonus ?? 0)
+      } else {
+        delta = -(recoveryFatigue + (agent.recoveryRateBonus ?? 0))
+      }
 
       return [
         id,
@@ -3131,6 +3145,7 @@ function settleWeekState(context: WeeklyExecutionContext, rng: SeededRng) {
     context.nextState.teams,
     context.sourceState.config,
     [...context.activeTeamIds],
+    context.nextState.cases,
     context.activeTeamStressModifiers
   )
   const directiveAdjustedAgents =

--- a/src/domain/sim/expeditionRecoveryNode.ts
+++ b/src/domain/sim/expeditionRecoveryNode.ts
@@ -1,0 +1,116 @@
+/**
+ * SPE-99 slice: deterministic expedition recovery-node validity for deployed operatives.
+ * Maps optional `fieldBase` staging bands on an in-progress contract to a compact recovery-mode
+ * taxonomy, then scales weekly mission fatigue accumulation (scalar `fatigue` only in this slice).
+ *
+ * Out of scope here: full sustenance simulation, injury gates (SPE-1653), human energy budget (SPE-1107).
+ */
+
+import type { CaseInstance, FieldBaseQualityBands, GameState } from '../models'
+import { getTeamAssignedCaseId, getTeamMemberIds } from '../teamSimulation'
+
+export type ExpeditionRecoveryMode =
+  | 'unsafe_pause'
+  | 'ordinary_rest'
+  | 'active_recovery'
+  | 'sanctuary_recovery'
+
+/** Extra scalar fatigue applied on top of baseline mission strain when staging is exposed. */
+export const UNSAFE_PAUSE_DEPLOYED_FATIGUE_SURCHARGE = 2
+
+/** Multiplier on baseline deployed mission fatigue when secured staging supports active recovery. */
+export const ACTIVE_RECOVERY_DEPLOYED_SCALE = 0.72
+
+/** Multiplier when staging meets sanctuary thresholds (protected deep recovery). */
+export const SANCTUARY_RECOVERY_DEPLOYED_SCALE = 0.55
+
+function isBand(value: unknown): value is 0 | 1 | 2 {
+  return value === 0 || value === 1 || value === 2
+}
+
+export function parseFieldBaseQualityBands(raw: unknown): FieldBaseQualityBands | null {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+  const record = raw as Record<string, unknown>
+  if (!isBand(record.medical) || !isBand(record.safety) || !isBand(record.sustenance)) {
+    return null
+  }
+  return { medical: record.medical, safety: record.safety, sustenance: record.sustenance }
+}
+
+/**
+ * Deterministic ladder from authored staging bands to recovery mode.
+ * - safety 0: exposed halt (unsafe_pause)
+ * - safety 1: harsh camp / ordinary operational rest surface
+ * - safety 2 + strong medical + sustenance: sanctuary-grade protected recovery
+ * - safety 2 + medical support: active recovery surface
+ */
+export function resolveExpeditionRecoveryModeFromBands(bands: FieldBaseQualityBands): ExpeditionRecoveryMode {
+  if (bands.safety <= 0) {
+    return 'unsafe_pause'
+  }
+  if (bands.safety === 1) {
+    return 'ordinary_rest'
+  }
+  if (bands.medical >= 2 && bands.sustenance >= 1) {
+    return 'sanctuary_recovery'
+  }
+  if (bands.medical >= 1) {
+    return 'active_recovery'
+  }
+  return 'ordinary_rest'
+}
+
+export function resolveDeployedRecoveryModeForCase(
+  currentCase: CaseInstance | undefined
+): ExpeditionRecoveryMode {
+  if (!currentCase || currentCase.status !== 'in_progress') {
+    return 'ordinary_rest'
+  }
+  const bands = parseFieldBaseQualityBands(currentCase.contract?.fieldBase)
+  if (!bands) {
+    return 'ordinary_rest'
+  }
+  return resolveExpeditionRecoveryModeFromBands(bands)
+}
+
+export function buildDeployedRecoveryModeByAgentId(
+  teams: GameState['teams'],
+  cases: GameState['cases'],
+  activeTeamIds: readonly string[]
+): Map<string, ExpeditionRecoveryMode> {
+  const map = new Map<string, ExpeditionRecoveryMode>()
+  for (const teamId of activeTeamIds) {
+    const team = teams[teamId]
+    if (!team) {
+      continue
+    }
+    const caseId = getTeamAssignedCaseId(team)
+    const mode = resolveDeployedRecoveryModeForCase(caseId ? cases[caseId] : undefined)
+    for (const agentId of getTeamMemberIds(team)) {
+      map.set(agentId, mode)
+    }
+  }
+  return map
+}
+
+export function scaleDeployedMissionFatigueDelta(
+  rawDelta: number,
+  mode: ExpeditionRecoveryMode
+): number {
+  switch (mode) {
+    case 'unsafe_pause':
+      return rawDelta + UNSAFE_PAUSE_DEPLOYED_FATIGUE_SURCHARGE
+    case 'ordinary_rest':
+      return rawDelta
+    case 'active_recovery':
+      return Math.max(1, Math.round(rawDelta * ACTIVE_RECOVERY_DEPLOYED_SCALE))
+    case 'sanctuary_recovery':
+      return Math.max(1, Math.round(rawDelta * SANCTUARY_RECOVERY_DEPLOYED_SCALE))
+    default: {
+      const exhaustive: never = mode
+      return exhaustive
+    }
+  }
+}

--- a/src/test/expeditionRecoveryNode.test.ts
+++ b/src/test/expeditionRecoveryNode.test.ts
@@ -222,4 +222,44 @@ describe('expeditionRecoveryNode (SPE-99)', () => {
     expect(deltaStripped).toBe(10)
     expect(deltaSanctuary).toBe(Math.max(1, Math.round(10 * SANCTUARY_RECOVERY_DEPLOYED_SCALE)))
   })
+
+  it('fieldBase sanctuary scaling still applies on the final deployed week before case resolution', () => {
+    const base = createStartingState()
+    const unlocked = refreshContractBoard({
+      ...base,
+      factions: {
+        ...base.factions!,
+        institutions: {
+          ...base.factions!.institutions,
+          reputation: 52,
+          reputationTier: 'friendly',
+        },
+      },
+      agency: {
+        ...base.agency!,
+        progressionUnlockIds: ['containment-liturgy'],
+      },
+      contracts: undefined,
+    })
+    const offer = getContractOffers(unlocked).find((o) => o.templateId === 'institutions-liturgy-expedition')!
+    let state = launchContract(unlocked, offer.id, 't_nightwatch')
+    state = {
+      ...state,
+      config: { ...state.config, durationModel: 'attrition', attritionPerWeek: 10 },
+    }
+    const caseEntry = Object.values(state.cases).find((c) => c.contract?.offerId === offer.id)!
+    const agentId = state.teams.t_nightwatch.agentIds[0]!
+
+    state = {
+      ...state,
+      cases: {
+        ...state.cases,
+        [caseEntry.id]: { ...caseEntry, weeksRemaining: 1 },
+      },
+    }
+    const fatigueBefore = state.agents[agentId]!.fatigue
+    const after = advanceWeek(state)
+    const delta = after.agents[agentId]!.fatigue - fatigueBefore
+    expect(delta).toBe(Math.max(1, Math.round(10 * SANCTUARY_RECOVERY_DEPLOYED_SCALE)))
+  })
 })

--- a/src/test/expeditionRecoveryNode.test.ts
+++ b/src/test/expeditionRecoveryNode.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { refreshContractBoard, getContractOffers, launchContract } from '../domain/contracts'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import {
+  ACTIVE_RECOVERY_DEPLOYED_SCALE,
+  SANCTUARY_RECOVERY_DEPLOYED_SCALE,
+  UNSAFE_PAUSE_DEPLOYED_FATIGUE_SURCHARGE,
+  buildDeployedRecoveryModeByAgentId,
+  parseFieldBaseQualityBands,
+  resolveDeployedRecoveryModeForCase,
+  resolveExpeditionRecoveryModeFromBands,
+  scaleDeployedMissionFatigueDelta,
+} from '../domain/sim/expeditionRecoveryNode'
+import type { CaseInstance, GameState } from '../domain/models'
+
+describe('expeditionRecoveryNode (SPE-99)', () => {
+  it('parses only well-formed field base bands', () => {
+    expect(parseFieldBaseQualityBands(null)).toBeNull()
+    expect(parseFieldBaseQualityBands({ medical: 2, safety: 1 })).toBeNull()
+    expect(parseFieldBaseQualityBands({ medical: 2, safety: 1, sustenance: 3 })).toBeNull()
+    expect(parseFieldBaseQualityBands({ medical: 2, safety: 1, sustenance: 0 })).toEqual({
+      medical: 2,
+      safety: 1,
+      sustenance: 0,
+    })
+  })
+
+  it('classifies recovery modes from staging bands', () => {
+    expect(
+      resolveExpeditionRecoveryModeFromBands({ medical: 1, safety: 0, sustenance: 2 })
+    ).toBe('unsafe_pause')
+    expect(
+      resolveExpeditionRecoveryModeFromBands({ medical: 2, safety: 1, sustenance: 2 })
+    ).toBe('ordinary_rest')
+    expect(
+      resolveExpeditionRecoveryModeFromBands({ medical: 1, safety: 2, sustenance: 0 })
+    ).toBe('active_recovery')
+    expect(
+      resolveExpeditionRecoveryModeFromBands({ medical: 2, safety: 2, sustenance: 1 })
+    ).toBe('sanctuary_recovery')
+  })
+
+  it('resolves ordinary_rest for non-in-progress cases or missing field base', () => {
+    const open: CaseInstance = {
+      id: 'c1',
+      templateId: 't1',
+      title: '',
+      description: '',
+      mode: 'probability',
+      kind: 'investigation',
+      status: 'open',
+      difficulty: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      weights: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      tags: [],
+      requiredTags: [],
+      preferredTags: [],
+      stage: 1,
+      durationWeeks: 2,
+      deadlineWeeks: 4,
+      deadlineRemaining: 4,
+      assignedTeamIds: [],
+      contract: { fieldBase: { medical: 2, safety: 2, sustenance: 1 } },
+      onFail: { type: 'none' },
+      onUnresolved: { type: 'none' },
+    }
+    expect(resolveDeployedRecoveryModeForCase(open)).toBe('ordinary_rest')
+
+    const inProgressNoBase: CaseInstance = { ...open, status: 'in_progress', contract: {} }
+    expect(resolveDeployedRecoveryModeForCase(inProgressNoBase)).toBe('ordinary_rest')
+  })
+
+  it('scales deployed mission fatigue deltas deterministically', () => {
+    expect(scaleDeployedMissionFatigueDelta(10, 'ordinary_rest')).toBe(10)
+    expect(scaleDeployedMissionFatigueDelta(10, 'unsafe_pause')).toBe(
+      10 + UNSAFE_PAUSE_DEPLOYED_FATIGUE_SURCHARGE
+    )
+    expect(scaleDeployedMissionFatigueDelta(10, 'active_recovery')).toBe(
+      Math.max(1, Math.round(10 * ACTIVE_RECOVERY_DEPLOYED_SCALE))
+    )
+    expect(scaleDeployedMissionFatigueDelta(10, 'sanctuary_recovery')).toBe(
+      Math.max(1, Math.round(10 * SANCTUARY_RECOVERY_DEPLOYED_SCALE))
+    )
+  })
+
+  it('maps active teams to per-agent recovery modes from case contracts', () => {
+    const caseWithSanctuary: CaseInstance = {
+      id: 'case-s',
+      templateId: 't1',
+      title: '',
+      description: '',
+      mode: 'probability',
+      kind: 'investigation',
+      status: 'in_progress',
+      difficulty: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      weights: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      tags: [],
+      requiredTags: [],
+      preferredTags: [],
+      stage: 1,
+      durationWeeks: 2,
+      deadlineWeeks: 4,
+      deadlineRemaining: 4,
+      assignedTeamIds: ['tm'],
+      contract: { fieldBase: { medical: 2, safety: 2, sustenance: 1 } },
+      onFail: { type: 'none' },
+      onUnresolved: { type: 'none' },
+    }
+    const teams: GameState['teams'] = {
+      tm: {
+        id: 'tm',
+        name: 'T',
+        agentIds: ['a1', 'a2'],
+        tags: [],
+        assignedCaseId: 'case-s',
+      },
+    }
+    const cases: GameState['cases'] = { 'case-s': caseWithSanctuary }
+    const map = buildDeployedRecoveryModeByAgentId(teams, cases, ['tm'])
+    expect(map.get('a1')).toBe('sanctuary_recovery')
+    expect(map.get('a2')).toBe('sanctuary_recovery')
+  })
+
+  it('liturgy expedition with fieldBase lowers deployed fatigue gain versus same case without packet', () => {
+    const base = createStartingState()
+    const unlocked = refreshContractBoard({
+      ...base,
+      factions: {
+        ...base.factions!,
+        institutions: {
+          ...base.factions!.institutions,
+          reputation: 52,
+          reputationTier: 'friendly',
+        },
+      },
+      agency: {
+        ...base.agency!,
+        progressionUnlockIds: ['containment-liturgy'],
+      },
+      contracts: undefined,
+    })
+    const offer =
+      getContractOffers(unlocked).find((o) => o.templateId === 'institutions-liturgy-expedition') ??
+      null
+    expect(offer?.fieldBase).toEqual({ medical: 2, safety: 2, sustenance: 1 })
+
+    const launched = launchContract(unlocked, offer!.id, 't_nightwatch')
+    const caseEntry = Object.values(launched.cases).find((c) => c.contract?.offerId === offer!.id)!
+    expect(caseEntry.contract?.fieldBase).toEqual({ medical: 2, safety: 2, sustenance: 1 })
+
+    const agentId = launched.teams.t_nightwatch.agentIds[0]!
+    const fatigueBefore = launched.agents[agentId]!.fatigue
+
+    const withSanctuary = advanceWeek({
+      ...launched,
+      config: { ...launched.config, durationModel: 'attrition', attritionPerWeek: 10 },
+    })
+
+    const strippedCase: CaseInstance = {
+      ...caseEntry,
+      contract: { ...caseEntry.contract, fieldBase: undefined },
+    }
+    const stripped = advanceWeek({
+      ...launched,
+      cases: { ...launched.cases, [caseEntry.id]: strippedCase },
+      config: { ...launched.config, durationModel: 'attrition', attritionPerWeek: 10 },
+    })
+
+    const deltaSanctuary = withSanctuary.agents[agentId]!.fatigue - fatigueBefore
+    const deltaStripped = stripped.agents[agentId]!.fatigue - fatigueBefore
+
+    expect(deltaSanctuary).toBeLessThan(deltaStripped)
+    expect(deltaStripped).toBe(10)
+    expect(deltaSanctuary).toBe(Math.max(1, Math.round(10 * SANCTUARY_RECOVERY_DEPLOYED_SCALE)))
+  })
+})


### PR DESCRIPTION
## Summary
Implements a bounded **SPE-99 slice A**: optional \ieldBase\ staging bands on contracts, deterministic recovery-mode taxonomy, and scaled **deployed** scalar mission fatigue in the weekly \dvanceWeek\ pass.

## Linear
- **SPE-99** (description updated with implementation tracking and reconciliation boundaries)

## Changes
- \FieldBaseQualityBands\ on \ContractOffer\ / \ActiveContractRuntime\; \institutions-liturgy-expedition\ authors a sanctuary-grade packet.
- New \expeditionRecoveryNode\ helpers: parse bands, map to \unsafe_pause\ | \ordinary_rest\ | \ctive_recovery\ | \sanctuary_recovery\, scale mission fatigue delta.
- \pplyAgentFatigue\ consumes per-agent mode from the team assigned case when \status === 'in_progress'\.

## Docs
- \docs/recovery-trauma-downtime-audit.md\ §1b

## Validation
- \
pm run lint\
- \
pm run test:run\ (full suite)

## Follow-up (out of this PR)
Full recovery graph, sustenance sim, health ladders, curse persistence, SPE-1654 rotation depth beyond the packet, \atiguePipeline\ parity if that path becomes canonical for channels.