### PR TITLE
SPE-1734a: Campaign rules and settings ledger

### DIFF
--- a/planning/mvp-scope.md
+++ b/planning/mvp-scope.md
@@ -104,6 +104,7 @@ Minimum expectation:
 - reports
 - pressure-relevant state
 - persistence-ready structure
+- SPE-1734 campaign ledger (bounded profile, run-state modifiers, module toggles, compatibility notes, and auditable setting history) as the canonical rules reference; the Front Desk reads it for player-facing summaries without treating scratch notes or hidden encounter truth as canonical
 
 ## 3.2 Weekly progression
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -1,4 +1,5 @@
 import { createStartingState } from '../../data/startingState'
+import { createSeedCampaignLedger, sanitizeCampaignLedger } from '../../domain/campaignLedger'
 import { getProductionRecipe } from '../../data/production'
 import { getTrainingProgram } from '../../data/training'
 import { recomputeAttritionDerivedState } from '../../domain/agent/attritionReset'
@@ -2163,6 +2164,10 @@ export function hydrateGame(game: unknown, fallback = createStartingState()): Ga
       productionQueue: sanitizeProductionQueue(game.productionQueue),
       market: sanitizeMarket(game.market, fallback.market, week),
       config: sanitizeGameConfig(game.config, fallback.config),
+      campaignLedger: sanitizeCampaignLedger(
+        game.campaignLedger,
+        fallback.campaignLedger ?? createSeedCampaignLedger()
+      ),
       contracts: hasPersistedContracts ? game.contracts : undefined,
       academyTier: clamp(
         sanitizeInteger(game.academyTier as number | undefined, fallback.academyTier ?? 0, 0),

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -1,4 +1,5 @@
 import { type GameState } from '../domain/models'
+import { createSeedCampaignLedger } from '../domain/campaignLedger'
 import { createDefaultWeeklyDirectiveState } from '../domain/directives'
 import { createInitialFactionState } from '../domain/factions'
 import { refreshContractBoard } from '../domain/contracts'
@@ -73,6 +74,8 @@ const startingStateTemplate: GameState = {
     containmentDeltaPerUnresolved: -6,
     clearanceThresholds: [0, 180, 420, 760, 1200],
   },
+
+  campaignLedger: createSeedCampaignLedger(),
 
   academyTier: 0,
 }

--- a/src/domain/campaignLedger.ts
+++ b/src/domain/campaignLedger.ts
@@ -120,12 +120,18 @@ function sanitizeModuleToggles(raw: unknown, fallback: CampaignModuleToggle[]): 
   return next.length > 0 ? next.slice(0, 24) : [...fallback]
 }
 
+const SETTING_HISTORY_CAP = 200
+
 function sanitizeSettingHistory(
   raw: unknown,
   fallback: CampaignSettingHistoryEntry[]
 ): CampaignSettingHistoryEntry[] {
   if (!Array.isArray(raw)) {
     return [...fallback]
+  }
+
+  if (raw.length === 0) {
+    return []
   }
 
   const next: CampaignSettingHistoryEntry[] = []
@@ -160,9 +166,11 @@ function sanitizeSettingHistory(
     })
   }
 
-  const bounded = next.length > 0 ? next.slice(0, 200) : [...fallback]
+  if (next.length === 0) {
+    return [...fallback]
+  }
 
