### PR TITLE
SPE-2008: Add medical accountability scorecard

### DIFF
--- a/src/domain/medicalAccountabilityScorecard.ts
+++ b/src/domain/medicalAccountabilityScorecard.ts
@@ -1,0 +1,999 @@
+/**
+ * SPE-2008: deterministic medical accountability scorecard.
+ *
+ * Composes upstream accountability signals from staff treatment telemetry,
+ * medical outcome deviation audit, and treatment-failure blame routing into
+ * compact scorecard rows, findings, summary counts, and audit-facing lines.
+ *
+ * Pure composer only. No GameState persistence, UI, doctrine enforcement,
+ * policy selection, blame-routing implementation, or real-world medical modeling.
+ */
+
+import type { StaffTreatmentTelemetryFinding } from './staffTreatmentTelemetry'
+import type { MedicalOutcomeDeviationFinding } from './medicalOutcomeDeviationAudit'
+import type { TreatmentFailureBlameRoutingFinding } from './treatmentFailureBlameRouting'
+
+export interface MedicalAccountabilitySiteSignal {
+  signalId: string
+  siteId: string
+  week?: number
+  careModeCoverageScore?: number
+  accommodationAccessScore?: number
+  governanceReviewCapacityScore?: number
+  notes?: string
+}
+
+export type MedicalAccountabilityScorecardFindingKind =
+  | 'high_alignment_poor_outcome'
+  | 'outcome_accountability_gap'
+  | 'subject_deflection_pressure'
+  | 'treatment_limitation_unacknowledged'
+  | 'accommodation_access_gap'
+  | 'care_mode_missing'
+  | 'governance_review_needed'
+  | 'insufficient_scorecard_evidence'
+
+export type MedicalAccountabilityScorecardSeverity = 'info' | 'warning' | 'critical'
+
+export interface MedicalAccountabilityScorecardRow {
+  rowId: string
+  siteId?: string
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  week?: number
+  doctrineAlignmentScore?: number
+  treatmentEfficacyScore?: number
+  outcomeDeviationCount: number
+  subjectDeflectionCount: number
+  accountabilityRouteQualityScore?: number
+  accommodationAccessScore?: number
+  careModeCoverageScore?: number
+  governanceReviewPressureScore?: number
+}
+
+export interface MedicalAccountabilityScorecardFinding {
+  kind: MedicalAccountabilityScorecardFindingKind
+  severity: MedicalAccountabilityScorecardSeverity
+  rowId: string
+  siteId?: string
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  week?: number
+  detail: string
+}
+
+export interface MedicalAccountabilityScorecardReport {
+  rows: readonly MedicalAccountabilityScorecardRow[]
+  findings: readonly MedicalAccountabilityScorecardFinding[]
+  summary: {
+    rowCount: number
+    highAlignmentPoorOutcomeCount: number
+    outcomeAccountabilityGapCount: number
+    subjectDeflectionPressureCount: number
+    treatmentLimitationUnacknowledgedCount: number
+    accommodationAccessGapCount: number
+    careModeMissingCount: number
+    governanceReviewNeededCount: number
+    insufficientEvidenceCount: number
+  }
+  lines: readonly string[]
+}
+
+export interface MedicalAccountabilityScorecardOptions {
+  highAlignmentThreshold?: number
+  poorOutcomeThreshold?: number
+  lowAccommodationAccessThreshold?: number
+  lowCareModeCoverageThreshold?: number
+  highGovernancePressureThreshold?: number
+  minimumEvidenceCount?: number
+}
+
+const SEVERITY_RANK: Readonly<Record<MedicalAccountabilityScorecardSeverity, number>> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+const FINDING_KIND_ORDER: readonly MedicalAccountabilityScorecardFindingKind[] = [
+  'governance_review_needed',
+  'subject_deflection_pressure',
+  'outcome_accountability_gap',
+  'high_alignment_poor_outcome',
+  'treatment_limitation_unacknowledged',
+  'accommodation_access_gap',
+  'care_mode_missing',
+  'insufficient_scorecard_evidence',
+]
+
+const OUTCOME_DEVIATION_KINDS = new Set<MedicalOutcomeDeviationFinding['kind']>([
+  'outcome_below_prediction',
+  'symptom_burden_not_improved',
+  'symptom_burden_worsened',
+  'escalation_above_expected',
+])
+
+const DEFAULT_OPTIONS: Required<MedicalAccountabilityScorecardOptions> = {
+  highAlignmentThreshold: 70,
+  poorOutcomeThreshold: 40,
+  lowAccommodationAccessThreshold: 40,
+  lowCareModeCoverageThreshold: 40,
+  highGovernancePressureThreshold: 70,
+  minimumEvidenceCount: 1,
+}
+
+interface RowBucket {
+  key: string
+  rowId: string
+  siteId?: string
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  week?: number
+  staffFindings: StaffTreatmentTelemetryFinding[]
+  deviationFindings: MedicalOutcomeDeviationFinding[]
+  blameFindings: TreatmentFailureBlameRoutingFinding[]
+  siteSignals: MedicalAccountabilitySiteSignal[]
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function normalizeWeek(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined
+  }
+  return Math.max(0, Math.trunc(value))
+}
+
+function normalizeMinimumEvidenceCount(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_OPTIONS.minimumEvidenceCount
+  }
+  return Math.max(1, Math.trunc(value))
+}
+
+function resolveOptions(
+  options: MedicalAccountabilityScorecardOptions | undefined
+): Required<MedicalAccountabilityScorecardOptions> {
+  return {
+    highAlignmentThreshold: clampScore(
+      options?.highAlignmentThreshold ?? DEFAULT_OPTIONS.highAlignmentThreshold
+    ),
+    poorOutcomeThreshold: clampScore(
+      options?.poorOutcomeThreshold ?? DEFAULT_OPTIONS.poorOutcomeThreshold
+    ),
+    lowAccommodationAccessThreshold: clampScore(
+      options?.lowAccommodationAccessThreshold ?? DEFAULT_OPTIONS.lowAccommodationAccessThreshold
+    ),
+    lowCareModeCoverageThreshold: clampScore(
+      options?.lowCareModeCoverageThreshold ?? DEFAULT_OPTIONS.lowCareModeCoverageThreshold
+    ),
+    highGovernancePressureThreshold: clampScore(
+      options?.highGovernancePressureThreshold ?? DEFAULT_OPTIONS.highGovernancePressureThreshold
+    ),
+    minimumEvidenceCount: normalizeMinimumEvidenceCount(options?.minimumEvidenceCount),
+  }
+}
+
+function subjectProtocolWeekKey(
+  subjectId: string,
+  protocolId: string,
+  week: number | undefined
+): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `subject\0${subjectId}\0${protocolId}\0${weekPart}`
+}
+
+function staffWeekKey(staffId: string, week: number | undefined): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `staff\0${staffId}\0${weekPart}`
+}
+
+function siteWeekKey(siteId: string, week: number | undefined): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `site\0${siteId}\0${weekPart}`
+}
+
+const AGGREGATE_KEY = 'aggregate\0'
+
+function rowIdForKey(key: string): string {
+  if (key === AGGREGATE_KEY) {
+    return 'row:aggregate'
+  }
+  if (key.startsWith('subject\0')) {
+    const parts = key.split('\0')
+    const subjectId = parts[1] ?? ''
+    const protocolId = parts[2] ?? ''
+    const weekPart = parts[3] ?? ''
+    return `row:subject:${subjectId}:${protocolId}:${weekPart}`
+  }
+  if (key.startsWith('staff\0')) {
+    const parts = key.split('\0')
+    const staffId = parts[1] ?? ''
+    const weekPart = parts[2] ?? ''
+    return `row:staff:${staffId}:${weekPart}`
+  }
+  if (key.startsWith('site\0')) {
+    const parts = key.split('\0')
+    const siteId = parts[1] ?? ''
+    const weekPart = parts[2] ?? ''
+    return `row:site:${siteId}:${weekPart}`
+  }
+  return `row:unknown:${key}`
+}
+
+function parseSubjectProtocolWeekKey(key: string): {
+  subjectId?: string
+  protocolId?: string
+  week?: number
+} {
+  if (!key.startsWith('subject\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const subjectId = parts[1]
+  const protocolId = parts[2]
+  const weekPart = parts[3]
+  if (!subjectId || !protocolId) {
+    return {}
+  }
+  return {
+    subjectId,
+    protocolId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
+function parseStaffWeekKey(key: string): { staffId?: string; week?: number } {
+  if (!key.startsWith('staff\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const staffId = parts[1]
+  const weekPart = parts[2]
+  if (!staffId) {
+    return {}
+  }
+  return {
+    staffId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
+function parseSiteWeekKey(key: string): { siteId?: string; week?: number } {
+  if (!key.startsWith('site\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const siteId = parts[1]
+  const weekPart = parts[2]
+  if (!siteId) {
+    return {}
+  }
+  return {
+    siteId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
+function getOrCreateBucket(
+  buckets: Map<string, RowBucket>,
+  key: string
+): RowBucket {
+  const existing = buckets.get(key)
+  if (existing) {
+    return existing
+  }
+
+  const subjectFields = parseSubjectProtocolWeekKey(key)
+  const staffFields = parseStaffWeekKey(key)
+  const siteFields = parseSiteWeekKey(key)
+
+  const bucket: RowBucket = {
+    key,
+    rowId: rowIdForKey(key),
+    siteId: siteFields.siteId,
+    staffId: staffFields.staffId,
+    subjectId: subjectFields.subjectId,
+    protocolId: subjectFields.protocolId,
+    week: subjectFields.week ?? staffFields.week ?? siteFields.week,
+    staffFindings: [],
+    deviationFindings: [],
+    blameFindings: [],
+    siteSignals: [],
+  }
+  buckets.set(key, bucket)
+  return bucket
+}
+
+function resolveStaffFindingKey(finding: StaffTreatmentTelemetryFinding): string {
+  const subjectId = finding.subjectId?.trim()
+  const protocolId = finding.protocolId?.trim()
+  const week = normalizeWeek(finding.week)
+  if (subjectId && protocolId) {
+    return subjectProtocolWeekKey(subjectId, protocolId, week)
+  }
+  const staffId = finding.staffId.trim()
+  if (staffId.length > 0) {
+    return staffWeekKey(staffId, week)
+  }
+  return AGGREGATE_KEY
+}
+
+function resolveDeviationFindingKey(finding: MedicalOutcomeDeviationFinding): string {
+  const subjectId = finding.subjectId.trim()
+  const protocolId = finding.protocolId.trim()
+  if (subjectId.length === 0 || protocolId.length === 0) {
+    return AGGREGATE_KEY
+  }
+  return subjectProtocolWeekKey(subjectId, protocolId, normalizeWeek(finding.week))
+}
+
+function resolveBlameFindingKey(finding: TreatmentFailureBlameRoutingFinding): string {
+  const subjectId = finding.subjectId.trim()
+  const protocolId = finding.protocolId.trim()
+  if (subjectId.length === 0 || protocolId.length === 0) {
+    return AGGREGATE_KEY
+  }
+  return subjectProtocolWeekKey(subjectId, protocolId, normalizeWeek(finding.week))
+}
+
+function normalizeSiteSignal(signal: MedicalAccountabilitySiteSignal): MedicalAccountabilitySiteSignal {
+  return {
+    ...signal,
+    signalId: signal.signalId.trim(),
+    siteId: signal.siteId.trim(),
+    week: normalizeWeek(signal.week),
+    careModeCoverageScore:
+      signal.careModeCoverageScore === undefined
+        ? undefined
+        : clampScore(signal.careModeCoverageScore),
+    accommodationAccessScore:
+      signal.accommodationAccessScore === undefined
+        ? undefined
+        : clampScore(signal.accommodationAccessScore),
+    governanceReviewCapacityScore:
+      signal.governanceReviewCapacityScore === undefined
+        ? undefined
+        : clampScore(signal.governanceReviewCapacityScore),
+  }
+}
+
+function dedupeSiteSignals(
+  signals: readonly MedicalAccountabilitySiteSignal[]
+): MedicalAccountabilitySiteSignal[] {
+  const sorted = [...signals]
+    .map(normalizeSiteSignal)
+    .filter((signal) => signal.signalId.length > 0 && signal.siteId.length > 0)
+    .sort((left, right) => left.signalId.localeCompare(right.signalId))
+
+  const seen = new Set<string>()
+  const deduped: MedicalAccountabilitySiteSignal[] = []
+  for (const signal of sorted) {
+    if (seen.has(signal.signalId)) {
+      continue
+    }
+    seen.add(signal.signalId)
+    deduped.push(signal)
+  }
+  return deduped
+}
+
+function meanRounded(values: readonly number[]): number | undefined {
+  if (values.length === 0) {
+    return undefined
+  }
+  const sum = values.reduce((total, value) => total + value, 0)
+  return Math.round(sum / values.length)
+}
+
+function deriveDoctrineAlignmentScore(
+  staffFindings: readonly StaffTreatmentTelemetryFinding[]
+): number | undefined {
+  const scores = staffFindings
+    .map((finding) => finding.alignmentScore)
+    .filter((score): score is number => score !== undefined && Number.isFinite(score))
+  if (scores.length > 0) {
+    return meanRounded(scores.map(clampScore))
+  }
+
+  if (
+    staffFindings.some(
+      (finding) =>
+        finding.kind === 'high_alignment_low_efficacy' ||
+        finding.kind === 'outcome_below_expected'
+    )
+  ) {
+    return DEFAULT_OPTIONS.highAlignmentThreshold
+  }
+
+  return undefined
+}
+
+function deriveTreatmentEfficacyScore(
+  staffFindings: readonly StaffTreatmentTelemetryFinding[],
+  deviationFindings: readonly MedicalOutcomeDeviationFinding[]
+): number | undefined {
+  const efficacyScores = staffFindings
+    .map((finding) => finding.efficacyScore)
+    .filter((score): score is number => score !== undefined && Number.isFinite(score))
+  if (efficacyScores.length > 0) {
+    return meanRounded(efficacyScores.map(clampScore))
+  }
+
+  if (staffFindings.some((finding) => finding.kind === 'high_alignment_low_efficacy')) {
+    return DEFAULT_OPTIONS.poorOutcomeThreshold
+  }
+
+  const outcomeDeviationCount = deviationFindings.filter((finding) =>
+    OUTCOME_DEVIATION_KINDS.has(finding.kind)
+  ).length
+  if (outcomeDeviationCount > 0) {
+    return Math.max(0, DEFAULT_OPTIONS.poorOutcomeThreshold - 5 * (outcomeDeviationCount - 1))
+  }
+
+  return undefined
+}
+
+function countOutcomeDeviations(
+  deviationFindings: readonly MedicalOutcomeDeviationFinding[]
+): number {
+  return deviationFindings.filter((finding) => OUTCOME_DEVIATION_KINDS.has(finding.kind)).length
+}
+
+function countSubjectDeflections(
+  blameFindings: readonly TreatmentFailureBlameRoutingFinding[]
+): number {
+  let count = blameFindings.filter(
+    (finding) => finding.kind === 'prohibited_subject_deflection'
+  ).length
+
+  const hasInstitutionalRequired = blameFindings.some(
+    (finding) => finding.kind === 'institutional_accountability_required'
+  )
+  const hasNonSubjectApproved = blameFindings.some(
+    (finding) =>
+      finding.kind === 'approved_accountability_route' &&
+      finding.recommendedAccountabilityFocus !== undefined &&
+      finding.recommendedAccountabilityFocus !== 'shared'
+  )
+  if (hasInstitutionalRequired && !hasNonSubjectApproved) {
+    count += 1
+  }
+
+  return count
+}
+
+/**
+ * Accountability route quality starts at 50 when blame-routing evidence exists.
+ * Penalizes deflection, missing limitation acknowledgment, and institutional gaps;
+ * rewards approved routes. Clamped 0–100.
+ */
+function deriveAccountabilityRouteQualityScore(
+  blameFindings: readonly TreatmentFailureBlameRoutingFinding[]
+): number | undefined {
+  if (blameFindings.length === 0) {
+    return undefined
+  }
+
+  let score = 50
+  for (const finding of blameFindings) {
+    switch (finding.kind) {
+      case 'prohibited_subject_deflection':
+        score -= 25
+        break
+      case 'missing_treatment_limitation_acknowledgment':
+        score -= 15
+        break
+      case 'institutional_accountability_required':
+        score -= 20
+        break
+      case 'approved_accountability_route':
+        score += 10
+        break
+      default:
+        break
+    }
+  }
+
+  return clampScore(score)
+}
+
+function deriveGovernanceReviewPressureScore(input: {
+  deviationFindings: readonly MedicalOutcomeDeviationFinding[]
+  blameFindings: readonly TreatmentFailureBlameRoutingFinding[]
+  governanceReviewCapacityScore?: number
+}): number | undefined {
+  const { deviationFindings, blameFindings, governanceReviewCapacityScore } = input
+
+  let pressure = 0
+  for (const finding of deviationFindings) {
+    if (finding.kind === 'governance_notification_candidate') {
+      pressure += finding.severity === 'critical' ? 45 : 30
+    } else if (finding.kind === 'escalation_above_expected' && finding.severity === 'critical') {
+      pressure += 20
+    } else if (finding.kind === 'outcome_below_prediction' && finding.severity === 'critical') {
+      pressure += 15
+    }
+  }
+
+  for (const finding of blameFindings) {
+    if (finding.kind === 'institutional_accountability_required') {
+      pressure += finding.severity === 'critical' ? 35 : 25
+    } else if (
+      finding.kind === 'prohibited_subject_deflection' &&
+      finding.severity === 'critical'
+    ) {
+      pressure += 20
+    }
+  }
+
+  if (
+    pressure === 0 &&
+    deviationFindings.length === 0 &&
+    blameFindings.length === 0 &&
+    governanceReviewCapacityScore === undefined
+  ) {
+    return undefined
+  }
+
+  if (governanceReviewCapacityScore !== undefined) {
+    pressure = Math.max(0, pressure - Math.round(governanceReviewCapacityScore * 0.5))
+  }
+
+  return clampScore(pressure)
+}
+
+function deriveSiteScores(siteSignals: readonly MedicalAccountabilitySiteSignal[]): {
+  accommodationAccessScore?: number
+  careModeCoverageScore?: number
+  governanceReviewCapacityScore?: number
+} {
+  const accommodation = meanRounded(
+    siteSignals
+      .map((signal) => signal.accommodationAccessScore)
+      .filter((score): score is number => score !== undefined)
+  )
+  const careMode = meanRounded(
+    siteSignals
+      .map((signal) => signal.careModeCoverageScore)
+      .filter((score): score is number => score !== undefined)
+  )
+  const governanceCapacity = meanRounded(
+    siteSignals
+      .map((signal) => signal.governanceReviewCapacityScore)
+      .filter((score): score is number => score !== undefined)
+  )
+
+  return {
+    accommodationAccessScore: accommodation,
+    careModeCoverageScore: careMode,
+    governanceReviewCapacityScore: governanceCapacity,
+  }
+}
+
+function upstreamEvidenceCount(bucket: RowBucket): number {
+  return (
+    bucket.staffFindings.length + bucket.deviationFindings.length + bucket.blameFindings.length
+  )
+}
+
+function buildRow(bucket: RowBucket): MedicalAccountabilityScorecardRow {
+  const siteScores = deriveSiteScores(bucket.siteSignals)
+  const outcomeDeviationCount = countOutcomeDeviations(bucket.deviationFindings)
+  const subjectDeflectionCount = countSubjectDeflections(bucket.blameFindings)
+
+  return {
+    rowId: bucket.rowId,
+    siteId: bucket.siteId,
+    staffId: bucket.staffId,
+    subjectId: bucket.subjectId,
+    protocolId: bucket.protocolId,
+    week: bucket.week,
+    doctrineAlignmentScore: deriveDoctrineAlignmentScore(bucket.staffFindings),
+    treatmentEfficacyScore: deriveTreatmentEfficacyScore(
+      bucket.staffFindings,
+      bucket.deviationFindings
+    ),
+    outcomeDeviationCount,
+    subjectDeflectionCount,
+    accountabilityRouteQualityScore: deriveAccountabilityRouteQualityScore(bucket.blameFindings),
+    accommodationAccessScore: siteScores.accommodationAccessScore,
+    careModeCoverageScore: siteScores.careModeCoverageScore,
+    governanceReviewPressureScore: deriveGovernanceReviewPressureScore({
+      deviationFindings: bucket.deviationFindings,
+      blameFindings: bucket.blameFindings,
+      governanceReviewCapacityScore: siteScores.governanceReviewCapacityScore,
+    }),
+  }
+}
+
+function hasCriticalUpstream(
+  bucket: RowBucket
+): boolean {
+  return (
+    bucket.deviationFindings.some((finding) => finding.severity === 'critical') ||
+    bucket.blameFindings.some((finding) => finding.severity === 'critical')
+  )
+}
+
+function buildRowFindings(
+  row: MedicalAccountabilityScorecardRow,
+  bucket: RowBucket,
+  options: Required<MedicalAccountabilityScorecardOptions>
+): MedicalAccountabilityScorecardFinding[] {
+  const findings: MedicalAccountabilityScorecardFinding[] = []
+  const shared = {
+    rowId: row.rowId,
+    siteId: row.siteId,
+    staffId: row.staffId,
+    subjectId: row.subjectId,
+    protocolId: row.protocolId,
+    week: row.week,
+  }
+
+  const highAlignmentPoorOutcome =
+    (row.doctrineAlignmentScore !== undefined &&
+      row.treatmentEfficacyScore !== undefined &&
+      row.doctrineAlignmentScore >= options.highAlignmentThreshold &&
+      row.treatmentEfficacyScore <= options.poorOutcomeThreshold) ||
+    bucket.staffFindings.some((finding) => finding.kind === 'high_alignment_low_efficacy')
+
+  if (highAlignmentPoorOutcome) {
+    findings.push({
+      kind: 'high_alignment_poor_outcome',
+      severity: 'warning',
+      ...shared,
+      detail:
+        'Doctrine alignment remains high while treatment efficacy or observed outcomes remain poor for this scorecard row.',
+    })
+  }
+
+  const accountabilityLow =
+    row.accountabilityRouteQualityScore === undefined ||
+    row.accountabilityRouteQualityScore < options.poorOutcomeThreshold
+  const blameInsufficient = bucket.blameFindings.some(
+    (finding) =>
+      finding.kind === 'institutional_accountability_required' ||
+      finding.kind === 'insufficient_failure_evidence'
+  )
+
+  if (row.outcomeDeviationCount > 0 && (accountabilityLow || blameInsufficient)) {
+    findings.push({
+      kind: 'outcome_accountability_gap',
+      severity: hasCriticalUpstream(bucket) ? 'critical' : 'warning',
+      ...shared,
+      detail:
+        'Outcome deviations are present without sufficient accountability route quality or institutional routing.',
+    })
+  }
+
+  if (row.subjectDeflectionCount > 0) {
+    const criticalDeflection = bucket.blameFindings.some(
+      (finding) =>
+        finding.kind === 'prohibited_subject_deflection' && finding.severity === 'critical'
+    )
+    findings.push({
+      kind: 'subject_deflection_pressure',
+      severity: criticalDeflection ? 'critical' : 'warning',
+      ...shared,
+      detail:
+        'Subject-side deflection or institutional accountability pressure is present on this row.',
+    })
+  }
+
+  if (
+    bucket.blameFindings.some(
+      (finding) => finding.kind === 'missing_treatment_limitation_acknowledgment'
+    )
+  ) {
+    findings.push({
+      kind: 'treatment_limitation_unacknowledged',
+      severity: 'warning',
+      ...shared,
+      detail: 'Treatment-limitation acknowledgment is missing for proposed institutional accountability.',
+    })
+  }
+
+  if (
+    row.accommodationAccessScore !== undefined &&
+    row.accommodationAccessScore < options.lowAccommodationAccessThreshold
+  ) {
+    findings.push({
+      kind: 'accommodation_access_gap',
+      severity: 'warning',
+      ...shared,
+      detail: `Accommodation access score ${row.accommodationAccessScore} is below the configured threshold.`,
+    })
+  }
+
+  if (
+    row.careModeCoverageScore !== undefined &&
+    row.careModeCoverageScore < options.lowCareModeCoverageThreshold
+  ) {
+    findings.push({
+      kind: 'care_mode_missing',
+      severity: 'warning',
+      ...shared,
+      detail: `Care-mode coverage score ${row.careModeCoverageScore} is below the configured threshold.`,
+    })
+  }
+
+  const governanceCritical = bucket.deviationFindings.some(
+    (finding) => finding.kind === 'governance_notification_candidate'
+  )
+  if (
+    (row.governanceReviewPressureScore !== undefined &&
+      row.governanceReviewPressureScore >= options.highGovernancePressureThreshold) ||
+    governanceCritical
+  ) {
+    findings.push({
+      kind: 'governance_review_needed',
+      severity: governanceCritical || hasCriticalUpstream(bucket) ? 'critical' : 'warning',
+      ...shared,
+      detail:
+        row.governanceReviewPressureScore !== undefined
+          ? `Governance review pressure score ${row.governanceReviewPressureScore} warrants review.`
+          : 'Upstream governance notification candidates require review for this row.',
+    })
+  }
+
+  const evidenceCount = upstreamEvidenceCount(bucket)
+  const siteOnly =
+    evidenceCount === 0 && bucket.siteSignals.length > 0 && bucket.key.startsWith('site\0')
+
+  if (
+    evidenceCount < options.minimumEvidenceCount ||
+    siteOnly
+  ) {
+    findings.push({
+      kind: 'insufficient_scorecard_evidence',
+      severity: 'info',
+      ...shared,
+      detail:
+        siteOnly
+          ? 'Site signal recorded without staff telemetry, deviation audit, or blame-routing evidence for this row.'
+          : `Fewer than ${options.minimumEvidenceCount} upstream evidence item(s) support this scorecard row.`,
+    })
+  }
+
+  return findings
+}
+
+function compareRows(left: MedicalAccountabilityScorecardRow, right: MedicalAccountabilityScorecardRow): number {
+  const siteLeft = left.siteId ?? '\uffff'
+  const siteRight = right.siteId ?? '\uffff'
+  const siteDelta = siteLeft.localeCompare(siteRight)
+  if (siteDelta !== 0) {
+    return siteDelta
+  }
+
+  const staffLeft = left.staffId ?? '\uffff'
+  const staffRight = right.staffId ?? '\uffff'
+  const staffDelta = staffLeft.localeCompare(staffRight)
+  if (staffDelta !== 0) {
+    return staffDelta
+  }
+
+  const subjectLeft = left.subjectId ?? '\uffff'
+  const subjectRight = right.subjectId ?? '\uffff'
+  const subjectDelta = subjectLeft.localeCompare(subjectRight)
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+
+  const protocolLeft = left.protocolId ?? '\uffff'
+  const protocolRight = right.protocolId ?? '\uffff'
+  const protocolDelta = protocolLeft.localeCompare(protocolRight)
+  if (protocolDelta !== 0) {
+    return protocolDelta
+  }
+
+  const weekLeft = left.week ?? Number.MAX_SAFE_INTEGER
+  const weekRight = right.week ?? Number.MAX_SAFE_INTEGER
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+
+  return left.rowId.localeCompare(right.rowId)
+}
+
+function compareFindings(
+  left: MedicalAccountabilityScorecardFinding,
+  right: MedicalAccountabilityScorecardFinding
+): number {
+  const severityDelta = SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity]
+  if (severityDelta !== 0) {
+    return severityDelta
+  }
+
+  const kindDelta =
+    FINDING_KIND_ORDER.indexOf(left.kind) - FINDING_KIND_ORDER.indexOf(right.kind)
+  if (kindDelta !== 0) {
+    return kindDelta
+  }
+
+  const rowDelta = left.rowId.localeCompare(right.rowId)
+  if (rowDelta !== 0) {
+    return rowDelta
+  }
+
+  const siteDelta = (left.siteId ?? '').localeCompare(right.siteId ?? '')
+  if (siteDelta !== 0) {
+    return siteDelta
+  }
+
+  const staffDelta = (left.staffId ?? '').localeCompare(right.staffId ?? '')
+  if (staffDelta !== 0) {
+    return staffDelta
+  }
+
+  const subjectDelta = (left.subjectId ?? '').localeCompare(right.subjectId ?? '')
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+
+  const protocolDelta = (left.protocolId ?? '').localeCompare(right.protocolId ?? '')
+  if (protocolDelta !== 0) {
+    return protocolDelta
+  }
+
+  const weekLeft = left.week ?? Number.MAX_SAFE_INTEGER
+  const weekRight = right.week ?? Number.MAX_SAFE_INTEGER
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+
+  return left.detail.localeCompare(right.detail)
+}
+
+function formatFindingLine(finding: MedicalAccountabilityScorecardFinding): string {
+  const parts = [
+    finding.severity,
+    finding.kind,
+    `row:${finding.rowId}`,
+  ]
+  if (finding.siteId !== undefined) {
+    parts.push(`site:${finding.siteId}`)
+  }
+  if (finding.staffId !== undefined) {
+    parts.push(`staff:${finding.staffId}`)
+  }
+  if (finding.subjectId !== undefined) {
+    parts.push(`subject:${finding.subjectId}`)
+  }
+  if (finding.protocolId !== undefined) {
+    parts.push(`protocol:${finding.protocolId}`)
+  }
+  if (finding.week !== undefined) {
+    parts.push(`week:${finding.week}`)
+  }
+  parts.push(finding.detail)
+  return parts.join(' · ')
+}
+
+function formatReportLines(
+  rows: readonly MedicalAccountabilityScorecardRow[],
+  findings: readonly MedicalAccountabilityScorecardFinding[]
+): string[] {
+  const deflectionCount = findings.filter(
+    (finding) => finding.kind === 'subject_deflection_pressure'
+  ).length
+  const governanceCount = findings.filter(
+    (finding) => finding.kind === 'governance_review_needed'
+  ).length
+
+  if (rows.length === 0 && findings.length === 0) {
+    return [
+      'Medical accountability scorecard: rows=0, findings=0, deflection=0, governance=0',
+    ]
+  }
+
+  return [
+    `Medical accountability scorecard: rows=${rows.length}, findings=${findings.length}, deflection=${deflectionCount}, governance=${governanceCount}`,
+    ...findings.map((finding) => formatFindingLine(finding)),
+  ]
+}
+
+function emptySummary(): MedicalAccountabilityScorecardReport['summary'] {
+  return {
+    rowCount: 0,
+    highAlignmentPoorOutcomeCount: 0,
+    outcomeAccountabilityGapCount: 0,
+    subjectDeflectionPressureCount: 0,
+    treatmentLimitationUnacknowledgedCount: 0,
+    accommodationAccessGapCount: 0,
+    careModeMissingCount: 0,
+    governanceReviewNeededCount: 0,
+    insufficientEvidenceCount: 0,
+  }
+}
+
+export function buildMedicalAccountabilityScorecard(input: {
+  staffTelemetryFindings?: readonly StaffTreatmentTelemetryFinding[]
+  medicalDeviationFindings?: readonly MedicalOutcomeDeviationFinding[]
+  blameRoutingFindings?: readonly TreatmentFailureBlameRoutingFinding[]
+  siteSignals?: readonly MedicalAccountabilitySiteSignal[]
+  options?: MedicalAccountabilityScorecardOptions
+}): MedicalAccountabilityScorecardReport {
+  const options = resolveOptions(input.options)
+  const staffFindings = input.staffTelemetryFindings ?? []
+  const deviationFindings = input.medicalDeviationFindings ?? []
+  const blameFindings = input.blameRoutingFindings ?? []
+  const siteSignals = dedupeSiteSignals(input.siteSignals ?? [])
+
+  if (
+    staffFindings.length === 0 &&
+    deviationFindings.length === 0 &&
+    blameFindings.length === 0 &&
+    siteSignals.length === 0
+  ) {
+    return {
+      rows: [],
+      findings: [],
+      summary: emptySummary(),
+      lines: formatReportLines([], []),
+    }
+  }
+
+  const buckets = new Map<string, RowBucket>()
+
+  for (const finding of staffFindings) {
+    const bucket = getOrCreateBucket(buckets, resolveStaffFindingKey(finding))
+    if (bucket.staffId === undefined && finding.staffId.trim().length > 0) {
+      bucket.staffId = finding.staffId.trim()
+    }
+    bucket.staffFindings.push(finding)
+  }
+
+  for (const finding of deviationFindings) {
+    getOrCreateBucket(buckets, resolveDeviationFindingKey(finding)).deviationFindings.push(finding)
+  }
+
+  for (const finding of blameFindings) {
+    getOrCreateBucket(buckets, resolveBlameFindingKey(finding)).blameFindings.push(finding)
+  }
+
+  for (const signal of siteSignals) {
+    getOrCreateBucket(buckets, siteWeekKey(signal.siteId, signal.week)).siteSignals.push(signal)
+  }
+
+  const rows = [...buckets.values()]
+    .map((bucket) => buildRow(bucket))
+    .sort(compareRows)
+
+  const findings = [...buckets.values()]
+    .flatMap((bucket) => {
+      const row = rows.find((candidate) => candidate.rowId === bucket.rowId)
+      return row ? buildRowFindings(row, bucket, options) : []
+    })
+    .sort(compareFindings)
+
+  const countByKind = (kind: MedicalAccountabilityScorecardFindingKind) =>
+    findings.filter((finding) => finding.kind === kind).length
+
+  const summary = {
+    rowCount: rows.length,
+    highAlignmentPoorOutcomeCount: countByKind('high_alignment_poor_outcome'),
+    outcomeAccountabilityGapCount: countByKind('outcome_accountability_gap'),
+    subjectDeflectionPressureCount: countByKind('subject_deflection_pressure'),
+    treatmentLimitationUnacknowledgedCount: countByKind('treatment_limitation_unacknowledged'),
+    accommodationAccessGapCount: countByKind('accommodation_access_gap'),
+    careModeMissingCount: countByKind('care_mode_missing'),
+    governanceReviewNeededCount: countByKind('governance_review_needed'),
+    insufficientEvidenceCount: countByKind('insufficient_scorecard_evidence'),
+  }
+
+  return {
+    rows,
+    findings,
+    summary,
+    lines: formatReportLines(rows, findings),
+  }
+}

--- a/src/domain/medicalAccountabilityScorecard.ts
+++ b/src/domain/medicalAccountabilityScorecard.ts
@@ -857,7 +857,7 @@ function formatFindingLine(finding: MedicalAccountabilityScorecardFinding): stri
   const parts = [
     finding.severity,
     finding.kind,
-    `row:${finding.rowId}`,
+    finding.rowId,
   ]
   if (finding.siteId !== undefined) {
     parts.push(`site:${finding.siteId}`)

--- a/src/domain/medicalAccountabilityScorecard.ts
+++ b/src/domain/medicalAccountabilityScorecard.ts
@@ -964,16 +964,17 @@ export function buildMedicalAccountabilityScorecard(input: {
     getOrCreateBucket(buckets, siteWeekKey(signal.siteId, signal.week)).siteSignals.push(signal)
   }
 
-  const rows = [...buckets.values()]
-    .map((bucket) => buildRow(bucket))
-    .sort(compareRows)
+  const rows: MedicalAccountabilityScorecardRow[] = []
+  const findings: MedicalAccountabilityScorecardFinding[] = []
 
-  const findings = [...buckets.values()]
-    .flatMap((bucket) => {
-      const row = rows.find((candidate) => candidate.rowId === bucket.rowId)
-      return row ? buildRowFindings(row, bucket, options) : []
-    })
-    .sort(compareFindings)
+  for (const bucket of buckets.values()) {
+    const row = buildRow(bucket, options)
+    rows.push(row)
+    findings.push(...buildRowFindings(row, bucket, options))
+  }
+
+  rows.sort(compareRows)
+  findings.sort(compareFindings)
 
   const countByKind = (kind: MedicalAccountabilityScorecardFindingKind) =>
     findings.filter((finding) => finding.kind === kind).length

--- a/src/domain/medicalAccountabilityScorecard.ts
+++ b/src/domain/medicalAccountabilityScorecard.ts
@@ -394,7 +394,8 @@ function meanRounded(values: readonly number[]): number | undefined {
 }
 
 function deriveDoctrineAlignmentScore(
-  staffFindings: readonly StaffTreatmentTelemetryFinding[]
+  staffFindings: readonly StaffTreatmentTelemetryFinding[],
+  options: Required<MedicalAccountabilityScorecardOptions>
 ): number | undefined {
   const scores = staffFindings
     .map((finding) => finding.alignmentScore)
@@ -410,7 +411,7 @@ function deriveDoctrineAlignmentScore(
         finding.kind === 'outcome_below_expected'
     )
   ) {
-    return DEFAULT_OPTIONS.highAlignmentThreshold
+    return options.highAlignmentThreshold
   }
 
   return undefined
@@ -418,7 +419,8 @@ function deriveDoctrineAlignmentScore(
 
 function deriveTreatmentEfficacyScore(
   staffFindings: readonly StaffTreatmentTelemetryFinding[],
-  deviationFindings: readonly MedicalOutcomeDeviationFinding[]
+  deviationFindings: readonly MedicalOutcomeDeviationFinding[],
+  options: Required<MedicalAccountabilityScorecardOptions>
 ): number | undefined {
   const efficacyScores = staffFindings
     .map((finding) => finding.efficacyScore)
@@ -428,14 +430,14 @@ function deriveTreatmentEfficacyScore(
   }
 
   if (staffFindings.some((finding) => finding.kind === 'high_alignment_low_efficacy')) {
-    return DEFAULT_OPTIONS.poorOutcomeThreshold
+    return options.poorOutcomeThreshold
   }
 
   const outcomeDeviationCount = deviationFindings.filter((finding) =>
     OUTCOME_DEVIATION_KINDS.has(finding.kind)
   ).length
   if (outcomeDeviationCount > 0) {
-    return Math.max(0, DEFAULT_OPTIONS.poorOutcomeThreshold - 5 * (outcomeDeviationCount - 1))
+    return Math.max(0, options.poorOutcomeThreshold - 5 * (outcomeDeviationCount - 1))
   }
 
   return undefined
@@ -584,7 +586,10 @@ function upstreamEvidenceCount(bucket: RowBucket): number {
   )
 }
 
-function buildRow(bucket: RowBucket): MedicalAccountabilityScorecardRow {
+function buildRow(
+  bucket: RowBucket,
+  options: Required<MedicalAccountabilityScorecardOptions>
+): MedicalAccountabilityScorecardRow {
   const siteScores = deriveSiteScores(bucket.siteSignals)
   const outcomeDeviationCount = countOutcomeDeviations(bucket.deviationFindings)
   const subjectDeflectionCount = countSubjectDeflections(bucket.blameFindings)
@@ -596,10 +601,11 @@ function buildRow(bucket: RowBucket): MedicalAccountabilityScorecardRow {
     subjectId: bucket.subjectId,
     protocolId: bucket.protocolId,
     week: bucket.week,
-    doctrineAlignmentScore: deriveDoctrineAlignmentScore(bucket.staffFindings),
+    doctrineAlignmentScore: deriveDoctrineAlignmentScore(bucket.staffFindings, options),
     treatmentEfficacyScore: deriveTreatmentEfficacyScore(
       bucket.staffFindings,
-      bucket.deviationFindings
+      bucket.deviationFindings,
+      options
     ),
     outcomeDeviationCount,
     subjectDeflectionCount,

--- a/src/domain/medicalAccountabilityScorecard.ts
+++ b/src/domain/medicalAccountabilityScorecard.ts
@@ -114,6 +114,10 @@ const OUTCOME_DEVIATION_KINDS = new Set<MedicalOutcomeDeviationFinding['kind']>(
   'escalation_above_expected',
 ])
 
+/** Coarse row scores when upstream findings omit numeric fields (not threshold overrides). */
+const INFERRED_HIGH_DOCTRINE_ALIGNMENT_SCORE = 85
+const INFERRED_LOW_TREATMENT_EFFICACY_SCORE = 30
+
 const DEFAULT_OPTIONS: Required<MedicalAccountabilityScorecardOptions> = {
   highAlignmentThreshold: 70,
   poorOutcomeThreshold: 40,
@@ -394,8 +398,7 @@ function meanRounded(values: readonly number[]): number | undefined {
 }
 
 function deriveDoctrineAlignmentScore(
-  staffFindings: readonly StaffTreatmentTelemetryFinding[],
-  options: Required<MedicalAccountabilityScorecardOptions>
+  staffFindings: readonly StaffTreatmentTelemetryFinding[]
 ): number | undefined {
   const scores = staffFindings
     .map((finding) => finding.alignmentScore)
@@ -404,14 +407,8 @@ function deriveDoctrineAlignmentScore(
     return meanRounded(scores.map(clampScore))
   }
 
-  if (
-    staffFindings.some(
-      (finding) =>
-        finding.kind === 'high_alignment_low_efficacy' ||
-        finding.kind === 'outcome_below_expected'
-    )
-  ) {
-    return options.highAlignmentThreshold
+  if (staffFindings.some((finding) => finding.kind === 'high_alignment_low_efficacy')) {
+    return INFERRED_HIGH_DOCTRINE_ALIGNMENT_SCORE
   }
 
   return undefined
@@ -419,8 +416,7 @@ function deriveDoctrineAlignmentScore(
 
 function deriveTreatmentEfficacyScore(
   staffFindings: readonly StaffTreatmentTelemetryFinding[],
-  deviationFindings: readonly MedicalOutcomeDeviationFinding[],
-  options: Required<MedicalAccountabilityScorecardOptions>
+  deviationFindings: readonly MedicalOutcomeDeviationFinding[]
 ): number | undefined {
   const efficacyScores = staffFindings
     .map((finding) => finding.efficacyScore)
@@ -430,14 +426,33 @@ function deriveTreatmentEfficacyScore(
   }
 
   if (staffFindings.some((finding) => finding.kind === 'high_alignment_low_efficacy')) {
-    return options.poorOutcomeThreshold
+    return INFERRED_LOW_TREATMENT_EFFICACY_SCORE
   }
 
   const outcomeDeviationCount = deviationFindings.filter((finding) =>
     OUTCOME_DEVIATION_KINDS.has(finding.kind)
   ).length
   if (outcomeDeviationCount > 0) {
-    return Math.max(0, options.poorOutcomeThreshold - 5 * (outcomeDeviationCount - 1))
+    return Math.max(
+      0,
+      INFERRED_LOW_TREATMENT_EFFICACY_SCORE - 5 * (outcomeDeviationCount - 1)
+    )
+  }
+
+  return undefined
+}
+
+function resolveBucketStaffId(
+  staffFindings: readonly StaffTreatmentTelemetryFinding[]
+): string | undefined {
+  const staffIds = [
+    ...new Set(
+      staffFindings.map((finding) => finding.staffId.trim()).filter((staffId) => staffId.length > 0)
+    ),
+  ].sort((left, right) => left.localeCompare(right))
+
+  if (staffIds.length === 1) {
+    return staffIds[0]
   }
 
   return undefined
@@ -586,10 +601,7 @@ function upstreamEvidenceCount(bucket: RowBucket): number {
   )
 }
 
-function buildRow(
-  bucket: RowBucket,
-  options: Required<MedicalAccountabilityScorecardOptions>
-): MedicalAccountabilityScorecardRow {
+function buildRow(bucket: RowBucket): MedicalAccountabilityScorecardRow {
   const siteScores = deriveSiteScores(bucket.siteSignals)
   const outcomeDeviationCount = countOutcomeDeviations(bucket.deviationFindings)
   const subjectDeflectionCount = countSubjectDeflections(bucket.blameFindings)
@@ -597,15 +609,14 @@ function buildRow(
   return {
     rowId: bucket.rowId,
     siteId: bucket.siteId,
-    staffId: bucket.staffId,
     subjectId: bucket.subjectId,
     protocolId: bucket.protocolId,
     week: bucket.week,
-    doctrineAlignmentScore: deriveDoctrineAlignmentScore(bucket.staffFindings, options),
+    staffId: resolveBucketStaffId(bucket.staffFindings) ?? bucket.staffId,
+    doctrineAlignmentScore: deriveDoctrineAlignmentScore(bucket.staffFindings),
     treatmentEfficacyScore: deriveTreatmentEfficacyScore(
       bucket.staffFindings,
-      bucket.deviationFindings,
-      options
+      bucket.deviationFindings
     ),
     outcomeDeviationCount,
     subjectDeflectionCount,
@@ -645,11 +656,10 @@ function buildRowFindings(
   }
 
   const highAlignmentPoorOutcome =
-    (row.doctrineAlignmentScore !== undefined &&
-      row.treatmentEfficacyScore !== undefined &&
-      row.doctrineAlignmentScore >= options.highAlignmentThreshold &&
-      row.treatmentEfficacyScore <= options.poorOutcomeThreshold) ||
-    bucket.staffFindings.some((finding) => finding.kind === 'high_alignment_low_efficacy')
+    row.doctrineAlignmentScore !== undefined &&
+    row.treatmentEfficacyScore !== undefined &&
+    row.doctrineAlignmentScore >= options.highAlignmentThreshold &&
+    row.treatmentEfficacyScore <= options.poorOutcomeThreshold
 
   if (highAlignmentPoorOutcome) {
     findings.push({
@@ -951,11 +961,7 @@ export function buildMedicalAccountabilityScorecard(input: {
   const buckets = new Map<string, RowBucket>()
 
   for (const finding of staffFindings) {
-    const bucket = getOrCreateBucket(buckets, resolveStaffFindingKey(finding))
-    if (bucket.staffId === undefined && finding.staffId.trim().length > 0) {
-      bucket.staffId = finding.staffId.trim()
-    }
-    bucket.staffFindings.push(finding)
+    getOrCreateBucket(buckets, resolveStaffFindingKey(finding)).staffFindings.push(finding)
   }
 
   for (const finding of deviationFindings) {
@@ -974,7 +980,7 @@ export function buildMedicalAccountabilityScorecard(input: {
   const findings: MedicalAccountabilityScorecardFinding[] = []
 
   for (const bucket of buckets.values()) {
-    const row = buildRow(bucket, options)
+    const row = buildRow(bucket)
     rows.push(row)
     findings.push(...buildRowFindings(row, bucket, options))
   }

--- a/src/test/medicalAccountabilityScorecard.test.ts
+++ b/src/test/medicalAccountabilityScorecard.test.ts
@@ -1,0 +1,549 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  buildMedicalAccountabilityScorecard,
+  type MedicalAccountabilitySiteSignal,
+} from '../domain/medicalAccountabilityScorecard'
+import type { MedicalOutcomeDeviationFinding } from '../domain/medicalOutcomeDeviationAudit'
+import type { StaffTreatmentTelemetryFinding } from '../domain/staffTreatmentTelemetry'
+import type { TreatmentFailureBlameRoutingFinding } from '../domain/treatmentFailureBlameRouting'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function staffFinding(
+  overrides: Partial<StaffTreatmentTelemetryFinding> &
+    Pick<StaffTreatmentTelemetryFinding, 'kind' | 'staffId' | 'detail'>
+): StaffTreatmentTelemetryFinding {
+  return { ...overrides }
+}
+
+function deviationFinding(
+  overrides: Partial<MedicalOutcomeDeviationFinding> &
+    Pick<
+      MedicalOutcomeDeviationFinding,
+      'kind' | 'severity' | 'subjectId' | 'protocolId' | 'detail'
+    >
+): MedicalOutcomeDeviationFinding {
+  return { ...overrides }
+}
+
+function blameFinding(
+  overrides: Partial<TreatmentFailureBlameRoutingFinding> &
+    Pick<
+      TreatmentFailureBlameRoutingFinding,
+      'kind' | 'severity' | 'subjectId' | 'protocolId' | 'detail'
+    >
+): TreatmentFailureBlameRoutingFinding {
+  return { ...overrides }
+}
+
+function siteSignal(
+  overrides: Partial<MedicalAccountabilitySiteSignal> &
+    Pick<MedicalAccountabilitySiteSignal, 'signalId' | 'siteId'>
+): MedicalAccountabilitySiteSignal {
+  return { ...overrides }
+}
+
+describe('medicalAccountabilityScorecard (SPE-2008)', () => {
+  it('returns empty report for empty input without throwing', () => {
+    const report = buildMedicalAccountabilityScorecard({})
+    expect(report.rows).toEqual([])
+    expect(report.findings).toEqual([])
+    expect(report.summary).toEqual({
+      rowCount: 0,
+      highAlignmentPoorOutcomeCount: 0,
+      outcomeAccountabilityGapCount: 0,
+      subjectDeflectionPressureCount: 0,
+      treatmentLimitationUnacknowledgedCount: 0,
+      accommodationAccessGapCount: 0,
+      careModeMissingCount: 0,
+      governanceReviewNeededCount: 0,
+      insufficientEvidenceCount: 0,
+    })
+    expect(report.lines[0]).toContain('rows=0')
+  })
+
+  it('builds row from staff telemetry finding', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'outcome_below_expected',
+          staffId: 'staff:medic-1',
+          subjectId: 'agent:patient-1',
+          protocolId: 'protocol:stabilize',
+          week: 3,
+          alignmentScore: 80,
+          efficacyScore: 35,
+          detail: 'Outcome below expected.',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]).toMatchObject({
+      staffId: 'staff:medic-1',
+      subjectId: 'agent:patient-1',
+      protocolId: 'protocol:stabilize',
+      week: 3,
+      doctrineAlignmentScore: 80,
+      treatmentEfficacyScore: 35,
+    })
+  })
+
+  it('builds row from medical deviation finding', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'outcome_below_prediction',
+          severity: 'warning',
+          subjectId: 'agent:patient-2',
+          protocolId: 'protocol:therapy',
+          week: 2,
+          detail: 'Observed outcome trails prediction.',
+        }),
+      ],
+    })
+    expect(report.rows[0]).toMatchObject({
+      subjectId: 'agent:patient-2',
+      protocolId: 'protocol:therapy',
+      week: 2,
+      outcomeDeviationCount: 1,
+    })
+  })
+
+  it('builds row from blame-routing finding', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'approved_accountability_route',
+          severity: 'info',
+          subjectId: 'agent:patient-3',
+          protocolId: 'protocol:stabilize',
+          week: 4,
+          detail: 'Staff route approved.',
+          recommendedAccountabilityFocus: 'staff',
+        }),
+      ],
+    })
+    expect(report.rows[0]?.accountabilityRouteQualityScore).toBe(60)
+  })
+
+  it('builds row from site signal', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      siteSignals: [
+        siteSignal({
+          signalId: 'site-signal:infirmary',
+          siteId: 'site:infirmary',
+          week: 1,
+          accommodationAccessScore: 55,
+          careModeCoverageScore: 60,
+        }),
+      ],
+    })
+    expect(report.rows[0]).toMatchObject({
+      siteId: 'site:infirmary',
+      week: 1,
+      accommodationAccessScore: 55,
+      careModeCoverageScore: 60,
+    })
+  })
+
+  it('emits high_alignment_poor_outcome when alignment high and efficacy poor', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:medic-4',
+          subjectId: 'agent:patient-4',
+          protocolId: 'protocol:stabilize',
+          alignmentScore: 85,
+          efficacyScore: 30,
+          detail: 'High alignment with low efficacy.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'high_alignment_poor_outcome')).toBe(true)
+    expect(report.summary.highAlignmentPoorOutcomeCount).toBe(1)
+  })
+
+  it('emits outcome_accountability_gap when deviation without accountability quality', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'outcome_below_prediction',
+          severity: 'warning',
+          subjectId: 'agent:patient-5',
+          protocolId: 'protocol:stabilize',
+          detail: 'Deviation present.',
+        }),
+      ],
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'institutional_accountability_required',
+          severity: 'warning',
+          subjectId: 'agent:patient-5',
+          protocolId: 'protocol:stabilize',
+          detail: 'Institutional review required.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'outcome_accountability_gap')).toBe(true)
+  })
+
+  it('emits subject_deflection_pressure for prohibited subject deflection', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'prohibited_subject_deflection',
+          severity: 'critical',
+          subjectId: 'agent:patient-6',
+          protocolId: 'protocol:stabilize',
+          detail: 'Automatic deflection blocked.',
+        }),
+      ],
+    })
+    const finding = report.findings.find((f) => f.kind === 'subject_deflection_pressure')
+    expect(finding?.severity).toBe('critical')
+    expect(report.summary.subjectDeflectionPressureCount).toBe(1)
+  })
+
+  it('emits treatment_limitation_unacknowledged from blame routing', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'missing_treatment_limitation_acknowledgment',
+          severity: 'warning',
+          subjectId: 'agent:patient-7',
+          protocolId: 'protocol:stabilize',
+          detail: 'Acknowledgment missing.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'treatment_limitation_unacknowledged')).toBe(
+      true
+    )
+  })
+
+  it('emits accommodation_access_gap when accommodation score is low', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      siteSignals: [
+        siteSignal({
+          signalId: 'site:low-acc',
+          siteId: 'site:ward-a',
+          accommodationAccessScore: 25,
+        }),
+      ],
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'outcome_below_prediction',
+          severity: 'warning',
+          subjectId: 'agent:ward-a',
+          protocolId: 'protocol:ward',
+          detail: 'Linked deviation for site row evidence.',
+        }),
+      ],
+    })
+    const siteRow = report.rows.find((row) => row.siteId === 'site:ward-a')
+    expect(siteRow?.accommodationAccessScore).toBe(25)
+    expect(
+      report.findings.some(
+        (f) => f.kind === 'accommodation_access_gap' && f.siteId === 'site:ward-a'
+      )
+    ).toBe(true)
+  })
+
+  it('emits care_mode_missing when care-mode coverage is low', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      siteSignals: [
+        siteSignal({
+          signalId: 'site:low-care',
+          siteId: 'site:ward-b',
+          careModeCoverageScore: 20,
+        }),
+      ],
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'missing_observation',
+          severity: 'info',
+          subjectId: 'agent:patient-8',
+          protocolId: 'protocol:observe',
+          detail: 'Missing observation only.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'care_mode_missing')).toBe(true)
+  })
+
+  it('emits governance_review_needed when governance pressure is high', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'governance_notification_candidate',
+          severity: 'critical',
+          subjectId: 'agent:patient-9',
+          protocolId: 'protocol:stabilize',
+          detail: 'Governance candidate.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'governance_review_needed')).toBe(true)
+    expect(report.rows[0]?.governanceReviewPressureScore).toBeGreaterThan(0)
+  })
+
+  it('emits insufficient_scorecard_evidence for sparse site-only row', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      siteSignals: [
+        siteSignal({
+          signalId: 'site:sparse',
+          siteId: 'site:sparse',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'insufficient_scorecard_evidence')).toBe(true)
+  })
+
+  it('improves accountability quality for approved accountability route', () => {
+    const withApproval = buildMedicalAccountabilityScorecard({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'approved_accountability_route',
+          severity: 'info',
+          subjectId: 'agent:patient-10',
+          protocolId: 'protocol:stabilize',
+          detail: 'Approved route.',
+        }),
+      ],
+    })
+    const withDeflection = buildMedicalAccountabilityScorecard({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'prohibited_subject_deflection',
+          severity: 'warning',
+          subjectId: 'agent:patient-10b',
+          protocolId: 'protocol:stabilize',
+          detail: 'Deflection blocked.',
+        }),
+      ],
+    })
+    expect(withApproval.rows[0]?.accountabilityRouteQualityScore).toBe(60)
+    expect(withDeflection.rows[0]?.accountabilityRouteQualityScore).toBe(25)
+  })
+
+  it('produces deterministic ordering across repeated calls', () => {
+    const input = {
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:z',
+          subjectId: 'agent:z',
+          protocolId: 'protocol:z',
+          week: 2,
+          alignmentScore: 90,
+          efficacyScore: 20,
+          detail: 'Z row.',
+        }),
+        staffFinding({
+          kind: 'outcome_below_expected',
+          staffId: 'staff:a',
+          subjectId: 'agent:a',
+          protocolId: 'protocol:a',
+          week: 1,
+          alignmentScore: 50,
+          efficacyScore: 50,
+          detail: 'A row.',
+        }),
+      ],
+    }
+    const first = buildMedicalAccountabilityScorecard(input)
+    const second = buildMedicalAccountabilityScorecard(input)
+    expect(first).toEqual(second)
+  })
+
+  it('does not mutate frozen inputs', () => {
+    const staffTelemetryFindings = Object.freeze([
+      Object.freeze(
+        staffFinding({
+          kind: 'outcome_below_expected',
+          staffId: 'staff:immutable',
+          detail: 'Immutable staff finding.',
+        })
+      ),
+    ]) as readonly StaffTreatmentTelemetryFinding[]
+
+    const before = JSON.stringify(staffTelemetryFindings)
+    buildMedicalAccountabilityScorecard({ staffTelemetryFindings })
+    expect(JSON.stringify(staffTelemetryFindings)).toBe(before)
+  })
+
+  it('handles duplicate site signal IDs deterministically', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      siteSignals: [
+        siteSignal({
+          signalId: 'dup-signal',
+          siteId: 'site:dup',
+          accommodationAccessScore: 30,
+        }),
+        siteSignal({
+          signalId: 'dup-signal',
+          siteId: 'site:dup',
+          accommodationAccessScore: 90,
+        }),
+      ],
+    })
+    const siteRows = report.rows.filter((row) => row.siteId === 'site:dup')
+    expect(siteRows).toHaveLength(1)
+    expect(siteRows[0]?.accommodationAccessScore).toBe(30)
+  })
+
+  it('applies threshold overrides', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:thresh',
+          subjectId: 'agent:thresh',
+          protocolId: 'protocol:thresh',
+          alignmentScore: 60,
+          efficacyScore: 45,
+          detail: 'Borderline row.',
+        }),
+      ],
+      options: {
+        highAlignmentThreshold: 55,
+        poorOutcomeThreshold: 50,
+      },
+    })
+    expect(report.findings.some((f) => f.kind === 'high_alignment_poor_outcome')).toBe(true)
+  })
+
+  it('summary counts match findings', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:summary',
+          subjectId: 'agent:summary',
+          protocolId: 'protocol:summary',
+          alignmentScore: 90,
+          efficacyScore: 20,
+          detail: 'Summary row.',
+        }),
+      ],
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'outcome_below_prediction',
+          severity: 'critical',
+          subjectId: 'agent:summary',
+          protocolId: 'protocol:summary',
+          detail: 'Deviation for summary.',
+        }),
+      ],
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'prohibited_subject_deflection',
+          severity: 'critical',
+          subjectId: 'agent:summary',
+          protocolId: 'protocol:summary',
+          detail: 'Deflection for summary.',
+        }),
+      ],
+    })
+
+    expect(report.summary.rowCount).toBe(report.rows.length)
+    expect(report.summary.highAlignmentPoorOutcomeCount).toBe(
+      report.findings.filter((f) => f.kind === 'high_alignment_poor_outcome').length
+    )
+    expect(report.summary.outcomeAccountabilityGapCount).toBe(
+      report.findings.filter((f) => f.kind === 'outcome_accountability_gap').length
+    )
+    expect(report.summary.subjectDeflectionPressureCount).toBe(
+      report.findings.filter((f) => f.kind === 'subject_deflection_pressure').length
+    )
+    expect(report.summary.treatmentLimitationUnacknowledgedCount).toBe(
+      report.findings.filter((f) => f.kind === 'treatment_limitation_unacknowledged').length
+    )
+    expect(report.summary.accommodationAccessGapCount).toBe(
+      report.findings.filter((f) => f.kind === 'accommodation_access_gap').length
+    )
+    expect(report.summary.careModeMissingCount).toBe(
+      report.findings.filter((f) => f.kind === 'care_mode_missing').length
+    )
+    expect(report.summary.governanceReviewNeededCount).toBe(
+      report.findings.filter((f) => f.kind === 'governance_review_needed').length
+    )
+    expect(report.summary.insufficientEvidenceCount).toBe(
+      report.findings.filter((f) => f.kind === 'insufficient_scorecard_evidence').length
+    )
+  })
+
+  it('lines contain no SCP or harvest batch source strings', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:lines',
+          subjectId: 'agent:lines',
+          protocolId: 'protocol:lines',
+          alignmentScore: 88,
+          efficacyScore: 22,
+          detail: 'Lines test row.',
+        }),
+      ],
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'prohibited_subject_deflection',
+          severity: 'warning',
+          subjectId: 'agent:lines',
+          protocolId: 'protocol:lines',
+          detail: 'Deflection lines test.',
+        }),
+      ],
+    })
+    const joined = report.lines.join('\n').toLowerCase()
+    expect(joined).not.toContain('scp-')
+    expect(joined).not.toContain('scp ')
+    expect(joined).not.toContain('9977')
+  })
+
+  it('does not import GameState or UI modules', () => {
+    const source = readFileSync(
+      path.join(__dirname, '../domain/medicalAccountabilityScorecard.ts'),
+      'utf8'
+    )
+    expect(source.includes("from './models'")).toBe(false)
+    expect(source.includes('gameStore')).toBe(false)
+    expect(source.includes('/features/')).toBe(false)
+  })
+
+  it('uses type-only imports from upstream modules', () => {
+    const source = readFileSync(
+      path.join(__dirname, '../domain/medicalAccountabilityScorecard.ts'),
+      'utf8'
+    )
+    expect(source).toMatch(/import type \{ StaffTreatmentTelemetryFinding \}/)
+    expect(source).toMatch(/import type \{ MedicalOutcomeDeviationFinding \}/)
+    expect(source).toMatch(/import type \{ TreatmentFailureBlameRoutingFinding \}/)
+    expect(source.includes('buildStaffTreatmentTelemetryReport')).toBe(false)
+    expect(source.includes('buildMedicalOutcomeDeviationAuditReport')).toBe(false)
+    expect(source.includes('buildTreatmentFailureBlameRoutingReport')).toBe(false)
+  })
+
+  it('has no reverse imports from upstream modules', () => {
+    const staffSource = readFileSync(
+      path.join(__dirname, '../domain/staffTreatmentTelemetry.ts'),
+      'utf8'
+    )
+    const deviationSource = readFileSync(
+      path.join(__dirname, '../domain/medicalOutcomeDeviationAudit.ts'),
+      'utf8'
+    )
+    const blameSource = readFileSync(
+      path.join(__dirname, '../domain/treatmentFailureBlameRouting.ts'),
+      'utf8'
+    )
+    expect(staffSource.includes('medicalAccountabilityScorecard')).toBe(false)
+    expect(deviationSource.includes('medicalAccountabilityScorecard')).toBe(false)
+    expect(blameSource.includes('medicalAccountabilityScorecard')).toBe(false)
+  })
+})

