### PR TITLE
SPE-1317: Add uncertain world-state evaluator

### DIFF
--- a/src/domain/uncertainWorldState.ts
+++ b/src/domain/uncertainWorldState.ts
@@ -1,0 +1,397 @@
+/**
+ * SPE-1317: deterministic unresolved world-state fact evaluation.
+ *
+ * Models bounded operational questions that are not yet fully knowable from current evidence.
+ * This module is pure and does not persist playable simulation aggregates, run actions, replace containment logic,
+ * perform random/probabilistic resolution, or implement SPE-1085 canon/lore systems.
+ */
+
+export type UncertainWorldStateFactStatus = 'unresolved' | 'resolved' | 'superseded'
+
+export type UncertainWorldStateFactKind =
+  | 'unseen_room_state'
+  | 'unverified_subject_property'
+
+export type UncertainWorldStateEvidenceStrength =
+  | 'weak'
+  | 'moderate'
+  | 'strong'
+  | 'decisive'
+
+export type UncertainWorldStateEvidenceSource =
+  | 'observation'
+  | 'report'
+  | 'map'
+  | 'sensor'
+  | 'witness'
+  | 'branch_continuity'
+  | 'system'
+
+export type UncertainWorldStateCheckTrigger =
+  | 'new_evidence'
+  | 'operator_review'
+  | 'map_update'
+  | 'observer_access'
+
+export interface UncertainWorldStateFact {
+  factId: string
+  subjectId: string
+  factKind: UncertainWorldStateFactKind
+  status: UncertainWorldStateFactStatus
+  question: string
+  possibleStates: readonly string[]
+  currentBestState?: string
+  resolvedState?: string
+  appliedEvidenceIds: readonly string[]
+  createdAtWeek?: number
+  resolvedAtWeek?: number
+  allowSupersession?: boolean
+}
+
+export interface UncertainWorldStateEvidence {
+  evidenceId: string
+  factId: string
+  subjectId: string
+  supportsState: string
+  strength: UncertainWorldStateEvidenceStrength
+  source: UncertainWorldStateEvidenceSource
+}
+
+export interface UncertainWorldStateCheck {
+  checkId: string
+  factId: string
+  trigger: UncertainWorldStateCheckTrigger
+  minimumStrength?: UncertainWorldStateEvidenceStrength
+}
+
+export interface UncertainWorldStateResolution {
+  factId: string
+  statusBefore: UncertainWorldStateFactStatus
+  statusAfter: UncertainWorldStateFactStatus
+  appliedEvidenceIds: readonly string[]
+  ignoredEvidenceIds: readonly string[]
+  resolvedState?: string
+  currentBestState?: string
+  note: string
+}
+
+export interface UncertainWorldStateReport {
+  facts: readonly UncertainWorldStateFact[]
+  resolutions: readonly UncertainWorldStateResolution[]
+  summary: {
+    unresolvedCount: number
+    resolvedCount: number
+    supersededCount: number
+  }
+}
+
+const STRENGTH_RANK: Readonly<Record<UncertainWorldStateEvidenceStrength, number>> = {
+  weak: 0,
+  moderate: 1,
+  strong: 2,
+  decisive: 3,
+}
+
+function strengthMeetsMinimum(
+  strength: UncertainWorldStateEvidenceStrength,
+  minimum: UncertainWorldStateEvidenceStrength | undefined
+): boolean {
+  if (minimum === undefined) {
+    return true
+  }
+  return STRENGTH_RANK[strength] >= STRENGTH_RANK[minimum]
+}
+
+/** Strictest check gate when multiple checks target the same fact (highest minimum rank). */
+function effectiveMinimumStrengthForFact(
+  checks: readonly UncertainWorldStateCheck[] | undefined,
+  factId: string
+): UncertainWorldStateEvidenceStrength | undefined {
+  if (checks === undefined || checks.length === 0) {
+    return undefined
+  }
+  const relevant = checks.filter((c) => c.factId === factId)
+  if (relevant.length === 0) {
+    return undefined
+  }
+  let best: UncertainWorldStateEvidenceStrength = 'weak'
+  let bestRank = STRENGTH_RANK.weak
+  for (const c of relevant) {
+    const min = c.minimumStrength ?? 'weak'
+    const rank = STRENGTH_RANK[min]
+    if (rank > bestRank) {
+      bestRank = rank
+      best = min
+    }
+  }
+  return best
+}
+
+function compareApplicableEvidence(
+  a: UncertainWorldStateEvidence,
+  b: UncertainWorldStateEvidence
+): number {
+  const ra = STRENGTH_RANK[a.strength]
+  const rb = STRENGTH_RANK[b.strength]
+  if (ra !== rb) {
+    return ra - rb
+  }
+  return a.evidenceId.localeCompare(b.evidenceId)
+}
+
+function sortUniqueStrings(ids: readonly string[]): string[] {
+  return [...new Set(ids)].sort((a, b) => a.localeCompare(b))
+}
+
+function formatChecksFragment(checks: readonly UncertainWorldStateCheck[] | undefined, factId: string): string {
+  if (checks === undefined || checks.length === 0) {
+    return ''
+  }
+  const rel = checks.filter((c) => c.factId === factId)
+  if (rel.length === 0) {
+    return ''
+  }
+  const parts = rel.map((c) => `${c.checkId} (${c.trigger})`)
+  return `Checks: ${parts.join('; ')}. `
+}
+
+function evaluateOneFact(input: {
+  fact: UncertainWorldStateFact
+  allEvidence: readonly UncertainWorldStateEvidence[]
+  checks: readonly UncertainWorldStateCheck[] | undefined
+  context: { week?: number } | undefined
+}): { fact: UncertainWorldStateFact; resolution: UncertainWorldStateResolution } {
+  const { fact, allEvidence, checks, context } = input
+  const statusBefore = fact.status
+
+  const baseApplied = [...fact.appliedEvidenceIds]
+  const appliedSet = new Set(baseApplied)
+  const newAppliedIds: string[] = []
+  const pushApplied = (id: string) => {
+    if (!appliedSet.has(id)) {
+      appliedSet.add(id)
+      newAppliedIds.push(id)
+    }
+  }
+
+  const ignored: string[] = []
+  const pushIgnored = (id: string) => {
+    if (!ignored.includes(id)) {
+      ignored.push(id)
+    }
+  }
+
+  const minStrength = effectiveMinimumStrengthForFact(checks, fact.factId)
+  const checkPrefix = formatChecksFragment(checks, fact.factId)
+
+  if (fact.status === 'superseded') {
+    const clone: UncertainWorldStateFact = {
+      ...fact,
+      possibleStates: [...fact.possibleStates],
+      appliedEvidenceIds: sortUniqueStrings(fact.appliedEvidenceIds),
+    }
+    const resolution: UncertainWorldStateResolution = {
+      factId: fact.factId,
+      statusBefore,
+      statusAfter: fact.status,
+      appliedEvidenceIds: clone.appliedEvidenceIds,
+      ignoredEvidenceIds: [],
+      resolvedState: clone.resolvedState,
+      currentBestState: clone.currentBestState,
+      note: `${checkPrefix}Fact already superseded; no evaluation applied.`,
+    }
+    return { fact: clone, resolution }
+  }
+
+  const candidates = allEvidence.filter((e) => e.factId === fact.factId)
+  const applicable: UncertainWorldStateEvidence[] = []
+
+  for (const ev of candidates) {
+    if (ev.subjectId !== fact.subjectId) {
+      pushIgnored(ev.evidenceId)
+      continue
+    }
+    if (!fact.possibleStates.includes(ev.supportsState)) {
+      pushIgnored(ev.evidenceId)
+      continue
+    }
+    if (!strengthMeetsMinimum(ev.strength, minStrength)) {
+      pushIgnored(ev.evidenceId)
+      continue
+    }
+    applicable.push(ev)
+  }
+
+  applicable.sort(compareApplicableEvidence)
+
+  let statusAfter: UncertainWorldStateFactStatus = fact.status
+  let currentBestState = fact.currentBestState
+  let resolvedState = fact.resolvedState
+  let resolvedAtWeek = fact.resolvedAtWeek
+
+  const supersessionFragments: string[] = []
+  let appliedNonDecisive = false
+  let didSupersedeResolution = false
+
+  for (const ev of applicable) {
+    if (ev.strength !== 'decisive') {
+      currentBestState = ev.supportsState
+      pushApplied(ev.evidenceId)
+      appliedNonDecisive = true
+      continue
+    }
+
+    if (statusAfter !== 'resolved') {
+      statusAfter = 'resolved'
+      resolvedState = ev.supportsState
+      currentBestState = ev.supportsState
+      if (context?.week !== undefined) {
+        resolvedAtWeek = context.week
+      }
+      pushApplied(ev.evidenceId)
+      continue
+    }
+
+    if (resolvedState === ev.supportsState) {
+      pushApplied(ev.evidenceId)
+      continue
+    }
+
+    if (fact.allowSupersession === true) {
+      const prior = resolvedState
+      resolvedState = ev.supportsState
+      currentBestState = ev.supportsState
+      if (context?.week !== undefined) {
+        resolvedAtWeek = context.week
+      }
+      pushApplied(ev.evidenceId)
+      if (prior !== undefined && prior !== ev.supportsState) {
+        supersessionFragments.push(`Superseded prior resolvedState '${prior}'.`)
+        didSupersedeResolution = true
+      }
+      continue
+    }
+
+    pushIgnored(ev.evidenceId)
+  }
+
+  const appliedEvidenceIdsSorted = sortUniqueStrings([...baseApplied, ...newAppliedIds])
+
+  const hadApplicable = applicable.length > 0
+
+  let noteBody: string
+  if (!hadApplicable) {
+    noteBody = `${checkPrefix}No applicable evidence for this fact.`
+  } else if (didSupersedeResolution) {
+    const detail =
+      supersessionFragments.length > 0 ? supersessionFragments.join(' ') : 'Conflicting decisive evidence.'
+    noteBody = `${checkPrefix}${detail} Decisive evidence superseded conflicting resolution.`
+  } else if (statusBefore !== 'resolved' && statusAfter === 'resolved') {
+    noteBody = `${checkPrefix}Fact resolved via decisive evidence.`
+  } else if (appliedNonDecisive && statusAfter !== 'resolved') {
+    noteBody = `${checkPrefix}Updated currentBestState from non-decisive evidence.`
+  } else if (statusBefore === 'resolved' && statusAfter === 'resolved' && newAppliedIds.length === 0) {
+    noteBody = `${checkPrefix}No new applicable evidence changed this fact.`
+  } else if (statusBefore === 'resolved' && statusAfter === 'resolved' && newAppliedIds.length > 0) {
+    noteBody = `${checkPrefix}Reinforced or adjusted resolved fact with additional decisive evidence.`
+  } else {
+    noteBody = `${checkPrefix}No material change from applicable evidence.`
+  }
+
+  const outFact: UncertainWorldStateFact = {
+    ...fact,
+    status: statusAfter,
+    possibleStates: [...fact.possibleStates],
+    currentBestState,
+    resolvedState,
+    resolvedAtWeek,
+    appliedEvidenceIds: appliedEvidenceIdsSorted,
+  }
+
+  const resolution: UncertainWorldStateResolution = {
+    factId: fact.factId,
+    statusBefore,
+    statusAfter,
+    appliedEvidenceIds: appliedEvidenceIdsSorted,
+    ignoredEvidenceIds: sortUniqueStrings(ignored),
+    resolvedState,
+    currentBestState,
+    note: noteBody.trim().replace(/\s+/g, ' '),
+  }
+
+  return { fact: outFact, resolution }
+}
+
+export function evaluateUncertainWorldStateFacts(input: {
+  facts: readonly UncertainWorldStateFact[]
+  evidence: readonly UncertainWorldStateEvidence[]
+  checks?: readonly UncertainWorldStateCheck[]
+  context?: { week?: number }
+}): UncertainWorldStateReport {
+  const sortedFacts = [...input.facts].sort((a, b) => a.factId.localeCompare(b.factId))
+  const outFacts: UncertainWorldStateFact[] = []
+  const resolutions: UncertainWorldStateResolution[] = []
+
+  for (const fact of sortedFacts) {
+    const { fact: next, resolution } = evaluateOneFact({
+      fact,
+      allEvidence: input.evidence,
+      checks: input.checks,
+      context: input.context,
+    })
+    outFacts.push(next)
+    resolutions.push(resolution)
+  }
+
+  resolutions.sort((a, b) => a.factId.localeCompare(b.factId))
+
+  const summary = outFacts.reduce(
+    (acc, f) => {
+      if (f.status === 'unresolved') {
+        acc.unresolvedCount += 1
+      }
+      if (f.status === 'resolved') {
+        acc.resolvedCount += 1
+      }
+      if (f.status === 'superseded') {
+        acc.supersededCount += 1
+      }
+      return acc
+    },
+    { unresolvedCount: 0, resolvedCount: 0, supersededCount: 0 }
+  )
+
+  return {
+    facts: outFacts,
+    resolutions,
+    summary,
+  }
+}
+
+export function resolveUncertainWorldStateCheck(input: {
+  fact: UncertainWorldStateFact
+  evidence: readonly UncertainWorldStateEvidence[]
+  check?: UncertainWorldStateCheck
+  context?: { week?: number }
+}): UncertainWorldStateResolution {
+  const report = evaluateUncertainWorldStateFacts({
+    facts: [input.fact],
+    evidence: input.evidence,
+    checks: input.check === undefined ? undefined : [input.check],
+    context: input.context,
+  })
+  const first = report.resolutions[0]
+  if (first !== undefined) {
+    return first
+  }
+  return {
+    factId: input.fact.factId,
+    statusBefore: input.fact.status,
+    statusAfter: input.fact.status,
+    appliedEvidenceIds: sortUniqueStrings(input.fact.appliedEvidenceIds),
+    ignoredEvidenceIds: [],
+    resolvedState: input.fact.resolvedState,
+    currentBestState: input.fact.currentBestState,
+    note: 'No fact supplied.',
+  }
+}

