### PR TITLE
SPE-2011: Add accommodation access audit

### DIFF
--- a/src/domain/accommodationAccessAudit.ts
+++ b/src/domain/accommodationAccessAudit.ts
@@ -1,0 +1,702 @@
+/**
+ * SPE-2011: deterministic accommodation access audit.
+ *
+ * Makes accommodation access versus cure-only doctrine pressure legible as
+ * audit rows, findings, summary counts, and audit-facing lines.
+ *
+ * Pure helper only. No GameState persistence, runtime enforcement, UI,
+ * care-mode selector, scorecard mutation, or real-world medical modeling.
+ */
+
+import type { MedicalOutcomeDeviationFinding } from './medicalOutcomeDeviationAudit'
+import type { TreatmentFailureBlameRoutingFinding } from './treatmentFailureBlameRouting'
+
+export type AccommodationCareMode =
+  | 'cure_attempt'
+  | 'symptom_management'
+  | 'stabilization'
+  | 'maintenance'
+  | 'accommodation'
+
+export type AccommodationDenialRationale =
+  | 'resource_limit'
+  | 'protocol_ceiling'
+  | 'doctrine_pressure'
+  | 'measurement_uncertainty'
+  | 'unknown'
+
+export interface AccommodationAccessSignal {
+  signalId: string
+  subjectId: string
+  protocolId: string
+  siteId?: string
+  week?: number
+  requestedCareMode?: AccommodationCareMode
+  offeredCareModes?: readonly AccommodationCareMode[]
+  accommodationAccessScore?: number
+  cureOnlyPressureScore?: number
+  treatmentLimitationAcknowledged?: boolean
+  denialRationale?: AccommodationDenialRationale
+}
+
+export type AccommodationAccessAuditFindingKind =
+  | 'accommodation_access_gap'
+  | 'cure_only_pressure_high'
+  | 'care_mode_unavailable'
+  | 'maintenance_framed_as_failure'
+  | 'treatment_limitation_unacknowledged'
+  | 'outcome_worsened_without_accommodation_review'
+  | 'accountability_route_conflicts_with_limitation'
+  | 'insufficient_accommodation_evidence'
+
+export type AccommodationAccessAuditSeverity = 'info' | 'warning' | 'critical'
+
+export interface AccommodationAccessAuditRow {
+  rowId: string
+  signalId?: string
+  subjectId: string
+  protocolId: string
+  siteId?: string
+  week?: number
+  requestedCareMode?: AccommodationCareMode
+  offeredCareModes: readonly AccommodationCareMode[]
+  accommodationAccessScore?: number
+  cureOnlyPressureScore?: number
+  treatmentLimitationAcknowledged?: boolean
+  denialRationale?: AccommodationDenialRationale
+}
+
+export interface AccommodationAccessAuditFinding {
+  kind: AccommodationAccessAuditFindingKind
+  severity: AccommodationAccessAuditSeverity
+  rowId: string
+  subjectId: string
+  protocolId: string
+  siteId?: string
+  week?: number
+  signalId?: string
+  detail: string
+}
+
+export interface AccommodationAccessAuditReport {
+  rows: readonly AccommodationAccessAuditRow[]
+  findings: readonly AccommodationAccessAuditFinding[]
+  summary: {
+    rowCount: number
+    accommodationAccessGapCount: number
+    cureOnlyPressureHighCount: number
+    careModeUnavailableCount: number
+    maintenanceFramedAsFailureCount: number
+    treatmentLimitationUnacknowledgedCount: number
+    outcomeWorsenedWithoutAccommodationReviewCount: number
+    accountabilityRouteConflictCount: number
+    insufficientEvidenceCount: number
+  }
+  lines: readonly string[]
+}
+
+export interface AccommodationAccessAuditOptions {
+  lowAccommodationAccessThreshold?: number
+  highCureOnlyPressureThreshold?: number
+  minimumEvidenceCount?: number
+}
+
+export interface AccommodationAccessAuditInput {
+  accommodationSignals: readonly AccommodationAccessSignal[]
+  medicalDeviationFindings?: readonly MedicalOutcomeDeviationFinding[]
+  blameRoutingFindings?: readonly TreatmentFailureBlameRoutingFinding[]
+  options?: AccommodationAccessAuditOptions
+}
+
+const CARE_MODE_SET = new Set<AccommodationCareMode>([
+  'accommodation',
+  'cure_attempt',
+  'maintenance',
+  'stabilization',
+  'symptom_management',
+])
+
+const CARE_MODE_ORDER: readonly AccommodationCareMode[] = [
+  'accommodation',
+  'cure_attempt',
+  'maintenance',
+  'stabilization',
+  'symptom_management',
+]
+
+const DENIAL_RATIONALE_SET = new Set<AccommodationDenialRationale>([
+  'resource_limit',
+  'protocol_ceiling',
+  'doctrine_pressure',
+  'measurement_uncertainty',
+  'unknown',
+])
+
+const LIMITATION_DENIAL_RATIONALES = new Set<AccommodationDenialRationale>([
+  'protocol_ceiling',
+  'resource_limit',
+  'measurement_uncertainty',
+])
+
+const OUTCOME_WORSENED_KINDS = new Set<MedicalOutcomeDeviationFinding['kind']>([
+  'outcome_below_prediction',
+  'symptom_burden_worsened',
+  'escalation_above_expected',
+])
+
+const ACCOUNTABILITY_CONFLICT_KINDS = new Set<TreatmentFailureBlameRoutingFinding['kind']>([
+  'prohibited_subject_deflection',
+  'institutional_accountability_required',
+])
+
+const SEVERITY_RANK: Readonly<Record<AccommodationAccessAuditSeverity, number>> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+const FINDING_KIND_ORDER: readonly AccommodationAccessAuditFindingKind[] = [
+  'care_mode_unavailable',
+  'accommodation_access_gap',
+  'cure_only_pressure_high',
+  'maintenance_framed_as_failure',
+  'treatment_limitation_unacknowledged',
+  'outcome_worsened_without_accommodation_review',
+  'accountability_route_conflicts_with_limitation',
+  'insufficient_accommodation_evidence',
+]
+
+const DEFAULT_OPTIONS = {
+  lowAccommodationAccessThreshold: 40,
+  highCureOnlyPressureThreshold: 70,
+  minimumEvidenceCount: 1,
+} as const
+
+type ResolvedOptions = {
+  lowAccommodationAccessThreshold: number
+  highCureOnlyPressureThreshold: number
+  minimumEvidenceCount: number
+}
+
+function clampThreshold(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback
+  }
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function normalizeMinimumEvidenceCount(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_OPTIONS.minimumEvidenceCount
+  }
+  return Math.max(1, Math.trunc(value))
+}
+
+function resolveOptions(options: AccommodationAccessAuditOptions | undefined): ResolvedOptions {
+  return {
+    lowAccommodationAccessThreshold: clampThreshold(
+      options?.lowAccommodationAccessThreshold,
+      DEFAULT_OPTIONS.lowAccommodationAccessThreshold
+    ),
+    highCureOnlyPressureThreshold: clampThreshold(
+      options?.highCureOnlyPressureThreshold,
+      DEFAULT_OPTIONS.highCureOnlyPressureThreshold
+    ),
+    minimumEvidenceCount: normalizeMinimumEvidenceCount(options?.minimumEvidenceCount),
+  }
+}
+
+function normalizeWeek(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined
+  }
+  return Math.max(0, Math.trunc(value))
+}
+
+function normalizeOptionalScore(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined
+  }
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function normalizeCareMode(value: string | undefined): AccommodationCareMode | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const trimmed = value.trim() as AccommodationCareMode
+  return CARE_MODE_SET.has(trimmed) ? trimmed : undefined
+}
+
+function normalizeDenialRationale(
+  value: string | undefined
+): AccommodationDenialRationale | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const trimmed = value.trim() as AccommodationDenialRationale
+  return DENIAL_RATIONALE_SET.has(trimmed) ? trimmed : undefined
+}
+
+function normalizeOfferedCareModes(
+  modes: readonly AccommodationCareMode[] | undefined
+): readonly AccommodationCareMode[] {
+  if (modes === undefined || modes.length === 0) {
+    return []
+  }
+  const unique = new Set<AccommodationCareMode>()
+  for (const mode of modes) {
+    const normalized = normalizeCareMode(mode)
+    if (normalized !== undefined) {
+      unique.add(normalized)
+    }
+  }
+  return CARE_MODE_ORDER.filter((mode) => unique.has(mode))
+}
+
+function dedupeById<T>(rows: readonly T[], resolveId: (row: T) => string): T[] {
+  const sorted = [...rows].sort((left, right) =>
+    resolveId(left).localeCompare(resolveId(right))
+  )
+  const seen = new Set<string>()
+  const deduped: T[] = []
+  for (const row of sorted) {
+    const id = resolveId(row)
+    if (seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    deduped.push(row)
+  }
+  return deduped
+}
+
+function normalizeSignal(signal: AccommodationAccessSignal): AccommodationAccessSignal {
+  return {
+    ...signal,
+    signalId: signal.signalId.trim(),
+    subjectId: signal.subjectId.trim(),
+    protocolId: signal.protocolId.trim(),
+    siteId: typeof signal.siteId === 'string' ? signal.siteId.trim() || undefined : undefined,
+    week: normalizeWeek(signal.week),
+    requestedCareMode: normalizeCareMode(signal.requestedCareMode),
+    offeredCareModes: normalizeOfferedCareModes(signal.offeredCareModes),
+    accommodationAccessScore: normalizeOptionalScore(signal.accommodationAccessScore),
+    cureOnlyPressureScore: normalizeOptionalScore(signal.cureOnlyPressureScore),
+    treatmentLimitationAcknowledged:
+      signal.treatmentLimitationAcknowledged === true
+        ? true
+        : signal.treatmentLimitationAcknowledged === false
+          ? false
+          : undefined,
+    denialRationale: normalizeDenialRationale(signal.denialRationale),
+  }
+}
+
+function buildRow(signal: AccommodationAccessSignal): AccommodationAccessAuditRow {
+  return {
+    rowId: `accommodation:${signal.signalId}`,
+    signalId: signal.signalId,
+    subjectId: signal.subjectId,
+    protocolId: signal.protocolId,
+    siteId: signal.siteId,
+    week: signal.week,
+    requestedCareMode: signal.requestedCareMode,
+    offeredCareModes: signal.offeredCareModes ?? [],
+    accommodationAccessScore: signal.accommodationAccessScore,
+    cureOnlyPressureScore: signal.cureOnlyPressureScore,
+    treatmentLimitationAcknowledged: signal.treatmentLimitationAcknowledged,
+    denialRationale: signal.denialRationale,
+  }
+}
+
+function compareRows(
+  left: AccommodationAccessAuditRow,
+  right: AccommodationAccessAuditRow
+): number {
+  const siteLeft = left.siteId ?? '\uffff'
+  const siteRight = right.siteId ?? '\uffff'
+  const siteDelta = siteLeft.localeCompare(siteRight)
+  if (siteDelta !== 0) {
+    return siteDelta
+  }
+
+  const subjectDelta = left.subjectId.localeCompare(right.subjectId)
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+
+  const protocolDelta = left.protocolId.localeCompare(right.protocolId)
+  if (protocolDelta !== 0) {
+    return protocolDelta
+  }
+
+  const weekLeft = left.week ?? Number.POSITIVE_INFINITY
+  const weekRight = right.week ?? Number.POSITIVE_INFINITY
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+
+  const signalLeft = left.signalId ?? '\uffff'
+  const signalRight = right.signalId ?? '\uffff'
+  return signalLeft.localeCompare(signalRight)
+}
+
+function compareFindings(
+  left: AccommodationAccessAuditFinding,
+  right: AccommodationAccessAuditFinding
+): number {
+  const severityDelta = SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity]
+  if (severityDelta !== 0) {
+    return severityDelta
+  }
+
+  const kindDelta =
+    FINDING_KIND_ORDER.indexOf(left.kind) - FINDING_KIND_ORDER.indexOf(right.kind)
+  if (kindDelta !== 0) {
+    return kindDelta
+  }
+
+  const siteLeft = left.siteId ?? '\uffff'
+  const siteRight = right.siteId ?? '\uffff'
+  const siteDelta = siteLeft.localeCompare(siteRight)
+  if (siteDelta !== 0) {
+    return siteDelta
+  }
+
+  const subjectDelta = left.subjectId.localeCompare(right.subjectId)
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+
+  const protocolDelta = left.protocolId.localeCompare(right.protocolId)
+  if (protocolDelta !== 0) {
+    return protocolDelta
+  }
+
+  const weekLeft = left.week ?? Number.POSITIVE_INFINITY
+  const weekRight = right.week ?? Number.POSITIVE_INFINITY
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+
+  const rowDelta = left.rowId.localeCompare(right.rowId)
+  if (rowDelta !== 0) {
+    return rowDelta
+  }
+
+  const signalLeft = left.signalId ?? '\uffff'
+  const signalRight = right.signalId ?? '\uffff'
+  return signalLeft.localeCompare(signalRight)
+}
+
+function matchesUpstream(
+  row: AccommodationAccessAuditRow,
+  finding: { subjectId: string; protocolId: string; week?: number }
+): boolean {
+  if (row.subjectId !== finding.subjectId || row.protocolId !== finding.protocolId) {
+    return false
+  }
+  if (row.week !== undefined && finding.week !== undefined && row.week !== finding.week) {
+    return false
+  }
+  return true
+}
+
+function sharedFindingFields(row: AccommodationAccessAuditRow): Pick<
+  AccommodationAccessAuditFinding,
+  'rowId' | 'subjectId' | 'protocolId' | 'siteId' | 'week' | 'signalId'
+> {
+  return {
+    rowId: row.rowId,
+    subjectId: row.subjectId,
+    protocolId: row.protocolId,
+    siteId: row.siteId,
+    week: row.week,
+    signalId: row.signalId,
+  }
+}
+
+function mapUpstreamSeverity(
+  severity: 'info' | 'warning' | 'critical' | undefined
+): AccommodationAccessAuditSeverity {
+  return severity === 'critical' ? 'critical' : 'warning'
+}
+
+function lacksAccommodationReview(row: AccommodationAccessAuditRow): boolean {
+  if (row.requestedCareMode === 'accommodation') {
+    return false
+  }
+  return !row.offeredCareModes.includes('accommodation')
+}
+
+function hasLimitationConflictContext(row: AccommodationAccessAuditRow): boolean {
+  return (
+    row.treatmentLimitationAcknowledged !== true || row.denialRationale === 'doctrine_pressure'
+  )
+}
+
+function countMeaningfulEvidence(row: AccommodationAccessAuditRow): number {
+  let count = 0
+  if (row.accommodationAccessScore !== undefined) {
+    count += 1
+  }
+  if (row.cureOnlyPressureScore !== undefined) {
+    count += 1
+  }
+  if (row.requestedCareMode !== undefined) {
+    count += 1
+  }
+  if (row.offeredCareModes.length > 0) {
+    count += 1
+  }
+  if (row.treatmentLimitationAcknowledged === true || row.treatmentLimitationAcknowledged === false) {
+    count += 1
+  }
+  if (row.denialRationale !== undefined) {
+    count += 1
+  }
+  return count
+}
+
+function hasLocalTreatmentLimitationUnacknowledged(row: AccommodationAccessAuditRow): boolean {
+  return (
+    row.denialRationale !== undefined &&
+    LIMITATION_DENIAL_RATIONALES.has(row.denialRationale) &&
+    row.treatmentLimitationAcknowledged !== true
+  )
+}
+
+function buildRowFindings(
+  row: AccommodationAccessAuditRow,
+  options: ResolvedOptions,
+  medicalDeviationFindings: readonly MedicalOutcomeDeviationFinding[],
+  blameRoutingFindings: readonly TreatmentFailureBlameRoutingFinding[]
+): AccommodationAccessAuditFinding[] {
+  const findings: AccommodationAccessAuditFinding[] = []
+  const shared = sharedFindingFields(row)
+
+  if (
+    row.accommodationAccessScore !== undefined &&
+    row.accommodationAccessScore <= options.lowAccommodationAccessThreshold
+  ) {
+    findings.push({
+      kind: 'accommodation_access_gap',
+      severity: row.accommodationAccessScore === 0 ? 'critical' : 'warning',
+      ...shared,
+      detail:
+        row.accommodationAccessScore === 0
+          ? 'Accommodation access score is zero; accommodation pathway appears fully blocked.'
+          : `Accommodation access score ${row.accommodationAccessScore} is at or below threshold ${options.lowAccommodationAccessThreshold}.`,
+    })
+  }
+
+  if (
+    row.cureOnlyPressureScore !== undefined &&
+    row.cureOnlyPressureScore >= options.highCureOnlyPressureThreshold
+  ) {
+    findings.push({
+      kind: 'cure_only_pressure_high',
+      severity: row.cureOnlyPressureScore === 100 ? 'critical' : 'warning',
+      ...shared,
+      detail:
+        row.cureOnlyPressureScore === 100
+          ? 'Cure-only doctrine pressure is maximal for this accommodation signal.'
+          : `Cure-only doctrine pressure score ${row.cureOnlyPressureScore} is at or above threshold ${options.highCureOnlyPressureThreshold}.`,
+    })
+  }
+
+  if (
+    row.requestedCareMode !== undefined &&
+    !row.offeredCareModes.includes(row.requestedCareMode)
+  ) {
+    const criticalMode =
+      row.requestedCareMode === 'accommodation' || row.requestedCareMode === 'maintenance'
+    findings.push({
+      kind: 'care_mode_unavailable',
+      severity: criticalMode ? 'critical' : 'warning',
+      ...shared,
+      detail: criticalMode
+        ? `Requested care mode ${row.requestedCareMode} is not among offered modes for this subject protocol context.`
+        : `Requested care mode ${row.requestedCareMode} is not available in the offered care-mode set.`,
+    })
+  }
+
+  if (
+    (row.requestedCareMode === 'maintenance' || row.requestedCareMode === 'accommodation') &&
+    row.denialRationale === 'doctrine_pressure' &&
+    row.cureOnlyPressureScore !== undefined &&
+    row.cureOnlyPressureScore >= options.highCureOnlyPressureThreshold
+  ) {
+    findings.push({
+      kind: 'maintenance_framed_as_failure',
+      severity: 'warning',
+      ...shared,
+      detail:
+        'Maintenance or accommodation care was denied under doctrine pressure while cure-only pressure remains high.',
+    })
+  }
+
+  let treatmentLimitationEmitted = false
+  if (hasLocalTreatmentLimitationUnacknowledged(row)) {
+    treatmentLimitationEmitted = true
+    findings.push({
+      kind: 'treatment_limitation_unacknowledged',
+      severity: 'warning',
+      ...shared,
+      detail:
+        'Treatment limitation was cited but not explicitly acknowledged in the accommodation access signal.',
+    })
+  }
+
+  if (!treatmentLimitationEmitted) {
+    const upstreamMissingAck = blameRoutingFindings.find(
+      (finding) =>
+        finding.kind === 'missing_treatment_limitation_acknowledgment' && matchesUpstream(row, finding)
+    )
+    if (upstreamMissingAck) {
+      treatmentLimitationEmitted = true
+      findings.push({
+        kind: 'treatment_limitation_unacknowledged',
+        severity: 'warning',
+        ...shared,
+        detail:
+          'Upstream blame-routing audit reports missing treatment-limitation acknowledgment for this subject protocol context.',
+      })
+    }
+  }
+
+  const upstreamOutcome = medicalDeviationFindings.find(
+    (finding) => OUTCOME_WORSENED_KINDS.has(finding.kind) && matchesUpstream(row, finding)
+  )
+  if (upstreamOutcome && lacksAccommodationReview(row)) {
+    findings.push({
+      kind: 'outcome_worsened_without_accommodation_review',
+      severity: mapUpstreamSeverity(upstreamOutcome.severity),
+      ...shared,
+      detail:
+        'Medical outcome deviation was recorded without accommodation offered or requested for review.',
+    })
+  }
+
+  const upstreamAccountability = blameRoutingFindings.find(
+    (finding) =>
+      ACCOUNTABILITY_CONFLICT_KINDS.has(finding.kind) &&
+      matchesUpstream(row, finding) &&
+      hasLimitationConflictContext(row)
+  )
+  if (upstreamAccountability) {
+    findings.push({
+      kind: 'accountability_route_conflicts_with_limitation',
+      severity: mapUpstreamSeverity(upstreamAccountability.severity),
+      ...shared,
+      detail:
+        'Accountability routing conflicts with unacknowledged treatment limitations or doctrine pressure on accommodation access.',
+    })
+  }
+
+  if (countMeaningfulEvidence(row) < options.minimumEvidenceCount) {
+    findings.push({
+      kind: 'insufficient_accommodation_evidence',
+      severity: 'info',
+      ...shared,
+      detail: `Fewer than ${options.minimumEvidenceCount} meaningful accommodation evidence field(s) support this audit row.`,
+    })
+  }
+
+  return findings
+}
+
+function formatFindingLine(
+  finding: AccommodationAccessAuditFinding,
+  row: AccommodationAccessAuditRow | undefined
+): string {
+  const parts = [
+    finding.severity,
+    finding.kind,
+    `subject:${finding.subjectId}`,
+    `protocol:${finding.protocolId}`,
+  ]
+  if (finding.siteId !== undefined) {
+    parts.push(`site:${finding.siteId}`)
+  }
+  if (finding.week !== undefined) {
+    parts.push(`week:${finding.week}`)
+  }
+  if (finding.kind === 'accommodation_access_gap' && row?.accommodationAccessScore !== undefined) {
+    parts.push(`score:${row.accommodationAccessScore}`)
+  }
+  if (finding.kind === 'care_mode_unavailable' && row?.requestedCareMode !== undefined) {
+    parts.push(`requested:${row.requestedCareMode}`)
+  }
+  parts.push(finding.detail)
+  return parts.join(' · ')
+}
+
+function formatReportLines(
+  rows: readonly AccommodationAccessAuditRow[],
+  findings: readonly AccommodationAccessAuditFinding[],
+  summary: AccommodationAccessAuditReport['summary']
+): string[] {
+  const rowById = new Map(rows.map((row) => [row.rowId, row]))
+  const header = `Accommodation access audit: rows=${rows.length}, findings=${findings.length}, accessGaps=${summary.accommodationAccessGapCount}, cureOnly=${summary.cureOnlyPressureHighCount}`
+  if (findings.length === 0) {
+    return [header]
+  }
+  return [
+    header,
+    ...findings.map((finding) => formatFindingLine(finding, rowById.get(finding.rowId))),
+  ]
+}
+
+export function buildAccommodationAccessAuditReport(
+  input: AccommodationAccessAuditInput
+): AccommodationAccessAuditReport {
+  const options = resolveOptions(input.options)
+
+  const normalizedSignals = input.accommodationSignals.map(normalizeSignal)
+  const validSignals = normalizedSignals.filter(
+    (signal) =>
+      signal.signalId.length > 0 && signal.subjectId.length > 0 && signal.protocolId.length > 0
+  )
+  const dedupedSignals = dedupeById(validSignals, (signal) => signal.signalId)
+  const rows = dedupedSignals.map(buildRow).sort(compareRows)
+
+  const medicalDeviationFindings = input.medicalDeviationFindings ?? []
+  const blameRoutingFindings = input.blameRoutingFindings ?? []
+
+  const findings: AccommodationAccessAuditFinding[] = []
+  for (const row of rows) {
+    findings.push(
+      ...buildRowFindings(row, options, medicalDeviationFindings, blameRoutingFindings)
+    )
+  }
+
+  findings.sort(compareFindings)
+
+  const countByKind = (kind: AccommodationAccessAuditFindingKind) =>
+    findings.filter((finding) => finding.kind === kind).length
+
+  const summary = {
+    rowCount: rows.length,
+    accommodationAccessGapCount: countByKind('accommodation_access_gap'),
+    cureOnlyPressureHighCount: countByKind('cure_only_pressure_high'),
+    careModeUnavailableCount: countByKind('care_mode_unavailable'),
+    maintenanceFramedAsFailureCount: countByKind('maintenance_framed_as_failure'),
+    treatmentLimitationUnacknowledgedCount: countByKind('treatment_limitation_unacknowledged'),
+    outcomeWorsenedWithoutAccommodationReviewCount: countByKind(
+      'outcome_worsened_without_accommodation_review'
+    ),
+    accountabilityRouteConflictCount: countByKind(
+      'accountability_route_conflicts_with_limitation'
+    ),
+    insufficientEvidenceCount: countByKind('insufficient_accommodation_evidence'),
+  }
+
+  return {
+    rows,
+    findings,
+    summary,
+    lines: formatReportLines(rows, findings, summary),
+  }
+}

