### PR TITLE
SPE-1699: One primary downtime slot per agent per week

### DIFF
--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -15,7 +15,7 @@
 ## 2. Recommended Canonical State Fields
 - `agent.recoveryStatus`: { state: 'healthy' | 'recovering' | 'traumatized' | 'incapacitated', detail?: string, sinceWeek: number }
 - `agent.trauma`: { traumaLevel: number, traumaTags: string[], lastEventWeek: number }
-- `agent.downtimeActivity`: { activity: 'rest' | 'training' | 'therapy' | 'other', sinceWeek: number }
+- `agent.downtimeActivity`: { activity: 'rest' | 'training' | 'therapy' | 'other' | 'coping', sinceWeek: number, foregoneThisInterval?: … }
 - `agent.fatigue`: number (existing, but recovery/downtime should update this deterministically)
 - `team.recoveryPressure`: number (aggregate of member states, for overlay/stability)
 
@@ -39,6 +39,7 @@ Victory does not automatically close the recovery ledger; model outcomes where *
   - Undergo therapy (reduce trauma, but not fatigue)
   - Other (custom activities, e.g., research, support)
 - Progression is deterministic: same state + same downtime plan = same outcome.
+- **SPE-1699 — one primary slot per operative per week:** player menu picks (`rest`, `therapy`, `coping`, `other`) are mutually exclusive for a given week. Formal **academy training** (`assignment.state === 'training'`) consumes the same slot; week-close writes `foregoneThisInterval` listing other menu actions not taken (full menu when training overrides). `other` is a compact logistics / prep placeholder (not SPE-1700 side-work risks). Selection UI: Teams roster; tick wiring unchanged (`advanceRecoveryDowntimeForWeek` after mission finalization).
 - Recovery rates and trauma reduction must be explicit, not random.
 - Downtime cannot erase major trauma instantly; recovery is gradual and stateful.
 
@@ -50,7 +51,12 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 - **Therapy channel:** trauma reduction from **therapy** downtime proceeds at full rate; fatigue recovery from therapy is **partial** while the flag remains (split recovery channels).
 - **Clearance:** one week of **therapy** downtime while agency `supportStaff.medical` meets `RECOVERY_CALIBRATION.exposureResidueMedicalClearThreshold` strips the flag (supervised washdown / decontamination).
 - **Assignment recovery:** `advanceRecoveryAgentsForWeek` withholds injury discharge to active duty until the flag is cleared, even after injury-duration weeks elapse. Writes merge from `nextAgents[agentId]` (then `updatedAgents`) when present so earlier week-open mutations are not dropped when appending the blocked-discharge history entry.
-- **Tick wiring:** `advanceRecoveryDowntimeForWeek` runs at end of `advanceWeek` after mission finalization; per-agent downtime selection defaults from `agent.downtimeActivity?.activity` or **rest**.
+- **Tick wiring:** `advanceRecoveryDowntimeForWeek` runs at end of `advanceWeek` after mission finalization; per-agent **effective** downtime is resolved per §3c (`resolveDowntimeSlotForAgent`), with the weekly map defaulting from the resolver (menu default **rest** when unset).
+
+### 3c. SPE-1699 slice — one-slot downtime (recovery menu vs academy training)
+
+- **Rule:** at most one **primary** downtime action applies per agent per weekly tick. Player-selectable recovery-phase actions are `rest`, `therapy`, `coping`, `other` (see Teams UI). **Academy training queue** activity (`assignment.state === 'training'`) **wins** over any stored menu pick and clears competing recovery uses for that tick.
+- **Evidence:** `resolveDowntimeSlotForAgent` in `downtimeSlot.ts`; `advanceRecoveryDowntimeForWeek` persists `foregoneThisInterval` on `agent.downtimeActivity`; `advanceWeek` pre-computes effective assignments from the resolver. Tests: `src/test/downtimeSlot.test.ts`.
 
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.
@@ -89,7 +95,7 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 ## 7. Open Questions
 - What are the canonical trauma tags and their gameplay effects?
 - Should trauma be capped, or can it accumulate indefinitely?
-- How do therapy and rest interact if both are assigned as downtime?
+- How do therapy and rest interact if both are assigned as downtime? **(SPE-1699: only one primary menu action per week; see §3c.)**
 - What are the thresholds for blocking deployment or training due to trauma?
 - How should recovery interact with agent relationships and team chemistry?
 - Should trauma have narrative consequences (e.g., unique events, dialogue)?

--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -56,7 +56,8 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 ### 3c. SPE-1699 slice — one-slot downtime (recovery menu vs academy training)
 
 - **Rule:** at most one **primary** downtime action applies per agent per weekly tick. Player-selectable recovery-phase actions are `rest`, `therapy`, `coping`, `other` (see Teams UI). **Academy training queue** activity (`assignment.state === 'training'`) **wins** over any stored menu pick and clears competing recovery uses for that tick.
