### PR TITLE
SPE-1702: Prerequisite-gated trusted courier downtime (first slice)

### DIFF
--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -15,8 +15,8 @@
 ## 2. Recommended Canonical State Fields
 - `agent.recoveryStatus`: { state: 'healthy' | 'recovering' | 'traumatized' | 'incapacitated', detail?: string, sinceWeek: number }
 - `agent.trauma`: { traumaLevel: number, traumaTags: string[], lastEventWeek: number }
-- `agent.downtimeActivity`: { activity: 'rest' | 'training' | 'therapy' | 'other' | 'coping' | 'sideWork', sinceWeek: number, foregoneThisInterval?: … }
-- `agent.downtimeSideWorkLast`: optional bounded summary of the last risky side-work resolution (SPE-1700)
+- `agent.downtimeActivity`: { activity: 'rest' | 'training' | 'therapy' | 'other' | 'coping' | 'sideWork' | 'sideWorkTrusted', sinceWeek: number, foregoneThisInterval?: … }
+- `agent.downtimeSideWorkLast`: optional bounded summary of the last risky side-work resolution (SPE-1700 / SPE-1702)
 - `agent.fatigue`: number (existing, but recovery/downtime should update this deterministically)
 - `agent.energyBudget`: { currentReserve: number, reserveBand: 'stable' | 'taxed' | 'depleted' | 'overdrawn', exertionDebt: number, estimateConfidence: 'low' | 'medium' | 'high', lastDutyCost?: number } (SPE-1107 human energy accounting; converts overdrawn exertion into fatigue channels)
 - `team.recoveryPressure`: number (aggregate of member states, for overlay/stability)
@@ -41,7 +41,7 @@ Victory does not automatically close the recovery ledger; model outcomes where *
   - Undergo therapy (reduce trauma, but not fatigue)
   - Other (custom activities, e.g., research, support)
 - Progression is deterministic: same state + same downtime plan = same outcome.
-- **SPE-1699 — one primary slot per operative per week:** player menu picks (`rest`, `therapy`, `coping`, `other`, `sideWork`) are mutually exclusive for a given week. Formal **academy training** (`assignment.state === 'training'`) consumes the same slot; week-close writes `foregoneThisInterval` listing other menu actions not taken (full menu when training overrides). `other` is a compact logistics / prep placeholder. **`sideWork`** is the SPE-1700 risky off-books courier slice (distinct from `other`). Selection UI: Teams roster; tick wiring unchanged (`advanceRecoveryDowntimeForWeek` after mission finalization).
+- **SPE-1699 — one primary slot per operative per week:** player menu picks (`rest`, `therapy`, `coping`, `other`, `sideWork`, `sideWorkTrusted`) are mutually exclusive for a given week. Formal **academy training** (`assignment.state === 'training'`) consumes the same slot; week-close writes `foregoneThisInterval` listing other menu actions not taken (full menu when training overrides). `other` is a compact logistics / prep placeholder. **`sideWork`** is the SPE-1700 risky off-books courier slice; **`sideWorkTrusted`** is the SPE-1702 higher-tier relay (prerequisite-gated). Selection UI: Teams roster; tick wiring unchanged (`advanceRecoveryDowntimeForWeek` after mission finalization).
 - Recovery rates and trauma reduction must be explicit, not random.
 - Downtime cannot erase major trauma instantly; recovery is gradual and stateful.
 - SPE-1107 energy reserve is charged by deterministic duty/upkeep costs before it becomes fatigue; idle rest can restore taxed/depleted reserve after upkeep, while overdrawn reserve becomes explicit exertion debt and physical fatigue burden rather than a hidden recovery reset.
@@ -58,7 +58,7 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 
 ### 3c. SPE-1699 slice — one-slot downtime (recovery menu vs academy training)
 
-- **Rule:** at most one **primary** downtime action applies per agent per weekly tick. Player-selectable recovery-phase actions are `rest`, `therapy`, `coping`, `other`, `sideWork` (see Teams UI). **Academy training queue** activity (`assignment.state === 'training'`) **wins** over any stored menu pick and clears competing recovery uses for that tick.
+- **Rule:** at most one **primary** downtime action applies per agent per weekly tick. Player-selectable recovery-phase actions are `rest`, `therapy`, `coping`, `other`, `sideWork`, `sideWorkTrusted` (see Teams UI). **Academy training queue** activity (`assignment.state === 'training'`) **wins** over any stored menu pick and clears competing recovery uses for that tick.
 - **Ordering:** `advanceWeek` captures each agent’s resolved effective slot at the **start** of `advanceQueues` (before `advanceTrainingQueues` removes completed programs from the queue and clears `assignment.state`), then `applyRecoveryDowntimeAfterMissions` consumes that snapshot. This keeps the **final week** of a training program on the `training` slot instead of incorrectly falling through to menu/`rest` after completion processing.
 - **Evidence:** `resolveDowntimeSlotForAgent` in `downtimeSlot.ts`; `advanceWeek` snapshot on `WeeklyExecutionContext.downtimeSlotEffectiveByAgentId`; `advanceRecoveryDowntimeForWeek` persists `foregoneThisInterval` on `agent.downtimeActivity`. Tests: `src/test/downtimeSlot.test.ts`.
 
@@ -71,10 +71,17 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 
 ### 3e. SPE-1700 slice — risky side-work (off-books courier)
 
-- **Menu:** `sideWork` uses the same weekly primary slot as SPE-1699; it cannot stack with training, therapy, rest, coping, or `other` in the same tick.
-- **Resolution:** `resolveOffBooksCourierSideWork` in `downtimeSideWork.ts` (calibration `SIDE_WORK_CALIBRATION`). Success grants bounded `agency.funding`, adds fatigue, and appends **`exposure:residue`** so SPE-1653 / SPE-1701 residue-therapy carry-in can apply on the next assignment. A **high pre-week fatigue** branch skips payout, spikes fatigue, and stamps tag `side-work-lockout:off-books-courier` (Teams select disabled afterward). If `sideWork` is still stored while locked out, week-close recovery **coerces** the effective slot to `rest`, stamps `downtimeSideWorkLast.outcome === 'denied'`, and skips courier events.
+- **Menu:** `sideWork` uses the same weekly primary slot as SPE-1699; it cannot stack with training, therapy, rest, coping, `other`, or `sideWorkTrusted` in the same tick.
+- **Resolution:** `resolveOffBooksCourierSideWork` in `downtimeSideWork.ts` (calibration `SIDE_WORK_CALIBRATION`). Success grants bounded `agency.funding`, adds fatigue, and appends **`exposure:residue`** so SPE-1653 / SPE-1701 residue-therapy carry-in can apply on the next assignment. A **high pre-week fatigue** branch skips payout, spikes fatigue, and stamps tag `side-work-lockout:off-books-courier` (Teams select disabled afterward for **both** courier menu picks). Successful **paid** runs also stamp compact prerequisite tag `side-work-prereq:off-books-courier-paid` (SPE-1702 unlock). If `sideWork` is still stored while locked out, week-close recovery **coerces** the effective slot to `rest`, stamps `downtimeSideWorkLast.outcome === 'denied'`, and skips courier events.
 - **Wiring:** `advanceRecoveryDowntimeForWeek` applies mutations and emits `staff.side_work.resolved`; `advanceWeek` merges optional `agencyFundingDelta` onto **both** top-level `funding` and `agency.funding` so weekly agency metrics do not drop the payout.
 - **Evidence:** `src/test/downtimeSideWork.test.ts`; developer overlay includes `downtimeSideWorkLast`.
