### PR TITLE
SPE-2003: Add medical outcome deviation audit

### DIFF
--- a/src/domain/medicalOutcomeDeviationAudit.ts
+++ b/src/domain/medicalOutcomeDeviationAudit.ts
@@ -1,0 +1,784 @@
+/**
+ * SPE-2003: deterministic medical outcome deviation audit.
+ *
+ * Compares expected medical/containment outcomes against observed outcomes and
+ * emits audit findings for deviation, symptom burden, escalation, missing observations,
+ * and governance-notification candidates.
+ *
+ * Pure helper only. No GameState persistence, runtime notifications, UI, staff-alignment
+ * scoring, blame routing, doctrine enforcement, or real-world medical modeling.
+ */
+
+export type MedicalOutcomeExpectationSource =
+  | 'protocol'
+  | 'clinician'
+  | 'governance'
+  | 'contract'
+  | 'system'
+
+export type MedicalOutcomeObservationSource =
+  | 'observation'
+  | 'report'
+  | 'telemetry'
+  | 'debrief'
+  | 'system'
+
+export type MedicalOutcomeEscalationTriggerKind =
+  | 'symptom_persistence'
+  | 'containment_failure'
+  | 'protocol_failure'
+  | 'operator_review'
+  | 'system'
+
+export type MedicalOutcomeDeviationKind =
+  | 'outcome_below_prediction'
+  | 'symptom_burden_not_improved'
+  | 'symptom_burden_worsened'
+  | 'escalation_above_expected'
+  | 'missing_observation'
+  | 'governance_notification_candidate'
+
+export type MedicalOutcomeDeviationSeverity = 'info' | 'warning' | 'critical'
+
+export type MedicalOutcomeGovernanceNotificationLevel =
+  | 'site_lead'
+  | 'governance'
+  | 'directive'
+
+export interface MedicalExpectedOutcome {
+  expectationId: string
+  subjectId: string
+  protocolId: string
+  expectedOutcomeScore: number
+  expectedSymptomBurdenDelta?: number
+  expectedEscalationCount?: number
+  expectedByWeek?: number
+  source: MedicalOutcomeExpectationSource
+  treatmentLimitationAcknowledged?: boolean
+}
+
+export interface MedicalObservedOutcome {
+  observationId: string
+  subjectId: string
+  protocolId: string
+  actualOutcomeScore: number
+  symptomBurdenDelta?: number
+  escalationCount?: number
+  observedWeek?: number
+  source: MedicalOutcomeObservationSource
+}
+
+export interface MedicalOutcomeEscalationEvent {
+  eventId: string
+  subjectId: string
+  protocolId?: string
+  week?: number
+  triggerKind: MedicalOutcomeEscalationTriggerKind
+}
+
+export interface MedicalOutcomeDeviationFinding {
+  kind: MedicalOutcomeDeviationKind
+  severity: MedicalOutcomeDeviationSeverity
+  subjectId: string
+  protocolId: string
+  expectationId?: string
+  observationId?: string
+  week?: number
+  outcomeGap?: number
+  symptomBurdenGap?: number
+  escalationExcess?: number
+  triggerKinds?: readonly MedicalOutcomeEscalationTriggerKind[]
+  recommendedNotificationLevel?: MedicalOutcomeGovernanceNotificationLevel
+  detail: string
+}
+
+export interface MedicalOutcomeDeviationAuditOptions {
+  outcomeGapThreshold?: number
+  criticalOutcomeGapThreshold?: number
+  symptomImprovementEpsilon?: number
+  symptomWorseningMargin?: number
+  criticalSymptomBurdenDelta?: number
+  criticalEscalationExcess?: number
+  governanceEscalationExcessThreshold?: number
+  treatMissingExpectedEscalationAsZero?: boolean
+}
+
+export interface MedicalOutcomeDeviationAuditReport {
+  findings: readonly MedicalOutcomeDeviationFinding[]
+  summary: {
+    pairedObservationCount: number
+    missingObservationCount: number
+    outcomeBelowPredictionCount: number
+    symptomBurdenNotImprovedCount: number
+    symptomBurdenWorsenedCount: number
+    escalationAboveExpectedCount: number
+    governanceNotificationCandidateCount: number
+    unpairedObservationCount: number
+    unpairedEscalationEventCount: number
+  }
+  lines: readonly string[]
+}
+
+export interface MedicalOutcomeDeviationAuditInput {
+  expectedOutcomes: readonly MedicalExpectedOutcome[]
+  observedOutcomes: readonly MedicalObservedOutcome[]
+  escalationEvents?: readonly MedicalOutcomeEscalationEvent[]
+  options?: MedicalOutcomeDeviationAuditOptions
+}
+
+const SEVERITY_RANK: Readonly<Record<MedicalOutcomeDeviationSeverity, number>> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+const FINDING_KIND_ORDER: readonly MedicalOutcomeDeviationKind[] = [
+  'outcome_below_prediction',
+  'symptom_burden_not_improved',
+  'symptom_burden_worsened',
+  'escalation_above_expected',
+  'missing_observation',
+  'governance_notification_candidate',
+]
+
+const DEFAULT_OPTIONS: Required<MedicalOutcomeDeviationAuditOptions> = {
+  outcomeGapThreshold: 15,
+  criticalOutcomeGapThreshold: 30,
+  symptomImprovementEpsilon: 0,
+  symptomWorseningMargin: 1,
+  criticalSymptomBurdenDelta: 10,
+  criticalEscalationExcess: 2,
+  governanceEscalationExcessThreshold: 1,
+  treatMissingExpectedEscalationAsZero: true,
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function clampDelta(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  return Math.round(value)
+}
+
+function normalizeWeek(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined
+  }
+  return Math.max(0, Math.trunc(value))
+}
+
+function normalizeThreshold(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback
+  }
+  return Math.max(0, Math.round(value))
+}
+
+function resolveOptions(
+  options: MedicalOutcomeDeviationAuditOptions | undefined
+): Required<MedicalOutcomeDeviationAuditOptions> {
+  return {
+    outcomeGapThreshold: normalizeThreshold(
+      options?.outcomeGapThreshold,
+      DEFAULT_OPTIONS.outcomeGapThreshold
+    ),
+    criticalOutcomeGapThreshold: normalizeThreshold(
+      options?.criticalOutcomeGapThreshold,
+      DEFAULT_OPTIONS.criticalOutcomeGapThreshold
+    ),
+    symptomImprovementEpsilon: normalizeThreshold(
+      options?.symptomImprovementEpsilon,
+      DEFAULT_OPTIONS.symptomImprovementEpsilon
+    ),
+    symptomWorseningMargin: normalizeThreshold(
+      options?.symptomWorseningMargin,
+      DEFAULT_OPTIONS.symptomWorseningMargin
+    ),
+    criticalSymptomBurdenDelta: normalizeThreshold(
+      options?.criticalSymptomBurdenDelta,
+      DEFAULT_OPTIONS.criticalSymptomBurdenDelta
+    ),
+    criticalEscalationExcess: normalizeThreshold(
+      options?.criticalEscalationExcess,
+      DEFAULT_OPTIONS.criticalEscalationExcess
+    ),
+    governanceEscalationExcessThreshold: normalizeThreshold(
+      options?.governanceEscalationExcessThreshold,
+      DEFAULT_OPTIONS.governanceEscalationExcessThreshold
+    ),
+    treatMissingExpectedEscalationAsZero:
+      options?.treatMissingExpectedEscalationAsZero ??
+      DEFAULT_OPTIONS.treatMissingExpectedEscalationAsZero,
+  }
+}
+
+function dedupeById<T>(
+  rows: readonly T[],
+  resolveId: (row: T) => string
+): T[] {
+  const sorted = [...rows].sort((left, right) =>
+    resolveId(left).localeCompare(resolveId(right))
+  )
+  const seen = new Set<string>()
+  const deduped: T[] = []
+  for (const row of sorted) {
+    const id = resolveId(row)
+    if (seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    deduped.push(row)
+  }
+  return deduped
+}
+
+function normalizeExpectedOutcome(row: MedicalExpectedOutcome): MedicalExpectedOutcome {
+  return {
+    ...row,
+    expectationId: row.expectationId.trim(),
+    subjectId: row.subjectId.trim(),
+    protocolId: row.protocolId.trim(),
+    expectedOutcomeScore: clampScore(row.expectedOutcomeScore),
+    expectedSymptomBurdenDelta:
+      row.expectedSymptomBurdenDelta === undefined
+        ? undefined
+        : clampDelta(row.expectedSymptomBurdenDelta),
+    expectedEscalationCount:
+      row.expectedEscalationCount === undefined
+        ? undefined
+        : Math.max(0, Math.trunc(row.expectedEscalationCount)),
+    expectedByWeek: normalizeWeek(row.expectedByWeek),
+  }
+}
+
+function normalizeObservedOutcome(row: MedicalObservedOutcome): MedicalObservedOutcome {
+  return {
+    ...row,
+    observationId: row.observationId.trim(),
+    subjectId: row.subjectId.trim(),
+    protocolId: row.protocolId.trim(),
+    actualOutcomeScore: clampScore(row.actualOutcomeScore),
+    symptomBurdenDelta:
+      row.symptomBurdenDelta === undefined ? undefined : clampDelta(row.symptomBurdenDelta),
+    escalationCount:
+      row.escalationCount === undefined
+        ? undefined
+        : Math.max(0, Math.trunc(row.escalationCount)),
+    observedWeek: normalizeWeek(row.observedWeek),
+  }
+}
+
+function normalizeEscalationEvent(row: MedicalOutcomeEscalationEvent): MedicalOutcomeEscalationEvent {
+  return {
+    ...row,
+    eventId: row.eventId.trim(),
+    subjectId: row.subjectId.trim(),
+    protocolId: typeof row.protocolId === 'string' ? row.protocolId.trim() : undefined,
+    week: normalizeWeek(row.week),
+  }
+}
+
+function matchesSubjectProtocol(
+  observation: MedicalObservedOutcome,
+  expectation: MedicalExpectedOutcome
+): boolean {
+  return (
+    observation.subjectId === expectation.subjectId &&
+    observation.protocolId === expectation.protocolId
+  )
+}
+
+function matchesWeek(
+  observation: MedicalObservedOutcome,
+  expectation: MedicalExpectedOutcome
+): boolean {
+  if (expectation.expectedByWeek === undefined) {
+    return true
+  }
+  return observation.observedWeek === expectation.expectedByWeek
+}
+
+function outcomeGapForPair(
+  expectation: MedicalExpectedOutcome,
+  observation: MedicalObservedOutcome
+): number {
+  return clampScore(expectation.expectedOutcomeScore) - clampScore(observation.actualOutcomeScore)
+}
+
+function compareObservationsWorst(
+  left: MedicalObservedOutcome,
+  right: MedicalObservedOutcome,
+  expectation: MedicalExpectedOutcome
+): number {
+  const gapDelta = outcomeGapForPair(expectation, right) - outcomeGapForPair(expectation, left)
+  if (gapDelta !== 0) {
+    return gapDelta
+  }
+
+  const escalationDelta =
+    (right.escalationCount ?? 0) - (left.escalationCount ?? 0)
+  if (escalationDelta !== 0) {
+    return escalationDelta
+  }
+
+  const burdenDelta =
+    (right.symptomBurdenDelta ?? 0) - (left.symptomBurdenDelta ?? 0)
+  if (burdenDelta !== 0) {
+    return burdenDelta
+  }
+
+  return left.observationId.localeCompare(right.observationId)
+}
+
+function selectWorstObservation(
+  candidates: readonly MedicalObservedOutcome[],
+  expectation: MedicalExpectedOutcome
+): MedicalObservedOutcome | undefined {
+  if (candidates.length === 0) {
+    return undefined
+  }
+  let worst = candidates[0]!
+  for (let index = 1; index < candidates.length; index += 1) {
+    const candidate = candidates[index]!
+    if (compareObservationsWorst(worst, candidate, expectation) > 0) {
+      worst = candidate
+    }
+  }
+  return worst
+}
+
+function resolvePairedObservation(
+  expectation: MedicalExpectedOutcome,
+  observations: readonly MedicalObservedOutcome[]
+): MedicalObservedOutcome | undefined {
+  const forSubjectProtocol = observations.filter((observation) =>
+    matchesSubjectProtocol(observation, expectation)
+  )
+  if (forSubjectProtocol.length === 0) {
+    return undefined
+  }
+
+  if (expectation.expectedByWeek !== undefined) {
+    const weekMatched = forSubjectProtocol.filter((observation) =>
+      matchesWeek(observation, expectation)
+    )
+    if (weekMatched.length > 0) {
+      return selectWorstObservation(weekMatched, expectation)
+    }
+    return selectWorstObservation(forSubjectProtocol, expectation)
+  }
+
+  return selectWorstObservation(forSubjectProtocol, expectation)
+}
+
+function resolveExpectedEscalationCount(
+  expectation: MedicalExpectedOutcome,
+  options: Required<MedicalOutcomeDeviationAuditOptions>
+): number {
+  if (expectation.expectedEscalationCount !== undefined) {
+    return expectation.expectedEscalationCount
+  }
+  return options.treatMissingExpectedEscalationAsZero ? 0 : 0
+}
+
+function matchEscalationEvents(input: {
+  expectation: MedicalExpectedOutcome
+  observation: MedicalObservedOutcome | undefined
+  events: readonly MedicalOutcomeEscalationEvent[]
+}): MedicalOutcomeEscalationEvent[] {
+  const { expectation, observation, events } = input
+  const week = expectation.expectedByWeek ?? observation?.observedWeek
+
+  return events.filter((event) => {
+    if (event.subjectId !== expectation.subjectId) {
+      return false
+    }
+    if (event.protocolId !== undefined && event.protocolId.length > 0) {
+      if (event.protocolId !== expectation.protocolId) {
+        return false
+      }
+    }
+    if (event.week !== undefined && week !== undefined && event.week !== week) {
+      return false
+    }
+    return true
+  })
+}
+
+function uniqueTriggerKinds(
+  events: readonly MedicalOutcomeEscalationEvent[]
+): MedicalOutcomeEscalationTriggerKind[] {
+  const kinds = events.map((event) => event.triggerKind)
+  return [...new Set(kinds)].sort((left, right) => left.localeCompare(right))
+}
+
+function resolveGovernanceNotificationLevel(input: {
+  outcomeGap: number
+  hasOutcomeDeviation: boolean
+  hasSymptomWorsened: boolean
+  escalationExcess: number
+  hasCriticalSibling: boolean
+  options: Required<MedicalOutcomeDeviationAuditOptions>
+}): MedicalOutcomeGovernanceNotificationLevel {
+  const { outcomeGap, hasOutcomeDeviation, hasSymptomWorsened, escalationExcess, options } = input
+  const hasEscalationExcess = escalationExcess >= options.governanceEscalationExcessThreshold
+  const hasMaterialGap = outcomeGap >= options.outcomeGapThreshold
+
+  if (hasMaterialGap && hasSymptomWorsened && hasEscalationExcess) {
+    return 'directive'
+  }
+  if (hasEscalationExcess || (hasMaterialGap && hasSymptomWorsened)) {
+    return 'governance'
+  }
+  if (
+    input.hasCriticalSibling ||
+    outcomeGap >= options.criticalOutcomeGapThreshold ||
+    hasOutcomeDeviation
+  ) {
+    return 'site_lead'
+  }
+  return 'site_lead'
+}
+
+function shouldEmitGovernanceCandidate(input: {
+  findings: readonly MedicalOutcomeDeviationFinding[]
+  outcomeGap: number
+  escalationExcess: number
+  hasSymptomWorsened: boolean
+  options: Required<MedicalOutcomeDeviationAuditOptions>
+}): boolean {
+  const hasCriticalSibling = input.findings.some((finding) => finding.severity === 'critical')
+  const hasMaterialGap = input.outcomeGap >= input.options.outcomeGapThreshold
+  const hasEscalationExcess =
+    input.escalationExcess >= input.options.governanceEscalationExcessThreshold
+
+  return (
+    hasCriticalSibling ||
+    input.outcomeGap >= input.options.criticalOutcomeGapThreshold ||
+    hasEscalationExcess ||
+    (hasMaterialGap && input.hasSymptomWorsened && hasEscalationExcess)
+  )
+}
+
+function compareFindings(
+  left: MedicalOutcomeDeviationFinding,
+  right: MedicalOutcomeDeviationFinding
+): number {
+  const severityDelta = SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity]
+  if (severityDelta !== 0) {
+    return severityDelta
+  }
+
+  const kindDelta =
+    FINDING_KIND_ORDER.indexOf(left.kind) - FINDING_KIND_ORDER.indexOf(right.kind)
+  if (kindDelta !== 0) {
+    return kindDelta
+  }
+
+  const subjectDelta = left.subjectId.localeCompare(right.subjectId)
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+
+  const protocolDelta = left.protocolId.localeCompare(right.protocolId)
+  if (protocolDelta !== 0) {
+    return protocolDelta
+  }
+
+  const weekLeft = left.week ?? Number.MAX_SAFE_INTEGER
+  const weekRight = right.week ?? Number.MAX_SAFE_INTEGER
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+
+  const expectationDelta = (left.expectationId ?? '').localeCompare(right.expectationId ?? '')
+  if (expectationDelta !== 0) {
+    return expectationDelta
+  }
+
+  return (left.observationId ?? '').localeCompare(right.observationId ?? '')
+}
+
+function formatFindingLine(finding: MedicalOutcomeDeviationFinding): string {
+  const parts = [
+    finding.severity,
+    finding.kind,
+    `subject:${finding.subjectId}`,
+    `protocol:${finding.protocolId}`,
+  ]
+  if (finding.week !== undefined) {
+    parts.push(`week:${finding.week}`)
+  }
+  if (finding.outcomeGap !== undefined) {
+    parts.push(`gap:${finding.outcomeGap}`)
+  }
+  if (finding.escalationExcess !== undefined) {
+    parts.push(`escalation_excess:${finding.escalationExcess}`)
+  }
+  if (finding.recommendedNotificationLevel !== undefined) {
+    parts.push(`level:${finding.recommendedNotificationLevel}`)
+  }
+  parts.push(finding.detail)
+  return parts.join(' · ')
+}
+
+function formatReportLines(
+  findings: readonly MedicalOutcomeDeviationFinding[],
+  summary: MedicalOutcomeDeviationAuditReport['summary']
+): string[] {
+  if (findings.length === 0) {
+    return [
+      `Medical outcome deviation audit: findings=0, paired=${summary.pairedObservationCount}, missing=${summary.missingObservationCount}`,
+    ]
+  }
+
+  return [
+    `Medical outcome deviation audit: findings=${findings.length}, paired=${summary.pairedObservationCount}, missing=${summary.missingObservationCount}`,
+    ...findings.map((finding) => formatFindingLine(finding)),
+  ]
+}
+
+function buildPairFindings(input: {
+  expectation: MedicalExpectedOutcome
+  observation: MedicalObservedOutcome | undefined
+  escalationEvents: readonly MedicalOutcomeEscalationEvent[]
+  options: Required<MedicalOutcomeDeviationAuditOptions>
+}): MedicalOutcomeDeviationFinding[] {
+  const { expectation, observation, escalationEvents, options } = input
+  const week = expectation.expectedByWeek ?? observation?.observedWeek
+  const findings: MedicalOutcomeDeviationFinding[] = []
+
+  if (!observation) {
+    findings.push({
+      kind: 'missing_observation',
+      severity: 'info',
+      subjectId: expectation.subjectId,
+      protocolId: expectation.protocolId,
+      expectationId: expectation.expectationId,
+      week,
+      detail: 'Expected medical outcome recorded without a matchable observation for this subject and protocol.',
+    })
+    return findings
+  }
+
+  const matchedEvents = matchEscalationEvents({
+    expectation,
+    observation,
+    events: escalationEvents,
+  })
+  const triggerKinds =
+    matchedEvents.length > 0 ? uniqueTriggerKinds(matchedEvents) : undefined
+
+  const outcomeGap = outcomeGapForPair(expectation, observation)
+  const expectedEscalation = resolveExpectedEscalationCount(expectation, options)
+  const observedEscalation = observation.escalationCount ?? 0
+  const escalationExcess = Math.max(0, observedEscalation - expectedEscalation)
+
+  let hasSymptomWorsened = false
+
+  if (outcomeGap >= options.outcomeGapThreshold) {
+    findings.push({
+      kind: 'outcome_below_prediction',
+      severity:
+        outcomeGap >= options.criticalOutcomeGapThreshold ? 'critical' : 'warning',
+      subjectId: expectation.subjectId,
+      protocolId: expectation.protocolId,
+      expectationId: expectation.expectationId,
+      observationId: observation.observationId,
+      week,
+      outcomeGap,
+      triggerKinds,
+      detail: `Observed outcome trails prediction by ${outcomeGap} points.`,
+    })
+  }
+
+  const expectedBurdenDelta = expectation.expectedSymptomBurdenDelta
+  const observedBurdenDelta = observation.symptomBurdenDelta
+
+  if (
+    expectedBurdenDelta !== undefined &&
+    expectedBurdenDelta < 0 &&
+    observedBurdenDelta !== undefined
+  ) {
+    const improvementTarget = expectedBurdenDelta - options.symptomImprovementEpsilon
+    if (observedBurdenDelta > improvementTarget) {
+      const symptomBurdenGap = observedBurdenDelta - expectedBurdenDelta
+      findings.push({
+        kind: 'symptom_burden_not_improved',
+        severity: 'warning',
+        subjectId: expectation.subjectId,
+        protocolId: expectation.protocolId,
+        expectationId: expectation.expectationId,
+        observationId: observation.observationId,
+        week,
+        symptomBurdenGap,
+        triggerKinds,
+        detail:
+          'Symptom burden did not improve enough relative to the predicted reduction for this protocol.',
+      })
+    }
+
+    const worsenedByPositiveDelta = observedBurdenDelta > 0
+    const worsenedByMargin =
+      observedBurdenDelta - expectedBurdenDelta >= options.symptomWorseningMargin
+    if (worsenedByPositiveDelta || worsenedByMargin) {
+      hasSymptomWorsened = true
+      const symptomBurdenGap = observedBurdenDelta - expectedBurdenDelta
+      const criticalWorsening = observedBurdenDelta >= options.criticalSymptomBurdenDelta
+      findings.push({
+        kind: 'symptom_burden_worsened',
+        severity: criticalWorsening ? 'critical' : 'warning',
+        subjectId: expectation.subjectId,
+        protocolId: expectation.protocolId,
+        expectationId: expectation.expectationId,
+        observationId: observation.observationId,
+        week,
+        symptomBurdenGap,
+        triggerKinds,
+        detail: criticalWorsening
+          ? 'Symptom burden increased materially while improvement was predicted.'
+          : 'Symptom burden worsened relative to the predicted improvement trajectory.',
+      })
+    }
+  }
+
+  if (escalationExcess > 0) {
+    findings.push({
+      kind: 'escalation_above_expected',
+      severity:
+        escalationExcess >= options.criticalEscalationExcess ? 'critical' : 'warning',
+      subjectId: expectation.subjectId,
+      protocolId: expectation.protocolId,
+      expectationId: expectation.expectationId,
+      observationId: observation.observationId,
+      week,
+      escalationExcess,
+      triggerKinds,
+      detail: `Escalation count exceeded prediction by ${escalationExcess}.`,
+    })
+  }
+
+  const hasOutcomeDeviation = findings.some(
+    (finding) => finding.kind === 'outcome_below_prediction'
+  )
+
+  if (
+    shouldEmitGovernanceCandidate({
+      findings,
+      outcomeGap,
+      escalationExcess,
+      hasSymptomWorsened,
+      options,
+    })
+  ) {
+    const recommendedNotificationLevel = resolveGovernanceNotificationLevel({
+      outcomeGap,
+      hasOutcomeDeviation,
+      hasSymptomWorsened,
+      escalationExcess,
+      hasCriticalSibling: findings.some((finding) => finding.severity === 'critical'),
+      options,
+    })
+    findings.push({
+      kind: 'governance_notification_candidate',
+      severity: 'critical',
+      subjectId: expectation.subjectId,
+      protocolId: expectation.protocolId,
+      expectationId: expectation.expectationId,
+      observationId: observation.observationId,
+      week,
+      outcomeGap,
+      escalationExcess,
+      triggerKinds,
+      recommendedNotificationLevel,
+      detail:
+        'Deviation severity warrants governance review; no notification was dispatched by this audit helper.',
+    })
+  }
+
+  return findings
+}
+
+export function buildMedicalOutcomeDeviationAuditReport(
+  input: MedicalOutcomeDeviationAuditInput
+): MedicalOutcomeDeviationAuditReport {
+  const options = resolveOptions(input.options)
+
+  const expectedOutcomes = dedupeById(
+    input.expectedOutcomes.map(normalizeExpectedOutcome).filter((row) => row.expectationId.length > 0),
+    (row) => row.expectationId
+  )
+  const observedOutcomes = dedupeById(
+    input.observedOutcomes.map(normalizeObservedOutcome).filter((row) => row.observationId.length > 0),
+    (row) => row.observationId
+  )
+  const escalationEvents = dedupeById(
+    (input.escalationEvents ?? []).map(normalizeEscalationEvent).filter((row) => row.eventId.length > 0),
+    (row) => row.eventId
+  )
+
+  const pairedObservationIds = new Set<string>()
+  const findings: MedicalOutcomeDeviationFinding[] = []
+
+  for (const expectation of expectedOutcomes) {
+    if (expectation.subjectId.length === 0 || expectation.protocolId.length === 0) {
+      continue
+    }
+    const observation = resolvePairedObservation(expectation, observedOutcomes)
+    if (observation) {
+      pairedObservationIds.add(observation.observationId)
+    }
+    findings.push(
+      ...buildPairFindings({
+        expectation,
+        observation,
+        escalationEvents,
+        options,
+      })
+    )
+  }
+
+  const unpairedObservationCount = observedOutcomes.filter(
+    (observation) => !pairedObservationIds.has(observation.observationId)
+  ).length
+
+  const usedEscalationEventIds = new Set<string>()
+  for (const expectation of expectedOutcomes) {
+    const observation = resolvePairedObservation(expectation, observedOutcomes)
+    for (const event of matchEscalationEvents({ expectation, observation, events: escalationEvents })) {
+      usedEscalationEventIds.add(event.eventId)
+    }
+  }
+  const unpairedEscalationEventCount = escalationEvents.filter(
+    (event) => !usedEscalationEventIds.has(event.eventId)
+  ).length
+
+  findings.sort(compareFindings)
+
+  const countByKind = (kind: MedicalOutcomeDeviationKind) =>
+    findings.filter((finding) => finding.kind === kind).length
+
+  const summary = {
+    pairedObservationCount: pairedObservationIds.size,
+    missingObservationCount: countByKind('missing_observation'),
+    outcomeBelowPredictionCount: countByKind('outcome_below_prediction'),
+    symptomBurdenNotImprovedCount: countByKind('symptom_burden_not_improved'),
+    symptomBurdenWorsenedCount: countByKind('symptom_burden_worsened'),
+    escalationAboveExpectedCount: countByKind('escalation_above_expected'),
+    governanceNotificationCandidateCount: countByKind('governance_notification_candidate'),
+    unpairedObservationCount,
+    unpairedEscalationEventCount,
+  }
+
+  return {
+    findings,
+    summary,
+    lines: formatReportLines(findings, summary),
+  }
+}

