### PR TITLE
SPE-2010: Add staff treatment telemetry comparator

### DIFF
--- a/src/domain/staffTreatmentTelemetry.ts
+++ b/src/domain/staffTreatmentTelemetry.ts
@@ -1,0 +1,558 @@
+/**
+ * SPE-2010: deterministic staff doctrine-alignment vs treatment-efficacy telemetry.
+ *
+ * Compares independent institutional belief-compliance signals with independent
+ * patient/subject outcome signals to detect decoupling (high alignment + poor outcomes,
+ * low alignment + good outcomes, material expected-vs-actual gaps).
+ *
+ * Does not enforce doctrine, route blame, render scorecards, persist GameState,
+ * import uncertainWorldState, or model real-world medical diagnoses.
+ */
+
+export type StaffDoctrineAlignmentSource =
+  | 'certification'
+  | 'training'
+  | 'directive'
+  | 'audit'
+  | 'manual'
+
+export interface StaffDoctrineAlignmentSignal {
+  staffId: string
+  doctrineId: string
+  alignmentScore: number
+  source: StaffDoctrineAlignmentSource
+  week?: number
+  signalId?: string
+}
+
+export interface TreatmentEfficacySignal {
+  subjectId: string
+  protocolId: string
+  staffId?: string
+  expectedOutcomeScore: number
+  actualOutcomeScore: number
+  symptomBurdenDelta?: number
+  escalationCount?: number
+  week?: number
+  signalId?: string
+}
+
+export type StaffTreatmentTelemetryFindingKind =
+  | 'high_alignment_low_efficacy'
+  | 'low_alignment_high_efficacy'
+  | 'outcome_below_expected'
+  | 'alignment_outcome_decoupled'
+  | 'insufficient_evidence'
+
+export interface StaffTreatmentTelemetryFinding {
+  kind: StaffTreatmentTelemetryFindingKind
+  staffId: string
+  subjectId?: string
+  doctrineId?: string
+  protocolId?: string
+  week?: number
+  alignmentScore?: number
+  efficacyScore?: number
+  expectedOutcomeScore?: number
+  actualOutcomeScore?: number
+  outcomeGap?: number
+  detail: string
+}
+
+export interface StaffTreatmentTelemetryOptions {
+  highAlignmentThreshold?: number
+  lowAlignmentThreshold?: number
+  lowEfficacyThreshold?: number
+  highEfficacyThreshold?: number
+  outcomeGapThreshold?: number
+  minimumEvidenceCount?: number
+}
+
+export interface StaffTreatmentTelemetryReport {
+  findings: readonly StaffTreatmentTelemetryFinding[]
+  summary: {
+    pairedObservationCount: number
+    insufficientEvidenceCount: number
+    highAlignmentLowEfficacyCount: number
+    lowAlignmentHighEfficacyCount: number
+    outcomeBelowExpectedCount: number
+    alignmentOutcomeDecoupledCount: number
+    unpairedAlignmentSignalCount: number
+    unpairedOutcomeSignalCount: number
+  }
+  lines: readonly string[]
+}
+
+export interface StaffTreatmentTelemetryInput {
+  staffSignals: readonly StaffDoctrineAlignmentSignal[]
+  treatmentOutcomes: readonly TreatmentEfficacySignal[]
+  options?: StaffTreatmentTelemetryOptions
+}
+
+const FINDING_KIND_ORDER: readonly StaffTreatmentTelemetryFindingKind[] = [
+  'high_alignment_low_efficacy',
+  'low_alignment_high_efficacy',
+  'outcome_below_expected',
+  'alignment_outcome_decoupled',
+  'insufficient_evidence',
+]
+
+const DEFAULT_OPTIONS: Required<StaffTreatmentTelemetryOptions> = {
+  highAlignmentThreshold: 70,
+  lowAlignmentThreshold: 40,
+  lowEfficacyThreshold: 40,
+  highEfficacyThreshold: 70,
+  outcomeGapThreshold: 15,
+  minimumEvidenceCount: 1,
+}
+
+type ScoreBand = 'high' | 'mid' | 'low'
+
+interface AlignmentBucket {
+  staffId: string
+  week?: number
+  alignmentScores: number[]
+  doctrineIds: string[]
+}
+
+interface OutcomeBucket {
+  staffId: string
+  week?: number
+  outcomes: TreatmentEfficacySignal[]
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function normalizeWeek(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined
+  }
+  return Math.max(0, Math.trunc(value))
+}
+
+function resolveAlignmentSignalId(signal: StaffDoctrineAlignmentSignal): string {
+  const explicit = typeof signal.signalId === 'string' ? signal.signalId.trim() : ''
+  if (explicit.length > 0) {
+    return explicit
+  }
+  const week = normalizeWeek(signal.week)
+  return `align:${signal.staffId}:${signal.doctrineId}:${signal.source}:${week ?? ''}`
+}
+
+function resolveOutcomeSignalId(signal: TreatmentEfficacySignal): string {
+  const explicit = typeof signal.signalId === 'string' ? signal.signalId.trim() : ''
+  if (explicit.length > 0) {
+    return explicit
+  }
+  const week = normalizeWeek(signal.week)
+  return `outcome:${signal.subjectId}:${signal.protocolId}:${signal.staffId ?? ''}:${week ?? ''}`
+}
+
+function dedupeBySignalId<T extends { signalId?: string }>(
+  rows: readonly T[],
+  resolveId: (row: T) => string
+): T[] {
+  const sorted = [...rows].sort((left, right) =>
+    resolveId(left).localeCompare(resolveId(right))
+  )
+  const seen = new Set<string>()
+  const deduped: T[] = []
+  for (const row of sorted) {
+    const id = resolveId(row)
+    if (seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    deduped.push(row)
+  }
+  return deduped
+}
+
+function bucketKey(staffId: string, week: number | undefined): string {
+  const normalizedStaff = staffId.trim()
+  if (week !== undefined) {
+    return `${normalizedStaff}\0${week}`
+  }
+  return `${normalizedStaff}\0`
+}
+
+function parseBucketKey(key: string): { staffId: string; week?: number } {
+  const parts = key.split('\0')
+  const staffId = parts[0] ?? ''
+  const weekPart = parts[1]
+  if (weekPart === undefined || weekPart.length === 0) {
+    return { staffId }
+  }
+  return { staffId, week: Number(weekPart) }
+}
+
+function meanRounded(values: readonly number[]): number {
+  if (values.length === 0) {
+    return 0
+  }
+  const sum = values.reduce((total, value) => total + value, 0)
+  return Math.round(sum / values.length)
+}
+
+function classifyBand(
+  score: number,
+  highThreshold: number,
+  lowThreshold: number
+): ScoreBand {
+  if (score >= highThreshold) {
+    return 'high'
+  }
+  if (score <= lowThreshold) {
+    return 'low'
+  }
+  return 'mid'
+}
+
+function bandsDiverge(alignmentBand: ScoreBand, efficacyBand: ScoreBand): boolean {
+  if (alignmentBand === efficacyBand) {
+    return false
+  }
+  if (alignmentBand === 'mid' || efficacyBand === 'mid') {
+    return true
+  }
+  return alignmentBand !== efficacyBand
+}
+
+function compareFindings(
+  left: StaffTreatmentTelemetryFinding,
+  right: StaffTreatmentTelemetryFinding
+): number {
+  const kindDelta =
+    FINDING_KIND_ORDER.indexOf(left.kind) - FINDING_KIND_ORDER.indexOf(right.kind)
+  if (kindDelta !== 0) {
+    return kindDelta
+  }
+  const staffDelta = left.staffId.localeCompare(right.staffId)
+  if (staffDelta !== 0) {
+    return staffDelta
+  }
+  const subjectDelta = (left.subjectId ?? '').localeCompare(right.subjectId ?? '')
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+  const weekLeft = left.week ?? -1
+  const weekRight = right.week ?? -1
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+  return (left.protocolId ?? '').localeCompare(right.protocolId ?? '')
+}
+
+function resolveOptions(
+  options: StaffTreatmentTelemetryOptions | undefined
+): Required<StaffTreatmentTelemetryOptions> {
+  return {
+    highAlignmentThreshold:
+      options?.highAlignmentThreshold ?? DEFAULT_OPTIONS.highAlignmentThreshold,
+    lowAlignmentThreshold:
+      options?.lowAlignmentThreshold ?? DEFAULT_OPTIONS.lowAlignmentThreshold,
+    lowEfficacyThreshold: options?.lowEfficacyThreshold ?? DEFAULT_OPTIONS.lowEfficacyThreshold,
+    highEfficacyThreshold:
+      options?.highEfficacyThreshold ?? DEFAULT_OPTIONS.highEfficacyThreshold,
+    outcomeGapThreshold: options?.outcomeGapThreshold ?? DEFAULT_OPTIONS.outcomeGapThreshold,
+    minimumEvidenceCount:
+      options?.minimumEvidenceCount ?? DEFAULT_OPTIONS.minimumEvidenceCount,
+  }
+}
+
+function normalizeAlignmentSignal(
+  signal: StaffDoctrineAlignmentSignal
+): StaffDoctrineAlignmentSignal {
+  return {
+    ...signal,
+    staffId: signal.staffId.trim(),
+    doctrineId: signal.doctrineId.trim(),
+    alignmentScore: clampScore(signal.alignmentScore),
+    week: normalizeWeek(signal.week),
+  }
+}
+
+function normalizeOutcomeSignal(signal: TreatmentEfficacySignal): TreatmentEfficacySignal {
+  return {
+    ...signal,
+    subjectId: signal.subjectId.trim(),
+    protocolId: signal.protocolId.trim(),
+    staffId: typeof signal.staffId === 'string' ? signal.staffId.trim() : undefined,
+    expectedOutcomeScore: clampScore(signal.expectedOutcomeScore),
+    actualOutcomeScore: clampScore(signal.actualOutcomeScore),
+    week: normalizeWeek(signal.week),
+  }
+}
+
+function buildOutcomeBuckets(
+  outcomes: readonly TreatmentEfficacySignal[]
+): Map<string, OutcomeBucket> {
+  const buckets = new Map<string, OutcomeBucket>()
+  for (const outcome of outcomes) {
+    if (!outcome.staffId || outcome.staffId.length === 0) {
+      continue
+    }
+    const week = outcome.week
+    const key = bucketKey(outcome.staffId, week)
+    const existing = buckets.get(key)
+    if (existing) {
+      existing.outcomes.push(outcome)
+    } else {
+      buckets.set(key, { staffId: outcome.staffId, week, outcomes: [outcome] })
+    }
+  }
+  return buckets
+}
+
+function resolvePairedOutcomes(
+  alignmentBucket: AlignmentBucket,
+  outcomeBuckets: Map<string, OutcomeBucket>
+): TreatmentEfficacySignal[] {
+  const staffId = alignmentBucket.staffId
+  if (alignmentBucket.week !== undefined) {
+    const exact = outcomeBuckets.get(bucketKey(staffId, alignmentBucket.week))
+    if (exact && exact.outcomes.length > 0) {
+      return exact.outcomes
+    }
+  }
+  const fallback = outcomeBuckets.get(bucketKey(staffId, undefined))
+  return fallback?.outcomes ?? []
+}
+
+function summarizeOutcomes(outcomes: readonly TreatmentEfficacySignal[]): {
+  efficacyScore: number
+  worstGap: number
+  worstOutcome?: TreatmentEfficacySignal
+} {
+  if (outcomes.length === 0) {
+    return { efficacyScore: 0, worstGap: 0 }
+  }
+
+  let efficacyTotal = 0
+  let worstGap = 0
+  let worstOutcome: TreatmentEfficacySignal | undefined
+
+  for (const outcome of outcomes) {
+    efficacyTotal += clampScore(outcome.actualOutcomeScore)
+    const gap = clampScore(outcome.expectedOutcomeScore) - clampScore(outcome.actualOutcomeScore)
+    if (gap > worstGap) {
+      worstGap = gap
+      worstOutcome = outcome
+    }
+  }
+
+  return {
+    efficacyScore: Math.round(efficacyTotal / outcomes.length),
+    worstGap,
+    worstOutcome,
+  }
+}
+
+function formatReportLines(findings: readonly StaffTreatmentTelemetryFinding[]): string[] {
+  if (findings.length === 0) {
+    return ['Staff treatment telemetry: no findings']
+  }
+  return [
+    'Staff treatment telemetry report',
+    ...findings.map(
+      (finding) =>
+        `[${finding.kind}] staff=${finding.staffId}` +
+        (finding.week !== undefined ? ` week=${finding.week}` : '') +
+        (finding.subjectId ? ` subject=${finding.subjectId}` : '') +
+        `: ${finding.detail}`
+    ),
+  ]
+}
+
+export function buildStaffTreatmentTelemetryReport(
+  input: StaffTreatmentTelemetryInput
+): StaffTreatmentTelemetryReport {
+  const options = resolveOptions(input.options)
+
+  const staffSignals = dedupeBySignalId(
+    input.staffSignals.map(normalizeAlignmentSignal),
+    resolveAlignmentSignalId
+  )
+  const treatmentOutcomes = dedupeBySignalId(
+    input.treatmentOutcomes.map(normalizeOutcomeSignal),
+    resolveOutcomeSignalId
+  )
+
+  const outcomeBuckets = buildOutcomeBuckets(treatmentOutcomes)
+  const unpairedOutcomeSignalCount = treatmentOutcomes.filter(
+    (outcome) => !outcome.staffId || outcome.staffId.length === 0
+  ).length
+
+  const alignmentBuckets = new Map<string, AlignmentBucket>()
+  for (const signal of staffSignals) {
+    if (signal.staffId.length === 0) {
+      continue
+    }
+    const key = bucketKey(signal.staffId, signal.week)
+    const existing = alignmentBuckets.get(key)
+    if (existing) {
+      existing.alignmentScores.push(signal.alignmentScore)
+      existing.doctrineIds.push(signal.doctrineId)
+    } else {
+      alignmentBuckets.set(key, {
+        staffId: signal.staffId,
+        week: signal.week,
+        alignmentScores: [signal.alignmentScore],
+        doctrineIds: [signal.doctrineId],
+      })
+    }
+  }
+
+  const findings: StaffTreatmentTelemetryFinding[] = []
+  let pairedObservationCount = 0
+
+  for (const [key, alignmentBucket] of alignmentBuckets) {
+    const pairedOutcomes = resolvePairedOutcomes(alignmentBucket, outcomeBuckets)
+    const meanAlignment = meanRounded(alignmentBucket.alignmentScores)
+    const doctrineId = alignmentBucket.doctrineIds[0]
+    const { staffId, week } = parseBucketKey(key)
+
+    if (pairedOutcomes.length < options.minimumEvidenceCount) {
+      findings.push({
+        kind: 'insufficient_evidence',
+        staffId,
+        doctrineId,
+        week: alignmentBucket.week ?? week,
+        alignmentScore: meanAlignment,
+        detail:
+          pairedOutcomes.length === 0
+            ? 'Doctrine alignment recorded without linkable treatment outcomes for this staff bucket.'
+            : `Fewer than ${options.minimumEvidenceCount} treatment outcome signal(s) for comparison.`,
+      })
+      continue
+    }
+
+    pairedObservationCount += pairedOutcomes.length
+    const { efficacyScore, worstGap, worstOutcome } = summarizeOutcomes(pairedOutcomes)
+    const alignmentBand = classifyBand(
+      meanAlignment,
+      options.highAlignmentThreshold,
+      options.lowAlignmentThreshold
+    )
+    const efficacyBand = classifyBand(
+      efficacyScore,
+      options.highEfficacyThreshold,
+      options.lowEfficacyThreshold
+    )
+
+    const subjectId = worstOutcome?.subjectId
+    const protocolId = worstOutcome?.protocolId
+    const sharedWeek =
+      alignmentBucket.week !== undefined &&
+      pairedOutcomes.some((outcome) => outcome.week === alignmentBucket.week)
+        ? alignmentBucket.week
+        : undefined
+
+    let primaryMismatchEmitted = false
+
+    if (alignmentBand === 'high' && efficacyBand === 'low') {
+      primaryMismatchEmitted = true
+      findings.push({
+        kind: 'high_alignment_low_efficacy',
+        staffId,
+        doctrineId,
+        subjectId,
+        protocolId,
+        week: sharedWeek,
+        alignmentScore: meanAlignment,
+        efficacyScore,
+        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        outcomeGap: worstGap,
+        detail:
+          'High institutional doctrine alignment coexists with low treatment efficacy for linked outcomes.',
+      })
+    }
+
+    if (alignmentBand === 'low' && efficacyBand === 'high') {
+      primaryMismatchEmitted = true
+      findings.push({
+        kind: 'low_alignment_high_efficacy',
+        staffId,
+        doctrineId,
+        subjectId,
+        protocolId,
+        week: sharedWeek,
+        alignmentScore: meanAlignment,
+        efficacyScore,
+        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        outcomeGap: worstGap,
+        detail:
+          'Low doctrine alignment coexists with high treatment efficacy for linked outcomes.',
+      })
+    }
+
+    if (worstGap >= options.outcomeGapThreshold) {
+      findings.push({
+        kind: 'outcome_below_expected',
+        staffId,
+        doctrineId,
+        subjectId,
+        protocolId,
+        week: sharedWeek,
+        alignmentScore: meanAlignment,
+        efficacyScore,
+        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        outcomeGap: worstGap,
+        detail: `Observed outcome trails expectation by ${worstGap} points in this staff bucket.`,
+      })
+    }
+
+    const decoupledByBands =
+      !primaryMismatchEmitted && bandsDiverge(alignmentBand, efficacyBand)
+    const decoupledByMidGap =
+      alignmentBand === 'mid' && worstGap >= options.outcomeGapThreshold
+    if (decoupledByBands || decoupledByMidGap) {
+      findings.push({
+        kind: 'alignment_outcome_decoupled',
+        staffId,
+        doctrineId,
+        subjectId,
+        protocolId,
+        week: sharedWeek,
+        alignmentScore: meanAlignment,
+        efficacyScore,
+        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        outcomeGap: worstGap,
+        detail:
+          'Doctrine alignment band and treatment efficacy band diverge without an extreme high/low pairing.',
+      })
+    }
+  }
+
+  findings.sort(compareFindings)
+
+  const countByKind = (kind: StaffTreatmentTelemetryFindingKind) =>
+    findings.filter((finding) => finding.kind === kind).length
+
+  const report: StaffTreatmentTelemetryReport = {
+    findings,
+    summary: {
+      pairedObservationCount,
+      insufficientEvidenceCount: countByKind('insufficient_evidence'),
+      highAlignmentLowEfficacyCount: countByKind('high_alignment_low_efficacy'),
+      lowAlignmentHighEfficacyCount: countByKind('low_alignment_high_efficacy'),
+      outcomeBelowExpectedCount: countByKind('outcome_below_expected'),
+      alignmentOutcomeDecoupledCount: countByKind('alignment_outcome_decoupled'),
+      unpairedAlignmentSignalCount: staffSignals.filter((signal) => signal.staffId.length === 0)
+        .length,
+      unpairedOutcomeSignalCount,
+    },
+    lines: formatReportLines(findings),
+  }
+
+  return report
+}

--- a/src/domain/staffTreatmentTelemetry.ts
+++ b/src/domain/staffTreatmentTelemetry.ts
@@ -5,6 +5,9 @@
  * patient/subject outcome signals to detect decoupling (high alignment + poor outcomes,
  * low alignment + good outcomes, material expected-vs-actual gaps).
  *
+ * Alignment buckets are keyed by staff, doctrine, and optional week so findings
+ * attribute doctrine adherence per policy, not the first doctrine in a merged bucket.
+ *
  * Does not enforce doctrine, route blame, render scorecards, persist GameState,
  * import uncertainWorldState, or model real-world medical diagnoses.
  */
@@ -110,9 +113,9 @@ type ScoreBand = 'high' | 'mid' | 'low'
 
 interface AlignmentBucket {
   staffId: string
+  doctrineId: string
   week?: number
   alignmentScores: number[]
-  doctrineIds: string[]
 }
 
 interface OutcomeBucket {
@@ -133,6 +136,13 @@ function normalizeWeek(value: number | undefined): number | undefined {
     return undefined
   }
   return Math.max(0, Math.trunc(value))
+}
+
+function normalizeMinimumEvidenceCount(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_OPTIONS.minimumEvidenceCount
+  }
+  return Math.max(1, Math.trunc(value))
 }
 
 function resolveAlignmentSignalId(signal: StaffDoctrineAlignmentSignal): string {
@@ -173,7 +183,7 @@ function dedupeBySignalId<T extends { signalId?: string }>(
   return deduped
 }
 
-function bucketKey(staffId: string, week: number | undefined): string {
+function staffOutcomeBucketKey(staffId: string, week: number | undefined): string {
   const normalizedStaff = staffId.trim()
   if (week !== undefined) {
     return `${normalizedStaff}\0${week}`
@@ -181,14 +191,28 @@ function bucketKey(staffId: string, week: number | undefined): string {
   return `${normalizedStaff}\0`
 }
 
-function parseBucketKey(key: string): { staffId: string; week?: number } {
+function alignmentBucketKey(
+  staffId: string,
+  doctrineId: string,
+  week: number | undefined
+): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `${staffId.trim()}\0${doctrineId.trim()}\0${weekPart}`
+}
+
+function parseAlignmentBucketKey(key: string): {
+  staffId: string
+  doctrineId: string
+  week?: number
+} {
   const parts = key.split('\0')
   const staffId = parts[0] ?? ''
-  const weekPart = parts[1]
+  const doctrineId = parts[1] ?? ''
+  const weekPart = parts[2]
   if (weekPart === undefined || weekPart.length === 0) {
-    return { staffId }
+    return { staffId, doctrineId }
   }
-  return { staffId, week: Number(weekPart) }
+  return { staffId, doctrineId, week: Number(weekPart) }
 }
 
 function meanRounded(values: readonly number[]): number {
@@ -223,6 +247,21 @@ function bandsDiverge(alignmentBand: ScoreBand, efficacyBand: ScoreBand): boolea
   return alignmentBand !== efficacyBand
 }
 
+function decoupledDetail(decoupledByBands: boolean, decoupledByMidGap: boolean): string {
+  if (decoupledByBands && decoupledByMidGap) {
+    return (
+      'Doctrine alignment band and treatment efficacy band diverge without an extreme high/low pairing, ' +
+      'and the expected-vs-actual outcome gap exceeds the threshold while scores remain in overlapping mid bands.'
+    )
+  }
+  if (decoupledByBands) {
+    return 'Doctrine alignment band and treatment efficacy band diverge without an extreme high/low pairing.'
+  }
+  return (
+    'Doctrine alignment and treatment efficacy remain in the same band, but the expected-vs-actual outcome gap exceeds the threshold.'
+  )
+}
+
 function compareFindings(
   left: StaffTreatmentTelemetryFinding,
   right: StaffTreatmentTelemetryFinding
@@ -235,6 +274,10 @@ function compareFindings(
   const staffDelta = left.staffId.localeCompare(right.staffId)
   if (staffDelta !== 0) {
     return staffDelta
+  }
+  const doctrineDelta = (left.doctrineId ?? '').localeCompare(right.doctrineId ?? '')
+  if (doctrineDelta !== 0) {
+    return doctrineDelta
   }
   const subjectDelta = (left.subjectId ?? '').localeCompare(right.subjectId ?? '')
   if (subjectDelta !== 0) {
@@ -260,8 +303,7 @@ function resolveOptions(
     highEfficacyThreshold:
       options?.highEfficacyThreshold ?? DEFAULT_OPTIONS.highEfficacyThreshold,
     outcomeGapThreshold: options?.outcomeGapThreshold ?? DEFAULT_OPTIONS.outcomeGapThreshold,
-    minimumEvidenceCount:
-      options?.minimumEvidenceCount ?? DEFAULT_OPTIONS.minimumEvidenceCount,
+    minimumEvidenceCount: normalizeMinimumEvidenceCount(options?.minimumEvidenceCount),
   }
 }
 
@@ -298,7 +340,7 @@ function buildOutcomeBuckets(
       continue
     }
     const week = outcome.week
-    const key = bucketKey(outcome.staffId, week)
+    const key = staffOutcomeBucketKey(outcome.staffId, week)
     const existing = buckets.get(key)
     if (existing) {
       existing.outcomes.push(outcome)
@@ -315,29 +357,27 @@ function resolvePairedOutcomes(
 ): TreatmentEfficacySignal[] {
   const staffId = alignmentBucket.staffId
   if (alignmentBucket.week !== undefined) {
-    const exact = outcomeBuckets.get(bucketKey(staffId, alignmentBucket.week))
+    const exact = outcomeBuckets.get(staffOutcomeBucketKey(staffId, alignmentBucket.week))
     if (exact && exact.outcomes.length > 0) {
       return exact.outcomes
     }
   }
-  const fallback = outcomeBuckets.get(bucketKey(staffId, undefined))
+  const fallback = outcomeBuckets.get(staffOutcomeBucketKey(staffId, undefined))
   return fallback?.outcomes ?? []
 }
 
 function summarizeOutcomes(outcomes: readonly TreatmentEfficacySignal[]): {
   efficacyScore: number
   worstGap: number
-  worstOutcome?: TreatmentEfficacySignal
+  worstOutcome: TreatmentEfficacySignal
 } {
-  if (outcomes.length === 0) {
-    return { efficacyScore: 0, worstGap: 0 }
-  }
+  const first = outcomes[0]!
+  let worstOutcome = first
+  let worstGap = clampScore(first.expectedOutcomeScore) - clampScore(first.actualOutcomeScore)
+  let efficacyTotal = clampScore(first.actualOutcomeScore)
 
-  let efficacyTotal = 0
-  let worstGap = 0
-  let worstOutcome: TreatmentEfficacySignal | undefined
-
-  for (const outcome of outcomes) {
+  for (let index = 1; index < outcomes.length; index += 1) {
+    const outcome = outcomes[index]!
     efficacyTotal += clampScore(outcome.actualOutcomeScore)
     const gap = clampScore(outcome.expectedOutcomeScore) - clampScore(outcome.actualOutcomeScore)
     if (gap > worstGap) {
@@ -362,6 +402,7 @@ function formatReportLines(findings: readonly StaffTreatmentTelemetryFinding[]):
     ...findings.map(
       (finding) =>
         `[${finding.kind}] staff=${finding.staffId}` +
+        (finding.doctrineId ? ` doctrine=${finding.doctrineId}` : '') +
         (finding.week !== undefined ? ` week=${finding.week}` : '') +
         (finding.subjectId ? ` subject=${finding.subjectId}` : '') +
         `: ${finding.detail}`
@@ -384,38 +425,34 @@ export function buildStaffTreatmentTelemetryReport(
   )
 
   const outcomeBuckets = buildOutcomeBuckets(treatmentOutcomes)
-  const unpairedOutcomeSignalCount = treatmentOutcomes.filter(
-    (outcome) => !outcome.staffId || outcome.staffId.length === 0
-  ).length
+  const allOutcomeSignalIds = treatmentOutcomes.map((outcome) => resolveOutcomeSignalId(outcome))
+  const pairedOutcomeSignalIds = new Set<string>()
 
   const alignmentBuckets = new Map<string, AlignmentBucket>()
   for (const signal of staffSignals) {
-    if (signal.staffId.length === 0) {
+    if (signal.staffId.length === 0 || signal.doctrineId.length === 0) {
       continue
     }
-    const key = bucketKey(signal.staffId, signal.week)
+    const key = alignmentBucketKey(signal.staffId, signal.doctrineId, signal.week)
     const existing = alignmentBuckets.get(key)
     if (existing) {
       existing.alignmentScores.push(signal.alignmentScore)
-      existing.doctrineIds.push(signal.doctrineId)
     } else {
       alignmentBuckets.set(key, {
         staffId: signal.staffId,
+        doctrineId: signal.doctrineId,
         week: signal.week,
         alignmentScores: [signal.alignmentScore],
-        doctrineIds: [signal.doctrineId],
       })
     }
   }
 
   const findings: StaffTreatmentTelemetryFinding[] = []
-  let pairedObservationCount = 0
 
   for (const [key, alignmentBucket] of alignmentBuckets) {
     const pairedOutcomes = resolvePairedOutcomes(alignmentBucket, outcomeBuckets)
     const meanAlignment = meanRounded(alignmentBucket.alignmentScores)
-    const doctrineId = alignmentBucket.doctrineIds[0]
-    const { staffId, week } = parseBucketKey(key)
+    const { staffId, doctrineId, week } = parseAlignmentBucketKey(key)
 
     if (pairedOutcomes.length < options.minimumEvidenceCount) {
       findings.push({
@@ -432,7 +469,10 @@ export function buildStaffTreatmentTelemetryReport(
       continue
     }
 
-    pairedObservationCount += pairedOutcomes.length
+    for (const outcome of pairedOutcomes) {
+      pairedOutcomeSignalIds.add(resolveOutcomeSignalId(outcome))
+    }
+
     const { efficacyScore, worstGap, worstOutcome } = summarizeOutcomes(pairedOutcomes)
     const alignmentBand = classifyBand(
       meanAlignment,
@@ -445,8 +485,8 @@ export function buildStaffTreatmentTelemetryReport(
       options.lowEfficacyThreshold
     )
 
-    const subjectId = worstOutcome?.subjectId
-    const protocolId = worstOutcome?.protocolId
+    const subjectId = worstOutcome.subjectId
+    const protocolId = worstOutcome.protocolId
     const sharedWeek =
       alignmentBucket.week !== undefined &&
       pairedOutcomes.some((outcome) => outcome.week === alignmentBucket.week)
@@ -466,8 +506,8 @@ export function buildStaffTreatmentTelemetryReport(
         week: sharedWeek,
         alignmentScore: meanAlignment,
         efficacyScore,
-        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
-        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        expectedOutcomeScore: worstOutcome.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome.actualOutcomeScore,
         outcomeGap: worstGap,
         detail:
           'High institutional doctrine alignment coexists with low treatment efficacy for linked outcomes.',
@@ -485,8 +525,8 @@ export function buildStaffTreatmentTelemetryReport(
         week: sharedWeek,
         alignmentScore: meanAlignment,
         efficacyScore,
-        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
-        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        expectedOutcomeScore: worstOutcome.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome.actualOutcomeScore,
         outcomeGap: worstGap,
         detail:
           'Low doctrine alignment coexists with high treatment efficacy for linked outcomes.',
@@ -503,8 +543,8 @@ export function buildStaffTreatmentTelemetryReport(
         week: sharedWeek,
         alignmentScore: meanAlignment,
         efficacyScore,
-        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
-        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        expectedOutcomeScore: worstOutcome.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome.actualOutcomeScore,
         outcomeGap: worstGap,
         detail: `Observed outcome trails expectation by ${worstGap} points in this staff bucket.`,
       })
@@ -513,7 +553,9 @@ export function buildStaffTreatmentTelemetryReport(
     const decoupledByBands =
       !primaryMismatchEmitted && bandsDiverge(alignmentBand, efficacyBand)
     const decoupledByMidGap =
-      alignmentBand === 'mid' && worstGap >= options.outcomeGapThreshold
+      alignmentBand === 'mid' &&
+      efficacyBand === 'mid' &&
+      worstGap >= options.outcomeGapThreshold
     if (decoupledByBands || decoupledByMidGap) {
       findings.push({
         kind: 'alignment_outcome_decoupled',
@@ -524,11 +566,10 @@ export function buildStaffTreatmentTelemetryReport(
         week: sharedWeek,
         alignmentScore: meanAlignment,
         efficacyScore,
-        expectedOutcomeScore: worstOutcome?.expectedOutcomeScore,
-        actualOutcomeScore: worstOutcome?.actualOutcomeScore,
+        expectedOutcomeScore: worstOutcome.expectedOutcomeScore,
+        actualOutcomeScore: worstOutcome.actualOutcomeScore,
         outcomeGap: worstGap,
-        detail:
-          'Doctrine alignment band and treatment efficacy band diverge without an extreme high/low pairing.',
+        detail: decoupledDetail(decoupledByBands, decoupledByMidGap),
       })
     }
   }
@@ -538,17 +579,22 @@ export function buildStaffTreatmentTelemetryReport(
   const countByKind = (kind: StaffTreatmentTelemetryFindingKind) =>
     findings.filter((finding) => finding.kind === kind).length
 
+  const unpairedOutcomeSignalCount = allOutcomeSignalIds.filter(
+    (signalId) => !pairedOutcomeSignalIds.has(signalId)
+  ).length
+
   const report: StaffTreatmentTelemetryReport = {
     findings,
     summary: {
-      pairedObservationCount,
+      pairedObservationCount: pairedOutcomeSignalIds.size,
       insufficientEvidenceCount: countByKind('insufficient_evidence'),
       highAlignmentLowEfficacyCount: countByKind('high_alignment_low_efficacy'),
       lowAlignmentHighEfficacyCount: countByKind('low_alignment_high_efficacy'),
       outcomeBelowExpectedCount: countByKind('outcome_below_expected'),
       alignmentOutcomeDecoupledCount: countByKind('alignment_outcome_decoupled'),
-      unpairedAlignmentSignalCount: staffSignals.filter((signal) => signal.staffId.length === 0)
-        .length,
+      unpairedAlignmentSignalCount: staffSignals.filter(
+        (signal) => signal.staffId.length === 0 || signal.doctrineId.length === 0
+      ).length,
       unpairedOutcomeSignalCount,
     },
     lines: formatReportLines(findings),

--- a/src/test/staffTreatmentTelemetry.test.ts
+++ b/src/test/staffTreatmentTelemetry.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildStaffTreatmentTelemetryReport,
+  type StaffDoctrineAlignmentSignal,
+  type TreatmentEfficacySignal,
+} from '../domain/staffTreatmentTelemetry'
+
+function align(
+  overrides: Partial<StaffDoctrineAlignmentSignal> &
+    Pick<StaffDoctrineAlignmentSignal, 'staffId' | 'doctrineId' | 'alignmentScore'>
+): StaffDoctrineAlignmentSignal {
+  return {
+    source: 'certification',
+    ...overrides,
+  }
+}
+
+function outcome(
+  overrides: Partial<TreatmentEfficacySignal> &
+    Pick<TreatmentEfficacySignal, 'subjectId' | 'protocolId' | 'expectedOutcomeScore' | 'actualOutcomeScore'>
+): TreatmentEfficacySignal {
+  return {
+    ...overrides,
+  }
+}
+
+describe('staffTreatmentTelemetry (SPE-2010)', () => {
+  it('returns empty findings for empty inputs without throwing', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [],
+      treatmentOutcomes: [],
+    })
+    expect(report.findings).toEqual([])
+    expect(report.summary).toEqual({
+      pairedObservationCount: 0,
+      insufficientEvidenceCount: 0,
+      highAlignmentLowEfficacyCount: 0,
+      lowAlignmentHighEfficacyCount: 0,
+      outcomeBelowExpectedCount: 0,
+      alignmentOutcomeDecoupledCount: 0,
+      unpairedAlignmentSignalCount: 0,
+      unpairedOutcomeSignalCount: 0,
+    })
+    expect(report.lines).toEqual(['Staff treatment telemetry: no findings'])
+  })
+
+  it('detects high alignment with low efficacy', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-1', doctrineId: 'doctrine:infirmary', alignmentScore: 90 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-1',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-1',
+          expectedOutcomeScore: 80,
+          actualOutcomeScore: 25,
+        }),
+      ],
+    })
+
+    expect(report.findings.map((finding) => finding.kind)).toContain('high_alignment_low_efficacy')
+    expect(report.summary.highAlignmentLowEfficacyCount).toBe(1)
+  })
+
+  it('detects low alignment with high efficacy', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-2', doctrineId: 'doctrine:infirmary', alignmentScore: 20 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-2',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-2',
+          expectedOutcomeScore: 70,
+          actualOutcomeScore: 85,
+        }),
+      ],
+    })
+
+    expect(report.findings.map((finding) => finding.kind)).toContain('low_alignment_high_efficacy')
+    expect(report.summary.lowAlignmentHighEfficacyCount).toBe(1)
+  })
+
+  it('detects outcome below expected when gap exceeds threshold', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-3', doctrineId: 'doctrine:ward', alignmentScore: 55 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-3',
+          protocolId: 'protocol:observe',
+          staffId: 'staff:medic-3',
+          expectedOutcomeScore: 80,
+          actualOutcomeScore: 60,
+        }),
+      ],
+    })
+
+    expect(report.findings.map((finding) => finding.kind)).toContain('outcome_below_expected')
+    expect(report.summary.outcomeBelowExpectedCount).toBeGreaterThanOrEqual(1)
+  })
+
+  it('emits insufficient_evidence when alignment lacks linkable outcomes', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-4', doctrineId: 'doctrine:ward', alignmentScore: 80 }),
+      ],
+      treatmentOutcomes: [],
+    })
+
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        kind: 'insufficient_evidence',
+        staffId: 'staff:medic-4',
+      }),
+    ])
+    expect(report.summary.insufficientEvidenceCount).toBe(1)
+  })
+
+  it('emits insufficient_evidence when paired outcomes are below minimumEvidenceCount', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-5', doctrineId: 'doctrine:ward', alignmentScore: 80 }),
+      ],
+      treatmentOutcomes: [],
+      options: { minimumEvidenceCount: 2 },
+    })
+
+    expect(report.findings[0]?.kind).toBe('insufficient_evidence')
+  })
+
+  it('emits no mismatch kinds when alignment and efficacy both agree high', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-6', doctrineId: 'doctrine:ward', alignmentScore: 85 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-6',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-6',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 88,
+        }),
+      ],
+    })
+
+    const mismatchKinds = report.findings.filter((finding) =>
+      [
+        'high_alignment_low_efficacy',
+        'low_alignment_high_efficacy',
+        'outcome_below_expected',
+        'alignment_outcome_decoupled',
+      ].includes(finding.kind)
+    )
+    expect(mismatchKinds).toHaveLength(0)
+  })
+
+  it('sorts findings deterministically by kind, staffId, subjectId, week, protocolId', () => {
+    const input = {
+      staffSignals: [
+        align({ staffId: 'staff:b', doctrineId: 'doctrine:a', alignmentScore: 90 }),
+        align({ staffId: 'staff:a', doctrineId: 'doctrine:a', alignmentScore: 20 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:z',
+          protocolId: 'protocol:z',
+          staffId: 'staff:b',
+          expectedOutcomeScore: 33,
+          actualOutcomeScore: 20,
+        }),
+        outcome({
+          subjectId: 'agent:a',
+          protocolId: 'protocol:a',
+          staffId: 'staff:a',
+          expectedOutcomeScore: 70,
+          actualOutcomeScore: 90,
+        }),
+      ],
+    }
+
+    const first = buildStaffTreatmentTelemetryReport(input)
+    const second = buildStaffTreatmentTelemetryReport(input)
+    expect(first.findings).toEqual(second.findings)
+    expect(first.findings.map((finding) => finding.kind)).toEqual([
+      'high_alignment_low_efficacy',
+      'low_alignment_high_efficacy',
+    ])
+  })
+
+  it('does not mutate frozen inputs', () => {
+    const staffSignals = Object.freeze([
+      Object.freeze(
+        align({ staffId: 'staff:medic-7', doctrineId: 'doctrine:ward', alignmentScore: 90 })
+      ),
+    ]) as readonly StaffDoctrineAlignmentSignal[]
+    const treatmentOutcomes = Object.freeze([
+      Object.freeze(
+        outcome({
+          subjectId: 'agent:patient-7',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-7',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 20,
+        })
+      ),
+    ]) as readonly TreatmentEfficacySignal[]
+
+    buildStaffTreatmentTelemetryReport({ staffSignals, treatmentOutcomes })
+
+    expect(staffSignals[0]?.alignmentScore).toBe(90)
+    expect(treatmentOutcomes[0]?.actualOutcomeScore).toBe(20)
+  })
+
+  it('applies threshold overrides', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-8', doctrineId: 'doctrine:ward', alignmentScore: 60 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-8',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-8',
+          expectedOutcomeScore: 80,
+          actualOutcomeScore: 55,
+        }),
+      ],
+      options: {
+        highAlignmentThreshold: 50,
+        lowEfficacyThreshold: 60,
+      },
+    })
+
+    expect(report.findings.map((finding) => finding.kind)).toContain('high_alignment_low_efficacy')
+  })
+
+  it('counts outcomes without staffId as unpaired and does not throw', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-9', doctrineId: 'doctrine:ward', alignmentScore: 90 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:orphan',
+          protocolId: 'protocol:observe',
+          expectedOutcomeScore: 80,
+          actualOutcomeScore: 20,
+        }),
+      ],
+    })
+
+    expect(report.summary.unpairedOutcomeSignalCount).toBe(1)
+    expect(report.findings[0]?.kind).toBe('insufficient_evidence')
+  })
+
+  it('deduplicates repeated signalId deterministically (first wins after stable sort)', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({
+          staffId: 'staff:medic-10',
+          doctrineId: 'doctrine:ward',
+          alignmentScore: 90,
+          signalId: 'align:dup',
+        }),
+        align({
+          staffId: 'staff:medic-10',
+          doctrineId: 'doctrine:ward',
+          alignmentScore: 10,
+          signalId: 'align:dup',
+        }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-10',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-10',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 20,
+          signalId: 'outcome:dup',
+        }),
+        outcome({
+          subjectId: 'agent:patient-10b',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-10',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 90,
+          signalId: 'outcome:dup',
+        }),
+      ],
+    })
+
+    expect(report.findings.map((finding) => finding.kind)).toContain('high_alignment_low_efficacy')
+    expect(report.summary.highAlignmentLowEfficacyCount).toBe(1)
+  })
+
+  it('detects alignment_outcome_decoupled for mid alignment with material outcome gap', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:medic-11', doctrineId: 'doctrine:ward', alignmentScore: 55 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-11',
+          protocolId: 'protocol:observe',
+          staffId: 'staff:medic-11',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 50,
+        }),
+      ],
+    })
+
+    expect(report.findings.map((finding) => finding.kind)).toContain('alignment_outcome_decoupled')
+  })
+
+  it('falls back to staff-only outcome bucket when week-specific outcomes are missing', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({
+          staffId: 'staff:medic-12',
+          doctrineId: 'doctrine:ward',
+          alignmentScore: 90,
+          week: 4,
+        }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-12',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-12',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 20,
+        }),
+      ],
+    })
+
+    expect(report.findings.map((finding) => finding.kind)).toContain('high_alignment_low_efficacy')
+  })
+
+  it('classifies scores exactly at default high/low thresholds', () => {
+    const atThreshold = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:edge-high', doctrineId: 'doctrine:ward', alignmentScore: 70 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:edge-high',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:edge-high',
+          expectedOutcomeScore: 80,
+          actualOutcomeScore: 40,
+        }),
+      ],
+    })
+    expect(atThreshold.findings.map((finding) => finding.kind)).toContain(
+      'high_alignment_low_efficacy'
+    )
+
+    const atLowBoundary = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:edge-low', doctrineId: 'doctrine:ward', alignmentScore: 40 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:edge-low',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:edge-low',
+          expectedOutcomeScore: 70,
+          actualOutcomeScore: 50,
+        }),
+      ],
+    })
+    expect(atLowBoundary.findings.map((finding) => finding.kind)).not.toContain(
+      'high_alignment_low_efficacy'
+    )
+
+    const lowHighBoundary = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:edge-lh', doctrineId: 'doctrine:ward', alignmentScore: 40 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:edge-lh',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:edge-lh',
+          expectedOutcomeScore: 70,
+          actualOutcomeScore: 70,
+        }),
+      ],
+    })
+    expect(lowHighBoundary.findings.map((finding) => finding.kind)).toContain(
+      'low_alignment_high_efficacy'
+    )
+  })
+
+  it('treats outcome gap at default threshold as material and below threshold as not', () => {
+    const atGap = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:gap', doctrineId: 'doctrine:ward', alignmentScore: 50 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:gap',
+          protocolId: 'protocol:observe',
+          staffId: 'staff:gap',
+          expectedOutcomeScore: 55,
+          actualOutcomeScore: 40,
+        }),
+      ],
+    })
+    expect(atGap.findings.map((finding) => finding.kind)).toContain('outcome_below_expected')
+
+    const belowGap = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:gap-2', doctrineId: 'doctrine:ward', alignmentScore: 50 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:gap-2',
+          protocolId: 'protocol:observe',
+          staffId: 'staff:gap-2',
+          expectedOutcomeScore: 54,
+          actualOutcomeScore: 40,
+        }),
+      ],
+    })
+    expect(belowGap.findings.map((finding) => finding.kind)).not.toContain('outcome_below_expected')
+  })
+
+  it('clamps non-finite outcome scores without throwing', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({
+          staffId: 'staff:nan',
+          doctrineId: 'doctrine:ward',
+          alignmentScore: 90,
+        }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:nan',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:nan',
+          expectedOutcomeScore: Number.POSITIVE_INFINITY,
+          actualOutcomeScore: Number.NaN,
+        }),
+      ],
+    })
+    const mismatch = report.findings.find(
+      (finding) => finding.kind === 'high_alignment_low_efficacy'
+    )
+    expect(mismatch?.efficacyScore).toBe(0)
+    expect(mismatch?.alignmentScore).toBe(90)
+  })
+
+  it('keeps summary counts aligned with findings', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:summary', doctrineId: 'doctrine:ward', alignmentScore: 90 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:summary',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:summary',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 20,
+        }),
+      ],
+    })
+    expect(report.summary.highAlignmentLowEfficacyCount).toBe(
+      report.findings.filter((finding) => finding.kind === 'high_alignment_low_efficacy').length
+    )
+    expect(report.summary.pairedObservationCount).toBe(1)
+    expect(report.lines[0]).toBe('Staff treatment telemetry report')
+  })
+
+  it('produces identical reports for the same state', () => {
+    const input = {
+      staffSignals: [
+        align({ staffId: 'staff:medic-13', doctrineId: 'doctrine:ward', alignmentScore: 90 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:patient-13',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:medic-13',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 20,
+        }),
+      ],
+    }
+    expect(buildStaffTreatmentTelemetryReport(input)).toEqual(
+      buildStaffTreatmentTelemetryReport(input)
+    )
+  })
+})

