### PR TITLE
SPE-1701: Downtime deployment carry-in (readiness slice)

### DIFF
--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -61,6 +61,13 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 - **Ordering:** `advanceWeek` captures each agent’s resolved effective slot at the **start** of `advanceQueues` (before `advanceTrainingQueues` removes completed programs from the queue and clears `assignment.state`), then `applyRecoveryDowntimeAfterMissions` consumes that snapshot. This keeps the **final week** of a training program on the `training` slot instead of incorrectly falling through to menu/`rest` after completion processing.
 - **Evidence:** `resolveDowntimeSlotForAgent` in `downtimeSlot.ts`; `advanceWeek` snapshot on `WeeklyExecutionContext.downtimeSlotEffectiveByAgentId`; `advanceRecoveryDowntimeForWeek` persists `foregoneThisInterval` on `agent.downtimeActivity`. Tests: `src/test/downtimeSlot.test.ts`.
 
+### 3d. SPE-1701 slice — deployment carry-in (readiness, first contract week)
+
+- **Stamp:** when teams are committed to an `in_progress` case (`assignTeam`, `launchMajorIncident`, and `unassignTeam` rebuilds), `rebuildDeploymentCarryInForCase` writes `case.deploymentCarryInByAgentId` from each assigned operative’s post-downtime fields (`downtimeActivity` incl. `foregoneThisInterval`, `recoveryStatus`, `trauma`, `vitals` / `exposure:residue`, `energyBudget`, scalar `fatigue`).
+- **Consume:** `buildTeamDeploymentReadinessState` adds a **bounded** summed readiness adjustment **only** while `weeksRemaining === durationWeeks` (first in-contract week), so carry-in does not stack with later-week readiness passes.
+- **Paths (slice 1):** `residue-therapy-foregone` (negative) when residue is present and therapy was listed as foregone; `well-rested-stable-energy` (positive) for a `rest` week with `energyBudget.reserveBand === 'stable'`, low fatigue, healthy recovery, no trauma, and no residue. Constants: `DOWNTIME_CARRY_IN_CALIBRATION` in `calibration.ts`. Logic: `computeDowntimeCarryInForAgent` in `downtimeCarryIn.ts`.
+- **Evidence:** tests `src/test/downtimeCarryIn.test.ts`; developer overlay surfaces `caseDeploymentCarryInByAgentId` on deployment summaries.
+
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.
 - High trauma reduces deployment readiness, training efficiency, and recovery speed.

--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -63,10 +63,10 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 
 ### 3d. SPE-1701 slice — deployment carry-in (readiness, first contract week)
 
-- **Stamp:** when teams are committed to an `in_progress` case (`assignTeam`, `launchMajorIncident`, and `unassignTeam` rebuilds), `rebuildDeploymentCarryInForCase` writes `case.deploymentCarryInByAgentId` from each assigned operative’s post-downtime fields (`downtimeActivity` incl. `foregoneThisInterval`, `recoveryStatus`, `trauma`, `vitals` / `exposure:residue`, `energyBudget`, scalar `fatigue`).
+- **Stamp:** when teams are committed to an `in_progress` case (`assignTeam`, `launchMajorIncident`, and `unassignTeam` rebuilds), `rebuildDeploymentCarryInForCase` writes `case.deploymentCarryInByAgentId` from each assigned operative’s post-downtime fields (`downtimeActivity` incl. `foregoneThisInterval`, `recoveryStatus`, `trauma`, `vitals` / `exposure:residue`, `energyBudget`, scalar `fatigue`). **SPE-1654 field-base staging rotation** (`applyFieldBaseStagingRotationAtWeekOpen`) also rebuilds carry-in after a successful swap so mid-contract roster changes cannot leave stale or missing stamps during the first contract week.
 - **Consume:** `buildTeamDeploymentReadinessState` adds a **bounded** summed readiness adjustment **only** while `weeksRemaining === durationWeeks` (first in-contract week), so carry-in does not stack with later-week readiness passes.
 - **Paths (slice 1):** `residue-therapy-foregone` (negative) when residue is present and therapy was listed as foregone; `well-rested-stable-energy` (positive) for a `rest` week with `energyBudget.reserveBand === 'stable'`, low fatigue, healthy recovery, no trauma, and no residue. Constants: `DOWNTIME_CARRY_IN_CALIBRATION` in `calibration.ts`. Logic: `computeDowntimeCarryInForAgent` in `downtimeCarryIn.ts`.
-- **Evidence:** tests `src/test/downtimeCarryIn.test.ts`; developer overlay surfaces `caseDeploymentCarryInByAgentId` on deployment summaries.
+- **Evidence:** tests `src/test/downtimeCarryIn.test.ts`, `src/test/fieldBaseStaging.test.ts` (rotation + carry-in sync); developer overlay surfaces `caseDeploymentCarryInByAgentId` on deployment summaries.
 
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.

--- a/src/domain/deploymentReadiness.ts
+++ b/src/domain/deploymentReadiness.ts
@@ -15,6 +15,7 @@ import {
   buildTeamWeakestLinkSummary,
   validateTeamComposition,
 } from './teamComposition'