--- a/src/domain/medicalOutcomeDeviationAudit.ts
+++ b/src/domain/medicalOutcomeDeviationAudit.ts
@@ -7,6 +7,9 @@
  *
  * Pure helper only. No GameState persistence, runtime notifications, UI, staff-alignment
  * scoring, blame routing, doctrine enforcement, or real-world medical modeling.
+ *
+ * Threshold and margin options are normalized to finite non-negative integers for
+ * deterministic audit behavior. Symptom burden deltas remain signed integers on inputs.
  */
 
 export type MedicalOutcomeExpectationSource =
@@ -92,10 +95,13 @@ export interface MedicalOutcomeDeviationFinding {
   detail: string
 }
 
+/** Numeric thresholds are normalized to finite non-negative integers. */
 export interface MedicalOutcomeDeviationAuditOptions {
   outcomeGapThreshold?: number
   criticalOutcomeGapThreshold?: number
+  /** Compared against signed symptomBurdenDelta values after normalization. */
   symptomImprovementEpsilon?: number
+  /** Compared against signed symptom burden deltas after normalization. */
   symptomWorseningMargin?: number
   criticalSymptomBurdenDelta?: number
   criticalEscalationExcess?: number
@@ -151,6 +157,10 @@ const DEFAULT_OPTIONS: Required<MedicalOutcomeDeviationAuditOptions> = {
   governanceEscalationExcessThreshold: 1,
   treatMissingExpectedEscalationAsZero: true,
 }
+
+type ExpectedEscalationResolution =
+  | { compareEscalation: true; expectedEscalationCount: number }
+  | { compareEscalation: false }
 
 function clampScore(value: number): number {
   if (!Number.isFinite(value)) {
@@ -218,10 +228,7 @@ function resolveOptions(
   }
 }
 
-function dedupeById<T>(
-  rows: readonly T[],
-  resolveId: (row: T) => string
-): T[] {
+function dedupeById<T>(rows: readonly T[], resolveId: (row: T) => string): T[] {
   const sorted = [...rows].sort((left, right) =>
     resolveId(left).localeCompare(resolveId(right))
   )
@@ -250,9 +257,9 @@ function normalizeExpectedOutcome(row: MedicalExpectedOutcome): MedicalExpectedO
         ? undefined
         : clampDelta(row.expectedSymptomBurdenDelta),
     expectedEscalationCount:
-      row.expectedEscalationCount === undefined
-        ? undefined
-        : Math.max(0, Math.trunc(row.expectedEscalationCount)),
+      row.expectedEscalationCount !== undefined && Number.isFinite(row.expectedEscalationCount)
+        ? Math.max(0, Math.trunc(row.expectedEscalationCount))
+        : undefined,
     expectedByWeek: normalizeWeek(row.expectedByWeek),
   }
 }
@@ -284,14 +291,27 @@ function normalizeEscalationEvent(row: MedicalOutcomeEscalationEvent): MedicalOu
   }
 }
 
