### PR TITLE
SPE-31a: Front Desk courier capacity opportunity card

### DIFF
--- a/docs/recovery-trauma-downtime-audit.md
+++ b/docs/recovery-trauma-downtime-audit.md
@@ -97,7 +97,7 @@ Victory does not automatically close the recovery ledger; model outcomes where *
 - **Current score:** derived from courier shell status (when present), informal baseline + paid courier prerequisite, compact risk breakdown (`getCourierShellRiskBreakdown`), and optional pending procurement order count — **not** written back to `GameState`.
 - **Gap kinds:** `below_required` (immediate shortfall), `below_desired_only` (meets immediate threshold but under structural target), `none`. `unresolved` stays true while current is below **desired**; listing mitigation hooks does **not** clear it.
 - **Mitigation hooks:** compact data records only (`front_business_investment`, `procurement`, `mutual_aid`); include delayed-payoff metadata on investment/procurement hooks; **no** automatic gap resolution.
-- **Evidence:** `src/test/capabilityGap.test.ts`; developer overlay **Capability gap — courier network (SPE-823a)** section.
+- **Evidence:** `src/test/capabilityGap.test.ts`; developer overlay **Capability gap — courier network (SPE-823a)** section; Front Desk hub **Logistics opportunity** card (`frontDeskView.ts` / `FrontDeskPage.tsx`) projects the same read-only report for players when a gap is unresolved.
 
 ## 4. Trauma & Readiness-Impact Rules
 - Trauma increases from mission failures, fatalities, or critical weakest-link outcomes.

--- a/src/features/operations/FrontDeskPage.test.tsx
+++ b/src/features/operations/FrontDeskPage.test.tsx
@@ -5,7 +5,31 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { useGameStore } from '../../app/store/gameStore'
 import { createStartingState } from '../../data/startingState'
+import type { GameState } from '../../domain/models'
+import { OFF_BOOKS_COURIER_PAID_PREREQ_TAG } from '../../domain/sim/downtimeSideWork'
+import { openCourierShellFront } from '../../domain/sim/frontBusiness'
+import { normalizeGameState } from '../../domain/teamSimulation'
 import FrontDeskPage from './FrontDeskPage'
