### PR TITLE
SPE-823a: Courier network capacity gap report (read-only)

### DIFF
--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -91,6 +91,14 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 - **Collapse:** when risk ≥ `courierShellCollapseRiskThreshold`, status becomes `collapsed`, `collapseReason: 'overstretched'`, and `FundingState.courierShellBudgetPressureDebt` is set to `courierShellCollapseBudgetPressureDebt` so `recomputeBudgetPressure` adds a **bounded** persistent pressure offset (not a loan simulator). `canonicalizeAgencyState` in `advanceWeek.ts` **preserves** `courierShellFront`, `fundingState`, and `progressionUnlockIds` through the weekly agency normalization seam.
 - **Evidence:** `src/test/frontBusiness.test.ts`; developer overlay **Courier shell front (SPE-1703a)** section.
 
+### 3h. SPE-823a — courier network capacity gap (read-only derived report)
+
+- **Report:** `buildCourierNetworkCapacityGapReport` in `capabilityGap.ts` — single family `courierNetworkCapacity`, static scenario id `spe-823a-logistics-baseline` with calibration thresholds `requiredCapacity` vs `desiredFutureCapacity` in `COURIER_NETWORK_CAPACITY_GAP_CALIBRATION`.
+- **Current score:** derived from courier shell status (when present), informal baseline + paid courier prerequisite, compact risk breakdown (`getCourierShellRiskBreakdown`), and optional pending procurement order count — **not** written back to `GameState`.
+- **Gap kinds:** `below_required` (immediate shortfall), `below_desired_only` (meets immediate threshold but under structural target), `none`. `unresolved` stays true while current is below **desired**; listing mitigation hooks does **not** clear it.
+- **Mitigation hooks:** compact data records only (`front_business_investment`, `procurement`, `mutual_aid`); include delayed-payoff metadata on investment/procurement hooks; **no** automatic gap resolution.
+- **Evidence:** `src/test/capabilityGap.test.ts`; developer overlay **Capability gap — courier network (SPE-823a)** section.
+
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.
 - High trauma reduces deployment readiness, training efficiency, and recovery speed.