+import { getTeamMemberIds } from './teamSimulation'
 import type {
   Agent,
   AgentAvailabilityState,
@@ -40,21 +41,6 @@ function shouldApplyDeploymentCarryInReadiness(mission: CaseInstance | undefined
   const duration = mission.durationWeeks
   const remaining = mission.weeksRemaining ?? duration
   return remaining === duration
-}
-
-function getTeamMemberIds(team: Pick<Team, 'memberIds' | 'agentIds'>): Id[] {
-  const memberIds = Array.isArray(team.memberIds) ? team.memberIds : undefined
-  const agentIds = Array.isArray(team.agentIds) ? team.agentIds : undefined
-
-  if (memberIds && agentIds) {
-    const sameMembers =
-      memberIds.length === agentIds.length &&
-      memberIds.every((memberId) => agentIds.includes(memberId))
-
-    return [...new Set(sameMembers ? memberIds : agentIds)]
-  }
-
-  return [...new Set(memberIds ?? agentIds ?? [])]
 }
 
 function getTeamMembers(team: Pick<Team, 'memberIds' | 'agentIds'>, agentsById: GameState['agents']) {

--- a/src/domain/deploymentReadiness.ts
+++ b/src/domain/deploymentReadiness.ts
@@ -4,7 +4,7 @@ import { assessFundingPressure } from './funding'
 import { getMissionIntelRisk, getMissionIntelSummary } from './intel'
 import { clamp } from './math'
 import { buildTeamNicheSummary, mapCoverageRolesToNiches } from './nicheIdentity'
-import { INTEL_CALIBRATION } from './sim/calibration'
+import { INTEL_CALIBRATION, DOWNTIME_CARRY_IN_CALIBRATION } from './sim/calibration'
 import { evaluateConstructionReadinessBurden } from './constructionProgress'
 import {
   createDefaultFatigueChannels,
@@ -19,6 +19,7 @@ import type {
   Agent,
   AgentAvailabilityState,
   AgentDeploymentReadinessSnapshot,
+  CaseInstance,
   DeploymentEligibilityResult,
   DeploymentHardBlockerCode,
   DeploymentReadinessCategory,
@@ -31,6 +32,15 @@ import type {
   TeamCoverageRole,
   TeamDeploymentReadinessState,
 } from './models'
+
+function shouldApplyDeploymentCarryInReadiness(mission: CaseInstance | undefined): boolean {
+  if (!mission || mission.status !== 'in_progress') {
+    return false
+  }
+  const duration = mission.durationWeeks
+  const remaining = mission.weeksRemaining ?? duration
+  return remaining === duration
+}
 
 function getTeamMemberIds(team: Pick<Team, 'memberIds' | 'agentIds'>): Id[] {
   const memberIds = Array.isArray(team.memberIds) ? team.memberIds : undefined
@@ -432,6 +442,28 @@ export function buildTeamDeploymentReadinessState(
       : 100
   const missionIntelEffect = getMissionIntelEffect(state, effectiveMissionId)
 
+  let deploymentCarryInReadinessDelta = 0
+  const deploymentCarryInCodes: string[] = []
+  if (
+    effectiveMission &&
+    shouldApplyDeploymentCarryInReadiness(effectiveMission) &&
+    effectiveMission.deploymentCarryInByAgentId
+  ) {
+    const carryInMap = effectiveMission.deploymentCarryInByAgentId
+    for (const member of members) {
+      const stamp = carryInMap[member.id]
+      if (stamp) {
+        deploymentCarryInReadinessDelta += stamp.readinessDelta
+        deploymentCarryInCodes.push(stamp.code)
+      }
+    }
+    deploymentCarryInReadinessDelta = clamp(
+      deploymentCarryInReadinessDelta,
+      -DOWNTIME_CARRY_IN_CALIBRATION.teamReadinessDeltaCap,
+      DOWNTIME_CARRY_IN_CALIBRATION.teamReadinessDeltaCap
+    )
+  }
+
   const nonIntelSoftRiskCount = eligibility.softRisks.filter(
     (riskCode) => riskCode !== 'intel-uncertainty'
   ).length
@@ -460,7 +492,8 @@ export function buildTeamDeploymentReadinessState(
       nonIntelSoftRiskCount * 6 +
       ((composition?.requiredCoverageRoles.length ?? 0) - (composition?.missingRoles.length ?? 0)) * 8 -
       missionIntelEffect.penalty -
-      constructionBurden,
+      constructionBurden +
+      deploymentCarryInReadinessDelta,
     0,
     100
   )
@@ -473,6 +506,12 @@ export function buildTeamDeploymentReadinessState(
     softRisks: [...eligibility.softRisks],
     nicheSummary,
     intelPenalty: missionIntelEffect.penalty,
+    deploymentCarryInReadinessDelta:
+      deploymentCarryInReadinessDelta !== 0 ? deploymentCarryInReadinessDelta : undefined,
+    deploymentCarryInCodes:
+      deploymentCarryInCodes.length > 0
+        ? [...new Set(deploymentCarryInCodes)].sort((a, b) => a.localeCompare(b))
+        : undefined,
     coverageCompleteness: {
       required: [...(missionValidation?.requiredRoles ?? composition?.requiredCoverageRoles ?? [])],
       covered: [...(missionValidation?.coveredRoles ?? composition?.coveredRoles ?? [])],

--- a/src/domain/fieldBaseStaging.ts
+++ b/src/domain/fieldBaseStaging.ts
@@ -20,6 +20,7 @@ import type {
   MissionRewardInventoryGrant,
   Team,
 } from './models'
+import { rebuildDeploymentCarryInForCase } from './sim/downtimeCarryIn'
 import { getTeamAssignedCaseId, getTeamMemberIds, normalizeGameState } from './teamSimulation'
 
 const QUALITY_MAX = 3
@@ -314,7 +315,18 @@ export function applyFieldBaseStagingRotationAtWeekOpen(state: GameState): GameS
       ...(rotatedIn ? { [incomingId]: rotatedIn } : {}),
     }
 
-    next = { ...next, teams: nextTeams, agents: nextAgents }
+    const interim: GameState = { ...next, teams: nextTeams, agents: nextAgents }
+    const carryIn = rebuildDeploymentCarryInForCase(interim, caseData.id)
+    next = {
+      ...interim,
+      cases: {
+        ...interim.cases,
+        [caseData.id]: {
+          ...interim.cases[caseData.id]!,
+          deploymentCarryInByAgentId: carryIn,
+        },
+      },
+    }
     teams = nextTeams
     mutated = true
   }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -120,6 +120,10 @@ export interface TeamDeploymentReadinessState {
   softRisks: DeploymentSoftRiskCode[]
   nicheSummary?: TeamNicheSummary
   intelPenalty?: number
+  /** SPE-1701: summed bounded carry-in readiness adjustment (first in-contract week only). */
+  deploymentCarryInReadinessDelta?: number
+  /** SPE-1701: carry-in reason codes contributing to the team delta. */
+  deploymentCarryInCodes?: string[]
   coverageCompleteness: {
     required: string[]
     covered: string[]
@@ -1226,6 +1230,15 @@ export interface CaseTemplate {
   raid?: { minTeams: number; maxTeams: number }
 }
 
+/** SPE-1701: deterministic deployment carry-in stamped at team→case assignment. */
+export type DeploymentCarryInCode = 'residue-therapy-foregone' | 'well-rested-stable-energy'
+
+export interface AgentDeploymentCarryInStamp {
+  readinessDelta: number
+  code: DeploymentCarryInCode
+  stampedWeek: number
+}
+
 export interface CaseInstance {
   /**
    * SPE-38: True if this operation suffered a support shortfall this week (deterministic, for fallout/penalty).
@@ -1293,6 +1306,12 @@ export interface CaseInstance {
   regionTag?: string
 
   raid?: { minTeams: number; maxTeams: number }
+
+  /**
+   * SPE-1701: per-agent deployment carry-in stamped when teams are assigned; consumed in
+   * `buildTeamDeploymentReadinessState` only while `weeksRemaining === durationWeeks` (first in-contract week).
+   */
+  deploymentCarryInByAgentId?: Record<Id, AgentDeploymentCarryInStamp>
 
   // Added for spatial/visibility/transition support (SPE-57, SPE-XX)
   siteLayer?: 'exterior' | 'transition' | 'interior'

--- a/src/domain/sim/assign.ts
+++ b/src/domain/sim/assign.ts
@@ -23,6 +23,7 @@ import {
 } from '../teamSimulation'
 import { validateTeam, validateTeamIds } from '../validateTeam'
 import { assignActiveAgentsToTeam, releaseAssignedAgentsFromTeams } from './agentAssignments'
+import { rebuildDeploymentCarryInForCase } from './downtimeCarryIn'
 import { releaseTeamsFromCases } from './teamRelease'
 
 function filterExistingTeamIds(teamIds: Id[], teams: GameState['teams']) {
@@ -139,26 +140,41 @@ export function assignTeam(state: GameState, caseId: Id, teamId: Id): GameState 
     })
   }
 
-  const nextState: GameState = {
+  const baseCasePayload = {
+    ...normalizedCase,
+    assignedTeamIds: nextAssignedTeamIds,
+    weeksRemaining: normalizedCase.weeksRemaining ?? normalizedCase.durationWeeks,
+    status: 'in_progress' as const,
+  }
+
+  const teamsPayload = {
+    ...teams,
+    [teamId]: {
+      ...teams[teamId],
+      assignedCaseId: caseId,
+      status: teams[teamId]?.status
+        ? { ...teams[teamId].status, assignedCaseId: caseId }
+        : teams[teamId]?.status,
+    },
+  }
+
+  const interimForCarryIn: GameState = {
     ...normalizedState,
     agents: nextAgents,
     cases: {
       ...normalizedState.cases,
-      [caseId]: {
-        ...normalizedCase,
-        assignedTeamIds: nextAssignedTeamIds,
-        weeksRemaining: normalizedCase.weeksRemaining ?? normalizedCase.durationWeeks,
-        status: 'in_progress',
-      },
+      [caseId]: baseCasePayload,
     },
-    teams: {
-      ...teams,
-      [teamId]: {
-        ...teams[teamId],
-        assignedCaseId: caseId,
-        status: teams[teamId]?.status
-          ? { ...teams[teamId].status, assignedCaseId: caseId }
-          : teams[teamId]?.status,
+    teams: teamsPayload,
+  }
+
+  const nextState: GameState = {
+    ...interimForCarryIn,
+    cases: {
+      ...interimForCarryIn.cases,
+      [caseId]: {
+        ...baseCasePayload,
+        deploymentCarryInByAgentId: rebuildDeploymentCarryInForCase(interimForCarryIn, caseId),
       },
     },
   }
@@ -284,6 +300,18 @@ export function launchMajorIncident(
     teams: nextTeams,
   }
 
+  const carryIn = rebuildDeploymentCarryInForCase(nextState, caseId)
+  const nextStateWithCarryIn: GameState = {
+    ...nextState,
+    cases: {
+      ...nextState.cases,
+      [caseId]: {
+        ...nextState.cases[caseId]!,
+        deploymentCarryInByAgentId: carryIn,
+      },
+    },
+  }
+
   const drafts: AnyOperationEventDraft[] = replacedTeamIds.map((replacedTeamId) =>
     createAssignmentTeamUnassignedDraft({
       week: normalizedState.week,
@@ -310,7 +338,7 @@ export function launchMajorIncident(
     )
   }
 
-  return normalizeGameState(appendOperationEventDrafts(nextState, drafts))
+  return normalizeGameState(appendOperationEventDrafts(nextStateWithCarryIn, drafts))
 }
 
 /**
@@ -351,19 +379,37 @@ export function unassignTeam(state: GameState, caseId: Id, teamId?: Id): GameSta
     week: normalizedState.week,
   })
 
-  const nextState: GameState = {
+  const baseCaseAfterUnassign = {
+    ...normalizedCase,
+    assignedTeamIds: remainingTeamIds,
+    status: remainingTeamIds.length > 0 ? ('in_progress' as const) : ('open' as const),
+    weeksRemaining: remainingTeamIds.length > 0 ? normalizedCase.weeksRemaining : undefined,
+  }
+
+  const interimState: GameState = {
     ...normalizedState,
     agents: nextAgents,
     cases: {
       ...normalizedState.cases,
-      [caseId]: {
-        ...normalizedCase,
-        assignedTeamIds: remainingTeamIds,
-        status: remainingTeamIds.length > 0 ? 'in_progress' : 'open',
-        weeksRemaining: remainingTeamIds.length > 0 ? normalizedCase.weeksRemaining : undefined,
-      },
+      [caseId]: baseCaseAfterUnassign,
     },
     teams,
+  }
+
+  const finalCasePayload = {
+    ...baseCaseAfterUnassign,
+    deploymentCarryInByAgentId:
+      remainingTeamIds.length > 0
+        ? rebuildDeploymentCarryInForCase(interimState, caseId)
+        : undefined,
+  }
+
+  const nextState: GameState = {
+    ...interimState,
+    cases: {
+      ...interimState.cases,
+      [caseId]: finalCasePayload,
+    },
   }
 
   return normalizeGameState(

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -400,3 +400,15 @@ export const LIVE_REGISTRY_ALERT_CENTER_CALIBRATION = {
    */
   escalationOverloadThreshold: 3,
 } as const
+
+/** SPE-1701 slice 1: deployment readiness deltas from post-downtime posture (first contract week only). */
+export const DOWNTIME_CARRY_IN_CALIBRATION = {
+  /** Extra readiness penalty when residue is present but supervised therapy was foregone. */
+  residueTherapyForegoneReadinessPenalty: 5,
+  /** Readiness lift for a genuinely rested week with stable energy (does not duplicate raw fatigue term). */
+  wellRestedStableEnergyReadinessBonus: 4,
+  /** Fatigue ceiling for the well-rested bonus (higher fatigue already depresses readiness via averageFatigue). */
+  wellRestedFatigueCeiling: 28,
+  /** Cap on summed per-agent carry-in applied to team readiness (prevents runaway stacking). */
+  teamReadinessDeltaCap: 12,
+} as const

--- a/src/domain/sim/downtimeCarryIn.ts
+++ b/src/domain/sim/downtimeCarryIn.ts
@@ -50,7 +50,9 @@ export function computeDowntimeCarryInForAgent(
 
 /**
  * Rebuild carry-in stamps for every operative on every team currently assigned to the case.
- * Call after assignment mutations so the map matches roster reality.
+ * Call after assignment mutations so the map matches roster reality. Also run after **field-base
+ * staging rotation** (`applyFieldBaseStagingRotationAtWeekOpen`) so mid-contract swaps do not leave
+ * stale stamps for rotated-out operatives or omit rotated-in operatives during first-week readiness.
  */
 export function rebuildDeploymentCarryInForCase(
   state: GameState,

--- a/src/domain/sim/downtimeCarryIn.ts
+++ b/src/domain/sim/downtimeCarryIn.ts
@@ -1,22 +1,8 @@
 import type { Agent } from '../agent/models'
-import type { AgentDeploymentCarryInStamp, GameState, Id, Team } from '../models'
+import type { AgentDeploymentCarryInStamp, GameState, Id } from '../models'
+import { getTeamMemberIds } from '../teamSimulation'
 import { DOWNTIME_CARRY_IN_CALIBRATION } from './calibration'
 import { vitalsHasExposureResidue } from './recoveryImpairments'
-
-function getTeamMemberIds(team: Pick<Team, 'memberIds' | 'agentIds'>): Id[] {
-  const memberIds = Array.isArray(team.memberIds) ? team.memberIds : undefined
-  const agentIds = Array.isArray(team.agentIds) ? team.agentIds : undefined
-
-  if (memberIds && agentIds) {
-    const sameMembers =
-      memberIds.length === agentIds.length &&
-      memberIds.every((memberId) => agentIds.includes(memberId))
-
-    return [...new Set(sameMembers ? memberIds : agentIds)]
-  }
-
-  return [...new Set(memberIds ?? agentIds ?? [])]
-}
 
 /**
  * SPE-1701: deterministic per-agent carry-in from post-downtime posture.

--- a/src/domain/sim/downtimeCarryIn.ts
+++ b/src/domain/sim/downtimeCarryIn.ts
@@ -1,0 +1,93 @@
+import type { Agent } from '../agent/models'
+import type { AgentDeploymentCarryInStamp, GameState, Id, Team } from '../models'
+import { DOWNTIME_CARRY_IN_CALIBRATION } from './calibration'
+import { vitalsHasExposureResidue } from './recoveryImpairments'
+
+function getTeamMemberIds(team: Pick<Team, 'memberIds' | 'agentIds'>): Id[] {
+  const memberIds = Array.isArray(team.memberIds) ? team.memberIds : undefined
+  const agentIds = Array.isArray(team.agentIds) ? team.agentIds : undefined
+
+  if (memberIds && agentIds) {
+    const sameMembers =
+      memberIds.length === agentIds.length &&
+      memberIds.every((memberId) => agentIds.includes(memberId))
+
+    return [...new Set(sameMembers ? memberIds : agentIds)]
+  }
+
+  return [...new Set(memberIds ?? agentIds ?? [])]
+}
+
+/**
+ * SPE-1701: deterministic per-agent carry-in from post-downtime posture.
+ * Negative path takes precedence over positive when both could apply.
+ */
+export function computeDowntimeCarryInForAgent(
+  agent: Agent,
+  week: number
+): AgentDeploymentCarryInStamp | undefined {
+  const foregone = agent.downtimeActivity?.foregoneThisInterval
+  const hasResidue = vitalsHasExposureResidue(agent.vitals)
+  const forewentTherapy = foregone?.includes('therapy')
+
+  if (hasResidue && forewentTherapy) {
+    return {
+      readinessDelta: -DOWNTIME_CARRY_IN_CALIBRATION.residueTherapyForegoneReadinessPenalty,
+      code: 'residue-therapy-foregone',
+      stampedWeek: week,
+    }
+  }
+
+  const recoveryOk = !agent.recoveryStatus || agent.recoveryStatus.state === 'healthy'
+  const traumaOk = (agent.trauma?.traumaLevel ?? 0) === 0
+  const fatigue = agent.fatigue
+  const restWeek = agent.downtimeActivity?.activity === 'rest'
+  const stableEnergy = agent.energyBudget?.reserveBand === 'stable'
+
+  if (
+    restWeek &&
+    stableEnergy &&
+    fatigue <= DOWNTIME_CARRY_IN_CALIBRATION.wellRestedFatigueCeiling &&
+    recoveryOk &&
+    traumaOk &&
+    !hasResidue
+  ) {
+    return {
+      readinessDelta: DOWNTIME_CARRY_IN_CALIBRATION.wellRestedStableEnergyReadinessBonus,
+      code: 'well-rested-stable-energy',
+      stampedWeek: week,
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Rebuild carry-in stamps for every operative on every team currently assigned to the case.
+ * Call after assignment mutations so the map matches roster reality.
+ */
+export function rebuildDeploymentCarryInForCase(
+  state: GameState,
+  caseId: Id
+): Record<Id, AgentDeploymentCarryInStamp> | undefined {
+  const caseData = state.cases[caseId]
+  if (!caseData || caseData.status !== 'in_progress' || caseData.assignedTeamIds.length === 0) {
+    return undefined
+  }
+
+  const out: Record<Id, AgentDeploymentCarryInStamp> = {}
+  for (const teamId of caseData.assignedTeamIds) {
+    const team = state.teams[teamId]
+    if (!team) continue
+    for (const agentId of getTeamMemberIds(team)) {
+      const agent = state.agents[agentId]
+      if (!agent) continue
+      const stamp = computeDowntimeCarryInForAgent(agent, state.week)
+      if (stamp) {
+        out[agentId] = stamp
+      }
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined
+}

--- a/src/domain/visibility.ts
+++ b/src/domain/visibility.ts
@@ -509,6 +509,10 @@ export function explainDeploymentReadiness(
       readiness.intelPenalty && readiness.intelPenalty > 0
         ? `Intel penalty is ${readiness.intelPenalty} at confidence ${intel.confidence.toFixed(2)}, uncertainty ${intel.uncertainty.toFixed(2)}, age ${intel.age}.`
         : undefined,
+      readiness.deploymentCarryInReadinessDelta !== undefined &&
+      readiness.deploymentCarryInReadinessDelta !== 0
+        ? `Downtime carry-in (first contract week): ${readiness.deploymentCarryInReadinessDelta > 0 ? '+' : ''}${readiness.deploymentCarryInReadinessDelta} readiness (${(readiness.deploymentCarryInCodes ?? []).join(', ') || 'codes'}).`
+        : undefined,
       `Readiness ${readiness.readinessScore} comes from fatigue ${readiness.averageFatigue}, minimum member readiness ${readiness.minimumMemberReadiness}, and coverage ${readiness.coverageCompleteness.covered.length}/${readiness.coverageCompleteness.required.length}.`,
       eligibility.explanationNotes[0],
     ]),

--- a/src/features/developer/developerOverlayView.ts
+++ b/src/features/developer/developerOverlayView.ts
@@ -295,10 +295,18 @@ export function buildDeveloperOverlaySnapshot(game: GameState): DeveloperOverlay
     })
     .sort((left, right) => left.teamId.localeCompare(right.teamId))
   const deploymentSummaries = Object.values(game.teams)
-    .map((team) => ({
-      teamId: team.id,
-      readiness: team.deploymentReadinessState,
-    }))
+    .map((team) => {
+      const assignedCaseId = team.status?.assignedCaseId ?? team.assignedCaseId
+      const caseDeploymentCarryInByAgentId =
+        assignedCaseId && game.cases[assignedCaseId]
+          ? (game.cases[assignedCaseId].deploymentCarryInByAgentId ?? null)
+          : null
+      return {
+        teamId: team.id,
+        readiness: team.deploymentReadinessState,
+        caseDeploymentCarryInByAgentId,
+      }
+    })
     .sort((left, right) => left.teamId.localeCompare(right.teamId))
   const bestTeams = rankBestAvailableTeams(
     Object.values(game.teams),

--- a/src/features/developer/developerOverlayView.ts
+++ b/src/features/developer/developerOverlayView.ts
@@ -2,7 +2,7 @@ import { buildDeveloperLogSnapshot } from '../../domain/developerLog'
 import { listQueuedRuntimeEvents } from '../../domain/eventQueue'
 import { buildFlagSystemSnapshot } from '../../domain/flagSystem'
 import { readGameStateManager } from '../../domain/gameStateManager'
-import type { GameFlagValue, GameState } from '../../domain/models'
+import type { AgentDeploymentCarryInStamp, GameFlagValue, GameState } from '../../domain/models'
 import { buildAgentLoadoutReadinessSummary, listEquippedItemAssignments } from '../../domain/equipment'
 import { listProgressClocks } from '../../domain/progressClocks'
 import { buildRecruitmentFunnelSummary } from '../../domain/recruitment'
@@ -119,6 +119,8 @@ export interface DeveloperOverlaySnapshot {
       estimatedDeployWeeks: number
       estimatedRecoveryWeeks: number
       explanation: DeploymentReadinessExplanation
+      /** SPE-1701: stamped carry-in map for assigned case (developer/debug). */
+      caseDeploymentCarryInByAgentId?: Record<string, AgentDeploymentCarryInStamp> | null
     }>
   }
   missions: {
@@ -470,6 +472,9 @@ export function buildDeveloperOverlaySnapshot(game: GameState): DeveloperOverlay
         estimatedDeployWeeks: summary.readiness?.estimatedDeployWeeks ?? 0,
         estimatedRecoveryWeeks: summary.readiness?.estimatedRecoveryWeeks ?? 0,
         explanation: explainDeploymentReadiness(game, summary.teamId),
+        ...(summary.caseDeploymentCarryInByAgentId != null
+          ? { caseDeploymentCarryInByAgentId: summary.caseDeploymentCarryInByAgentId }
+          : {}),
       })),
     },
     missions: {

--- a/src/test/downtimeCarryIn.test.ts
+++ b/src/test/downtimeCarryIn.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { buildTeamDeploymentReadinessState } from '../domain/deploymentReadiness'
+import { assignTeam, unassignTeam } from '../domain/sim/assign'
+import { DOWNTIME_CARRY_IN_CALIBRATION } from '../domain/sim/calibration'
+import {
+  computeDowntimeCarryInForAgent,
+  rebuildDeploymentCarryInForCase,
+} from '../domain/sim/downtimeCarryIn'
+import { EXPOSURE_RESIDUE_STATUS_FLAG } from '../domain/sim/recoveryImpairments'
+
+describe('SPE-1701 downtime deployment carry-in', () => {
+  it('computes negative carry-in when residue is present and therapy was foregone', () => {
+    const stamp = computeDowntimeCarryInForAgent(
+      {
+        id: 'x',
+        name: 'X',
+        role: 'tech',
+        baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+        tags: [],
+        relationships: {},
+        fatigue: 40,
+        status: 'active',
+        downtimeActivity: {
+          activity: 'rest',
+          sinceWeek: 2,
+          foregoneThisInterval: ['therapy', 'coping', 'other'],
+        },
+        vitals: { statusFlags: [EXPOSURE_RESIDUE_STATUS_FLAG] },
+      },
+      3
+    )
+    expect(stamp?.code).toBe('residue-therapy-foregone')
+    expect(stamp?.readinessDelta).toBe(
+      -DOWNTIME_CARRY_IN_CALIBRATION.residueTherapyForegoneReadinessPenalty
+    )
+  })
+
+  it('computes positive carry-in for stable-energy rest week without residue', () => {
+    const stamp = computeDowntimeCarryInForAgent(
+      {
+        id: 'x',
+        name: 'X',
+        role: 'tech',
+        baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+        tags: [],
+        relationships: {},
+        fatigue: 20,
+        status: 'active',
+        downtimeActivity: { activity: 'rest', sinceWeek: 2 },
+        recoveryStatus: { state: 'healthy', sinceWeek: 1 },
+        trauma: { traumaLevel: 0, traumaTags: [], lastEventWeek: 1 },
+        energyBudget: {
+          currentReserve: 88,
+          reserveBand: 'stable',
+          exertionDebt: 0,
+          estimateConfidence: 'high',
+        },
+      },
+      3
+    )
+    expect(stamp?.code).toBe('well-rested-stable-energy')
+    expect(stamp?.readinessDelta).toBe(
+      DOWNTIME_CARRY_IN_CALIBRATION.wellRestedStableEnergyReadinessBonus
+    )
+  })
+
+  it('prefers negative carry-in when residue and foregone therapy would also satisfy rest bonus', () => {
+    const stamp = computeDowntimeCarryInForAgent(
+      {
+        id: 'x',
+        name: 'X',
+        role: 'tech',
+        baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+        tags: [],
+        relationships: {},
+        fatigue: 10,
+        status: 'active',
+        downtimeActivity: {
+          activity: 'rest',
+          sinceWeek: 2,
+          foregoneThisInterval: ['therapy'],
+        },
+        vitals: { statusFlags: [EXPOSURE_RESIDUE_STATUS_FLAG] },
+        energyBudget: {
+          currentReserve: 90,
+          reserveBand: 'stable',
+          exertionDebt: 0,
+          estimateConfidence: 'high',
+        },
+      },
+      3
+    )
+    expect(stamp?.code).toBe('residue-therapy-foregone')
+  })
+
+  it('stamps carry-in on assignTeam and rebuilds deterministically', () => {
+    let state = createStartingState()
+    const ids = ['a_ava', 'a_kellan', 'a_mina', 'a_rook'] as const
+    const nextAgents = { ...state.agents }
+    for (const id of ids) {
+      const base = nextAgents[id]!
+      nextAgents[id] = {
+        ...base,
+        downtimeActivity: {
+          activity: 'rest',
+          sinceWeek: 1,
+          foregoneThisInterval: ['therapy', 'coping', 'other'],
+        },
+        vitals: {
+          ...base.vitals,
+          statusFlags: [...(base.vitals?.statusFlags ?? []), EXPOSURE_RESIDUE_STATUS_FLAG],
+        },
+      }
+    }
+    state = { ...state, agents: nextAgents }
+    const assigned = assignTeam(state, 'case-001', 't_nightwatch')
+    const map = assigned.cases['case-001']?.deploymentCarryInByAgentId
+    expect(map).toBeDefined()
+    for (const id of ids) {
+      expect(map?.[id]?.code).toBe('residue-therapy-foregone')
+    }
+    const again = assignTeam(assigned, 'case-001', 't_nightwatch')
+    expect(again.cases['case-001']?.deploymentCarryInByAgentId).toEqual(map)
+  })
+
+  it('clears carry-in when last team unassigns to open', () => {
+    let state = createStartingState()
+    const agentId = 'a_ava'
+    const base = state.agents[agentId]!
+    state = {
+      ...state,
+      agents: {
+        ...state.agents,
+        [agentId]: {
+          ...base,
+          downtimeActivity: {
+            activity: 'rest',
+            sinceWeek: 1,
+            foregoneThisInterval: ['therapy'],
+          },
+          vitals: {
+            ...base.vitals,
+            statusFlags: [...(base.vitals?.statusFlags ?? []), EXPOSURE_RESIDUE_STATUS_FLAG],
+          },
+        },
+      },
+    }
+    const assigned = assignTeam(state, 'case-001', 't_nightwatch')
+    expect(assigned.cases['case-001']?.deploymentCarryInByAgentId?.[agentId]).toBeDefined()
+    const open = unassignTeam(assigned, 'case-001', 't_nightwatch')
+    expect(open.cases['case-001']?.deploymentCarryInByAgentId).toBeUndefined()
+  })
+
+  it('applies carry-in to readiness only on first in-contract week', () => {
+    let state = createStartingState()
+    const agentId = 'a_ava'
+    const base = state.agents[agentId]!
+    state = {
+      ...state,
+      agents: {
+        ...state.agents,
+        [agentId]: {
+          ...base,
+          downtimeActivity: {
+            activity: 'rest',
+            sinceWeek: 1,
+            foregoneThisInterval: ['therapy'],
+          },
+          vitals: {
+            ...base.vitals,
+            statusFlags: [...(base.vitals?.statusFlags ?? []), EXPOSURE_RESIDUE_STATUS_FLAG],
+          },
+        },
+      },
+    }
+    const assigned = assignTeam(state, 'case-001', 't_nightwatch')
+    const rFirst = buildTeamDeploymentReadinessState(assigned, 't_nightwatch')
+    expect(rFirst.deploymentCarryInReadinessDelta).toBeLessThan(0)
+
+    const laterWeek = {
+      ...assigned,
+      cases: {
+        ...assigned.cases,
+        'case-001': {
+          ...assigned.cases['case-001']!,
+          weeksRemaining: assigned.cases['case-001']!.durationWeeks - 1,
+        },
+      },
+    }
+    const rLater = buildTeamDeploymentReadinessState(laterWeek, 't_nightwatch')
+    expect(rLater.deploymentCarryInReadinessDelta).toBeUndefined()
+  })
+
+  it('sums positive carry-in with a team-level cap', () => {
+    let state = createStartingState()
+    const ids = ['a_ava', 'a_kellan', 'a_mina', 'a_rook'] as const
+    const nextAgents = { ...state.agents }
+    for (const id of ids) {
+      const base = nextAgents[id]!
+      nextAgents[id] = {
+        ...base,
+        fatigue: 15,
+        downtimeActivity: { activity: 'rest', sinceWeek: 1 },
+        recoveryStatus: { state: 'healthy', sinceWeek: 1 },
+        trauma: { traumaLevel: 0, traumaTags: [], lastEventWeek: 1 },
+        energyBudget: {
+          currentReserve: 90,
+          reserveBand: 'stable',
+          exertionDebt: 0,
+          estimateConfidence: 'high',
+        },
+      }
+    }
+    state = { ...state, agents: nextAgents }
+    const assigned = assignTeam(state, 'case-001', 't_nightwatch')
+    const readiness = buildTeamDeploymentReadinessState(assigned, 't_nightwatch')
+    expect(readiness.deploymentCarryInReadinessDelta).toBe(
+      DOWNTIME_CARRY_IN_CALIBRATION.teamReadinessDeltaCap
+    )
+  })
+
+  it('rebuildDeploymentCarryInForCase returns undefined when case is not in progress', () => {
+    const state = createStartingState()
+    expect(rebuildDeploymentCarryInForCase(state, 'case-001')).toBeUndefined()
+  })
+})

--- a/src/test/fieldBaseStaging.test.ts
+++ b/src/test/fieldBaseStaging.test.ts
@@ -11,6 +11,7 @@ import {
   sanitizePersistedFieldBasePacket,
 } from '../domain/fieldBaseStaging'
 import type { CaseInstance, GameState } from '../domain/models'
+import { computeDowntimeCarryInForAgent } from '../domain/sim/downtimeCarryIn'
 import { getTeamMoveEligibility } from '../domain/sim/teamManagement'
 
 const SAMPLE_PACKET = {
@@ -172,5 +173,95 @@ describe('field base staging (SPE-1654)', () => {
     expect(getTeamMoveEligibility(next, 'a_ava', null).allowed).toBe(true)
     expect(getTeamMoveEligibility(next, 'a_casey', null).allowed).toBe(false)
     expect(formatFieldBaseStagingLegibilityLine(SAMPLE_PACKET)).toContain('test-bivouac')
+  })
+
+  it('SPE-1701: rebuilds deployment carry-in after field-base rotation so stamps match roster', () => {
+    const shell = createStartingState()
+    const deployedTeamId = 't_nightwatch'
+    const sansSato = shell.teams.t_greentape!.agentIds.filter((id) => id !== 'a_sato')
+
+    const baseCase: CaseInstance = {
+      id: 'case_exp',
+      templateId: 'occult-005',
+      title: 'Expedition',
+      description: 'd',
+      mode: 'probability',
+      kind: 'case',
+      status: 'in_progress',
+      difficulty: { combat: 10, investigation: 10, utility: 10, social: 10 },
+      weights: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      tags: [],
+      requiredTags: [],
+      preferredTags: [],
+      stage: 1,
+      durationWeeks: 3,
+      deadlineWeeks: 4,
+      deadlineRemaining: 3,
+      assignedTeamIds: [deployedTeamId],
+      onFail: { type: 'none' },
+      onUnresolved: { type: 'none' },
+      contract: {
+        templateId: 'institutions-liturgy-expedition',
+        fieldBase: { ...SAMPLE_PACKET },
+      },
+      deploymentCarryInByAgentId: {
+        a_ava: { readinessDelta: -5, code: 'residue-therapy-foregone', stampedWeek: 1 },
+      },
+    }
+
+    const assignedToExp = {
+      state: 'assigned' as const,
+      caseId: 'case_exp',
+      teamId: deployedTeamId,
+      startedWeek: 1,
+    }
+
+    const game: GameState = {
+      ...shell,
+      cases: {
+        ...shell.cases,
+        case_exp: baseCase,
+      },
+      teams: {
+        ...shell.teams,
+        t_greentape: {
+          ...shell.teams.t_greentape!,
+          agentIds: sansSato,
+          memberIds: sansSato,
+        },
+        [deployedTeamId]: {
+          ...shell.teams[deployedTeamId]!,
+          assignedCaseId: 'case_exp',
+        },
+      },
+      agents: {
+        ...shell.agents,
+        a_ava: {
+          ...shell.agents.a_ava!,
+          fatigue: 85,
+          assignment: assignedToExp,
+        },
+        a_kellan: { ...shell.agents.a_kellan!, assignment: assignedToExp },
+        a_mina: { ...shell.agents.a_mina!, assignment: assignedToExp },
+        a_rook: { ...shell.agents.a_rook!, assignment: assignedToExp },
+        a_casey: { ...shell.agents.a_casey!, assignment: { state: 'idle' } },
+      },
+    }
+
+    const next = applyFieldBaseStagingRotationAtWeekOpen(game)
+    const map = next.cases.case_exp?.deploymentCarryInByAgentId
+    expect(map?.a_ava).toBeUndefined()
+
+    const membersAfter = next.teams[deployedTeamId]!.memberIds ?? next.teams[deployedTeamId]!.agentIds
+    for (const agentId of membersAfter) {
+      const agent = next.agents[agentId]
+      expect(agent).toBeDefined()
+      const expected = computeDowntimeCarryInForAgent(agent!, next.week)
+      if (expected) {
+        expect(map?.[agentId]).toEqual(expected)
+      } else {
+        expect(map?.[agentId]).toBeUndefined()
+      }
+    }
   })
 })

--- a/systems/team-management.md
+++ b/systems/team-management.md
@@ -268,6 +268,10 @@ Some expedition contracts carry a compact **field-base staging packet** (`fieldB
 
 Rotated-out operatives receive a **bounded, deterministic fatigue shave** derived from staging `medical` and `safety` bands. **Supply** band scales recoverable **material** quantities in the mission reward breakdown. Legibility lines are appended to mission reward reasons. **Agent assignment** (`assignment.team_assigned` / `assignment.team_unassigned` history) is updated for the incoming and outgoing operatives so roster membership and deployment records stay aligned.
 
+### 4.8a Downtime deployment carry-in (SPE-1701)
+
+When a team is committed to an active case, the sim stamps compact **per-operative carry-in** on the case from the operative’s last downtime posture (`deploymentCarryInByAgentId`). **Deployment readiness** may apply a small bounded adjustment from that stamp **only during the first in-contract week** (`weeksRemaining === durationWeeks`), so post-downtime choices have an explicit mission-facing hook without duplicating raw fatigue or residue recovery math. Unassigning the last team clears the stamp map.
+
 ### 4.9 Facility-linked equipment quality (SPE-21)
 
 Equipment and facility-backed fabrication should use **semantic quality bands** (for example: prototype, field-grade, depot-refit, purpose-built, disposable) that shift **reliability** and **performance envelopes** instead of a flat numeric item ladder.


### PR DESCRIPTION
## Linear

Implements first repo slice for [SPE-1701 — Downtime carry-in consequences](https://linear.app/spectranoir/issue/SPE-1701/downtime-carry-in-consequences) (foundation: SPE-1699 / #1789).

## Boundary

**In scope**
- Pure helper \computeDowntimeCarryInForAgent\ + \ebuildDeploymentCarryInForCase\ in \src/domain/sim/downtimeCarryIn.ts\ using existing agent fields (\downtimeActivity\ + \oregoneThisInterval\, recovery/trauma, \exposure:residue\, SPE-1107 \energyBudget\, fatigue).
- Stamp \case.deploymentCarryInByAgentId\ on \ssignTeam\, \launchMajorIncident\, and rebuild/clear on \unassignTeam\.
- Consume in \uildTeamDeploymentReadinessState\ as a bounded readiness score adjustment **only** when \weeksRemaining === durationWeeks\ (first in-contract week).
- Negative path: residue + therapy foregone → readiness penalty.
- Positive path: rest + stable energy band + low fatigue + healthy/no trauma/no residue → readiness bonus; team sum capped via \DOWNTIME_CARRY_IN_CALIBRATION\.
- Visibility: \isibility.ts\ deployment explanation line; developer overlay \caseDeploymentCarryInByAgentId\ on deployment summaries.
- Docs: \docs/recovery-trauma-downtime-audit.md\ §3d, \systems/team-management.md\ §4.8a.
- Tests: \src/test/downtimeCarryIn.test.ts\.

**Out of scope**
- SPE-1700 side-work, SPE-560 carousing, SPE-1051 scars, SPE-40 action budget, SPE-1411 prep slots, SPE-1376 margin pipeline, new economy/debt hooks, broad UI.

## Files changed

- \src/domain/sim/downtimeCarryIn.ts\ (new)
- \src/domain/sim/calibration.ts\ — \DOWNTIME_CARRY_IN_CALIBRATION\
- \src/domain/models.ts\ — \AgentDeploymentCarryInStamp\, case + readiness fields
- \src/domain/sim/assign.ts\ — stamp/rebuild/clear carry-in
- \src/domain/deploymentReadiness.ts\ — first-week consumption
- \src/domain/visibility.ts\ — explanation detail
- \src/features/developer/developerOverlayView.ts\ — carry-in on deployment summaries
- \docs/recovery-trauma-downtime-audit.md\, \systems/team-management.md\
- \src/test/downtimeCarryIn.test.ts\ (new)

## Tests run

- \
pm run test:run -- src/test/downtimeCarryIn.test.ts\
- \
pm run test:run -- src/test/downtimeSlot.test.ts src/test/recoveryExposureResidue.test.ts src/test/responderEnergyBudget.test.ts src/test/deployment.readiness.timeCost.test.ts\
- \
pm run lint\
- \git diff --check\

Made with [Cursor](https://cursor.com)