--- a/src/test/medicalAccountabilityScorecard.test.ts
+++ b/src/test/medicalAccountabilityScorecard.test.ts
@@ -417,7 +417,7 @@ describe('medicalAccountabilityScorecard (SPE-2008)', () => {
     expect(report.findings.some((f) => f.kind === 'high_alignment_poor_outcome')).toBe(true)
   })
 
-  it('uses resolved options for inferred alignment and efficacy fallback scores', () => {
+  it('uses coarse inferred row scores when upstream findings omit numeric fields', () => {
     const report = buildMedicalAccountabilityScorecard({
       staffTelemetryFindings: [
         staffFinding({
@@ -428,13 +428,68 @@ describe('medicalAccountabilityScorecard (SPE-2008)', () => {
           detail: 'Kind-only telemetry without numeric scores.',
         }),
       ],
-      options: {
-        highAlignmentThreshold: 88,
-        poorOutcomeThreshold: 22,
-      },
     })
-    expect(report.rows[0]?.doctrineAlignmentScore).toBe(88)
-    expect(report.rows[0]?.treatmentEfficacyScore).toBe(22)
+    expect(report.rows[0]?.doctrineAlignmentScore).toBe(85)
+    expect(report.rows[0]?.treatmentEfficacyScore).toBe(30)
+  })
+
+  it('applies configured thresholds to kind-only rows without bypassing options', () => {
+    const sharedInput = {
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:opts',
+          subjectId: 'agent:opts',
+          protocolId: 'protocol:opts',
+          detail: 'Kind-only telemetry.',
+        }),
+      ],
+    }
+
+    const strict = buildMedicalAccountabilityScorecard({
+      ...sharedInput,
+      options: { highAlignmentThreshold: 90, poorOutcomeThreshold: 25 },
+    })
+    const lenient = buildMedicalAccountabilityScorecard({
+      ...sharedInput,
+      options: { highAlignmentThreshold: 70, poorOutcomeThreshold: 40 },
+    })
+
+    expect(strict.findings.some((f) => f.kind === 'high_alignment_poor_outcome')).toBe(false)
+    expect(lenient.findings.some((f) => f.kind === 'high_alignment_poor_outcome')).toBe(true)
+  })
+
+  it('resolves staffId deterministically and omits it for mixed-staff subject rows', () => {
+    const findingA = staffFinding({
+      kind: 'outcome_below_expected',
+      staffId: 'staff:alpha',
+      subjectId: 'agent:shared',
+      protocolId: 'protocol:shared',
+      week: 2,
+      alignmentScore: 80,
+      efficacyScore: 35,
+      detail: 'Alpha staff row.',
+    })
+    const findingB = staffFinding({
+      kind: 'outcome_below_expected',
+      staffId: 'staff:beta',
+      subjectId: 'agent:shared',
+      protocolId: 'protocol:shared',
+      week: 2,
+      alignmentScore: 75,
+      efficacyScore: 30,
+      detail: 'Beta staff row.',
+    })
+
+    const forward = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [findingA, findingB],
+    })
+    const reverse = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [findingB, findingA],
+    })
+
+    expect(forward).toEqual(reverse)
+    expect(forward.rows[0]?.staffId).toBeUndefined()
   })
 
   it('summary counts match findings', () => {

--- a/src/test/medicalAccountabilityScorecard.test.ts
+++ b/src/test/medicalAccountabilityScorecard.test.ts
@@ -579,6 +579,7 @@ describe('medicalAccountabilityScorecard (SPE-2008)', () => {
     expect(joined).not.toContain('scp-')
     expect(joined).not.toContain('scp ')
     expect(joined).not.toContain('9977')
+    expect(report.lines.join('\n')).not.toContain('row:row:')
   })
 
   it('does not import GameState or UI modules', () => {

--- a/src/test/medicalAccountabilityScorecard.test.ts
+++ b/src/test/medicalAccountabilityScorecard.test.ts
@@ -417,6 +417,26 @@ describe('medicalAccountabilityScorecard (SPE-2008)', () => {
     expect(report.findings.some((f) => f.kind === 'high_alignment_poor_outcome')).toBe(true)
   })
 
+  it('uses resolved options for inferred alignment and efficacy fallback scores', () => {
+    const report = buildMedicalAccountabilityScorecard({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:fallback',
+          subjectId: 'agent:fallback',
+          protocolId: 'protocol:fallback',
+          detail: 'Kind-only telemetry without numeric scores.',
+        }),
+      ],
+      options: {
+        highAlignmentThreshold: 88,
+        poorOutcomeThreshold: 22,
+      },
+    })
+    expect(report.rows[0]?.doctrineAlignmentScore).toBe(88)
+    expect(report.rows[0]?.treatmentEfficacyScore).toBe(22)
+  })
+
   it('summary counts match findings', () => {
     const report = buildMedicalAccountabilityScorecard({
       staffTelemetryFindings: [


### PR DESCRIPTION
## Summary

- Adds pure `buildMedicalAccountabilityScorecard` composer (`src/domain/medicalAccountabilityScorecard.ts`) that deterministically folds upstream **finding arrays** from SPE-2010 staff treatment telemetry, SPE-2003 medical outcome deviation audit, and SPE-2006 treatment-failure blame routing into scorecard rows, eight first-slice finding kinds, summary counts, and audit-facing lines.
- Uses **type-only** imports from upstream modules; does not call upstream report builders or recompute upstream logic.
- Adds 23 focused Vitest cases in `src/test/medicalAccountabilityScorecard.test.ts`.

**Linear:** https://linear.app/spectranoir/issue/SPE-2008/batch-9977-ideological-medicine-scorecard-with-outcome-accountability

**Upstream dependencies:** SPE-2010, SPE-2003, SPE-2006 (merged on main via #2140)

**Smallest boundary:** pure composer + tests only.

## Files changed

- `src/domain/medicalAccountabilityScorecard.ts`
- `src/test/medicalAccountabilityScorecard.test.ts`

## Validation run

- `npm run test:run -- src/test/medicalAccountabilityScorecard.test.ts`
- `npm run test:run -- src/test/staffTreatmentTelemetry.test.ts`
- `npm run test:run -- src/test/medicalOutcomeDeviationAudit.test.ts`
- `npm run test:run -- src/test/treatmentFailureBlameRouting.test.ts`
- `npm run test:run` (full suite: 3170 passed)
- `npm run lint`
- `git diff --check`

## Gap / edge-case / boundary audit

1. **Scorecard correctness:** Consumes upstream findings only; conservative grouping (subject+protocol+week, staff+week, site+week, aggregate); all eight finding kinds implemented; missing site scores stay undefined (not zero); accountability route quality documented (neutral 50 with simple deltas).
2. **Dependency correctness:** Type-only upstream imports; no reverse imports; no GameState/UI.
3. **Determinism / mutation:** Sorted rows/findings/lines; inputs not mutated; duplicate site `signalId` deduped by first sorted entry.
4. **Boundary check:** No persistence, tick, UI, doctrine enforcement, care-mode selector, policy ledger, or upstream reimplementation.
5. **Documentation:** Module header only; no backlog/planning edits.

## Out of scope

- GameState persistence, weekly tick, runtime integration
- UI / developer overlay
- Doctrine enforcement, care-mode selector, policy ledger
- Blame-routing / deviation / telemetry implementation
- Real-world diagnosis or protected-class encoding
- SCP / franchise strings in generated output

## Test plan

- [x] Empty input → empty report
- [x] Each upstream source builds rows
- [x] Each scorecard finding kind + summary alignment
- [x] Determinism, immutability, threshold overrides, line hygiene