--- a/src/test/staffTreatmentTelemetry.test.ts
+++ b/src/test/staffTreatmentTelemetry.test.ts
@@ -480,6 +480,185 @@ describe('staffTreatmentTelemetry (SPE-2010)', () => {
     expect(report.lines[0]).toBe('Staff treatment telemetry report')
   })
 
+  it('normalizes minimumEvidenceCount to at least 1', () => {
+    const mismatchKinds = [
+      'high_alignment_low_efficacy',
+      'low_alignment_high_efficacy',
+      'outcome_below_expected',
+      'alignment_outcome_decoupled',
+    ] as const
+
+    for (const minimumEvidenceCount of [0, -3, Number.NaN, 2.9]) {
+      const report = buildStaffTreatmentTelemetryReport({
+        staffSignals: [
+          align({ staffId: 'staff:min', doctrineId: 'doctrine:ward', alignmentScore: 90 }),
+        ],
+        treatmentOutcomes: [],
+        options: { minimumEvidenceCount },
+      })
+      expect(report.findings.map((finding) => finding.kind)).toEqual(['insufficient_evidence'])
+      expect(
+        report.findings.some((finding) => mismatchKinds.includes(finding.kind as (typeof mismatchKinds)[number]))
+      ).toBe(false)
+    }
+
+    const withOutcome = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:min-2', doctrineId: 'doctrine:ward', alignmentScore: 90 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:min-2',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:min-2',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 20,
+        }),
+      ],
+      options: { minimumEvidenceCount: 0 },
+    })
+    expect(withOutcome.findings.map((finding) => finding.kind)).toContain(
+      'high_alignment_low_efficacy'
+    )
+  })
+
+  it('attributes findings per doctrine for the same staff and week', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({
+          staffId: 'staff:multi',
+          doctrineId: 'doctrine:strict',
+          alignmentScore: 90,
+          week: 3,
+        }),
+        align({
+          staffId: 'staff:multi',
+          doctrineId: 'doctrine:pragmatic',
+          alignmentScore: 20,
+          week: 3,
+        }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:multi',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:multi',
+          expectedOutcomeScore: 80,
+          actualOutcomeScore: 25,
+          week: 3,
+        }),
+      ],
+    })
+
+    const strictFinding = report.findings.find(
+      (finding) => finding.doctrineId === 'doctrine:strict'
+    )
+    const pragmaticFinding = report.findings.find(
+      (finding) => finding.doctrineId === 'doctrine:pragmatic'
+    )
+
+    expect(strictFinding?.kind).toBe('high_alignment_low_efficacy')
+    expect(pragmaticFinding?.kind).not.toBe('high_alignment_low_efficacy')
+    expect(pragmaticFinding?.kind).not.toBe('low_alignment_high_efficacy')
+  })
+
+  it('retains subject and protocol context when outcomes meet or exceed expectations', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:context', doctrineId: 'doctrine:ward', alignmentScore: 90 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:context',
+          protocolId: 'protocol:observe',
+          staffId: 'staff:context',
+          expectedOutcomeScore: 55,
+          actualOutcomeScore: 60,
+        }),
+      ],
+    })
+
+    const decoupled = report.findings.find(
+      (finding) => finding.kind === 'alignment_outcome_decoupled'
+    )
+    expect(decoupled?.subjectId).toBe('agent:context')
+    expect(decoupled?.protocolId).toBe('protocol:observe')
+    expect(decoupled?.outcomeGap).toBeLessThanOrEqual(0)
+  })
+
+  it('uses same-band gap detail for mid/mid decoupled findings', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({ staffId: 'staff:midgap', doctrineId: 'doctrine:ward', alignmentScore: 55 }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:midgap',
+          protocolId: 'protocol:observe',
+          staffId: 'staff:midgap',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 55,
+        }),
+      ],
+    })
+
+    const decoupled = report.findings.find(
+      (finding) => finding.kind === 'alignment_outcome_decoupled'
+    )
+    expect(decoupled?.detail).toBe(
+      'Doctrine alignment and treatment efficacy remain in the same band, but the expected-vs-actual outcome gap exceeds the threshold.'
+    )
+  })
+
+  it('counts paired outcomes uniquely across doctrine buckets sharing staff-only fallback', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [
+        align({
+          staffId: 'staff:pair',
+          doctrineId: 'doctrine:a',
+          alignmentScore: 90,
+        }),
+        align({
+          staffId: 'staff:pair',
+          doctrineId: 'doctrine:b',
+          alignmentScore: 85,
+        }),
+      ],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:pair',
+          protocolId: 'protocol:stabilize',
+          staffId: 'staff:pair',
+          expectedOutcomeScore: 90,
+          actualOutcomeScore: 20,
+          signalId: 'outcome:shared',
+        }),
+      ],
+    })
+
+    expect(report.summary.pairedObservationCount).toBe(1)
+    expect(report.summary.unpairedOutcomeSignalCount).toBe(0)
+  })
+
+  it('counts staff-linked outcomes with no alignment bucket as unpaired', () => {
+    const report = buildStaffTreatmentTelemetryReport({
+      staffSignals: [],
+      treatmentOutcomes: [
+        outcome({
+          subjectId: 'agent:lonely',
+          protocolId: 'protocol:observe',
+          staffId: 'staff:lonely',
+          expectedOutcomeScore: 80,
+          actualOutcomeScore: 20,
+        }),
+      ],
+    })
+
+    expect(report.summary.pairedObservationCount).toBe(0)
+    expect(report.summary.unpairedOutcomeSignalCount).toBe(1)
+    expect(report.findings).toHaveLength(0)
+  })
+
   it('produces identical reports for the same state', () => {
     const input = {
       staffSignals: [


### PR DESCRIPTION
## Summary

- Adds a pure domain comparator ([SPE-2010](https://linear.app/spectranoir/issue/SPE-2010)) that ingests independent staff doctrine-alignment signals and treatment-efficacy outcome signals, then emits deterministic mismatch findings.
- Absorbs the closed duplicate SPE-2002 metric split (belief compliance vs health outcomes) without GameState persistence, runtime hooks, or UI.

## Smallest boundary

Pure helper + tests only: `buildStaffTreatmentTelemetryReport({ staffSignals, treatmentOutcomes, options? })` returns `findings`, `summary`, and `lines`.

## Files changed

- `src/domain/staffTreatmentTelemetry.ts`
- `src/test/staffTreatmentTelemetry.test.ts`

**Excluded from PR:** `planning/backlog.md` (pre-existing local edits, out of scope).

## Review hardening (b54247f)

- Normalize `minimumEvidenceCount` to at least 1
- Bucket alignment by `staffId + doctrineId + week`
- Stabilize worst-outcome context from the first paired outcome
- Count paired outcomes uniquely across buckets; include unmatched staff outcomes in unpaired count
- Accurate `alignment_outcome_decoupled` detail for band divergence vs same-band material gap

## Validation

- `npm run test:run -- src/test/staffTreatmentTelemetry.test.ts` (25 tests)
- `npm run test:run -- src/test/uncertainWorldState.test.ts`
- `npm run test:run -- src/test/branchContinuity.test.ts src/test/branchContinuityAudit.test.ts`
- `npm run lint`
- `git diff --check`
- `npm run test:run` (327 files, 3088 tests)

## Gap / edge-case / boundary audit

| Area | Result |
|------|--------|
| Telemetry model | Doctrine-specific attribution; mismatch/gap/insufficient-evidence preserved |
| Threshold/input safety | `minimumEvidenceCount` normalized; boundary + non-finite tests |
| Pairing/accounting | Unique paired outcome IDs; unpaired includes orphan staff outcomes |
| Determinism | Sorted findings, stable summary/lines, non-mutating inputs |
| Boundary | No GameState/UI/hooks/enforcement/audit/blame/scorecard/batch strings |

## Out of scope

- GameState projection / persistence
- Weekly tick / runtime integration
- UI / developer overlay
- SPE-2001 / SPE-2003 / SPE-2006 / SPE-2008
- `uncertainWorldState` import

## Test plan

- [x] Targeted telemetry tests (25)
- [x] Full suite green
- [x] Lint clean
- [x] Review threads addressed in b54247f