### PR TITLE
SPE-1761: Project GameState into branch path facts

### DIFF
--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -115,9 +115,9 @@ function resolvePathId(game: GameState, options?: BranchPathProjectionOptions) {
 
   const profile = game.campaignLedger?.profile
   const homeBaseId = sanitizePathSegment(profile?.homeBaseId ?? '')
-  const week = typeof game.week === 'number' && Number.isFinite(game.week) ? Math.max(0, Math.trunc(game.week)) : 0
+  const week = typeof game.week === 'number' && Number.isFinite(game.week) && !Number.isNaN(game.week) ? Math.max(0, Math.trunc(game.week)) : 0
   const rngSeed =
-    typeof game.rngSeed === 'number' && Number.isFinite(game.rngSeed) ? Math.trunc(game.rngSeed) : 0
+    typeof game.rngSeed === 'number' && Number.isFinite(game.rngSeed) && !Number.isNaN(game.rngSeed) ? Math.trunc(game.rngSeed) : 0
 
   if (homeBaseId.length > 0) {
     return `run:${homeBaseId}:w${week}:s${rngSeed}`

--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -21,6 +21,7 @@ import type {
   BranchSimulationTruth,
 } from './branchContinuity'
 import { readGameStateManager } from './gameStateManager'
+import type { KnowledgeTier } from './knowledge'
 import type { Agent, GameFlagValue, GameState, KnowledgeState } from './models'
 
 export interface BranchPathProjectionOptions {
@@ -38,7 +39,12 @@ const COMPANION_STATUSES = new Set<BranchCompanionStatus>([
   'absent',
 ])
 
-const PLAYER_KNOWN_KNOWLEDGE_TIERS = new Set<KnowledgeState['tier']>([
+/**
+ * Player-known band from canonical `knowledge.ts` `KnowledgeTier` (used by `KnowledgeState.tier`).
+ * Not the legacy `KnowledgeTier` alias in `models.ts` (`unknown` | `fragmented` | `partial` | `confirmed`)
+ * used for older campaign-handoff typing.
+ */
+const PLAYER_KNOWN_KNOWLEDGE_TIERS = new Set<KnowledgeTier>([
   'observed',
   'confirmed',
   'operationalized',

--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -1,0 +1,497 @@
+/**
+ * SPE-1761: pure projection from `GameState` into SPE-1760 `BranchPathFacts`.
+ *
+ * Prepares validator input only — does not run branch continuity validation,
+ * persist path state, or hook runtime story/encounter flows.
+ */
+
+import type {
+  BranchCompanionStatus,
+  BranchInjuryStatus,
+  BranchPathFacts,
+  BranchSimulationTruth,
+} from './branchContinuity'
+import { readGameStateManager } from './gameStateManager'
+import type { Agent, GameFlagValue, GameState, KnowledgeState } from './models'
+
+export interface BranchPathProjectionOptions {
+  pathId?: string
+  includeSimulationTruth?: boolean
+  flagPrefix?: string
+  knowledgeEntityId?: string
+}
+
+const COMPANION_STATUSES = new Set<BranchCompanionStatus>([
+  'present',
+  'lost',
+  'rescued',
+  'betrayed',
+  'absent',
+])
+
+const PLAYER_KNOWN_KNOWLEDGE_TIERS = new Set<KnowledgeState['tier']>([
+  'observed',
+  'confirmed',
+  'operationalized',
+  'institutionalized',
+])
+
+const CHOICE_EXECUTED_PREFIX = 'Choice executed: '
+
+function normalizeString(value: string | undefined | null) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeStringList(values: readonly string[]) {
+  return [...new Set(values.map(normalizeString).filter((value) => value.length > 0))].sort((left, right) =>
+    left.localeCompare(right)
+  )
+}
+
+function isSeedFlagValue(value: unknown): value is string | number | boolean {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  )
+}
+
+function isTruthyFlag(value: GameFlagValue | undefined) {
+  if (value === undefined) {
+    return false
+  }
+
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0
+  }
+
+  return normalizeString(value).length > 0
+}
+
+function isHiddenSimulationFlagKey(flagId: string) {
+  return flagId.startsWith('sim.hidden.')
+}
+
+function isEventFlagKey(flagId: string) {
+  return flagId.startsWith('event:') || flagId.startsWith('event.')
+}
+
+function isClueFlagKey(flagId: string) {
+  return flagId.startsWith('clue:') || flagId.startsWith('clue.')
+}
+
+function isChoiceFlagKey(flagId: string) {
+  return flagId.startsWith('choice:') || flagId.startsWith('choice.')
+}
+
+function sanitizePathSegment(value: string) {
+  const trimmed = normalizeString(value)
+  if (trimmed.length === 0) {
+    return ''
+  }
+
+  return trimmed.replace(/[^a-zA-Z0-9._-]+/g, '-')
+}
+
+function resolvePathId(game: GameState, options?: BranchPathProjectionOptions) {
+  const override = normalizeString(options?.pathId)
+  if (override.length > 0) {
+    return override
+  }
+
+  const profile = game.campaignLedger?.profile
+  const homeBaseId = sanitizePathSegment(profile?.homeBaseId ?? '')
+  const week = typeof game.week === 'number' && Number.isFinite(game.week) ? Math.max(0, Math.trunc(game.week)) : 0
+  const rngSeed =
+    typeof game.rngSeed === 'number' && Number.isFinite(game.rngSeed) ? Math.trunc(game.rngSeed) : 0
+
+  if (homeBaseId.length > 0) {
+    return `run:${homeBaseId}:w${week}:s${rngSeed}`
+  }
+
+  return `game:week-${week}`
+}
+
+function projectAcquiredItemIds(inventory: Record<string, number>) {
+  const acquired: string[] = []
+
+  for (const [itemId, quantity] of Object.entries(inventory)) {
+    const normalizedId = normalizeString(itemId)
+    if (normalizedId.length === 0) {
+      continue
+    }
+
+    if (typeof quantity === 'number' && Number.isFinite(quantity) && quantity > 0) {
+      acquired.push(normalizedId)
+    }
+  }
+
+  return normalizeStringList(acquired)
+}
+
+function projectSeedValues(
+  globalFlags: Record<string, GameFlagValue>,
+  options?: BranchPathProjectionOptions
+) {
+  const flagPrefix = normalizeString(options?.flagPrefix)
+  const seedValues: Record<string, string | number | boolean> = {}
+
+  for (const [flagId, value] of Object.entries(globalFlags)) {
+    const normalizedId = normalizeString(flagId)
+    if (normalizedId.length === 0 || isHiddenSimulationFlagKey(normalizedId)) {
+      continue
+    }
+
+    if (flagPrefix.length > 0 && !normalizedId.startsWith(flagPrefix)) {
+      continue
+    }
+
+    if (!isSeedFlagValue(value)) {
+      continue
+    }
+
+    seedValues[normalizedId] = typeof value === 'number' ? Math.trunc(value) : value
+  }
+
+  const sortedEntries = Object.entries(seedValues).sort(([left], [right]) => left.localeCompare(right))
+  return Object.fromEntries(sortedEntries) as Readonly<Record<string, string | number | boolean>>
+}
+
+function projectRoomOfOriginId(
+  sceneHistory: readonly { locationId: string }[],
+  currentLocation: { locationId?: string; hubId?: string }
+) {
+  const firstSceneLocation = normalizeString(sceneHistory[0]?.locationId)
+  if (firstSceneLocation.length > 0) {
+    return firstSceneLocation
+  }
+
+  const currentLocationId = normalizeString(currentLocation.locationId)
+  if (currentLocationId.length > 0) {
+    return currentLocationId
+  }
+
+  const hubId = normalizeString(currentLocation.hubId)
+  return hubId.length > 0 ? hubId : undefined
+}
+
+function projectCompanionStatusById(globalFlags: Record<string, GameFlagValue>) {
+  const companionStatusById: Record<string, BranchCompanionStatus> = {}
+
+  for (const [flagId, value] of Object.entries(globalFlags)) {
+    const normalizedId = normalizeString(flagId)
+    if (normalizedId.length === 0) {
+      continue
+    }
+
+    const companionMatch = /^companion\.(.+)$/.exec(normalizedId)
+    if (companionMatch) {
+      const companionId = normalizeString(companionMatch[1])
+      if (companionId.length === 0) {
+        continue
+      }
+
+      if (typeof value === 'string') {
+        if (COMPANION_STATUSES.has(value as BranchCompanionStatus)) {
+          companionStatusById[companionId] = value as BranchCompanionStatus
+        }
+      } else if (value === true) {
+        companionStatusById[companionId] = 'present'
+      }
+      continue
+    }
+
+    const npcMatch = /^npc\.(.+)\.companion$/.exec(normalizedId)
+    if (npcMatch) {
+      const companionId = normalizeString(npcMatch[1])
+      if (companionId.length === 0) {
+        continue
+      }
+
+      if (typeof value === 'string') {
+        if (COMPANION_STATUSES.has(value as BranchCompanionStatus)) {
+          companionStatusById[companionId] = value as BranchCompanionStatus
+        }
+      } else if (value === true) {
+        companionStatusById[companionId] = 'present'
+      }
+    }
+  }
+
+  const sortedEntries = Object.entries(companionStatusById).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )
+  return Object.fromEntries(sortedEntries) as Readonly<Record<string, BranchCompanionStatus>>
+}
+
+function projectInjuryStatus(agent: Agent): BranchInjuryStatus {
+  const vitals = agent.vitals
+  if (!vitals || typeof vitals.wounds !== 'number' || !Number.isFinite(vitals.wounds)) {
+    return 'none'
+  }
+
+  const wounds = Math.max(0, vitals.wounds)
+  const statusFlags = vitals.statusFlags ?? []
+  const hasRecoveringSignal =
+    agent.status === 'recovering' ||
+    statusFlags.some((flag) => {
+      const normalized = normalizeString(flag).toLowerCase()
+      return normalized === 'recovering' || normalized === 'healed'
+    })
+
+  if (hasRecoveringSignal && wounds > 0) {
+    return 'healed'
+  }
+
+  if (wounds > 0) {
+    return 'wounded'
+  }
+
+  return 'none'
+}
+
+function projectInjuryStatusBySubjectId(agents: Record<string, Agent>) {
+  const injuryStatusBySubjectId: Record<string, BranchInjuryStatus> = {}
+
+  for (const [agentId, agent] of Object.entries(agents)) {
+    const normalizedId = normalizeString(agentId)
+    if (normalizedId.length === 0) {
+      continue
+    }
+
+    injuryStatusBySubjectId[`agent:${normalizedId}`] = projectInjuryStatus(agent)
+  }
+
+  const sortedEntries = Object.entries(injuryStatusBySubjectId).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )
+  return Object.fromEntries(sortedEntries) as Readonly<Record<string, BranchInjuryStatus>>
+}
+
+function projectWitnessedEventIds(
+  globalFlags: Record<string, GameFlagValue>,
+  oneShotEvents: Record<string, { seen?: boolean }>
+) {
+  const witnessed: string[] = []
+
+  for (const [eventId, record] of Object.entries(oneShotEvents)) {
+    const normalizedId = normalizeString(eventId)
+    if (normalizedId.length === 0 || isHiddenSimulationFlagKey(normalizedId)) {
+      continue
+    }
+
+    if (record?.seen !== false) {
+      witnessed.push(normalizedId)
+    }
+  }
+
+  for (const [flagId, value] of Object.entries(globalFlags)) {
+    const normalizedId = normalizeString(flagId)
+    if (normalizedId.length === 0 || isHiddenSimulationFlagKey(normalizedId)) {
+      continue
+    }
+
+    if (isEventFlagKey(normalizedId) && isTruthyFlag(value)) {
+      witnessed.push(normalizedId)
+    }
+  }
+
+  return normalizeStringList(witnessed)
+}
+
+function projectLearnedClueIds(
+  knowledge: Record<string, KnowledgeState>,
+  globalFlags: Record<string, GameFlagValue>,
+  knowledgeEntityId?: string
+) {
+  const learned: string[] = []
+  const entityFilter = normalizeString(knowledgeEntityId)
+
+  for (const entry of Object.values(knowledge)) {
+    if (!entry) {
+      continue
+    }
+
+    if (entityFilter.length > 0 && normalizeString(entry.entityId) !== entityFilter) {
+      continue
+    }
+
+    if (!PLAYER_KNOWN_KNOWLEDGE_TIERS.has(entry.tier)) {
+      continue
+    }
+
+    const subjectId = normalizeString(entry.subjectId)
+    if (subjectId.length > 0) {
+      learned.push(subjectId)
+    }
+  }
+
+  for (const [flagId, value] of Object.entries(globalFlags)) {
+    const normalizedId = normalizeString(flagId)
+    if (normalizedId.length === 0 || isHiddenSimulationFlagKey(normalizedId)) {
+      continue
+    }
+
+    if (isClueFlagKey(normalizedId) && isTruthyFlag(value)) {
+      learned.push(normalizedId)
+    }
+  }
+
+  return normalizeStringList(learned)
+}
+
+function projectPriorChoiceIds(
+  globalFlags: Record<string, GameFlagValue>,
+  lastChoiceId: string | undefined,
+  eventLog: readonly { type: string; summary: string }[]
+) {
+  const priorChoices: string[] = []
+
+  const authoringChoice = normalizeString(lastChoiceId)
+  if (authoringChoice.length > 0) {
+    priorChoices.push(authoringChoice)
+  }
+
+  for (const entry of eventLog) {
+    if (entry.type !== 'choice.executed') {
+      continue
+    }
+
+    const summary = normalizeString(entry.summary)
+    if (!summary.startsWith(CHOICE_EXECUTED_PREFIX)) {
+      continue
+    }
+
+    const choiceId = normalizeString(summary.slice(CHOICE_EXECUTED_PREFIX.length))
+    if (choiceId.length > 0) {
+      priorChoices.push(choiceId)
+    }
+  }
+
+  for (const [flagId, value] of Object.entries(globalFlags)) {
+    const normalizedId = normalizeString(flagId)
+    if (normalizedId.length === 0 || isHiddenSimulationFlagKey(normalizedId)) {
+      continue
+    }
+
+    if (isChoiceFlagKey(normalizedId) && isTruthyFlag(value)) {
+      priorChoices.push(normalizedId)
+    }
+  }
+
+  return normalizeStringList(priorChoices)
+}
+
+function collectHiddenEventIds(
+  globalFlags: Record<string, GameFlagValue>,
+  encounterState: Record<string, { hiddenModifierIds?: readonly string[] }>
+) {
+  const hiddenEvents: string[] = []
+
+  for (const encounter of Object.values(encounterState)) {
+    for (const modifierId of encounter.hiddenModifierIds ?? []) {
+      const normalized = normalizeString(modifierId)
+      if (normalized.length > 0) {
+        hiddenEvents.push(normalized)
+      }
+    }
+  }
+
+  for (const [flagId, value] of Object.entries(globalFlags)) {
+    const normalizedId = normalizeString(flagId)
+    if (!normalizedId.startsWith('sim.hidden.event.') || !isTruthyFlag(value)) {
+      continue
+    }
+
+    const eventId = normalizeString(normalizedId.slice('sim.hidden.event.'.length))
+    if (eventId.length > 0) {
+      hiddenEvents.push(eventId)
+    }
+  }
+
+  return normalizeStringList(hiddenEvents)
+}
+
+function collectHiddenLearnedClueIds(globalFlags: Record<string, GameFlagValue>) {
+  const hiddenClues: string[] = []
+
+  for (const [flagId, value] of Object.entries(globalFlags)) {
+    const normalizedId = normalizeString(flagId)
+    if (!normalizedId.startsWith('sim.hidden.clue.') || !isTruthyFlag(value)) {
+      continue
+    }
+
+    const clueId = normalizeString(normalizedId.slice('sim.hidden.clue.'.length))
+    if (clueId.length > 0) {
+      hiddenClues.push(clueId)
+    }
+  }
+
+  return normalizeStringList(hiddenClues)
+}
+
+function projectSimulationTruth(
+  globalFlags: Record<string, GameFlagValue>,
+  encounterState: Record<string, { hiddenModifierIds?: readonly string[] }>
+): BranchSimulationTruth | undefined {
+  const hiddenEventIds = collectHiddenEventIds(globalFlags, encounterState)
+  const hiddenLearnedClueIds = collectHiddenLearnedClueIds(globalFlags)
+
+  if (hiddenEventIds.length === 0 && hiddenLearnedClueIds.length === 0) {
+    return undefined
+  }
+
+  return {
+    ...(hiddenEventIds.length > 0 ? { hiddenEventIds } : {}),
+    ...(hiddenLearnedClueIds.length > 0 ? { hiddenLearnedClueIds } : {}),
+  }
+}
+
+export function projectBranchPathFactsFromGameState(
+  game: GameState,
+  options?: BranchPathProjectionOptions
+): BranchPathFacts {
+  const runtime = readGameStateManager(game)
+  const pathId = resolvePathId(game, options)
+  const acquiredItemIds = projectAcquiredItemIds(runtime.inventory)
+  const seedValues = projectSeedValues(runtime.globalFlags, options)
+  const roomOfOriginId = projectRoomOfOriginId(runtime.sceneHistory, runtime.currentLocation)
+  const companionStatusById = projectCompanionStatusById(runtime.globalFlags)
+  const injuryStatusBySubjectId = projectInjuryStatusBySubjectId(game.agents ?? {})
+  const witnessedEventIds = projectWitnessedEventIds(runtime.globalFlags, runtime.oneShotEvents)
+  const learnedClueIds = projectLearnedClueIds(
+    game.knowledge ?? {},
+    runtime.globalFlags,
+    options?.knowledgeEntityId
+  )
+  const priorChoiceIds = projectPriorChoiceIds(
+    runtime.globalFlags,
+    runtime.ui.authoring?.lastChoiceId,
+    runtime.ui.debug.eventLog ?? []
+  )
+
+  const pathFacts: BranchPathFacts = {
+    pathId,
+    acquiredItemIds,
+    seedValues,
+    companionStatusById,
+    injuryStatusBySubjectId,
+    witnessedEventIds,
+    learnedClueIds,
+    priorChoiceIds,
+    ...(roomOfOriginId ? { roomOfOriginId } : {}),
+  }
+
+  if (options?.includeSimulationTruth === true) {
+    const simulationTruth = projectSimulationTruth(runtime.globalFlags, runtime.encounterState)
+    if (simulationTruth) {
+      return { ...pathFacts, simulationTruth }
+    }
+  }
+
+  return pathFacts
+}

--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -12,7 +12,8 @@
  * - Companions: `companion.<id>` or `npc.<id>.companion` with union status values.
  * - Hidden truth (opt-in): encounter `hiddenModifierIds`, `sim.hidden.event.*`, `sim.hidden.clue.*`
  *   (unqualified suffixes normalized to `event:` / `clue:` for validator ID matching).
- * - Room of origin: first `sceneHistory` entry (oldest visit; history is append-ordered in gameStateManager).
+ * - Room of origin: earliest `sceneHistory` visit by `week` when present, else index 0
+ *   (canonical `recordSceneVisit` appends oldest→newest; index 0 is the fallback for legacy entries).
  * - Injuries: `wounds > 0` → `wounded`; `wounds === 0` with recovering/healed signal → `healed`; else `none`.
  */
 
@@ -232,13 +233,35 @@ function projectSeedValues(
   return Object.fromEntries(sortedEntries) as Readonly<Record<string, string | number | boolean>>
 }
 
+function resolveSceneHistoryWeek(entry: { week?: number }) {
+  if (typeof entry.week !== 'number' || !Number.isFinite(entry.week)) {
+    return undefined
+  }
+
+  return Math.max(0, Math.trunc(entry.week))
+}
+
 function projectRoomOfOriginId(
-  sceneHistory: readonly { locationId: string }[],
+  sceneHistory: readonly { locationId: string; week?: number }[],
   currentLocation: { locationId?: string; hubId?: string }
 ) {
-  const firstSceneLocation = normalizeString(sceneHistory[0]?.locationId)
-  if (firstSceneLocation.length > 0) {
-    return firstSceneLocation
+  if (sceneHistory.length > 0) {
+    const weeks = sceneHistory
+      .map(resolveSceneHistoryWeek)
+      .filter((week): week is number => week !== undefined)
+
+    let originEntry = sceneHistory[0]
+
+    if (weeks.length > 0) {
+      const earliestWeek = Math.min(...weeks)
+      originEntry =
+        sceneHistory.find((entry) => resolveSceneHistoryWeek(entry) === earliestWeek) ?? originEntry
+    }
+
+    const firstSceneLocation = normalizeString(originEntry.locationId)
+    if (firstSceneLocation.length > 0) {
+      return firstSceneLocation
+    }
   }
 
   const currentLocationId = normalizeString(currentLocation.locationId)

--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -10,7 +10,8 @@
  * - Learned clues: player-known knowledge tiers plus `clue:*` / `clue.*` flags.
  * - Prior choices: dev-log `choice.executed`, authoring `lastChoiceId`, `choice:*` / `choice.*` flags.
  * - Companions: `companion.<id>` or `npc.<id>.companion` with union status values.
- * - Hidden truth (opt-in): encounter `hiddenModifierIds`, `sim.hidden.event.*`, `sim.hidden.clue.*`.
+ * - Hidden truth (opt-in): encounter `hiddenModifierIds`, `sim.hidden.event.*`, `sim.hidden.clue.*`
+ *   (unqualified suffixes normalized to `event:` / `clue:` for validator ID matching).
  * - Room of origin: first `sceneHistory` entry (oldest visit; history is append-ordered in gameStateManager).
  * - Injuries: `wounds > 0` → `wounded`; `wounds === 0` with recovering/healed signal → `healed`; else `none`.
  */
@@ -95,6 +96,26 @@ function isHiddenSimulationFlagKey(flagId: string) {
 /** Event-shaped ids for witnessed-event projection (flags and consumed one-shots). */
 function isEventShapedKey(id: string) {
   return id.startsWith('event:') || id.startsWith('event.')
+}
+
+/** Align hidden simulation event ids with witnessed-event namespace for validator matching. */
+function normalizeHiddenEventId(rawId: string) {
+  const normalized = normalizeString(rawId)
+  if (normalized.length === 0) {
+    return ''
+  }
+
+  return isEventShapedKey(normalized) ? normalized : `event:${normalized}`
+}
+
+/** Align hidden simulation clue ids with learned-clue namespace for validator matching. */
+function normalizeHiddenClueId(rawId: string) {
+  const normalized = normalizeString(rawId)
+  if (normalized.length === 0) {
+    return ''
+  }
+
+  return isClueFlagKey(normalized) ? normalized : `clue:${normalized}`
 }
 
 function isClueFlagKey(flagId: string) {
@@ -411,9 +432,9 @@ function collectHiddenEventIds(
 
   for (const encounter of Object.values(encounterState)) {
     for (const modifierId of encounter.hiddenModifierIds ?? []) {
-      const normalized = normalizeString(modifierId)
-      if (normalized.length > 0) {
-        hiddenEvents.push(normalized)
+      const eventId = normalizeHiddenEventId(modifierId)
+      if (eventId.length > 0) {
+        hiddenEvents.push(eventId)
       }
     }
   }
@@ -424,7 +445,7 @@ function collectHiddenEventIds(
       continue
     }
 
-    const eventId = normalizeString(normalizedId.slice('sim.hidden.event.'.length))
+    const eventId = normalizeHiddenEventId(normalizedId.slice('sim.hidden.event.'.length))
     if (eventId.length > 0) {
       hiddenEvents.push(eventId)
     }
@@ -442,7 +463,7 @@ function collectHiddenLearnedClueIds(globalFlags: Record<string, GameFlagValue>)
       continue
     }
 
-    const clueId = normalizeString(normalizedId.slice('sim.hidden.clue.'.length))
+    const clueId = normalizeHiddenClueId(normalizedId.slice('sim.hidden.clue.'.length))
     if (clueId.length > 0) {
       hiddenClues.push(clueId)
     }

--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -12,6 +12,7 @@
  * - Companions: `companion.<id>` or `npc.<id>.companion` with union status values.
  * - Hidden truth (opt-in): encounter `hiddenModifierIds`, `sim.hidden.event.*`, `sim.hidden.clue.*`.
  * - Room of origin: first `sceneHistory` entry (oldest visit; history is append-ordered in gameStateManager).
+ * - Injuries: `wounds > 0` → `wounded`; `wounds === 0` with recovering/healed signal → `healed`; else `none`.
  */
 
 import type {
@@ -252,6 +253,10 @@ function projectInjuryStatus(agent: Agent): BranchInjuryStatus {
 
   const wounds = Math.max(0, vitals.wounds)
   const statusFlags = vitals.statusFlags ?? []
+  if (wounds > 0) {
+    return 'wounded'
+  }
+
   const hasRecoveringSignal =
     agent.status === 'recovering' ||
     statusFlags.some((flag) => {
@@ -259,12 +264,8 @@ function projectInjuryStatus(agent: Agent): BranchInjuryStatus {
       return normalized === 'recovering' || normalized === 'healed'
     })
 
-  if (hasRecoveringSignal && wounds > 0) {
+  if (hasRecoveringSignal) {
     return 'healed'
-  }
-
-  if (wounds > 0) {
-    return 'wounded'
   }
 
   return 'none'

--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -3,6 +3,15 @@
  *
  * Prepares validator input only — does not run branch continuity validation,
  * persist path state, or hook runtime story/encounter flows.
+ *
+ * Prefix conventions (read-only projection):
+ * - Witnessed events: `event:*` / `event.*` flags and event-shaped consumed one-shots only
+ *   (generic one-shots such as `frontdesk.*` are gating keys, not witnessed events).
+ * - Learned clues: player-known knowledge tiers plus `clue:*` / `clue.*` flags.
+ * - Prior choices: dev-log `choice.executed`, authoring `lastChoiceId`, `choice:*` / `choice.*` flags.
+ * - Companions: `companion.<id>` or `npc.<id>.companion` with union status values.
+ * - Hidden truth (opt-in): encounter `hiddenModifierIds`, `sim.hidden.event.*`, `sim.hidden.clue.*`.
+ * - Room of origin: first `sceneHistory` entry (oldest visit; history is append-ordered in gameStateManager).
  */
 
 import type {
@@ -76,8 +85,9 @@ function isHiddenSimulationFlagKey(flagId: string) {
   return flagId.startsWith('sim.hidden.')
 }
 
-function isEventFlagKey(flagId: string) {
-  return flagId.startsWith('event:') || flagId.startsWith('event.')
+/** Event-shaped ids for witnessed-event projection (flags and consumed one-shots). */
+function isEventShapedKey(id: string) {
+  return id.startsWith('event:') || id.startsWith('event.')
 }
 
 function isClueFlagKey(flagId: string) {
@@ -284,7 +294,7 @@ function projectWitnessedEventIds(
       continue
     }
 
-    if (record?.seen !== false) {
+    if (record?.seen !== false && isEventShapedKey(normalizedId)) {
       witnessed.push(normalizedId)
     }
   }
@@ -295,7 +305,7 @@ function projectWitnessedEventIds(
       continue
     }
 
-    if (isEventFlagKey(normalizedId) && isTruthyFlag(value)) {
+    if (isEventShapedKey(normalizedId) && isTruthyFlag(value)) {
       witnessed.push(normalizedId)
     }
   }

--- a/src/domain/branchContinuityProjection.ts
+++ b/src/domain/branchContinuityProjection.ts
@@ -98,24 +98,57 @@ function isEventShapedKey(id: string) {
   return id.startsWith('event:') || id.startsWith('event.')
 }
 
-/** Align hidden simulation event ids with witnessed-event namespace for validator matching. */
+const HIDDEN_EVENT_FLAG_PREFIXES = ['sim.hidden.event.', 'sim.hidden.event:'] as const
+const HIDDEN_CLUE_FLAG_PREFIXES = ['sim.hidden.clue.', 'sim.hidden.clue:'] as const
+
+function extractHiddenFlagSuffix(flagId: string, prefixes: readonly string[]) {
+  const normalizedId = normalizeString(flagId)
+  for (const prefix of prefixes) {
+    if (normalizedId.startsWith(prefix)) {
+      return normalizeString(normalizedId.slice(prefix.length))
+    }
+  }
+  return ''
+}
+
+/**
+ * Canonical event id for validator exact matching (`event:` preferred over `event.`).
+ */
 function normalizeHiddenEventId(rawId: string) {
   const normalized = normalizeString(rawId)
   if (normalized.length === 0) {
     return ''
   }
 
-  return isEventShapedKey(normalized) ? normalized : `event:${normalized}`
+  if (normalized.startsWith('event.')) {
+    return `event:${normalized.slice('event.'.length)}`
+  }
+
+  if (normalized.startsWith('event:')) {
+    return normalized
+  }
+
+  return `event:${normalized}`
 }
 
-/** Align hidden simulation clue ids with learned-clue namespace for validator matching. */
+/**
+ * Canonical clue id for validator exact matching (`clue:` preferred over `clue.`).
+ */
 function normalizeHiddenClueId(rawId: string) {
   const normalized = normalizeString(rawId)
   if (normalized.length === 0) {
     return ''
   }
 
-  return isClueFlagKey(normalized) ? normalized : `clue:${normalized}`
+  if (normalized.startsWith('clue.')) {
+    return `clue:${normalized.slice('clue.'.length)}`
+  }
+
+  if (normalized.startsWith('clue:')) {
+    return normalized
+  }
+
+  return `clue:${normalized}`
 }
 
 function isClueFlagKey(flagId: string) {
@@ -440,12 +473,12 @@ function collectHiddenEventIds(
   }
 
   for (const [flagId, value] of Object.entries(globalFlags)) {
-    const normalizedId = normalizeString(flagId)
-    if (!normalizedId.startsWith('sim.hidden.event.') || !isTruthyFlag(value)) {
+    if (!isTruthyFlag(value)) {
       continue
     }
 
-    const eventId = normalizeHiddenEventId(normalizedId.slice('sim.hidden.event.'.length))
+    const suffix = extractHiddenFlagSuffix(flagId, HIDDEN_EVENT_FLAG_PREFIXES)
+    const eventId = normalizeHiddenEventId(suffix)
     if (eventId.length > 0) {
       hiddenEvents.push(eventId)
     }
@@ -458,12 +491,12 @@ function collectHiddenLearnedClueIds(globalFlags: Record<string, GameFlagValue>)
   const hiddenClues: string[] = []
 
   for (const [flagId, value] of Object.entries(globalFlags)) {
-    const normalizedId = normalizeString(flagId)
-    if (!normalizedId.startsWith('sim.hidden.clue.') || !isTruthyFlag(value)) {
+    if (!isTruthyFlag(value)) {
       continue
     }
 
-    const clueId = normalizeHiddenClueId(normalizedId.slice('sim.hidden.clue.'.length))
+    const suffix = extractHiddenFlagSuffix(flagId, HIDDEN_CLUE_FLAG_PREFIXES)
+    const clueId = normalizeHiddenClueId(suffix)
     if (clueId.length > 0) {
       hiddenClues.push(clueId)
     }

--- a/src/test/branchContinuityProjection.test.ts
+++ b/src/test/branchContinuityProjection.test.ts
@@ -52,6 +52,29 @@ describe('branchContinuityProjection', () => {
     expect(pathFacts.pathId).toBe('fixture:custom-path')
   })
 
+  it('derives roomOfOriginId from earliest scene history week when weeks are present', () => {
+    const game = ensureManagedGameState({
+      ...createStartingState(),
+      runtimeState: {
+        ...readGameStateManager(createStartingState()),
+        sceneHistory: [
+          { sceneId: 'recent', locationId: 'room:recent-wing', week: 5 },
+          { sceneId: 'mid', locationId: 'room:mid-wing', week: 3 },
+          { sceneId: 'origin', locationId: 'room:origin-hall', week: 1 },
+        ],
+        currentLocation: {
+          hubId: 'operations-desk',
+          locationId: 'room:recent-wing',
+          sceneId: 'dashboard',
+          updatedWeek: 5,
+        },
+      },
+    })
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+    expect(pathFacts.roomOfOriginId).toBe('room:origin-hall')
+  })
+
   it('derives roomOfOriginId from first scene history, then current location', () => {
     let game = createStartingState()
     game = setCurrentLocation(game, {

--- a/src/test/branchContinuityProjection.test.ts
+++ b/src/test/branchContinuityProjection.test.ts
@@ -356,6 +356,31 @@ describe('branchContinuityProjection', () => {
     expect(pathFacts.learnedClueIds).not.toContain('clue:strahd-motive')
   })
 
+  it('canonicalizes unqualified and dotted hidden flag suffixes', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'sim.hidden.event.strahd-betrayal-reveal', true)
+    game = setGlobalFlag(game, 'sim.hidden.event:balcony-fall', true)
+    game = setGlobalFlag(game, 'sim.hidden.event.event.hall-ambush', true)
+    game = setGlobalFlag(game, 'sim.hidden.clue.strahd-motive', true)
+    game = setGlobalFlag(game, 'sim.hidden.clue:rival-secret', true)
+    game = setGlobalFlag(game, 'sim.hidden.clue.clue.archive-leak', true)
+
+    const pathFacts = projectBranchPathFactsFromGameState(game, {
+      includeSimulationTruth: true,
+    })
+
+    expect(pathFacts.simulationTruth?.hiddenEventIds).toEqual([
+      'event:balcony-fall',
+      'event:hall-ambush',
+      'event:strahd-betrayal-reveal',
+    ])
+    expect(pathFacts.simulationTruth?.hiddenLearnedClueIds).toEqual([
+      'clue:archive-leak',
+      'clue:rival-secret',
+      'clue:strahd-motive',
+    ])
+  })
+
   it('normalizes hidden simulation ids for player_awareness_leak validator matching', () => {
     let game = createStartingState()
     game = setGlobalFlag(game, 'sim.hidden.event.strahd-betrayal-reveal', true)

--- a/src/test/branchContinuityProjection.test.ts
+++ b/src/test/branchContinuityProjection.test.ts
@@ -116,7 +116,7 @@ describe('branchContinuityProjection', () => {
     const woundedFacts = projectBranchPathFactsFromGameState(wounded)
     expect(woundedFacts.injuryStatusBySubjectId[`agent:${agentId}`]).toBe('wounded')
 
-    const healed = ensureManagedGameState({
+    const recoveringWithWounds = ensureManagedGameState({
       ...wounded,
       agents: {
         ...wounded.agents,
@@ -126,6 +126,25 @@ describe('branchContinuityProjection', () => {
           vitals: {
             ...wounded.agents[agentId].vitals,
             wounds: 12,
+            statusFlags: ['recovering'],
+          },
+        },
+      },
+    })
+
+    const recoveringFacts = projectBranchPathFactsFromGameState(recoveringWithWounds)
+    expect(recoveringFacts.injuryStatusBySubjectId[`agent:${agentId}`]).toBe('wounded')
+
+    const healed = ensureManagedGameState({
+      ...wounded,
+      agents: {
+        ...wounded.agents,
+        [agentId]: {
+          ...wounded.agents[agentId],
+          status: 'recovering',
+          vitals: {
+            ...wounded.agents[agentId].vitals,
+            wounds: 0,
             statusFlags: ['recovering'],
           },
         },

--- a/src/test/branchContinuityProjection.test.ts
+++ b/src/test/branchContinuityProjection.test.ts
@@ -217,6 +217,35 @@ describe('branchContinuityProjection', () => {
     expect(pathFacts.seedValues['branch.seed.doorCode']).toBe(417)
   })
 
+  it('projects learned clues only for player-known canonical knowledge tiers', () => {
+    const game = ensureManagedGameState({
+      ...createStartingState(),
+      knowledge: {
+        'team-a::clue-known': {
+          tier: 'confirmed',
+          entityId: 'team-a',
+          subjectId: 'clue:known',
+          subjectType: 'procedure',
+        },
+        'team-a::clue-partial': {
+          tier: 'partial',
+          entityId: 'team-a',
+          subjectId: 'clue:partial-only',
+          subjectType: 'procedure',
+        },
+        'team-a::clue-relayed': {
+          tier: 'relayed',
+          entityId: 'team-a',
+          subjectId: 'clue:relayed-only',
+          subjectType: 'procedure',
+        },
+      },
+    })
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+    expect(pathFacts.learnedClueIds).toEqual(['clue:known'])
+  })
+
   it('filters knowledge by options.knowledgeEntityId', () => {
     const game = ensureManagedGameState({
       ...createStartingState(),

--- a/src/test/branchContinuityProjection.test.ts
+++ b/src/test/branchContinuityProjection.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import type { BranchPathFacts } from '../domain/branchContinuity'
+import { projectBranchPathFactsFromGameState } from '../domain/branchContinuityProjection'
+import { appendDeveloperLogEvent } from '../domain/developerLog'
+import {
+  adjustInventoryQuantity,
+  ensureManagedGameState,
+  markOneShotEvent,
+  readGameStateManager,
+  recordSceneVisit,
+  setCurrentLocation,
+  setEncounterRuntimeState,
+  setGlobalFlag,
+  setUiDebugState,
+} from '../domain/gameStateManager'
+import type { GameState, KnowledgeState } from '../domain/models'
+
+function expectValidBranchPathFacts(pathFacts: BranchPathFacts) {
+  expect(typeof pathFacts.pathId).toBe('string')
+  expect(pathFacts.pathId.length).toBeGreaterThan(0)
+  expect(Array.isArray(pathFacts.acquiredItemIds)).toBe(true)
+  expect(pathFacts.seedValues).toBeTypeOf('object')
+  expect(pathFacts.companionStatusById).toBeTypeOf('object')
+  expect(pathFacts.injuryStatusBySubjectId).toBeTypeOf('object')
+  expect(Array.isArray(pathFacts.witnessedEventIds)).toBe(true)
+  expect(Array.isArray(pathFacts.learnedClueIds)).toBe(true)
+  expect(Array.isArray(pathFacts.priorChoiceIds)).toBe(true)
+}
+
+describe('branchContinuityProjection', () => {
+  it('projects createStartingState() to valid BranchPathFacts', () => {
+    const game = createStartingState()
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+
+    expectValidBranchPathFacts(pathFacts)
+    expect(pathFacts.pathId).toMatch(/^run:/)
+    expect(pathFacts.acquiredItemIds.length).toBeGreaterThan(0)
+    expect(pathFacts.witnessedEventIds).toEqual([])
+    expect(pathFacts.learnedClueIds).toEqual([])
+    expect(pathFacts.priorChoiceIds).toEqual([])
+    expect(pathFacts.companionStatusById).toEqual({})
+    expect(pathFacts.simulationTruth).toBeUndefined()
+  })
+
+  it('honors options.pathId override', () => {
+    const game = createStartingState()
+    const pathFacts = projectBranchPathFactsFromGameState(game, {
+      pathId: 'fixture:custom-path',
+    })
+
+    expect(pathFacts.pathId).toBe('fixture:custom-path')
+  })
+
+  it('derives roomOfOriginId from first scene history, then current location', () => {
+    let game = createStartingState()
+    game = setCurrentLocation(game, {
+      hubId: 'recruitment',
+      locationId: 'recruitment-board',
+      sceneId: 'candidate-sweep',
+    })
+    game = recordSceneVisit(game, {
+      locationId: 'room:great-hall',
+      sceneId: 'intro-scene',
+    })
+
+    const fromHistory = projectBranchPathFactsFromGameState(game)
+    expect(fromHistory.roomOfOriginId).toBe('room:great-hall')
+
+    const sparse = ensureManagedGameState({
+      ...createStartingState(),
+      runtimeState: {
+        ...readGameStateManager(createStartingState()),
+        sceneHistory: [],
+        currentLocation: {
+          hubId: 'operations-desk',
+          locationId: 'room:ops-wing',
+          sceneId: 'dashboard',
+          updatedWeek: 1,
+        },
+      },
+    })
+
+    const fromCurrent = projectBranchPathFactsFromGameState(sparse)
+    expect(fromCurrent.roomOfOriginId).toBe('room:ops-wing')
+  })
+
+  it('projects acquired item ids from inventory quantities', () => {
+    let game = createStartingState()
+    game = adjustInventoryQuantity(game, 'custom_supplies', 2)
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+    expect(pathFacts.acquiredItemIds).toContain('custom_supplies')
+  })
+
+  it('projects injury status from agent vitals and recovery signals', () => {
+    const game = createStartingState()
+    const agentId = Object.keys(game.agents)[0]
+    expect(agentId).toBeDefined()
+
+    const wounded = ensureManagedGameState({
+      ...game,
+      agents: {
+        ...game.agents,
+        [agentId]: {
+          ...game.agents[agentId],
+          vitals: {
+            ...game.agents[agentId].vitals,
+            wounds: 30,
+            statusFlags: [],
+          },
+        },
+      },
+    })
+
+    const woundedFacts = projectBranchPathFactsFromGameState(wounded)
+    expect(woundedFacts.injuryStatusBySubjectId[`agent:${agentId}`]).toBe('wounded')
+
+    const healed = ensureManagedGameState({
+      ...wounded,
+      agents: {
+        ...wounded.agents,
+        [agentId]: {
+          ...wounded.agents[agentId],
+          status: 'recovering',
+          vitals: {
+            ...wounded.agents[agentId].vitals,
+            wounds: 12,
+            statusFlags: ['recovering'],
+          },
+        },
+      },
+    })
+
+    const healedFacts = projectBranchPathFactsFromGameState(healed)
+    expect(healedFacts.injuryStatusBySubjectId[`agent:${agentId}`]).toBe('healed')
+  })
+
+  it('projects player-known ids from flags, one-shots, knowledge, and choices', () => {
+    let game = createStartingState()
+
+    const knowledgeEntry: KnowledgeState = {
+      tier: 'confirmed',
+      entityId: 'team-alpha',
+      entityType: 'team',
+      subjectId: 'clue:archive-leak',
+      subjectType: 'procedure',
+      lastConfirmedWeek: 1,
+    }
+
+    game = setGlobalFlag(game, 'event:hall-ambush', true)
+    game = setGlobalFlag(game, 'clue:secret-passage', true)
+    game = setGlobalFlag(game, 'choice:barricade-door', true)
+    game = setGlobalFlag(game, 'branch.seed.doorCode', 417)
+    game = markOneShotEvent(game, 'event.opening-brief', 'intro_scene')
+    game = setUiDebugState(game, {
+      authoring: {
+        lastChoiceId: 'frontdesk.notice.weekly-report.acknowledge',
+        updatedWeek: 1,
+      },
+    })
+    game = appendDeveloperLogEvent(game, {
+      type: 'choice.executed',
+      summary: 'Choice executed: choice:archive-review',
+    })
+    game = {
+      ...game,
+      knowledge: {
+        ...game.knowledge,
+        'team-alpha::clue:archive-leak': knowledgeEntry,
+      },
+    }
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+
+    expect(pathFacts.witnessedEventIds).toEqual(
+      expect.arrayContaining(['event.opening-brief', 'event:hall-ambush'])
+    )
+    expect(pathFacts.learnedClueIds).toEqual(
+      expect.arrayContaining(['clue:archive-leak', 'clue:secret-passage'])
+    )
+    expect(pathFacts.priorChoiceIds).toEqual(
+      expect.arrayContaining([
+        'choice:archive-review',
+        'choice:barricade-door',
+        'frontdesk.notice.weekly-report.acknowledge',
+      ])
+    )
+    expect(pathFacts.seedValues['branch.seed.doorCode']).toBe(417)
+  })
+
+  it('filters knowledge by options.knowledgeEntityId', () => {
+    const game = ensureManagedGameState({
+      ...createStartingState(),
+      knowledge: {
+        'team-a::subject-1': {
+          tier: 'observed',
+          entityId: 'team-a',
+          subjectId: 'clue:alpha',
+          subjectType: 'procedure',
+        },
+        'team-b::subject-2': {
+          tier: 'confirmed',
+          entityId: 'team-b',
+          subjectId: 'clue:beta',
+          subjectType: 'procedure',
+        },
+      },
+    })
+
+    const filtered = projectBranchPathFactsFromGameState(game, { knowledgeEntityId: 'team-a' })
+    expect(filtered.learnedClueIds).toEqual(['clue:alpha'])
+
+    const unfiltered = projectBranchPathFactsFromGameState(game)
+    expect(unfiltered.learnedClueIds).toEqual(expect.arrayContaining(['clue:alpha', 'clue:beta']))
+  })
+
+  it('tolerates sparse legacy saves without throwing', () => {
+    const sparse = {
+      ...createStartingState(),
+      runtimeState: undefined,
+      knowledge: undefined,
+      agents: undefined,
+      campaignLedger: undefined,
+      inventory: {},
+    } as unknown as GameState
+
+    expect(() => projectBranchPathFactsFromGameState(sparse)).not.toThrow()
+
+    const pathFacts = projectBranchPathFactsFromGameState(sparse)
+    expectValidBranchPathFacts(pathFacts)
+    expect(pathFacts.pathId).toBe('game:week-1')
+    expect(pathFacts.acquiredItemIds).toEqual([])
+    expect(pathFacts.companionStatusById).toEqual({})
+    expect(pathFacts.injuryStatusBySubjectId).toEqual({})
+    expect(pathFacts.learnedClueIds).toEqual([])
+    expect(pathFacts.priorChoiceIds).toEqual([])
+  })
+
+  it('defaults missing companion map to {} and ignores unknown companion values', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'companion.npc-irena', 'lost')
+    game = setGlobalFlag(game, 'npc.npc-missing.companion', 'not-a-status')
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+    expect(pathFacts.companionStatusById).toEqual({ 'npc-irena': 'lost' })
+  })
+
+  it('omits simulationTruth by default', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'sim.hidden.event.strahd-betrayal-reveal', true)
+    game = setEncounterRuntimeState(game, 'case-001', {
+      hiddenModifierIds: ['latent-surge'],
+    })
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+    expect(pathFacts.simulationTruth).toBeUndefined()
+    expect(pathFacts.witnessedEventIds).not.toContain('latent-surge')
+    expect(pathFacts.witnessedEventIds).not.toContain('strahd-betrayal-reveal')
+  })
+
+  it('keeps hidden simulation truth separate when includeSimulationTruth is true', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'sim.hidden.event.strahd-betrayal-reveal', true)
+    game = setGlobalFlag(game, 'sim.hidden.clue.strahd-motive', true)
+    game = setEncounterRuntimeState(game, 'case-001', {
+      hiddenModifierIds: ['latent-surge'],
+    })
+
+    const pathFacts = projectBranchPathFactsFromGameState(game, {
+      includeSimulationTruth: true,
+    })
+
+    expect(pathFacts.simulationTruth?.hiddenEventIds).toEqual(
+      expect.arrayContaining(['latent-surge', 'strahd-betrayal-reveal'])
+    )
+    expect(pathFacts.simulationTruth?.hiddenLearnedClueIds).toEqual(['strahd-motive'])
+    expect(pathFacts.witnessedEventIds).not.toContain('latent-surge')
+    expect(pathFacts.witnessedEventIds).not.toContain('strahd-betrayal-reveal')
+    expect(pathFacts.learnedClueIds).not.toContain('strahd-motive')
+  })
+
+  it('produces deterministic sorted output', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'event:z-last', true)
+    game = setGlobalFlag(game, 'event:a-first', true)
+    game = adjustInventoryQuantity(game, 'zeta_item', 1)
+    game = adjustInventoryQuantity(game, 'alpha_item', 1)
+
+    const first = projectBranchPathFactsFromGameState(game)
+    const second = projectBranchPathFactsFromGameState(game)
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+    expect(first.witnessedEventIds).toEqual([...first.witnessedEventIds].sort())
+    expect(first.acquiredItemIds).toEqual([...first.acquiredItemIds].sort())
+  })
+
+  it('does not mutate the input GameState', () => {
+    const game = createStartingState()
+    const before = JSON.stringify(game)
+
+    projectBranchPathFactsFromGameState(game, { includeSimulationTruth: true })
+
+    expect(JSON.stringify(game)).toBe(before)
+  })
+
+  it('applies options.flagPrefix to seedValues only', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'branch.seed.alpha', 1)
+    game = setGlobalFlag(game, 'other.flag', true)
+
+    const pathFacts = projectBranchPathFactsFromGameState(game, { flagPrefix: 'branch.seed.' })
+    expect(Object.keys(pathFacts.seedValues)).toEqual(['branch.seed.alpha'])
+    expect(pathFacts.seedValues['branch.seed.alpha']).toBe(1)
+  })
+})

--- a/src/test/branchContinuityProjection.test.ts
+++ b/src/test/branchContinuityProjection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
-import type { BranchPathFacts } from '../domain/branchContinuity'
+import { validateBranchContinuity, type BranchPathFacts } from '../domain/branchContinuity'
 import { projectBranchPathFactsFromGameState } from '../domain/branchContinuityProjection'
 import { appendDeveloperLogEvent } from '../domain/developerLog'
 import {
@@ -348,12 +348,62 @@ describe('branchContinuityProjection', () => {
     })
 
     expect(pathFacts.simulationTruth?.hiddenEventIds).toEqual(
-      expect.arrayContaining(['latent-surge', 'strahd-betrayal-reveal'])
+      expect.arrayContaining(['event:latent-surge', 'event:strahd-betrayal-reveal'])
     )
-    expect(pathFacts.simulationTruth?.hiddenLearnedClueIds).toEqual(['strahd-motive'])
-    expect(pathFacts.witnessedEventIds).not.toContain('latent-surge')
-    expect(pathFacts.witnessedEventIds).not.toContain('strahd-betrayal-reveal')
-    expect(pathFacts.learnedClueIds).not.toContain('strahd-motive')
+    expect(pathFacts.simulationTruth?.hiddenLearnedClueIds).toEqual(['clue:strahd-motive'])
+    expect(pathFacts.witnessedEventIds).not.toContain('event:latent-surge')
+    expect(pathFacts.witnessedEventIds).not.toContain('event:strahd-betrayal-reveal')
+    expect(pathFacts.learnedClueIds).not.toContain('clue:strahd-motive')
+  })
+
+  it('normalizes hidden simulation ids for player_awareness_leak validator matching', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'sim.hidden.event.strahd-betrayal-reveal', true)
+    game = setGlobalFlag(game, 'sim.hidden.clue.strahd-motive', true)
+
+    const pathFacts = projectBranchPathFactsFromGameState(game, {
+      includeSimulationTruth: true,
+    })
+
+    const eventReport = validateBranchContinuity({
+      pathFacts,
+      nodes: [
+        {
+          nodeId: 'node:betrayal-dialogue',
+          assumesPlayerKnows: { witnessedEventIds: ['event:strahd-betrayal-reveal'] },
+        },
+      ],
+    })
+    expect(
+      eventReport.warnings.find(
+        (warning) =>
+          warning.nodeId === 'node:betrayal-dialogue' &&
+          warning.warningClass === 'player_awareness_leak'
+      )
+    ).toBeDefined()
+    expect(
+      eventReport.warnings.find(
+        (warning) =>
+          warning.nodeId === 'node:betrayal-dialogue' &&
+          warning.warningClass === 'unwitnessed_event'
+      )
+    ).toBeUndefined()
+
+    const clueReport = validateBranchContinuity({
+      pathFacts,
+      nodes: [
+        {
+          nodeId: 'node:rival-motive',
+          assumesPlayerKnows: { learnedClueIds: ['clue:strahd-motive'] },
+        },
+      ],
+    })
+    expect(
+      clueReport.warnings.find(
+        (warning) =>
+          warning.nodeId === 'node:rival-motive' && warning.warningClass === 'player_awareness_leak'
+      )
+    ).toBeDefined()
   })
 
   it('produces deterministic sorted output', () => {

--- a/src/test/branchContinuityProjection.test.ts
+++ b/src/test/branchContinuityProjection.test.ts
@@ -136,6 +136,34 @@ describe('branchContinuityProjection', () => {
     expect(healedFacts.injuryStatusBySubjectId[`agent:${agentId}`]).toBe('healed')
   })
 
+  it('projects only event-shaped consumed one-shots into witnessedEventIds', () => {
+    let game = createStartingState()
+    game = markOneShotEvent(game, 'event:hall-ambush', 'intro_scene')
+    game = markOneShotEvent(game, 'event.opening-brief', 'intro_scene')
+    game = markOneShotEvent(game, 'frontdesk.welcome', 'frontdesk')
+    game = markOneShotEvent(game, 'recruit.firstContact', 'recruitment')
+    game = markOneShotEvent(game, 'containment.notice', 'ops')
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+
+    expect(pathFacts.witnessedEventIds).toEqual(
+      expect.arrayContaining(['event:hall-ambush', 'event.opening-brief'])
+    )
+    expect(pathFacts.witnessedEventIds).not.toEqual(
+      expect.arrayContaining(['frontdesk.welcome', 'recruit.firstContact', 'containment.notice'])
+    )
+    expect(pathFacts.witnessedEventIds).toHaveLength(2)
+  })
+
+  it('projects event-shaped global flags into witnessedEventIds', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'event:hall-ambush', true)
+    game = setGlobalFlag(game, 'frontdesk.notice.seen', true)
+
+    const pathFacts = projectBranchPathFactsFromGameState(game)
+    expect(pathFacts.witnessedEventIds).toEqual(['event:hall-ambush'])
+  })
+
   it('projects player-known ids from flags, one-shots, knowledge, and choices', () => {
     let game = createStartingState()
 


### PR DESCRIPTION
## Summary

- Adds pure `projectBranchPathFactsFromGameState` in `src/domain/branchContinuityProjection.ts` to derive SPE-1760 `BranchPathFacts` from existing `GameState` surfaces.
- Adds focused projection tests in `src/test/branchContinuityProjection.test.ts`.
- **Review hardening (3bf675a):** witnessed-event projection includes consumed one-shots only when keys match `event:*` or `event.*`; generic gating one-shots are excluded.

## Linear

- Implementation: [SPE-1761](https://linear.app/spectranoir/issue/SPE-1761/branch-continuity-validator-gamestate-path-facts-projection)
- Parent (context): [SPE-1464](https://linear.app/spectranoir/issue/SPE-1464/branch-continuity-validator)
- Depends on merged [SPE-1760](https://linear.app/spectranoir/issue/SPE-1760/branch-continuity-validator-path-facts-first-slice) / PR #1806

## Smallest boundary

Projection-only: prepares `BranchPathFacts` input; does not run `validateBranchContinuity` at runtime, persist branch-path state, or surface results in UI.

## Files changed

- `src/domain/branchContinuityProjection.ts` (new)
- `src/test/branchContinuityProjection.test.ts` (new)

## Validation

- `npm run test:run -- src/test/branchContinuityProjection.test.ts` (16 tests)
- `npm run test:run -- src/test/branchContinuity.test.ts`
- `npm run test:run -- src/test/contentBranching.test.ts src/test/outcomeBranching.test.ts src/test/campaignLedger.test.ts src/test/sim.mapAwareness.test.ts`
- `npm run test:run` (323 files, 2990 tests)
- `npm run lint`
- `git diff --check`

## Out of scope

- New `GameState` fields or persistent branch-path state
- Runtime validation hooks (story / encounter / contract / report)
- Authored graph import or CI lint for authored content
- Developer overlay or player-facing UI
- Clue-artifact storage
- SPE-1085 canon/lore work
- SPE-1317 uncertain-state work
- Unrelated `screenRouting.ts` fixes