+
+### 3f. SPE-1702 slice — prerequisite-gated trusted courier relay
+
+- **Menu:** `sideWorkTrusted` shares the SPE-1699 primary slot; mutually exclusive with `sideWork` and the rest of the recovery menu.
+- **Prerequisite:** tag `side-work-prereq:off-books-courier-paid` (stamped automatically on any **paid** off-books courier resolution). Teams disables the option with an explicit **title** string when the tag is missing or when courier **lockout** applies (lockout takes precedence in copy order).
+- **Resolution:** `resolveTrustedCourierSideWork` — bounded **higher** `agency.funding` and fatigue deltas than base courier, **stricter** high-fatigue lockout threshold (`trustedCourierHighFatigueThreshold`), same exposure residue on success, and the **same** `side-work-lockout:off-books-courier` tag on lockout so SPE-1701 carry-in and Teams gating stay unified. Persisted `sideWorkTrusted` while ineligible is coerced to `rest` with `downtimeSideWorkLast.outcome === 'denied'` / `optionId: 'trustedCourier'` (mirrors SPE-1700 denied path).
+- **Evidence:** `src/test/downtimeSideWork.test.ts` (SPE-1702 section); helper `isInactiveSideWorkResolution` for deterministic inactive previews.
 
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.

--- a/src/domain/agent/models.ts
+++ b/src/domain/agent/models.ts
@@ -719,16 +719,18 @@ export interface AgentTraumaState {
 }
 
 export interface AgentDowntimeActivity {
-  activity: 'rest' | 'training' | 'therapy' | 'other' | 'coping' | 'sideWork'
+  activity: 'rest' | 'training' | 'therapy' | 'other' | 'coping' | 'sideWork' | 'sideWorkTrusted'
   sinceWeek: number
   /** SPE-1699: deterministic list of other primary actions not taken this weekly tick. */
-  foregoneThisInterval?: Array<'rest' | 'training' | 'therapy' | 'other' | 'coping' | 'sideWork'>
+  foregoneThisInterval?: Array<
+    'rest' | 'training' | 'therapy' | 'other' | 'coping' | 'sideWork' | 'sideWorkTrusted'
+  >
 }
 
