### PR TITLE
SPE-1811: Adapt authored branch nodes for continuity audit

### DIFF
--- a/src/domain/branchContinuityAuthoring.ts
+++ b/src/domain/branchContinuityAuthoring.ts
@@ -1,0 +1,145 @@
+/**
+ * SPE-1811: map explicit authored continuity assumptions into SPE-1760 `BranchContinuityNode` inputs.
+ *
+ * Converts caller-supplied authored nodes into validator inputs for projected audits such as
+ * `buildBranchContinuityAuditReport`. This module does not import or scan all authored content,
+ * does not register CI lint, and does not wire runtime validation, encounters, contracts, reports,
+ * developer overlays, or UI.
+ *
+ * Runtime branch selection (`contentBranching` / `AuthoredBranch`) remains separate from these
+ * continuity-audit assumptions until a future integration explicitly connects them.
+ */
+
+import type {
+  BranchContinuityNode,
+  BranchNodeRequirements,
+  BranchPlayerKnowledgeAssumption,
+} from './branchContinuity'
+
+export interface AuthoredBranchContinuityNode {
+  id: string
+  label?: string
+  continuity?: AuthoredBranchContinuityAssumptions
+}
+
+export interface AuthoredBranchContinuityAssumptions {
+  requires?: BranchNodeRequirements
+  assumesPlayerKnows?: BranchPlayerKnowledgeAssumption
+  citesOfficialClaimIds?: readonly string[]
+}
+
+function copyStringList(values: readonly string[]) {
+  return [...values]
+}
+
+function slimRequires(requires: BranchNodeRequirements | undefined): BranchNodeRequirements | undefined {
+  if (requires === undefined) {
+    return undefined
+  }
+
+  const out: BranchNodeRequirements = {}
+
+  if (requires.anyItemIds !== undefined) {
+    out.anyItemIds = copyStringList(requires.anyItemIds)
+  }
+  if (requires.allItemIds !== undefined) {
+    out.allItemIds = copyStringList(requires.allItemIds)
+  }
+  if (requires.injuryBySubjectId !== undefined) {
+    out.injuryBySubjectId = { ...requires.injuryBySubjectId }
+  }
+  if (requires.companionStatusById !== undefined) {
+    out.companionStatusById = { ...requires.companionStatusById }
+  }
+  if (requires.roomOfOriginId !== undefined) {
+    out.roomOfOriginId = requires.roomOfOriginId
+  }
+  if (requires.witnessedEventIds !== undefined) {
+    out.witnessedEventIds = copyStringList(requires.witnessedEventIds)
+  }
+  if (requires.learnedClueIds !== undefined) {
+    out.learnedClueIds = copyStringList(requires.learnedClueIds)
+  }
+  if (requires.priorChoiceIds !== undefined) {
+    out.priorChoiceIds = copyStringList(requires.priorChoiceIds)
+  }
+  if (requires.requiredRecordRevisionIds !== undefined) {
+    out.requiredRecordRevisionIds = copyStringList(requires.requiredRecordRevisionIds)
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function slimAssumesPlayerKnows(
+  assumption: BranchPlayerKnowledgeAssumption | undefined
+): BranchPlayerKnowledgeAssumption | undefined {
+  if (assumption === undefined) {
+    return undefined
+  }
+
+  const out: BranchPlayerKnowledgeAssumption = {}
+
+  if (assumption.witnessedEventIds !== undefined) {
+    out.witnessedEventIds = copyStringList(assumption.witnessedEventIds)
+  }
+  if (assumption.learnedClueIds !== undefined) {
+    out.learnedClueIds = copyStringList(assumption.learnedClueIds)
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function slimAuthoredContinuity(
+  continuity: AuthoredBranchContinuityAssumptions
+): Pick<BranchContinuityNode, 'requires' | 'assumesPlayerKnows' | 'citesOfficialClaimIds'> {
+  const requires = slimRequires(continuity.requires)
+  const assumesPlayerKnows = slimAssumesPlayerKnows(continuity.assumesPlayerKnows)
+  const citesOfficialClaimIds =
+    continuity.citesOfficialClaimIds !== undefined
+      ? copyStringList(continuity.citesOfficialClaimIds)
+      : undefined
+
+  const out: Pick<BranchContinuityNode, 'requires' | 'assumesPlayerKnows' | 'citesOfficialClaimIds'> =
+    {}
+
+  if (requires !== undefined) {
+    out.requires = requires
+  }
+  if (assumesPlayerKnows !== undefined) {
+    out.assumesPlayerKnows = assumesPlayerKnows
+  }
+  if (citesOfficialClaimIds !== undefined) {
+    out.citesOfficialClaimIds = citesOfficialClaimIds
+  }
+
+  return out
+}
+
+export function buildBranchContinuityNodesFromAuthoredGraph(
+  authoredNodes: readonly AuthoredBranchContinuityNode[]
+): BranchContinuityNode[] {
+  return authoredNodes.map((authored) => {
+    const node: BranchContinuityNode = {
+      nodeId: authored.id,
+    }
+
+    if (authored.label !== undefined) {
+      node.label = authored.label
+    }
+
+    if (authored.continuity !== undefined) {
+      const slimmed = slimAuthoredContinuity(authored.continuity)
+      if (slimmed.requires !== undefined) {
+        node.requires = slimmed.requires
+      }
+      if (slimmed.assumesPlayerKnows !== undefined) {
+        node.assumesPlayerKnows = slimmed.assumesPlayerKnows
+      }
+      if (slimmed.citesOfficialClaimIds !== undefined) {
+        node.citesOfficialClaimIds = slimmed.citesOfficialClaimIds
+      }
+    }
+
+    return node
+  })
+}

--- a/src/domain/branchContinuityAuthoring.ts
+++ b/src/domain/branchContinuityAuthoring.ts
@@ -13,6 +13,8 @@
  * Those are treated like omissions; empty arrays and empty record fields are omitted from output.
  * Entries whose `id` is not a non-empty string after trim are omitted (no fallback ids) so `nodeId` is
  * always a valid string for SPE-1760 validation and reporting.
+ * Array elements that are not non-null plain objects (e.g. `null`, primitives) are skipped so `.id` is
+ * never read on invalid rows.
  */
 
 import type {
@@ -31,6 +33,11 @@ export interface AuthoredBranchContinuityAssumptions {
   requires?: BranchNodeRequirements
   assumesPlayerKnows?: BranchPlayerKnowledgeAssumption
   citesOfficialClaimIds?: readonly string[]
+}
+
+/** Each authored row must be a non-null, non-array object before reading fields (JSON arrays may contain nulls). */
+function isAuthoredContinuityRecord(value: unknown): value is Partial<AuthoredBranchContinuityNode> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 /** Trims and validates `id` from runtime payloads; returns undefined for non-strings and whitespace-only. */
@@ -178,7 +185,12 @@ export function buildBranchContinuityNodesFromAuthoredGraph(
 ): BranchContinuityNode[] {
   const result: BranchContinuityNode[] = []
 
-  for (const authored of authoredNodes) {
+  for (const entry of authoredNodes) {
+    if (!isAuthoredContinuityRecord(entry)) {
+      continue
+    }
+
+    const authored = entry
     const nodeId = normalizeAuthoredNodeId((authored as { id: unknown }).id)
     if (nodeId === undefined) {
       continue

--- a/src/domain/branchContinuityAuthoring.ts
+++ b/src/domain/branchContinuityAuthoring.ts
@@ -11,6 +11,8 @@
  *
  * Runtime hardening: authored payloads (for example from JSON) may use `null` for optional fields.
  * Those are treated like omissions; empty arrays and empty record fields are omitted from output.
+ * Entries whose `id` is not a non-empty string after trim are omitted (no fallback ids) so `nodeId` is
+ * always a valid string for SPE-1760 validation and reporting.
  */
 
 import type {
@@ -29,6 +31,16 @@ export interface AuthoredBranchContinuityAssumptions {
   requires?: BranchNodeRequirements
   assumesPlayerKnows?: BranchPlayerKnowledgeAssumption
   citesOfficialClaimIds?: readonly string[]
+}
+
+/** Trims and validates `id` from runtime payloads; returns undefined for non-strings and whitespace-only. */
+function normalizeAuthoredNodeId(id: unknown): string | undefined {
+  if (typeof id !== 'string') {
+    return undefined
+  }
+
+  const trimmed = id.trim()
+  return trimmed.length > 0 ? trimmed : undefined
 }
 
 /** Non-empty copy of string list entries; rejects null, non-arrays, empty arrays, and all-non-string elements. */
@@ -164,9 +176,16 @@ function slimAuthoredContinuity(
 export function buildBranchContinuityNodesFromAuthoredGraph(
   authoredNodes: readonly AuthoredBranchContinuityNode[]
 ): BranchContinuityNode[] {
-  return authoredNodes.map((authored) => {
+  const result: BranchContinuityNode[] = []
+
+  for (const authored of authoredNodes) {
+    const nodeId = normalizeAuthoredNodeId((authored as { id: unknown }).id)
+    if (nodeId === undefined) {
+      continue
+    }
+
     const node: BranchContinuityNode = {
-      nodeId: authored.id,
+      nodeId,
     }
 
     if (typeof authored.label === 'string') {
@@ -186,6 +205,8 @@ export function buildBranchContinuityNodesFromAuthoredGraph(
       }
     }
 
-    return node
-  })
+    result.push(node)
+  }
+
+  return result
 }

--- a/src/domain/branchContinuityAuthoring.ts
+++ b/src/domain/branchContinuityAuthoring.ts
@@ -8,6 +8,9 @@
  *
  * Runtime branch selection (`contentBranching` / `AuthoredBranch`) remains separate from these
  * continuity-audit assumptions until a future integration explicitly connects them.
+ *
+ * Runtime hardening: authored payloads (for example from JSON) may use `null` for optional fields.
+ * Those are treated like omissions; empty arrays and empty record fields are omitted from output.
  */
 
 import type {
@@ -28,62 +31,109 @@ export interface AuthoredBranchContinuityAssumptions {
   citesOfficialClaimIds?: readonly string[]
 }
 
-function copyStringList(values: readonly string[]) {
-  return [...values]
+/** Non-empty copy of string list entries; rejects null, non-arrays, empty arrays, and all-non-string elements. */
+function copyNonEmptyStringList(values: unknown): string[] | undefined {
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined
+  }
+
+  const strings = values.filter((entry): entry is string => typeof entry === 'string')
+  if (strings.length === 0) {
+    return undefined
+  }
+
+  return [...strings]
 }
 
-function slimRequires(requires: BranchNodeRequirements | undefined): BranchNodeRequirements | undefined {
-  if (requires === undefined) {
+function copyRecordIfNonEmpty(value: unknown): Record<string, unknown> | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+
+  const record = value as Record<string, unknown>
+  if (Object.keys(record).length === 0) {
+    return undefined
+  }
+
+  return { ...record }
+}
+
+function slimRequires(requires: BranchNodeRequirements | null | undefined): BranchNodeRequirements | undefined {
+  if (requires == null) {
     return undefined
   }
 
   const out: BranchNodeRequirements = {}
 
-  if (requires.anyItemIds !== undefined) {
-    out.anyItemIds = copyStringList(requires.anyItemIds)
+  const anyItemIds = copyNonEmptyStringList(requires.anyItemIds)
+  if (anyItemIds !== undefined) {
+    out.anyItemIds = anyItemIds
   }
-  if (requires.allItemIds !== undefined) {
-    out.allItemIds = copyStringList(requires.allItemIds)
+
+  const allItemIds = copyNonEmptyStringList(requires.allItemIds)
+  if (allItemIds !== undefined) {
+    out.allItemIds = allItemIds
   }
-  if (requires.injuryBySubjectId !== undefined) {
-    out.injuryBySubjectId = { ...requires.injuryBySubjectId }
+
+  const injuryBySubjectId = copyRecordIfNonEmpty(requires.injuryBySubjectId) as
+    | BranchNodeRequirements['injuryBySubjectId']
+    | undefined
+  if (injuryBySubjectId !== undefined) {
+    out.injuryBySubjectId = injuryBySubjectId
   }
-  if (requires.companionStatusById !== undefined) {
-    out.companionStatusById = { ...requires.companionStatusById }
+
+  const companionStatusById = copyRecordIfNonEmpty(requires.companionStatusById) as
+    | BranchNodeRequirements['companionStatusById']
+    | undefined
+  if (companionStatusById !== undefined) {
+    out.companionStatusById = companionStatusById
   }
-  if (requires.roomOfOriginId !== undefined) {
-    out.roomOfOriginId = requires.roomOfOriginId
+
+  const room = requires.roomOfOriginId
+  if (typeof room === 'string' && room.trim().length > 0) {
+    out.roomOfOriginId = room.trim()
   }
-  if (requires.witnessedEventIds !== undefined) {
-    out.witnessedEventIds = copyStringList(requires.witnessedEventIds)
+
+  const witnessedEventIds = copyNonEmptyStringList(requires.witnessedEventIds)
+  if (witnessedEventIds !== undefined) {
+    out.witnessedEventIds = witnessedEventIds
   }
-  if (requires.learnedClueIds !== undefined) {
-    out.learnedClueIds = copyStringList(requires.learnedClueIds)
+
+  const learnedClueIds = copyNonEmptyStringList(requires.learnedClueIds)
+  if (learnedClueIds !== undefined) {
+    out.learnedClueIds = learnedClueIds
   }
-  if (requires.priorChoiceIds !== undefined) {
-    out.priorChoiceIds = copyStringList(requires.priorChoiceIds)
+
+  const priorChoiceIds = copyNonEmptyStringList(requires.priorChoiceIds)
+  if (priorChoiceIds !== undefined) {
+    out.priorChoiceIds = priorChoiceIds
   }
-  if (requires.requiredRecordRevisionIds !== undefined) {
-    out.requiredRecordRevisionIds = copyStringList(requires.requiredRecordRevisionIds)
+
+  const requiredRecordRevisionIds = copyNonEmptyStringList(requires.requiredRecordRevisionIds)
+  if (requiredRecordRevisionIds !== undefined) {
+    out.requiredRecordRevisionIds = requiredRecordRevisionIds
   }
 
   return Object.keys(out).length > 0 ? out : undefined
 }
 
 function slimAssumesPlayerKnows(
-  assumption: BranchPlayerKnowledgeAssumption | undefined
+  assumption: BranchPlayerKnowledgeAssumption | null | undefined
 ): BranchPlayerKnowledgeAssumption | undefined {
-  if (assumption === undefined) {
+  if (assumption == null) {
     return undefined
   }
 
   const out: BranchPlayerKnowledgeAssumption = {}
 
-  if (assumption.witnessedEventIds !== undefined) {
-    out.witnessedEventIds = copyStringList(assumption.witnessedEventIds)
+  const witnessedEventIds = copyNonEmptyStringList(assumption.witnessedEventIds)
+  if (witnessedEventIds !== undefined) {
+    out.witnessedEventIds = witnessedEventIds
   }
-  if (assumption.learnedClueIds !== undefined) {
-    out.learnedClueIds = copyStringList(assumption.learnedClueIds)
+
+  const learnedClueIds = copyNonEmptyStringList(assumption.learnedClueIds)
+  if (learnedClueIds !== undefined) {
+    out.learnedClueIds = learnedClueIds
   }
 
   return Object.keys(out).length > 0 ? out : undefined
@@ -94,13 +144,9 @@ function slimAuthoredContinuity(
 ): Pick<BranchContinuityNode, 'requires' | 'assumesPlayerKnows' | 'citesOfficialClaimIds'> {
   const requires = slimRequires(continuity.requires)
   const assumesPlayerKnows = slimAssumesPlayerKnows(continuity.assumesPlayerKnows)
-  const citesOfficialClaimIds =
-    continuity.citesOfficialClaimIds !== undefined
-      ? copyStringList(continuity.citesOfficialClaimIds)
-      : undefined
+  const citesOfficialClaimIds = copyNonEmptyStringList(continuity.citesOfficialClaimIds)
 
-  const out: Pick<BranchContinuityNode, 'requires' | 'assumesPlayerKnows' | 'citesOfficialClaimIds'> =
-    {}
+  const out: Pick<BranchContinuityNode, 'requires' | 'assumesPlayerKnows' | 'citesOfficialClaimIds'> = {}
 
   if (requires !== undefined) {
     out.requires = requires
@@ -123,11 +169,11 @@ export function buildBranchContinuityNodesFromAuthoredGraph(
       nodeId: authored.id,
     }
 
-    if (authored.label !== undefined) {
+    if (typeof authored.label === 'string') {
       node.label = authored.label
     }
 
-    if (authored.continuity !== undefined) {
+    if (authored.continuity != null) {
       const slimmed = slimAuthoredContinuity(authored.continuity)
       if (slimmed.requires !== undefined) {
         node.requires = slimmed.requires

--- a/src/test/branchContinuityAuthoring.test.ts
+++ b/src/test/branchContinuityAuthoring.test.ts
@@ -107,11 +107,63 @@ describe('branchContinuityAuthoring', () => {
   it('does not throw when continuity is missing or empty', () => {
     const withMissingContinuity: AuthoredBranchContinuityNode[] = [{ id: 'a' }]
     const withEmptyContinuity: AuthoredBranchContinuityNode[] = [{ id: 'b', continuity: {} }]
+    const withNullContinuity = [{ id: 'node:null-continuity', continuity: null }] as unknown as
+      AuthoredBranchContinuityNode[]
 
     expect(() => buildBranchContinuityNodesFromAuthoredGraph(withMissingContinuity)).not.toThrow()
     expect(() => buildBranchContinuityNodesFromAuthoredGraph(withEmptyContinuity)).not.toThrow()
+    expect(() => buildBranchContinuityNodesFromAuthoredGraph(withNullContinuity)).not.toThrow()
     expect(buildBranchContinuityNodesFromAuthoredGraph(withEmptyContinuity)).toEqual([
       { nodeId: 'b' },
+    ])
+    expect(buildBranchContinuityNodesFromAuthoredGraph(withNullContinuity)).toEqual([
+      { nodeId: 'node:null-continuity' },
+    ])
+  })
+
+  it('treats JSON null nested continuity fields as omissions without throwing', () => {
+    const jsonLike = [
+      {
+        id: 'node:null-nested',
+        continuity: {
+          requires: null,
+          assumesPlayerKnows: null,
+          citesOfficialClaimIds: null,
+        },
+      },
+    ] as unknown as readonly AuthoredBranchContinuityNode[]
+
+    expect(() => buildBranchContinuityNodesFromAuthoredGraph(jsonLike)).not.toThrow()
+    expect(buildBranchContinuityNodesFromAuthoredGraph(jsonLike)).toEqual([
+      { nodeId: 'node:null-nested' },
+    ])
+  })
+
+  it('omits label when JSON sets label to null', () => {
+    const authored = [{ id: 'node:no-label', label: null }] as unknown as AuthoredBranchContinuityNode[]
+    expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([{ nodeId: 'node:no-label' }])
+  })
+
+  it('omits empty string lists and empty records from requires output', () => {
+    const authored = [
+      {
+        id: 'node:empty-trim',
+        continuity: {
+          requires: {
+            allItemIds: [],
+            anyItemIds: ['item:a'],
+            injuryBySubjectId: {},
+            companionStatusById: {},
+          },
+        },
+      },
+    ] as unknown as AuthoredBranchContinuityNode[]
+
+    expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([
+      {
+        nodeId: 'node:empty-trim',
+        requires: { anyItemIds: ['item:a'] },
+      },
     ])
   })
 

--- a/src/test/branchContinuityAuthoring.test.ts
+++ b/src/test/branchContinuityAuthoring.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import type {
+  BranchContinuityNode,
+  BranchCorrectedRecord,
+  BranchNodeRequirements,
+  BranchOfficialClaim,
+} from '../domain/branchContinuity'
+import { buildBranchContinuityAuditReport } from '../domain/branchContinuityAudit'
+import {
+  buildBranchContinuityNodesFromAuthoredGraph,
+  type AuthoredBranchContinuityNode,
+} from '../domain/branchContinuityAuthoring'
+import { appendDeveloperLogEvent } from '../domain/developerLog'
+import { setGlobalFlag } from '../domain/gameStateManager'
+
+function createCorrectedRecords(): readonly BranchCorrectedRecord[] {
+  return [
+    {
+      recordId: 'record:map-correction-1',
+      supersededClaimId: 'claim:map-wing-east',
+      revisionId: 'revision:map-wing-west',
+      effectiveFromChoiceId: 'choice:archive-review',
+      summary: 'Archive review corrected the east-wing map claim.',
+    },
+  ]
+}
+
+function createOfficialClaims(): readonly BranchOfficialClaim[] {
+  return [
+    {
+      claimId: 'claim:map-wing-east',
+      subjectId: 'archive:wing-map',
+      summary: 'East wing is the primary escape route.',
+    },
+  ]
+}
+
+function createGameWithArchiveReviewChoice() {
+  let game = createStartingState()
+  game = setGlobalFlag(game, 'choice:archive-review', true)
+  game = appendDeveloperLogEvent(game, {
+    type: 'choice.executed',
+    summary: 'Choice executed: choice:archive-review',
+  })
+  return game
+}
+
+describe('branchContinuityAuthoring', () => {
+  it('returns an empty array for empty authored input', () => {
+    expect(buildBranchContinuityNodesFromAuthoredGraph([])).toEqual([])
+  })
+
+  it('maps a minimal authored node to a BranchContinuityNode', () => {
+    const authored: AuthoredBranchContinuityNode[] = [{ id: 'node:minimal' }]
+    expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([
+      { nodeId: 'node:minimal' },
+    ])
+  })
+
+  it('preserves label when defined', () => {
+    const authored: AuthoredBranchContinuityNode[] = [{ id: 'node:l', label: 'Lab brief' }]
+    expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([
+      { nodeId: 'node:l', label: 'Lab brief' },
+    ])
+  })
+
+  it('maps a full continuity payload to match a hand-built BranchContinuityNode', () => {
+    const requires: BranchNodeRequirements = {
+      allItemIds: ['item:alpha'],
+      anyItemIds: ['item:beta'],
+      witnessedEventIds: ['event:gate'],
+      learnedClueIds: ['clue:hint'],
+      priorChoiceIds: ['choice:open'],
+    }
+    const authored: AuthoredBranchContinuityNode[] = [
+      {
+        id: 'node:full',
+        label: 'Full',
+        continuity: {
+          requires,
+          assumesPlayerKnows: { learnedClueIds: ['clue:other'] },
+          citesOfficialClaimIds: ['claim:x'],
+        },
+      },
+    ]
+
+    const expected: BranchContinuityNode[] = [
+      {
+        nodeId: 'node:full',
+        label: 'Full',
+        requires: {
+          allItemIds: ['item:alpha'],
+          anyItemIds: ['item:beta'],
+          witnessedEventIds: ['event:gate'],
+          learnedClueIds: ['clue:hint'],
+          priorChoiceIds: ['choice:open'],
+        },
+        assumesPlayerKnows: { learnedClueIds: ['clue:other'] },
+        citesOfficialClaimIds: ['claim:x'],
+      },
+    ]
+
+    expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual(expected)
+  })
+
+  it('does not throw when continuity is missing or empty', () => {
+    const withMissingContinuity: AuthoredBranchContinuityNode[] = [{ id: 'a' }]
+    const withEmptyContinuity: AuthoredBranchContinuityNode[] = [{ id: 'b', continuity: {} }]
+
+    expect(() => buildBranchContinuityNodesFromAuthoredGraph(withMissingContinuity)).not.toThrow()
+    expect(() => buildBranchContinuityNodesFromAuthoredGraph(withEmptyContinuity)).not.toThrow()
+    expect(buildBranchContinuityNodesFromAuthoredGraph(withEmptyContinuity)).toEqual([
+      { nodeId: 'b' },
+    ])
+  })
+
+  it('omits optional nested branches when empty or undefined after slimming', () => {
+    const slimEmptyRequires: AuthoredBranchContinuityNode[] = [
+      { id: 'node:slim', continuity: { requires: {} } },
+    ]
+    expect(buildBranchContinuityNodesFromAuthoredGraph(slimEmptyRequires)).toEqual([
+      { nodeId: 'node:slim' },
+    ])
+
+    const partialRequires: AuthoredBranchContinuityNode[] = [
+      {
+        id: 'node:partial',
+        continuity: {
+          requires: { allItemIds: ['item:only'] },
+        },
+      },
+    ]
+    expect(buildBranchContinuityNodesFromAuthoredGraph(partialRequires)).toEqual([
+      {
+        nodeId: 'node:partial',
+        requires: { allItemIds: ['item:only'] },
+      },
+    ])
+  })
+
+  it('produces deterministic output and preserves authored order', () => {
+    const authored: AuthoredBranchContinuityNode[] = [
+      { id: 'node:z' },
+      { id: 'node:a', label: 'A' },
+    ]
+    const first = buildBranchContinuityNodesFromAuthoredGraph(authored)
+    const second = buildBranchContinuityNodesFromAuthoredGraph(authored)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+    expect(first.map((node) => node.nodeId)).toEqual(['node:z', 'node:a'])
+  })
+
+  it('does not mutate authored graph arrays or objects', () => {
+    const itemIds = ['item:holy-symbol']
+    const authored: AuthoredBranchContinuityNode[] = [
+      {
+        id: 'node:mutate',
+        continuity: { requires: { allItemIds: itemIds } },
+      },
+    ]
+    const beforeAuthored = JSON.stringify(authored)
+    const beforeItems = JSON.stringify(itemIds)
+
+    const nodes = buildBranchContinuityNodesFromAuthoredGraph(authored)
+
+    expect(JSON.stringify(authored)).toBe(beforeAuthored)
+    expect(JSON.stringify(itemIds)).toBe(beforeItems)
+    expect(nodes[0]?.requires?.allItemIds).not.toBe(itemIds)
+    itemIds.push('item:other')
+    expect(nodes[0]?.requires?.allItemIds).toEqual(['item:holy-symbol'])
+  })
+
+  it('drops unknown requires properties instead of forwarding them', () => {
+    const requiresWithUnknown = {
+      allItemIds: ['item:keep'],
+      unknownField: 'strip',
+    } as unknown as BranchNodeRequirements
+    const [node] = buildBranchContinuityNodesFromAuthoredGraph([
+      { id: 'node:req', continuity: { requires: requiresWithUnknown } },
+    ])
+    expect(node.requires).toEqual({ allItemIds: ['item:keep'] })
+    expect(node.requires).not.toHaveProperty('unknownField')
+  })
+
+  it('ignores unknown top-level keys on authored nodes at runtime', () => {
+    const rogue = {
+      id: 'node:rogue',
+      extraTopLevel: true,
+    } as AuthoredBranchContinuityNode & { extraTopLevel?: boolean }
+    const [node] = buildBranchContinuityNodesFromAuthoredGraph([rogue])
+    expect(node).toEqual({ nodeId: 'node:rogue' })
+    expect(node).not.toHaveProperty('extraTopLevel')
+  })
+
+  it('feeds adapter output into buildBranchContinuityAuditReport', () => {
+    const game = createStartingState()
+    const nodes = buildBranchContinuityNodesFromAuthoredGraph([{ id: 'node:audit-feed' }])
+
+    const report = buildBranchContinuityAuditReport({ game, nodes })
+
+    expect(report.summary.nodeCount).toBe(1)
+    expect(report.validation.pathId).toBe(report.pathFacts.pathId)
+  })
+
+  it('surfaces missing_item when adapter nodes require inventory absent from the path', () => {
+    const game = createStartingState()
+    const nodes = buildBranchContinuityNodesFromAuthoredGraph([
+      {
+        id: 'node:needs-holy-symbol',
+        continuity: { requires: { allItemIds: ['item:holy-symbol'] } },
+      },
+    ])
+
+    const report = buildBranchContinuityAuditReport({ game, nodes })
+    const warning = report.validation.warnings.find(
+      (entry) =>
+        entry.nodeId === 'node:needs-holy-symbol' && entry.warningClass === 'missing_item'
+    )
+
+    expect(warning).toMatchObject({ severity: 'error', audience: 'simulation' })
+  })
+
+  it('produces zero warnings when requires match starting inventory projection', () => {
+    const game = createStartingState()
+    expect(game.inventory.electronic_parts).toBeGreaterThan(0)
+
+    const nodes = buildBranchContinuityNodesFromAuthoredGraph([
+      {
+        id: 'node:stock-check',
+        continuity: { requires: { allItemIds: ['electronic_parts'] } },
+      },
+    ])
+
+    const report = buildBranchContinuityAuditReport({ game, nodes })
+    expect(report.validation.warnings).toHaveLength(0)
+  })
+
+  it('passes corrected records and official claims for stale_official_claim via adapter', () => {
+    const game = createGameWithArchiveReviewChoice()
+    const nodes = buildBranchContinuityNodesFromAuthoredGraph([
+      {
+        id: 'node:old-map-briefing',
+        continuity: { citesOfficialClaimIds: ['claim:map-wing-east'] },
+      },
+    ])
+
+    const report = buildBranchContinuityAuditReport({
+      game,
+      nodes,
+      correctedRecords: createCorrectedRecords(),
+      officialClaims: createOfficialClaims(),
+    })
+
+    const warning = report.validation.warnings.find(
+      (entry) =>
+        entry.nodeId === 'node:old-map-briefing' && entry.warningClass === 'stale_official_claim'
+    )
+
+    expect(warning).toMatchObject({
+      severity: 'warning',
+      audience: 'institutional',
+      relatedIds: ['claim:map-wing-east'],
+    })
+  })
+
+  it('remains an explicit supplied-node adapter without runtime graph import hooks', async () => {
+    const authoringModule = await import('../domain/branchContinuityAuthoring')
+    expect(Object.keys(authoringModule).sort()).toEqual(['buildBranchContinuityNodesFromAuthoredGraph'])
+
+    const game = createStartingState()
+    const report = buildBranchContinuityAuditReport({
+      game,
+      nodes: buildBranchContinuityNodesFromAuthoredGraph([{ id: 'node:explicit-only' }]),
+    })
+    expect(report.summary.nodeCount).toBe(1)
+  })
+
+  it('does not mutate GameState when running an audit with adapter output', () => {
+    const game = createStartingState()
+    const before = JSON.stringify(game)
+    buildBranchContinuityAuditReport({
+      game,
+      nodes: buildBranchContinuityNodesFromAuthoredGraph([
+        { id: 'node:g', continuity: { requires: { allItemIds: ['item:ghost'] } } },
+      ]),
+    })
+    expect(JSON.stringify(game)).toBe(before)
+  })
+})

--- a/src/test/branchContinuityAuthoring.test.ts
+++ b/src/test/branchContinuityAuthoring.test.ts
@@ -131,6 +131,77 @@ describe('branchContinuityAuthoring', () => {
     })
   })
 
+  describe('malformed authored array elements', () => {
+    it('skips null element without throwing', () => {
+      const graph = [null] as unknown as readonly AuthoredBranchContinuityNode[]
+      expect(() => buildBranchContinuityNodesFromAuthoredGraph(graph)).not.toThrow()
+      expect(buildBranchContinuityNodesFromAuthoredGraph(graph)).toEqual([])
+    })
+
+    it('skips undefined element without throwing', () => {
+      const graph = [undefined] as unknown as readonly AuthoredBranchContinuityNode[]
+      expect(() => buildBranchContinuityNodesFromAuthoredGraph(graph)).not.toThrow()
+      expect(buildBranchContinuityNodesFromAuthoredGraph(graph)).toEqual([])
+    })
+
+    it('skips primitive string element without throwing', () => {
+      const graph = ['literal-string'] as unknown as readonly AuthoredBranchContinuityNode[]
+      expect(() => buildBranchContinuityNodesFromAuthoredGraph(graph)).not.toThrow()
+      expect(buildBranchContinuityNodesFromAuthoredGraph(graph)).toEqual([])
+    })
+
+    it('skips number and boolean elements without throwing', () => {
+      const graph = [0, 42, true, false] as unknown as readonly AuthoredBranchContinuityNode[]
+      expect(() => buildBranchContinuityNodesFromAuthoredGraph(graph)).not.toThrow()
+      expect(buildBranchContinuityNodesFromAuthoredGraph(graph)).toEqual([])
+    })
+
+    it('preserves order for valid objects while dropping non-objects', () => {
+      const graph = [
+        null,
+        { id: 'node:keep-a' },
+        'skip-me',
+        99,
+        false,
+        { id: 'node:keep-b' },
+        undefined,
+      ] as unknown as readonly AuthoredBranchContinuityNode[]
+
+      expect(buildBranchContinuityNodesFromAuthoredGraph(graph)).toEqual([
+        { nodeId: 'node:keep-a' },
+        { nodeId: 'node:keep-b' },
+      ])
+    })
+
+    it('does not crash audit when array mixes null, primitives, and valid nodes', () => {
+      const graph = [
+        null,
+        { id: 'node:audit-safe', continuity: { requires: { allItemIds: ['item:holy-symbol'] } } },
+        'bad',
+        undefined,
+      ] as unknown as readonly AuthoredBranchContinuityNode[]
+
+      const game = createStartingState()
+      expect(() =>
+        buildBranchContinuityAuditReport({
+          game,
+          nodes: buildBranchContinuityNodesFromAuthoredGraph(graph),
+        })
+      ).not.toThrow()
+
+      const report = buildBranchContinuityAuditReport({
+        game,
+        nodes: buildBranchContinuityNodesFromAuthoredGraph(graph),
+      })
+      expect(report.summary.nodeCount).toBe(1)
+      expect(
+        report.validation.warnings.some(
+          (w) => w.nodeId === 'node:audit-safe' && w.warningClass === 'missing_item'
+        )
+      ).toBe(true)
+    })
+  })
+
   it('maps a full continuity payload to match a hand-built BranchContinuityNode', () => {
     const requires: BranchNodeRequirements = {
       allItemIds: ['item:alpha'],

--- a/src/test/branchContinuityAuthoring.test.ts
+++ b/src/test/branchContinuityAuthoring.test.ts
@@ -65,6 +65,72 @@ describe('branchContinuityAuthoring', () => {
     ])
   })
 
+  describe('malformed authored node ids', () => {
+    it('skips id: null without throwing', () => {
+      const authored = [{ id: null }] as unknown as AuthoredBranchContinuityNode[]
+      expect(() => buildBranchContinuityNodesFromAuthoredGraph(authored)).not.toThrow()
+      expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([])
+    })
+
+    it('skips non-string id without throwing', () => {
+      const authored = [{ id: 123 }] as unknown as AuthoredBranchContinuityNode[]
+      expect(() => buildBranchContinuityNodesFromAuthoredGraph(authored)).not.toThrow()
+      expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([])
+    })
+
+    it('skips empty or whitespace-only id without throwing', () => {
+      for (const id of ['', '   ', '\t\n']) {
+        const authored = [{ id }] as unknown as AuthoredBranchContinuityNode[]
+        expect(() => buildBranchContinuityNodesFromAuthoredGraph(authored)).not.toThrow()
+        expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([])
+      }
+    })
+
+    it('keeps valid nodes in order and drops malformed entries', () => {
+      const authored = [
+        { id: null },
+        { id: '  node:first  ' },
+        { id: 123 },
+        { id: 'node:second' },
+        { id: '' },
+      ] as unknown as AuthoredBranchContinuityNode[]
+
+      expect(buildBranchContinuityNodesFromAuthoredGraph(authored)).toEqual([
+        { nodeId: 'node:first' },
+        { nodeId: 'node:second' },
+      ])
+    })
+
+    it('does not crash buildBranchContinuityAuditReport when malformed ids are mixed with valid', () => {
+      const mixed = [
+        { id: null },
+        { id: 123 },
+        { id: '' },
+        { id: 'node:warn', continuity: { requires: { allItemIds: ['item:holy-symbol'] } } },
+      ] as unknown as AuthoredBranchContinuityNode[]
+
+      const game = createStartingState()
+      expect(() =>
+        buildBranchContinuityAuditReport({
+          game,
+          nodes: buildBranchContinuityNodesFromAuthoredGraph(mixed),
+        })
+      ).not.toThrow()
+
+      const report = buildBranchContinuityAuditReport({
+        game,
+        nodes: buildBranchContinuityNodesFromAuthoredGraph(mixed),
+      })
+
+      expect(report.summary.nodeCount).toBe(1)
+      expect(
+        report.validation.warnings.some(
+          (w) => w.nodeId === 'node:warn' && w.warningClass === 'missing_item'
+        )
+      ).toBe(true)
+    })
+  })
+
   it('maps a full continuity payload to match a hand-built BranchContinuityNode', () => {
     const requires: BranchNodeRequirements = {
       allItemIds: ['item:alpha'],


### PR DESCRIPTION
## Summary

- Adds `buildBranchContinuityNodesFromAuthoredGraph` and typed authored input shapes that map into SPE-1760 `BranchContinuityNode` (allowlisted field slimming, no extra key forwarding, stable order).
- Runtime hardening: JSON `null` for optional fields is treated like omission; empty arrays and empty record fragments are omitted from output; labels forward only when `typeof === 'string'`.
- Authored entries with invalid `id` values (non-string, empty, or whitespace-only after trim) are omitted so every emitted `nodeId` is safe for validator sorting and reporting; no synthetic ids.
- Authored graph elements that are not non-null plain objects (`null`, `undefined`, primitives, arrays) are skipped before any property access.
- Tests cover mapping, JSON-like fixtures (via `unknown` casts), malformed ids and array elements, mutation safety, integration with SPE-1762 `buildBranchContinuityAuditReport` (including `missing_item` and `stale_official_claim`), and explicit supplied-node auditing (no graph import).

## Post-review hardening

- Commit `6d01ba0`: nullish guards on `continuity`, `requires`, `assumesPlayerKnows`, `citesOfficialClaimIds`; safe non-empty string list extraction; empty `injury`/`companion` maps omitted; inline review threads replied on GitHub.
- Commit `397090c`: `normalizeAuthoredNodeId` — only non-empty trimmed string ids are emitted; malformed authored rows skipped in order-preserving fashion; tests + reply on review thread.
- Commit `da13de4`: `isAuthoredContinuityRecord` — skip non-object graph elements before reading `id`; regression tests for null/undefined/primitives mixed with valid nodes + audit path; reply on active thread.

## Linear

- [SPE-1811 — Branch continuity validator — authored node audit adapter](https://linear.app/spectranoir/issue/SPE-1811/branch-continuity-validator-authored-node-audit-adapter)
- Parent (context only, not closed): [SPE-1464 — Branch continuity validator](https://linear.app/spectranoir/issue/SPE-1464/branch-continuity-validator)

## Dependencies

- SPE-1760 (`BranchContinuityNode`, `validateBranchContinuity`)
- SPE-1761 (`projectBranchPathFactsFromGameState`)
- SPE-1762 (`buildBranchContinuityAuditReport`)

## Smallest boundary

Pure adapter + tests only: `src/domain/branchContinuityAuthoring.ts`, `src/test/branchContinuityAuthoring.test.ts`.

## Files changed

- `src/domain/branchContinuityAuthoring.ts`
- `src/test/branchContinuityAuthoring.test.ts`

## Validation run

- `npm run test:run -- src/test/branchContinuityAuthoring.test.ts`
- `npm run test:run -- src/test/branchContinuityAudit.test.ts`
- `npm run test:run -- src/test/branchContinuity.test.ts`
- `npm run test:run -- src/test/branchContinuityProjection.test.ts`
- `npm run lint`
- `git diff --check`
- `npm run test:run` (325 files, 3037 tests)

## Gap / edge-case / boundary audit

1. **JSON / null tolerance:** Non-object authored array elements omitted; malformed node `id` values omitted; `continuity`, nested `requires` / `assumesPlayerKnows` / `citesOfficialClaimIds` may be JSON `null`; empty arrays and empty objects are omitted; non-array list payloads do not throw.
2. **Adapter correctness:** Supported fields match SPE-1760; only allowlisted keys; no invented requirements or fallback ids; unknown nested keys on `requires` objects are not forwarded.
3. **Integration:** Adapter output is consumed only via caller-supplied arrays into `buildBranchContinuityAuditReport`; corrected records and official claims remain audit-input pass-through (unchanged from SPE-1762); malformed rows/elements do not crash the audit path.
4. **Determinism & mutation:** Output order follows input among retained nodes; lists copied; tests assert no mutation of authored fixtures or `GameState` from audit.
5. **Boundary:** No content-wide lint, runtime story/contract/report hooks, UI, persistence, clue storage, SPE-1085, or SPE-1317.
6. **Documentation:** Module JSDoc on `branchContinuityAuthoring.ts` (JSON, id, and element-shape hardening); no markdown doc updates required.

## Explicitly out of scope

- Automatic import or CI lint of all authored content
- Runtime story / encounter / contract / report hooks, developer overlay, Front Desk / player UI
- New `GameState` fields, persistent branch-path or archive state, clue-artifact storage
- SPE-1085 canon/lore and SPE-1317 uncertain-state resolution
- Integrating `AuthoredBranch` from `contentBranching.ts` into this adapter

## Test plan

- [x] Adapter unit and integration tests (audit helper) as listed above
- [x] Full test suite green (`da13de4`)
