### PR TITLE
SPE-1653: exposure residue recovery gate (slice 1)

### DIFF
--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -49,7 +49,7 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 - **Rest channel:** while the flag is present, ordinary **rest** does not reduce fatigue and applies a small bounded weekly fatigue recurrence until the gate clears.
 - **Therapy channel:** trauma reduction from **therapy** downtime proceeds at full rate; fatigue recovery from therapy is **partial** while the flag remains (split recovery channels).
 - **Clearance:** one week of **therapy** downtime while agency `supportStaff.medical` meets `RECOVERY_CALIBRATION.exposureResidueMedicalClearThreshold` strips the flag (supervised washdown / decontamination).
-- **Assignment recovery:** `advanceRecoveryAgentsForWeek` withholds injury discharge to active duty until the flag is cleared, even after injury-duration weeks elapse.
+- **Assignment recovery:** `advanceRecoveryAgentsForWeek` withholds injury discharge to active duty until the flag is cleared, even after injury-duration weeks elapse. Writes merge from `nextAgents[agentId]` (then `updatedAgents`) when present so earlier week-open mutations are not dropped when appending the blocked-discharge history entry.
 - **Tick wiring:** `advanceRecoveryDowntimeForWeek` runs at end of `advanceWeek` after mission finalization; per-agent downtime selection defaults from `agent.downtimeActivity?.activity` or **rest**.
 
 ## 4. Trauma & Readiness-Impact Rules

--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -36,6 +36,16 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 - Recovery rates and trauma reduction must be explicit, not random.
 - Downtime cannot erase major trauma instantly; recovery is gradual and stateful.
 
+### 3b. SPE-1653 slice — exposure residue (recovery gate)
+
+- **Flag:** `exposure:residue` on `agent.vitals.statusFlags` (compact deterministic impairment).
+- **When it applies:** anomaly-tagged case context and mission **fail** without injury, **or** any **injury** on an anomaly-tagged case (`applyMissionResolutionAgentMutations`).
+- **Rest channel:** while the flag is present, ordinary **rest** does not reduce fatigue and applies a small bounded weekly fatigue recurrence until the gate clears.
+- **Therapy channel:** trauma reduction from **therapy** downtime proceeds at full rate; fatigue recovery from therapy is **partial** while the flag remains (split recovery channels).
+- **Clearance:** one week of **therapy** downtime while agency `supportStaff.medical` meets `RECOVERY_CALIBRATION.exposureResidueMedicalClearThreshold` strips the flag (supervised washdown / decontamination).
+- **Assignment recovery:** `advanceRecoveryAgentsForWeek` withholds injury discharge to active duty until the flag is cleared, even after injury-duration weeks elapse.
+- **Tick wiring:** `advanceRecoveryDowntimeForWeek` runs at end of `advanceWeek` after mission finalization; per-agent downtime selection defaults from `agent.downtimeActivity?.activity` or **rest**.
+
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.
 - High trauma reduces deployment readiness, training efficiency, and recovery speed.

--- a/src/domain/agentDefaults.ts
+++ b/src/domain/agentDefaults.ts
@@ -46,6 +46,20 @@ export function createDefaultAgentVitals(
   }
 }
 