--- a/src/domain/accommodationAccessAudit.ts
+++ b/src/domain/accommodationAccessAudit.ts
@@ -53,7 +53,7 @@ export type AccommodationAccessAuditSeverity = 'info' | 'warning' | 'critical'
 
 export interface AccommodationAccessAuditRow {
   rowId: string
-  signalId?: string
+  signalId: string
   subjectId: string
   protocolId: string
   siteId?: string
@@ -228,6 +228,10 @@ function normalizeCareMode(value: string | undefined): AccommodationCareMode | u
   return CARE_MODE_SET.has(trimmed) ? trimmed : undefined
 }
 
+function normalizeTrimmedString(value: unknown): string {
+  return String(value ?? '').trim()
+}
+
 function normalizeDenialRationale(
   value: string | undefined
 ): AccommodationDenialRationale | undefined {
@@ -255,12 +259,9 @@ function normalizeOfferedCareModes(
 }
 
 function dedupeById<T>(rows: readonly T[], resolveId: (row: T) => string): T[] {
-  const sorted = [...rows].sort((left, right) =>
-    resolveId(left).localeCompare(resolveId(right))
-  )
   const seen = new Set<string>()
   const deduped: T[] = []
-  for (const row of sorted) {
+  for (const row of rows) {
     const id = resolveId(row)
     if (seen.has(id)) {
       continue
@@ -274,9 +275,9 @@ function dedupeById<T>(rows: readonly T[], resolveId: (row: T) => string): T[] {
 function normalizeSignal(signal: AccommodationAccessSignal): AccommodationAccessSignal {
   return {
     ...signal,
-    signalId: signal.signalId.trim(),
-    subjectId: signal.subjectId.trim(),
-    protocolId: signal.protocolId.trim(),
+    signalId: normalizeTrimmedString(signal.signalId),
+    subjectId: normalizeTrimmedString(signal.subjectId),
+    protocolId: normalizeTrimmedString(signal.protocolId),
     siteId: typeof signal.siteId === 'string' ? signal.siteId.trim() || undefined : undefined,
     week: normalizeWeek(signal.week),
     requestedCareMode: normalizeCareMode(signal.requestedCareMode),
@@ -337,9 +338,7 @@ function compareRows(
     return weekLeft - weekRight
   }
 
-  const signalLeft = left.signalId ?? '\uffff'
-  const signalRight = right.signalId ?? '\uffff'
-  return signalLeft.localeCompare(signalRight)
+  return left.signalId.localeCompare(right.signalId)
 }
 
 function compareFindings(
@@ -390,17 +389,49 @@ function compareFindings(
   return signalLeft.localeCompare(signalRight)
 }
 
-function matchesUpstream(
+function upstreamPairKey(subjectId: string, protocolId: string): string {
+  return `${subjectId}\0${protocolId}`
+}
+
+type UpstreamFindingBucket<T> = {
+  byWeek: Map<number, T[]>
+  noWeek: T[]
+}
+
+function buildUpstreamFindingIndex<T extends { subjectId: string; protocolId: string; week?: number }>(
+  findings: readonly T[]
+): Map<string, UpstreamFindingBucket<T>> {
+  const index = new Map<string, UpstreamFindingBucket<T>>()
+  for (const finding of findings) {
+    const key = upstreamPairKey(finding.subjectId, finding.protocolId)
+    let bucket = index.get(key)
+    if (bucket === undefined) {
+      bucket = { byWeek: new Map(), noWeek: [] }
+      index.set(key, bucket)
+    }
+    if (finding.week !== undefined) {
+      const weekFindings = bucket.byWeek.get(finding.week) ?? []
+      weekFindings.push(finding)
+      bucket.byWeek.set(finding.week, weekFindings)
+    } else {
+      bucket.noWeek.push(finding)
+    }
+  }
+  return index
+}
+
+function getUpstreamCandidates<T extends { subjectId: string; protocolId: string; week?: number }>(
   row: AccommodationAccessAuditRow,
-  finding: { subjectId: string; protocolId: string; week?: number }
-): boolean {
-  if (row.subjectId !== finding.subjectId || row.protocolId !== finding.protocolId) {
-    return false
+  index: Map<string, UpstreamFindingBucket<T>>
+): readonly T[] {
+  const bucket = index.get(upstreamPairKey(row.subjectId, row.protocolId))
+  if (bucket === undefined) {
+    return []
   }
-  if (row.week !== undefined && finding.week !== undefined && row.week !== finding.week) {
-    return false
+  if (row.week !== undefined) {
+    return bucket.byWeek.get(row.week) ?? []
   }
-  return true
+  return bucket.noWeek
 }
 
 function sharedFindingFields(row: AccommodationAccessAuditRow): Pick<
@@ -470,11 +501,13 @@ function hasLocalTreatmentLimitationUnacknowledged(row: AccommodationAccessAudit
 function buildRowFindings(
   row: AccommodationAccessAuditRow,
   options: ResolvedOptions,
-  medicalDeviationFindings: readonly MedicalOutcomeDeviationFinding[],
-  blameRoutingFindings: readonly TreatmentFailureBlameRoutingFinding[]
+  medicalDeviationIndex: Map<string, UpstreamFindingBucket<MedicalOutcomeDeviationFinding>>,
+  blameRoutingIndex: Map<string, UpstreamFindingBucket<TreatmentFailureBlameRoutingFinding>>
 ): AccommodationAccessAuditFinding[] {
   const findings: AccommodationAccessAuditFinding[] = []
   const shared = sharedFindingFields(row)
+  const medicalDeviationFindings = getUpstreamCandidates(row, medicalDeviationIndex)
+  const blameRoutingFindings = getUpstreamCandidates(row, blameRoutingIndex)
 
   if (
     row.accommodationAccessScore !== undefined &&
@@ -551,8 +584,7 @@ function buildRowFindings(
 
   if (!treatmentLimitationEmitted) {
     const upstreamMissingAck = blameRoutingFindings.find(
-      (finding) =>
-        finding.kind === 'missing_treatment_limitation_acknowledgment' && matchesUpstream(row, finding)
+      (finding) => finding.kind === 'missing_treatment_limitation_acknowledgment'
     )
     if (upstreamMissingAck) {
       treatmentLimitationEmitted = true
@@ -566,8 +598,8 @@ function buildRowFindings(
     }
   }
 
-  const upstreamOutcome = medicalDeviationFindings.find(
-    (finding) => OUTCOME_WORSENED_KINDS.has(finding.kind) && matchesUpstream(row, finding)
+  const upstreamOutcome = medicalDeviationFindings.find((finding) =>
+    OUTCOME_WORSENED_KINDS.has(finding.kind)
   )
   if (upstreamOutcome && lacksAccommodationReview(row)) {
     findings.push({
@@ -581,9 +613,7 @@ function buildRowFindings(
 
   const upstreamAccountability = blameRoutingFindings.find(
     (finding) =>
-      ACCOUNTABILITY_CONFLICT_KINDS.has(finding.kind) &&
-      matchesUpstream(row, finding) &&
-      hasLimitationConflictContext(row)
+      ACCOUNTABILITY_CONFLICT_KINDS.has(finding.kind) && hasLimitationConflictContext(row)
   )
   if (upstreamAccountability) {
     findings.push({
@@ -662,35 +692,59 @@ export function buildAccommodationAccessAuditReport(
   const dedupedSignals = dedupeById(validSignals, (signal) => signal.signalId)
   const rows = dedupedSignals.map(buildRow).sort(compareRows)
 
-  const medicalDeviationFindings = input.medicalDeviationFindings ?? []
-  const blameRoutingFindings = input.blameRoutingFindings ?? []
+  const medicalDeviationIndex = buildUpstreamFindingIndex(input.medicalDeviationFindings ?? [])
+  const blameRoutingIndex = buildUpstreamFindingIndex(input.blameRoutingFindings ?? [])
 
   const findings: AccommodationAccessAuditFinding[] = []
   for (const row of rows) {
-    findings.push(
-      ...buildRowFindings(row, options, medicalDeviationFindings, blameRoutingFindings)
-    )
+    findings.push(...buildRowFindings(row, options, medicalDeviationIndex, blameRoutingIndex))
   }
 
   findings.sort(compareFindings)
 
-  const countByKind = (kind: AccommodationAccessAuditFindingKind) =>
-    findings.filter((finding) => finding.kind === kind).length
-
   const summary = {
     rowCount: rows.length,
-    accommodationAccessGapCount: countByKind('accommodation_access_gap'),
-    cureOnlyPressureHighCount: countByKind('cure_only_pressure_high'),
-    careModeUnavailableCount: countByKind('care_mode_unavailable'),
-    maintenanceFramedAsFailureCount: countByKind('maintenance_framed_as_failure'),
-    treatmentLimitationUnacknowledgedCount: countByKind('treatment_limitation_unacknowledged'),
-    outcomeWorsenedWithoutAccommodationReviewCount: countByKind(
-      'outcome_worsened_without_accommodation_review'
-    ),
-    accountabilityRouteConflictCount: countByKind(
-      'accountability_route_conflicts_with_limitation'
-    ),
-    insufficientEvidenceCount: countByKind('insufficient_accommodation_evidence'),
+    accommodationAccessGapCount: 0,
+    cureOnlyPressureHighCount: 0,
+    careModeUnavailableCount: 0,
+    maintenanceFramedAsFailureCount: 0,
+    treatmentLimitationUnacknowledgedCount: 0,
+    outcomeWorsenedWithoutAccommodationReviewCount: 0,
+    accountabilityRouteConflictCount: 0,
+    insufficientEvidenceCount: 0,
+  }
+
+  for (const finding of findings) {
+    switch (finding.kind) {
+      case 'accommodation_access_gap':
+        summary.accommodationAccessGapCount += 1
+        break
+      case 'cure_only_pressure_high':
+        summary.cureOnlyPressureHighCount += 1
+        break
+      case 'care_mode_unavailable':
+        summary.careModeUnavailableCount += 1
+        break
+      case 'maintenance_framed_as_failure':
+        summary.maintenanceFramedAsFailureCount += 1
+        break
+      case 'treatment_limitation_unacknowledged':
+        summary.treatmentLimitationUnacknowledgedCount += 1
+        break
+      case 'outcome_worsened_without_accommodation_review':
+        summary.outcomeWorsenedWithoutAccommodationReviewCount += 1
+        break
+      case 'accountability_route_conflicts_with_limitation':
+        summary.accountabilityRouteConflictCount += 1
+        break
+      case 'insufficient_accommodation_evidence':
+        summary.insufficientEvidenceCount += 1
+        break
+      default: {
+        const _exhaustive: never = finding.kind
+        void _exhaustive
+      }
+    }
   }
 
   return {

--- a/src/domain/accommodationAccessAudit.ts
+++ b/src/domain/accommodationAccessAudit.ts
@@ -220,32 +220,38 @@ function normalizeOptionalScore(value: number | undefined): number | undefined {
   return Math.max(0, Math.min(100, Math.round(value)))
 }
 
-function normalizeCareMode(value: string | undefined): AccommodationCareMode | undefined {
-  if (value === undefined) {
+function normalizeCareMode(value: unknown): AccommodationCareMode | undefined {
+  if (typeof value !== 'string') {
     return undefined
   }
-  const trimmed = value.trim() as AccommodationCareMode
-  return CARE_MODE_SET.has(trimmed) ? trimmed : undefined
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return undefined
+  }
+  return CARE_MODE_SET.has(trimmed as AccommodationCareMode)
+    ? (trimmed as AccommodationCareMode)
+    : undefined
 }
 
 function normalizeTrimmedString(value: unknown): string {
   return String(value ?? '').trim()
 }
 
-function normalizeDenialRationale(
-  value: string | undefined
-): AccommodationDenialRationale | undefined {
-  if (value === undefined) {
+function normalizeDenialRationale(value: unknown): AccommodationDenialRationale | undefined {
+  if (typeof value !== 'string') {
     return undefined
   }
-  const trimmed = value.trim() as AccommodationDenialRationale
-  return DENIAL_RATIONALE_SET.has(trimmed) ? trimmed : undefined
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return undefined
+  }
+  return DENIAL_RATIONALE_SET.has(trimmed as AccommodationDenialRationale)
+    ? (trimmed as AccommodationDenialRationale)
+    : undefined
 }
 
-function normalizeOfferedCareModes(
-  modes: readonly AccommodationCareMode[] | undefined
-): readonly AccommodationCareMode[] {
-  if (modes === undefined || modes.length === 0) {
+function normalizeOfferedCareModes(modes: unknown): readonly AccommodationCareMode[] {
+  if (!Array.isArray(modes) || modes.length === 0) {
     return []
   }
   const unique = new Set<AccommodationCareMode>()

--- a/src/domain/accommodationAccessAudit.ts
+++ b/src/domain/accommodationAccessAudit.ts
@@ -454,17 +454,52 @@ function mapUpstreamSeverity(
   return severity === 'critical' ? 'critical' : 'warning'
 }
 
-function lacksAccommodationReview(row: AccommodationAccessAuditRow): boolean {
-  if (row.requestedCareMode === 'accommodation') {
-    return false
-  }
-  return !row.offeredCareModes.includes('accommodation')
+function hasExplicitCareModeEvidence(row: AccommodationAccessAuditRow): boolean {
+  return row.requestedCareMode !== undefined || row.offeredCareModes.length > 0
 }
 
-function hasLimitationConflictContext(row: AccommodationAccessAuditRow): boolean {
-  return (
-    row.treatmentLimitationAcknowledged !== true || row.denialRationale === 'doctrine_pressure'
-  )
+function lacksAccommodationReview(row: AccommodationAccessAuditRow): boolean {
+  if (
+    row.requestedCareMode === 'accommodation' ||
+    row.requestedCareMode === 'maintenance'
+  ) {
+    return false
+  }
+  if (
+    row.offeredCareModes.includes('accommodation') ||
+    row.offeredCareModes.includes('maintenance')
+  ) {
+    return false
+  }
+  return true
+}
+
+function hasExplicitLimitationConflictContext(
+  row: AccommodationAccessAuditRow,
+  options: ResolvedOptions
+): boolean {
+  if (row.treatmentLimitationAcknowledged === true) {
+    return false
+  }
+  if (row.treatmentLimitationAcknowledged === false) {
+    return true
+  }
+  if (row.denialRationale === 'doctrine_pressure') {
+    return true
+  }
+  if (
+    row.denialRationale !== undefined &&
+    LIMITATION_DENIAL_RATIONALES.has(row.denialRationale)
+  ) {
+    return true
+  }
+  if (
+    row.cureOnlyPressureScore !== undefined &&
+    row.cureOnlyPressureScore >= options.highCureOnlyPressureThreshold
+  ) {
+    return true
+  }
+  return false
 }
 
 function countMeaningfulEvidence(row: AccommodationAccessAuditRow): number {
@@ -601,7 +636,11 @@ function buildRowFindings(
   const upstreamOutcome = medicalDeviationFindings.find((finding) =>
     OUTCOME_WORSENED_KINDS.has(finding.kind)
   )
-  if (upstreamOutcome && lacksAccommodationReview(row)) {
+  if (
+    upstreamOutcome &&
+    hasExplicitCareModeEvidence(row) &&
+    lacksAccommodationReview(row)
+  ) {
     findings.push({
       kind: 'outcome_worsened_without_accommodation_review',
       severity: mapUpstreamSeverity(upstreamOutcome.severity),
@@ -613,7 +652,8 @@ function buildRowFindings(
 
   const upstreamAccountability = blameRoutingFindings.find(
     (finding) =>
-      ACCOUNTABILITY_CONFLICT_KINDS.has(finding.kind) && hasLimitationConflictContext(row)
+      ACCOUNTABILITY_CONFLICT_KINDS.has(finding.kind) &&
+      hasExplicitLimitationConflictContext(row, options)
   )
   if (upstreamAccountability) {
     findings.push({

--- a/src/test/accommodationAccessAudit.test.ts
+++ b/src/test/accommodationAccessAudit.test.ts
@@ -101,6 +101,95 @@ describe('accommodationAccessAudit (SPE-2011)', () => {
     expect(report.findings).toEqual([])
   })
 
+  it('normalizes nullish enum-like fields without throwing', () => {
+    const malformed = {
+      signalId: 'sig:enum-null',
+      subjectId: 'agent:enum',
+      protocolId: 'protocol:care',
+      requestedCareMode: null,
+      offeredCareModes: null,
+      denialRationale: null,
+      accommodationAccessScore: 50,
+      cureOnlyPressureScore: 40,
+    } as unknown as AccommodationAccessSignal
+
+    expect(() =>
+      buildAccommodationAccessAuditReport({ accommodationSignals: [malformed] })
+    ).not.toThrow()
+
+    const report = buildAccommodationAccessAuditReport({ accommodationSignals: [malformed] })
+    expect(report.rows[0]?.requestedCareMode).toBeUndefined()
+    expect(report.rows[0]?.offeredCareModes).toEqual([])
+    expect(report.rows[0]?.denialRationale).toBeUndefined()
+    expect(
+      report.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(false)
+    expect(
+      report.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(false)
+    expect(
+      report.findings.some((finding) => finding.kind === 'care_mode_unavailable')
+    ).toBe(false)
+  })
+
+  it('filters invalid offeredCareModes entries and preserves valid care modes', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        {
+          signalId: 'sig:enum-mixed',
+          subjectId: 'agent:enum-mixed',
+          protocolId: 'protocol:care',
+          offeredCareModes: [
+            null,
+            'stabilization',
+            'not_a_mode',
+            'accommodation',
+            42,
+            'stabilization',
+          ],
+          requestedCareMode: 'symptom_management',
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        } as unknown as AccommodationAccessSignal,
+      ],
+    })
+    expect(report.rows[0]?.offeredCareModes).toEqual(['accommodation', 'stabilization'])
+    expect(
+      report.findings.some((finding) => finding.kind === 'care_mode_unavailable')
+    ).toBe(true)
+  })
+
+  it('preserves valid enum-like fields after null-safe normalization', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:enum-valid',
+          subjectId: 'agent:enum-valid',
+          protocolId: 'protocol:care',
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['cure_attempt'],
+          denialRationale: 'protocol_ceiling',
+          treatmentLimitationAcknowledged: false,
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+    })
+    expect(report.rows[0]?.requestedCareMode).toBe('accommodation')
+    expect(report.rows[0]?.offeredCareModes).toEqual(['cure_attempt'])
+    expect(report.rows[0]?.denialRationale).toBe('protocol_ceiling')
+    expect(
+      report.findings.some((finding) => finding.kind === 'care_mode_unavailable')
+    ).toBe(true)
+    expect(
+      report.findings.some((finding) => finding.kind === 'treatment_limitation_unacknowledged')
+    ).toBe(true)
+  })
+
   it('skips invalid blank signalId, subjectId, and protocolId', () => {
     const report = buildAccommodationAccessAuditReport({
       accommodationSignals: [

--- a/src/test/accommodationAccessAudit.test.ts
+++ b/src/test/accommodationAccessAudit.test.ts
@@ -85,6 +85,22 @@ describe('accommodationAccessAudit (SPE-2011)', () => {
     })
   })
 
+  it('skips malformed nullish string fields without throwing', () => {
+    const malformed = [
+      { signalId: null, subjectId: 'agent:a', protocolId: 'protocol:p' },
+      { signalId: 'sig:b', subjectId: undefined, protocolId: 'protocol:p' },
+      { signalId: 'sig:c', subjectId: 'agent:c', protocolId: null },
+    ] as unknown as AccommodationAccessSignal[]
+
+    expect(() =>
+      buildAccommodationAccessAuditReport({ accommodationSignals: malformed })
+    ).not.toThrow()
+
+    const report = buildAccommodationAccessAuditReport({ accommodationSignals: malformed })
+    expect(report.rows).toEqual([])
+    expect(report.findings).toEqual([])
+  })
+
   it('skips invalid blank signalId, subjectId, and protocolId', () => {
     const report = buildAccommodationAccessAuditReport({
       accommodationSignals: [
@@ -103,7 +119,7 @@ describe('accommodationAccessAudit (SPE-2011)', () => {
     expect(report.rows[0]?.signalId).toBe('sig:valid')
   })
 
-  it('deduplicates duplicate signalId deterministically', () => {
+  it('deduplicates duplicate signalId deterministically keeping first input order', () => {
     const report = buildAccommodationAccessAuditReport({
       accommodationSignals: [
         signal({
@@ -123,6 +139,24 @@ describe('accommodationAccessAudit (SPE-2011)', () => {
     expect(report.rows).toHaveLength(1)
     expect(report.rows[0]?.subjectId).toBe('agent:first')
     expect(report.rows[0]?.accommodationAccessScore).toBe(10)
+
+    const reversed = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:dup',
+          subjectId: 'agent:second',
+          protocolId: 'protocol:b',
+          accommodationAccessScore: 90,
+        }),
+        signal({
+          signalId: 'sig:dup',
+          subjectId: 'agent:first',
+          protocolId: 'protocol:a',
+          accommodationAccessScore: 10,
+        }),
+      ],
+    })
+    expect(reversed.rows[0]?.subjectId).toBe('agent:second')
   })
 
   it('emits accommodation_access_gap for low accommodation access', () => {
@@ -399,6 +433,133 @@ describe('accommodationAccessAudit (SPE-2011)', () => {
       (row) => row.kind === 'accountability_route_conflicts_with_limitation'
     )
     expect(finding?.severity).toBe('critical')
+  })
+
+  it('matches upstream findings only when week presence and values align', () => {
+    const sharedDeviation = deviationFinding({
+      kind: 'symptom_burden_worsened',
+      subjectId: 'agent:week',
+      protocolId: 'protocol:care',
+      detail: 'Symptom burden worsened.',
+    })
+    const sharedBlame = blameFinding({
+      kind: 'prohibited_subject_deflection',
+      subjectId: 'agent:week',
+      protocolId: 'protocol:care',
+      detail: 'Subject deflection blocked.',
+    })
+
+    const rowNoWeekUpstreamWeek = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:row-no-week',
+          subjectId: 'agent:week',
+          protocolId: 'protocol:care',
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+      medicalDeviationFindings: [{ ...sharedDeviation, week: 4 }],
+      blameRoutingFindings: [{ ...sharedBlame, week: 4 }],
+    })
+    expect(
+      rowNoWeekUpstreamWeek.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(false)
+    expect(
+      rowNoWeekUpstreamWeek.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(false)
+
+    const rowWeekUpstreamNoWeek = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:row-week',
+          subjectId: 'agent:week',
+          protocolId: 'protocol:care',
+          week: 4,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          denialRationale: 'doctrine_pressure',
+          treatmentLimitationAcknowledged: false,
+        }),
+      ],
+      medicalDeviationFindings: [sharedDeviation],
+      blameRoutingFindings: [sharedBlame],
+    })
+    expect(
+      rowWeekUpstreamNoWeek.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(false)
+    expect(
+      rowWeekUpstreamNoWeek.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(false)
+
+    const bothWeekMatch = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:both-week',
+          subjectId: 'agent:week',
+          protocolId: 'protocol:care',
+          week: 4,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          denialRationale: 'doctrine_pressure',
+          treatmentLimitationAcknowledged: false,
+        }),
+      ],
+      medicalDeviationFindings: [{ ...sharedDeviation, week: 4, severity: 'critical' }],
+      blameRoutingFindings: [{ ...sharedBlame, week: 4, severity: 'critical' }],
+    })
+    expect(
+      bothWeekMatch.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(true)
+    expect(
+      bothWeekMatch.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(true)
+
+    const neitherWeekMatch = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:neither-week',
+          subjectId: 'agent:week',
+          protocolId: 'protocol:care',
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          denialRationale: 'doctrine_pressure',
+          treatmentLimitationAcknowledged: false,
+        }),
+      ],
+      medicalDeviationFindings: [sharedDeviation],
+      blameRoutingFindings: [sharedBlame],
+    })
+    expect(
+      neitherWeekMatch.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(true)
+    expect(
+      neitherWeekMatch.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(true)
   })
 
   it('does not match upstream findings for unrelated subject, protocol, or week', () => {

--- a/src/test/accommodationAccessAudit.test.ts
+++ b/src/test/accommodationAccessAudit.test.ts
@@ -1,0 +1,681 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  buildAccommodationAccessAuditReport,
+  type AccommodationAccessSignal,
+} from '../domain/accommodationAccessAudit'
+import type { MedicalOutcomeDeviationFinding } from '../domain/medicalOutcomeDeviationAudit'
+import type { TreatmentFailureBlameRoutingFinding } from '../domain/treatmentFailureBlameRouting'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function signal(
+  overrides: Partial<AccommodationAccessSignal> &
+    Pick<AccommodationAccessSignal, 'signalId' | 'subjectId' | 'protocolId'>
+): AccommodationAccessSignal {
+  return { ...overrides }
+}
+
+function deviationFinding(
+  overrides: Partial<MedicalOutcomeDeviationFinding> &
+    Pick<MedicalOutcomeDeviationFinding, 'kind' | 'subjectId' | 'protocolId' | 'detail'>
+): MedicalOutcomeDeviationFinding {
+  return {
+    severity: 'warning',
+    ...overrides,
+  }
+}
+
+function blameFinding(
+  overrides: Partial<TreatmentFailureBlameRoutingFinding> &
+    Pick<TreatmentFailureBlameRoutingFinding, 'kind' | 'subjectId' | 'protocolId' | 'detail'>
+): TreatmentFailureBlameRoutingFinding {
+  return {
+    severity: 'warning',
+    ...overrides,
+  }
+}
+
+describe('accommodationAccessAudit (SPE-2011)', () => {
+  it('returns empty report for empty input without throwing', () => {
+    const report = buildAccommodationAccessAuditReport({ accommodationSignals: [] })
+    expect(report.rows).toEqual([])
+    expect(report.findings).toEqual([])
+    expect(report.summary).toEqual({
+      rowCount: 0,
+      accommodationAccessGapCount: 0,
+      cureOnlyPressureHighCount: 0,
+      careModeUnavailableCount: 0,
+      maintenanceFramedAsFailureCount: 0,
+      treatmentLimitationUnacknowledgedCount: 0,
+      outcomeWorsenedWithoutAccommodationReviewCount: 0,
+      accountabilityRouteConflictCount: 0,
+      insufficientEvidenceCount: 0,
+    })
+    expect(report.lines[0]).toContain('rows=0')
+    expect(report.lines[0]).toContain('findings=0')
+  })
+
+  it('builds row from valid accommodation signal', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:1',
+          subjectId: 'agent:patient-1',
+          protocolId: 'protocol:stabilize',
+          siteId: 'site:alpha',
+          week: 2,
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['accommodation', 'stabilization'],
+          accommodationAccessScore: 55,
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]).toMatchObject({
+      rowId: 'accommodation:sig:1',
+      signalId: 'sig:1',
+      subjectId: 'agent:patient-1',
+      protocolId: 'protocol:stabilize',
+      siteId: 'site:alpha',
+      week: 2,
+      offeredCareModes: ['accommodation', 'stabilization'],
+    })
+  })
+
+  it('skips invalid blank signalId, subjectId, and protocolId', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({ signalId: '', subjectId: 'agent:a', protocolId: 'protocol:p' }),
+        signal({ signalId: 'sig:a', subjectId: '  ', protocolId: 'protocol:p' }),
+        signal({ signalId: 'sig:b', subjectId: 'agent:b', protocolId: '' }),
+        signal({
+          signalId: 'sig:valid',
+          subjectId: 'agent:valid',
+          protocolId: 'protocol:ok',
+          accommodationAccessScore: 80,
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]?.signalId).toBe('sig:valid')
+  })
+
+  it('deduplicates duplicate signalId deterministically', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:dup',
+          subjectId: 'agent:first',
+          protocolId: 'protocol:a',
+          accommodationAccessScore: 10,
+        }),
+        signal({
+          signalId: 'sig:dup',
+          subjectId: 'agent:second',
+          protocolId: 'protocol:b',
+          accommodationAccessScore: 90,
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]?.subjectId).toBe('agent:first')
+    expect(report.rows[0]?.accommodationAccessScore).toBe(10)
+  })
+
+  it('emits accommodation_access_gap for low accommodation access', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:low',
+          subjectId: 'agent:low',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 30,
+          cureOnlyPressureScore: 50,
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['cure_attempt'],
+        }),
+      ],
+    })
+    const finding = report.findings.find((row) => row.kind === 'accommodation_access_gap')
+    expect(finding?.severity).toBe('warning')
+  })
+
+  it('emits critical accommodation_access_gap when score is zero', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:zero',
+          subjectId: 'agent:zero',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 0,
+          cureOnlyPressureScore: 50,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['cure_attempt'],
+        }),
+      ],
+    })
+    const finding = report.findings.find((row) => row.kind === 'accommodation_access_gap')
+    expect(finding?.severity).toBe('critical')
+  })
+
+  it('emits cure_only_pressure_high for high cure-only pressure', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:pressure',
+          subjectId: 'agent:pressure',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 60,
+          cureOnlyPressureScore: 75,
+          requestedCareMode: 'maintenance',
+          offeredCareModes: ['maintenance'],
+        }),
+      ],
+    })
+    const finding = report.findings.find((row) => row.kind === 'cure_only_pressure_high')
+    expect(finding?.severity).toBe('warning')
+  })
+
+  it('emits critical cure_only_pressure_high when score is 100', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:max',
+          subjectId: 'agent:max',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 60,
+          cureOnlyPressureScore: 100,
+          requestedCareMode: 'maintenance',
+          offeredCareModes: ['maintenance'],
+        }),
+      ],
+    })
+    const finding = report.findings.find((row) => row.kind === 'cure_only_pressure_high')
+    expect(finding?.severity).toBe('critical')
+  })
+
+  it('emits care_mode_unavailable when requested mode is missing from offered modes', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:mode',
+          subjectId: 'agent:mode',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 60,
+          cureOnlyPressureScore: 50,
+          requestedCareMode: 'symptom_management',
+          offeredCareModes: ['cure_attempt', 'stabilization'],
+        }),
+      ],
+    })
+    const finding = report.findings.find((row) => row.kind === 'care_mode_unavailable')
+    expect(finding?.severity).toBe('warning')
+  })
+
+  it('emits critical care_mode_unavailable for unavailable accommodation or maintenance', () => {
+    const accommodationReport = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:acc',
+          subjectId: 'agent:acc',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 60,
+          cureOnlyPressureScore: 50,
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['cure_attempt'],
+        }),
+      ],
+    })
+    const maintenanceReport = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:maint',
+          subjectId: 'agent:maint',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 60,
+          cureOnlyPressureScore: 50,
+          requestedCareMode: 'maintenance',
+          offeredCareModes: ['cure_attempt'],
+        }),
+      ],
+    })
+    expect(
+      accommodationReport.findings.find((row) => row.kind === 'care_mode_unavailable')?.severity
+    ).toBe('critical')
+    expect(
+      maintenanceReport.findings.find((row) => row.kind === 'care_mode_unavailable')?.severity
+    ).toBe('critical')
+  })
+
+  it('emits maintenance_framed_as_failure under doctrine pressure', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:doctrine',
+          subjectId: 'agent:doctrine',
+          protocolId: 'protocol:care',
+          requestedCareMode: 'maintenance',
+          offeredCareModes: ['cure_attempt'],
+          denialRationale: 'doctrine_pressure',
+          cureOnlyPressureScore: 80,
+          accommodationAccessScore: 60,
+        }),
+      ],
+    })
+    expect(
+      report.findings.some((finding) => finding.kind === 'maintenance_framed_as_failure')
+    ).toBe(true)
+  })
+
+  it('emits treatment_limitation_unacknowledged for limitation denial without acknowledgment', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:limit',
+          subjectId: 'agent:limit',
+          protocolId: 'protocol:care',
+          denialRationale: 'protocol_ceiling',
+          treatmentLimitationAcknowledged: false,
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+    })
+    expect(
+      report.findings.some((finding) => finding.kind === 'treatment_limitation_unacknowledged')
+    ).toBe(true)
+  })
+
+  it('suppresses local treatment_limitation_unacknowledged when limitation is acknowledged', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:ack',
+          subjectId: 'agent:ack',
+          protocolId: 'protocol:care',
+          denialRationale: 'resource_limit',
+          treatmentLimitationAcknowledged: true,
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+    })
+    expect(
+      report.findings.some((finding) => finding.kind === 'treatment_limitation_unacknowledged')
+    ).toBe(false)
+  })
+
+  it('emits treatment_limitation_unacknowledged from matching SPE-2006 upstream finding', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:upstream-ack',
+          subjectId: 'agent:upstream',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'missing_treatment_limitation_acknowledgment',
+          subjectId: 'agent:upstream',
+          protocolId: 'protocol:care',
+          detail: 'Fixture upstream missing acknowledgment.',
+        }),
+      ],
+    })
+    expect(
+      report.findings.some((finding) => finding.kind === 'treatment_limitation_unacknowledged')
+    ).toBe(true)
+  })
+
+  it('emits outcome_worsened_without_accommodation_review from matching deviation finding', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:outcome',
+          subjectId: 'agent:outcome',
+          protocolId: 'protocol:care',
+          week: 3,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization', 'cure_attempt'],
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'symptom_burden_worsened',
+          subjectId: 'agent:outcome',
+          protocolId: 'protocol:care',
+          week: 3,
+          severity: 'critical',
+          detail: 'Symptom burden worsened.',
+        }),
+      ],
+    })
+    const finding = report.findings.find(
+      (row) => row.kind === 'outcome_worsened_without_accommodation_review'
+    )
+    expect(finding?.severity).toBe('critical')
+  })
+
+  it('emits accountability_route_conflicts_with_limitation from matching blame finding', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:blame',
+          subjectId: 'agent:blame',
+          protocolId: 'protocol:care',
+          denialRationale: 'doctrine_pressure',
+          treatmentLimitationAcknowledged: false,
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'prohibited_subject_deflection',
+          subjectId: 'agent:blame',
+          protocolId: 'protocol:care',
+          severity: 'critical',
+          detail: 'Subject deflection blocked.',
+        }),
+      ],
+    })
+    const finding = report.findings.find(
+      (row) => row.kind === 'accountability_route_conflicts_with_limitation'
+    )
+    expect(finding?.severity).toBe('critical')
+  })
+
+  it('does not match upstream findings for unrelated subject, protocol, or week', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:match',
+          subjectId: 'agent:match',
+          protocolId: 'protocol:care',
+          week: 1,
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'symptom_burden_worsened',
+          subjectId: 'agent:other',
+          protocolId: 'protocol:care',
+          detail: 'Wrong subject.',
+        }),
+        deviationFinding({
+          kind: 'symptom_burden_worsened',
+          subjectId: 'agent:match',
+          protocolId: 'protocol:other',
+          detail: 'Wrong protocol.',
+        }),
+        deviationFinding({
+          kind: 'symptom_burden_worsened',
+          subjectId: 'agent:match',
+          protocolId: 'protocol:care',
+          week: 9,
+          detail: 'Wrong week.',
+        }),
+      ],
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'institutional_accountability_required',
+          subjectId: 'agent:other',
+          protocolId: 'protocol:care',
+          detail: 'Wrong subject blame.',
+        }),
+      ],
+    })
+    expect(
+      report.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(false)
+    expect(
+      report.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(false)
+  })
+
+  it('emits insufficient_accommodation_evidence for sparse row', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:sparse',
+          subjectId: 'agent:sparse',
+          protocolId: 'protocol:care',
+        }),
+      ],
+    })
+    expect(
+      report.findings.some((finding) => finding.kind === 'insufficient_accommodation_evidence')
+    ).toBe(true)
+  })
+
+  it('applies threshold overrides from options', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:opts',
+          subjectId: 'agent:opts',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 55,
+          cureOnlyPressureScore: 65,
+        }),
+      ],
+      options: {
+        lowAccommodationAccessThreshold: 50,
+        highCureOnlyPressureThreshold: 80,
+        minimumEvidenceCount: 3,
+      },
+    })
+    expect(
+      report.findings.some((finding) => finding.kind === 'accommodation_access_gap')
+    ).toBe(false)
+    expect(
+      report.findings.some((finding) => finding.kind === 'cure_only_pressure_high')
+    ).toBe(false)
+    expect(
+      report.findings.some((finding) => finding.kind === 'insufficient_accommodation_evidence')
+    ).toBe(true)
+  })
+
+  it('sorts rows, findings, and lines deterministically', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:z',
+          subjectId: 'agent:z',
+          protocolId: 'protocol:z',
+          siteId: 'site:b',
+          accommodationAccessScore: 0,
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['cure_attempt'],
+        }),
+        signal({
+          signalId: 'sig:a',
+          subjectId: 'agent:a',
+          protocolId: 'protocol:a',
+          siteId: 'site:a',
+          cureOnlyPressureScore: 100,
+          requestedCareMode: 'maintenance',
+          offeredCareModes: ['cure_attempt'],
+        }),
+      ],
+    })
+    expect(report.rows.map((row) => row.signalId)).toEqual(['sig:a', 'sig:z'])
+    const reportRepeat = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:z',
+          subjectId: 'agent:z',
+          protocolId: 'protocol:z',
+          siteId: 'site:b',
+          accommodationAccessScore: 0,
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['cure_attempt'],
+        }),
+        signal({
+          signalId: 'sig:a',
+          subjectId: 'agent:a',
+          protocolId: 'protocol:a',
+          siteId: 'site:a',
+          cureOnlyPressureScore: 100,
+          requestedCareMode: 'maintenance',
+          offeredCareModes: ['cure_attempt'],
+        }),
+      ],
+    })
+    expect(reportRepeat.rows).toEqual(report.rows)
+    expect(reportRepeat.findings).toEqual(report.findings)
+    expect(reportRepeat.lines).toEqual(report.lines)
+    expect(report.findings[0]?.severity).toBe('critical')
+    expect(report.lines.length).toBeGreaterThan(1)
+  })
+
+  it('does not mutate frozen inputs', () => {
+    const accommodationSignals = Object.freeze([
+      Object.freeze(
+        signal({
+          signalId: 'sig:frozen',
+          subjectId: 'agent:frozen',
+          protocolId: 'protocol:frozen',
+          offeredCareModes: Object.freeze(['cure_attempt'] as const),
+        })
+      ),
+    ])
+    const medicalDeviationFindings = Object.freeze([
+      Object.freeze(
+        deviationFinding({
+          kind: 'outcome_below_prediction',
+          subjectId: 'agent:other',
+          protocolId: 'protocol:other',
+          detail: 'Unrelated.',
+        })
+      ),
+    ])
+    buildAccommodationAccessAuditReport({
+      accommodationSignals,
+      medicalDeviationFindings,
+    })
+    expect(accommodationSignals).toHaveLength(1)
+    expect(medicalDeviationFindings).toHaveLength(1)
+  })
+
+  it('summary counts match findings', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:summary',
+          subjectId: 'agent:summary',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 10,
+          cureOnlyPressureScore: 90,
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['cure_attempt'],
+          denialRationale: 'protocol_ceiling',
+          treatmentLimitationAcknowledged: false,
+        }),
+      ],
+    })
+    expect(report.summary.rowCount).toBe(report.rows.length)
+    expect(report.summary.accommodationAccessGapCount).toBe(
+      report.findings.filter((finding) => finding.kind === 'accommodation_access_gap').length
+    )
+    expect(report.summary.cureOnlyPressureHighCount).toBe(
+      report.findings.filter((finding) => finding.kind === 'cure_only_pressure_high').length
+    )
+    expect(report.summary.careModeUnavailableCount).toBe(
+      report.findings.filter((finding) => finding.kind === 'care_mode_unavailable').length
+    )
+    expect(report.summary.treatmentLimitationUnacknowledgedCount).toBe(
+      report.findings.filter((finding) => finding.kind === 'treatment_limitation_unacknowledged')
+        .length
+    )
+    expect(report.summary.insufficientEvidenceCount).toBe(
+      report.findings.filter((finding) => finding.kind === 'insufficient_accommodation_evidence')
+        .length
+    )
+  })
+
+  it('dedupes and sorts offered care modes', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:modes',
+          subjectId: 'agent:modes',
+          protocolId: 'protocol:care',
+          offeredCareModes: ['stabilization', 'cure_attempt', 'stabilization', 'accommodation'],
+          accommodationAccessScore: 80,
+        }),
+      ],
+    })
+    expect(report.rows[0]?.offeredCareModes).toEqual([
+      'accommodation',
+      'cure_attempt',
+      'stabilization',
+    ])
+  })
+
+  it('lines contain no SCP or source-specific strings', () => {
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:lines',
+          subjectId: 'agent:lines',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 0,
+          cureOnlyPressureScore: 100,
+          requestedCareMode: 'accommodation',
+          offeredCareModes: ['cure_attempt'],
+        }),
+      ],
+    })
+    const joined = report.lines.join('\n').toLowerCase()
+    expect(joined).not.toContain('scp-')
+    expect(joined).not.toContain('scp ')
+    expect(joined).not.toContain('9977')
+  })
+
+  it('does not import medicalAccountabilityScorecard, GameState, or UI modules', () => {
+    const source = readFileSync(
+      path.join(__dirname, '../domain/accommodationAccessAudit.ts'),
+      'utf8'
+    )
+    expect(source.includes('medicalAccountabilityScorecard')).toBe(false)
+    expect(source.includes("from './models'")).toBe(false)
+    expect(source.includes('gameStore')).toBe(false)
+    expect(source.includes('/features/')).toBe(false)
+  })
+
+  it('uses type-only imports from SPE-2003 and SPE-2006 modules', () => {
+    const source = readFileSync(
+      path.join(__dirname, '../domain/accommodationAccessAudit.ts'),
+      'utf8'
+    )
+    expect(source).toContain("import type { MedicalOutcomeDeviationFinding }")
+    expect(source).toContain("import type { TreatmentFailureBlameRoutingFinding }")
+    expect(source.includes('buildMedicalOutcomeDeviationAuditReport')).toBe(false)
+    expect(source.includes('buildTreatmentFailureBlameRoutingReport')).toBe(false)
+  })
+})