--- a/src/domain/uncertainWorldState.ts
+++ b/src/domain/uncertainWorldState.ts
@@ -302,7 +302,7 @@ function evaluateOneFact(input: {
     ...fact,
     status: statusAfter,
     possibleStates: [...fact.possibleStates],
-    currentBestState,
+    currentBestState: statusAfter === 'resolved' ? resolvedState : currentBestState,
     resolvedState,
     resolvedAtWeek,
     appliedEvidenceIds: appliedEvidenceIdsSorted,

--- a/src/domain/uncertainWorldState.ts
+++ b/src/domain/uncertainWorldState.ts
@@ -313,7 +313,7 @@ function evaluateOneFact(input: {
     statusBefore,
     statusAfter,
     appliedEvidenceIds: appliedEvidenceIdsSorted,
-    ignoredEvidenceIds: sortUniqueStrings(ignored),
+    ignoredEvidenceIds: sortUniqueStrings([...ignoredSet]),
     resolvedState,
     currentBestState: statusAfter === 'resolved' ? resolvedState : currentBestState,
     note: noteBody.trim().replace(/\s+/g, ' '),

--- a/src/domain/uncertainWorldState.ts
+++ b/src/domain/uncertainWorldState.ts
@@ -315,7 +315,7 @@ function evaluateOneFact(input: {
     appliedEvidenceIds: appliedEvidenceIdsSorted,
     ignoredEvidenceIds: sortUniqueStrings(ignored),
     resolvedState,
-    currentBestState,
+    currentBestState: statusAfter === 'resolved' ? resolvedState : currentBestState,
     note: noteBody.trim().replace(/\s+/g, ' '),
   }
 

--- a/src/domain/uncertainWorldState.ts
+++ b/src/domain/uncertainWorldState.ts
@@ -4,6 +4,9 @@
  * Models bounded operational questions that are not yet fully knowable from current evidence.
  * This module is pure and does not persist playable simulation aggregates, run actions, replace containment logic,
  * perform random/probabilistic resolution, or implement SPE-1085 canon/lore systems.
+ *
+ * For facts in `resolved` status, non-decisive evidence does not update `currentBestState`; when `resolvedState` is known,
+ * outputs keep `currentBestState` aligned with it.
  */
 
 export type UncertainWorldStateFactStatus = 'unresolved' | 'resolved' | 'superseded'
@@ -102,21 +105,16 @@ function strengthMeetsMinimum(
   return STRENGTH_RANK[strength] >= STRENGTH_RANK[minimum]
 }
 
-/** Strictest check gate when multiple checks target the same fact (highest minimum rank). */
-function effectiveMinimumStrengthForFact(
-  checks: readonly UncertainWorldStateCheck[] | undefined,
-  factId: string
+/** Strictest gate when multiple checks target the same fact (highest minimum rank). */
+function effectiveMinimumStrengthForChecks(
+  checksForFact: readonly UncertainWorldStateCheck[]
 ): UncertainWorldStateEvidenceStrength | undefined {
-  if (checks === undefined || checks.length === 0) {
-    return undefined
-  }
-  const relevant = checks.filter((c) => c.factId === factId)
-  if (relevant.length === 0) {
+  if (checksForFact.length === 0) {
     return undefined
   }
   let best: UncertainWorldStateEvidenceStrength = 'weak'
   let bestRank = STRENGTH_RANK.weak
-  for (const c of relevant) {
+  for (const c of checksForFact) {
     const min = c.minimumStrength ?? 'weak'
     const rank = STRENGTH_RANK[min]
     if (rank > bestRank) {
@@ -143,25 +141,38 @@ function sortUniqueStrings(ids: readonly string[]): string[] {
   return [...new Set(ids)].sort((a, b) => a.localeCompare(b))
 }
 
-function formatChecksFragment(checks: readonly UncertainWorldStateCheck[] | undefined, factId: string): string {
-  if (checks === undefined || checks.length === 0) {
+function formatChecksFragment(checksForFact: readonly UncertainWorldStateCheck[]): string {
+  if (checksForFact.length === 0) {
     return ''
   }
-  const rel = checks.filter((c) => c.factId === factId)
-  if (rel.length === 0) {
-    return ''
-  }
-  const parts = rel.map((c) => `${c.checkId} (${c.trigger})`)
+  const parts = checksForFact.map((c) => `${c.checkId} (${c.trigger})`).sort((a, b) => a.localeCompare(b))
   return `Checks: ${parts.join('; ')}. `
+}
+
+/** Once resolved, mirror resolvedState onto currentBestState whenever resolvedState is defined. */
+function finalizeCanonicalStates(
+  statusAfter: UncertainWorldStateFactStatus,
+  resolvedState: string | undefined,
+  currentBestAfterLoop: string | undefined,
+  fact: UncertainWorldStateFact
+): { resolvedState: string | undefined; currentBestState: string | undefined } {
+  if (statusAfter !== 'resolved') {
+    return { resolvedState, currentBestState: currentBestAfterLoop }
+  }
+  const canonicalResolved = resolvedState ?? fact.resolvedState
+  if (canonicalResolved !== undefined) {
+    return { resolvedState: canonicalResolved, currentBestState: canonicalResolved }
+  }
+  return { resolvedState: undefined, currentBestState: currentBestAfterLoop }
 }
 
 function evaluateOneFact(input: {
   fact: UncertainWorldStateFact
-  allEvidence: readonly UncertainWorldStateEvidence[]
-  checks: readonly UncertainWorldStateCheck[] | undefined
+  candidates: readonly UncertainWorldStateEvidence[]
+  checksForFact: readonly UncertainWorldStateCheck[]
   context: { week?: number } | undefined
 }): { fact: UncertainWorldStateFact; resolution: UncertainWorldStateResolution } {
-  const { fact, allEvidence, checks, context } = input
+  const { fact, candidates, checksForFact, context } = input
   const statusBefore = fact.status
 
   const baseApplied = [...fact.appliedEvidenceIds]
@@ -174,15 +185,13 @@ function evaluateOneFact(input: {
     }
   }
 
-  const ignored: string[] = []
+  const ignoredIds = new Set<string>()
   const pushIgnored = (id: string) => {
-    if (!ignored.includes(id)) {
-      ignored.push(id)
-    }
+    ignoredIds.add(id)
   }
 
-  const minStrength = effectiveMinimumStrengthForFact(checks, fact.factId)
-  const checkPrefix = formatChecksFragment(checks, fact.factId)
+  const minStrength = effectiveMinimumStrengthForChecks(checksForFact)
+  const checkPrefix = formatChecksFragment(checksForFact)
 
   if (fact.status === 'superseded') {
     const clone: UncertainWorldStateFact = {
@@ -203,7 +212,6 @@ function evaluateOneFact(input: {
     return { fact: clone, resolution }
   }
 
-  const candidates = allEvidence.filter((e) => e.factId === fact.factId)
   const applicable: UncertainWorldStateEvidence[] = []
 
   for (const ev of candidates) {
@@ -232,9 +240,15 @@ function evaluateOneFact(input: {
   const supersessionFragments: string[] = []
   let appliedNonDecisive = false
   let didSupersedeResolution = false
+  let ignoredWeakWhileResolved = false
 
   for (const ev of applicable) {
     if (ev.strength !== 'decisive') {
+      if (statusAfter === 'resolved') {
+        ignoredWeakWhileResolved = true
+        pushIgnored(ev.evidenceId)
+        continue
+      }
       currentBestState = ev.supportsState
       pushApplied(ev.evidenceId)
       appliedNonDecisive = true
@@ -275,7 +289,12 @@ function evaluateOneFact(input: {
     pushIgnored(ev.evidenceId)
   }
 
+  const sync = finalizeCanonicalStates(statusAfter, resolvedState, currentBestState, fact)
+  resolvedState = sync.resolvedState
+  currentBestState = sync.currentBestState
+
   const appliedEvidenceIdsSorted = sortUniqueStrings([...baseApplied, ...newAppliedIds])
+  const ignoredEvidenceSorted = sortUniqueStrings([...ignoredIds])
 
   const hadApplicable = applicable.length > 0
 
@@ -290,10 +309,12 @@ function evaluateOneFact(input: {
     noteBody = `${checkPrefix}Fact resolved via decisive evidence.`
   } else if (appliedNonDecisive && statusAfter !== 'resolved') {
     noteBody = `${checkPrefix}Updated currentBestState from non-decisive evidence.`
-  } else if (statusBefore === 'resolved' && statusAfter === 'resolved' && newAppliedIds.length === 0) {
-    noteBody = `${checkPrefix}No new applicable evidence changed this fact.`
   } else if (statusBefore === 'resolved' && statusAfter === 'resolved' && newAppliedIds.length > 0) {
     noteBody = `${checkPrefix}Reinforced or adjusted resolved fact with additional decisive evidence.`
+  } else if (statusBefore === 'resolved' && statusAfter === 'resolved' && ignoredWeakWhileResolved) {
+    noteBody = `${checkPrefix}Non-decisive evidence ignored while fact remains resolved; decisive handling unchanged.`
+  } else if (statusBefore === 'resolved' && statusAfter === 'resolved' && newAppliedIds.length === 0) {
+    noteBody = `${checkPrefix}No new applicable evidence changed this fact.`
   } else {
     noteBody = `${checkPrefix}No material change from applicable evidence.`
   }
@@ -302,7 +323,7 @@ function evaluateOneFact(input: {
     ...fact,
     status: statusAfter,
     possibleStates: [...fact.possibleStates],
-    currentBestState: statusAfter === 'resolved' ? resolvedState : currentBestState,
+    currentBestState,
     resolvedState,
     resolvedAtWeek,
     appliedEvidenceIds: appliedEvidenceIdsSorted,
@@ -313,13 +334,41 @@ function evaluateOneFact(input: {
     statusBefore,
     statusAfter,
     appliedEvidenceIds: appliedEvidenceIdsSorted,
-    ignoredEvidenceIds: sortUniqueStrings([...ignoredSet]),
+    ignoredEvidenceIds: ignoredEvidenceSorted,
     resolvedState,
-    currentBestState: statusAfter === 'resolved' ? resolvedState : currentBestState,
+    currentBestState,
     note: noteBody.trim().replace(/\s+/g, ' '),
   }
 
   return { fact: outFact, resolution }
+}
+
+/** Deterministic buckets: preserves global evidence order within each factId group. */
+function evidenceByFactId(evidence: readonly UncertainWorldStateEvidence[]): Map<string, UncertainWorldStateEvidence[]> {
+  const buckets = new Map<string, UncertainWorldStateEvidence[]>()
+  for (const ev of evidence) {
+    const cur = buckets.get(ev.factId)
+    if (cur === undefined) {
+      buckets.set(ev.factId, [ev])
+    } else {
+      cur.push(ev)
+    }
+  }
+  return buckets
+}
+
+/** Group checks once for deterministic lookup without rescanning the full checklist each fact. */
+function checksByFactId(checks: readonly UncertainWorldStateCheck[]): Map<string, UncertainWorldStateCheck[]> {
+  const buckets = new Map<string, UncertainWorldStateCheck[]>()
+  for (const c of checks) {
+    const cur = buckets.get(c.factId)
+    if (cur === undefined) {
+      buckets.set(c.factId, [c])
+    } else {
+      cur.push(c)
+    }
+  }
+  return buckets
 }
 
 export function evaluateUncertainWorldStateFacts(input: {
@@ -329,14 +378,20 @@ export function evaluateUncertainWorldStateFacts(input: {
   context?: { week?: number }
 }): UncertainWorldStateReport {
   const sortedFacts = [...input.facts].sort((a, b) => a.factId.localeCompare(b.factId))
+  const buckets = evidenceByFactId(input.evidence)
+  const checks = input.checks ?? []
+  const checkBuckets = checksByFactId(checks)
+
   const outFacts: UncertainWorldStateFact[] = []
   const resolutions: UncertainWorldStateResolution[] = []
 
   for (const fact of sortedFacts) {
+    const checksForFact = checkBuckets.get(fact.factId) ?? []
+    const candidates = buckets.get(fact.factId) ?? []
     const { fact: next, resolution } = evaluateOneFact({
       fact,
-      allEvidence: input.evidence,
-      checks: input.checks,
+      candidates,
+      checksForFact,
       context: input.context,
     })
     outFacts.push(next)
@@ -384,14 +439,20 @@ export function resolveUncertainWorldStateCheck(input: {
   if (first !== undefined) {
     return first
   }
+  const sync = finalizeCanonicalStates(
+    input.fact.status,
+    input.fact.resolvedState,
+    input.fact.currentBestState,
+    input.fact
+  )
   return {
     factId: input.fact.factId,
     statusBefore: input.fact.status,
     statusAfter: input.fact.status,
     appliedEvidenceIds: sortUniqueStrings(input.fact.appliedEvidenceIds),
     ignoredEvidenceIds: [],
-    resolvedState: input.fact.resolvedState,
-    currentBestState: input.fact.currentBestState,
+    resolvedState: sync.resolvedState,
+    currentBestState: sync.currentBestState,
     note: 'No fact supplied.',
   }
 }

--- a/src/test/uncertainWorldState.test.ts
+++ b/src/test/uncertainWorldState.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import {
+  evaluateUncertainWorldStateFacts,
+  resolveUncertainWorldStateCheck,
+  type UncertainWorldStateEvidence,
+  type UncertainWorldStateFact,
+} from '../domain/uncertainWorldState'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function baseFact(overrides: Partial<UncertainWorldStateFact>): UncertainWorldStateFact {
+  return {
+    factId: 'fact:room-1',
+    subjectId: 'subject:room-1',
+    factKind: 'unseen_room_state',
+    status: 'unresolved',
+    question: 'What is the operational state of the unseen room?',
+    possibleStates: ['clear', 'occupied', 'sealed'],
+    appliedEvidenceIds: [],
+    ...overrides,
+  }
+}
+
+function ev(
+  overrides: Partial<UncertainWorldStateEvidence> & Pick<UncertainWorldStateEvidence, 'evidenceId'>
+): UncertainWorldStateEvidence {
+  return {
+    factId: 'fact:room-1',
+    subjectId: 'subject:room-1',
+    supportsState: 'clear',
+    strength: 'weak',
+    source: 'observation',
+    ...overrides,
+  }
+}
+
+describe('uncertainWorldState (SPE-1317)', () => {
+  it('empty facts/evidence returns empty report and no throw', () => {
+    const report = evaluateUncertainWorldStateFacts({ facts: [], evidence: [] })
+    expect(report.facts).toEqual([])
+    expect(report.resolutions).toEqual([])
+    expect(report.summary).toEqual({ unresolvedCount: 0, resolvedCount: 0, supersededCount: 0 })
+  })
+
+  it('unresolved fact remains unresolved with no evidence', () => {
+    const fact = baseFact({})
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence: [] })
+    expect(report.facts[0]?.status).toBe('unresolved')
+    expect(report.resolutions[0]?.note).toContain('No applicable evidence')
+  })
+
+  it('ignores evidence with wrong factId', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:1', factId: 'fact:other' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.status).toBe('unresolved')
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toEqual([])
+  })
+
+  it('ignores evidence with wrong subjectId', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:1', subjectId: 'subject:other', supportsState: 'clear' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.currentBestState).toBeUndefined()
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toContain('ev:1')
+  })
+
+  it('ignores supportsState outside possibleStates', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:bad', supportsState: 'flooded' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toContain('ev:bad')
+    expect(report.facts[0]?.status).toBe('unresolved')
+  })
+
+  it('weak evidence updates currentBestState without resolving', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:w', supportsState: 'occupied', strength: 'weak' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.currentBestState).toBe('occupied')
+    expect(report.facts[0]?.status).toBe('unresolved')
+  })
+
+  it('moderate evidence updates currentBestState without resolving', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:m', supportsState: 'sealed', strength: 'moderate' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.currentBestState).toBe('sealed')
+    expect(report.facts[0]?.status).toBe('unresolved')
+  })
+
+  it('strong evidence updates currentBestState without resolving', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:s', supportsState: 'clear', strength: 'strong' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.currentBestState).toBe('clear')
+    expect(report.facts[0]?.status).toBe('unresolved')
+  })
+
+  it('decisive evidence resolves the fact', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:d', supportsState: 'sealed', strength: 'decisive' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.status).toBe('resolved')
+    expect(report.facts[0]?.resolvedState).toBe('sealed')
+    expect(report.facts[0]?.currentBestState).toBe('sealed')
+  })
+
+  it('context.week sets resolvedAtWeek when resolving', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:d', supportsState: 'clear', strength: 'decisive' })]
+    const report = evaluateUncertainWorldStateFacts({
+      facts: [fact],
+      evidence,
+      context: { week: 12 },
+    })
+    expect(report.facts[0]?.resolvedAtWeek).toBe(12)
+  })
+
+  it('check minimumStrength filters weaker evidence', () => {
+    const fact = baseFact({ factId: 'fact:x' })
+    const evidence = [
+      {
+        evidenceId: 'ev:w',
+        factId: 'fact:x',
+        subjectId: 'subject:room-1',
+        supportsState: 'clear',
+        strength: 'weak' as const,
+        source: 'report' as const,
+      },
+    ]
+    const report = evaluateUncertainWorldStateFacts({
+      facts: [fact],
+      evidence,
+      checks: [
+        {
+          checkId: 'check:audit',
+          factId: 'fact:x',
+          trigger: 'operator_review',
+          minimumStrength: 'strong',
+        },
+      ],
+    })
+    expect(report.facts[0]?.status).toBe('unresolved')
+    expect(report.facts[0]?.currentBestState).toBeUndefined()
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toContain('ev:w')
+  })
+
+  it('preserves check trigger (and id) in resolution note', () => {
+    const fact = baseFact({ factId: 'fact:x' })
+    const evidence = [
+      {
+        evidenceId: 'ev:s',
+        factId: 'fact:x',
+        subjectId: 'subject:room-1',
+        supportsState: 'clear',
+        strength: 'strong' as const,
+        source: 'report' as const,
+      },
+    ]
+    const report = evaluateUncertainWorldStateFacts({
+      facts: [fact],
+      evidence,
+      checks: [
+        {
+          checkId: 'check:map',
+          factId: 'fact:x',
+          trigger: 'map_update',
+          minimumStrength: 'moderate',
+        },
+      ],
+    })
+    expect(report.resolutions[0]?.note).toContain('check:map')
+    expect(report.resolutions[0]?.note).toContain('map_update')
+  })
+
+  it('ignores later conflicting decisive evidence when allowSupersession is false', () => {
+    const fact = baseFact({
+      status: 'resolved',
+      resolvedState: 'clear',
+      currentBestState: 'clear',
+      allowSupersession: false,
+    })
+    const evidence = [ev({ evidenceId: 'ev:flip', supportsState: 'occupied', strength: 'decisive' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.resolvedState).toBe('clear')
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toContain('ev:flip')
+  })
+
+  it('supersedes prior resolution when allowSupersession is true', () => {
+    const fact = baseFact({
+      status: 'resolved',
+      resolvedState: 'clear',
+      currentBestState: 'clear',
+      allowSupersession: true,
+    })
+    const evidence = [ev({ evidenceId: 'ev:flip', supportsState: 'occupied', strength: 'decisive' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.resolvedState).toBe('occupied')
+    expect(report.facts[0]?.status).toBe('resolved')
+    expect(report.resolutions[0]?.note.toLowerCase()).toContain('supersed')
+    expect(report.resolutions[0]?.appliedEvidenceIds).toContain('ev:flip')
+  })
+
+  it('applies evidence in deterministic order (strength then evidenceId)', () => {
+    const fact = baseFact({})
+    const evidence: UncertainWorldStateEvidence[] = [
+      ev({ evidenceId: 'ev:b', supportsState: 'sealed', strength: 'weak' }),
+      ev({ evidenceId: 'ev:a', supportsState: 'clear', strength: 'weak' }),
+      ev({ evidenceId: 'ev:c', supportsState: 'occupied', strength: 'moderate' }),
+    ]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.currentBestState).toBe('occupied')
+  })
+
+  it('outputs facts sorted by factId', () => {
+    const f1 = baseFact({ factId: 'fact:z' })
+    const f2 = baseFact({ factId: 'fact:a' })
+    const report = evaluateUncertainWorldStateFacts({ facts: [f1, f2], evidence: [] })
+    expect(report.facts.map((f) => f.factId)).toEqual(['fact:a', 'fact:z'])
+  })
+
+  it('deduplicates appliedEvidenceIds', () => {
+    const fact = baseFact({ appliedEvidenceIds: ['ev:old'] })
+    const evidence = [
+      ev({ evidenceId: 'ev:old', supportsState: 'clear', strength: 'weak' }),
+      ev({ evidenceId: 'ev:old', supportsState: 'occupied', strength: 'moderate' }),
+    ]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    const applied = report.facts[0]?.appliedEvidenceIds ?? []
+    expect(applied.filter((id) => id === 'ev:old').length).toBe(1)
+  })
+
+  it('does not mutate input fact, evidence, checks, or nested arrays', () => {
+    const fact = baseFact({
+      possibleStates: ['a', 'b'],
+      appliedEvidenceIds: ['x'],
+    })
+    const ps = fact.possibleStates
+    const applied = fact.appliedEvidenceIds
+    const evidence = [ev({ evidenceId: 'e1', supportsState: 'a', strength: 'decisive' })]
+    const checks = [
+      { checkId: 'c1', factId: 'fact:room-1', trigger: 'new_evidence' as const, minimumStrength: 'weak' as const },
+    ]
+    evaluateUncertainWorldStateFacts({ facts: [fact], evidence, checks })
+    expect(fact.possibleStates).toBe(ps)
+    expect(fact.appliedEvidenceIds).toBe(applied)
+    expect(fact.possibleStates).toEqual(['a', 'b'])
+    expect(evidence[0]?.supportsState).toBe('a')
+    expect(checks[0]?.checkId).toBe('c1')
+  })
+
+  it('uncertainWorldState stays dependency-free — no imports (no GameState / branch continuity / map awareness wiring)', () => {
+    const srcPath = path.join(__dirname, '../domain/uncertainWorldState.ts')
+    const src = readFileSync(srcPath, 'utf8')
+    expect(/^import\b/m.test(src)).toBe(false)
+  })
+
+  it('covers unseen_room_state and unverified_subject_property fact kinds', () => {
+    const room = baseFact({ factId: 'f1', factKind: 'unseen_room_state' })
+    const prop = baseFact({
+      factId: 'f2',
+      factKind: 'unverified_subject_property',
+      subjectId: 'anomaly:scp-foo',
+      question: 'Is the subject regenerating?',
+      possibleStates: ['yes', 'no'],
+    })
+    const evidence: UncertainWorldStateEvidence[] = [
+      { ...ev({ evidenceId: 'e1', factId: 'f1' }), supportsState: 'clear', strength: 'strong' },
+      {
+        evidenceId: 'e2',
+        factId: 'f2',
+        subjectId: 'anomaly:scp-foo',
+        supportsState: 'no',
+        strength: 'decisive',
+        source: 'system',
+      },
+    ]
+    const report = evaluateUncertainWorldStateFacts({ facts: [room, prop], evidence })
+    const byId = Object.fromEntries(report.facts.map((f) => [f.factId, f]))
+    expect(byId['f1']?.factKind).toBe('unseen_room_state')
+    expect(byId['f1']?.status).toBe('unresolved')
+    expect(byId['f2']?.factKind).toBe('unverified_subject_property')
+    expect(byId['f2']?.status).toBe('resolved')
+  })
+
+  it('resolveUncertainWorldStateCheck mirrors single-fact evaluation', () => {
+    const fact = baseFact({})
+    const check = { checkId: 'c', factId: 'fact:room-1', trigger: 'observer_access' as const }
+    const resolution = resolveUncertainWorldStateCheck({
+      fact,
+      evidence: [ev({ evidenceId: 'e', supportsState: 'sealed', strength: 'moderate' })],
+      check,
+    })
+    const full = evaluateUncertainWorldStateFacts({
+      facts: [fact],
+      evidence: [ev({ evidenceId: 'e', supportsState: 'sealed', strength: 'moderate' })],
+      checks: [check],
+    })
+    expect(resolution).toMatchObject(full.resolutions[0] ?? {})
+  })
+
+  it('is deterministic across identical runs', () => {
+    const fact = baseFact({ factId: 'f-mid' })
+    const facts = [
+      baseFact({ factId: 'f-z' }),
+      fact,
+      baseFact({ factId: 'f-a' }),
+    ]
+    const evidence = [
+      ev({ evidenceId: 'e2', factId: 'f-mid', supportsState: 'occupied', strength: 'weak' }),
+      ev({ evidenceId: 'e1', factId: 'f-mid', supportsState: 'clear', strength: 'decisive' }),
+    ]
+    const a = evaluateUncertainWorldStateFacts({ facts, evidence })
+    const b = evaluateUncertainWorldStateFacts({ facts, evidence })
+    expect(a).toEqual(b)
+  })
+})

--- a/src/test/uncertainWorldState.test.ts
+++ b/src/test/uncertainWorldState.test.ts
@@ -109,6 +109,58 @@ describe('uncertainWorldState (SPE-1317)', () => {
     expect(report.facts[0]?.currentBestState).toBe('sealed')
   })
 
+  it('resolves unresolved facts so report currentBestState matches resolvedState', () => {
+    const fact = baseFact({})
+    const evidence = [ev({ evidenceId: 'ev:d', supportsState: 'sealed', strength: 'decisive' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    const f = report.facts[0]
+    const r = report.resolutions[0]
+    expect(f?.resolvedState).toBe('sealed')
+    expect(f?.currentBestState).toBe('sealed')
+    expect(r?.resolvedState).toBe('sealed')
+    expect(r?.currentBestState).toBe('sealed')
+  })
+
+  it('already resolved fact ignores weak evidence for another state (no currentBest drift)', () => {
+    const fact = baseFact({
+      status: 'resolved',
+      resolvedState: 'clear',
+      currentBestState: 'clear',
+    })
+    const evidence = [ev({ evidenceId: 'ev:nudge', supportsState: 'occupied', strength: 'weak' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.resolvedState).toBe('clear')
+    expect(report.facts[0]?.currentBestState).toBe('clear')
+    expect(report.resolutions[0]?.currentBestState).toBe('clear')
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toContain('ev:nudge')
+  })
+
+  it('already resolved fact ignores moderate evidence for another state', () => {
+    const fact = baseFact({
+      status: 'resolved',
+      resolvedState: 'clear',
+      currentBestState: 'clear',
+    })
+    const evidence = [ev({ evidenceId: 'ev:m2', supportsState: 'sealed', strength: 'moderate' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.resolvedState).toBe('clear')
+    expect(report.facts[0]?.currentBestState).toBe('clear')
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toContain('ev:m2')
+  })
+
+  it('already resolved fact ignores strong evidence for another state', () => {
+    const fact = baseFact({
+      status: 'resolved',
+      resolvedState: 'clear',
+      currentBestState: 'clear',
+    })
+    const evidence = [ev({ evidenceId: 'ev:s2', supportsState: 'occupied', strength: 'strong' })]
+    const report = evaluateUncertainWorldStateFacts({ facts: [fact], evidence })
+    expect(report.facts[0]?.resolvedState).toBe('clear')
+    expect(report.facts[0]?.currentBestState).toBe('clear')
+    expect(report.resolutions[0]?.ignoredEvidenceIds).toContain('ev:s2')
+  })
+
   it('context.week sets resolvedAtWeek when resolving', () => {
     const fact = baseFact({})
     const evidence = [ev({ evidenceId: 'ev:d', supportsState: 'clear', strength: 'decisive' })]


### PR DESCRIPTION
## Linear
https://linear.app/spectranoir/issue/SPE-1317/uncertain-world-state-checks

## Smallest boundary
Pure deterministic `evaluateUncertainWorldStateFacts` (plus optional single-fact wrapper) with immutable inputs — no persistence, UI, runtime hooks, branch-continuity wiring, map/knowledge adapters, probabilistic resolution, SPE-1085 canon scope, or action resolution changes.

## Files changed
- `src/domain/uncertainWorldState.ts`
- `src/test/uncertainWorldState.test.ts`

## Validation (latest push)
Review-harden commit: [`f0475cc`](https://github.com/JamesJedi420/containment-protocol/commit/f0475cc) on [`jamesdyedbq/spe-1317-uncertain-world-state-evaluator`](https://github.com/JamesJedi420/containment-protocol/compare/main...jamesdyedbq/spe-1317-uncertain-world-state-evaluator).
- `npm run test:run -- src/test/uncertainWorldState.test.ts` (26 examples)
- `npm run test:run -- src/test/branchContinuity.test.ts src/test/branchContinuityAudit.test.ts`
- `npm run test:run -- src/test/sim.mapAwareness.test.ts`
- `npm run lint`
- `npm run test:run` full suite (**326** files, **3063** tests)

Note: repo has no `src/test/knowledge.test.ts` filter target (Vitest reports no matching file).

## Review-harden (in slice)
- Resolved facts ignore weak/moderate/strong contradiction evidence (tracked in deterministic `ignoredEvidenceIds` via a `Set`); outputs run through `finalizeCanonicalStates` so `currentBestState` matches `resolvedState` when `resolvedState` is known after evaluation.
- Group evidence by `factId` once per batch; index checks once per batch (then per-fact list only).
- Check fragments sorted for stable notes when multiple checks apply.

## Gap / edge-case / boundary audit (pre-merge)

1. **Unresolved correctness** — `unresolved` is preserved with no/zero applicable evidence; non-decisive strengths only advance `currentBestState` while still `unresolved`; decisive promotes to `resolved` with aligned `resolvedState` / `currentBestState`; `possibleStates` guard enforced.

2. **Resolved-state consistency** — For `resolved` outputs with a canonical `resolvedState`, `currentBestState` mirrors it on both facts and resolutions; contradictory non-decisive evidence is ignored, not merged into `appliedEvidenceIds`.

3. **Evidence / collapse** — Wrong `factId`, `subjectId`, or state outside `possibleStates` routed to ignored; check `minimumStrength` uses strictest gate when multiple checks share a fact; conflicting decisive respects `allowSupersession`; reinforcing decisive same state merges ids.

4. **Determinism / mutation** — Facts and resolutions emitted in sorted `factId` order; applicable evidence sorted strength asc then `evidenceId` asc; `appliedEvidenceIds` / ignored ids sorted uniquely from sets; shallow copies for outputs; nested arrays duplicated where needed (`possibleStates`).

5. **Boundary** — Module has zero runtime imports (`import` assertions in tests); no GameState aggregates, continuity, map-awareness coupling; no RNG/probability paths.

6. **Documentation** — SPE-1317 module banner narrowed for resolved-vs-best behavioral contract.

## Out of scope (explicit)
GameState persistence, UI, simulation hooks, branch-continuity / map-projection adapters, observer/sensors, probabilistic dice, canon/lore SPE-1085 systems, mission/action resolution edits, backlog/planning doc churn.

## Test plan for reviewers
- Run targeted uncertain-world-state suite above (includes resolved-fact drift regression cases).
- Sanity: reinforcing vs superseding decisive on an already resolved fact (`allowSupersession` toggles behavior).