-/** SPE-1700: last resolved risky downtime outcome for inspection / debug. */
+/** SPE-1700 / SPE-1702: last resolved risky downtime outcome for inspection / debug. */
 export interface AgentDowntimeSideWorkLast {
   week: number
-  optionId: 'offBooksCourier'
+  optionId: 'offBooksCourier' | 'trustedCourier'
   outcome: 'paid' | 'lockout' | 'denied'
   fundingDelta: number
   fatigueDelta: number
@@ -881,7 +883,7 @@ export interface Agent {
   trauma?: AgentTraumaState
   downtimeActivity?: AgentDowntimeActivity
 
-  /** SPE-1700: most recent risky side-work resolution (bounded; optional). */
+  /** SPE-1700 / SPE-1702: most recent risky side-work resolution (bounded; optional). */
   downtimeSideWorkLast?: AgentDowntimeSideWorkLast
 
   /**

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -642,7 +642,7 @@ export const operationEventPayloadSchemas = {
   'staff.side_work.resolved': z.object({
     week: z.number(),
     agentId: z.string(),
-    optionId: z.literal('offBooksCourier'),
+    optionId: z.enum(['offBooksCourier', 'trustedCourier']),
     outcome: z.enum(['paid', 'lockout']),
     fundingDelta: z.number(),
     fatigueDelta: z.number(),

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -582,7 +582,7 @@ export interface OperationEventPayloadMap {
   'staff.side_work.resolved': {
     week: number
     agentId: Id
-    optionId: 'offBooksCourier'
+    optionId: 'offBooksCourier' | 'trustedCourier'
     outcome: 'paid' | 'lockout'
     fundingDelta: number
     fatigueDelta: number

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -415,11 +415,16 @@ export const DOWNTIME_CARRY_IN_CALIBRATION = {
   offBooksCourierLockoutReadinessPenalty: 8,
 } as const
 
-/** SPE-1700 slice 1: single risky downtime path (off-books courier). */
+/** SPE-1700 slice 1: single risky downtime path (off-books courier). SPE-1702: trusted relay tier. */
 export const SIDE_WORK_CALIBRATION = {
   /** Pre-week fatigue at or above this threshold triggers the lockout branch (no payout). */
   offBooksCourierHighFatigueThreshold: 68,
   offBooksCourierSuccessFundingDelta: 220,
   offBooksCourierSuccessFatigueDelta: 14,
   offBooksCourierLockoutFatigueDelta: 22,
+  /** SPE-1702: stricter gate than base courier — relay fails into shared lockout sooner when tired. */
+  trustedCourierHighFatigueThreshold: 62,
+  trustedCourierSuccessFundingDelta: 360,
+  trustedCourierSuccessFatigueDelta: 24,
+  trustedCourierLockoutFatigueDelta: 26,
 } as const

--- a/src/domain/sim/downtimeSideWork.ts
+++ b/src/domain/sim/downtimeSideWork.ts
@@ -1,8 +1,8 @@
 import type { Agent } from '../agent/models'
 import { SIDE_WORK_CALIBRATION } from './calibration'
 
-/** Single bounded risky downtime job for SPE-1700 slice 1. */
-export type DowntimeSideWorkOptionId = 'offBooksCourier'
+/** Bounded risky downtime jobs (SPE-1700 courier + SPE-1702 trusted relay). */
+export type DowntimeSideWorkOptionId = 'offBooksCourier' | 'trustedCourier'
 
 /**
  * Courier lockout marker. First SPE-1700 slice: no automatic decay or redemption here; clearing
@@ -10,11 +10,28 @@ export type DowntimeSideWorkOptionId = 'offBooksCourier'
  */
 export const OFF_BOOKS_COURIER_LOCKOUT_TAG = 'side-work-lockout:off-books-courier' as const
 
+/**
+ * SPE-1702: compact prerequisite — at least one successful paid off-books courier payout.
+ * Stamped when that outcome resolves; unlocks the higher-tier trusted relay menu pick.
+ */
+export const OFF_BOOKS_COURIER_PAID_PREREQ_TAG = 'side-work-prereq:off-books-courier-paid' as const
+
 export interface OffBooksCourierResolution {
   fundingDelta: number
   fatigueDelta: number
   applyExposureResidue: boolean
   applyLockoutTag: boolean
+}
+
+export type TrustedCourierResolution = OffBooksCourierResolution
+
+export function isInactiveSideWorkResolution(r: OffBooksCourierResolution): boolean {
+  return (
+    r.fundingDelta === 0 &&
+    r.fatigueDelta === 0 &&
+    !r.applyExposureResidue &&
+    !r.applyLockoutTag
+  )
 }
 
 /**
@@ -46,6 +63,67 @@ export function resolveOffBooksCourierSideWork(agent: Agent): OffBooksCourierRes
   }
 }
 
+/**
+ * SPE-1702: higher-tier relay — requires prior paid courier contact; stricter fatigue gate and
+ * larger bounded payout / strain. Shares the same lockout tag as the base courier when the
+ * high-fatigue branch fires.
+ */
+export function resolveTrustedCourierSideWork(agent: Agent): TrustedCourierResolution {
+  if (agent.tags.includes(OFF_BOOKS_COURIER_LOCKOUT_TAG)) {
+    return {
+      fundingDelta: 0,
+      fatigueDelta: 0,
+      applyExposureResidue: false,
+      applyLockoutTag: false,
+    }
+  }
+  if (!agent.tags.includes(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)) {
+    return {
+      fundingDelta: 0,
+      fatigueDelta: 0,
+      applyExposureResidue: false,
+      applyLockoutTag: false,
+    }
+  }
+  if (agent.fatigue >= SIDE_WORK_CALIBRATION.trustedCourierHighFatigueThreshold) {
+    return {
+      fundingDelta: 0,
+      fatigueDelta: SIDE_WORK_CALIBRATION.trustedCourierLockoutFatigueDelta,
+      applyExposureResidue: false,
+      applyLockoutTag: true,
+    }
+  }
+  return {
+    fundingDelta: SIDE_WORK_CALIBRATION.trustedCourierSuccessFundingDelta,
+    fatigueDelta: SIDE_WORK_CALIBRATION.trustedCourierSuccessFatigueDelta,
+    applyExposureResidue: true,
+    applyLockoutTag: false,
+  }
+}
+
 export function canSelectOffBooksCourierSideWork(agent: Agent): boolean {
   return !agent.tags.includes(OFF_BOOKS_COURIER_LOCKOUT_TAG)
+}
+
+export function canSelectTrustedCourierSideWork(agent: Agent): boolean {
+  return (
+    canSelectOffBooksCourierSideWork(agent) && agent.tags.includes(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)
+  )
+}
+
+export type TrustedCourierPrimaryBlockerCode = 'courier_lockout' | 'missing_paid_courier'
+
+export function getTrustedCourierPrimaryBlocker(agent: Agent): TrustedCourierPrimaryBlockerCode | null {
+  if (agent.tags.includes(OFF_BOOKS_COURIER_LOCKOUT_TAG)) return 'courier_lockout'
+  if (!agent.tags.includes(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)) return 'missing_paid_courier'
+  return null
+}
+
+export function trustedCourierPrimaryBlockerLabel(code: TrustedCourierPrimaryBlockerCode): string {
+  switch (code) {
+    case 'courier_lockout':
+      return 'Off-books courier contact burned — risky side-work unavailable.'
+    case 'missing_paid_courier':
+      return 'Requires a successful paid off-books courier run first.'
+  }
 }

--- a/src/domain/sim/downtimeSlot.ts
+++ b/src/domain/sim/downtimeSlot.ts
@@ -1,13 +1,28 @@
 import type { Agent } from '../agent/models'
 import type { GameState, Id } from '../models'
 import type { DowntimeActivity } from './recoveryDowntime'
-import { canSelectOffBooksCourierSideWork } from './downtimeSideWork'
+import {
+  canSelectOffBooksCourierSideWork,
+  canSelectTrustedCourierSideWork,
+} from './downtimeSideWork'
 
 /** Re-export for feature modules that must not import `downtimeSideWork` directly. */
-export { canSelectOffBooksCourierSideWork }
+export {
+  canSelectOffBooksCourierSideWork,
+  canSelectTrustedCourierSideWork,
+  getTrustedCourierPrimaryBlocker,
+  trustedCourierPrimaryBlockerLabel,
+} from './downtimeSideWork'
 
-/** Menu actions the player can assign as a single weekly primary (SPE-1699 + SPE-1700 side-work). */
-export const PLAYER_PRIMARY_DOWNTIME_MENU = ['rest', 'therapy', 'coping', 'other', 'sideWork'] as const
+/** Menu actions the player can assign as a single weekly primary (SPE-1699 + SPE-1700/1702 side-work). */
+export const PLAYER_PRIMARY_DOWNTIME_MENU = [
+  'rest',
+  'therapy',
+  'coping',
+  'other',
+  'sideWork',
+  'sideWorkTrusted',
+] as const
 
 export type PlayerPrimaryDowntimeMenu = (typeof PLAYER_PRIMARY_DOWNTIME_MENU)[number]
 
@@ -23,6 +38,7 @@ const DOWNTIME_ACTIVITY_VALUES: readonly DowntimeActivity[] = [
   'other',
   'coping',
   'sideWork',
+  'sideWorkTrusted',
 ]
 
 function isDowntimeActivity(value: string | undefined): value is DowntimeActivity {
@@ -88,6 +104,7 @@ const PRIMARY_DOWNTIME_LABEL: Record<DowntimeActivity, string> = {
   coping: 'Off-duty coping',
   other: 'Logistics / side prep',
   sideWork: 'Risky off-books courier',
+  sideWorkTrusted: 'Trusted courier relay (gated)',
   training: 'Academy training (slot)',
 }
 
@@ -110,6 +127,9 @@ export function setAgentPrimaryDowntimePlan(
     return state
   }
   if (activity === 'sideWork' && !canSelectOffBooksCourierSideWork(agent)) {
+    return state
+  }
+  if (activity === 'sideWorkTrusted' && !canSelectTrustedCourierSideWork(agent)) {
     return state
   }
 

--- a/src/domain/sim/recoveryDowntime.ts
+++ b/src/domain/sim/recoveryDowntime.ts
@@ -1,4 +1,4 @@
-import type { AgentDowntimeSideWorkLast } from '../agent/models'
+import type { Agent, AgentDowntimeSideWorkLast } from '../agent/models'
 import type {
   FundingState,
   GameState,
@@ -26,6 +26,8 @@ import {
   OFF_BOOKS_COURIER_PAID_PREREQ_TAG,
   resolveOffBooksCourierSideWork,
   resolveTrustedCourierSideWork,
+  type DowntimeSideWorkOptionId,
+  type OffBooksCourierResolution,
 } from './downtimeSideWork'
 
 export type RecoveryState = 'healthy' | 'recovering' | 'traumatized' | 'incapacitated'
@@ -60,6 +62,81 @@ export interface AdvanceRecoveryDowntimeInput {
   replacementPressureState?: ReplacementPressureState
   supportStaff?: SupportStaffSummary
   substancePolicy?: 'permitted' | 'restricted' | 'prohibited'
+}
+
+/** SPE-1700 / SPE-1702: single mutation path for risky side-work tiers (review-hardening dedupe). */
+function applyStaffSideWorkResolutionMutations(input: {
+  week: number
+  agentId: Id
+  optionId: DowntimeSideWorkOptionId
+  r: OffBooksCourierResolution
+  fatigue: number
+  agencyFundingDelta: number
+  agentTags: string[]
+  agentVitals: Agent['vitals']
+}): {
+  fatigue: number
+  agencyFundingDelta: number
+  agentTags: string[]
+  agentVitals: Agent['vitals']
+  sideWorkRunLast: AgentDowntimeSideWorkLast
+  sideWorkEvent: AnyOperationEventDraft
+} {
+  const { week, agentId, optionId, r } = input
+  let { fatigue, agencyFundingDelta, agentTags, agentVitals } = input
+  fatigue = clamp(fatigue + r.fatigueDelta, 0, 100)
+  agencyFundingDelta += r.fundingDelta
+  if (r.applyLockoutTag) {
+    agentTags = agentTags.includes(OFF_BOOKS_COURIER_LOCKOUT_TAG)
+      ? agentTags
+      : [...agentTags, OFF_BOOKS_COURIER_LOCKOUT_TAG]
+  }
+  if (optionId === 'offBooksCourier' && !r.applyLockoutTag && r.fundingDelta > 0) {
+    agentTags = agentTags.includes(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)
+      ? agentTags
+      : [...agentTags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG]
+  }
+  const baseVitals = agentVitals ?? {
+    health: 100,
+    stress: 0,
+    wounds: 0,
+    morale: 50,
+    statusFlags: [] as string[],
+  }
+  agentVitals = {
+    ...baseVitals,
+    statusFlags: r.applyExposureResidue
+      ? appendExposureResidueToFlags(baseVitals.statusFlags)
+      : (baseVitals.statusFlags ?? []),
+  }
+  const outcome = r.applyLockoutTag ? 'lockout' : 'paid'
+  const sideWorkRunLast: AgentDowntimeSideWorkLast = {
+    week,
+    optionId,
+    outcome,
+    fundingDelta: r.fundingDelta,
+    fatigueDelta: r.fatigueDelta,
+  }
+  const sideWorkEvent: AnyOperationEventDraft = {
+    type: 'staff.side_work.resolved',
+    sourceSystem: 'agent',
+    payload: {
+      week,
+      agentId,
+      optionId,
+      outcome,
+      fundingDelta: r.fundingDelta,
+      fatigueDelta: r.fatigueDelta,
+    },
+  }
+  return {
+    fatigue,
+    agencyFundingDelta,
+    agentTags,
+    agentVitals,
+    sideWorkRunLast,
+    sideWorkEvent,
+  }
 }
 
 export function advanceRecoveryDowntimeForWeek({
@@ -100,32 +177,21 @@ export function advanceRecoveryDowntimeForWeek({
       mapActivity !== undefined ? { explicitEffective: mapActivity } : undefined
     )
     let sideWorkDeniedLast: AgentDowntimeSideWorkLast | undefined
-    if (downtime === 'sideWork') {
-      const courierPreview = resolveOffBooksCourierSideWork(agent)
-      const ineligibleCourier =
-        !canSelectOffBooksCourierSideWork(agent) || isInactiveSideWorkResolution(courierPreview)
-      if (ineligibleCourier) {
+    if (downtime === 'sideWork' || downtime === 'sideWorkTrusted') {
+      const optionId: DowntimeSideWorkOptionId =
+        downtime === 'sideWorkTrusted' ? 'trustedCourier' : 'offBooksCourier'
+      const preview =
+        downtime === 'sideWorkTrusted' ? resolveTrustedCourierSideWork(agent) : resolveOffBooksCourierSideWork(agent)
+      const eligible =
+        downtime === 'sideWorkTrusted'
+          ? canSelectTrustedCourierSideWork(agent)
+          : canSelectOffBooksCourierSideWork(agent)
+      if (!eligible || isInactiveSideWorkResolution(preview)) {
         downtime = 'rest'
         foregone = foregonePrimaryMenuExcept('rest')
         sideWorkDeniedLast = {
           week,
-          optionId: 'offBooksCourier',
-          outcome: 'denied',
-          fundingDelta: 0,
-          fatigueDelta: 0,
-        }
-      }
-    }
-    if (downtime === 'sideWorkTrusted') {
-      const trustedPreview = resolveTrustedCourierSideWork(agent)
-      const ineligibleTrusted =
-        !canSelectTrustedCourierSideWork(agent) || isInactiveSideWorkResolution(trustedPreview)
-      if (ineligibleTrusted) {
-        downtime = 'rest'
-        foregone = foregonePrimaryMenuExcept('rest')
-        sideWorkDeniedLast = {
-          week,
-          optionId: 'trustedCourier',
+          optionId,
           outcome: 'denied',
           fundingDelta: 0,
           fatigueDelta: 0,
@@ -321,97 +387,28 @@ export function advanceRecoveryDowntimeForWeek({
     }
 
     let sideWorkRunLast = agent.downtimeSideWorkLast
-    if (downtime === 'sideWork') {
-      const r = resolveOffBooksCourierSideWork(agent)
-      if (r.fundingDelta !== 0 || r.fatigueDelta !== 0 || r.applyExposureResidue || r.applyLockoutTag) {
-        fatigue = clamp(fatigue + r.fatigueDelta, 0, 100)
-        agencyFundingDelta += r.fundingDelta
-        if (r.applyLockoutTag) {
-          agentTags = agentTags.includes(OFF_BOOKS_COURIER_LOCKOUT_TAG)
-            ? agentTags
-            : [...agentTags, OFF_BOOKS_COURIER_LOCKOUT_TAG]
-        }
-        if (!r.applyLockoutTag && r.fundingDelta > 0) {
-          agentTags = agentTags.includes(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)
-            ? agentTags
-            : [...agentTags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG]
-        }
-        const baseVitals = agentVitals ?? {
-          health: 100,
-          stress: 0,
-          wounds: 0,
-          morale: 50,
-          statusFlags: [] as string[],
-        }
-        agentVitals = {
-          ...baseVitals,
-          statusFlags: r.applyExposureResidue
-            ? appendExposureResidueToFlags(baseVitals.statusFlags)
-            : (baseVitals.statusFlags ?? []),
-        }
-        sideWorkRunLast = {
+    if (downtime === 'sideWork' || downtime === 'sideWorkTrusted') {
+      const optionId: DowntimeSideWorkOptionId =
+        downtime === 'sideWorkTrusted' ? 'trustedCourier' : 'offBooksCourier'
+      const r =
+        downtime === 'sideWorkTrusted' ? resolveTrustedCourierSideWork(agent) : resolveOffBooksCourierSideWork(agent)
+      if (!isInactiveSideWorkResolution(r)) {
+        const applied = applyStaffSideWorkResolutionMutations({
           week,
-          optionId: 'offBooksCourier',
-          outcome: r.applyLockoutTag ? 'lockout' : 'paid',
-          fundingDelta: r.fundingDelta,
-          fatigueDelta: r.fatigueDelta,
-        }
-        eventDrafts.push({
-          type: 'staff.side_work.resolved',
-          sourceSystem: 'agent',
-          payload: {
-            week,
-            agentId,
-            optionId: 'offBooksCourier',
-            outcome: r.applyLockoutTag ? 'lockout' : 'paid',
-            fundingDelta: r.fundingDelta,
-            fatigueDelta: r.fatigueDelta,
-          },
+          agentId: agent.id,
+          optionId,
+          r,
+          fatigue,
+          agencyFundingDelta,
+          agentTags,
+          agentVitals,
         })
-      }
-    }
-    if (downtime === 'sideWorkTrusted') {
-      const r = resolveTrustedCourierSideWork(agent)
-      if (r.fundingDelta !== 0 || r.fatigueDelta !== 0 || r.applyExposureResidue || r.applyLockoutTag) {
-        fatigue = clamp(fatigue + r.fatigueDelta, 0, 100)
-        agencyFundingDelta += r.fundingDelta
-        if (r.applyLockoutTag) {
-          agentTags = agentTags.includes(OFF_BOOKS_COURIER_LOCKOUT_TAG)
-            ? agentTags
-            : [...agentTags, OFF_BOOKS_COURIER_LOCKOUT_TAG]
-        }
-        const baseVitals = agentVitals ?? {
-          health: 100,
-          stress: 0,
-          wounds: 0,
-          morale: 50,
-          statusFlags: [] as string[],
-        }
-        agentVitals = {
-          ...baseVitals,
-          statusFlags: r.applyExposureResidue
-            ? appendExposureResidueToFlags(baseVitals.statusFlags)
-            : (baseVitals.statusFlags ?? []),
-        }
-        sideWorkRunLast = {
-          week,
-          optionId: 'trustedCourier',
-          outcome: r.applyLockoutTag ? 'lockout' : 'paid',
-          fundingDelta: r.fundingDelta,
-          fatigueDelta: r.fatigueDelta,
-        }
-        eventDrafts.push({
-          type: 'staff.side_work.resolved',
-          sourceSystem: 'agent',
-          payload: {
-            week,
-            agentId,
-            optionId: 'trustedCourier',
-            outcome: r.applyLockoutTag ? 'lockout' : 'paid',
-            fundingDelta: r.fundingDelta,
-            fatigueDelta: r.fatigueDelta,
-          },
-        })
+        fatigue = applied.fatigue
+        agencyFundingDelta = applied.agencyFundingDelta
+        agentTags = applied.agentTags
+        agentVitals = applied.agentVitals
+        sideWorkRunLast = applied.sideWorkRunLast
+        eventDrafts.push(applied.sideWorkEvent)
       }
     }
 

--- a/src/domain/sim/recoveryDowntime.ts
+++ b/src/domain/sim/recoveryDowntime.ts
@@ -16,16 +16,27 @@ import {
 } from './recoveryImpairments'
 import {
   canSelectOffBooksCourierSideWork,
+  canSelectTrustedCourierSideWork,
   foregonePrimaryMenuExcept,
   resolveDowntimeSlotForAgent,
 } from './downtimeSlot'
 import {
+  isInactiveSideWorkResolution,
   OFF_BOOKS_COURIER_LOCKOUT_TAG,
+  OFF_BOOKS_COURIER_PAID_PREREQ_TAG,
   resolveOffBooksCourierSideWork,
+  resolveTrustedCourierSideWork,
 } from './downtimeSideWork'
 
 export type RecoveryState = 'healthy' | 'recovering' | 'traumatized' | 'incapacitated'
-export type DowntimeActivity = 'rest' | 'training' | 'therapy' | 'other' | 'coping' | 'sideWork'
+export type DowntimeActivity =
+  | 'rest'
+  | 'training'
+  | 'therapy'
+  | 'other'
+  | 'coping'
+  | 'sideWork'
+  | 'sideWorkTrusted'
 
 export interface RecoveryProgressionResult {
   updatedAgents: GameState['agents']
@@ -92,17 +103,29 @@ export function advanceRecoveryDowntimeForWeek({
     if (downtime === 'sideWork') {
       const courierPreview = resolveOffBooksCourierSideWork(agent)
       const ineligibleCourier =
-        !canSelectOffBooksCourierSideWork(agent) ||
-        (courierPreview.fundingDelta === 0 &&
-          courierPreview.fatigueDelta === 0 &&
-          !courierPreview.applyExposureResidue &&
-          !courierPreview.applyLockoutTag)
+        !canSelectOffBooksCourierSideWork(agent) || isInactiveSideWorkResolution(courierPreview)
       if (ineligibleCourier) {
         downtime = 'rest'
         foregone = foregonePrimaryMenuExcept('rest')
         sideWorkDeniedLast = {
           week,
           optionId: 'offBooksCourier',
+          outcome: 'denied',
+          fundingDelta: 0,
+          fatigueDelta: 0,
+        }
+      }
+    }
+    if (downtime === 'sideWorkTrusted') {
+      const trustedPreview = resolveTrustedCourierSideWork(agent)
+      const ineligibleTrusted =
+        !canSelectTrustedCourierSideWork(agent) || isInactiveSideWorkResolution(trustedPreview)
+      if (ineligibleTrusted) {
+        downtime = 'rest'
+        foregone = foregonePrimaryMenuExcept('rest')
+        sideWorkDeniedLast = {
+          week,
+          optionId: 'trustedCourier',
           outcome: 'denied',
           fundingDelta: 0,
           fatigueDelta: 0,
@@ -297,9 +320,58 @@ export function advanceRecoveryDowntimeForWeek({
       }
     }
 
-    let courierRunLast = agent.downtimeSideWorkLast
+    let sideWorkRunLast = agent.downtimeSideWorkLast
     if (downtime === 'sideWork') {
       const r = resolveOffBooksCourierSideWork(agent)
+      if (r.fundingDelta !== 0 || r.fatigueDelta !== 0 || r.applyExposureResidue || r.applyLockoutTag) {
+        fatigue = clamp(fatigue + r.fatigueDelta, 0, 100)
+        agencyFundingDelta += r.fundingDelta
+        if (r.applyLockoutTag) {
+          agentTags = agentTags.includes(OFF_BOOKS_COURIER_LOCKOUT_TAG)
+            ? agentTags
+            : [...agentTags, OFF_BOOKS_COURIER_LOCKOUT_TAG]
+        }
+        if (!r.applyLockoutTag && r.fundingDelta > 0) {
+          agentTags = agentTags.includes(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)
+            ? agentTags
+            : [...agentTags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG]
+        }
+        const baseVitals = agentVitals ?? {
+          health: 100,
+          stress: 0,
+          wounds: 0,
+          morale: 50,
+          statusFlags: [] as string[],
+        }
+        agentVitals = {
+          ...baseVitals,
+          statusFlags: r.applyExposureResidue
+            ? appendExposureResidueToFlags(baseVitals.statusFlags)
+            : (baseVitals.statusFlags ?? []),
+        }
+        sideWorkRunLast = {
+          week,
+          optionId: 'offBooksCourier',
+          outcome: r.applyLockoutTag ? 'lockout' : 'paid',
+          fundingDelta: r.fundingDelta,
+          fatigueDelta: r.fatigueDelta,
+        }
+        eventDrafts.push({
+          type: 'staff.side_work.resolved',
+          sourceSystem: 'agent',
+          payload: {
+            week,
+            agentId,
+            optionId: 'offBooksCourier',
+            outcome: r.applyLockoutTag ? 'lockout' : 'paid',
+            fundingDelta: r.fundingDelta,
+            fatigueDelta: r.fatigueDelta,
+          },
+        })
+      }
+    }
+    if (downtime === 'sideWorkTrusted') {
+      const r = resolveTrustedCourierSideWork(agent)
       if (r.fundingDelta !== 0 || r.fatigueDelta !== 0 || r.applyExposureResidue || r.applyLockoutTag) {
         fatigue = clamp(fatigue + r.fatigueDelta, 0, 100)
         agencyFundingDelta += r.fundingDelta
@@ -321,9 +393,9 @@ export function advanceRecoveryDowntimeForWeek({
             ? appendExposureResidueToFlags(baseVitals.statusFlags)
             : (baseVitals.statusFlags ?? []),
         }
-        courierRunLast = {
+        sideWorkRunLast = {
           week,
-          optionId: 'offBooksCourier',
+          optionId: 'trustedCourier',
           outcome: r.applyLockoutTag ? 'lockout' : 'paid',
           fundingDelta: r.fundingDelta,
           fatigueDelta: r.fatigueDelta,
@@ -334,7 +406,7 @@ export function advanceRecoveryDowntimeForWeek({
           payload: {
             week,
             agentId,
-            optionId: 'offBooksCourier',
+            optionId: 'trustedCourier',
             outcome: r.applyLockoutTag ? 'lockout' : 'paid',
             fundingDelta: r.fundingDelta,
             fatigueDelta: r.fatigueDelta,
@@ -365,7 +437,10 @@ export function advanceRecoveryDowntimeForWeek({
       tags: agentTags,
       copingStreak,
       downtimeSideWorkLast:
-        sideWorkDeniedLast ?? (downtime === 'sideWork' ? courierRunLast : agent.downtimeSideWorkLast),
+        sideWorkDeniedLast ??
+        (downtime === 'sideWork' || downtime === 'sideWorkTrusted'
+          ? sideWorkRunLast
+          : agent.downtimeSideWorkLast),
     }
   }
 

--- a/src/features/teams/TeamsPage.tsx
+++ b/src/features/teams/TeamsPage.tsx
@@ -10,6 +10,8 @@ import {
   canSelectPrimaryDowntimePlan,
   formatForegoneDowntimeSummary,
   getPrimaryDowntimeLabel,
+  getTrustedCourierPrimaryBlocker,
+  trustedCourierPrimaryBlockerLabel,
   type PlayerPrimaryDowntimeMenu,
 } from './downtimePlanView'
 import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
@@ -541,15 +543,27 @@ function TeamCard({
                       setAgentPrimaryDowntimePlan(agent.id, event.target.value as PlayerPrimaryDowntimeMenu)
                     }
                   >
-                    {PLAYER_PRIMARY_DOWNTIME_MENU.map((act) => (
-                      <option
-                        key={act}
-                        value={act}
-                        disabled={act === 'sideWork' && !canSelectOffBooksCourierSideWork(agent)}
-                      >
-                        {getPrimaryDowntimeLabel(act)}
-                      </option>
-                    ))}
+                    {PLAYER_PRIMARY_DOWNTIME_MENU.map((act) => {
+                      const trustedBlocker =
+                        act === 'sideWorkTrusted' ? getTrustedCourierPrimaryBlocker(agent) : null
+                      return (
+                        <option
+                          key={act}
+                          value={act}
+                          disabled={
+                            (act === 'sideWork' && !canSelectOffBooksCourierSideWork(agent)) ||
+                            (act === 'sideWorkTrusted' && trustedBlocker !== null)
+                          }
+                          title={
+                            act === 'sideWorkTrusted' && trustedBlocker
+                              ? trustedCourierPrimaryBlockerLabel(trustedBlocker)
+                              : undefined
+                          }
+                        >
+                          {getPrimaryDowntimeLabel(act)}
+                        </option>
+                      )
+                    })}
                   </select>
                 ) : agent.assignment?.state === 'training' ? (
                   <span className="rounded border border-white/10 px-2 py-1 text-[11px] uppercase tracking-wide">

--- a/src/features/teams/downtimePlanView.ts
+++ b/src/features/teams/downtimePlanView.ts
@@ -6,7 +6,10 @@ export {
   PLAYER_PRIMARY_DOWNTIME_MENU,
   canSelectOffBooksCourierSideWork,
   canSelectPrimaryDowntimePlan,
+  canSelectTrustedCourierSideWork,
   formatForegoneDowntimeSummary,
   getPrimaryDowntimeLabel,
+  getTrustedCourierPrimaryBlocker,
+  trustedCourierPrimaryBlockerLabel,
   type PlayerPrimaryDowntimeMenu,
 } from '../../domain/sim/downtimeSlot'

--- a/src/test/downtimeCarryIn.test.ts
+++ b/src/test/downtimeCarryIn.test.ts
@@ -101,7 +101,7 @@ describe('SPE-1701 downtime deployment carry-in', () => {
         downtimeActivity: {
           activity: 'rest',
           sinceWeek: 2,
-          foregoneThisInterval: ['therapy', 'coping', 'other', 'sideWork'],
+          foregoneThisInterval: ['therapy', 'coping', 'other', 'sideWork', 'sideWorkTrusted'],
         },
         vitals: { statusFlags: [EXPOSURE_RESIDUE_STATUS_FLAG] },
       },

--- a/src/test/downtimeSideWork.test.ts
+++ b/src/test/downtimeSideWork.test.ts
@@ -7,7 +7,12 @@ import { computeDowntimeCarryInForAgent } from '../domain/sim/downtimeCarryIn'
 import { setAgentPrimaryDowntimePlan, canSelectOffBooksCourierSideWork } from '../domain/sim/downtimeSlot'
 import {
   OFF_BOOKS_COURIER_LOCKOUT_TAG,
+  OFF_BOOKS_COURIER_PAID_PREREQ_TAG,
+  canSelectTrustedCourierSideWork,
+  getTrustedCourierPrimaryBlocker,
+  isInactiveSideWorkResolution,
   resolveOffBooksCourierSideWork,
+  resolveTrustedCourierSideWork,
 } from '../domain/sim/downtimeSideWork'
 import { advanceRecoveryDowntimeForWeek } from '../domain/sim/recoveryDowntime'
 import type { DowntimeActivity } from '../domain/sim/recoveryDowntime'
@@ -81,6 +86,7 @@ describe('SPE-1700 off-books courier side-work', () => {
     expect(updated.fatigue).toBe(30 + SIDE_WORK_CALIBRATION.offBooksCourierSuccessFatigueDelta)
     expect(updated.vitals?.statusFlags).toContain(EXPOSURE_RESIDUE_STATUS_FLAG)
     expect(updated.downtimeSideWorkLast?.outcome).toBe('paid')
+    expect(updated.tags).toContain(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)
     expect(result.eventDrafts.some((e) => e.type === 'staff.side_work.resolved')).toBe(true)
   })
 
@@ -125,6 +131,7 @@ describe('SPE-1700 off-books courier side-work', () => {
     expect(state.agents[agentId]?.downtimeActivity?.activity).toBe('sideWork')
     const next = advanceWeek(state)
     expect(next.agents[agentId]?.downtimeSideWorkLast?.outcome).toBe('paid')
+    expect(next.agents[agentId]?.tags).toContain(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)
     expect(next.agents[agentId]?.downtimeSideWorkLast?.fundingDelta).toBe(
       SIDE_WORK_CALIBRATION.offBooksCourierSuccessFundingDelta
     )
@@ -174,5 +181,148 @@ describe('SPE-1700 off-books courier side-work', () => {
     expect(updated.downtimeSideWorkLast?.outcome).toBe('denied')
     expect(result.agencyFundingDelta).toBeUndefined()
     expect(result.eventDrafts.some((e) => e.type === 'staff.side_work.resolved')).toBe(false)
+  })
+})
+
+describe('SPE-1702 trusted courier prerequisite gate', () => {
+  it('resolveTrustedCourierSideWork is inactive without paid-courier prerequisite tag', () => {
+    const agent = {
+      id: 'a1',
+      name: 'A',
+      role: 'tech' as const,
+      baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      tags: [],
+      relationships: {},
+      fatigue: 30,
+      status: 'active' as const,
+    }
+    expect(isInactiveSideWorkResolution(resolveTrustedCourierSideWork(agent))).toBe(true)
+  })
+
+  it('paid courier week stamps prerequisite tag and unlocks trusted selection', () => {
+    const agents = {
+      a1: {
+        id: 'a1',
+        name: 'A',
+        role: 'tech' as const,
+        baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+        tags: [],
+        relationships: {},
+        fatigue: 30,
+        status: 'active' as const,
+        vitals: {
+          health: 100,
+          stress: 0,
+          morale: 50,
+          wounds: 0,
+          statusFlags: [] as string[],
+        },
+        assignment: { state: 'idle' as const },
+      },
+    }
+    const afterCourier = advanceRecoveryDowntimeForWeek({
+      week: 2,
+      sourceAgents: agents,
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'sideWork' as DowntimeActivity },
+    })
+    const u = afterCourier.updatedAgents.a1!
+    expect(u.tags).toContain(OFF_BOOKS_COURIER_PAID_PREREQ_TAG)
+    expect(canSelectTrustedCourierSideWork(u)).toBe(true)
+    expect(getTrustedCourierPrimaryBlocker(u)).toBeNull()
+  })
+
+  it('trusted courier pays higher bounded funding than base courier when eligible', () => {
+    const agent = {
+      id: 'a1',
+      name: 'A',
+      role: 'tech' as const,
+      baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      tags: [OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
+      relationships: {},
+      fatigue: 40,
+      status: 'active' as const,
+    }
+    const r = resolveTrustedCourierSideWork(agent)
+    expect(r.fundingDelta).toBe(SIDE_WORK_CALIBRATION.trustedCourierSuccessFundingDelta)
+    expect(r.fundingDelta).toBeGreaterThan(SIDE_WORK_CALIBRATION.offBooksCourierSuccessFundingDelta)
+    expect(r.fatigueDelta).toBe(SIDE_WORK_CALIBRATION.trustedCourierSuccessFatigueDelta)
+    expect(r.applyExposureResidue).toBe(true)
+  })
+
+  it('setAgentPrimaryDowntimePlan refuses sideWorkTrusted without prerequisite tag', () => {
+    const game = createStartingState()
+    const agentId = Object.keys(game.agents)[0]!
+    const agent = game.agents[agentId]!
+    const idle: typeof agent = { ...agent, assignment: { state: 'idle' as const } }
+    const g2 = { ...game, agents: { ...game.agents, [agentId]: idle } }
+    expect(canSelectTrustedCourierSideWork(idle)).toBe(false)
+    expect(getTrustedCourierPrimaryBlocker(idle)).toBe('missing_paid_courier')
+    const next = setAgentPrimaryDowntimePlan(g2, agentId, 'sideWorkTrusted')
+    expect(next.agents[agentId]?.downtimeActivity?.activity).not.toBe('sideWorkTrusted')
+  })
+
+  it('setAgentPrimaryDowntimePlan refuses sideWorkTrusted when courier lockout is present', () => {
+    const game = createStartingState()
+    const agentId = Object.keys(game.agents)[0]!
+    const agent = game.agents[agentId]!
+    const locked: typeof agent = {
+      ...agent,
+      tags: [...agent.tags, OFF_BOOKS_COURIER_LOCKOUT_TAG, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
+      assignment: { state: 'idle' as const },
+    }
+    const g2 = { ...game, agents: { ...game.agents, [agentId]: locked } }
+    expect(getTrustedCourierPrimaryBlocker(locked)).toBe('courier_lockout')
+    const next = setAgentPrimaryDowntimePlan(g2, agentId, 'sideWorkTrusted')
+    expect(next.agents[agentId]?.downtimeActivity?.activity).not.toBe('sideWorkTrusted')
+  })
+
+  it('coerces persisted sideWorkTrusted to rest when ineligible and records denied outcome', () => {
+    const agents = {
+      a1: {
+        id: 'a1',
+        name: 'A',
+        role: 'tech' as const,
+        baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+        tags: [],
+        relationships: {},
+        fatigue: 30,
+        status: 'active' as const,
+        vitals: {
+          health: 100,
+          stress: 0,
+          morale: 50,
+          wounds: 0,
+          statusFlags: [] as string[],
+        },
+        downtimeActivity: { activity: 'sideWorkTrusted' as const, sinceWeek: 1 },
+      },
+    }
+    const result = advanceRecoveryDowntimeForWeek({
+      week: 2,
+      sourceAgents: agents,
+      sourceTeams: {},
+      downtimeAssignments: { a1: 'sideWorkTrusted' as DowntimeActivity },
+    })
+    const updated = result.updatedAgents.a1!
+    expect(updated.downtimeActivity?.activity).toBe('rest')
+    expect(updated.downtimeSideWorkLast?.outcome).toBe('denied')
+    expect(updated.downtimeSideWorkLast?.optionId).toBe('trustedCourier')
+  })
+
+  it('trusted courier lockout uses shared courier lockout tag at stricter fatigue threshold', () => {
+    const agent = {
+      id: 'a1',
+      name: 'A',
+      role: 'tech' as const,
+      baseStats: { combat: 1, investigation: 1, utility: 1, social: 1 },
+      tags: [OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
+      relationships: {},
+      fatigue: SIDE_WORK_CALIBRATION.trustedCourierHighFatigueThreshold,
+      status: 'active' as const,
+    }
+    const r = resolveTrustedCourierSideWork(agent)
+    expect(r.applyLockoutTag).toBe(true)
+    expect(r.fundingDelta).toBe(0)
   })
 })

--- a/src/test/downtimeSlot.test.ts
+++ b/src/test/downtimeSlot.test.ts
@@ -45,7 +45,7 @@ describe('resolveDowntimeSlotForAgent (SPE-1699)', () => {
     }
     const { effective, foregone } = resolveDowntimeSlotForAgent(agent)
     expect(effective).toBe('therapy')
-    expect(foregone).toEqual(['rest', 'coping', 'other', 'sideWork'])
+    expect(foregone).toEqual(PLAYER_PRIMARY_DOWNTIME_MENU.filter((a) => a !== 'therapy'))
   })
 
   it('honors explicit downtime map entries over stale agent.downtimeActivity', () => {
@@ -57,7 +57,7 @@ describe('resolveDowntimeSlotForAgent (SPE-1699)', () => {
       explicitEffective: 'coping' as DowntimeActivity,
     })
     expect(effective).toBe('coping')
-    expect(foregone).toEqual(['rest', 'therapy', 'other', 'sideWork'])
+    expect(foregone).toEqual(PLAYER_PRIMARY_DOWNTIME_MENU.filter((a) => a !== 'coping'))
   })
 
   it('accepts explicit training from pre-queue snapshot after assignment returns to idle', () => {
@@ -124,7 +124,9 @@ describe('advanceRecoveryDowntimeForWeek foregone metadata', () => {
     })
     const updated = result.updatedAgents.a1
     expect(updated.downtimeActivity?.activity).toBe('coping')
-    expect(updated.downtimeActivity?.foregoneThisInterval).toEqual(['rest', 'therapy', 'other', 'sideWork'])
+    expect(updated.downtimeActivity?.foregoneThisInterval).toEqual(
+      PLAYER_PRIMARY_DOWNTIME_MENU.filter((a) => a !== 'coping')
+    )
     expect(formatForegoneDowntimeSummary(updated.downtimeActivity?.foregoneThisInterval ?? [])).toContain(
       'Therapy'
     )

--- a/systems/team-management.md
+++ b/systems/team-management.md
@@ -236,7 +236,7 @@ Models the fact that teams cannot deploy at full capacity indefinitely.
 
 - operative recovery
 - trauma burden
-- team downtime (**SPE-1699:** one primary weekly downtime action per operative on the recovery menu, including **SPE-1700** `sideWork` / off-books courier; academy training consumes the same slot)
+- team downtime (**SPE-1699:** one primary weekly downtime action per operative on the recovery menu, including **SPE-1700** `sideWork` / off-books courier and **SPE-1702** `sideWorkTrusted` / trusted relay when unlocked; academy training consumes the same slot)
 - equipment recovery interactions
 - replacement pressure after loss
 
@@ -270,7 +270,7 @@ Rotated-out operatives receive a **bounded, deterministic fatigue shave** derive
 
 ### 4.8a Downtime deployment carry-in (SPE-1701)
 
-When a team is committed to an active case, the sim stamps compact **per-operative carry-in** on the case from the operative’s last downtime posture (`deploymentCarryInByAgentId`). **Deployment readiness** may apply a small bounded adjustment from that stamp **only during the first in-contract week** (`weeksRemaining === durationWeeks`), so post-downtime choices have an explicit mission-facing hook without duplicating raw fatigue or residue recovery math. Unassigning the last team clears the stamp map. **SPE-1700** adds courier lockout as a carry-in code path evaluated **before** residue/therapy so it is not masked by overlapping exposure residue; successful courier runs surface exposure residue and reuse the existing residue-vs-therapy foregone penalty when therapy was skipped that week.
+When a team is committed to an active case, the sim stamps compact **per-operative carry-in** on the case from the operative’s last downtime posture (`deploymentCarryInByAgentId`). **Deployment readiness** may apply a small bounded adjustment from that stamp **only during the first in-contract week** (`weeksRemaining === durationWeeks`), so post-downtime choices have an explicit mission-facing hook without duplicating raw fatigue or residue recovery math. Unassigning the last team clears the stamp map. **SPE-1700** adds courier lockout as a carry-in code path evaluated **before** residue/therapy so it is not masked by overlapping exposure residue; successful courier runs surface exposure residue and reuse the existing residue-vs-therapy foregone penalty when therapy was skipped that week. **SPE-1702** trusted relay shares the same lockout tag when its high-fatigue branch fires, so carry-in and Teams gating stay aligned.
 
 ### 4.9 Facility-linked equipment quality (SPE-21)
 


### PR DESCRIPTION
## Linear
https://linear.app/spectranoir/issue/SPE-1702/prerequisite-gated-downtime-opportunities

## Smallest boundary
- One new weekly primary downtime pick: \sideWorkTrusted\ (trusted courier relay).
- Prerequisite: compact tag \side-work-prereq:off-books-courier-paid\ stamped after a **paid** off-books courier resolution.
- Bounded higher funding/fatigue vs base courier; stricter fatigue lockout threshold; same exposure residue + shared \side-work-lockout:off-books-courier\ on lockout.
- Teams: disabled option + \	itle\ reason (lockout vs missing prerequisite). Denied/coerced paths mirror SPE-1700.

## Files changed
- Domain: \downtimeSideWork.ts\, \downtimeSlot.ts\, \ecoveryDowntime.ts\, \calibration.ts\, \gent/models.ts\, event types/validation
- UI: \TeamsPage.tsx\, \downtimePlanView.ts\
- Tests: \downtimeSideWork.test.ts\, \downtimeSlot.test.ts\, \downtimeCarryIn.test.ts\
- Docs: \docs/recovery-trauma-downtime-audit.md\, \systems/team-management.md\

## Validation
- \
pm run test:run -- src/test/downtimeSideWork.test.ts src/test/downtimeSlot.test.ts src/test/downtimeCarryIn.test.ts\
- \
pm run test:run -- src/domain/sim/recoveryDowntime.test.ts src/test/sim.staffCoping.test.ts\
- \
pm run lint\
- \git diff --check\
- \
pm run test:run\ (318 files, 2918 tests)

## Explicitly out of scope
- Fraud/bluff access paths, credential simulator, clearance/membership systems (SPE-1046), general prerequisite engine (SPE-714), front businesses / investment loop (SPE-1703), lockout decay, RNG, broad UI redesign, side-work catalog beyond this second tier.

Made with [Cursor](https://cursor.com)