### PR TITLE
SPE-1107: responder energy budget slice

### DIFF
--- a/architecture/fatigue-stress-exhaustion-multi-axis.md
+++ b/architecture/fatigue-stress-exhaustion-multi-axis.md
@@ -21,6 +21,12 @@ Author only the subset the campaign needs; unused channels stay inert.
 
 Surface **visible bands** (e.g., fresh / strained / depleted / critical) per channel or as a composite summary — reports should cite **which channel** bound an outcome.
 
+## Responder Energy Budget (SPE-1107)
+
+Responder energy is a sibling accounting layer that sits before fatigue accumulation. It tracks compact operational reserve bands (`stable`, `taxed`, `depleted`, `overdrawn`), deterministic duty-cost classes, and bounded estimate confidence. Baseline upkeep is charged even when a responder is idle; idle upkeep stays a flat floor while heavier duties resolve through relative exertion so conditioning, injury, and current reserve state can make the same task cheaper or more expensive for different responders.
+
+This layer does not replace the SPE-130 channels. When reserve is overdrawn, the budget converts explicit exertion debt into `physicalExhaustion` so downstream readiness and recovery systems consume the burden through the existing fatigue surfaces.
+
 ## Recovery
 
 - **Rest**, **medical ladder** (SPE-68), **downtime activities**, **doctrine rotations** — each channel may prefer different recovery vectors.

--- a/docs/deployment-readiness-time-cost-audit.md
+++ b/docs/deployment-readiness-time-cost-audit.md
@@ -51,6 +51,7 @@ Keep readiness state compact, canonical, and deterministic.
 - `deployable` (boolean)
 - `availabilityState` (`idle | assigned | training | recovering | unavailable`)
 - `fatigue`
+- `energyBudget` (`currentReserve`, `reserveBand`, `exertionDebt`, `estimateConfidence`)
 - `loadoutReadiness`
 - `certificationReadiness`
 - `trainingLockReason?`
@@ -80,6 +81,8 @@ Time cost should be additive, bounded, and source-attributable.
   - Mission duration model (`durationWeeks`, stage pressure, kind).
 - **Recovery tail**
   - Fatigue/stress after action and current attrition policy.
+- **Responder energy tail**
+  - Baseline upkeep and duty exertion may leave reserve debt that converts into existing fatigue channels when overdrawn.
 
 ### Deterministic total model
 
@@ -115,6 +118,7 @@ Deployment eligibility should return structured outputs, not a boolean only.
 
 - Low cohesion band (`unstable`/`fragile`).
 - High fatigue burden.
+- Depleted or overdrawn responder energy reserve when it has converted into fatigue/readiness burden.
 - Weakest-link risks (minimum member readiness below threshold).
 - Optional strategic mismatch (e.g., suboptimal category fit).
 

--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -17,6 +17,7 @@
 - `agent.trauma`: { traumaLevel: number, traumaTags: string[], lastEventWeek: number }
 - `agent.downtimeActivity`: { activity: 'rest' | 'training' | 'therapy' | 'other', sinceWeek: number }
 - `agent.fatigue`: number (existing, but recovery/downtime should update this deterministically)
+- `agent.energyBudget`: { currentReserve: number, reserveBand: 'stable' | 'taxed' | 'depleted' | 'overdrawn', exertionDebt: number, estimateConfidence: 'low' | 'medium' | 'high', lastDutyCost?: number } (SPE-1107 human energy accounting; converts overdrawn exertion into fatigue channels)
 - `team.recoveryPressure`: number (aggregate of member states, for overlay/stability)
 
 ## 3. Downtime Rules & Deterministic Progression
@@ -41,6 +42,7 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 - Progression is deterministic: same state + same downtime plan = same outcome.
 - Recovery rates and trauma reduction must be explicit, not random.
 - Downtime cannot erase major trauma instantly; recovery is gradual and stateful.
+- SPE-1107 energy reserve is charged by deterministic duty/upkeep costs before it becomes fatigue; idle rest can restore taxed/depleted reserve after upkeep, while overdrawn reserve becomes explicit exertion debt and physical fatigue burden rather than a hidden recovery reset.
 
 ### 3b. SPE-1653 slice — exposure residue (recovery gate)
 
@@ -65,6 +67,8 @@ Victory does not automatically close the recovery ledger; model outcomes where *
   - Recovery pressure from weakest-link is aggregated at team/agency level for overlays.
 - **Deployment Readiness:**
   - Readiness checks must consider trauma and recovery state, not just fatigue.