-  return [...bounded].sort((left, right) => {
+  const sorted = [...next].sort((left, right) => {
     if (left.effectiveFromWeek !== right.effectiveFromWeek) {
       return left.effectiveFromWeek - right.effectiveFromWeek
     }
@@ -173,6 +181,8 @@ function sanitizeSettingHistory(
 
     return left.id.localeCompare(right.id)
   })
+
+  return sorted.length > SETTING_HISTORY_CAP ? sorted.slice(-SETTING_HISTORY_CAP) : sorted
 }
 
 function sanitizeCompatibility(

--- a/src/domain/campaignLedger.ts
+++ b/src/domain/campaignLedger.ts
@@ -360,6 +360,36 @@ export interface CampaignRulesSummary {
   activeModuleLabels: readonly string[]
 }
 
+/** Presentation-only: aligns Front Desk summary with live `game.config` for mirrored modifiers. */
+function formatChallengePostureSummaryLine(game: GameState): string {
+  const elevated = game.config.challengeModeEnabled
+  return `Challenge posture · ${
+    elevated ? 'Elevated (challenge mode on)' : 'Standard (challenge mode off)'
+  }`
+}
+
+/** Presentation-only: mirrors hydrate coercion — attrition only when challenge mode is on. */
+function formatDurationModelSummaryLine(game: GameState): string {
+  const model = game.config.challengeModeEnabled ? game.config.durationModel : 'capacity'
+  const detail =
+    model === 'attrition'
+      ? 'Attrition model (cross-session operative attrition continuity)'
+      : 'Capacity model (no cross-session operative attrition)'
+  return `Duration / attrition integrity · ${detail}`
+}
+
+function formatRunStateModifierSummaryLine(game: GameState, modifier: CampaignRunStateModifier): string {
+  if (modifier.id === 'challenge_posture') {
+    return formatChallengePostureSummaryLine(game)
+  }
+
+  if (modifier.id === 'duration_model') {
+    return formatDurationModelSummaryLine(game)
+  }
+
+  return `${modifier.label} · ${modifier.value}`
+}
+
 export function buildCampaignRulesSummary(game: GameState): CampaignRulesSummary {
   const ledger = getCurrentCampaignRulesLedger(game)
   const week = game.week
@@ -377,7 +407,7 @@ export function buildCampaignRulesSummary(game: GameState): CampaignRulesSummary
       ? `Effective tone / scope (week ${week}) · ${effectiveTone}`
       : `Tone / scope anchor · ${ledger.profile.toneScopeLabel}`,
     `Active rules profile · ${ledger.activeRulesProfileLabel} (${ledger.activeRulesProfileId})`,
-    ...ledger.runStateModifiers.map((modifier) => `${modifier.label} · ${modifier.value}`),
+    ...ledger.runStateModifiers.map((modifier) => formatRunStateModifierSummaryLine(game, modifier)),
     `Modules on · ${enabledModules.map((toggle) => toggle.label).join(' · ') || '—'}`,
   ]
 

--- a/src/domain/campaignLedger.ts
+++ b/src/domain/campaignLedger.ts
@@ -194,13 +194,17 @@ function sanitizeCompatibility(
   }
 
   const compatible = typeof raw.compatible === 'boolean' ? raw.compatible : fallback.compatible
-  const notes = Array.isArray(raw.notes)
+
+  const rawNotesPresent = Object.prototype.hasOwnProperty.call(raw, 'notes')
+  const notes = rawNotesPresent && Array.isArray(raw.notes)
     ? raw.notes
         .filter((note): note is string => typeof note === 'string' && note.trim().length > 0)
         .map((note) => clampString(note.trim(), MAX_STRING))
         .slice(0, 12)
     : [...fallback.notes]
-  const warnings = Array.isArray(raw.warnings)
+
+  const rawWarningsPresent = Object.prototype.hasOwnProperty.call(raw, 'warnings')
+  const warnings = rawWarningsPresent && Array.isArray(raw.warnings)
     ? raw.warnings
         .filter((note): note is string => typeof note === 'string' && note.trim().length > 0)
         .map((note) => clampString(note.trim(), MAX_STRING))
@@ -209,8 +213,8 @@ function sanitizeCompatibility(
 
   return {
     compatible,
-    notes: notes.length > 0 ? notes : [...fallback.notes],
-    warnings,
+    notes: rawNotesPresent && Array.isArray(raw.notes) ? notes : [...fallback.notes],
+    warnings: rawWarningsPresent && Array.isArray(raw.warnings) ? warnings : [...fallback.warnings],
   }
 }
 
@@ -295,6 +299,7 @@ export function sanitizeCampaignLedger(raw: unknown, fallback: CampaignLedgerSta
   }
 }
 
+/** Defensive sanitize: tests and partial fixtures may bypass `hydrateGame`; re-entry is cheap vs sim work. */
 export function getCurrentCampaignRulesLedger(game: GameState): CampaignLedgerState {
   const fallback = createSeedCampaignLedger()
   return sanitizeCampaignLedger(game.campaignLedger, fallback)

--- a/src/domain/campaignLedger.ts
+++ b/src/domain/campaignLedger.ts
@@ -1,0 +1,395 @@
+import type {
+  CampaignLedgerCompatibilitySnapshot,
+  CampaignLedgerState,
+  CampaignModuleToggle,
+  CampaignOperationalProfile,
+  CampaignRunStateModifier,
+  CampaignSettingHistoryEntry,
+  CampaignSettingHistorySource,
+  GameState,
+} from './models'
+
+const MAX_STRING = 480
+const MAX_LABEL = 160
+const MAX_ID = 96
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function clampString(value: string, max: number) {
+  if (value.length <= max) {
+    return value
+  }
+  return `${value.slice(0, max - 1)}…`
+}
+
+function sanitizeId(value: unknown, fallback: string) {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  return clampString(raw.length > 0 ? raw : fallback, MAX_ID)
+}
+
+function sanitizeLabel(value: unknown, fallback: string) {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  return clampString(raw.length > 0 ? raw : fallback, MAX_LABEL)
+}
+
+function sanitizeBody(value: unknown, fallback: string) {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  return clampString(raw.length > 0 ? raw : fallback, MAX_STRING)
+}
+
+function sanitizeSource(value: unknown): CampaignSettingHistorySource {
+  if (value === 'seed' || value === 'migration' || value === 'player' || value === 'system') {
+    return value
+  }
+  return 'migration'
+}
+
+function sanitizeProfile(raw: unknown, fallback: CampaignOperationalProfile): CampaignOperationalProfile {
+  if (!isRecord(raw)) {
+    return { ...fallback }
+  }
+
+  return {
+    organizationName: sanitizeLabel(raw.organizationName, fallback.organizationName),
+    homeBaseId: sanitizeId(raw.homeBaseId, fallback.homeBaseId),
+    homeBaseLabel: sanitizeLabel(raw.homeBaseLabel, fallback.homeBaseLabel),
+    operationalRegionId: sanitizeId(raw.operationalRegionId, fallback.operationalRegionId),
+    operationalRegionLabel: sanitizeLabel(raw.operationalRegionLabel, fallback.operationalRegionLabel),
+    majorHookSummary: sanitizeBody(raw.majorHookSummary, fallback.majorHookSummary),
+    doctrineLabel: sanitizeLabel(raw.doctrineLabel, fallback.doctrineLabel),
+    toneScopeLabel: sanitizeBody(raw.toneScopeLabel, fallback.toneScopeLabel),
+  }
+}
+
+function sanitizeRunStateModifiers(
+  raw: unknown,
+  fallback: CampaignRunStateModifier[]
+): CampaignRunStateModifier[] {
+  if (!Array.isArray(raw)) {
+    return [...fallback]
+  }
+
+  const next: CampaignRunStateModifier[] = []
+
+  for (const entry of raw) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const id = sanitizeId(entry.id, '')
+    if (id.length === 0) {
+      continue
+    }
+
+    next.push({
+      id,
+      label: sanitizeLabel(entry.label, id),
+      value: sanitizeBody(entry.value, '—'),
+    })
+  }
+
+  return next.length > 0 ? next.slice(0, 12) : [...fallback]
+}
+
+function sanitizeModuleToggles(raw: unknown, fallback: CampaignModuleToggle[]): CampaignModuleToggle[] {
+  if (!Array.isArray(raw)) {
+    return [...fallback]
+  }
+
+  const next: CampaignModuleToggle[] = []
+
+  for (const entry of raw) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const moduleId = sanitizeId(entry.moduleId, '')
+    if (moduleId.length === 0) {
+      continue
+    }
+
+    next.push({
+      moduleId,
+      label: sanitizeLabel(entry.label, moduleId),
+      enabled: typeof entry.enabled === 'boolean' ? entry.enabled : false,
+    })
+  }
+
+  return next.length > 0 ? next.slice(0, 24) : [...fallback]
+}
+
+function sanitizeSettingHistory(
+  raw: unknown,
+  fallback: CampaignSettingHistoryEntry[]
+): CampaignSettingHistoryEntry[] {
+  if (!Array.isArray(raw)) {
+    return [...fallback]
+  }
+
+  const next: CampaignSettingHistoryEntry[] = []
+
+  for (const entry of raw) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const id = sanitizeId(entry.id, '')
+    const settingId = sanitizeId(entry.settingId, '')
+    if (id.length === 0 || settingId.length === 0) {
+      continue
+    }
+
+    const effectiveFromWeek = Math.max(
+      1,
+      Math.trunc(typeof entry.effectiveFromWeek === 'number' ? entry.effectiveFromWeek : 1)
+    )
+    const changedAtWeek = Math.trunc(typeof entry.changedAtWeek === 'number' ? entry.changedAtWeek : 0)
+
+    next.push({
+      id,
+      settingId,
+      value: sanitizeBody(entry.value, ''),
+      effectiveFromWeek,
+      changedAtWeek,
+      source: sanitizeSource(entry.source),
+      ...(typeof entry.note === 'string' && entry.note.trim().length > 0
+        ? { note: clampString(entry.note.trim(), 240) }
+        : {}),
+    })
+  }
+
+  const bounded = next.length > 0 ? next.slice(0, 200) : [...fallback]
+
+  return [...bounded].sort((left, right) => {
+    if (left.effectiveFromWeek !== right.effectiveFromWeek) {
+      return left.effectiveFromWeek - right.effectiveFromWeek
+    }
+
+    if (left.changedAtWeek !== right.changedAtWeek) {
+      return left.changedAtWeek - right.changedAtWeek
+    }
+
+    return left.id.localeCompare(right.id)
+  })
+}
+
+function sanitizeCompatibility(
+  raw: unknown,
+  fallback: CampaignLedgerCompatibilitySnapshot
+): CampaignLedgerCompatibilitySnapshot {
+  if (!isRecord(raw)) {
+    return { ...fallback, notes: [...fallback.notes], warnings: [...fallback.warnings] }
+  }
+
+  const compatible = typeof raw.compatible === 'boolean' ? raw.compatible : fallback.compatible
+  const notes = Array.isArray(raw.notes)
+    ? raw.notes
+        .filter((note): note is string => typeof note === 'string' && note.trim().length > 0)
+        .map((note) => clampString(note.trim(), MAX_STRING))
+        .slice(0, 12)
+    : [...fallback.notes]
+  const warnings = Array.isArray(raw.warnings)
+    ? raw.warnings
+        .filter((note): note is string => typeof note === 'string' && note.trim().length > 0)
+        .map((note) => clampString(note.trim(), MAX_STRING))
+        .slice(0, 12)
+    : [...fallback.warnings]
+
+  return {
+    compatible,
+    notes: notes.length > 0 ? notes : [...fallback.notes],
+    warnings,
+  }
+}
+
+/** Deterministic starter ledger aligned with default `GameConfig` (challenge off, capacity model). */
+export function createSeedCampaignLedger(): CampaignLedgerState {
+  return {
+    profile: {
+      organizationName: 'Containment Protocol',
+      homeBaseId: 'haven_subsurface_command',
+      homeBaseLabel: 'Haven subsurface command campus',
+      operationalRegionId: 'mid_atlantic_corridor',
+      operationalRegionLabel: 'Mid-Atlantic metro corridor',
+      majorHookSummary:
+        'A black-budget containment authority holds a thinning line between public denial and escalating phenomena.',
+      doctrineLabel: 'Measured containment with recoverable field teams.',
+      toneScopeLabel: 'Grounded investigation leaning tactical containment.',
+    },
+    activeRulesProfileId: 'baseline-standard',
+    activeRulesProfileLabel: 'Baseline standard containment',
+    runStateModifiers: [
+      {
+        id: 'challenge_posture',
+        label: 'Challenge posture',
+        value: 'Standard (challenge mode off)',
+      },
+      {
+        id: 'duration_model',
+        label: 'Duration / attrition integrity',
+        value: 'Capacity model (no cross-session operative attrition)',
+      },
+    ],
+    moduleToggles: [
+      { moduleId: 'courier_network', label: 'Courier network slice', enabled: true },
+      { moduleId: 'weekly_directives', label: 'Weekly directive discipline', enabled: true },
+    ],
+    settingHistory: [
+      {
+        id: 'hist_tone_scope_w1',
+        settingId: 'toneScopeLabel',
+        value: 'Grounded investigation leaning tactical containment.',
+        effectiveFromWeek: 1,
+        changedAtWeek: 0,
+        source: 'seed',
+        note: 'Opening posture anchor for contract tone.',
+      },
+      {
+        id: 'hist_tone_scope_w2',
+        settingId: 'toneScopeLabel',
+        value: 'Grounded investigation with bounded surreal anomaly contact.',
+        effectiveFromWeek: 2,
+        changedAtWeek: 1,
+        source: 'seed',
+        note: 'Doctrine board records a deliberate expansion of surreal contact bounds.',
+      },
+    ],
+    compatibility: {
+      compatible: true,
+      notes: [
+        'Courier logistics visibility assumes weekly directive timestamps stay stable for procurement coupling.',
+      ],
+      warnings: [],
+    },
+  }
+}
+
+export function sanitizeCampaignLedger(raw: unknown, fallback: CampaignLedgerState): CampaignLedgerState {
+  if (!isRecord(raw)) {
+    return structuredClone(fallback)
+  }
+
+  return {
+    profile: sanitizeProfile(raw.profile, fallback.profile),
+    activeRulesProfileId: sanitizeId(raw.activeRulesProfileId, fallback.activeRulesProfileId),
+    activeRulesProfileLabel: sanitizeLabel(
+      raw.activeRulesProfileLabel,
+      fallback.activeRulesProfileLabel
+    ),
+    runStateModifiers: sanitizeRunStateModifiers(raw.runStateModifiers, fallback.runStateModifiers),
+    moduleToggles: sanitizeModuleToggles(raw.moduleToggles, fallback.moduleToggles),
+    settingHistory: sanitizeSettingHistory(raw.settingHistory, fallback.settingHistory),
+    compatibility: sanitizeCompatibility(raw.compatibility, fallback.compatibility),
+  }
+}
+
+export function getCurrentCampaignRulesLedger(game: GameState): CampaignLedgerState {
+  const fallback = createSeedCampaignLedger()
+  return sanitizeCampaignLedger(game.campaignLedger, fallback)
+}
+
+export function getCampaignSettingEffectiveAt(
+  game: GameState,
+  settingId: string,
+  week: number
+): string | null {
+  const ledger = getCurrentCampaignRulesLedger(game)
+  const normalizedId = settingId.trim()
+  if (normalizedId.length === 0) {
+    return null
+  }
+
+  const candidates = ledger.settingHistory.filter(
+    (entry) => entry.settingId === normalizedId && entry.effectiveFromWeek <= week
+  )
+
+  if (candidates.length === 0) {
+    return null
+  }
+
+  const best = candidates.reduce((current, entry) => {
+    if (entry.effectiveFromWeek > current.effectiveFromWeek) {
+      return entry
+    }
+
+    if (entry.effectiveFromWeek < current.effectiveFromWeek) {
+      return current
+    }
+
+    if (entry.changedAtWeek > current.changedAtWeek) {
+      return entry
+    }
+
+    if (entry.changedAtWeek < current.changedAtWeek) {
+      return current
+    }
+
+    return entry.id.localeCompare(current.id) >= 0 ? entry : current
+  })
+
+  return best.value.length > 0 ? best.value : null
+}
+
+export interface CampaignModuleCompatibilityReport {
+  activeModuleIds: string[]
+  compatible: boolean
+  notes: string[]
+  warnings: string[]
+}
+
+export function buildCampaignModuleCompatibilityReport(game: GameState): CampaignModuleCompatibilityReport {
+  const ledger = getCurrentCampaignRulesLedger(game)
+  const activeModuleIds = ledger.moduleToggles
+    .filter((toggle) => toggle.enabled)
+    .map((toggle) => toggle.moduleId)
+
+  return {
+    activeModuleIds,
+    compatible: ledger.compatibility.compatible,
+    notes: [...ledger.compatibility.notes],
+    warnings: [...ledger.compatibility.warnings],
+  }
+}
+
+export interface CampaignRulesSummary {
+  headline: string
+  lines: readonly string[]
+  compatibilitySummary: string
+  activeModuleLabels: readonly string[]
+}
+
+export function buildCampaignRulesSummary(game: GameState): CampaignRulesSummary {
+  const ledger = getCurrentCampaignRulesLedger(game)
+  const week = game.week
+  const effectiveTone = getCampaignSettingEffectiveAt(game, 'toneScopeLabel', week)
+
+  const enabledModules = ledger.moduleToggles.filter((toggle) => toggle.enabled)
+
+  const lines: string[] = [
+    `Organization · ${ledger.profile.organizationName}`,
+    `Home base · ${ledger.profile.homeBaseLabel} (${ledger.profile.homeBaseId})`,
+    `Operational region · ${ledger.profile.operationalRegionLabel} (${ledger.profile.operationalRegionId})`,
+    `Major hook · ${ledger.profile.majorHookSummary}`,
+    `Doctrine · ${ledger.profile.doctrineLabel}`,
+    effectiveTone
+      ? `Effective tone / scope (week ${week}) · ${effectiveTone}`
+      : `Tone / scope anchor · ${ledger.profile.toneScopeLabel}`,
+    `Active rules profile · ${ledger.activeRulesProfileLabel} (${ledger.activeRulesProfileId})`,
+    ...ledger.runStateModifiers.map((modifier) => `${modifier.label} · ${modifier.value}`),
+    `Modules on · ${enabledModules.map((toggle) => toggle.label).join(' · ') || '—'}`,
+  ]
+
+  const compatibility = buildCampaignModuleCompatibilityReport(game)
+  const compatibilitySummary = compatibility.compatible
+    ? `Compatibility · OK (${compatibility.notes[0] ?? 'No additional notes.'})`
+    : `Compatibility · Review required (${[...compatibility.warnings, ...compatibility.notes].join(' ')})`
+
+  return {
+    headline: `${ledger.profile.organizationName} · ${ledger.activeRulesProfileLabel}`,
+    lines,
+    compatibilitySummary,
+    activeModuleLabels: enabledModules.map((toggle) => toggle.label),
+  }
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -2301,6 +2301,64 @@ export interface DistrictScheduleState {
 }
 // ── end SPE-109 types ────────────────────────────────────────────────────────
 
+/** SPE-1734: Auditable source for a ledger history row (single-player coarse grain). */
+export type CampaignSettingHistorySource = 'seed' | 'migration' | 'player' | 'system'
+
+/** SPE-1734: Compact operational header shared across contracts and summaries. */
+export interface CampaignOperationalProfile {
+  organizationName: string
+  homeBaseId: string
+  homeBaseLabel: string
+  operationalRegionId: string
+  operationalRegionLabel: string
+  majorHookSummary: string
+  doctrineLabel: string
+  toneScopeLabel: string
+}
+
+/** SPE-1734: Bounded display of an active run-state modifier. */
+export interface CampaignRunStateModifier {
+  id: string
+  label: string
+  value: string
+}
+
+/** SPE-1734: Toggle for a named deterministic module slice. */
+export interface CampaignModuleToggle {
+  moduleId: string
+  label: string
+  enabled: boolean
+}
+
+/** SPE-1734: Effective-period history row for a setting id. */
+export interface CampaignSettingHistoryEntry {
+  id: string
+  settingId: string
+  value: string
+  effectiveFromWeek: number
+  changedAtWeek: number
+  source: CampaignSettingHistorySource
+  note?: string
+}
+
+/** SPE-1734: Stored compatibility expectations for enabled module sets. */
+export interface CampaignLedgerCompatibilitySnapshot {
+  compatible: boolean
+  notes: readonly string[]
+  warnings: readonly string[]
+}
+
+/** SPE-1734: Canonical campaign rules / profile ledger (read-only in first slice). */
+export interface CampaignLedgerState {
+  profile: CampaignOperationalProfile
+  activeRulesProfileId: string
+  activeRulesProfileLabel: string
+  runStateModifiers: CampaignRunStateModifier[]
+  moduleToggles: CampaignModuleToggle[]
+  settingHistory: CampaignSettingHistoryEntry[]
+  compatibility: CampaignLedgerCompatibilitySnapshot
+}
+
 export interface GameState {
   /** Canonical legitimacy/access state for bounded gating (SPE-53 legitimacy pass) */
   legitimacy?: LegitimacyState
@@ -2362,6 +2420,12 @@ export interface GameState {
   }
   partyCards?: PartyCardState
   config: GameConfig
+
+  /**
+   * SPE-1734: Canonical campaign profile, run-state modifiers, module toggles, and setting history.
+   * Hydration always normalizes via `sanitizeCampaignLedger` so older saves receive a safe default.
+   */
+  campaignLedger?: CampaignLedgerState
 
   /**
    * SPE-282: Deployment momentum stacks (earn/spend) when `challengeModeEnabled` + attrition duration model.

--- a/src/features/operations/FrontDeskPage.test.tsx
+++ b/src/features/operations/FrontDeskPage.test.tsx
@@ -37,6 +37,7 @@ describe('FrontDeskPage', () => {
     expect(screen.getByRole('region', { name: /operations hub overview/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /operations \/ assignments \/ queues/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /current campaign state/i })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /campaign profile and rules ledger/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /active pressures/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /recent reports \/ events/i })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /immediate attention/i })).toBeInTheDocument()

--- a/src/features/operations/FrontDeskPage.tsx
+++ b/src/features/operations/FrontDeskPage.tsx
@@ -294,16 +294,16 @@ export default function FrontDeskPage() {
               <h3 className="font-medium">{view.campaignRulesSummary.title}</h3>
               <p className="text-sm font-semibold text-cyan-100/85">{view.campaignRulesSummary.headline}</p>
               <ul className="space-y-1.5 text-sm opacity-80">
-                {view.campaignRulesSummary.lines.map((line) => (
-                  <li key={line}>{line}</li>
+                {view.campaignRulesSummary.lines.map((line, index) => (
+                  <li key={`campaign-rules-line-${index}`}>{line}</li>
                 ))}
               </ul>
               <p className="text-xs opacity-70">{view.campaignRulesSummary.compatibilitySummary}</p>
               {view.campaignRulesSummary.activeModuleLabels.length > 0 ? (
                 <div className="flex flex-wrap gap-1.5 pt-1">
-                  {view.campaignRulesSummary.activeModuleLabels.map((label) => (
+                  {view.campaignRulesSummary.activeModuleLabels.map((label, index) => (
                     <span
-                      key={label}
+                      key={`campaign-rules-module-${index}`}
                       className="rounded-full border border-white/12 bg-white/5 px-2 py-0.5 text-[11px] opacity-85"
                     >
                       {label}

--- a/src/features/operations/FrontDeskPage.tsx
+++ b/src/features/operations/FrontDeskPage.tsx
@@ -287,6 +287,31 @@ export default function FrontDeskPage() {
                 <li key={line}>{line}</li>
               ))}
             </ul>
+            <section
+              className="space-y-2 border-t border-white/10 pt-3"
+              aria-label="Campaign profile and rules ledger"
+            >
+              <h3 className="font-medium">{view.campaignRulesSummary.title}</h3>
+              <p className="text-sm font-semibold text-cyan-100/85">{view.campaignRulesSummary.headline}</p>
+              <ul className="space-y-1.5 text-sm opacity-80">
+                {view.campaignRulesSummary.lines.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+              <p className="text-xs opacity-70">{view.campaignRulesSummary.compatibilitySummary}</p>
+              {view.campaignRulesSummary.activeModuleLabels.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5 pt-1">
+                  {view.campaignRulesSummary.activeModuleLabels.map((label) => (
+                    <span
+                      key={label}
+                      className="rounded-full border border-white/12 bg-white/5 px-2 py-0.5 text-[11px] opacity-85"
+                    >
+                      {label}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </section>
             <div className="space-y-2 border-t border-white/10 pt-3">
               <div className="flex items-center justify-between gap-3">
                 <h3 className="font-medium">Front Desk Notices</h3>

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -19,6 +19,7 @@ import {
   assessFundingPressure,
   getCanonicalFundingState,
 } from '../../domain/funding'
+import { buildCampaignRulesSummary } from '../../domain/campaignLedger'
 import type { GameState } from '../../domain/models'
 import { PROGRESS_CLOCK_IDS } from '../../domain/progressClocks'
 import { getTeamMemberIds } from '../../domain/teamSimulation'
@@ -162,6 +163,15 @@ export interface FrontDeskCourierCapacityOpportunityView {
   guidanceNote: string
 }
 
+/** SPE-1734: Bounded player-facing readout of the canonical campaign ledger. */
+export interface FrontDeskCampaignRulesSummaryView {
+  title: string
+  headline: string
+  lines: readonly string[]
+  compatibilitySummary: string
+  activeModuleLabels: readonly string[]
+}
+
 export interface FrontDeskHubView {
   weekLabel: string
   cycleLabel: string
@@ -183,6 +193,7 @@ export interface FrontDeskHubView {
   standingSummary: FrontDeskStandingSummaryView
   latestReport: FrontDeskLatestReportView | null
   courierCapacityOpportunity: FrontDeskCourierCapacityOpportunityView | null
+  campaignRulesSummary: FrontDeskCampaignRulesSummaryView
 }
 
 function buildDirectorMessage(
@@ -1231,6 +1242,7 @@ export function getFrontDeskHubView(game: GameState): FrontDeskHubView {
   const briefing = getFrontDeskBriefingView(game)
   const operationsReport = getOperationsReportView(game)
   const attritionPressure = assessAttritionPressure(game)
+  const rulesSummary = buildCampaignRulesSummary(game)
 
   return {
     weekLabel: `Week ${game.week} / Active cap ${game.config.maxActiveCases}`,
@@ -1279,5 +1291,12 @@ export function getFrontDeskHubView(game: GameState): FrontDeskHubView {
     courierCapacityOpportunity: buildCourierNetworkCapacityOpportunityCard(
       buildCourierNetworkCapacityGapReport(game),
     ),
+    campaignRulesSummary: {
+      title: 'Campaign profile & rules ledger',
+      headline: rulesSummary.headline,
+      lines: rulesSummary.lines,
+      compatibilitySummary: rulesSummary.compatibilitySummary,
+      activeModuleLabels: rulesSummary.activeModuleLabels,
+    },
   }
 }

--- a/src/test/campaignLedger.test.ts
+++ b/src/test/campaignLedger.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  buildCampaignModuleCompatibilityReport,
+  buildCampaignRulesSummary,
+  createSeedCampaignLedger,
+  getCampaignSettingEffectiveAt,
+  getCurrentCampaignRulesLedger,
+  sanitizeCampaignLedger,
+} from '../domain/campaignLedger'
+import { hydrateGame } from '../app/store/runTransfer'
+
+describe('SPE-1734 campaign ledger', () => {
+  it('seeds a ledger in starting state with two run modifiers and two enabled modules', () => {
+    const game = createStartingState()
+    expect(game.campaignLedger).toBeDefined()
+    const ledger = getCurrentCampaignRulesLedger(game)
+    expect(ledger.runStateModifiers.length).toBeGreaterThanOrEqual(2)
+    expect(ledger.moduleToggles.filter((t) => t.enabled).length).toBeGreaterThanOrEqual(2)
+    expect(ledger.compatibility.notes.length).toBeGreaterThan(0)
+  })
+
+  it('resolves effective tone by week using setting history', () => {
+    const game = createStartingState()
+    expect(getCampaignSettingEffectiveAt(game, 'toneScopeLabel', 1)).toContain('tactical containment')
+    expect(getCampaignSettingEffectiveAt(game, 'toneScopeLabel', 2)).toContain('surreal anomaly')
+  })
+
+  it('hydrates missing ledger from fallback without throwing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame({ week: 5, rngSeed: 1, rngState: 1 }, fallback)
+    expect(hydrated.campaignLedger).toBeDefined()
+    expect(getCurrentCampaignRulesLedger(hydrated).profile.organizationName.length).toBeGreaterThan(0)
+  })
+
+  it('sanitizes malformed persisted ledger deterministically', () => {
+    const fallback = createSeedCampaignLedger()
+    const sanitized = sanitizeCampaignLedger(
+      {
+        profile: { organizationName: 123 },
+        runStateModifiers: [{ id: '', label: 'x', value: 'y' }],
+        settingHistory: [{ id: '', settingId: 'toneScopeLabel', value: 'bad', effectiveFromWeek: 0 }],
+      },
+      fallback
+    )
+    expect(sanitized.profile.organizationName).toBe(fallback.profile.organizationName)
+    expect(sanitized.runStateModifiers.length).toBeGreaterThanOrEqual(2)
+    expect(sanitized.settingHistory.every((row) => row.id.length > 0)).toBe(true)
+  })
+
+  it('builds a compatibility report from enabled modules', () => {
+    const game = createStartingState()
+    const report = buildCampaignModuleCompatibilityReport(game)
+    expect(report.activeModuleIds).toContain('courier_network')
+    expect(report.activeModuleIds).toContain('weekly_directives')
+    expect(report.compatible).toBe(true)
+    expect(report.notes[0]).toMatch(/directive/i)
+  })
+
+  it('builds a campaign rules summary for downstream surfaces', () => {
+    const game = createStartingState()
+    const summary = buildCampaignRulesSummary(game)
+    expect(summary.headline).toMatch(/Containment Protocol/)
+    expect(summary.lines.some((l) => l.includes('Mid-Atlantic'))).toBe(true)
+    expect(summary.compatibilitySummary).toMatch(/Compatibility/)
+  })
+})

--- a/src/test/campaignLedger.test.ts
+++ b/src/test/campaignLedger.test.ts
@@ -64,4 +64,13 @@ describe('SPE-1734 campaign ledger', () => {
     expect(summary.lines.some((l) => l.includes('Mid-Atlantic'))).toBe(true)
     expect(summary.compatibilitySummary).toMatch(/Compatibility/)
   })
+
+  it('reflects live game.config for mirrored challenge and duration lines (Front Desk presets)', () => {
+    const game = createStartingState()
+    game.config.challengeModeEnabled = true
+    game.config.durationModel = 'attrition'
+    const summary = buildCampaignRulesSummary(game)
+    expect(summary.lines.some((l) => /Challenge posture · .*challenge mode on/i.test(l))).toBe(true)
+    expect(summary.lines.some((l) => /Attrition model/i.test(l))).toBe(true)
+  })
 })

--- a/src/test/campaignLedger.test.ts
+++ b/src/test/campaignLedger.test.ts
@@ -48,6 +48,35 @@ describe('SPE-1734 campaign ledger', () => {
     expect(sanitized.settingHistory.every((row) => row.id.length > 0)).toBe(true)
   })
 
+  it('keeps the chronologically latest setting history rows when capping past 200 entries', () => {
+    const base = createSeedCampaignLedger()
+    const many = Array.from({ length: 250 }, (_, index) => {
+      const week = index + 1
+      return {
+        id: `hist_tone_${week}`,
+        settingId: 'toneScopeLabel',
+        value: `VALUE_${week}`,
+        effectiveFromWeek: week,
+        changedAtWeek: week - 1,
+        source: 'seed' as const,
+      }
+    })
+    // Newest-first order would lose late weeks if we capped before sorting.
+    many.reverse()
+
+    const game = createStartingState()
+    game.campaignLedger = { ...base, settingHistory: many }
+
+    expect(getCurrentCampaignRulesLedger(game).settingHistory).toHaveLength(200)
+    expect(getCampaignSettingEffectiveAt(game, 'toneScopeLabel', 250)).toBe('VALUE_250')
+  })
+
+  it('preserves intentionally empty persisted setting history', () => {
+    const base = createSeedCampaignLedger()
+    const sanitized = sanitizeCampaignLedger({ ...base, settingHistory: [] }, base)
+    expect(sanitized.settingHistory).toEqual([])
+  })
+
   it('builds a compatibility report from enabled modules', () => {
     const game = createStartingState()
     const report = buildCampaignModuleCompatibilityReport(game)

--- a/src/test/campaignLedger.test.ts
+++ b/src/test/campaignLedger.test.ts
@@ -77,6 +77,27 @@ describe('SPE-1734 campaign ledger', () => {
     expect(sanitized.settingHistory).toEqual([])
   })
 
+  it('preserves intentionally empty compatibility notes through sanitize, hydrate, and summary', () => {
+    const base = createSeedCampaignLedger()
+    const clearedNotes = {
+      ...base,
+      compatibility: { ...base.compatibility, notes: [] },
+    }
+    expect(sanitizeCampaignLedger(clearedNotes, base).compatibility.notes).toEqual([])
+
+    const game = createStartingState()
+    game.campaignLedger = clearedNotes
+    expect(getCurrentCampaignRulesLedger(game).compatibility.notes).toEqual([])
+
+    const summary = buildCampaignRulesSummary(game)
+    expect(summary.compatibilitySummary).toBe('Compatibility · OK (No additional notes.)')
+    expect(summary.compatibilitySummary).not.toContain('Courier logistics')
+
+    const seed = createStartingState()
+    const hydrated = hydrateGame({ ...seed, campaignLedger: clearedNotes }, seed)
+    expect(hydrated.campaignLedger?.compatibility.notes).toEqual([])
+  })
+
   it('builds a compatibility report from enabled modules', () => {
     const game = createStartingState()
     const report = buildCampaignModuleCompatibilityReport(game)

--- a/src/test/frontDeskView.test.ts
+++ b/src/test/frontDeskView.test.ts
@@ -166,6 +166,14 @@ describe('frontDeskView', () => {
     expect(hub.standingSummary.links.some((link) => link.href === '/factions')).toBe(true)
   })
 
+  it('surfaces SPE-1734 campaign ledger lines on the hub view for the Front Desk consumer', () => {
+    const hub = getFrontDeskHubView(createStartingState())
+    expect(hub.campaignRulesSummary.title).toMatch(/rules ledger/i)
+    expect(hub.campaignRulesSummary.lines.some((line) => line.includes('Mid-Atlantic'))).toBe(true)
+    expect(hub.campaignRulesSummary.compatibilitySummary).toMatch(/Compatibility/i)
+    expect(hub.campaignRulesSummary.activeModuleLabels.length).toBeGreaterThanOrEqual(2)
+  })
+
   it('shows a special recruit notice for supportive sourced candidates', () => {
     const state = createStartingState()
     state.candidates = [createSponsoredCandidate()]


### PR DESCRIPTION
## Linear

https://linear.app/spectranoir/issue/SPE-1734/campaign-rules-and-settings-ledger

## Summary (SPE-1734a boundary)

SPE-1734a adds a compact canonical campaign ledger seeded in starting state and safely hydrated for old saves. The ledger stores player-safe operational profile fields, active rules profile, run-state modifiers, module toggles, compatibility notes, and setting history with effective periods. Front Desk reads a bounded summary from the ledger as the first downstream consumer. This PR does not implement SPE-1749 dashboard, generic mod loading, unrestricted house rules, annotation UI, contract generation changes, full compatibility engine, hidden-truth exposure, or broad UI redesign.

## Files changed

- \src/domain/models.ts\ — \campaignLedger\ types on \GameState\
- \src/domain/campaignLedger.ts\ — seed, sanitize, pure helpers, summary (mirrored challenge/duration lines derived from live \game.config\ for display)
- \src/data/startingState.ts\ — seed ledger
- \src/app/store/runTransfer.ts\ — hydrate/sanitize path
- \src/features/operations/frontDeskView.ts\ + \FrontDeskPage.tsx\ — Front Desk consumer
- \src/test/campaignLedger.test.ts\, \rontDeskView.test.ts\, \FrontDeskPage.test.tsx\
- \planning/mvp-scope.md\ — minimal canonical-state note

## Validation

- \
pm run test:run -- src/test/campaignLedger.test.ts\
- \
pm run test:run -- src/test/frontDeskView.test.ts src/features/operations/FrontDeskPage.test.tsx\
- \
pm run test:run -- src/app/store/runTransfer.test.ts\
- \
pm run lint\
- \git diff --check origin/main...HEAD\
- \
pm run test:run\ (full suite)

## Out of scope

SPE-1749 dashboard, mod loader, house-rule sandbox, contract generation, full compatibility engine, hidden-truth leakage, broad UI redesign, ledger editing UI.

## Follow-up

- Deeper reconciliation if \campaignLedger.runStateModifiers\ should be rewritten when \updateConfig\ runs (beyond presentation); optional sync of \ctiveRulesProfileLabel\ with presets.


Made with [Cursor](https://cursor.com)