+/**
+ * Fallback vitals when spreading mission/recovery mutations onto agents without persisted vitals.
+ * Preserves long-standing sim behavior: `stress` mirrors raw fatigue (not `clampPercent` bands).
+ */
+export function createSimulationAgentVitalsBaseline(fatigue: number, wounds = 0): AgentVitals {
+  return {
+    health: 100,
+    stress: fatigue,
+    morale: Math.max(0, 100 - fatigue),
+    wounds,
+    statusFlags: [],
+  }
+}
+
 export function createDefaultAgentProgression(
   level: number = 1,
   potentialTier: PotentialTier = 'C',

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -238,6 +238,7 @@ import { decayCreditPackets, type CivicCreditPacket } from '../civicCreditChanne
 import { decayAccessPackets, type CivicAccessPacket } from '../civicAccessChannel'
 import { listQueuedRuntimeEvents } from '../eventQueue'
 import { advanceRecoveryAgentsForWeek } from './recoveryPipeline'
+import { advanceRecoveryDowntimeForWeek, type DowntimeActivity } from './recoveryDowntime'
 import { finalizeMissionResultsFromDrafts } from './missionFinalizationPipeline'
 import { advanceTrainingQueues } from './training'
 import { recordRelationshipSnapshot } from './chemistryPolish'
@@ -3524,6 +3525,32 @@ function shiftMarket(context: WeeklyExecutionContext, rng: SeededRng) {
   context.eventDrafts.push(...marketResult.eventDrafts)
 }
 
+function applyRecoveryDowntimeAfterMissions(context: WeeklyExecutionContext) {
+  const downtimeAssignments: Record<string, DowntimeActivity> = {}
+  for (const id of Object.keys(context.nextState.agents)) {
+    const agent = context.nextState.agents[id]
+    downtimeAssignments[id] = (agent?.downtimeActivity?.activity as DowntimeActivity) ?? 'rest'
+  }
+
+  const downtimeResult = advanceRecoveryDowntimeForWeek({
+    week: context.sourceState.week,
+    sourceAgents: context.nextState.agents,
+    sourceTeams: context.nextState.teams,
+    downtimeAssignments,
+    fundingState: context.nextState.agency?.fundingState,
+    replacementPressureState: context.nextState.replacementPressureState,
+    supportStaff: context.nextState.supportStaff,
+    substancePolicy: context.nextState.config.substancePolicy,
+  })
+
+  context.nextState = {
+    ...context.nextState,
+    agents: downtimeResult.updatedAgents,
+    teams: downtimeResult.updatedTeams,
+  }
+  context.eventDrafts.push(...downtimeResult.eventDrafts)
+}
+
 function finalizeMissionResults(context: WeeklyExecutionContext) {
   context.missionResultByCaseId = finalizeMissionResultsFromDrafts({
     sourceState: context.sourceState,
@@ -3969,6 +3996,7 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   applySpontaneousRelationshipEvents(context, rng)
   shiftMarket(context, rng)
   finalizeMissionResults(context)
+  applyRecoveryDowntimeAfterMissions(context)
   // SPE-53: Generate hub simulation and attach notes
   generateAndAttachHubNotes(context)
 

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -78,6 +78,10 @@ export const RECOVERY_CALIBRATION = {
   copingDependencyThreshold: 3,
   copingProhibitedMoralePenalty: 5,
   therapyCopingStreakDecrement: 3,
+  /** SPE-1653: weekly fatigue drift while exposure residue persists and downtime is ordinary rest only. */
+  exposureResidueRestRecurrenceFatigue: 2,
+  /** Medical staff count required for supervised washdown clearing exposure residue during therapy downtime. */
+  exposureResidueMedicalClearThreshold: 2,
 } as const
 
 // Band-gated overrides for second escalation band

--- a/src/domain/sim/missionResolutionAgents.ts
+++ b/src/domain/sim/missionResolutionAgents.ts
@@ -48,7 +48,7 @@ import { applyAgentXp } from '../progression'
 import { type InjurySeverity, withInjuryFlags } from './recoveryPipeline'
 import { appendExposureResidueToFlags } from './recoveryImpairments'
 import { applyBetrayalConsequences } from './betrayal'
-import { createDefaultAgentProgression } from '../agentDefaults'
+import { createDefaultAgentProgression, createSimulationAgentVitalsBaseline } from '../agentDefaults'
 import { evaluateMissionAgentFailureRisk } from './injuryForecast'
 
 const XP_GAIN_SUCCESS = 150
@@ -684,13 +684,7 @@ export function applyMissionResolutionAgentMutations({
       : ({ state: 'idle' } as const)
     const nextVitals = casualty.fatal
       ? {
-          ...(agent.vitals ?? {
-            health: 100,
-            stress: agent.fatigue,
-            morale: Math.max(0, 100 - agent.fatigue),
-            wounds: 0,
-            statusFlags: [],
-          }),
+          ...(agent.vitals ?? createSimulationAgentVitalsBaseline(agent.fatigue)),
           health: 0,
           morale: 0,
           wounds: 100,
@@ -698,13 +692,7 @@ export function applyMissionResolutionAgentMutations({
         }
       : injurySeverity
       ? {
-          ...(agent.vitals ?? {
-            health: 100,
-            stress: agent.fatigue,
-            morale: Math.max(0, 100 - agent.fatigue),
-            wounds: 0,
-            statusFlags: [],
-          }),
+          ...(agent.vitals ?? createSimulationAgentVitalsBaseline(agent.fatigue)),
           health: clamp(
             (agent.vitals?.health ?? 100) - (injurySeverity === 'moderate' ? 25 : 10),
             0,
@@ -875,13 +863,7 @@ export function applyMissionResolutionAgentMutations({
       anomalyExposure >= 1 &&
       (injurySeverity !== null || outcome.result === 'fail')
     ) {
-      const baseVitals = nextAgent.vitals ?? {
-        health: 100,
-        stress: nextAgent.fatigue,
-        morale: Math.max(0, 100 - nextAgent.fatigue),
-        wounds: 0,
-        statusFlags: [] as string[],
-      }
+      const baseVitals = nextAgent.vitals ?? createSimulationAgentVitalsBaseline(nextAgent.fatigue)
       nextAgent = {
         ...nextAgent,
         vitals: {

--- a/src/domain/sim/missionResolutionAgents.ts
+++ b/src/domain/sim/missionResolutionAgents.ts
@@ -46,6 +46,7 @@ import type {
 } from '../models'
 import { applyAgentXp } from '../progression'
 import { type InjurySeverity, withInjuryFlags } from './recoveryPipeline'
+import { appendExposureResidueToFlags } from './recoveryImpairments'
 import { applyBetrayalConsequences } from './betrayal'
 import { createDefaultAgentProgression } from '../agentDefaults'
 import { evaluateMissionAgentFailureRisk } from './injuryForecast'
@@ -867,6 +868,27 @@ export function applyMissionResolutionAgentMutations({
           caseTitle: effectiveCase.title,
         })
       )
+    }
+
+    if (
+      !casualty.fatal &&
+      anomalyExposure >= 1 &&
+      (injurySeverity !== null || outcome.result === 'fail')
+    ) {
+      const baseVitals = nextAgent.vitals ?? {
+        health: 100,
+        stress: nextAgent.fatigue,
+        morale: Math.max(0, 100 - nextAgent.fatigue),
+        wounds: 0,
+        statusFlags: [] as string[],
+      }
+      nextAgent = {
+        ...nextAgent,
+        vitals: {
+          ...baseVitals,
+          statusFlags: appendExposureResidueToFlags(baseVitals.statusFlags),
+        },
+      }
     }
 
     nextAgents[agent.id] = nextAgent

--- a/src/domain/sim/recoveryDowntime.ts
+++ b/src/domain/sim/recoveryDowntime.ts
@@ -8,6 +8,10 @@ import type {
 import { clamp } from '../math'
 import { RECOVERY_CALIBRATION } from './calibration'
 import type { AnyOperationEventDraft } from '../events'
+import {
+  stripExposureResidueFromFlags,
+  vitalsHasExposureResidue,
+} from './recoveryImpairments'
 
 export type RecoveryState = 'healthy' | 'recovering' | 'traumatized' | 'incapacitated'
 export type DowntimeActivity = 'rest' | 'training' | 'therapy' | 'other' | 'coping'
@@ -81,6 +85,13 @@ export function advanceRecoveryDowntimeForWeek({
     let recoveryStatus = agent.recoveryStatus ?? inferredRecoveryStatus
     let trauma = agent.trauma || { traumaLevel: 0, traumaTags: [], lastEventWeek: week }
     let fatigue = agent.fatigue
+    const medicalStaff = supportStaff?.medical ?? 0
+    const supervisedExposureWashdown =
+      downtime === 'therapy' &&
+      medicalStaff >= RECOVERY_CALIBRATION.exposureResidueMedicalClearThreshold
+    const stripExposureResidue =
+      vitalsHasExposureResidue(agent.vitals) && supervisedExposureWashdown
+    const exposureResidueGating = vitalsHasExposureResidue(agent.vitals) && !stripExposureResidue
 
     // Progression logic
     switch (recoveryStatus.state) {
@@ -91,26 +102,33 @@ export function advanceRecoveryDowntimeForWeek({
         break
       case 'recovering':
         if (downtime === 'rest') {
-          fatigue = clamp(
-            fatigue -
-              Math.max(
-                0,
-                RECOVERY_CALIBRATION.downtimeFatigueRecovery.rest - combinedThroughputPenalty
-              ),
-            0,
-            100
-          )
+          if (exposureResidueGating) {
+            fatigue = clamp(
+              fatigue + RECOVERY_CALIBRATION.exposureResidueRestRecurrenceFatigue,
+              0,
+              100
+            )
+          } else {
+            fatigue = clamp(
+              fatigue -
+                Math.max(
+                  0,
+                  RECOVERY_CALIBRATION.downtimeFatigueRecovery.rest - combinedThroughputPenalty
+                ),
+              0,
+              100
+            )
+          }
         }
         if (downtime === 'therapy') {
-          fatigue = clamp(
-            fatigue -
-              Math.max(
-                0,
-                RECOVERY_CALIBRATION.downtimeFatigueRecovery.therapy - combinedThroughputPenalty
-              ),
+          const therapyFatigueDelta = Math.max(
             0,
-            100
+            RECOVERY_CALIBRATION.downtimeFatigueRecovery.therapy - combinedThroughputPenalty
           )
+          const effectiveTherapyFatigue = exposureResidueGating
+            ? Math.max(0, Math.floor(therapyFatigueDelta / 2))
+            : therapyFatigueDelta
+          fatigue = clamp(fatigue - effectiveTherapyFatigue, 0, 100)
         }
         if (downtime === 'therapy' && trauma.traumaLevel > 0) {
           trauma = {
@@ -130,7 +148,8 @@ export function advanceRecoveryDowntimeForWeek({
         // If fatigue and trauma are both low, agent may return to healthy
         if (
           fatigue <= RECOVERY_CALIBRATION.healthyReturnFatigueThreshold &&
-          trauma.traumaLevel === 0
+          trauma.traumaLevel === 0 &&
+          !exposureResidueGating
         ) {
           recoveryStatus = { state: 'healthy', sinceWeek: week }
         }
@@ -239,13 +258,21 @@ export function advanceRecoveryDowntimeForWeek({
       }
     }
 
+    const finalVitals =
+      agentVitals && stripExposureResidue
+        ? {
+            ...agentVitals,
+            statusFlags: stripExposureResidueFromFlags(agentVitals.statusFlags),
+          }
+        : agentVitals
+
     updatedAgents[agentId] = {
       ...agent,
       recoveryStatus,
       trauma,
       downtimeActivity: { activity: downtime, sinceWeek: week },
       fatigue,
-      vitals: agentVitals,
+      vitals: finalVitals,
       tags: agentTags,
       copingStreak,
     }

--- a/src/domain/sim/recoveryDowntime.ts
+++ b/src/domain/sim/recoveryDowntime.ts
@@ -89,9 +89,9 @@ export function advanceRecoveryDowntimeForWeek({
     const supervisedExposureWashdown =
       downtime === 'therapy' &&
       medicalStaff >= RECOVERY_CALIBRATION.exposureResidueMedicalClearThreshold
-    const stripExposureResidue =
-      vitalsHasExposureResidue(agent.vitals) && supervisedExposureWashdown
-    const exposureResidueGating = vitalsHasExposureResidue(agent.vitals) && !stripExposureResidue
+    const hasResidue = vitalsHasExposureResidue(agent.vitals)
+    const stripExposureResidue = hasResidue && supervisedExposureWashdown
+    const exposureResidueGating = hasResidue && !stripExposureResidue
 
     // Progression logic
     switch (recoveryStatus.state) {

--- a/src/domain/sim/recoveryImpairments.ts
+++ b/src/domain/sim/recoveryImpairments.ts
@@ -1,0 +1,23 @@
+import type { AgentVitals } from '../models'
+
+/**
+ * SPE-1653 slice: compact deterministic exposure residue that gates physical recovery
+ * until supervised washdown (therapy downtime + medical support).
+ */
+export const EXPOSURE_RESIDUE_STATUS_FLAG = 'exposure:residue' as const
+
+export function vitalsHasExposureResidue(vitals: AgentVitals | undefined): boolean {
+  return (vitals?.statusFlags ?? []).includes(EXPOSURE_RESIDUE_STATUS_FLAG)
+}
+
+export function appendExposureResidueToFlags(flags: string[] | undefined): string[] {
+  const base = flags ?? []
+  if (base.includes(EXPOSURE_RESIDUE_STATUS_FLAG)) {
+    return base
+  }
+  return [...base, EXPOSURE_RESIDUE_STATUS_FLAG]
+}
+
+export function stripExposureResidueFromFlags(flags: string[] | undefined): string[] {
+  return (flags ?? []).filter((f) => f !== EXPOSURE_RESIDUE_STATUS_FLAG)
+}

--- a/src/domain/sim/recoveryPipeline.ts
+++ b/src/domain/sim/recoveryPipeline.ts
@@ -80,25 +80,27 @@ export function advanceRecoveryAgentsForWeek({
   const updatedAgents = { ...nextAgents }
 
   for (const [agentId, agent] of Object.entries(sourceAgents)) {
+    const priorAgent = updatedAgents[agentId] ?? nextAgents[agentId] ?? agent
+
     if (
-      (agent.status !== 'injured' && agent.status !== 'recovering') ||
-      agent.assignment?.state !== 'recovery'
+      (priorAgent.status !== 'injured' && priorAgent.status !== 'recovering') ||
+      priorAgent.assignment?.state !== 'recovery'
     ) {
       continue
     }
 
-    const severity = getInjurySeverityFlag(agent.vitals?.statusFlags) ?? 'minor'
-    const startedWeek = agent.assignment.startedWeek ?? Math.max(0, week - 1)
-      const elapsedWeeks = Math.max(0, week - startedWeek)
-    const moraleRecoveryDelta = getRecoveryMoraleDelta(agent)
+    const severity = getInjurySeverityFlag(priorAgent.vitals?.statusFlags) ?? 'minor'
+    const startedWeek = priorAgent.assignment.startedWeek ?? Math.max(0, week - 1)
+    const elapsedWeeks = Math.max(0, week - startedWeek)
+    const moraleRecoveryDelta = getRecoveryMoraleDelta(priorAgent)
 
-      if (elapsedWeeks >= getRecoveryDurationWeeks(severity)) {
-      if (vitalsHasExposureResidue(agent.vitals)) {
+    if (elapsedWeeks >= getRecoveryDurationWeeks(severity)) {
+      if (vitalsHasExposureResidue(priorAgent.vitals)) {
         updatedAgents[agentId] = appendAgentHistoryEntry(
-          agent,
+          priorAgent,
           buildRecoveryHistoryEntry(
             week,
-            `${agent.name} remains in recovery until exposure residue is cleared under medical washdown.`
+            `${priorAgent.name} remains in recovery until exposure residue is cleared under medical washdown.`
           ),
           { recoveryWeeks: 1 }
         )
@@ -107,73 +109,73 @@ export function advanceRecoveryAgentsForWeek({
       updatedAgents[agentId] = appendAgentHistoryEntry(
         setAgentAssignment(
           {
-            ...agent,
+            ...priorAgent,
             status: 'active',
             vitals: {
-              ...(agent.vitals ?? {
+              ...(priorAgent.vitals ?? {
                 health: 100,
-                stress: agent.fatigue,
-                morale: Math.max(0, 100 - agent.fatigue),
+                stress: priorAgent.fatigue,
+                morale: Math.max(0, 100 - priorAgent.fatigue),
                 wounds: 0,
                 statusFlags: [],
               }),
               health: 100,
               morale: clamp(
                 Math.max(
-                  agent.vitals?.morale ?? 100,
+                  priorAgent.vitals?.morale ?? 100,
                   RECOVERY_CALIBRATION.returningMoraleFloor + moraleRecoveryDelta
                 ),
                 0,
                 100
               ),
               wounds: 0,
-              statusFlags: withInjuryFlags(agent.vitals?.statusFlags),
+              statusFlags: withInjuryFlags(priorAgent.vitals?.statusFlags),
             },
           },
           { state: 'idle' }
         ),
-        buildRecoveryHistoryEntry(week, `${agent.name} returned to active duty.`),
+        buildRecoveryHistoryEntry(week, `${priorAgent.name} returned to active duty.`),
         { recoveryWeeks: 1 }
       )
       continue
     }
 
-      if (elapsedWeeks >= 1 && agent.status === 'injured') {
+    if (elapsedWeeks >= 1 && priorAgent.status === 'injured') {
       updatedAgents[agentId] = appendAgentHistoryEntry(
         {
-          ...agent,
+          ...priorAgent,
           status: 'recovering',
           vitals: {
-            ...(agent.vitals ?? {
+            ...(priorAgent.vitals ?? {
               health: 100,
-              stress: agent.fatigue,
-              morale: Math.max(0, 100 - agent.fatigue),
+              stress: priorAgent.fatigue,
+              morale: Math.max(0, 100 - priorAgent.fatigue),
               wounds: severity === 'moderate' ? 25 : 10,
               statusFlags: [],
             }),
             morale: clamp(
-              (agent.vitals?.morale ?? Math.max(0, 100 - agent.fatigue)) -
+              (priorAgent.vitals?.morale ?? Math.max(0, 100 - priorAgent.fatigue)) -
                 RECOVERY_CALIBRATION.recoveringMoralePenalty +
                 moraleRecoveryDelta,
               0,
               100
             ),
             wounds: severity === 'moderate' ? 25 : 10,
-            statusFlags: withInjuryFlags(agent.vitals?.statusFlags, severity),
+            statusFlags: withInjuryFlags(priorAgent.vitals?.statusFlags, severity),
           },
         },
-        buildRecoveryHistoryEntry(week, `${agent.name} is recovering from a ${severity} injury.`),
+        buildRecoveryHistoryEntry(week, `${priorAgent.name} is recovering from a ${severity} injury.`),
         { recoveryWeeks: 1 }
       )
       continue
     }
 
-    if (agent.status === 'injured') {
-      updatedAgents[agentId] = agent
+    if (priorAgent.status === 'injured') {
+      updatedAgents[agentId] = priorAgent
       continue
     }
 
-    updatedAgents[agentId] = appendAgentHistoryEntries(agent, [], { recoveryWeeks: 1 })
+    updatedAgents[agentId] = appendAgentHistoryEntries(priorAgent, [], { recoveryWeeks: 1 })
   }
 
   return updatedAgents

--- a/src/domain/sim/recoveryPipeline.ts
+++ b/src/domain/sim/recoveryPipeline.ts
@@ -9,6 +9,7 @@ import type { Agent, AgentHistoryEntry, GameState } from '../models'
 import { RECOVERY_CALIBRATION } from './calibration'
 import { vitalsHasExposureResidue } from './recoveryImpairments'
 import { aggregateTraitEffects, resolveAgentTraitEffects } from '../traits'
+import { createSimulationAgentVitalsBaseline } from '../agentDefaults'
 
 const MINOR_RECOVERY_DURATION_WEEKS = RECOVERY_CALIBRATION.minorRecoveryDurationWeeks
 const MODERATE_RECOVERY_DURATION_WEEKS = RECOVERY_CALIBRATION.moderateRecoveryDurationWeeks
@@ -112,13 +113,7 @@ export function advanceRecoveryAgentsForWeek({
             ...priorAgent,
             status: 'active',
             vitals: {
-              ...(priorAgent.vitals ?? {
-                health: 100,
-                stress: priorAgent.fatigue,
-                morale: Math.max(0, 100 - priorAgent.fatigue),
-                wounds: 0,
-                statusFlags: [],
-              }),
+              ...(priorAgent.vitals ?? createSimulationAgentVitalsBaseline(priorAgent.fatigue)),
               health: 100,
               morale: clamp(
                 Math.max(
@@ -146,13 +141,11 @@ export function advanceRecoveryAgentsForWeek({
           ...priorAgent,
           status: 'recovering',
           vitals: {
-            ...(priorAgent.vitals ?? {
-              health: 100,
-              stress: priorAgent.fatigue,
-              morale: Math.max(0, 100 - priorAgent.fatigue),
-              wounds: severity === 'moderate' ? 25 : 10,
-              statusFlags: [],
-            }),
+            ...(priorAgent.vitals ??
+              createSimulationAgentVitalsBaseline(
+                priorAgent.fatigue,
+                severity === 'moderate' ? 25 : 10
+              )),
             morale: clamp(
               (priorAgent.vitals?.morale ?? Math.max(0, 100 - priorAgent.fatigue)) -
                 RECOVERY_CALIBRATION.recoveringMoralePenalty +

--- a/src/domain/sim/recoveryPipeline.ts
+++ b/src/domain/sim/recoveryPipeline.ts
@@ -7,6 +7,7 @@ import { aggregateAbilityEffects, resolveAgentAbilityEffects } from '../abilitie
 import { clamp } from '../math'
 import type { Agent, AgentHistoryEntry, GameState } from '../models'
 import { RECOVERY_CALIBRATION } from './calibration'
+import { vitalsHasExposureResidue } from './recoveryImpairments'
 import { aggregateTraitEffects, resolveAgentTraitEffects } from '../traits'
 
 const MINOR_RECOVERY_DURATION_WEEKS = RECOVERY_CALIBRATION.minorRecoveryDurationWeeks
@@ -92,6 +93,17 @@ export function advanceRecoveryAgentsForWeek({
     const moraleRecoveryDelta = getRecoveryMoraleDelta(agent)
 
       if (elapsedWeeks >= getRecoveryDurationWeeks(severity)) {
+      if (vitalsHasExposureResidue(agent.vitals)) {
+        updatedAgents[agentId] = appendAgentHistoryEntry(
+          agent,
+          buildRecoveryHistoryEntry(
+            week,
+            `${agent.name} remains in recovery until exposure residue is cleared under medical washdown.`
+          ),
+          { recoveryWeeks: 1 }
+        )
+        continue
+      }
       updatedAgents[agentId] = appendAgentHistoryEntry(
         setAgentAssignment(
           {

--- a/src/test/recoveryExposureResidue.test.ts
+++ b/src/test/recoveryExposureResidue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { appendAgentHistoryEntry } from '../domain/agent/lifecycle'
 import { advanceRecoveryAgentsForWeek } from '../domain/sim/recoveryPipeline'
 import { advanceRecoveryDowntimeForWeek } from '../domain/sim/recoveryDowntime'
 import { EXPOSURE_RESIDUE_STATUS_FLAG } from '../domain/sim/recoveryImpairments'
@@ -174,5 +175,45 @@ describe('SPE-1653 exposure residue', () => {
       nextAgents: { a1: clearedAgent },
     })
     expect(out2.a1.assignment?.state).toBe('idle')
+  })
+
+  it('preserves week-open nextAgents mutations when residue blocks discharge', () => {
+    const startedWeek = 0
+    const week = 3
+    const sourceAgent = baseAgent({
+      status: 'recovering',
+      assignment: { state: 'recovery', startedWeek, teamId: 't1' },
+      vitals: {
+        health: 95,
+        stress: 5,
+        morale: 70,
+        wounds: 5,
+        statusFlags: ['injury:minor', EXPOSURE_RESIDUE_STATUS_FLAG],
+      },
+    })
+    const nextAgent = appendAgentHistoryEntry(
+      sourceAgent,
+      {
+        week: week - 1,
+        eventType: 'simulation.weekly_tick',
+        note: 'Week-open bookkeeping retained.',
+      },
+      {}
+    )
+
+    const out = advanceRecoveryAgentsForWeek({
+      week,
+      sourceAgents: { a1: sourceAgent },
+      nextAgents: { a1: nextAgent },
+    })
+
+    expect(out.a1.history?.timeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ note: 'Week-open bookkeeping retained.' }),
+        expect.objectContaining({
+          note: expect.stringContaining('remains in recovery until exposure residue'),
+        }),
+      ])
+    )
   })
 })

--- a/src/test/recoveryExposureResidue.test.ts
+++ b/src/test/recoveryExposureResidue.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import { advanceRecoveryAgentsForWeek } from '../domain/sim/recoveryPipeline'
+import { advanceRecoveryDowntimeForWeek } from '../domain/sim/recoveryDowntime'
+import { EXPOSURE_RESIDUE_STATUS_FLAG } from '../domain/sim/recoveryImpairments'
+import { RECOVERY_CALIBRATION } from '../domain/sim/calibration'
+import type { Agent, GameState, SupportStaffSummary } from '../domain/models'
+
+const medicalStaff = (medical: number): SupportStaffSummary => ({
+  admin: 0,
+  logistics: 0,
+  medical,
+  intel: 0,
+  total: medical,
+  pressure: 0,
+})
+
+function baseAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'a1',
+    name: 'Test Op',
+    role: 'operative',
+    status: 'recovering',
+    fatigue: 40,
+    tags: [],
+    relationships: {},
+    vitals: {
+      health: 90,
+      stress: 10,
+      morale: 60,
+      wounds: 10,
+      statusFlags: ['injury:minor'],
+    },
+    assignment: { state: 'recovery', startedWeek: 0 },
+    ...overrides,
+  } as Agent
+}
+
+describe('SPE-1653 exposure residue', () => {
+  it('blocks rest fatigue recovery and applies recurrence while residue persists', () => {
+    const agent = baseAgent({
+      recoveryStatus: { state: 'recovering', sinceWeek: 1 },
+      fatigue: 40,
+      vitals: {
+        health: 90,
+        stress: 10,
+        morale: 60,
+        wounds: 10,
+        statusFlags: ['injury:minor', EXPOSURE_RESIDUE_STATUS_FLAG],
+      },
+    })
+    const r = advanceRecoveryDowntimeForWeek({
+      week: 2,
+      sourceAgents: { a1: agent },
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'rest' },
+    })
+    expect(r.updatedAgents.a1.fatigue).toBe(
+      40 + RECOVERY_CALIBRATION.exposureResidueRestRecurrenceFatigue
+    )
+  })
+
+  it('clears residue after therapy downtime with sufficient medical staff', () => {
+    const agent = baseAgent({
+      recoveryStatus: { state: 'recovering', sinceWeek: 1 },
+      vitals: {
+        health: 90,
+        stress: 10,
+        morale: 60,
+        wounds: 10,
+        statusFlags: [EXPOSURE_RESIDUE_STATUS_FLAG],
+      },
+    })
+    const r = advanceRecoveryDowntimeForWeek({
+      week: 2,
+      sourceAgents: { a1: agent },
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'therapy' },
+      supportStaff: medicalStaff(RECOVERY_CALIBRATION.exposureResidueMedicalClearThreshold),
+    })
+    expect(r.updatedAgents.a1.vitals?.statusFlags ?? []).not.toContain(EXPOSURE_RESIDUE_STATUS_FLAG)
+  })
+
+  it('therapy without medical capacity keeps residue but still reduces trauma', () => {
+    const agent = baseAgent({
+      recoveryStatus: { state: 'recovering', sinceWeek: 1 },
+      trauma: { traumaLevel: 2, traumaTags: [], lastEventWeek: 1 },
+      fatigue: 50,
+      vitals: {
+        health: 90,
+        stress: 10,
+        morale: 60,
+        wounds: 10,
+        statusFlags: [EXPOSURE_RESIDUE_STATUS_FLAG],
+      },
+    })
+    const r = advanceRecoveryDowntimeForWeek({
+      week: 2,
+      sourceAgents: { a1: agent },
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'therapy' },
+      supportStaff: medicalStaff(1),
+    })
+    expect(r.updatedAgents.a1.vitals?.statusFlags ?? []).toContain(EXPOSURE_RESIDUE_STATUS_FLAG)
+    expect(r.updatedAgents.a1.trauma?.traumaLevel).toBe(1)
+  })
+
+  it('applies partial therapy fatigue recovery while residue gates full rest channel', () => {
+    const withResidue = baseAgent({
+      recoveryStatus: { state: 'recovering', sinceWeek: 1 },
+      fatigue: 50,
+      vitals: {
+        health: 90,
+        stress: 10,
+        morale: 60,
+        wounds: 10,
+        statusFlags: [EXPOSURE_RESIDUE_STATUS_FLAG],
+      },
+    })
+    const cleared = {
+      ...withResidue,
+      vitals: {
+        ...withResidue.vitals!,
+        statusFlags: [],
+      },
+    }
+    const therapyResidue = advanceRecoveryDowntimeForWeek({
+      week: 2,
+      sourceAgents: { a1: withResidue },
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'therapy' },
+    })
+    const therapyClear = advanceRecoveryDowntimeForWeek({
+      week: 2,
+      sourceAgents: { a1: cleared },
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'therapy' },
+    })
+    expect(therapyResidue.updatedAgents.a1.fatigue).toBeGreaterThan(therapyClear.updatedAgents.a1.fatigue)
+  })
+
+  it('blocks injury discharge from recovery assignment until residue clears', () => {
+    const startedWeek = 0
+    const week = 3
+    const agent = baseAgent({
+      status: 'recovering',
+      assignment: { state: 'recovery', startedWeek, teamId: 't1' },
+      vitals: {
+        health: 95,
+        stress: 5,
+        morale: 70,
+        wounds: 5,
+        statusFlags: ['injury:minor', EXPOSURE_RESIDUE_STATUS_FLAG],
+      },
+    })
+    const next: GameState['agents'] = { a1: agent }
+    const out = advanceRecoveryAgentsForWeek({
+      week,
+      sourceAgents: { a1: agent },
+      nextAgents: next,
+    })
+    expect(out.a1.assignment?.state).toBe('recovery')
+    expect(out.a1.vitals?.statusFlags ?? []).toContain(EXPOSURE_RESIDUE_STATUS_FLAG)
+
+    const clearedAgent = {
+      ...agent,
+      vitals: {
+        ...agent.vitals!,
+        statusFlags: ['injury:minor'],
+      },
+    }
+    const out2 = advanceRecoveryAgentsForWeek({
+      week,
+      sourceAgents: { a1: clearedAgent },
+      nextAgents: { a1: clearedAgent },
+    })
+    expect(out2.a1.assignment?.state).toBe('idle')
+  })
+})

--- a/src/test/sim.injuryRecovery.test.ts
+++ b/src/test/sim.injuryRecovery.test.ts
@@ -140,6 +140,21 @@ describe('injury and recovery lifecycle', () => {
     const recoveryBase = {
       ...injured,
       gameOver: false,
+      supportStaff: {
+        admin: 0,
+        logistics: 0,
+        medical: 4,
+        intel: 0,
+        total: 4,
+        pressure: 0,
+      },
+      agents: {
+        ...injured.agents,
+        a_ava: {
+          ...injured.agents.a_ava,
+          downtimeActivity: { activity: 'therapy' as const, sinceWeek: injured.week },
+        },
+      },
       cases: Object.fromEntries(
         Object.entries(injured.cases).map(([id, currentCase]) => [
           id,


### PR DESCRIPTION
## Summary
Implements a single deterministic impairment flag (\exposure:residue\) that gates ordinary rest recovery and injury discharge until supervised therapy downtime clears it under sufficient medical staff.

## Linear
- Parent: SPE-1653 (description updated with slice 1 boundary; issue remains open for follow-on impairment work)

## Changes
- Mission resolution attaches residue on anomaly-context **fail** without injury, or **any injury** under anomaly context.
- \dvanceRecoveryDowntimeForWeek\: rest blocked + bounded recurrence while gated; therapy keeps full trauma reduction but partial fatigue recovery until cleared; clearance at therapy + medical threshold.
- \dvanceRecoveryAgentsForWeek\: blocks return to active while residue persists.
- \dvanceWeek\: runs downtime pass after \inalizeMissionResults\.
- Tests: \ecoveryExposureResidue.test.ts\; injury recovery scenario sets therapy + medical so discharge timing stays honest.
- Doc: \docs/recovery-trauma-downtime-audit.md\ §3b.

## Validation
- \
pm run lint\
- \
pm run test:run\ (2869 tests)

Made with [Cursor](https://cursor.com)