+- **Responder Energy Budget:**
+  - Idle upkeep, duty activity, and post-mission exertion debt are accounted for before they feed existing fatigue/readiness consumers.
 - **Training:**
   - Training is less effective or blocked for agents with high trauma or in recovery.
 - **Teams:**

--- a/src/domain/agent/models.ts
+++ b/src/domain/agent/models.ts
@@ -766,6 +766,30 @@ export interface AgentOverdriveState {
   recoveryDebt: number
 }
 
+/**
+ * SPE-1107 slice 1 compact human energy accounting.
+ *
+ * This is a bounded operational budget, not a literal body battery. It tracks
+ * current reserve and debt clearly enough for planning/debugging, then converts
+ * overdrawn work into the existing fatigue channel surfaces.
+ */
+export type AgentEnergyReserveBand = 'stable' | 'taxed' | 'depleted' | 'overdrawn'
+
+export type AgentEnergyEstimateConfidence = 'low' | 'medium' | 'high'
+
+export interface AgentEnergyBudgetState {
+  /** Current usable operational reserve, expressed as a compact 0..100 planning value. */
+  currentReserve: number
+  /** Readable reserve summary derived from currentReserve + exertionDebt. */
+  reserveBand: AgentEnergyReserveBand
+  /** Explicit later burden from work that exceeded available reserve. */
+  exertionDebt: number
+  /** Bounded confidence in the current reserve estimate; not a claim of exact body truth. */
+  estimateConfidence: AgentEnergyEstimateConfidence
+  /** Most recent deterministic duty cost after relative-exertion modifiers. */
+  lastDutyCost?: number
+}
+
 export interface Agent {
   id: Id
   name: string
@@ -857,6 +881,13 @@ export interface Agent {
    * Optional and backward-compatible; absent means no overdrive state/history.
    */
   overdrive?: AgentOverdriveState
+
+  /**
+   * SPE-1107 slice 1 responder energy budget.
+   * Optional for persistence compatibility; absent agents receive the default
+   * stable state when energy accounting first touches them.
+   */
+  energyBudget?: AgentEnergyBudgetState
 
   /**
    * SPE-1070 slice 1: consecutive off-duty coping weeks.

--- a/src/domain/responderEnergyBudget.ts
+++ b/src/domain/responderEnergyBudget.ts
@@ -1,9 +1,9 @@
+import type { Agent } from './models'
 import type {
-  Agent,
   AgentEnergyBudgetState,
   AgentEnergyReserveBand,
   AgentFatigueChannels,
-} from './models'
+} from './agent/models'
 import { createDefaultFatigueChannels } from './agentFatigueChannels'
 import { clamp } from './math'
 import { RESPONDER_ENERGY_CALIBRATION } from './sim/calibration'

--- a/src/domain/responderEnergyBudget.ts
+++ b/src/domain/responderEnergyBudget.ts
@@ -181,7 +181,7 @@ export function applyResponderEnergyExertion(
 ): ResponderEnergyExertionResult {
   const previousBudget = normalizeEnergyBudget(agent.energyBudget ?? createDefaultResponderEnergyBudget())
   const currentReserve = clamp(previousBudget.currentReserve, 0, 100)
-  const exertionCost = resolveResponderExertionCost(agent, dutyClass)
+  const exertionCost = resolveResponderExertionCost(agent, dutyClass, previousBudget)
   const rawReserve = currentReserve - exertionCost
   const exertionDebt = previousBudget.exertionDebt + Math.max(0, -rawReserve)
   const nextReserve = clamp(rawReserve, 0, 100)

--- a/src/domain/responderEnergyBudget.ts
+++ b/src/domain/responderEnergyBudget.ts
@@ -107,14 +107,14 @@ function normalizeEnergyBudget(energyBudget: AgentEnergyBudgetState): AgentEnerg
 
 export function resolveResponderExertionCost(
   agent: Agent,
-  dutyClass: ResponderDutyCostClass
+  dutyClass: ResponderDutyCostClass,
+  energyBudget: AgentEnergyBudgetState = normalizeEnergyBudget(agent.energyBudget ?? createDefaultResponderEnergyBudget())
 ): number {
   const baseCost = getResponderDutyCost(dutyClass)
   if (dutyClass === 'idle_upkeep') {
     return baseCost
   }
 
-  const energyBudget = normalizeEnergyBudget(agent.energyBudget ?? createDefaultResponderEnergyBudget())
   const reserveBandMultiplier =
     RESPONDER_ENERGY_CALIBRATION.reserveBandMultipliers[energyBudget.reserveBand]
 

--- a/src/domain/responderEnergyBudget.ts
+++ b/src/domain/responderEnergyBudget.ts
@@ -1,0 +1,204 @@
+import type {
+  Agent,
+  AgentEnergyBudgetState,
+  AgentEnergyReserveBand,
+  AgentFatigueChannels,
+} from './models'
+import { createDefaultFatigueChannels } from './agentFatigueChannels'
+import { clamp } from './math'
+import { RESPONDER_ENERGY_CALIBRATION } from './sim/calibration'
+
+export type ResponderDutyCostClass = keyof typeof RESPONDER_ENERGY_CALIBRATION.dutyCosts
+
+export interface ResponderEnergyBandInput {
+  currentReserve: number
+  exertionDebt: number
+}
+
+export interface ResponderEnergyExertionResult {
+  energyBudget: AgentEnergyBudgetState
+  fatigueChannels: AgentFatigueChannels
+}
+
+export function getResponderDutyCost(dutyClass: ResponderDutyCostClass): number {
+  return RESPONDER_ENERGY_CALIBRATION.dutyCosts[dutyClass]
+}
+
+export function classifyResponderEnergyReserve({
+  currentReserve,
+  exertionDebt,
+}: ResponderEnergyBandInput): AgentEnergyReserveBand {
+  if (exertionDebt > 0) {
+    return 'overdrawn'
+  }
+
+  if (currentReserve >= RESPONDER_ENERGY_CALIBRATION.reserveBands.stable) {
+    return 'stable'
+  }
+
+  if (currentReserve >= RESPONDER_ENERGY_CALIBRATION.reserveBands.taxed) {
+    return 'taxed'
+  }
+
+  return 'depleted'
+}
+
+export function createDefaultResponderEnergyBudget(): AgentEnergyBudgetState {
+  const currentReserve = RESPONDER_ENERGY_CALIBRATION.defaultReserve
+
+  return {
+    currentReserve,
+    reserveBand: classifyResponderEnergyReserve({ currentReserve, exertionDebt: 0 }),
+    exertionDebt: 0,
+    estimateConfidence: 'medium',
+  }
+}
+
+function getPhysicalCapacity(agent: Agent): number {
+  if (agent.stats) {
+    return Math.round((agent.stats.physical.strength + agent.stats.physical.endurance) / 2)
+  }
+
+  return Math.round((agent.baseStats.combat + agent.baseStats.utility) / 2)
+}
+
+function getConditioningMultiplier(agent: Agent): number {
+  const capacity = getPhysicalCapacity(agent)
+  const { conditioningThresholds, conditioningMultipliers } = RESPONDER_ENERGY_CALIBRATION
+
+  if (capacity >= conditioningThresholds.strong) {
+    return conditioningMultipliers.strong
+  }
+
+  if (capacity >= conditioningThresholds.capable) {
+    return conditioningMultipliers.capable
+  }
+
+  if (capacity < conditioningThresholds.strained) {
+    return conditioningMultipliers.strained
+  }
+
+  return conditioningMultipliers.baseline
+}
+
+function getStatusMultiplier(agent: Agent): number {
+  if (agent.status === 'injured') {
+    return RESPONDER_ENERGY_CALIBRATION.statusMultipliers.injured
+  }
+
+  if (agent.status === 'recovering' || agent.assignment?.state === 'recovery') {
+    return RESPONDER_ENERGY_CALIBRATION.statusMultipliers.recovering
+  }
+
+  return 1
+}
+
+function normalizeEnergyBudget(energyBudget: AgentEnergyBudgetState): AgentEnergyBudgetState {
+  const currentReserve = clamp(energyBudget.currentReserve, 0, 100)
+  const exertionDebt = Math.max(0, Math.trunc(energyBudget.exertionDebt))
+
+  return {
+    ...energyBudget,
+    currentReserve,
+    exertionDebt,
+    reserveBand: classifyResponderEnergyReserve({ currentReserve, exertionDebt }),
+  }
+}
+
+export function resolveResponderExertionCost(
+  agent: Agent,
+  dutyClass: ResponderDutyCostClass
+): number {
+  const baseCost = getResponderDutyCost(dutyClass)
+  if (dutyClass === 'idle_upkeep') {
+    return baseCost
+  }
+
+  const energyBudget = normalizeEnergyBudget(agent.energyBudget ?? createDefaultResponderEnergyBudget())
+  const reserveBandMultiplier =
+    RESPONDER_ENERGY_CALIBRATION.reserveBandMultipliers[energyBudget.reserveBand]
+
+  return Math.max(
+    1,
+    Math.round(
+      baseCost *
+        getConditioningMultiplier(agent) *
+        getStatusMultiplier(agent) *
+        reserveBandMultiplier
+    )
+  )
+}
+
+function applyOverdrawnPhysicalBurden(
+  channels: AgentFatigueChannels,
+  exertionCost: number,
+  exertionDebt: number
+): AgentFatigueChannels {
+  if (exertionDebt <= 0) {
+    return channels
+  }
+
+  const rawDelta =
+    Math.ceil(exertionDebt / RESPONDER_ENERGY_CALIBRATION.overdrawnPhysicalDebtDivisor) +
+    Math.ceil(exertionCost * RESPONDER_ENERGY_CALIBRATION.overdrawnPhysicalCostShare)
+  const physicalDelta = Math.min(RESPONDER_ENERGY_CALIBRATION.maxOverdrawnPhysicalDelta, rawDelta)
+
+  return {
+    ...channels,
+    physicalExhaustion: clamp(channels.physicalExhaustion + physicalDelta, 0, 100),
+  }
+}
+
+export function applyResponderEnergyRecovery(
+  energyBudget: AgentEnergyBudgetState
+): AgentEnergyBudgetState {
+  const normalizedBudget = normalizeEnergyBudget(energyBudget)
+
+  if (normalizedBudget.reserveBand === 'stable' && normalizedBudget.exertionDebt <= 0) {
+    return normalizedBudget
+  }
+
+  const debtRecovered = Math.min(
+    normalizedBudget.exertionDebt,
+    RESPONDER_ENERGY_CALIBRATION.idleDebtRecovery
+  )
+  const exertionDebt = normalizedBudget.exertionDebt - debtRecovered
+  const reserveRecovery = exertionDebt > 0 ? 0 : RESPONDER_ENERGY_CALIBRATION.idleReserveRecovery
+  const currentReserve = clamp(normalizedBudget.currentReserve + reserveRecovery, 0, 100)
+
+  return {
+    ...normalizedBudget,
+    currentReserve,
+    exertionDebt,
+    reserveBand: classifyResponderEnergyReserve({ currentReserve, exertionDebt }),
+  }
+}
+
+export function applyResponderEnergyExertion(
+  agent: Agent,
+  dutyClass: ResponderDutyCostClass,
+  sourceChannels: AgentFatigueChannels = agent.fatigueChannels ?? createDefaultFatigueChannels()
+): ResponderEnergyExertionResult {
+  const previousBudget = normalizeEnergyBudget(agent.energyBudget ?? createDefaultResponderEnergyBudget())
+  const currentReserve = clamp(previousBudget.currentReserve, 0, 100)
+  const exertionCost = resolveResponderExertionCost(agent, dutyClass)
+  const rawReserve = currentReserve - exertionCost
+  const exertionDebt = previousBudget.exertionDebt + Math.max(0, -rawReserve)
+  const nextReserve = clamp(rawReserve, 0, 100)
+  const reserveBand = classifyResponderEnergyReserve({
+    currentReserve: nextReserve,
+    exertionDebt,
+  })
+  const energyBudget: AgentEnergyBudgetState = {
+    currentReserve: nextReserve,
+    reserveBand,
+    exertionDebt,
+    estimateConfidence: previousBudget.estimateConfidence,
+    lastDutyCost: exertionCost,
+  }
+
+  return {
+    energyBudget,
+    fatigueChannels: applyOverdrawnPhysicalBurden(sourceChannels, exertionCost, exertionDebt),
+  }
+}

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -84,6 +84,47 @@ export const RECOVERY_CALIBRATION = {
   exposureResidueMedicalClearThreshold: 2,
 } as const
 
+export const RESPONDER_ENERGY_CALIBRATION = {
+  defaultReserve: 100,
+  reserveBands: {
+    stable: 70,
+    taxed: 35,
+  },
+  dutyCosts: {
+    idle_upkeep: 2,
+    patrol: 8,
+    carry: 13,
+    sprint_response: 18,
+    prolonged_field_operation: 24,
+  },
+  conditioningThresholds: {
+    strong: 75,
+    capable: 55,
+    strained: 40,
+  },
+  conditioningMultipliers: {
+    strong: 0.75,
+    capable: 0.9,
+    baseline: 1,
+    strained: 1.25,
+  },
+  statusMultipliers: {
+    injured: 1.35,
+    recovering: 1.25,
+  },
+  reserveBandMultipliers: {
+    stable: 1,
+    taxed: 1.1,
+    depleted: 1.25,
+    overdrawn: 1.4,
+  },
+  overdrawnPhysicalDebtDivisor: 2,
+  overdrawnPhysicalCostShare: 0.25,
+  maxOverdrawnPhysicalDelta: 12,
+  idleReserveRecovery: 6,
+  idleDebtRecovery: 4,
+} as const
+
 // Band-gated overrides for second escalation band
 export function getHealthyReturnFatigueThreshold(week: number) {
   return isSecondEscalationBandWeek(week) ? 18 : RECOVERY_CALIBRATION.healthyReturnFatigueThreshold;

--- a/src/domain/sim/fatiguePipeline.ts
+++ b/src/domain/sim/fatiguePipeline.ts
@@ -8,6 +8,11 @@ import {
   createDefaultFatigueChannels,
   resetCapabilityUsesPhaseCounter,
 } from '../agentFatigueChannels'
+import {
+  applyResponderEnergyExertion,
+  applyResponderEnergyRecovery,
+  type ResponderDutyCostClass,
+} from '../responderEnergyBudget'
 import { getTeamMemberIds } from '../teamSimulation'
 
 function getMissionFatigue(config: GameState['config']) {
@@ -94,14 +99,25 @@ export function applyWeeklyAgentFatigue({
         channels: resetChannels,
         overdrive: agent.overdrive ?? createDefaultOverdriveState(),
       })
+      const dutyClass: ResponderDutyCostClass = isActive
+        ? 'prolonged_field_operation'
+        : isTraining
+          ? 'patrol'
+          : 'idle_upkeep'
+      const exertionTick = applyResponderEnergyExertion(agent, dutyClass, debtTick.channels)
+      const energyBudget =
+        isActive || isTraining
+          ? exertionTick.energyBudget
+          : applyResponderEnergyRecovery(exertionTick.energyBudget)
 
       return [
         id,
         {
           ...agent,
           fatigue: clamp(agent.fatigue + delta, 0, 100),
-          fatigueChannels: debtTick.channels,
+          fatigueChannels: exertionTick.fatigueChannels,
           overdrive: debtTick.overdrive,
+          energyBudget,
         },
       ]
     })

--- a/src/test/responderEnergyBudget.test.ts
+++ b/src/test/responderEnergyBudget.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import type { Agent } from '../domain/models'
+import { applyWeeklyAgentFatigue } from '../domain/sim/fatiguePipeline'
+import {
+  applyResponderEnergyExertion,
+  applyResponderEnergyRecovery,
+  classifyResponderEnergyReserve,
+  createDefaultResponderEnergyBudget,
+  getResponderDutyCost,
+  resolveResponderExertionCost,
+} from '../domain/responderEnergyBudget'
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'agent-energy',
+    name: 'Energy Agent',
+    role: 'field_recon',
+    baseStats: { combat: 5, investigation: 5, utility: 5, social: 5 },
+    stats: {
+      physical: { strength: 50, endurance: 50 },
+      tactical: { awareness: 50, reaction: 50 },
+      cognitive: { analysis: 50, investigation: 50 },
+      social: { negotiation: 50, influence: 50 },
+      stability: { resistance: 50, tolerance: 50 },
+      technical: { equipment: 50, anomaly: 50 },
+    },
+    tags: [],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+    ...overrides,
+  }
+}
+
+describe('responder energy budget', () => {
+  it('uses deterministic duty-cost classes', () => {
+    expect(getResponderDutyCost('idle_upkeep')).toBeLessThan(getResponderDutyCost('patrol'))
+    expect(getResponderDutyCost('patrol')).toBeLessThan(getResponderDutyCost('carry'))
+    expect(getResponderDutyCost('carry')).toBeLessThan(getResponderDutyCost('sprint_response'))
+    expect(getResponderDutyCost('sprint_response')).toBeLessThan(
+      getResponderDutyCost('prolonged_field_operation')
+    )
+  })
+
+  it('resolves the same duty as higher exertion for lower conditioning and injury', () => {
+    const conditioned = makeAgent({
+      stats: {
+        ...makeAgent().stats!,
+        physical: { strength: 80, endurance: 85 },
+      },
+    })
+    const strained = makeAgent({
+      status: 'injured',
+      stats: {
+        ...makeAgent().stats!,
+        physical: { strength: 35, endurance: 30 },
+      },
+    })
+
+    expect(resolveResponderExertionCost(conditioned, 'carry')).toBeLessThan(
+      resolveResponderExertionCost(strained, 'carry')
+    )
+  })
+
+  it('increases non-idle exertion cost when reserve is already taxed', () => {
+    const stable = makeAgent({
+      energyBudget: {
+        currentReserve: 90,
+        reserveBand: 'stable',
+        exertionDebt: 0,
+        estimateConfidence: 'medium',
+      },
+    })
+    const taxed = makeAgent({
+      energyBudget: {
+        currentReserve: 45,
+        reserveBand: 'taxed',
+        exertionDebt: 0,
+        estimateConfidence: 'medium',
+      },
+    })
+
+    expect(resolveResponderExertionCost(taxed, 'patrol')).toBeGreaterThan(
+      resolveResponderExertionCost(stable, 'patrol')
+    )
+  })
+
+  it('derives reserve band from numeric state instead of trusting stale stored band', () => {
+    const staleStable = makeAgent({
+      energyBudget: {
+        currentReserve: 20,
+        reserveBand: 'stable',
+        exertionDebt: 0,
+        estimateConfidence: 'medium',
+      },
+    })
+    const realStable = makeAgent({
+      energyBudget: {
+        currentReserve: 90,
+        reserveBand: 'stable',
+        exertionDebt: 0,
+        estimateConfidence: 'medium',
+      },
+    })
+
+    expect(resolveResponderExertionCost(staleStable, 'patrol')).toBeGreaterThan(
+      resolveResponderExertionCost(realStable, 'patrol')
+    )
+    expect(applyResponderEnergyRecovery(staleStable.energyBudget!).currentReserve).toBeGreaterThan(
+      staleStable.energyBudget!.currentReserve
+    )
+  })
+
+  it('classifies compact reserve bands from reserve and debt', () => {
+    expect(classifyResponderEnergyReserve({ currentReserve: 82, exertionDebt: 0 })).toBe('stable')
+    expect(classifyResponderEnergyReserve({ currentReserve: 48, exertionDebt: 0 })).toBe('taxed')
+    expect(classifyResponderEnergyReserve({ currentReserve: 18, exertionDebt: 0 })).toBe('depleted')
+    expect(classifyResponderEnergyReserve({ currentReserve: 0, exertionDebt: 3 })).toBe('overdrawn')
+  })
+
+  it('charges baseline upkeep to idle agents during the weekly fatigue pass', () => {
+    const state = createStartingState()
+    const idleAgentId = Object.keys(state.agents).find(
+      (agentId) => !state.teams['t_nightwatch'].agentIds.includes(agentId)
+    )
+
+    expect(idleAgentId).toBeDefined()
+    state.agents[idleAgentId!] = {
+      ...state.agents[idleAgentId!],
+      energyBudget: createDefaultResponderEnergyBudget(),
+    }
+
+    const result = applyWeeklyAgentFatigue({
+      agents: state.agents,
+      teams: state.teams,
+      config: state.config,
+      activeTeamIds: ['t_nightwatch'],
+    })
+
+    expect(result[idleAgentId!].energyBudget!.currentReserve).toBeLessThan(
+      state.agents[idleAgentId!].energyBudget!.currentReserve
+    )
+    expect(result[idleAgentId!].energyBudget!.lastDutyCost).toBe(
+      getResponderDutyCost('idle_upkeep')
+    )
+  })
+
+  it('restores taxed idle reserve after upkeep without erasing the upkeep record', () => {
+    const state = createStartingState()
+    const idleAgentId = Object.keys(state.agents).find(
+      (agentId) => !state.teams['t_nightwatch'].agentIds.includes(agentId)
+    )
+
+    expect(idleAgentId).toBeDefined()
+    state.agents[idleAgentId!] = {
+      ...state.agents[idleAgentId!],
+      energyBudget: {
+        currentReserve: 50,
+        reserveBand: 'taxed',
+        exertionDebt: 0,
+        estimateConfidence: 'medium',
+      },
+    }
+
+    const result = applyWeeklyAgentFatigue({
+      agents: state.agents,
+      teams: state.teams,
+      config: state.config,
+      activeTeamIds: ['t_nightwatch'],
+    })
+
+    expect(result[idleAgentId!].energyBudget!.currentReserve).toBeGreaterThan(50)
+    expect(result[idleAgentId!].energyBudget!.lastDutyCost).toBe(
+      getResponderDutyCost('idle_upkeep')
+    )
+  })
+
+  it('maps active and training agents to bounded weekly duty costs', () => {
+    const state = createStartingState()
+    const activeAgentId = state.teams['t_nightwatch'].agentIds[0]
+    const trainingAgentId = state.teams['t_greentape'].agentIds[0]
+
+    state.agents[activeAgentId] = {
+      ...state.agents[activeAgentId],
+      energyBudget: createDefaultResponderEnergyBudget(),
+    }
+    state.agents[trainingAgentId] = {
+      ...state.agents[trainingAgentId],
+      assignment: {
+        state: 'training',
+        startedWeek: state.week,
+      },
+      energyBudget: createDefaultResponderEnergyBudget(),
+    }
+
+    const result = applyWeeklyAgentFatigue({
+      agents: state.agents,
+      teams: state.teams,
+      config: state.config,
+      activeTeamIds: ['t_nightwatch'],
+    })
+
+    expect(result[activeAgentId].energyBudget!.lastDutyCost).toBe(
+      resolveResponderExertionCost(state.agents[activeAgentId], 'prolonged_field_operation')
+    )
+    expect(result[trainingAgentId].energyBudget!.lastDutyCost).toBe(
+      resolveResponderExertionCost(state.agents[trainingAgentId], 'patrol')
+    )
+  })
+
+  it('converts overdrawn exertion into downstream physical fatigue debt', () => {
+    const agent = makeAgent({
+      energyBudget: {
+        currentReserve: 4,
+        reserveBand: 'depleted',
+        exertionDebt: 0,
+        estimateConfidence: 'medium',
+      },
+    })
+
+    const result = applyResponderEnergyExertion(agent, 'prolonged_field_operation')
+
+    expect(result.energyBudget.reserveBand).toBe('overdrawn')
+    expect(result.energyBudget.exertionDebt).toBeGreaterThan(0)
+    expect(result.fatigueChannels.physicalExhaustion).toBeGreaterThan(0)
+  })
+})

--- a/systems/mission-resolution.md
+++ b/systems/mission-resolution.md
@@ -126,6 +126,7 @@ Mission resolution reads team-side state such as:
 - role coverage
 - certifications
 - injuries / trauma / fatigue
+- responder energy reserve and exertion debt
 - current deployment burden if relevant
 
 These define whether the field unit can execute the mission reliably.
@@ -142,6 +143,7 @@ Examples:
 - missing certification coverage
 - critical loadout gap
 - injury penalty on a required role
+- overdrawn responder energy converting into physical fatigue burden
 
 The system should avoid broad per-person action scripting.
 

--- a/systems/team-management.md
+++ b/systems/team-management.md
@@ -15,6 +15,7 @@ It includes:
 - cohesion
 - readiness
 - injuries, trauma, downtime, and recovery
+- responder energy reserve, upkeep, and exertion debt
 - replacement pressure
 - bounded assignment consequences across weeks
 
@@ -85,6 +86,7 @@ That means team management should emphasize:
 - bottlenecks
 - role coverage
 - recovery burden
+- energy reserve and exertion debt
 
 The goal is not “build your favorite party.”
 The goal is:


### PR DESCRIPTION
## Summary
- Adds a compact optional responder energy budget state with reserve bands, exertion debt, confidence, and last duty cost.
- Adds deterministic duty-cost classes plus relative exertion from conditioning, injury/recovery, and reserve state.
- Wires weekly fatigue progression to charge idle upkeep, training patrol, and prolonged field operation, with overdrawn energy converting into physical fatigue channels.
- Documents the SPE-1107 boundary in fatigue, recovery/readiness, mission, and team docs.

## Test plan
- npm run test:run -- src/test/responderEnergyBudget.test.ts src/test/sim.fatiguePipeline.test.ts src/test/agentFatigueChannels.test.ts
- npm run lint
- git diff --check
- npm run test:run

## Linear
- Updated SPE-1107 description before coding to record the slice 1 boundary and follow-on scope.