-function matchesSubjectProtocol(
-  observation: MedicalObservedOutcome,
-  expectation: MedicalExpectedOutcome
-): boolean {
-  return (
-    observation.subjectId === expectation.subjectId &&
-    observation.protocolId === expectation.protocolId
-  )
+function subjectProtocolKey(subjectId: string, protocolId: string): string {
+  return `${subjectId}\0${protocolId}`
+}
+
+function buildObservationsBySubjectProtocol(
+  observations: readonly MedicalObservedOutcome[]
+): Map<string, MedicalObservedOutcome[]> {
+  const grouped = new Map<string, MedicalObservedOutcome[]>()
+  for (const observation of observations) {
+    if (observation.subjectId.length === 0 || observation.protocolId.length === 0) {
+      continue
+    }
+    const key = subjectProtocolKey(observation.subjectId, observation.protocolId)
+    const existing = grouped.get(key)
+    if (existing) {
+      existing.push(observation)
+    } else {
+      grouped.set(key, [observation])
+    }
+  }
+  return grouped
 }
 
 function matchesWeek(
@@ -321,14 +341,12 @@ function compareObservationsWorst(
     return gapDelta
   }
 
-  const escalationDelta =
-    (right.escalationCount ?? 0) - (left.escalationCount ?? 0)
+  const escalationDelta = (right.escalationCount ?? 0) - (left.escalationCount ?? 0)
   if (escalationDelta !== 0) {
     return escalationDelta
   }
 
-  const burdenDelta =
-    (right.symptomBurdenDelta ?? 0) - (left.symptomBurdenDelta ?? 0)
+  const burdenDelta = (right.symptomBurdenDelta ?? 0) - (left.symptomBurdenDelta ?? 0)
   if (burdenDelta !== 0) {
     return burdenDelta
   }
@@ -355,11 +373,12 @@ function selectWorstObservation(
 
 function resolvePairedObservation(
   expectation: MedicalExpectedOutcome,
-  observations: readonly MedicalObservedOutcome[]
+  observationsBySubjectProtocol: Map<string, MedicalObservedOutcome[]>
 ): MedicalObservedOutcome | undefined {
-  const forSubjectProtocol = observations.filter((observation) =>
-    matchesSubjectProtocol(observation, expectation)
-  )
+  const forSubjectProtocol =
+    observationsBySubjectProtocol.get(
+      subjectProtocolKey(expectation.subjectId, expectation.protocolId)
+    ) ?? []
   if (forSubjectProtocol.length === 0) {
     return undefined
   }
@@ -377,14 +396,30 @@ function resolvePairedObservation(
   return selectWorstObservation(forSubjectProtocol, expectation)
 }
 
-function resolveExpectedEscalationCount(
+function resolveExpectedEscalation(
   expectation: MedicalExpectedOutcome,
   options: Required<MedicalOutcomeDeviationAuditOptions>
-): number {
+): ExpectedEscalationResolution {
   if (expectation.expectedEscalationCount !== undefined) {
-    return expectation.expectedEscalationCount
+    return {
+      compareEscalation: true,
+      expectedEscalationCount: expectation.expectedEscalationCount,
+    }
   }
-  return options.treatMissingExpectedEscalationAsZero ? 0 : 0
+  if (options.treatMissingExpectedEscalationAsZero) {
+    return { compareEscalation: true, expectedEscalationCount: 0 }
+  }
+  return { compareEscalation: false }
+}
+
+function resolveEventMatchWeek(input: {
+  expectation: MedicalExpectedOutcome
+  observation: MedicalObservedOutcome | undefined
+}): number | undefined {
+  if (input.observation !== undefined) {
+    return input.observation.observedWeek ?? input.expectation.expectedByWeek
+  }
+  return input.expectation.expectedByWeek
 }
 
 function matchEscalationEvents(input: {
@@ -393,7 +428,7 @@ function matchEscalationEvents(input: {
   events: readonly MedicalOutcomeEscalationEvent[]
 }): MedicalOutcomeEscalationEvent[] {
   const { expectation, observation, events } = input
-  const week = expectation.expectedByWeek ?? observation?.observedWeek
+  const week = resolveEventMatchWeek({ expectation, observation })
 
   return events.filter((event) => {
     if (event.subjectId !== expectation.subjectId) {
@@ -420,14 +455,14 @@ function uniqueTriggerKinds(
 
 function resolveGovernanceNotificationLevel(input: {
   outcomeGap: number
-  hasOutcomeDeviation: boolean
   hasSymptomWorsened: boolean
   escalationExcess: number
-  hasCriticalSibling: boolean
+  compareEscalation: boolean
   options: Required<MedicalOutcomeDeviationAuditOptions>
 }): MedicalOutcomeGovernanceNotificationLevel {
-  const { outcomeGap, hasOutcomeDeviation, hasSymptomWorsened, escalationExcess, options } = input
-  const hasEscalationExcess = escalationExcess >= options.governanceEscalationExcessThreshold
+  const { outcomeGap, hasSymptomWorsened, escalationExcess, compareEscalation, options } = input
+  const hasEscalationExcess =
+    compareEscalation && escalationExcess >= options.governanceEscalationExcessThreshold
   const hasMaterialGap = outcomeGap >= options.outcomeGapThreshold
 
   if (hasMaterialGap && hasSymptomWorsened && hasEscalationExcess) {
@@ -436,13 +471,6 @@ function resolveGovernanceNotificationLevel(input: {
   if (hasEscalationExcess || (hasMaterialGap && hasSymptomWorsened)) {
     return 'governance'
   }
-  if (
-    input.hasCriticalSibling ||
-    outcomeGap >= options.criticalOutcomeGapThreshold ||
-    hasOutcomeDeviation
-  ) {
-    return 'site_lead'
-  }
   return 'site_lead'
 }
 
@@ -450,12 +478,14 @@ function shouldEmitGovernanceCandidate(input: {
   findings: readonly MedicalOutcomeDeviationFinding[]
   outcomeGap: number
   escalationExcess: number
+  compareEscalation: boolean
   hasSymptomWorsened: boolean
   options: Required<MedicalOutcomeDeviationAuditOptions>
 }): boolean {
   const hasCriticalSibling = input.findings.some((finding) => finding.severity === 'critical')
   const hasMaterialGap = input.outcomeGap >= input.options.outcomeGapThreshold
   const hasEscalationExcess =
+    input.compareEscalation &&
     input.escalationExcess >= input.options.governanceEscalationExcessThreshold
 
   return (
@@ -549,8 +579,9 @@ function buildPairFindings(input: {
   observation: MedicalObservedOutcome | undefined
   escalationEvents: readonly MedicalOutcomeEscalationEvent[]
   options: Required<MedicalOutcomeDeviationAuditOptions>
+  usedEscalationEventIds: Set<string>
 }): MedicalOutcomeDeviationFinding[] {
-  const { expectation, observation, escalationEvents, options } = input
+  const { expectation, observation, escalationEvents, options, usedEscalationEventIds } = input
   const week = expectation.expectedByWeek ?? observation?.observedWeek
   const findings: MedicalOutcomeDeviationFinding[] = []
 
@@ -562,7 +593,8 @@ function buildPairFindings(input: {
       protocolId: expectation.protocolId,
       expectationId: expectation.expectationId,
       week,
-      detail: 'Expected medical outcome recorded without a matchable observation for this subject and protocol.',
+      detail:
+        'Expected medical outcome recorded without a matchable observation for this subject and protocol.',
     })
     return findings
   }
@@ -572,21 +604,25 @@ function buildPairFindings(input: {
     observation,
     events: escalationEvents,
   })
+  for (const event of matchedEvents) {
+    usedEscalationEventIds.add(event.eventId)
+  }
   const triggerKinds =
     matchedEvents.length > 0 ? uniqueTriggerKinds(matchedEvents) : undefined
 
   const outcomeGap = outcomeGapForPair(expectation, observation)
-  const expectedEscalation = resolveExpectedEscalationCount(expectation, options)
+  const escalationResolution = resolveExpectedEscalation(expectation, options)
   const observedEscalation = observation.escalationCount ?? 0
-  const escalationExcess = Math.max(0, observedEscalation - expectedEscalation)
+  const escalationExcess = escalationResolution.compareEscalation
+    ? Math.max(0, observedEscalation - escalationResolution.expectedEscalationCount)
+    : 0
 
   let hasSymptomWorsened = false
 
   if (outcomeGap >= options.outcomeGapThreshold) {
     findings.push({
       kind: 'outcome_below_prediction',
-      severity:
-        outcomeGap >= options.criticalOutcomeGapThreshold ? 'critical' : 'warning',
+      severity: outcomeGap >= options.criticalOutcomeGapThreshold ? 'critical' : 'warning',
       subjectId: expectation.subjectId,
       protocolId: expectation.protocolId,
       expectationId: expectation.expectationId,
@@ -648,7 +684,7 @@ function buildPairFindings(input: {
     }
   }
 
-  if (escalationExcess > 0) {
+  if (escalationResolution.compareEscalation && escalationExcess > 0) {
     findings.push({
       kind: 'escalation_above_expected',
       severity:
@@ -664,25 +700,21 @@ function buildPairFindings(input: {
     })
   }
 
-  const hasOutcomeDeviation = findings.some(
-    (finding) => finding.kind === 'outcome_below_prediction'
-  )
-
   if (
     shouldEmitGovernanceCandidate({
       findings,
       outcomeGap,
       escalationExcess,
+      compareEscalation: escalationResolution.compareEscalation,
       hasSymptomWorsened,
       options,
     })
   ) {
     const recommendedNotificationLevel = resolveGovernanceNotificationLevel({
       outcomeGap,
-      hasOutcomeDeviation,
       hasSymptomWorsened,
       escalationExcess,
-      hasCriticalSibling: findings.some((finding) => finding.severity === 'critical'),
+      compareEscalation: escalationResolution.compareEscalation,
       options,
     })
     findings.push({
@@ -694,7 +726,7 @@ function buildPairFindings(input: {
       observationId: observation.observationId,
       week,
       outcomeGap,
-      escalationExcess,
+      escalationExcess: escalationResolution.compareEscalation ? escalationExcess : undefined,
       triggerKinds,
       recommendedNotificationLevel,
       detail:
@@ -711,26 +743,34 @@ export function buildMedicalOutcomeDeviationAuditReport(
   const options = resolveOptions(input.options)
 
   const expectedOutcomes = dedupeById(
-    input.expectedOutcomes.map(normalizeExpectedOutcome).filter((row) => row.expectationId.length > 0),
+    input.expectedOutcomes
+      .map(normalizeExpectedOutcome)
+      .filter((row) => row.expectationId.length > 0),
     (row) => row.expectationId
   )
   const observedOutcomes = dedupeById(
-    input.observedOutcomes.map(normalizeObservedOutcome).filter((row) => row.observationId.length > 0),
+    input.observedOutcomes
+      .map(normalizeObservedOutcome)
+      .filter((row) => row.observationId.length > 0),
     (row) => row.observationId
   )
   const escalationEvents = dedupeById(
-    (input.escalationEvents ?? []).map(normalizeEscalationEvent).filter((row) => row.eventId.length > 0),
+    (input.escalationEvents ?? [])
+      .map(normalizeEscalationEvent)
+      .filter((row) => row.eventId.length > 0),
     (row) => row.eventId
   )
 
+  const observationsBySubjectProtocol = buildObservationsBySubjectProtocol(observedOutcomes)
   const pairedObservationIds = new Set<string>()
+  const usedEscalationEventIds = new Set<string>()
   const findings: MedicalOutcomeDeviationFinding[] = []
 
   for (const expectation of expectedOutcomes) {
     if (expectation.subjectId.length === 0 || expectation.protocolId.length === 0) {
       continue
     }
-    const observation = resolvePairedObservation(expectation, observedOutcomes)
+    const observation = resolvePairedObservation(expectation, observationsBySubjectProtocol)
     if (observation) {
       pairedObservationIds.add(observation.observationId)
     }
@@ -740,6 +780,7 @@ export function buildMedicalOutcomeDeviationAuditReport(
         observation,
         escalationEvents,
         options,
+        usedEscalationEventIds,
       })
     )
   }
@@ -747,14 +788,6 @@ export function buildMedicalOutcomeDeviationAuditReport(
   const unpairedObservationCount = observedOutcomes.filter(
     (observation) => !pairedObservationIds.has(observation.observationId)
   ).length
-
-  const usedEscalationEventIds = new Set<string>()
-  for (const expectation of expectedOutcomes) {
-    const observation = resolvePairedObservation(expectation, observedOutcomes)
-    for (const event of matchEscalationEvents({ expectation, observation, events: escalationEvents })) {
-      usedEscalationEventIds.add(event.eventId)
-    }
-  }
   const unpairedEscalationEventCount = escalationEvents.filter(
     (event) => !usedEscalationEventIds.has(event.eventId)
   ).length

--- a/src/test/medicalOutcomeDeviationAudit.test.ts
+++ b/src/test/medicalOutcomeDeviationAudit.test.ts
@@ -597,6 +597,153 @@ describe('medicalOutcomeDeviationAudit (SPE-2003)', () => {
     expect(report.summary.pairedObservationCount).toBe(1)
   })
 
+  it('matches escalation events to fallback observation week, not expectation week', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:week-esc',
+          subjectId: 'agent:week-esc',
+          protocolId: 'protocol:contain',
+          expectedOutcomeScore: 90,
+          expectedByWeek: 3,
+          expectedEscalationCount: 0,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:week-esc',
+          subjectId: 'agent:week-esc',
+          protocolId: 'protocol:contain',
+          actualOutcomeScore: 88,
+          observedWeek: 4,
+          escalationCount: 1,
+        }),
+      ],
+      escalationEvents: [
+        escalation({
+          eventId: 'evt:week-4',
+          subjectId: 'agent:week-esc',
+          protocolId: 'protocol:contain',
+          week: 4,
+          triggerKind: 'symptom_persistence',
+        }),
+        escalation({
+          eventId: 'evt:week-3',
+          subjectId: 'agent:week-esc',
+          protocolId: 'protocol:contain',
+          week: 3,
+          triggerKind: 'operator_review',
+        }),
+      ],
+    })
+    const escalationFinding = report.findings.find(
+      (finding) => finding.kind === 'escalation_above_expected'
+    )
+    expect(escalationFinding?.triggerKinds).toEqual(['symptom_persistence'])
+    expect(report.summary.unpairedEscalationEventCount).toBe(1)
+  })
+
+  describe('treatMissingExpectedEscalationAsZero', () => {
+    it('emits escalation finding when omitted expected count defaults to zero', () => {
+      const report = buildMedicalOutcomeDeviationAuditReport({
+        expectedOutcomes: [
+          expected({
+            expectationId: 'exp:esc-default',
+            subjectId: 'agent:esc-default',
+            protocolId: 'protocol:contain',
+            expectedOutcomeScore: 88,
+          }),
+        ],
+        observedOutcomes: [
+          observed({
+            observationId: 'obs:esc-default',
+            subjectId: 'agent:esc-default',
+            protocolId: 'protocol:contain',
+            actualOutcomeScore: 87,
+            escalationCount: 1,
+          }),
+        ],
+        options: { treatMissingExpectedEscalationAsZero: true },
+      })
+      expect(report.findings.map((finding) => finding.kind)).toContain('escalation_above_expected')
+    })
+
+    it('suppresses escalation finding when zero-defaulting is disabled', () => {
+      const report = buildMedicalOutcomeDeviationAuditReport({
+        expectedOutcomes: [
+          expected({
+            expectationId: 'exp:esc-skip',
+            subjectId: 'agent:esc-skip',
+            protocolId: 'protocol:contain',
+            expectedOutcomeScore: 88,
+          }),
+        ],
+        observedOutcomes: [
+          observed({
+            observationId: 'obs:esc-skip',
+            subjectId: 'agent:esc-skip',
+            protocolId: 'protocol:contain',
+            actualOutcomeScore: 87,
+            escalationCount: 1,
+          }),
+        ],
+        options: { treatMissingExpectedEscalationAsZero: false },
+      })
+      expect(report.findings.map((finding) => finding.kind)).not.toContain('escalation_above_expected')
+    })
+
+    it('suppresses governance candidate caused only by skipped escalation excess', () => {
+      const report = buildMedicalOutcomeDeviationAuditReport({
+        expectedOutcomes: [
+          expected({
+            expectationId: 'exp:gov-skip',
+            subjectId: 'agent:gov-skip',
+            protocolId: 'protocol:contain',
+            expectedOutcomeScore: 88,
+          }),
+        ],
+        observedOutcomes: [
+          observed({
+            observationId: 'obs:gov-skip',
+            subjectId: 'agent:gov-skip',
+            protocolId: 'protocol:contain',
+            actualOutcomeScore: 87,
+            escalationCount: 1,
+          }),
+        ],
+        options: { treatMissingExpectedEscalationAsZero: false },
+      })
+      expect(report.findings.map((finding) => finding.kind)).not.toContain(
+        'governance_notification_candidate'
+      )
+    })
+
+    it('still compares finite expectedEscalationCount when zero-defaulting is disabled', () => {
+      const report = buildMedicalOutcomeDeviationAuditReport({
+        expectedOutcomes: [
+          expected({
+            expectationId: 'exp:esc-explicit',
+            subjectId: 'agent:esc-explicit',
+            protocolId: 'protocol:contain',
+            expectedOutcomeScore: 88,
+            expectedEscalationCount: 0,
+          }),
+        ],
+        observedOutcomes: [
+          observed({
+            observationId: 'obs:esc-explicit',
+            subjectId: 'agent:esc-explicit',
+            protocolId: 'protocol:contain',
+            actualOutcomeScore: 87,
+            escalationCount: 1,
+          }),
+        ],
+        options: { treatMissingExpectedEscalationAsZero: false },
+      })
+      expect(report.findings.map((finding) => finding.kind)).toContain('escalation_above_expected')
+    })
+  })
+
   it('annotates findings with matching escalation triggerKinds', () => {
     const report = buildMedicalOutcomeDeviationAuditReport({
       expectedOutcomes: [

--- a/src/test/medicalOutcomeDeviationAudit.test.ts
+++ b/src/test/medicalOutcomeDeviationAudit.test.ts
@@ -1,0 +1,753 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  buildMedicalOutcomeDeviationAuditReport,
+  type MedicalExpectedOutcome,
+  type MedicalObservedOutcome,
+  type MedicalOutcomeEscalationEvent,
+} from '../domain/medicalOutcomeDeviationAudit'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function expected(
+  overrides: Partial<MedicalExpectedOutcome> &
+    Pick<MedicalExpectedOutcome, 'expectationId' | 'subjectId' | 'protocolId' | 'expectedOutcomeScore'>
+): MedicalExpectedOutcome {
+  return {
+    source: 'protocol',
+    ...overrides,
+  }
+}
+
+function observed(
+  overrides: Partial<MedicalObservedOutcome> &
+    Pick<MedicalObservedOutcome, 'observationId' | 'subjectId' | 'protocolId' | 'actualOutcomeScore'>
+): MedicalObservedOutcome {
+  return {
+    source: 'observation',
+    ...overrides,
+  }
+}
+
+function escalation(
+  overrides: Partial<MedicalOutcomeEscalationEvent> &
+    Pick<MedicalOutcomeEscalationEvent, 'eventId' | 'subjectId' | 'triggerKind'>
+): MedicalOutcomeEscalationEvent {
+  return {
+    ...overrides,
+  }
+}
+
+describe('medicalOutcomeDeviationAudit (SPE-2003)', () => {
+  it('returns empty report for empty input without throwing', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [],
+      observedOutcomes: [],
+    })
+    expect(report.findings).toEqual([])
+    expect(report.summary).toEqual({
+      pairedObservationCount: 0,
+      missingObservationCount: 0,
+      outcomeBelowPredictionCount: 0,
+      symptomBurdenNotImprovedCount: 0,
+      symptomBurdenWorsenedCount: 0,
+      escalationAboveExpectedCount: 0,
+      governanceNotificationCandidateCount: 0,
+      unpairedObservationCount: 0,
+      unpairedEscalationEventCount: 0,
+    })
+    expect(report.lines[0]).toContain('findings=0')
+  })
+
+  it('emits outcome_below_prediction at default threshold', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:1',
+          subjectId: 'agent:patient-1',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 80,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:1',
+          subjectId: 'agent:patient-1',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 60,
+        }),
+      ],
+    })
+    expect(report.findings.map((finding) => finding.kind)).toContain('outcome_below_prediction')
+    expect(report.findings.find((finding) => finding.kind === 'outcome_below_prediction')?.severity).toBe(
+      'warning'
+    )
+  })
+
+  it('does not emit outcome_below_prediction when gap is below threshold', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:gap-low',
+          subjectId: 'agent:gap-low',
+          protocolId: 'protocol:observe',
+          expectedOutcomeScore: 54,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:gap-low',
+          subjectId: 'agent:gap-low',
+          protocolId: 'protocol:observe',
+          actualOutcomeScore: 40,
+        }),
+      ],
+    })
+    expect(report.findings.map((finding) => finding.kind)).not.toContain('outcome_below_prediction')
+  })
+
+  it('emits critical outcome_below_prediction for large gaps', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:critical-gap',
+          subjectId: 'agent:critical-gap',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:critical-gap',
+          subjectId: 'agent:critical-gap',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 50,
+        }),
+      ],
+    })
+    const outcomeFinding = report.findings.find(
+      (finding) => finding.kind === 'outcome_below_prediction'
+    )
+    expect(outcomeFinding?.severity).toBe('critical')
+    expect(outcomeFinding?.outcomeGap).toBe(40)
+  })
+
+  it('emits symptom_burden_not_improved when improvement is insufficient', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:burden',
+          subjectId: 'agent:burden',
+          protocolId: 'protocol:therapy',
+          expectedOutcomeScore: 70,
+          expectedSymptomBurdenDelta: -10,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:burden',
+          subjectId: 'agent:burden',
+          protocolId: 'protocol:therapy',
+          actualOutcomeScore: 68,
+          symptomBurdenDelta: -4,
+        }),
+      ],
+    })
+    expect(report.findings.map((finding) => finding.kind)).toContain('symptom_burden_not_improved')
+  })
+
+  it('emits symptom_burden_worsened with warning or critical severity', () => {
+    const warningReport = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:worse',
+          subjectId: 'agent:worse',
+          protocolId: 'protocol:therapy',
+          expectedOutcomeScore: 70,
+          expectedSymptomBurdenDelta: -8,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:worse',
+          subjectId: 'agent:worse',
+          protocolId: 'protocol:therapy',
+          actualOutcomeScore: 65,
+          symptomBurdenDelta: 3,
+        }),
+      ],
+    })
+    expect(warningReport.findings.map((finding) => finding.kind)).toContain('symptom_burden_worsened')
+    expect(
+      warningReport.findings.find((finding) => finding.kind === 'symptom_burden_worsened')?.severity
+    ).toBe('warning')
+
+    const criticalReport = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:worse-critical',
+          subjectId: 'agent:worse-critical',
+          protocolId: 'protocol:therapy',
+          expectedOutcomeScore: 70,
+          expectedSymptomBurdenDelta: -8,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:worse-critical',
+          subjectId: 'agent:worse-critical',
+          protocolId: 'protocol:therapy',
+          actualOutcomeScore: 65,
+          symptomBurdenDelta: 12,
+        }),
+      ],
+    })
+    expect(
+      criticalReport.findings.find((finding) => finding.kind === 'symptom_burden_worsened')?.severity
+    ).toBe('critical')
+  })
+
+  it('emits escalation_above_expected when observed count exceeds expected', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:esc',
+          subjectId: 'agent:esc',
+          protocolId: 'protocol:contain',
+          expectedOutcomeScore: 75,
+          expectedEscalationCount: 0,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:esc',
+          subjectId: 'agent:esc',
+          protocolId: 'protocol:contain',
+          actualOutcomeScore: 74,
+          escalationCount: 2,
+        }),
+      ],
+    })
+    expect(report.findings.map((finding) => finding.kind)).toContain('escalation_above_expected')
+  })
+
+  it('emits missing_observation as info when no observation matches', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:missing',
+          subjectId: 'agent:missing',
+          protocolId: 'protocol:observe',
+          expectedOutcomeScore: 80,
+        }),
+      ],
+      observedOutcomes: [],
+    })
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        kind: 'missing_observation',
+        severity: 'info',
+        subjectId: 'agent:missing',
+      }),
+    ])
+    expect(report.findings.map((finding) => finding.kind)).not.toContain(
+      'governance_notification_candidate'
+    )
+  })
+
+  it('emits governance_notification_candidate for critical outcome gap', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:gov-gap',
+          subjectId: 'agent:gov-gap',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 95,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:gov-gap',
+          subjectId: 'agent:gov-gap',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 55,
+        }),
+      ],
+    })
+    const governance = report.findings.find(
+      (finding) => finding.kind === 'governance_notification_candidate'
+    )
+    expect(governance).toBeDefined()
+    expect(governance?.recommendedNotificationLevel).toBe('site_lead')
+  })
+
+  it('emits governance_notification_candidate with governance level for escalation excess', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:gov-esc',
+          subjectId: 'agent:gov-esc',
+          protocolId: 'protocol:contain',
+          expectedOutcomeScore: 88,
+          expectedEscalationCount: 0,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:gov-esc',
+          subjectId: 'agent:gov-esc',
+          protocolId: 'protocol:contain',
+          actualOutcomeScore: 87,
+          escalationCount: 1,
+        }),
+      ],
+    })
+    const governance = report.findings.find(
+      (finding) => finding.kind === 'governance_notification_candidate'
+    )
+    expect(governance?.recommendedNotificationLevel).toBe('governance')
+  })
+
+  it('recommends directive level for compound deviation', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:compound',
+          subjectId: 'agent:compound',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+          expectedSymptomBurdenDelta: -12,
+          expectedEscalationCount: 0,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:compound',
+          subjectId: 'agent:compound',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 60,
+          symptomBurdenDelta: 5,
+          escalationCount: 1,
+        }),
+      ],
+    })
+    const governance = report.findings.find(
+      (finding) => finding.kind === 'governance_notification_candidate'
+    )
+    expect(governance?.recommendedNotificationLevel).toBe('directive')
+  })
+
+  it('emits no deviation findings when observation meets expectation', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:ok',
+          subjectId: 'agent:ok',
+          protocolId: 'protocol:observe',
+          expectedOutcomeScore: 80,
+          expectedSymptomBurdenDelta: -5,
+          expectedEscalationCount: 0,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:ok',
+          subjectId: 'agent:ok',
+          protocolId: 'protocol:observe',
+          actualOutcomeScore: 82,
+          symptomBurdenDelta: -8,
+          escalationCount: 0,
+        }),
+      ],
+    })
+    const deviationKinds = report.findings.filter((finding) =>
+      [
+        'outcome_below_prediction',
+        'symptom_burden_not_improved',
+        'symptom_burden_worsened',
+        'escalation_above_expected',
+        'missing_observation',
+        'governance_notification_candidate',
+      ].includes(finding.kind)
+    )
+    expect(deviationKinds).toHaveLength(0)
+  })
+
+  it('sorts findings deterministically across repeated calls', () => {
+    const input = {
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:b',
+          subjectId: 'agent:b',
+          protocolId: 'protocol:z',
+          expectedOutcomeScore: 90,
+        }),
+        expected({
+          expectationId: 'exp:a',
+          subjectId: 'agent:a',
+          protocolId: 'protocol:a',
+          expectedOutcomeScore: 90,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:b',
+          subjectId: 'agent:b',
+          protocolId: 'protocol:z',
+          actualOutcomeScore: 20,
+        }),
+        observed({
+          observationId: 'obs:a',
+          subjectId: 'agent:a',
+          protocolId: 'protocol:a',
+          actualOutcomeScore: 20,
+        }),
+      ],
+    }
+    const first = buildMedicalOutcomeDeviationAuditReport(input)
+    const second = buildMedicalOutcomeDeviationAuditReport(input)
+    expect(first.findings).toEqual(second.findings)
+    expect(first.findings[0]?.subjectId).toBe('agent:a')
+  })
+
+  it('does not mutate frozen inputs', () => {
+    const expectedOutcomes = Object.freeze([
+      Object.freeze(
+        expected({
+          expectationId: 'exp:freeze',
+          subjectId: 'agent:freeze',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+        })
+      ),
+    ]) as readonly MedicalExpectedOutcome[]
+    const observedOutcomes = Object.freeze([
+      Object.freeze(
+        observed({
+          observationId: 'obs:freeze',
+          subjectId: 'agent:freeze',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 20,
+        })
+      ),
+    ]) as readonly MedicalObservedOutcome[]
+
+    buildMedicalOutcomeDeviationAuditReport({ expectedOutcomes, observedOutcomes })
+
+    expect(expectedOutcomes[0]?.expectedOutcomeScore).toBe(90)
+    expect(observedOutcomes[0]?.actualOutcomeScore).toBe(20)
+  })
+
+  it('applies threshold overrides', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:override',
+          subjectId: 'agent:override',
+          protocolId: 'protocol:observe',
+          expectedOutcomeScore: 60,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:override',
+          subjectId: 'agent:override',
+          protocolId: 'protocol:observe',
+          actualOutcomeScore: 50,
+        }),
+      ],
+      options: { outcomeGapThreshold: 5 },
+    })
+    expect(report.findings.map((finding) => finding.kind)).toContain('outcome_below_prediction')
+  })
+
+  it('deduplicates duplicate expectationId deterministically', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:dup',
+          subjectId: 'agent:dup',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+        }),
+        expected({
+          expectationId: 'exp:dup',
+          subjectId: 'agent:dup',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 50,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:dup',
+          subjectId: 'agent:dup',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 20,
+        }),
+      ],
+    })
+    expect(report.summary.outcomeBelowPredictionCount).toBe(1)
+    expect(report.findings.find((finding) => finding.kind === 'outcome_below_prediction')?.outcomeGap).toBe(
+      70
+    )
+  })
+
+  it('deduplicates duplicate observationId deterministically', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:obs-dup',
+          subjectId: 'agent:obs-dup',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:dup',
+          subjectId: 'agent:obs-dup',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 20,
+        }),
+        observed({
+          observationId: 'obs:dup',
+          subjectId: 'agent:obs-dup',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 80,
+        }),
+      ],
+    })
+    expect(report.findings.map((finding) => finding.kind)).toContain('outcome_below_prediction')
+    expect(report.findings.find((finding) => finding.kind === 'outcome_below_prediction')?.outcomeGap).toBe(
+      70
+    )
+  })
+
+  it('clamps non-finite scores without throwing', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:nan',
+          subjectId: 'agent:nan',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: Number.POSITIVE_INFINITY,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:nan',
+          subjectId: 'agent:nan',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: Number.NaN,
+        }),
+      ],
+    })
+    expect(report.findings.map((finding) => finding.kind)).not.toContain('outcome_below_prediction')
+  })
+
+  it('keeps summary counts aligned with findings', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:summary',
+          subjectId: 'agent:summary',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:summary',
+          subjectId: 'agent:summary',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 20,
+        }),
+      ],
+    })
+    expect(report.summary.outcomeBelowPredictionCount).toBe(
+      report.findings.filter((finding) => finding.kind === 'outcome_below_prediction').length
+    )
+    expect(report.summary.pairedObservationCount).toBe(1)
+  })
+
+  it('falls back to week-agnostic observation when expected week has no exact match', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:week',
+          subjectId: 'agent:week',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+          expectedByWeek: 4,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:week',
+          subjectId: 'agent:week',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 20,
+          observedWeek: 2,
+        }),
+      ],
+    })
+    expect(report.findings.map((finding) => finding.kind)).toContain('outcome_below_prediction')
+    expect(report.summary.pairedObservationCount).toBe(1)
+  })
+
+  it('annotates findings with matching escalation triggerKinds', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:triggers',
+          subjectId: 'agent:triggers',
+          protocolId: 'protocol:contain',
+          expectedOutcomeScore: 90,
+          expectedEscalationCount: 0,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:triggers',
+          subjectId: 'agent:triggers',
+          protocolId: 'protocol:contain',
+          actualOutcomeScore: 70,
+          escalationCount: 1,
+        }),
+      ],
+      escalationEvents: [
+        escalation({
+          eventId: 'evt:1',
+          subjectId: 'agent:triggers',
+          protocolId: 'protocol:contain',
+          triggerKind: 'symptom_persistence',
+        }),
+        escalation({
+          eventId: 'evt:2',
+          subjectId: 'agent:triggers',
+          protocolId: 'protocol:contain',
+          triggerKind: 'operator_review',
+        }),
+      ],
+    })
+    const escalationFinding = report.findings.find(
+      (finding) => finding.kind === 'escalation_above_expected'
+    )
+    expect(escalationFinding?.triggerKinds).toEqual(['operator_review', 'symptom_persistence'])
+  })
+
+  it('counts unpaired observations', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:lonely',
+          subjectId: 'agent:lonely',
+          protocolId: 'protocol:observe',
+          actualOutcomeScore: 50,
+        }),
+      ],
+    })
+    expect(report.summary.unpairedObservationCount).toBe(1)
+    expect(report.summary.pairedObservationCount).toBe(0)
+  })
+
+  it('counts unpaired escalation events', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:evt',
+          subjectId: 'agent:evt',
+          protocolId: 'protocol:observe',
+          expectedOutcomeScore: 80,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:evt',
+          subjectId: 'agent:evt',
+          protocolId: 'protocol:observe',
+          actualOutcomeScore: 79,
+        }),
+      ],
+      escalationEvents: [
+        escalation({
+          eventId: 'evt:unpaired',
+          subjectId: 'agent:other',
+          triggerKind: 'system',
+        }),
+      ],
+    })
+    expect(report.summary.unpairedEscalationEventCount).toBe(1)
+  })
+
+  it('does not import staffTreatmentTelemetry', () => {
+    const source = readFileSync(
+      path.join(__dirname, '../domain/medicalOutcomeDeviationAudit.ts'),
+      'utf8'
+    )
+    expect(source.includes('staffTreatmentTelemetry')).toBe(false)
+  })
+
+  it('does not include SCP strings in generated lines', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:lines',
+          subjectId: 'agent:lines',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:lines',
+          subjectId: 'agent:lines',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 20,
+        }),
+      ],
+    })
+    const joined = report.lines.join('\n').toLowerCase()
+    expect(joined).not.toContain('scp-')
+    expect(joined).not.toContain('scp ')
+    expect(joined).not.toContain('9977')
+  })
+
+  it('chooses worst observation deterministically when multiple match', () => {
+    const report = buildMedicalOutcomeDeviationAuditReport({
+      expectedOutcomes: [
+        expected({
+          expectationId: 'exp:multi',
+          subjectId: 'agent:multi',
+          protocolId: 'protocol:stabilize',
+          expectedOutcomeScore: 90,
+        }),
+      ],
+      observedOutcomes: [
+        observed({
+          observationId: 'obs:better',
+          subjectId: 'agent:multi',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 70,
+          escalationCount: 0,
+        }),
+        observed({
+          observationId: 'obs:worst',
+          subjectId: 'agent:multi',
+          protocolId: 'protocol:stabilize',
+          actualOutcomeScore: 20,
+          escalationCount: 2,
+          symptomBurdenDelta: 8,
+        }),
+      ],
+    })
+    expect(
+      report.findings.find((finding) => finding.kind === 'outcome_below_prediction')?.observationId
+    ).toBe('obs:worst')
+    expect(report.summary.pairedObservationCount).toBe(1)
+    expect(report.summary.unpairedObservationCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds pure deterministic `buildMedicalOutcomeDeviationAuditReport` for predicted-vs-observed medical/containment outcome deviation (SPE-2003).
- Linear: https://linear.app/spectranoir/issue/SPE-2003/batch-9977-medical-outcome-deviation-audit-system
- SPE-2073 remains Duplicate/canceled; **SPE-2003 is the canonical implementation owner**.

## Smallest boundary

- New domain helper + fixture tests only.
- No GameState, weekly tick, UI, SPE-2010 import, staff alignment, scorecard, blame routing, doctrine, or policy selector.

## Files changed

- `src/domain/medicalOutcomeDeviationAudit.ts`
- `src/test/medicalOutcomeDeviationAudit.test.ts`

## Review hardening (43b0336)

- Honor `treatMissingExpectedEscalationAsZero: false` (skip escalation comparison when expected count omitted).
- Match escalation events to paired observation week on fallback pairing.
- Pre-group observations by subject/protocol; single-pass escalation event accounting.
- Simplify governance notification level resolution; document threshold normalization.

## Validation

- `npm run test:run -- src/test/medicalOutcomeDeviationAudit.test.ts` (31 tests)
- `npm run test:run -- src/test/staffTreatmentTelemetry.test.ts` (adjacent)
- `npm run test:run -- src/test/uncertainWorldState.test.ts` (adjacent)
- `npm run test:run` (3119 tests)
- `npm run lint`
- `git diff --check`

## Gap / edge-case / boundary audit

| Category | Result |
| --- | --- |
| Audit model | Expected/observed independent; escalation option honored; governance candidates have no side effects |
| Pairing | subject+protocol+week with fallback; observation week used for escalation events; dedupe first-wins |
| Determinism | Stable sort, lines, summary; inputs not mutated |
| Boundaries | No GameState, SPE-2010, UI, notifications, batch strings in lines |
| Docs | Module header + option JSDoc for threshold normalization |

## Out of scope

- GameState persistence, runtime integration, UI
- SPE-2010 adapter, recovery/trauma projection, uncertainWorldState
- SPE-2008 scorecard, SPE-2006 blame routing, SPE-2001 doctrine, SPE-2004 policy selector

## Test plan

- [x] Targeted SPE-2003 tests (31)
- [x] Adjacent staff telemetry + uncertain world state tests
- [x] Full suite + lint