-- **Evidence:** `resolveDowntimeSlotForAgent` in `downtimeSlot.ts`; `advanceRecoveryDowntimeForWeek` persists `foregoneThisInterval` on `agent.downtimeActivity`; `advanceWeek` pre-computes effective assignments from the resolver. Tests: `src/test/downtimeSlot.test.ts`.
+- **Ordering:** `advanceWeek` captures each agent’s resolved effective slot at the **start** of `advanceQueues` (before `advanceTrainingQueues` removes completed programs from the queue and clears `assignment.state`), then `applyRecoveryDowntimeAfterMissions` consumes that snapshot. This keeps the **final week** of a training program on the `training` slot instead of incorrectly falling through to menu/`rest` after completion processing.
+- **Evidence:** `resolveDowntimeSlotForAgent` in `downtimeSlot.ts`; `advanceWeek` snapshot on `WeeklyExecutionContext.downtimeSlotEffectiveByAgentId`; `advanceRecoveryDowntimeForWeek` persists `foregoneThisInterval` on `agent.downtimeActivity`. Tests: `src/test/downtimeSlot.test.ts`.
 
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -111,6 +111,10 @@ import {
   spendSkillPoint,
   transitionCertification,
 } from '../../domain/sim/training'
+import {
+  setAgentPrimaryDowntimePlan as applyPrimaryDowntimePlanToGame,
+  type PlayerPrimaryDowntimeMenu,
+} from '../../domain/sim/downtimeSlot'
 import { upgradeAcademy } from '../../domain/sim/academyUpgrade'
 import {
   assignInstructor,
@@ -229,6 +233,8 @@ interface GameStore {
   setTeamLeader: (teamId: Id, leaderId: Id | null) => void
   moveAgentBetweenTeams: (agentId: Id, targetTeamId?: Id | null) => void
   deleteEmptyTeam: (teamId: Id) => void
+  /** SPE-1699: set the single weekly primary downtime menu action for an eligible operative. */
+  setAgentPrimaryDowntimePlan: (agentId: Id, activity: PlayerPrimaryDowntimeMenu) => void
   queueTraining: (agentId: Id, trainingId: string) => void
   queueTeamTraining: (teamId: Id, trainingId: string) => void
   cancelTraining: (agentId: Id) => void
@@ -1240,6 +1246,9 @@ export const useGameStore = create<GameStore>()(
             },
           }
         }),
+
+      setAgentPrimaryDowntimePlan: (agentId, activity) =>
+        set((s) => ({ game: applyPrimaryDowntimePlanToGame(s.game, agentId, activity) })),
 
       queueTraining: (agentId, trainingId) =>
         set((s) => ({ game: queueTraining(s.game, agentId, trainingId) })),