--- a/src/domain/capabilityGap.ts
+++ b/src/domain/capabilityGap.ts
@@ -82,7 +82,8 @@ function computeCourierNetworkCurrent(
 
   notes.push({ key: 'shellTier', value: `${tierLabel} (base ${tier})` })
 
-  const breakdown = getCourierShellRiskBreakdown(game, game.week)
+  const fundingState = getCanonicalFundingState(game, game.week)
+  const breakdown = getCourierShellRiskBreakdown(game, game.week, fundingState.budgetPressure)
   const lockPen = Math.min(
     cal.lockoutPenaltyCap,
     breakdown.lockoutCount * cal.lockoutPenaltyPerLockout
@@ -105,8 +106,9 @@ function computeCourierNetworkCurrent(
     value: `lock=${lockPen} residue=${resPen} budget=${bpPen}`,
   })
 
-  const fundingState = getCanonicalFundingState(game, game.week)
-  const pendingProcurement = fundingState.procurementBacklog.filter((e) => e.status === 'pending').length
+  const pendingProcurement = (fundingState.procurementBacklog ?? []).filter(
+    (entry) => entry && entry.status === 'pending'
+  ).length
   const procPen = Math.min(
     cal.pendingProcurementPenaltyCap,
     pendingProcurement * cal.pendingProcurementPenaltyPerOrder

--- a/src/domain/capabilityGap.ts
+++ b/src/domain/capabilityGap.ts
@@ -1,0 +1,182 @@
+import type { GameState } from './models'
+import { getCanonicalFundingState } from './funding'
+import {
+  agencyHasPaidCourierPrerequisite,
+  getCourierShellRiskBreakdown,
+} from './sim/frontBusiness'
+import { COURIER_NETWORK_CAPACITY_GAP_CALIBRATION } from './sim/calibration'
+
+export type CapabilityGapFamilyId = 'courierNetworkCapacity'
+
+export type CapabilityGapKind = 'below_required' | 'below_desired_only' | 'none'
+
+export type CapabilityGapMitigationKind = 'front_business_investment' | 'procurement' | 'mutual_aid'
+
+export type CapabilityGapPayoffTiming = 'immediate' | 'delayed_weeks'
+
+export interface CapabilityGapMitigationHook {
+  kind: CapabilityGapMitigationKind
+  label: string
+  delayedPayoffWeeks?: number
+  payoffTiming?: CapabilityGapPayoffTiming
+  /** Always 0 in SPE-823a — hooks do not apply immediate score deltas. */
+  immediateCapacityDelta?: number
+  detail?: string
+}
+
+export interface CapabilityGapComponentNote {
+  key: string
+  value: string
+}
+
+export interface CapabilityGapReport {
+  family: CapabilityGapFamilyId
+  scenarioId: typeof COURIER_NETWORK_CAPACITY_GAP_CALIBRATION.scenarioId
+  current: number
+  required: number
+  desiredFuture: number
+  gapKind: CapabilityGapKind
+  /** True while `current` is below the desired structural target (mitigations do not clear this). */
+  unresolved: boolean
+  componentNotes: CapabilityGapComponentNote[]
+  mitigationHooks: CapabilityGapMitigationHook[]
+}
+
+function clampNonNegative(n: number): number {
+  if (!Number.isFinite(n)) return 0
+  return Math.max(0, Math.trunc(n))
+}
+
+function computeCourierNetworkCurrent(
+  game: GameState
+): { current: number; componentNotes: CapabilityGapComponentNote[] } {
+  const cal = COURIER_NETWORK_CAPACITY_GAP_CALIBRATION
+  const front = game.agency?.courierShellFront
+  const notes: CapabilityGapComponentNote[] = []
+
+  let tier = cal.informalNetworkBaseScore
+  let tierLabel = 'informal_base'
+
+  if (front?.type === 'courierShell') {
+    switch (front.status) {
+      case 'active':
+        tier = cal.shellActiveScore
+        tierLabel = 'shell_active'
+        break
+      case 'strained':
+        tier = cal.shellStrainedScore
+        tierLabel = 'shell_strained'
+        break
+      case 'collapsed':
+        tier = cal.shellCollapsedScore
+        tierLabel = 'shell_collapsed'
+        break
+      default:
+        tierLabel = 'shell_unknown'
+        break
+    }
+  } else if (agencyHasPaidCourierPrerequisite(game)) {
+    tier += cal.paidInformalPrereqBoost
+    tierLabel = `${tierLabel}+paid_prereq`
+  }
+
+  notes.push({ key: 'shellTier', value: `${tierLabel} (base ${tier})` })
+
+  const breakdown = getCourierShellRiskBreakdown(game, game.week)
+  const lockPen = Math.min(
+    cal.lockoutPenaltyCap,
+    breakdown.lockoutCount * cal.lockoutPenaltyPerLockout
+  )
+  const resPen = Math.min(
+    cal.residuePenaltyCap,
+    breakdown.residueCount * cal.residuePenaltyPerResidue
+  )
+  const bpPen = Math.min(
+    cal.budgetPressurePenaltyCap,
+    breakdown.budgetPressure * cal.budgetPressurePenaltyPerPoint
+  )
+
+  notes.push({
+    key: 'riskBreakdown',
+    value: `lockouts=${breakdown.lockoutCount} residue=${breakdown.residueCount} budgetPressure=${breakdown.budgetPressure} rawRisk=${breakdown.riskScore}`,
+  })
+  notes.push({
+    key: 'penaltiesApplied',
+    value: `lock=${lockPen} residue=${resPen} budget=${bpPen}`,
+  })
+
+  const fundingState = getCanonicalFundingState(game, game.week)
+  const pendingProcurement = fundingState.procurementBacklog.filter((e) => e.status === 'pending').length
+  const procPen = Math.min(
+    cal.pendingProcurementPenaltyCap,
+    pendingProcurement * cal.pendingProcurementPenaltyPerOrder
+  )
+  notes.push({ key: 'pendingProcurementOrders', value: String(pendingProcurement) })
+
+  const current = clampNonNegative(tier - lockPen - resPen - bpPen - procPen)
+  notes.push({ key: 'currentScore', value: String(current) })
+
+  return { current, componentNotes: notes }
+}
+
+function buildMitigationHooks(): CapabilityGapMitigationHook[] {
+  const cal = COURIER_NETWORK_CAPACITY_GAP_CALIBRATION
+  return [
+    {
+      kind: 'front_business_investment',
+      label: 'Reinvest courier shell / licensed desk capacity',
+      delayedPayoffWeeks: cal.frontBusinessHookDelayedPayoffWeeks,
+      payoffTiming: 'delayed_weeks',
+      immediateCapacityDelta: 0,
+      detail:
+        'Spend and staff time now; usable network capacity rises only after the desk stabilizes (weekly resolve path).',
+    },
+    {
+      kind: 'procurement',
+      label: 'Emergency logistics procurement / broker backlog',
+      delayedPayoffWeeks: cal.procurementHookDelayedPayoffWeeks,
+      payoffTiming: 'delayed_weeks',
+      immediateCapacityDelta: 0,
+      detail: 'Clears channel friction after fulfillment; does not instantly raise the derived score.',
+    },
+    {
+      kind: 'mutual_aid',
+      label: 'Mutual-aid courier relay (temporary coverage)',
+      payoffTiming: 'immediate',
+      immediateCapacityDelta: 0,
+      detail: 'Borrow partner capacity for urgent runs; underlying structural shortfall remains visible.',
+    },
+  ]
+}
+
+/**
+ * SPE-823a: deterministic read-only courier network capacity gap (no `GameState` writes).
+ */
+export function buildCourierNetworkCapacityGapReport(game: GameState): CapabilityGapReport {
+  const cal = COURIER_NETWORK_CAPACITY_GAP_CALIBRATION
+  const { current, componentNotes } = computeCourierNetworkCurrent(game)
+  const required = cal.requiredCapacity
+  const desiredFuture = cal.desiredFutureCapacity
+
+  let gapKind: CapabilityGapKind = 'none'
+  if (current < required) {
+    gapKind = 'below_required'
+  } else if (current < desiredFuture) {
+    gapKind = 'below_desired_only'
+  }
+
+  const unresolved = current < desiredFuture
+  const mitigationHooks = unresolved ? buildMitigationHooks() : []
+
+  return {
+    family: 'courierNetworkCapacity',
+    scenarioId: cal.scenarioId,
+    current,
+    required,
+    desiredFuture,
+    gapKind,
+    unresolved,
+    componentNotes,
+    mitigationHooks,
+  }
+}

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -443,3 +443,34 @@ export const FRONT_BUSINESS_CALIBRATION = {
   /** Added to recomputed `budgetPressure` when the shell collapses (bounded, persistent debt field). */
   courierShellCollapseBudgetPressureDebt: 2,
 } as const
+
+/**
+ * SPE-823a: read-only courier network capacity gap slice (derived report; not persisted on `GameState`).
+ * Targets are authored thresholds for the static scenario id — not a procedural scenario generator.
+ */
+export const COURIER_NETWORK_CAPACITY_GAP_CALIBRATION = {
+  scenarioId: 'spe-823a-logistics-baseline' as const,
+  /** Immediate minimum courier/logistics support score for the baseline slice. */
+  requiredCapacity: 20,
+  /** Higher structural target: branch can meet immediate need yet remain undercapitalized. */
+  desiredFutureCapacity: 36,
+  /** Score floor when no licensed shell exists (informal agency logistics only). */
+  informalNetworkBaseScore: 4,
+  /** Added when at least one operative has `side-work-prereq:off-books-courier-paid`. */
+  paidInformalPrereqBoost: 10,
+  shellActiveScore: 42,
+  shellStrainedScore: 32,
+  shellCollapsedScore: 12,
+  lockoutPenaltyPerLockout: 8,
+  lockoutPenaltyCap: 16,
+  residuePenaltyPerResidue: 4,
+  residuePenaltyCap: 12,
+  budgetPressurePenaltyPerPoint: 2,
+  budgetPressurePenaltyCap: 12,
+  pendingProcurementPenaltyPerOrder: 2,
+  pendingProcurementPenaltyCap: 8,
+  /** Weeks until notional desk reinforcement improves usable network capacity (hook only). */
+  frontBusinessHookDelayedPayoffWeeks: 3,
+  /** Weeks until procurement backlog fulfillment eases logistics friction (hook only). */
+  procurementHookDelayedPayoffWeeks: 1,
+} as const

--- a/src/domain/sim/frontBusiness.ts
+++ b/src/domain/sim/frontBusiness.ts
@@ -39,7 +39,9 @@ export interface CourierShellRiskBreakdown {
 
 export function getCourierShellRiskBreakdown(
   game: Pick<GameState, 'agents' | 'agency' | 'config' | 'funding' | 'week'>,
-  budgetPressureWeek?: number
+  budgetPressureWeek?: number,
+  /** When set, skips a second `getCanonicalFundingState` read (SPE-823a / Copilot dedupe). */
+  precomputedBudgetPressure?: number
 ): CourierShellRiskBreakdown {
   const lockoutCount = countCourierLockouts(game.agents)
   const residueCount = countExposureResidueAgents(game.agents)
@@ -47,10 +49,10 @@ export function getCourierShellRiskBreakdown(
     typeof budgetPressureWeek === 'number' && Number.isFinite(budgetPressureWeek)
       ? Math.max(0, Math.trunc(budgetPressureWeek))
       : undefined
-  const budgetPressure = getCanonicalFundingState(
-    game,
-    referenceWeek
-  ).budgetPressure
+  const budgetPressure =
+    typeof precomputedBudgetPressure === 'number' && Number.isFinite(precomputedBudgetPressure)
+      ? precomputedBudgetPressure
+      : getCanonicalFundingState(game, referenceWeek).budgetPressure
   return {
     riskScore: lockoutCount * 2 + residueCount + budgetPressure,
     lockoutCount,

--- a/src/features/developer/DeveloperOverlay.tsx
+++ b/src/features/developer/DeveloperOverlay.tsx
@@ -155,6 +155,36 @@ export function DeveloperOverlay() {
               }
             />
 
+            <OverlaySection
+              title="Capability gap — courier network (SPE-823a)"
+              rows={[
+                `Family: ${snapshot.courierNetworkCapacityGap.family}`,
+                `Scenario: ${snapshot.courierNetworkCapacityGap.scenarioId}`,
+                `Current / required / desired: ${snapshot.courierNetworkCapacityGap.current} / ${snapshot.courierNetworkCapacityGap.required} / ${snapshot.courierNetworkCapacityGap.desiredFuture}`,
+                `Gap kind: ${snapshot.courierNetworkCapacityGap.gapKind}`,
+                `Unresolved (structural visibility): ${snapshot.courierNetworkCapacityGap.unresolved ? 'yes' : 'no'}`,
+                ...snapshot.courierNetworkCapacityGap.componentNotes.map(
+                  (n) => `Component ${n.key}: ${n.value}`
+                ),
+                ...(snapshot.courierNetworkCapacityGap.mitigationHooks.length > 0
+                  ? [
+                      'Mitigation hooks (data only — do not auto-resolve):',
+                      ...snapshot.courierNetworkCapacityGap.mitigationHooks.map((h) => {
+                        const delayed =
+                          typeof h.delayedPayoffWeeks === 'number'
+                            ? `delayed ${h.delayedPayoffWeeks}w`
+                            : 'no delayed weeks'
+                        const delta =
+                          h.immediateCapacityDelta === undefined
+                            ? ''
+                            : ` / immediateΔ=${h.immediateCapacityDelta}`
+                        return `${h.kind}: ${h.label} (${h.payoffTiming ?? 'n/a'}, ${delayed}${delta})`
+                      }),
+                    ]
+                  : ['Mitigation hooks: none (no unresolved structural gap).']),
+              ]}
+            />
+
             <OverlayListSection
               title={`Stability Recovery Actions (${snapshot.stability.recoveryActions.length})`}
               rows={snapshot.stability.recoveryActions.map(

--- a/src/features/developer/developerOverlayView.ts
+++ b/src/features/developer/developerOverlayView.ts
@@ -31,6 +31,10 @@ import {
   type WeeklyPressureExplanation,
 } from '../../domain/visibility'
 import { getFrontDeskBriefingView } from '../operations/frontDeskView'
+import {
+  buildCourierNetworkCapacityGapReport,
+  type CapabilityGapReport,
+} from '../../domain/capabilityGap'
 
 export const DEVELOPER_OVERLAY_FLAG = 'developerOverlay'
 
@@ -249,6 +253,8 @@ export interface DeveloperOverlaySnapshot {
   courierShellFront: CourierShellFrontState | null
   /** SPE-1703a: additive budget-pressure debt after shell collapse (when present). */
   courierShellBudgetPressureDebt: number | null
+  /** SPE-823a: read-only courier network capacity gap (derived; not persisted). */
+  courierNetworkCapacityGap: CapabilityGapReport
 }
 
 /**
@@ -615,5 +621,6 @@ export function buildDeveloperOverlaySnapshot(game: GameState): DeveloperOverlay
     agentRecoveryDebug,
     courierShellFront: game.agency?.courierShellFront ?? null,
     courierShellBudgetPressureDebt: game.agency?.fundingState?.courierShellBudgetPressureDebt ?? null,
+    courierNetworkCapacityGap: buildCourierNetworkCapacityGapReport(game),
   }
 }

--- a/src/test/capabilityGap.test.ts
+++ b/src/test/capabilityGap.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../domain/sim/downtimeSideWork'
 import { openCourierShellFront } from '../domain/sim/frontBusiness'
 import { normalizeGameState } from '../domain/teamSimulation'
-import type { CourierShellFrontState, GameState } from '../domain/models'
+import type { CourierShellFrontState, FundingState, GameState } from '../domain/models'
 
 function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
   const agentId = Object.keys(base.agents)[0]!
@@ -112,5 +112,21 @@ describe('SPE-823a courier network capacity gap report', () => {
     const frozen = structuredClone(game)
     buildCourierNetworkCapacityGapReport(game)
     expect(game).toEqual(frozen)
+  })
+
+  it('builds when agency fundingState omits procurementBacklog (defensive backlog read)', () => {
+    const base = withPaidCourierAndFunding(createStartingState(), 9000)
+    const fs = { ...base.agency!.fundingState! } as Record<string, unknown>
+    delete fs.procurementBacklog
+    const game: GameState = normalizeGameState({
+      ...base,
+      agency: {
+        ...base.agency!,
+        fundingState: fs as FundingState,
+      },
+    })
+    expect(() => buildCourierNetworkCapacityGapReport(game)).not.toThrow()
+    const report = buildCourierNetworkCapacityGapReport(game)
+    expect(report.componentNotes.some((n) => n.key === 'pendingProcurementOrders')).toBe(true)
   })
 })

--- a/src/test/capabilityGap.test.ts
+++ b/src/test/capabilityGap.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { buildCourierNetworkCapacityGapReport } from '../domain/capabilityGap'
+import { COURIER_NETWORK_CAPACITY_GAP_CALIBRATION } from '../domain/sim/calibration'
+import {
+  OFF_BOOKS_COURIER_LOCKOUT_TAG,
+  OFF_BOOKS_COURIER_PAID_PREREQ_TAG,
+} from '../domain/sim/downtimeSideWork'
+import { openCourierShellFront } from '../domain/sim/frontBusiness'
+import { normalizeGameState } from '../domain/teamSimulation'
+import type { CourierShellFrontState, GameState } from '../domain/models'
+
+function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
+  const agentId = Object.keys(base.agents)[0]!
+  const agent = base.agents[agentId]!
+  return normalizeGameState({
+    ...base,
+    funding,
+    agency: {
+      ...base.agency!,
+      funding,
+    },
+    agents: {
+      ...base.agents,
+      [agentId]: {
+        ...agent,
+        tags: [...agent.tags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
+      },
+    },
+  })
+}
+
+describe('SPE-823a courier network capacity gap report', () => {
+  it('computes deterministic inventory (same state → same report)', () => {
+    const game = withPaidCourierAndFunding(createStartingState(), 9000)
+    const a = buildCourierNetworkCapacityGapReport(game)
+    const b = buildCourierNetworkCapacityGapReport(game)
+    expect(a).toEqual(b)
+    expect(a.family).toBe('courierNetworkCapacity')
+    expect(a.scenarioId).toBe(COURIER_NETWORK_CAPACITY_GAP_CALIBRATION.scenarioId)
+  })
+
+  it('detects below-required gap when informal courier path only scores under threshold', () => {
+    const game = withPaidCourierAndFunding(createStartingState(), 9000)
+    expect(game.agency?.courierShellFront).toBeUndefined()
+    const report = buildCourierNetworkCapacityGapReport(game)
+    expect(report.current).toBeLessThan(report.required)
+    expect(report.gapKind).toBe('below_required')
+    expect(report.unresolved).toBe(true)
+  })
+
+  it('detects below-desired-only structural gap when immediate need is met', () => {
+    const opened = openCourierShellFront(withPaidCourierAndFunding(createStartingState(), 12000))
+    expect(opened.agency?.courierShellFront?.status).toBe('active')
+    const agentId = Object.keys(opened.agents)[0]!
+    const strainedWithLockout: GameState = normalizeGameState({
+      ...opened,
+      agency: {
+        ...opened.agency!,
+        courierShellFront: {
+          ...(opened.agency!.courierShellFront as CourierShellFrontState),
+          status: 'strained',
+        },
+      },
+      agents: {
+        ...opened.agents,
+        [agentId]: {
+          ...opened.agents[agentId]!,
+          tags: [...opened.agents[agentId]!.tags, OFF_BOOKS_COURIER_LOCKOUT_TAG],
+        },
+      },
+    })
+    const report = buildCourierNetworkCapacityGapReport(strainedWithLockout)
+    expect(report.current).toBeGreaterThanOrEqual(report.required)
+    expect(report.current).toBeLessThan(report.desiredFuture)
+    expect(report.gapKind).toBe('below_desired_only')
+    expect(report.unresolved).toBe(true)
+  })
+
+  it('reports no gap when active shell clears structural target', () => {
+    const opened = openCourierShellFront(withPaidCourierAndFunding(createStartingState(), 12000))
+    const report = buildCourierNetworkCapacityGapReport(opened)
+    expect(report.gapKind).toBe('none')
+    expect(report.unresolved).toBe(false)
+    expect(report.mitigationHooks).toEqual([])
+    expect(report.current).toBeGreaterThanOrEqual(report.desiredFuture)
+  })
+
+  it('emits at least two mitigation hooks when a gap exists, with delayed payoff on investment hook', () => {
+    const game = withPaidCourierAndFunding(createStartingState(), 9000)
+    const report = buildCourierNetworkCapacityGapReport(game)
+    expect(report.mitigationHooks.length).toBeGreaterThanOrEqual(2)
+    const investment = report.mitigationHooks.find((h) => h.kind === 'front_business_investment')
+    expect(investment).toBeDefined()
+    expect(investment?.delayedPayoffWeeks).toBe(
+      COURIER_NETWORK_CAPACITY_GAP_CALIBRATION.frontBusinessHookDelayedPayoffWeeks
+    )
+    expect(investment?.immediateCapacityDelta).toBe(0)
+    expect(investment?.payoffTiming).toBe('delayed_weeks')
+  })
+
+  it('keeps unresolved true when mitigation hooks exist (hooks do not resolve)', () => {
+    const game = withPaidCourierAndFunding(createStartingState(), 9000)
+    const report = buildCourierNetworkCapacityGapReport(game)
+    expect(report.mitigationHooks.length).toBeGreaterThan(0)
+    expect(report.unresolved).toBe(true)
+  })
+
+  it('does not mutate input game state', () => {
+    const game = createStartingState()
+    const frozen = structuredClone(game)
+    buildCourierNetworkCapacityGapReport(game)
+    expect(game).toEqual(frozen)
+  })
+})


### PR DESCRIPTION
## Linear

https://linear.app/spectranoir/issue/SPE-823/capability-gap-and-investment-loop

## Smallest boundary (SPE-823a)

Single deterministic read-only \courierNetworkCapacity\ gap report: compare derived current score to calibration \equiredCapacity\ vs \desiredFutureCapacity\ for scenario \spe-823a-logistics-baseline\. Emit compact mitigation hooks (data only; delayed payoff on investment/procurement). No \GameState\ persistence, no extra capability families, no scenario generator.

## Files changed

- \src/domain/capabilityGap.ts\ — \uildCourierNetworkCapacityGapReport\
- \src/domain/sim/calibration.ts\ — \COURIER_NETWORK_CAPACITY_GAP_CALIBRATION\
- \src/features/developer/developerOverlayView.ts\ / \DeveloperOverlay.tsx\ — overlay consumer
- \src/test/capabilityGap.test.ts\
- \docs/recovery-trauma-downtime-audit.md\ — §3h

## Validation

- \
pm run test:run -- src/test/capabilityGap.test.ts\
- \
pm run test:run -- src/test/frontBusiness.test.ts src/test/downtimeSideWork.test.ts src/test/downtimeCarryIn.test.ts src/test/downtimeSlot.test.ts src/test/developerOverlayView.test.ts\
- \
pm run test:run -- src/test/funding.integration.test.ts\
- \
pm run lint\
- \git diff --check\
- \
pm run test:run\ (320 files, 2937 tests)

## Out of scope

Capability registry, persistent gap ledger, multiple families, scenario generator, planning UI, auto-resolution, SPE-1252 capital stock, SPE-86 service nodes, budget simulator, RNG, multi-consumer rollout, new side-work/front types.

Made with [Cursor](https://cursor.com)