+
+function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
+  const agentId = Object.keys(base.agents)[0]!
+  const agent = base.agents[agentId]!
+  return normalizeGameState({
+    ...base,
+    funding,
+    agency: {
+      ...base.agency!,
+      funding,
+    },
+    agents: {
+      ...base.agents,
+      [agentId]: {
+        ...agent,
+        tags: [...agent.tags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
+      },
+    },
+  })
+}
 
 function renderFrontDesk() {
   return render(
@@ -15,6 +39,8 @@ function renderFrontDesk() {
         <Route path="/report" element={<p>Reports home</p>} />
         <Route path="/recruitment" element={<p>Recruitment home</p>} />
         <Route path="/teams" element={<p>Teams home</p>} />
+        <Route path="/markets-suppliers" element={<p>Markets home</p>} />
+        <Route path="/agency" element={<p>Agency home</p>} />
       </Routes>
     </MemoryRouter>
   )
@@ -40,6 +66,7 @@ describe('FrontDeskPage', () => {
     expect(screen.getByRole('heading', { name: /procurement snapshot/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /agency standing/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /latest report/i })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /courier network capacity opportunity/i })).toBeInTheDocument()
 
     await user.click(screen.getByRole('link', { name: /weekly reports/i }))
     expect(screen.getByText(/reports home/i)).toBeInTheDocument()
@@ -90,6 +117,23 @@ describe('FrontDeskPage', () => {
       expect(screen.getByRole('link', { name: /^week 1$/i })).toBeInTheDocument()
       expect(screen.getByText(/1 resolved, 0 unresolved triggers, 0 spawned cases/i)).toBeInTheDocument()
     })
+  })
+
+  it('hides the courier logistics opportunity card when the capacity gap is resolved', () => {
+    renderFrontDesk()
+    const cleared = openCourierShellFront(withPaidCourierAndFunding(createStartingState(), 12000))
+    act(() => {
+      useGameStore.setState({ game: cleared })
+    })
+    expect(screen.queryByRole('region', { name: /courier network capacity opportunity/i })).not.toBeInTheDocument()
+  })
+
+  it('links logistics opportunity drill-ins to markets and agency routes', async () => {
+    const user = userEvent.setup()
+    renderFrontDesk()
+
+    await user.click(screen.getByRole('link', { name: /review procurement backlog/i }))
+    expect(screen.getByText(/markets home/i)).toBeInTheDocument()
   })
 
   it('logs the selected front-desk routes once per route signature', async () => {

--- a/src/features/operations/FrontDeskPage.test.tsx
+++ b/src/features/operations/FrontDeskPage.test.tsx
@@ -5,31 +5,9 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { useGameStore } from '../../app/store/gameStore'
 import { createStartingState } from '../../data/startingState'
-import type { GameState } from '../../domain/models'
-import { OFF_BOOKS_COURIER_PAID_PREREQ_TAG } from '../../domain/sim/downtimeSideWork'
 import { openCourierShellFront } from '../../domain/sim/frontBusiness'
-import { normalizeGameState } from '../../domain/teamSimulation'
 import FrontDeskPage from './FrontDeskPage'
-
-function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
-  const agentId = Object.keys(base.agents)[0]!
-  const agent = base.agents[agentId]!
-  return normalizeGameState({
-    ...base,
-    funding,
-    agency: {
-      ...base.agency!,
-      funding,
-    },
-    agents: {
-      ...base.agents,
-      [agentId]: {
-        ...agent,
-        tags: [...agent.tags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
-      },
-    },
-  })
-}
+import { withPaidCourierAndFunding } from '../../test/fixtures/withPaidCourierAndFunding'
 
 function renderFrontDesk() {
   return render(

--- a/src/features/operations/FrontDeskPage.tsx
+++ b/src/features/operations/FrontDeskPage.tsx
@@ -333,6 +333,54 @@ export default function FrontDeskPage() {
             </div>
           </section>
 
+          {view.courierCapacityOpportunity ? (
+            <section className="panel space-y-3" aria-label="Courier network capacity opportunity">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <h2 className="text-lg font-semibold">Logistics opportunity</h2>
+                  <p className="text-xs opacity-60">Courier and channel logistics summary.</p>
+                </div>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[11px] ${toneChipClass(view.courierCapacityOpportunity.tone)}`}
+                >
+                  {view.courierCapacityOpportunity.gapKindLabel}
+                </span>
+              </div>
+              <div
+                className={`rounded border px-3 py-3 space-y-2 ${toneSurfaceClass(view.courierCapacityOpportunity.tone)}`}
+              >
+                <p className="text-sm font-medium">{view.courierCapacityOpportunity.title}</p>
+                <p className="text-sm opacity-80">{view.courierCapacityOpportunity.summary}</p>
+                <p className="text-sm font-semibold text-amber-100/90">{view.courierCapacityOpportunity.capacityLine}</p>
+                <div className="flex flex-wrap gap-1.5 pt-1">
+                  {view.courierCapacityOpportunity.mitigationLabels.map((label) => (
+                    <span
+                      key={label}
+                      className="rounded-full border border-white/12 bg-white/5 px-2 py-0.5 text-[11px] opacity-85"
+                    >
+                      {label}
+                    </span>
+                  ))}
+                </div>
+                <p className="text-xs opacity-65 pt-1">{view.courierCapacityOpportunity.guidanceNote}</p>
+                <div className="flex flex-wrap gap-3 pt-1 text-[11px] uppercase tracking-[0.14em]">
+                  <Link
+                    to={view.courierCapacityOpportunity.primaryHref}
+                    className="opacity-70 hover:opacity-100"
+                  >
+                    {view.courierCapacityOpportunity.primaryLinkLabel}
+                  </Link>
+                  <Link
+                    to={view.courierCapacityOpportunity.secondaryHref}
+                    className="opacity-70 hover:opacity-100"
+                  >
+                    {view.courierCapacityOpportunity.secondaryLinkLabel}
+                  </Link>
+                </div>
+              </div>
+            </section>
+          ) : null}
+
           <section className="panel space-y-3" aria-label="Active pressures">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="space-y-1">

--- a/src/features/operations/FrontDeskPage.tsx
+++ b/src/features/operations/FrontDeskPage.tsx
@@ -353,9 +353,9 @@ export default function FrontDeskPage() {
                 <p className="text-sm opacity-80">{view.courierCapacityOpportunity.summary}</p>
                 <p className="text-sm font-semibold text-amber-100/90">{view.courierCapacityOpportunity.capacityLine}</p>
                 <div className="flex flex-wrap gap-1.5 pt-1">
-                  {view.courierCapacityOpportunity.mitigationLabels.map((label) => (
+                  {view.courierCapacityOpportunity.mitigationLabels.map((label, index) => (
                     <span
-                      key={label}
+                      key={`${label}-${index}`}
                       className="rounded-full border border-white/12 bg-white/5 px-2 py-0.5 text-[11px] opacity-85"
                     >
                       {label}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -1187,41 +1187,37 @@ export function buildCourierNetworkCapacityOpportunityCard(
     return null
   }
 
+  const sharedFields = {
+    id: 'courier-network-capacity-gap' as const,
+    capacityLine: `Current ${report.current} · Immediate floor ${report.required} · Structural target ${report.desiredFuture}`,
+    mitigationLabels: report.mitigationHooks.map((hook) => hook.label),
+    primaryHref: APP_ROUTES.marketsSuppliers,
+    primaryLinkLabel: 'Review procurement backlog',
+    secondaryHref: APP_ROUTES.agency,
+    secondaryLinkLabel: 'Review agency funding',
+    guidanceNote:
+      'These mitigations are planning labels only. Use existing procurement, agency funding, and weekly progression flows already in the sim.',
+  }
+
   if (report.gapKind === 'below_required') {
     return {
-      id: 'courier-network-capacity-gap',
+      ...sharedFields,
       title: 'Courier network below immediate floor',
       summary:
         'Logistics support is under the baseline immediate floor. Reduce lockouts, exposure residue drag, budget strain, and pending procurement pressure where you can.',
-      capacityLine: `Current ${report.current} · Immediate floor ${report.required} · Structural target ${report.desiredFuture}`,
       gapKindLabel: 'Below immediate floor',
       tone: 'danger',
-      mitigationLabels: report.mitigationHooks.map((hook) => hook.label),
-      primaryHref: APP_ROUTES.marketsSuppliers,
-      primaryLinkLabel: 'Review procurement backlog',
-      secondaryHref: APP_ROUTES.agency,
-      secondaryLinkLabel: 'Review agency funding',
-      guidanceNote:
-        'These mitigations are planning labels only. Use existing procurement, agency funding, and weekly progression flows already in the sim.',
     }
   }
 
   if (report.gapKind === 'below_desired_only') {
     return {
-      id: 'courier-network-capacity-gap',
+      ...sharedFields,
       title: 'Courier network below structural target',
       summary:
         'The immediate logistics floor is met, but overall courier network support remains under the structural baseline for this scenario.',
-      capacityLine: `Current ${report.current} · Immediate floor ${report.required} · Structural target ${report.desiredFuture}`,
       gapKindLabel: 'Below structural target',
       tone: 'warning',
-      mitigationLabels: report.mitigationHooks.map((hook) => hook.label),
-      primaryHref: APP_ROUTES.marketsSuppliers,
-      primaryLinkLabel: 'Review procurement backlog',
-      secondaryHref: APP_ROUTES.agency,
-      secondaryLinkLabel: 'Review agency funding',
-      guidanceNote:
-        'These mitigations are planning labels only. Use existing procurement, agency funding, and weekly progression flows already in the sim.',
     }
   }
 

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -5,6 +5,8 @@ import {
 } from '../../components/layout/shellStatusBarView'
 import { buildAgencySummary } from '../../domain/agency'
 import { assessAttritionPressure } from '../../domain/agent/attrition'
+import { buildCourierNetworkCapacityGapReport } from '../../domain/capabilityGap'
+import type { CapabilityGapReport } from '../../domain/capabilityGap'
 import type { AuthoredChoiceDefinition } from '../../domain/choiceSystem'
 import {
   buildAuthoredBranchContext,
@@ -144,6 +146,22 @@ export interface FrontDeskLatestReportView {
   detail: string
 }
 
+/** SPE-31a: player-facing projection of the SPE-823a courier network capacity gap (presentation only). */
+export interface FrontDeskCourierCapacityOpportunityView {
+  id: 'courier-network-capacity-gap'
+  title: string
+  summary: string
+  capacityLine: string
+  gapKindLabel: string
+  tone: FrontDeskNoticeTone
+  mitigationLabels: string[]
+  primaryHref: string
+  primaryLinkLabel: string
+  secondaryHref: string
+  secondaryLinkLabel: string
+  guidanceNote: string
+}
+
 export interface FrontDeskHubView {
   weekLabel: string
   cycleLabel: string
@@ -164,6 +182,7 @@ export interface FrontDeskHubView {
   procurementSnapshot: FrontDeskProcurementSnapshotView
   standingSummary: FrontDeskStandingSummaryView
   latestReport: FrontDeskLatestReportView | null
+  courierCapacityOpportunity: FrontDeskCourierCapacityOpportunityView | null
 }
 
 function buildDirectorMessage(
@@ -1161,6 +1180,54 @@ function buildLatestReportView(game: GameState): FrontDeskLatestReportView | nul
   }
 }
 
+export function buildCourierNetworkCapacityOpportunityCard(
+  report: CapabilityGapReport,
+): FrontDeskCourierCapacityOpportunityView | null {
+  if (!report.unresolved || report.gapKind === 'none') {
+    return null
+  }
+
+  if (report.gapKind === 'below_required') {
+    return {
+      id: 'courier-network-capacity-gap',
+      title: 'Courier network below immediate floor',
+      summary:
+        'Logistics support is under the baseline immediate floor. Reduce lockouts, exposure residue drag, budget strain, and pending procurement pressure where you can.',
+      capacityLine: `Current ${report.current} · Immediate floor ${report.required} · Structural target ${report.desiredFuture}`,
+      gapKindLabel: 'Below immediate floor',
+      tone: 'danger',
+      mitigationLabels: report.mitigationHooks.map((hook) => hook.label),
+      primaryHref: APP_ROUTES.marketsSuppliers,
+      primaryLinkLabel: 'Review procurement backlog',
+      secondaryHref: APP_ROUTES.agency,
+      secondaryLinkLabel: 'Review agency funding',
+      guidanceNote:
+        'These mitigations are planning labels only. Use existing procurement, agency funding, and weekly progression flows already in the sim.',
+    }
+  }
+
+  if (report.gapKind === 'below_desired_only') {
+    return {
+      id: 'courier-network-capacity-gap',
+      title: 'Courier network below structural target',
+      summary:
+        'The immediate logistics floor is met, but overall courier network support remains under the structural baseline for this scenario.',
+      capacityLine: `Current ${report.current} · Immediate floor ${report.required} · Structural target ${report.desiredFuture}`,
+      gapKindLabel: 'Below structural target',
+      tone: 'warning',
+      mitigationLabels: report.mitigationHooks.map((hook) => hook.label),
+      primaryHref: APP_ROUTES.marketsSuppliers,
+      primaryLinkLabel: 'Review procurement backlog',
+      secondaryHref: APP_ROUTES.agency,
+      secondaryLinkLabel: 'Review agency funding',
+      guidanceNote:
+        'These mitigations are planning labels only. Use existing procurement, agency funding, and weekly progression flows already in the sim.',
+    }
+  }
+
+  return null
+}
+
 export function getFrontDeskHubView(game: GameState): FrontDeskHubView {
   const shell = buildShellStatusBarView(game)
   const agency = buildAgencySummary(game)
@@ -1213,5 +1280,8 @@ export function getFrontDeskHubView(game: GameState): FrontDeskHubView {
     procurementSnapshot: buildProcurementSnapshot(game),
     standingSummary: buildStandingSummary(game),
     latestReport: buildLatestReportView(game),
+    courierCapacityOpportunity: buildCourierNetworkCapacityOpportunityCard(
+      buildCourierNetworkCapacityGapReport(game),
+    ),
   }
 }

--- a/src/test/capabilityGap.test.ts
+++ b/src/test/capabilityGap.test.ts
@@ -5,31 +5,11 @@ import { buildCourierNetworkCapacityGapReport } from '../domain/capabilityGap'
 import { COURIER_NETWORK_CAPACITY_GAP_CALIBRATION } from '../domain/sim/calibration'
 import {
   OFF_BOOKS_COURIER_LOCKOUT_TAG,
-  OFF_BOOKS_COURIER_PAID_PREREQ_TAG,
 } from '../domain/sim/downtimeSideWork'
 import { openCourierShellFront } from '../domain/sim/frontBusiness'
 import { normalizeGameState } from '../domain/teamSimulation'
 import type { CourierShellFrontState, FundingState, GameState } from '../domain/models'
-
-function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
-  const agentId = Object.keys(base.agents)[0]!
-  const agent = base.agents[agentId]!
-  return normalizeGameState({
-    ...base,
-    funding,
-    agency: {
-      ...base.agency!,
-      funding,
-    },
-    agents: {
-      ...base.agents,
-      [agentId]: {
-        ...agent,
-        tags: [...agent.tags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
-      },
-    },
-  })
-}
+import { withPaidCourierAndFunding } from './fixtures/withPaidCourierAndFunding'
 
 describe('SPE-823a courier network capacity gap report', () => {
   it('computes deterministic inventory (same state → same report)', () => {

--- a/src/test/fixtures/withPaidCourierAndFunding.ts
+++ b/src/test/fixtures/withPaidCourierAndFunding.ts
@@ -1,0 +1,23 @@
+import type { GameState } from '../../domain/models'
+import { OFF_BOOKS_COURIER_PAID_PREREQ_TAG } from '../../domain/sim/downtimeSideWork'
+import { normalizeGameState } from '../../domain/teamSimulation'
+
+/** Test fixture: first agent gets paid-courier prerequisite; mirrors capability-gap hub scenarios. */
+export function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
+  const agentId = Object.keys(base.agents)[0]!
+  return normalizeGameState({
+    ...base,
+    funding,
+    agency: {
+      ...base.agency!,
+      funding,
+    },
+    agents: {
+      ...base.agents,
+      [agentId]: {
+        ...base.agents[agentId]!,
+        tags: [...base.agents[agentId]!.tags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
+      },
+    },
+  })
+}

--- a/src/test/frontDeskView.test.ts
+++ b/src/test/frontDeskView.test.ts
@@ -1,13 +1,45 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { applyAuthoredChoice } from '../domain/choiceSystem'
+import { buildCourierNetworkCapacityGapReport } from '../domain/capabilityGap'
 import { consumeOneShotContent, setPersistentFlag } from '../domain/flagSystem'
 import type { Candidate } from '../domain/recruitment/types'
-import { getFrontDeskBriefingView, getFrontDeskHubView } from '../features/operations/frontDeskView'
+import type { CourierShellFrontState, GameState } from '../domain/models'
+import {
+  OFF_BOOKS_COURIER_LOCKOUT_TAG,
+  OFF_BOOKS_COURIER_PAID_PREREQ_TAG,
+} from '../domain/sim/downtimeSideWork'
+import { openCourierShellFront } from '../domain/sim/frontBusiness'
+import { normalizeGameState } from '../domain/teamSimulation'
+import {
+  buildCourierNetworkCapacityOpportunityCard,
+  getFrontDeskBriefingView,
+  getFrontDeskHubView,
+} from '../features/operations/frontDeskView'
 import {
   FRONT_DESK_TRIGGER_IDS,
   getEligibleFrontDeskSceneTriggerIds,
 } from '../features/operations/frontDeskTriggers'
+
+function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
+  const agentId = Object.keys(base.agents)[0]!
+  const agent = base.agents[agentId]!
+  return normalizeGameState({
+    ...base,
+    funding,
+    agency: {
+      ...base.agency!,
+      funding,
+    },
+    agents: {
+      ...base.agents,
+      [agentId]: {
+        ...agent,
+        tags: [...agent.tags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
+      },
+    },
+  })
+}
 
 function createSponsoredCandidate(): Candidate {
   return {
@@ -186,5 +218,58 @@ describe('frontDeskView', () => {
     expect(getEligibleFrontDeskSceneTriggerIds(state)).not.toContain(
       FRONT_DESK_TRIGGER_IDS.specialRecruitOpportunity
     )
+  })
+})
+
+describe('SPE-31a hub courier capacity opportunity card', () => {
+  it('returns null when the courier gap report has no unresolved gap', () => {
+    const opened = openCourierShellFront(withPaidCourierAndFunding(createStartingState(), 12000))
+    const report = buildCourierNetworkCapacityGapReport(opened)
+    expect(buildCourierNetworkCapacityOpportunityCard(report)).toBeNull()
+  })
+
+  it('returns a danger card for below-required gaps with mitigation labels', () => {
+    const game = withPaidCourierAndFunding(createStartingState(), 9000)
+    const card = buildCourierNetworkCapacityOpportunityCard(buildCourierNetworkCapacityGapReport(game))
+    expect(card).not.toBeNull()
+    expect(card!.tone).toBe('danger')
+    expect(card!.gapKindLabel).toBe('Below immediate floor')
+    expect(card!.mitigationLabels.length).toBeGreaterThanOrEqual(2)
+    expect(card!.capacityLine).toMatch(/Current \d+ · Immediate floor \d+ · Structural target \d+/)
+  })
+
+  it('returns a warning card for below-desired-only structural gaps', () => {
+    const opened = openCourierShellFront(withPaidCourierAndFunding(createStartingState(), 12000))
+    const agentId = Object.keys(opened.agents)[0]!
+    const strainedWithLockout: GameState = normalizeGameState({
+      ...opened,
+      agency: {
+        ...opened.agency!,
+        courierShellFront: {
+          ...(opened.agency!.courierShellFront as CourierShellFrontState),
+          status: 'strained',
+        },
+      },
+      agents: {
+        ...opened.agents,
+        [agentId]: {
+          ...opened.agents[agentId]!,
+          tags: [...opened.agents[agentId]!.tags, OFF_BOOKS_COURIER_LOCKOUT_TAG],
+        },
+      },
+    })
+    const card = buildCourierNetworkCapacityOpportunityCard(
+      buildCourierNetworkCapacityGapReport(strainedWithLockout),
+    )
+    expect(card).not.toBeNull()
+    expect(card!.tone).toBe('warning')
+    expect(card!.gapKindLabel).toBe('Below structural target')
+  })
+
+  it('does not mutate game state when building the hub view', () => {
+    const game = withPaidCourierAndFunding(createStartingState(), 9000)
+    const frozen = structuredClone(game)
+    getFrontDeskHubView(game)
+    expect(game).toEqual(frozen)
   })
 })

--- a/src/test/frontDeskView.test.ts
+++ b/src/test/frontDeskView.test.ts
@@ -7,7 +7,6 @@ import type { Candidate } from '../domain/recruitment/types'
 import type { CourierShellFrontState, GameState } from '../domain/models'
 import {
   OFF_BOOKS_COURIER_LOCKOUT_TAG,
-  OFF_BOOKS_COURIER_PAID_PREREQ_TAG,
 } from '../domain/sim/downtimeSideWork'
 import { openCourierShellFront } from '../domain/sim/frontBusiness'
 import { normalizeGameState } from '../domain/teamSimulation'
@@ -20,26 +19,7 @@ import {
   FRONT_DESK_TRIGGER_IDS,
   getEligibleFrontDeskSceneTriggerIds,
 } from '../features/operations/frontDeskTriggers'
-
-function withPaidCourierAndFunding(base: GameState, funding: number): GameState {
-  const agentId = Object.keys(base.agents)[0]!
-  const agent = base.agents[agentId]!
-  return normalizeGameState({
-    ...base,
-    funding,
-    agency: {
-      ...base.agency!,
-      funding,
-    },
-    agents: {
-      ...base.agents,
-      [agentId]: {
-        ...agent,
-        tags: [...agent.tags, OFF_BOOKS_COURIER_PAID_PREREQ_TAG],
-      },
-    },
-  })
-}
+import { withPaidCourierAndFunding } from './fixtures/withPaidCourierAndFunding'
 
 function createSponsoredCandidate(): Candidate {
   return {


### PR DESCRIPTION
## Linear

https://linear.app/spectranoir/issue/SPE-31/operations-hub-opportunity-surface

## Smallest boundary (SPE-31a)

SPE-31a projects the existing SPE-823a \courierNetworkCapacity\ gap report into the Front Desk / Operations Hub as one player-facing opportunity card. The card is presentation-only, appears only when the report is unresolved, distinguishes immediate-floor gaps from desired-future structural gaps, shows compact mitigation labels, and links only to existing operational surfaces. It does not add new simulation, new capability-gap scoring, new routes, mitigation execution, persisted hub state, town-tag lead generation, strategic action capacity, SPE-1252 capital stock, or SPE-86 service nodes.

## Files changed

- \src/features/operations/frontDeskView.ts\ — \uildCourierNetworkCapacityOpportunityCard\, \getFrontDeskHubView\ wires \uildCourierNetworkCapacityGapReport(game)\ once
- \src/features/operations/FrontDeskPage.tsx\ — hub region for the card
- \src/test/frontDeskView.test.ts\ — view-model / immutability tests
- \src/features/operations/FrontDeskPage.test.tsx\ — hub UI coverage
- \docs/recovery-trauma-downtime-audit.md\ — §3h evidence line for player-facing projection

## Validation

- \git diff --check origin/main...HEAD\
- \
pm run test:run -- src/test/frontDeskView.test.ts src/features/operations/FrontDeskPage.test.tsx src/test/capabilityGap.test.ts src/app/App.workflow.test.tsx\
- \
pm run lint\
- \
pm run test:run\ (full suite, 320 files)

## Out of scope

New simulation systems, duplicated capability-gap scoring in the hub, new routes/screens, mitigation execution, new procurement/front-business actions, town-first contract generation, civic tag packets, tag-conflict leads, value-stream tagging, strategic action capacity, exploration/knowledge projection, multiple opportunity families, broad hub redesign, SPE-1252, SPE-86.

Made with [Cursor](https://cursor.com)