--- a/src/domain/agent/models.ts
+++ b/src/domain/agent/models.ts
@@ -721,6 +721,8 @@ export interface AgentTraumaState {
 export interface AgentDowntimeActivity {
   activity: 'rest' | 'training' | 'therapy' | 'other' | 'coping'
   sinceWeek: number
+  /** SPE-1699: deterministic list of other primary actions not taken this weekly tick. */
+  foregoneThisInterval?: Array<'rest' | 'training' | 'therapy' | 'other' | 'coping'>
 }
 
 /**

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -242,6 +242,7 @@ import { decayCreditPackets, type CivicCreditPacket } from '../civicCreditChanne
 import { decayAccessPackets, type CivicAccessPacket } from '../civicAccessChannel'
 import { listQueuedRuntimeEvents } from '../eventQueue'
 import { advanceRecoveryAgentsForWeek } from './recoveryPipeline'
+import { resolveDowntimeSlotForAgent } from './downtimeSlot'
 import { advanceRecoveryDowntimeForWeek, type DowntimeActivity } from './recoveryDowntime'
 import { finalizeMissionResultsFromDrafts } from './missionFinalizationPipeline'
 import { advanceTrainingQueues } from './training'
@@ -3567,7 +3568,7 @@ function applyRecoveryDowntimeAfterMissions(context: WeeklyExecutionContext) {
   const downtimeAssignments: Record<string, DowntimeActivity> = {}
   for (const id of Object.keys(context.nextState.agents)) {
     const agent = context.nextState.agents[id]
-    downtimeAssignments[id] = (agent?.downtimeActivity?.activity as DowntimeActivity) ?? 'rest'
+    downtimeAssignments[id] = resolveDowntimeSlotForAgent(agent).effective
   }
 
   const downtimeResult = advanceRecoveryDowntimeForWeek({

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -1617,6 +1617,13 @@ interface WeeklyExecutionContext {
   generatedRecruitmentCandidates: GameState['candidates']
   hubNotes?: ReportNote[]
   noteBaseTimestamp?: number
+  /**
+   * SPE-1699: per-agent effective downtime slot resolved at the start of `advanceQueues`,
+   * before `advanceTrainingQueues` clears completed training assignments. Used by
+   * `applyRecoveryDowntimeAfterMissions` so the closing week of academy training still
+   * resolves as `training`.
+   */
+  downtimeSlotEffectiveByAgentId?: Record<string, DowntimeActivity>
 }
 
 interface BuiltWeeklyReport {
@@ -3511,6 +3518,14 @@ function advanceWeirdRoomDwell(context: WeeklyExecutionContext) {
 }
 
 function advanceQueues(context: WeeklyExecutionContext) {
+  const downtimeSlotEffectiveByAgentId: Record<string, DowntimeActivity> = {}
+  for (const id of Object.keys(context.nextState.agents)) {
+    const agent = context.nextState.agents[id]
+    if (!agent) continue
+    downtimeSlotEffectiveByAgentId[id] = resolveDowntimeSlotForAgent(agent).effective
+  }
+  context.downtimeSlotEffectiveByAgentId = downtimeSlotEffectiveByAgentId
+
   const trainingResult = advanceTrainingQueues(context.nextState)
   context.nextState = trainingResult.state
   context.eventDrafts.push(...trainingResult.eventDrafts)
@@ -3566,9 +3581,11 @@ function shiftMarket(context: WeeklyExecutionContext, rng: SeededRng) {
 
 function applyRecoveryDowntimeAfterMissions(context: WeeklyExecutionContext) {
   const downtimeAssignments: Record<string, DowntimeActivity> = {}
+  const snapshot = context.downtimeSlotEffectiveByAgentId
   for (const id of Object.keys(context.nextState.agents)) {
     const agent = context.nextState.agents[id]
-    downtimeAssignments[id] = resolveDowntimeSlotForAgent(agent).effective
+    if (!agent) continue
+    downtimeAssignments[id] = snapshot?.[id] ?? resolveDowntimeSlotForAgent(agent).effective
   }
 
   const downtimeResult = advanceRecoveryDowntimeForWeek({

--- a/src/domain/sim/downtimeSlot.ts
+++ b/src/domain/sim/downtimeSlot.ts
@@ -1,0 +1,108 @@
+import type { Agent } from '../agent/models'
+import type { GameState, Id } from '../models'
+import type { DowntimeActivity } from './recoveryDowntime'
+
+/** Menu actions the player can assign as a single weekly primary (SPE-1699). */
+export const PLAYER_PRIMARY_DOWNTIME_MENU = ['rest', 'therapy', 'coping', 'other'] as const
+
+export type PlayerPrimaryDowntimeMenu = (typeof PLAYER_PRIMARY_DOWNTIME_MENU)[number]
+
+const DOWNTIME_ACTIVITY_VALUES: readonly DowntimeActivity[] = [
+  'rest',
+  'training',
+  'therapy',
+  'other',
+  'coping',
+]
+
+function isDowntimeActivity(value: string | undefined): value is DowntimeActivity {
+  return value !== undefined && (DOWNTIME_ACTIVITY_VALUES as readonly string[]).includes(value)
+}
+
+function normalizeRequestedDowntime(raw: string | undefined): DowntimeActivity {
+  if (!raw || !isDowntimeActivity(raw) || raw === 'training') {
+    return 'rest'
+  }
+  return raw
+}
+
+export interface ResolveDowntimeSlotOptions {
+  /** When set (e.g. from `advanceRecoveryDowntimeForWeek` maps in tests), wins over `agent.downtimeActivity`. */
+  explicitEffective?: DowntimeActivity
+}
+
+export interface ResolvedDowntimeSlot {
+  effective: DowntimeActivity
+  foregone: DowntimeActivity[]
+}
+
+/**
+ * SPE-1699: one primary downtime slot per agent per weekly tick.
+ * Formal academy training consumes the slot; recovery-menu picks are listed as foregone that week.
+ */
+export function resolveDowntimeSlotForAgent(
+  agent: Agent,
+  opts?: ResolveDowntimeSlotOptions
+): ResolvedDowntimeSlot {
+  if (agent.assignment?.state === 'training') {
+    return {
+      effective: 'training',
+      foregone: [...PLAYER_PRIMARY_DOWNTIME_MENU],
+    }
+  }
+
+  const raw = opts?.explicitEffective ?? agent.downtimeActivity?.activity
+  const effective = normalizeRequestedDowntime(raw)
+  const foregone = PLAYER_PRIMARY_DOWNTIME_MENU.filter((a) => a !== effective)
+  return { effective, foregone }
+}
+
+export function canSelectPrimaryDowntimePlan(agent: Agent): boolean {
+  if (agent.status === 'dead' || agent.status === 'resigned') {
+    return false
+  }
+  const st = agent.assignment?.state
+  return st !== 'assigned' && st !== 'training' && st !== 'resolving'
+}
+
+const PRIMARY_DOWNTIME_LABEL: Record<DowntimeActivity, string> = {
+  rest: 'Rest & recovery',
+  therapy: 'Therapy / supervised washdown',
+  coping: 'Off-duty coping',
+  other: 'Logistics / side prep',
+  training: 'Academy training (slot)',
+}
+
+export function getPrimaryDowntimeLabel(activity: DowntimeActivity): string {
+  return PRIMARY_DOWNTIME_LABEL[activity]
+}
+
+export function formatForegoneDowntimeSummary(foregone: readonly DowntimeActivity[]): string {
+  if (foregone.length === 0) return ''
+  return foregone.map((a) => getPrimaryDowntimeLabel(a)).join('; ')
+}
+
+export function setAgentPrimaryDowntimePlan(
+  state: GameState,
+  agentId: Id,
+  activity: PlayerPrimaryDowntimeMenu
+): GameState {
+  const agent = state.agents[agentId]
+  if (!agent || !canSelectPrimaryDowntimePlan(agent)) {
+    return state
+  }
+
+  return {
+    ...state,
+    agents: {
+      ...state.agents,
+      [agentId]: {
+        ...agent,
+        downtimeActivity: {
+          activity,
+          sinceWeek: state.week,
+        },
+      },
+    },
+  }
+}

--- a/src/domain/sim/downtimeSlot.ts
+++ b/src/domain/sim/downtimeSlot.ts
@@ -51,6 +51,13 @@ export function resolveDowntimeSlotForAgent(
     }
   }
 
+  if (opts?.explicitEffective === 'training') {
+    return {
+      effective: 'training',
+      foregone: [...PLAYER_PRIMARY_DOWNTIME_MENU],
+    }
+  }
+
   const raw = opts?.explicitEffective ?? agent.downtimeActivity?.activity
   const effective = normalizeRequestedDowntime(raw)
   const foregone = PLAYER_PRIMARY_DOWNTIME_MENU.filter((a) => a !== effective)

--- a/src/domain/sim/downtimeSlot.ts
+++ b/src/domain/sim/downtimeSlot.ts
@@ -69,7 +69,7 @@ export function canSelectPrimaryDowntimePlan(agent: Agent): boolean {
     return false
   }
   const st = agent.assignment?.state
-  return st !== 'assigned' && st !== 'training' && st !== 'resolving'
+  return st !== 'assigned' && st !== 'training'
 }
 
 const PRIMARY_DOWNTIME_LABEL: Record<DowntimeActivity, string> = {

--- a/src/domain/sim/recoveryDowntime.ts
+++ b/src/domain/sim/recoveryDowntime.ts
@@ -12,6 +12,7 @@ import {
   stripExposureResidueFromFlags,
   vitalsHasExposureResidue,
 } from './recoveryImpairments'
+import { resolveDowntimeSlotForAgent } from './downtimeSlot'
 
 export type RecoveryState = 'healthy' | 'recovering' | 'traumatized' | 'incapacitated'
 export type DowntimeActivity = 'rest' | 'training' | 'therapy' | 'other' | 'coping'
@@ -69,7 +70,11 @@ export function advanceRecoveryDowntimeForWeek({
 
   // 1. Apply downtime activity assignments and progress recovery/trauma deterministically
   for (const [agentId, agent] of Object.entries(sourceAgents)) {
-    const downtime = downtimeAssignments[agentId] || 'rest'
+    const mapActivity = downtimeAssignments[agentId]
+    const { effective: downtime, foregone } = resolveDowntimeSlotForAgent(
+      agent,
+      mapActivity !== undefined ? { explicitEffective: mapActivity } : undefined
+    )
     const inferredRecoveryStatus =
       agent.status === 'injured' ||
       agent.status === 'recovering' ||
@@ -270,7 +275,11 @@ export function advanceRecoveryDowntimeForWeek({
       ...agent,
       recoveryStatus,
       trauma,
-      downtimeActivity: { activity: downtime, sinceWeek: week },
+      downtimeActivity: {
+        activity: downtime,
+        sinceWeek: week,
+        ...(foregone.length > 0 ? { foregoneThisInterval: [...foregone] } : {}),
+      },
       fatigue,
       vitals: finalVitals,
       tags: agentTags,

--- a/src/domain/visibility.ts
+++ b/src/domain/visibility.ts
@@ -723,3 +723,6 @@ export function explainWeeklyPressureState(
     intelConfidenceTrend,
   }
 }
+
+/** SPE-1699: foregone-downtime line for developer overlay — re-export so feature code avoids direct `sim/` imports. */
+export { formatForegoneDowntimeSummary } from './sim/downtimeSlot'

--- a/src/features/developer/developerOverlayView.ts
+++ b/src/features/developer/developerOverlayView.ts
@@ -7,7 +7,6 @@ import { buildAgentLoadoutReadinessSummary, listEquippedItemAssignments } from '
 import { listProgressClocks } from '../../domain/progressClocks'
 import { buildRecruitmentFunnelSummary } from '../../domain/recruitment'
 import { buildTrainingCertificationSummary } from '../../domain/sim/training'
-import { formatForegoneDowntimeSummary } from '../../domain/sim/downtimeSlot'
 import {
   buildTeamCompositionState,
   buildTeamWeakestLinkSummary,
@@ -20,6 +19,7 @@ import {
   explainMissionRouting,
   explainWeakestLinkResolution,
   explainWeeklyPressureState,
+  formatForegoneDowntimeSummary,
   type DeploymentReadinessExplanation,
   type RoutingExplanation,
   type WeakestLinkExplanation,

--- a/src/features/developer/developerOverlayView.ts
+++ b/src/features/developer/developerOverlayView.ts
@@ -7,6 +7,7 @@ import { buildAgentLoadoutReadinessSummary, listEquippedItemAssignments } from '
 import { listProgressClocks } from '../../domain/progressClocks'
 import { buildRecruitmentFunnelSummary } from '../../domain/recruitment'
 import { buildTrainingCertificationSummary } from '../../domain/sim/training'
+import { formatForegoneDowntimeSummary } from '../../domain/sim/downtimeSlot'
 import {
   buildTeamCompositionState,
   buildTeamWeakestLinkSummary,
@@ -321,12 +322,23 @@ export function buildDeveloperOverlaySnapshot(game: GameState): DeveloperOverlay
     )
 
   // Add agent recovery/trauma/downtime debug summary
-  const agentRecoveryDebug = Object.values(game.agents).map(agent => ({
+  const agentRecoveryDebug = Object.values(game.agents).map((agent) => ({
     agentId: agent.id,
     name: agent.name,
     recoveryStatus: agent.recoveryStatus ?? null,
     trauma: agent.trauma ?? null,
-    downtimeActivity: agent.downtimeActivity ?? null,
+    downtimeActivity: agent.downtimeActivity
+      ? {
+          ...agent.downtimeActivity,
+          ...(agent.downtimeActivity.foregoneThisInterval?.length
+            ? {
+                foregoneSummary: formatForegoneDowntimeSummary(
+                  agent.downtimeActivity.foregoneThisInterval
+                ),
+              }
+            : {}),
+        }
+      : null,
     fatigue: agent.fatigue,
     status: agent.status,
   }))

--- a/src/features/teams/TeamsPage.test.tsx
+++ b/src/features/teams/TeamsPage.test.tsx
@@ -2,9 +2,11 @@ import '../../test/setup'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router'
+import { trainingCatalog } from '../../data/training'
 import { assignTeam } from '../../domain/sim/assign'
 import { createStartingState } from '../../data/startingState'
 import { useGameStore } from '../../app/store/gameStore'
+import { queueTraining } from '../../domain/sim/training'
 import TeamsPage from './TeamsPage'
 import { beforeEach, it, expect } from 'vitest'
 
@@ -234,4 +236,40 @@ it('shows actionable CTAs when no teams match current filters', async () => {
   await waitFor(() => {
     expect(screen.getByTestId('location-search')).toHaveTextContent('')
   })
+})
+
+it('updates primary downtime in the store when the roster select changes', async () => {
+  const user = userEvent.setup()
+  renderTeamsPage()
+
+  const select = screen.getByLabelText(/Primary downtime for Ava Brooks/i)
+  await user.selectOptions(select, 'therapy')
+
+  expect(useGameStore.getState().game.agents.a_ava.downtimeActivity?.activity).toBe('therapy')
+})
+
+it('locks downtime controls for agents in academy training', async () => {
+  const combatDrills = trainingCatalog.find((p) => p.trainingId === 'combat-drills')
+  expect(combatDrills).toBeDefined()
+  const game = queueTraining(createStartingState(), 'a_ava', combatDrills!.trainingId)
+  useGameStore.setState({ game })
+  renderTeamsPage()
+
+  const trainingLock = screen.getByText(/Academy training \(slot\)/)
+  const avaRow = trainingLock.closest('li')
+  expect(avaRow).toBeTruthy()
+  expect(within(avaRow!).getByText('Ava Brooks')).toBeInTheDocument()
+  expect(within(avaRow!).queryByRole('combobox')).not.toBeInTheDocument()
+})
+
+it('locks downtime controls for agents assigned to an active case', async () => {
+  const game = assignTeam(createStartingState(), 'case-001', 't_nightwatch')
+  useGameStore.setState({ game })
+  renderTeamsPage()
+
+  const avaDowntimeLabel = screen.getByText('Primary downtime for Ava Brooks')
+  const avaRow = avaDowntimeLabel.closest('li')
+  expect(avaRow).toBeTruthy()
+  expect(within(avaRow!).getByText(/Downtime plan locked while deployed or resolving/)).toBeInTheDocument()
+  expect(within(avaRow!).queryByRole('combobox')).not.toBeInTheDocument()
 })

--- a/src/features/teams/TeamsPage.tsx
+++ b/src/features/teams/TeamsPage.tsx
@@ -10,7 +10,7 @@ import {
   formatForegoneDowntimeSummary,
   getPrimaryDowntimeLabel,
   type PlayerPrimaryDowntimeMenu,
-} from '../../domain/sim/downtimeSlot'
+} from './downtimePlanView'
 import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
 import {
   IconFieldRecon,

--- a/src/features/teams/TeamsPage.tsx
+++ b/src/features/teams/TeamsPage.tsx
@@ -4,6 +4,13 @@ import { APP_ROUTES } from '../../app/routes'
 import { toSearchString } from '../../app/searchParams'
 import { useGameStore } from '../../app/store/gameStore'
 import { type AgentRole, type GameState } from '../../domain/models'
+import {
+  PLAYER_PRIMARY_DOWNTIME_MENU,
+  canSelectPrimaryDowntimePlan,
+  formatForegoneDowntimeSummary,
+  getPrimaryDowntimeLabel,
+  type PlayerPrimaryDowntimeMenu,
+} from '../../domain/sim/downtimeSlot'
 import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
 import {
   IconFieldRecon,
@@ -49,7 +56,7 @@ import {
 import { getTeamAssignableCaseViews } from './teamInsights'
 
 export default function TeamsPage() {
-  const { game, assign, unassign, createTeam } = useGameStore()
+  const { game, assign, unassign, createTeam, setAgentPrimaryDowntimePlan } = useGameStore()
   const [searchParams, setSearchParams] = useSearchParams()
   const [newTeamName, setNewTeamName] = useState('')
   const [seedAgentId, setSeedAgentId] = useState('')
@@ -270,6 +277,7 @@ export default function TeamsPage() {
               querySuffix={querySuffix}
               assign={assign}
               unassign={unassign}
+              setAgentPrimaryDowntimePlan={setAgentPrimaryDowntimePlan}
             />
           ))}
         </ul>
@@ -312,12 +320,14 @@ function TeamCard({
   querySuffix,
   assign,
   unassign,
+  setAgentPrimaryDowntimePlan,
 }: {
   view: TeamListItemView
   game: GameState
   querySuffix: string
   assign: (caseId: string, teamId: string) => void
   unassign: (caseId: string, teamId?: string) => void
+  setAgentPrimaryDowntimePlan: (agentId: string, activity: PlayerPrimaryDowntimeMenu) => void
 }) {
   const assignedCase = view.assignedCase
   const assignedCaseId = getTeamAssignedCaseId(view.team)
@@ -495,19 +505,64 @@ function TeamCard({
       </div>
 
       <ul className="space-y-1 border-t border-white/10 pt-3">
-        {view.capabilitySummary.agents.map((agent) => (
-          <li key={agent.id} className="flex flex-wrap items-center justify-between gap-3 text-sm">
-            <span className="font-medium">{agent.name}</span>
-            <span
-              className="inline-flex flex-wrap items-center gap-1 opacity-60"
-              title={TOOLTIPS['agent.role']}
-            >
-              <RoleIcon role={agent.role} className="h-3.5 w-3.5" />
-              {ROLE_LABELS[agent.role]} / Fatigue {agent.fatigue} / Tags{' '}
-              {agent.tags.join(', ') || 'None'}
-            </span>
-          </li>
-        ))}
+        {view.capabilitySummary.agents.map((agent) => {
+          const canPlan = canSelectPrimaryDowntimePlan(agent)
+          const rawActivity = agent.downtimeActivity?.activity
+          const planned: PlayerPrimaryDowntimeMenu =
+            rawActivity &&
+            (PLAYER_PRIMARY_DOWNTIME_MENU as readonly string[]).includes(rawActivity)
+              ? (rawActivity as PlayerPrimaryDowntimeMenu)
+              : ('rest' as PlayerPrimaryDowntimeMenu)
+          const foregoneLine = agent.downtimeActivity?.foregoneThisInterval?.length
+            ? `Foregone this week: ${formatForegoneDowntimeSummary(agent.downtimeActivity.foregoneThisInterval)}`
+            : null
+
+          return (
+            <li key={agent.id} className="space-y-1 border-b border-white/5 pb-2 text-sm last:border-0">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="font-medium">{agent.name}</span>
+                <span
+                  className="inline-flex flex-wrap items-center gap-1 opacity-60"
+                  title={TOOLTIPS['agent.role']}
+                >
+                  <RoleIcon role={agent.role} className="h-3.5 w-3.5" />
+                  {ROLE_LABELS[agent.role]} / Fatigue {agent.fatigue} / Tags{' '}
+                  {agent.tags.join(', ') || 'None'}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 text-xs opacity-80">
+                <label htmlFor={`downtime-${agent.id}`} className="sr-only">
+                  Primary downtime for {agent.name}
+                </label>
+                {canPlan ? (
+                  <select
+                    id={`downtime-${agent.id}`}
+                    className="form-select max-w-xs text-xs"
+                    value={planned}
+                    onChange={(event) =>
+                      setAgentPrimaryDowntimePlan(agent.id, event.target.value as PlayerPrimaryDowntimeMenu)
+                    }
+                  >
+                    {PLAYER_PRIMARY_DOWNTIME_MENU.map((act) => (
+                      <option key={act} value={act}>
+                        {getPrimaryDowntimeLabel(act)}
+                      </option>
+                    ))}
+                  </select>
+                ) : agent.assignment?.state === 'training' ? (
+                  <span className="rounded border border-white/10 px-2 py-1 text-[11px] uppercase tracking-wide">
+                    Slot: {getPrimaryDowntimeLabel('training')} — recovery menu foregone
+                  </span>
+                ) : (
+                  <span className="text-[11px] uppercase tracking-wide opacity-60">
+                    Downtime plan locked while deployed or resolving
+                  </span>
+                )}
+              </div>
+              {foregoneLine ? <p className="text-[11px] opacity-55">{foregoneLine}</p> : null}
+            </li>
+          )
+        })}
       </ul>
     </li>
   )

--- a/src/features/teams/TeamsPage.tsx
+++ b/src/features/teams/TeamsPage.tsx
@@ -509,10 +509,7 @@ function TeamCard({
           const canPlan = canSelectPrimaryDowntimePlan(agent)
           const rawActivity = agent.downtimeActivity?.activity
           const planned: PlayerPrimaryDowntimeMenu =
-            rawActivity &&
-            (PLAYER_PRIMARY_DOWNTIME_MENU as readonly string[]).includes(rawActivity)
-              ? (rawActivity as PlayerPrimaryDowntimeMenu)
-              : ('rest' as PlayerPrimaryDowntimeMenu)
+            PLAYER_PRIMARY_DOWNTIME_MENU.find((act) => act === rawActivity) ?? 'rest'
           const foregoneLine = agent.downtimeActivity?.foregoneThisInterval?.length
             ? `Foregone this week: ${formatForegoneDowntimeSummary(agent.downtimeActivity.foregoneThisInterval)}`
             : null

--- a/src/features/teams/downtimePlanView.ts
+++ b/src/features/teams/downtimePlanView.ts
@@ -1,0 +1,11 @@
+/**
+ * SPE-1699: teams roster primary-downtime view model.
+ * Centralizes `domain/sim/downtimeSlot` so page/components under `features/teams/` do not import sim directly.
+ */
+export {
+  PLAYER_PRIMARY_DOWNTIME_MENU,
+  canSelectPrimaryDowntimePlan,
+  formatForegoneDowntimeSummary,
+  getPrimaryDowntimeLabel,
+  type PlayerPrimaryDowntimeMenu,
+} from '../../domain/sim/downtimeSlot'

--- a/src/test/downtimeSlot.test.ts
+++ b/src/test/downtimeSlot.test.ts
@@ -8,8 +8,11 @@ import {
   resolveDowntimeSlotForAgent,
   setAgentPrimaryDowntimePlan,
 } from '../domain/sim/downtimeSlot'
+import { trainingCatalog } from '../data/training'
+import { advanceWeek } from '../domain/sim/advanceWeek'
 import { advanceRecoveryDowntimeForWeek } from '../domain/sim/recoveryDowntime'
 import type { DowntimeActivity } from '../domain/sim/recoveryDowntime'
+import { queueTraining } from '../domain/sim/training'
 import { createStartingState } from '../data/startingState'
 
 const baseAgent: Agent = {
@@ -57,14 +60,26 @@ describe('resolveDowntimeSlotForAgent (SPE-1699)', () => {
     expect(foregone).toEqual(['rest', 'therapy', 'other'])
   })
 
-  it('coerces invalid training request to rest when not in academy training', () => {
+  it('accepts explicit training from pre-queue snapshot after assignment returns to idle', () => {
     const agent: Agent = {
       ...baseAgent,
+      assignment: { state: 'idle' },
       downtimeActivity: { activity: 'therapy', sinceWeek: 1 },
     }
-    const { effective } = resolveDowntimeSlotForAgent(agent, {
+    const { effective, foregone } = resolveDowntimeSlotForAgent(agent, {
       explicitEffective: 'training' as DowntimeActivity,
     })
+    expect(effective).toBe('training')
+    expect(foregone).toEqual([...PLAYER_PRIMARY_DOWNTIME_MENU])
+  })
+
+  it('coerces stale persisted downtimeActivity.training to rest when not in training', () => {
+    const agent: Agent = {
+      ...baseAgent,
+      assignment: { state: 'idle' },
+      downtimeActivity: { activity: 'training', sinceWeek: 1 },
+    }
+    const { effective } = resolveDowntimeSlotForAgent(agent)
     expect(effective).toBe('rest')
   })
 })
@@ -113,6 +128,25 @@ describe('advanceRecoveryDowntimeForWeek foregone metadata', () => {
     expect(formatForegoneDowntimeSummary(updated.downtimeActivity?.foregoneThisInterval ?? [])).toContain(
       'Therapy'
     )
+  })
+})
+
+describe('advanceWeek + training completion (SPE-1699)', () => {
+  it('keeps the training slot for downtime on the week academy training completes', () => {
+    const state = createStartingState()
+    const combatDrills = trainingCatalog.find((p) => p.trainingId === 'combat-drills')
+    expect(combatDrills).toBeDefined()
+    const queued = queueTraining(state, 'a_ava', combatDrills!.trainingId)
+    expect(queued.agents.a_ava.assignment?.state).toBe('training')
+    const prepared = {
+      ...queued,
+      trainingQueue: queued.trainingQueue.map((e) =>
+        e.agentId === 'a_ava' ? { ...e, remainingWeeks: 1 } : e
+      ),
+    }
+    const next = advanceWeek(prepared)
+    expect(next.agents.a_ava.assignment?.state).toBe('idle')
+    expect(next.agents.a_ava.downtimeActivity?.activity).toBe('training')
   })
 })
 

--- a/src/test/downtimeSlot.test.ts
+++ b/src/test/downtimeSlot.test.ts
@@ -156,7 +156,12 @@ describe('canSelectPrimaryDowntimePlan', () => {
     expect(
       canSelectPrimaryDowntimePlan({
         ...baseAgent,
-        assignment: { state: 'assigned', startedWeek: 1, teamId: 't1' },
+        assignment: {
+          state: 'assigned',
+          startedWeek: 1,
+          teamId: 't1',
+          caseId: 'case-fixture-001',
+        },
       })
     ).toBe(false)
     expect(

--- a/src/test/downtimeSlot.test.ts
+++ b/src/test/downtimeSlot.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Agent } from '../domain/agent/models'
+import {
+  PLAYER_PRIMARY_DOWNTIME_MENU,
+  canSelectPrimaryDowntimePlan,
+  formatForegoneDowntimeSummary,
+  resolveDowntimeSlotForAgent,
+  setAgentPrimaryDowntimePlan,
+} from '../domain/sim/downtimeSlot'
+import { advanceRecoveryDowntimeForWeek } from '../domain/sim/recoveryDowntime'
+import type { DowntimeActivity } from '../domain/sim/recoveryDowntime'
+import { createStartingState } from '../data/startingState'
+
+const baseAgent: Agent = {
+  id: 'a1',
+  name: 'Test Agent',
+  role: 'tech',
+  baseStats: { combat: 10, investigation: 10, utility: 10, social: 10 },
+  tags: [],
+  relationships: {},
+  fatigue: 50,
+  status: 'active',
+}
+
+describe('resolveDowntimeSlotForAgent (SPE-1699)', () => {
+  it('uses academy training as the sole effective slot when assignment is training', () => {
+    const agent: Agent = {
+      ...baseAgent,
+      assignment: { state: 'training', startedWeek: 1, trainingProgramId: 'combat-drills' },
+      downtimeActivity: { activity: 'therapy', sinceWeek: 1 },
+    }
+    const { effective, foregone } = resolveDowntimeSlotForAgent(agent)
+    expect(effective).toBe('training')
+    expect(foregone).toEqual([...PLAYER_PRIMARY_DOWNTIME_MENU])
+  })
+
+  it('lists other menu actions as foregone when therapy is chosen', () => {
+    const agent: Agent = {
+      ...baseAgent,
+      downtimeActivity: { activity: 'therapy', sinceWeek: 1 },
+    }
+    const { effective, foregone } = resolveDowntimeSlotForAgent(agent)
+    expect(effective).toBe('therapy')
+    expect(foregone).toEqual(['rest', 'coping', 'other'])
+  })
+
+  it('honors explicit downtime map entries over stale agent.downtimeActivity', () => {
+    const agent: Agent = {
+      ...baseAgent,
+      downtimeActivity: { activity: 'rest', sinceWeek: 1 },
+    }
+    const { effective, foregone } = resolveDowntimeSlotForAgent(agent, {
+      explicitEffective: 'coping' as DowntimeActivity,
+    })
+    expect(effective).toBe('coping')
+    expect(foregone).toEqual(['rest', 'therapy', 'other'])
+  })
+
+  it('coerces invalid training request to rest when not in academy training', () => {
+    const agent: Agent = {
+      ...baseAgent,
+      downtimeActivity: { activity: 'therapy', sinceWeek: 1 },
+    }
+    const { effective } = resolveDowntimeSlotForAgent(agent, {
+      explicitEffective: 'training' as DowntimeActivity,
+    })
+    expect(effective).toBe('rest')
+  })
+})
+
+describe('setAgentPrimaryDowntimePlan', () => {
+  it('refuses to change downtime for deployed agents', () => {
+    const game = createStartingState()
+    const agentId = Object.keys(game.agents)[0]!
+    const agent = game.agents[agentId]!
+    const teamId = Object.keys(game.teams)[0] ?? 't_nightwatch'
+    const locked: Agent = {
+      ...agent,
+      assignment: {
+        state: 'assigned',
+        startedWeek: game.week,
+        teamId,
+        caseId: 'nonexistent-case-id',
+      },
+    }
+    const lockedGame = { ...game, agents: { ...game.agents, [agentId]: locked } }
+    const next = setAgentPrimaryDowntimePlan(lockedGame, agentId, 'therapy')
+    expect(next.agents[agentId]?.downtimeActivity?.activity).not.toBe('therapy')
+  })
+})
+
+describe('advanceRecoveryDowntimeForWeek foregone metadata', () => {
+  it('persists foregoneThisInterval on the agent downtime record', () => {
+    const agents = {
+      a1: {
+        ...baseAgent,
+        recoveryStatus: { state: 'recovering' as const, sinceWeek: 1 },
+        trauma: { traumaLevel: 1, traumaTags: [], lastEventWeek: 1 },
+        downtimeActivity: { activity: 'coping' as DowntimeActivity, sinceWeek: 1 },
+        fatigue: 40,
+      },
+    }
+    const result = advanceRecoveryDowntimeForWeek({
+      week: 3,
+      sourceAgents: agents,
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'coping' as DowntimeActivity },
+    })
+    const updated = result.updatedAgents.a1
+    expect(updated.downtimeActivity?.activity).toBe('coping')
+    expect(updated.downtimeActivity?.foregoneThisInterval).toEqual(['rest', 'therapy', 'other'])
+    expect(formatForegoneDowntimeSummary(updated.downtimeActivity?.foregoneThisInterval ?? [])).toContain(
+      'Therapy'
+    )
+  })
+})
+
+describe('canSelectPrimaryDowntimePlan', () => {
+  it('allows idle agents and blocks assigned or training', () => {
+    expect(canSelectPrimaryDowntimePlan({ ...baseAgent, assignment: { state: 'idle' } })).toBe(true)
+    expect(
+      canSelectPrimaryDowntimePlan({
+        ...baseAgent,
+        assignment: { state: 'assigned', startedWeek: 1, teamId: 't1' },
+      })
+    ).toBe(false)
+    expect(
+      canSelectPrimaryDowntimePlan({
+        ...baseAgent,
+        assignment: { state: 'training', startedWeek: 1, trainingProgramId: 'x' },
+      })
+    ).toBe(false)
+  })
+})

--- a/systems/team-management.md
+++ b/systems/team-management.md
@@ -234,7 +234,7 @@ Models the fact that teams cannot deploy at full capacity indefinitely.
 
 - operative recovery
 - trauma burden
-- team downtime
+- team downtime (**SPE-1699:** one primary weekly downtime action per operative on the recovery menu; academy training consumes the same slot)
 - equipment recovery interactions
 - replacement pressure after loss
 


### PR DESCRIPTION
Implements the first honest slice for Linear SPE-1699: one mutually exclusive primary downtime action per operative per weekly tick, anchored on \gent.downtimeActivity\ and coordinated with the academy training queue (\ssignment.state === 'training'\ consumes the slot).

- New \esolveDowntimeSlotForAgent\ / \setAgentPrimaryDowntimePlan\ in \src/domain/sim/downtimeSlot.ts\
- Week-close persists \oregoneThisInterval\ from \dvanceRecoveryDowntimeForWeek\; \dvanceWeek\ uses resolved effective activities
- Teams roster UI + store action; developer overlay adds \oregoneSummary\
- Docs: \docs/recovery-trauma-downtime-audit.md\ §3c, \systems/team-management.md\
- Tests: \src/test/downtimeSlot.test.ts\ plus existing recovery/staffCoping/teams coverage

Linear description updated to match this boundary. Out of scope: SPE-560/1700/1701, department planners, city sim.