--- a/src/test/accommodationAccessAudit.test.ts
+++ b/src/test/accommodationAccessAudit.test.ts
@@ -435,6 +435,237 @@ describe('accommodationAccessAudit (SPE-2011)', () => {
     expect(finding?.severity).toBe('critical')
   })
 
+  it('does not emit outcome_worsened_without_accommodation_review for sparse rows without care-mode evidence', () => {
+    const worsening = deviationFinding({
+      kind: 'symptom_burden_worsened',
+      subjectId: 'agent:sparse-outcome',
+      protocolId: 'protocol:care',
+      detail: 'Symptom burden worsened.',
+    })
+    const report = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:sparse-outcome',
+          subjectId: 'agent:sparse-outcome',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+      medicalDeviationFindings: [worsening],
+    })
+    expect(
+      report.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(false)
+  })
+
+  it('emits outcome_worsened_without_accommodation_review only with explicit care-mode evidence', () => {
+    const worsening = deviationFinding({
+      kind: 'outcome_below_prediction',
+      subjectId: 'agent:care-mode',
+      protocolId: 'protocol:care',
+      detail: 'Outcome below prediction.',
+    })
+
+    const requestedOnly = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:requested',
+          subjectId: 'agent:care-mode',
+          protocolId: 'protocol:care',
+          requestedCareMode: 'stabilization',
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+      medicalDeviationFindings: [worsening],
+    })
+    expect(
+      requestedOnly.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(true)
+
+    const offeredOnly = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:offered',
+          subjectId: 'agent:care-mode',
+          protocolId: 'protocol:care',
+          offeredCareModes: ['cure_attempt', 'stabilization'],
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+      medicalDeviationFindings: [worsening],
+    })
+    expect(
+      offeredOnly.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(true)
+
+    const maintenanceOffered = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:maintenance-offered',
+          subjectId: 'agent:care-mode',
+          protocolId: 'protocol:care',
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['maintenance', 'cure_attempt'],
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+      medicalDeviationFindings: [worsening],
+    })
+    expect(
+      maintenanceOffered.findings.some(
+        (finding) => finding.kind === 'outcome_worsened_without_accommodation_review'
+      )
+    ).toBe(false)
+  })
+
+  it('does not emit accountability_route_conflicts_with_limitation without explicit limitation context', () => {
+    const deflection = blameFinding({
+      kind: 'prohibited_subject_deflection',
+      subjectId: 'agent:sparse-blame',
+      protocolId: 'protocol:care',
+      detail: 'Subject deflection blocked.',
+    })
+
+    const sparse = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:sparse-blame',
+          subjectId: 'agent:sparse-blame',
+          protocolId: 'protocol:care',
+          accommodationAccessScore: 50,
+          cureOnlyPressureScore: 40,
+        }),
+      ],
+      blameRoutingFindings: [deflection],
+    })
+    expect(
+      sparse.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(false)
+  })
+
+  it('emits accountability_route_conflicts_with_limitation only with explicit limitation or doctrine context', () => {
+    const deflection = blameFinding({
+      kind: 'prohibited_subject_deflection',
+      subjectId: 'agent:limit-context',
+      protocolId: 'protocol:care',
+      severity: 'critical',
+      detail: 'Subject deflection blocked.',
+    })
+
+    const protocolCeiling = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:protocol-ceiling',
+          subjectId: 'agent:limit-context',
+          protocolId: 'protocol:care',
+          denialRationale: 'protocol_ceiling',
+          accommodationAccessScore: 50,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      blameRoutingFindings: [deflection],
+    })
+    expect(
+      protocolCeiling.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(true)
+
+    const doctrinePressure = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:doctrine',
+          subjectId: 'agent:limit-context',
+          protocolId: 'protocol:care',
+          denialRationale: 'doctrine_pressure',
+          accommodationAccessScore: 50,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      blameRoutingFindings: [deflection],
+    })
+    expect(
+      doctrinePressure.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(true)
+
+    const highCurePressure = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:high-cure',
+          subjectId: 'agent:limit-context',
+          protocolId: 'protocol:care',
+          cureOnlyPressureScore: 85,
+          accommodationAccessScore: 50,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      blameRoutingFindings: [deflection],
+    })
+    expect(
+      highCurePressure.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(true)
+
+    const explicitFalseAck = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:false-ack',
+          subjectId: 'agent:limit-context',
+          protocolId: 'protocol:care',
+          treatmentLimitationAcknowledged: false,
+          accommodationAccessScore: 50,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      blameRoutingFindings: [deflection],
+    })
+    expect(
+      explicitFalseAck.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(true)
+
+    const acknowledged = buildAccommodationAccessAuditReport({
+      accommodationSignals: [
+        signal({
+          signalId: 'sig:ack-true',
+          subjectId: 'agent:limit-context',
+          protocolId: 'protocol:care',
+          denialRationale: 'resource_limit',
+          treatmentLimitationAcknowledged: true,
+          accommodationAccessScore: 50,
+          requestedCareMode: 'stabilization',
+          offeredCareModes: ['stabilization'],
+        }),
+      ],
+      blameRoutingFindings: [deflection],
+    })
+    expect(
+      acknowledged.findings.some(
+        (finding) => finding.kind === 'accountability_route_conflicts_with_limitation'
+      )
+    ).toBe(false)
+  })
+
   it('matches upstream findings only when week presence and values align', () => {
     const sharedDeviation = deviationFinding({
       kind: 'symptom_burden_worsened',


### PR DESCRIPTION
## Summary

- Adds pure `buildAccommodationAccessAuditReport` helper for SPE-2011 (accommodation access vs cure-only doctrine pressure).
- Emits deterministic rows, findings, summary counts, and audit-facing lines from accommodation/care-mode signals.
- Optionally consumes **type-only** upstream finding fixtures from SPE-2003 and SPE-2006 without calling upstream report builders.

Linear: https://linear.app/spectranoir/issue/SPE-2011

## Review hardening

**a6c122c:** strict upstream week matching, null-safe ID normalization, required row `signalId`, O(N) dedupe, pre-indexed upstream findings, single-pass summary.

**18f2c59:** gate upstream cross-findings on explicit row evidence (care-mode + limitation/doctrine context).

**ae887ca:** null-safe enum normalization (`requestedCareMode`, `offeredCareModes`, `denialRationale`) for malformed persisted rows.

## Files changed

- `src/domain/accommodationAccessAudit.ts`
- `src/test/accommodationAccessAudit.test.ts` (35 tests)

## Validation run

- `npm run test:run -- src/test/accommodationAccessAudit.test.ts`
- Adjacent SPE-2003/2006/2008 tests
- `npm run test:run` (331 files, 3208 tests)
- `npm run lint`
- `git diff --check`

## Boundary

Pure helper only. No GameState, UI, scorecard, runtime, doctrine enforcement, ledger, diagnosis modeling, or source-specific strings.

## Explicitly out of scope

GameState persistence, weekly tick, UI, care-mode selector (SPE-2004), accommodation ledger (SPE-2005), SPE-2008 scorecard, doctrine enforcement, policy ledger, staff recovery, diagnosis/protected-class modeling, source-specific strings.