### PR TITLE
SPE-2001: Add institutional denial doctrine pressure report

### DIFF
--- a/src/domain/institutionalDenialDoctrinePressure.ts
+++ b/src/domain/institutionalDenialDoctrinePressure.ts
@@ -1,0 +1,1252 @@
+/**
+ * SPE-2001: deterministic institutional denial doctrine pressure report.
+ *
+ * Makes denial-doctrine pressure legible as audit rows, findings, summary counts,
+ * and audit-facing lines before any doctrine enforcement engine exists.
+ *
+ * Pure report helper only. No GameState persistence, weekly tick, runtime
+ * enforcement, UI, doctrine validation, policy selection, or real-world modeling.
+ */
+
+import type { AccommodationAccessAuditFinding } from './accommodationAccessAudit'
+import type { MedicalAccountabilityScorecardFinding } from './medicalAccountabilityScorecard'
+import type { MedicalOutcomeDeviationFinding } from './medicalOutcomeDeviationAudit'
+import type { StaffTreatmentTelemetryFinding } from './staffTreatmentTelemetry'
+import type { TreatmentFailureBlameRoutingFinding } from './treatmentFailureBlameRouting'
+
+export type InstitutionalDenialDoctrinePressureSignalKind =
+  | 'approved_language_requirement'
+  | 'care_mode_discussion_restricted'
+  | 'dissenting_staff_exclusion_pressure'
+  | 'treatment_limitation_suppressed'
+  | 'subject_side_deflection_reinforced'
+  | 'patient_report_dismissed'
+  | 'overclassification_pressure'
+  | 'material_outcome_suppressed'
+  | 'support_access_restricted'
+
+export type InstitutionalDenialDoctrinePressureSeverity =
+  | 'info'
+  | 'warning'
+  | 'critical'
+
+export interface InstitutionalDenialDoctrinePressureSignal {
+  signalId: string
+  kind: InstitutionalDenialDoctrinePressureSignalKind
+  severity?: InstitutionalDenialDoctrinePressureSeverity
+  siteId?: string
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  doctrineId?: string
+  week?: number
+  pressureScore?: number
+  detail?: string
+}
+
+export type InstitutionalDenialDoctrinePressureFindingKind =
+  | 'approved_language_pressure'
+  | 'care_mode_discussion_restriction'
+  | 'dissenting_staff_exclusion_pressure'
+  | 'treatment_limitation_suppression'
+  | 'subject_deflection_reinforcement'
+  | 'patient_report_dismissal'
+  | 'overclassification_pressure'
+  | 'material_outcome_suppression'
+  | 'support_access_restriction'
+  | 'high_alignment_poor_outcome_pressure'
+  | 'insufficient_pressure_evidence'
+
+export interface InstitutionalDenialDoctrinePressureRow {
+  rowId: string
+  siteId?: string
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  doctrineId?: string
+  week?: number
+  pressureScore: number
+  signalCount: number
+  upstreamFindingCount: number
+  contradictionCount: number
+}
+
+export interface InstitutionalDenialDoctrinePressureFinding {
+  kind: InstitutionalDenialDoctrinePressureFindingKind
+  severity: InstitutionalDenialDoctrinePressureSeverity
+  rowId: string
+  siteId?: string
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  doctrineId?: string
+  week?: number
+  detail: string
+}
+
+export interface InstitutionalDenialDoctrinePressureReport {
+  rows: readonly InstitutionalDenialDoctrinePressureRow[]
+  findings: readonly InstitutionalDenialDoctrinePressureFinding[]
+  summary: {
+    rowCount: number
+    approvedLanguagePressureCount: number
+    careModeDiscussionRestrictionCount: number
+    dissentingStaffExclusionPressureCount: number
+    treatmentLimitationSuppressionCount: number
+    subjectDeflectionReinforcementCount: number
+    patientReportDismissalCount: number
+    overclassificationPressureCount: number
+    materialOutcomeSuppressionCount: number
+    supportAccessRestrictionCount: number
+    highAlignmentPoorOutcomePressureCount: number
+    insufficientEvidenceCount: number
+  }
+  lines: readonly string[]
+}
+
+export interface InstitutionalDenialDoctrinePressureOptions {
+  highPressureThreshold?: number
+  criticalPressureThreshold?: number
+  minimumEvidenceCount?: number
+}
+
+const DEFAULT_OPTIONS: Required<InstitutionalDenialDoctrinePressureOptions> = {
+  highPressureThreshold: 70,
+  criticalPressureThreshold: 90,
+  minimumEvidenceCount: 1,
+}
+
+const SEVERITY_RANK: Readonly<Record<InstitutionalDenialDoctrinePressureSeverity, number>> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+const FINDING_KIND_ORDER: readonly InstitutionalDenialDoctrinePressureFindingKind[] = [
+  'subject_deflection_reinforcement',
+  'treatment_limitation_suppression',
+  'material_outcome_suppression',
+  'high_alignment_poor_outcome_pressure',
+  'approved_language_pressure',
+  'care_mode_discussion_restriction',
+  'dissenting_staff_exclusion_pressure',
+  'patient_report_dismissal',
+  'overclassification_pressure',
+  'support_access_restriction',
+  'insufficient_pressure_evidence',
+]
+
+const SIGNAL_TO_FINDING: Readonly<
+  Record<
+    InstitutionalDenialDoctrinePressureSignalKind,
+    InstitutionalDenialDoctrinePressureFindingKind
+  >
+> = {
+  approved_language_requirement: 'approved_language_pressure',
+  care_mode_discussion_restricted: 'care_mode_discussion_restriction',
+  dissenting_staff_exclusion_pressure: 'dissenting_staff_exclusion_pressure',
+  treatment_limitation_suppressed: 'treatment_limitation_suppression',
+  subject_side_deflection_reinforced: 'subject_deflection_reinforcement',
+  patient_report_dismissed: 'patient_report_dismissal',
+  overclassification_pressure: 'overclassification_pressure',
+  material_outcome_suppressed: 'material_outcome_suppression',
+  support_access_restricted: 'support_access_restriction',
+}
+
+const CONTRADICTION_SIGNAL_KINDS = new Set<InstitutionalDenialDoctrinePressureSignalKind>([
+  'material_outcome_suppressed',
+  'overclassification_pressure',
+  'patient_report_dismissed',
+])
+
+const CONTRADICTION_FINDING_KINDS = new Set<InstitutionalDenialDoctrinePressureFindingKind>([
+  'material_outcome_suppression',
+  'high_alignment_poor_outcome_pressure',
+  'overclassification_pressure',
+  'patient_report_dismissal',
+  'subject_deflection_reinforcement',
+])
+
+const CRITICAL_DEVIATION_KINDS = new Set<MedicalOutcomeDeviationFinding['kind']>([
+  'outcome_below_prediction',
+  'symptom_burden_not_improved',
+  'symptom_burden_worsened',
+  'escalation_above_expected',
+])
+
+const AGGREGATE_KEY = 'aggregate\0'
+
+interface RowBucket {
+  key: string
+  rowId: string
+  siteId?: string
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  doctrineId?: string
+  week?: number
+  signals: InstitutionalDenialDoctrinePressureSignal[]
+  staffFindings: StaffTreatmentTelemetryFinding[]
+  deviationFindings: MedicalOutcomeDeviationFinding[]
+  blameFindings: TreatmentFailureBlameRoutingFinding[]
+  scorecardFindings: MedicalAccountabilityScorecardFinding[]
+  accommodationFindings: AccommodationAccessAuditFinding[]
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function normalizeWeek(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined
+  }
+  return Math.max(0, Math.trunc(value))
+}
+
+function normalizeMinimumEvidenceCount(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_OPTIONS.minimumEvidenceCount
+  }
+  return Math.max(1, Math.trunc(value))
+}
+
+function resolveOptions(
+  options: InstitutionalDenialDoctrinePressureOptions | undefined
+): Required<InstitutionalDenialDoctrinePressureOptions> {
+  return {
+    highPressureThreshold: clampScore(
+      options?.highPressureThreshold ?? DEFAULT_OPTIONS.highPressureThreshold
+    ),
+    criticalPressureThreshold: clampScore(
+      options?.criticalPressureThreshold ?? DEFAULT_OPTIONS.criticalPressureThreshold
+    ),
+    minimumEvidenceCount: normalizeMinimumEvidenceCount(options?.minimumEvidenceCount),
+  }
+}
+
+function subjectProtocolWeekKey(
+  subjectId: string,
+  protocolId: string,
+  week: number | undefined
+): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `subject\0${subjectId}\0${protocolId}\0${weekPart}`
+}
+
+function staffDoctrineWeekKey(
+  staffId: string,
+  doctrineId: string,
+  week: number | undefined
+): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `staff-doctrine\0${staffId}\0${doctrineId}\0${weekPart}`
+}
+
+function staffWeekKey(staffId: string, week: number | undefined): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `staff\0${staffId}\0${weekPart}`
+}
+
+function siteWeekKey(siteId: string, week: number | undefined): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `site\0${siteId}\0${weekPart}`
+}
+
+function rowIdForKey(key: string): string {
+  if (key === AGGREGATE_KEY) {
+    return 'row:aggregate'
+  }
+  if (key.startsWith('subject\0')) {
+    const parts = key.split('\0')
+    return `row:subject:${parts[1] ?? ''}:${parts[2] ?? ''}:${parts[3] ?? ''}`
+  }
+  if (key.startsWith('staff-doctrine\0')) {
+    const parts = key.split('\0')
+    return `row:staff-doctrine:${parts[1] ?? ''}:${parts[2] ?? ''}:${parts[3] ?? ''}`
+  }
+  if (key.startsWith('staff\0')) {
+    const parts = key.split('\0')
+    return `row:staff:${parts[1] ?? ''}:${parts[2] ?? ''}`
+  }
+  if (key.startsWith('site\0')) {
+    const parts = key.split('\0')
+    return `row:site:${parts[1] ?? ''}:${parts[2] ?? ''}`
+  }
+  return `row:unknown:${key}`
+}
+
+function parseSubjectProtocolWeekKey(key: string): {
+  subjectId?: string
+  protocolId?: string
+  week?: number
+} {
+  if (!key.startsWith('subject\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const subjectId = parts[1]
+  const protocolId = parts[2]
+  const weekPart = parts[3]
+  if (!subjectId || !protocolId) {
+    return {}
+  }
+  return {
+    subjectId,
+    protocolId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
+function parseStaffDoctrineWeekKey(key: string): {
+  staffId?: string
+  doctrineId?: string
+  week?: number
+} {
+  if (!key.startsWith('staff-doctrine\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const staffId = parts[1]
+  const doctrineId = parts[2]
+  const weekPart = parts[3]
+  if (!staffId || !doctrineId) {
+    return {}
+  }
+  return {
+    staffId,
+    doctrineId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
+function parseStaffWeekKey(key: string): { staffId?: string; week?: number } {
+  if (!key.startsWith('staff\0') || key.startsWith('staff-doctrine\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const staffId = parts[1]
+  const weekPart = parts[2]
+  if (!staffId) {
+    return {}
+  }
+  return {
+    staffId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
+function parseSiteWeekKey(key: string): { siteId?: string; week?: number } {
+  if (!key.startsWith('site\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const siteId = parts[1]
+  const weekPart = parts[2]
+  if (!siteId) {
+    return {}
+  }
+  return {
+    siteId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
+function getOrCreateBucket(buckets: Map<string, RowBucket>, key: string): RowBucket {
+  const existing = buckets.get(key)
+  if (existing) {
+    return existing
+  }
+
+  const subjectFields = parseSubjectProtocolWeekKey(key)
+  const staffDoctrineFields = parseStaffDoctrineWeekKey(key)
+  const staffFields = parseStaffWeekKey(key)
+  const siteFields = parseSiteWeekKey(key)
+
+  const bucket: RowBucket = {
+    key,
+    rowId: rowIdForKey(key),
+    siteId: siteFields.siteId,
+    staffId: staffDoctrineFields.staffId ?? staffFields.staffId,
+    subjectId: subjectFields.subjectId,
+    protocolId: subjectFields.protocolId,
+    doctrineId: staffDoctrineFields.doctrineId,
+    week:
+      subjectFields.week ??
+      staffDoctrineFields.week ??
+      staffFields.week ??
+      siteFields.week,
+    signals: [],
+    staffFindings: [],
+    deviationFindings: [],
+    blameFindings: [],
+    scorecardFindings: [],
+    accommodationFindings: [],
+  }
+  buckets.set(key, bucket)
+  return bucket
+}
+
+function resolveSignalKey(signal: InstitutionalDenialDoctrinePressureSignal): string {
+  const subjectId = signal.subjectId?.trim()
+  const protocolId = signal.protocolId?.trim()
+  const week = normalizeWeek(signal.week)
+  if (subjectId && protocolId) {
+    return subjectProtocolWeekKey(subjectId, protocolId, week)
+  }
+
+  const staffId = signal.staffId?.trim()
+  const doctrineId = signal.doctrineId?.trim()
+  if (staffId && doctrineId) {
+    return staffDoctrineWeekKey(staffId, doctrineId, week)
+  }
+
+  const siteId = signal.siteId?.trim()
+  if (siteId) {
+    return siteWeekKey(siteId, week)
+  }
+
+  if (staffId) {
+    return staffWeekKey(staffId, week)
+  }
+
+  return AGGREGATE_KEY
+}
+
+function resolveSubjectProtocolFindingKey(input: {
+  subjectId?: string
+  protocolId?: string
+  week?: number
+}): string {
+  const subjectId = input.subjectId?.trim()
+  const protocolId = input.protocolId?.trim()
+  const week = normalizeWeek(input.week)
+  if (subjectId && protocolId) {
+    return subjectProtocolWeekKey(subjectId, protocolId, week)
+  }
+  return AGGREGATE_KEY
+}
+
+function resolveStaffFindingKey(finding: StaffTreatmentTelemetryFinding): string {
+  const subjectId = finding.subjectId?.trim()
+  const protocolId = finding.protocolId?.trim()
+  const week = normalizeWeek(finding.week)
+  if (subjectId && protocolId) {
+    return subjectProtocolWeekKey(subjectId, protocolId, week)
+  }
+  return AGGREGATE_KEY
+}
+
+function resolveScorecardFindingKey(finding: MedicalAccountabilityScorecardFinding): string {
+  const subjectKey = resolveSubjectProtocolFindingKey(finding)
+  if (subjectKey !== AGGREGATE_KEY) {
+    return subjectKey
+  }
+  const staffId = finding.staffId?.trim()
+  if (staffId) {
+    return staffWeekKey(staffId, normalizeWeek(finding.week))
+  }
+  const siteId = finding.siteId?.trim()
+  if (siteId) {
+    return siteWeekKey(siteId, normalizeWeek(finding.week))
+  }
+  return AGGREGATE_KEY
+}
+
+function dedupeSignals(
+  signals: readonly InstitutionalDenialDoctrinePressureSignal[]
+): InstitutionalDenialDoctrinePressureSignal[] {
+  const seen = new Set<string>()
+  const deduped: InstitutionalDenialDoctrinePressureSignal[] = []
+  for (const signal of signals) {
+    const signalId = signal.signalId.trim()
+    const kind = signal.kind
+    if (signalId.length === 0 || !(kind in SIGNAL_TO_FINDING)) {
+      continue
+    }
+    if (seen.has(signalId)) {
+      continue
+    }
+    seen.add(signalId)
+    deduped.push({
+      ...signal,
+      signalId,
+      siteId: signal.siteId?.trim() || undefined,
+      staffId: signal.staffId?.trim() || undefined,
+      subjectId: signal.subjectId?.trim() || undefined,
+      protocolId: signal.protocolId?.trim() || undefined,
+      doctrineId: signal.doctrineId?.trim() || undefined,
+      week: normalizeWeek(signal.week),
+      pressureScore:
+        signal.pressureScore === undefined ? undefined : clampScore(signal.pressureScore),
+      detail: signal.detail?.trim() || undefined,
+    })
+  }
+  return deduped
+}
+
+function scoreFromSeverity(
+  severity: InstitutionalDenialDoctrinePressureSeverity | undefined
+): number {
+  if (severity === 'critical') {
+    return 100
+  }
+  if (severity === 'warning') {
+    return 75
+  }
+  if (severity === 'info') {
+    return 25
+  }
+  return 50
+}
+
+function signalPressureScore(signal: InstitutionalDenialDoctrinePressureSignal): number {
+  if (signal.pressureScore !== undefined) {
+    return clampScore(signal.pressureScore)
+  }
+  return scoreFromSeverity(signal.severity)
+}
+
+function hasMedicalAccountabilityContext(bucket: RowBucket): boolean {
+  return (
+    bucket.signals.length > 0 ||
+    bucket.deviationFindings.length > 0 ||
+    bucket.scorecardFindings.length > 0
+  )
+}
+
+function hasExplicitDoctrineSignal(bucket: RowBucket): boolean {
+  return bucket.signals.length > 0
+}
+
+function countContradictionEvidence(bucket: RowBucket): number {
+  let count = 0
+  for (const signal of bucket.signals) {
+    if (CONTRADICTION_SIGNAL_KINDS.has(signal.kind)) {
+      count += 1
+    }
+    if (signal.kind === 'subject_side_deflection_reinforced') {
+      count += 1
+    }
+  }
+  for (const finding of bucket.staffFindings) {
+    if (finding.kind === 'high_alignment_low_efficacy') {
+      count += 1
+    }
+  }
+  for (const finding of bucket.deviationFindings) {
+    if (
+      finding.kind === 'governance_notification_candidate' ||
+      (finding.severity === 'critical' && CRITICAL_DEVIATION_KINDS.has(finding.kind))
+    ) {
+      count += 1
+    }
+  }
+  for (const finding of bucket.blameFindings) {
+    if (
+      finding.kind === 'prohibited_subject_deflection' ||
+      finding.kind === 'institutional_accountability_required'
+    ) {
+      count += 1
+    }
+  }
+  for (const finding of bucket.scorecardFindings) {
+    const mapped = mapScorecardKind(finding.kind)
+    if (mapped !== undefined && CONTRADICTION_FINDING_KINDS.has(mapped)) {
+      count += 1
+    }
+  }
+  for (const finding of bucket.accommodationFindings) {
+    if (
+      finding.kind === 'outcome_worsened_without_accommodation_review' ||
+      finding.kind === 'accountability_route_conflicts_with_limitation'
+    ) {
+      count += 1
+    }
+  }
+  return count
+}
+
+function mapScorecardKind(
+  kind: MedicalAccountabilityScorecardFinding['kind']
+): InstitutionalDenialDoctrinePressureFindingKind | undefined {
+  switch (kind) {
+    case 'high_alignment_poor_outcome':
+      return 'high_alignment_poor_outcome_pressure'
+    case 'subject_deflection_pressure':
+      return 'subject_deflection_reinforcement'
+    case 'treatment_limitation_unacknowledged':
+      return 'treatment_limitation_suppression'
+    case 'outcome_accountability_gap':
+    case 'governance_review_needed':
+      return 'material_outcome_suppression'
+    default:
+      return undefined
+  }
+}
+
+function upstreamEvidenceCount(bucket: RowBucket): number {
+  return (
+    bucket.staffFindings.length +
+    bucket.deviationFindings.length +
+    bucket.blameFindings.length +
+    bucket.scorecardFindings.length +
+    bucket.accommodationFindings.length
+  )
+}
+
+function contributingEvidenceCount(bucket: RowBucket): number {
+  let count = bucket.signals.length
+  for (const finding of bucket.staffFindings) {
+    if (finding.kind === 'high_alignment_low_efficacy') {
+      count += 1
+    }
+  }
+  for (const finding of bucket.deviationFindings) {
+    if (finding.kind !== 'missing_observation') {
+      count += 1
+    }
+  }
+  for (const finding of bucket.blameFindings) {
+    if (
+      finding.kind === 'prohibited_subject_deflection' ||
+      finding.kind === 'missing_treatment_limitation_acknowledgment' ||
+      finding.kind === 'institutional_accountability_required'
+    ) {
+      count += 1
+    }
+  }
+  for (const finding of bucket.scorecardFindings) {
+    if (mapScorecardKind(finding.kind) !== undefined) {
+      count += 1
+    }
+  }
+  for (const finding of bucket.accommodationFindings) {
+    if (
+      finding.kind === 'care_mode_unavailable' ||
+      finding.kind === 'treatment_limitation_unacknowledged' ||
+      finding.kind === 'outcome_worsened_without_accommodation_review' ||
+      finding.kind === 'accountability_route_conflicts_with_limitation' ||
+      finding.kind === 'cure_only_pressure_high'
+    ) {
+      count += 1
+    }
+  }
+  return count
+}
+
+function buildRow(bucket: RowBucket): InstitutionalDenialDoctrinePressureRow {
+  const signalScores = bucket.signals.map(signalPressureScore)
+  const hasEvidence = bucket.signals.length > 0 || upstreamEvidenceCount(bucket) > 0
+  const pressureScore =
+    signalScores.length > 0
+      ? clampScore(Math.max(...signalScores))
+      : hasEvidence
+        ? 50
+        : 0
+
+  return {
+    rowId: bucket.rowId,
+    siteId: bucket.siteId,
+    staffId: bucket.staffId,
+    subjectId: bucket.subjectId,
+    protocolId: bucket.protocolId,
+    doctrineId: bucket.doctrineId,
+    week: bucket.week,
+    pressureScore,
+    signalCount: bucket.signals.length,
+    upstreamFindingCount: upstreamEvidenceCount(bucket),
+    contradictionCount: countContradictionEvidence(bucket),
+  }
+}
+
+function hasCriticalUpstream(bucket: RowBucket): boolean {
+  return (
+    bucket.deviationFindings.some((finding) => finding.severity === 'critical') ||
+    bucket.blameFindings.some((finding) => finding.severity === 'critical') ||
+    bucket.scorecardFindings.some((finding) => finding.severity === 'critical') ||
+    bucket.accommodationFindings.some((finding) => finding.severity === 'critical')
+  )
+}
+
+function hasWarningUpstream(bucket: RowBucket): boolean {
+  return (
+    bucket.deviationFindings.some((finding) => finding.severity === 'warning') ||
+    bucket.blameFindings.some((finding) => finding.severity === 'warning') ||
+    bucket.scorecardFindings.some((finding) => finding.severity === 'warning') ||
+    bucket.accommodationFindings.some((finding) => finding.severity === 'warning')
+  )
+}
+
+function resolveFindingSeverity(input: {
+  row: InstitutionalDenialDoctrinePressureRow
+  kind: InstitutionalDenialDoctrinePressureFindingKind
+  bucket: RowBucket
+  options: Required<InstitutionalDenialDoctrinePressureOptions>
+  preserveCritical?: boolean
+}): InstitutionalDenialDoctrinePressureSeverity {
+  const { row, kind, bucket, options, preserveCritical } = input
+  if (kind === 'insufficient_pressure_evidence') {
+    return 'info'
+  }
+  if (preserveCritical || hasCriticalUpstream(bucket)) {
+    return 'critical'
+  }
+  if (
+    row.pressureScore >= options.criticalPressureThreshold ||
+    (kind === 'material_outcome_suppression' &&
+      bucket.deviationFindings.some(
+        (finding) =>
+          finding.kind === 'governance_notification_candidate' &&
+          finding.severity === 'critical'
+      ))
+  ) {
+    return 'critical'
+  }
+  if (row.pressureScore >= options.highPressureThreshold || hasWarningUpstream(bucket)) {
+    return 'warning'
+  }
+  return 'info'
+}
+
+function sharedFindingFields(
+  row: InstitutionalDenialDoctrinePressureRow
+): Pick<
+  InstitutionalDenialDoctrinePressureFinding,
+  'rowId' | 'siteId' | 'staffId' | 'subjectId' | 'protocolId' | 'doctrineId' | 'week'
+> {
+  return {
+    rowId: row.rowId,
+    siteId: row.siteId,
+    staffId: row.staffId,
+    subjectId: row.subjectId,
+    protocolId: row.protocolId,
+    doctrineId: row.doctrineId,
+    week: row.week,
+  }
+}
+
+function pushFinding(
+  findings: InstitutionalDenialDoctrinePressureFinding[],
+  input: {
+    kind: InstitutionalDenialDoctrinePressureFindingKind
+    row: InstitutionalDenialDoctrinePressureRow
+    bucket: RowBucket
+    options: Required<InstitutionalDenialDoctrinePressureOptions>
+    detail: string
+    preserveCritical?: boolean
+  }
+): void {
+  findings.push({
+    kind: input.kind,
+    severity: resolveFindingSeverity({
+      row: input.row,
+      kind: input.kind,
+      bucket: input.bucket,
+      options: input.options,
+      preserveCritical: input.preserveCritical,
+    }),
+    ...sharedFindingFields(input.row),
+    detail: input.detail,
+  })
+}
+
+function buildRowFindings(
+  row: InstitutionalDenialDoctrinePressureRow,
+  bucket: RowBucket,
+  options: Required<InstitutionalDenialDoctrinePressureOptions>
+): InstitutionalDenialDoctrinePressureFinding[] {
+  const findings: InstitutionalDenialDoctrinePressureFinding[] = []
+
+  for (const signal of bucket.signals) {
+    const kind = SIGNAL_TO_FINDING[signal.kind]
+    pushFinding(findings, {
+      kind,
+      row,
+      bucket,
+      options,
+      detail:
+        signal.detail ??
+        `Explicit doctrine-pressure signal ${signal.kind} recorded for this row.`,
+      preserveCritical: signal.severity === 'critical',
+    })
+  }
+
+  for (const finding of bucket.staffFindings) {
+    if (finding.kind === 'high_alignment_low_efficacy') {
+      pushFinding(findings, {
+        kind: 'high_alignment_poor_outcome_pressure',
+        row,
+        bucket,
+        options,
+        detail:
+          finding.detail ||
+          'Staff alignment remains high while treatment efficacy or outcomes remain poor.',
+      })
+    }
+  }
+
+  for (const finding of bucket.blameFindings) {
+    if (finding.kind === 'prohibited_subject_deflection') {
+      pushFinding(findings, {
+        kind: 'subject_deflection_reinforcement',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+        preserveCritical: finding.severity === 'critical',
+      })
+    } else if (finding.kind === 'missing_treatment_limitation_acknowledgment') {
+      pushFinding(findings, {
+        kind: 'treatment_limitation_suppression',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+      })
+    } else if (
+      finding.kind === 'institutional_accountability_required' &&
+      hasMedicalAccountabilityContext(bucket)
+    ) {
+      pushFinding(findings, {
+        kind: 'material_outcome_suppression',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+        preserveCritical: finding.severity === 'critical',
+      })
+    }
+  }
+
+  for (const finding of bucket.deviationFindings) {
+    if (finding.kind === 'governance_notification_candidate') {
+      pushFinding(findings, {
+        kind: 'material_outcome_suppression',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+        preserveCritical: finding.severity === 'critical',
+      })
+    } else if (
+      finding.severity === 'critical' &&
+      CRITICAL_DEVIATION_KINDS.has(finding.kind) &&
+      hasExplicitDoctrineSignal(bucket)
+    ) {
+      pushFinding(findings, {
+        kind: 'material_outcome_suppression',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+        preserveCritical: true,
+      })
+    }
+  }
+
+  for (const finding of bucket.scorecardFindings) {
+    const mapped = mapScorecardKind(finding.kind)
+    if (mapped !== undefined) {
+      pushFinding(findings, {
+        kind: mapped,
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+        preserveCritical: finding.severity === 'critical',
+      })
+    }
+  }
+
+  for (const finding of bucket.accommodationFindings) {
+    if (finding.kind === 'care_mode_unavailable') {
+      pushFinding(findings, {
+        kind: 'care_mode_discussion_restriction',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+      })
+    } else if (finding.kind === 'treatment_limitation_unacknowledged') {
+      pushFinding(findings, {
+        kind: 'treatment_limitation_suppression',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+      })
+    } else if (finding.kind === 'outcome_worsened_without_accommodation_review') {
+      pushFinding(findings, {
+        kind: 'material_outcome_suppression',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+        preserveCritical: finding.severity === 'critical',
+      })
+    } else if (finding.kind === 'accountability_route_conflicts_with_limitation') {
+      pushFinding(findings, {
+        kind: row.subjectId ? 'subject_deflection_reinforcement' : 'material_outcome_suppression',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+      })
+    } else if (
+      finding.kind === 'cure_only_pressure_high' &&
+      hasExplicitDoctrineSignal(bucket)
+    ) {
+      pushFinding(findings, {
+        kind: 'care_mode_discussion_restriction',
+        row,
+        bucket,
+        options,
+        detail: finding.detail,
+      })
+    }
+  }
+
+  const evidenceCount = contributingEvidenceCount(bucket)
+  if (evidenceCount < options.minimumEvidenceCount) {
+    pushFinding(findings, {
+      kind: 'insufficient_pressure_evidence',
+      row,
+      bucket,
+      options,
+      detail: `Fewer than ${options.minimumEvidenceCount} evidence item(s) support this doctrine-pressure row.`,
+    })
+  }
+
+  return findings
+}
+
+function compareRows(
+  left: InstitutionalDenialDoctrinePressureRow,
+  right: InstitutionalDenialDoctrinePressureRow
+): number {
+  const siteLeft = left.siteId ?? '\uffff'
+  const siteRight = right.siteId ?? '\uffff'
+  const siteDelta = siteLeft.localeCompare(siteRight)
+  if (siteDelta !== 0) {
+    return siteDelta
+  }
+
+  const staffLeft = left.staffId ?? '\uffff'
+  const staffRight = right.staffId ?? '\uffff'
+  const staffDelta = staffLeft.localeCompare(staffRight)
+  if (staffDelta !== 0) {
+    return staffDelta
+  }
+
+  const subjectLeft = left.subjectId ?? '\uffff'
+  const subjectRight = right.subjectId ?? '\uffff'
+  const subjectDelta = subjectLeft.localeCompare(subjectRight)
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+
+  const protocolLeft = left.protocolId ?? '\uffff'
+  const protocolRight = right.protocolId ?? '\uffff'
+  const protocolDelta = protocolLeft.localeCompare(protocolRight)
+  if (protocolDelta !== 0) {
+    return protocolDelta
+  }
+
+  const doctrineLeft = left.doctrineId ?? '\uffff'
+  const doctrineRight = right.doctrineId ?? '\uffff'
+  const doctrineDelta = doctrineLeft.localeCompare(doctrineRight)
+  if (doctrineDelta !== 0) {
+    return doctrineDelta
+  }
+
+  const weekLeft = left.week ?? Number.MAX_SAFE_INTEGER
+  const weekRight = right.week ?? Number.MAX_SAFE_INTEGER
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+
+  return left.rowId.localeCompare(right.rowId)
+}
+
+function compareFindings(
+  left: InstitutionalDenialDoctrinePressureFinding,
+  right: InstitutionalDenialDoctrinePressureFinding
+): number {
+  const severityDelta = SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity]
+  if (severityDelta !== 0) {
+    return severityDelta
+  }
+
+  const kindDelta =
+    FINDING_KIND_ORDER.indexOf(left.kind) - FINDING_KIND_ORDER.indexOf(right.kind)
+  if (kindDelta !== 0) {
+    return kindDelta
+  }
+
+  const rowDelta = left.rowId.localeCompare(right.rowId)
+  if (rowDelta !== 0) {
+    return rowDelta
+  }
+
+  const siteDelta = (left.siteId ?? '').localeCompare(right.siteId ?? '')
+  if (siteDelta !== 0) {
+    return siteDelta
+  }
+
+  const staffDelta = (left.staffId ?? '').localeCompare(right.staffId ?? '')
+  if (staffDelta !== 0) {
+    return staffDelta
+  }
+
+  const subjectDelta = (left.subjectId ?? '').localeCompare(right.subjectId ?? '')
+  if (subjectDelta !== 0) {
+    return subjectDelta
+  }
+
+  const protocolDelta = (left.protocolId ?? '').localeCompare(right.protocolId ?? '')
+  if (protocolDelta !== 0) {
+    return protocolDelta
+  }
+
+  const doctrineDelta = (left.doctrineId ?? '').localeCompare(right.doctrineId ?? '')
+  if (doctrineDelta !== 0) {
+    return doctrineDelta
+  }
+
+  const weekLeft = left.week ?? Number.MAX_SAFE_INTEGER
+  const weekRight = right.week ?? Number.MAX_SAFE_INTEGER
+  if (weekLeft !== weekRight) {
+    return weekLeft - weekRight
+  }
+
+  return left.detail.localeCompare(right.detail)
+}
+
+function formatFindingLine(
+  finding: InstitutionalDenialDoctrinePressureFinding,
+  row: InstitutionalDenialDoctrinePressureRow
+): string {
+  const parts = [finding.severity, finding.kind, finding.rowId]
+  if (finding.siteId !== undefined) {
+    parts.push(`site:${finding.siteId}`)
+  }
+  if (finding.staffId !== undefined) {
+    parts.push(`staff:${finding.staffId}`)
+  }
+  if (finding.subjectId !== undefined) {
+    parts.push(`subject:${finding.subjectId}`)
+  }
+  if (finding.protocolId !== undefined) {
+    parts.push(`protocol:${finding.protocolId}`)
+  }
+  if (finding.doctrineId !== undefined) {
+    parts.push(`doctrine:${finding.doctrineId}`)
+  }
+  if (finding.week !== undefined) {
+    parts.push(`week:${finding.week}`)
+  }
+  parts.push(`pressure:${row.pressureScore}`)
+  parts.push(finding.detail)
+  return parts.join(' · ')
+}
+
+function formatReportLines(
+  rows: readonly InstitutionalDenialDoctrinePressureRow[],
+  findings: readonly InstitutionalDenialDoctrinePressureFinding[]
+): string[] {
+  const criticalCount = findings.filter((finding) => finding.severity === 'critical').length
+  if (rows.length === 0 && findings.length === 0) {
+    return [
+      'Institutional denial doctrine pressure: rows=0, findings=0, critical=0',
+    ]
+  }
+
+  const rowById = new Map(rows.map((row) => [row.rowId, row]))
+  return [
+    `Institutional denial doctrine pressure: rows=${rows.length}, findings=${findings.length}, critical=${criticalCount}`,
+    ...findings.map((finding) =>
+      formatFindingLine(finding, rowById.get(finding.rowId) ?? {
+        rowId: finding.rowId,
+        pressureScore: 0,
+        signalCount: 0,
+        upstreamFindingCount: 0,
+        contradictionCount: 0,
+      })
+    ),
+  ]
+}
+
+function emptySummary(): InstitutionalDenialDoctrinePressureReport['summary'] {
+  return {
+    rowCount: 0,
+    approvedLanguagePressureCount: 0,
+    careModeDiscussionRestrictionCount: 0,
+    dissentingStaffExclusionPressureCount: 0,
+    treatmentLimitationSuppressionCount: 0,
+    subjectDeflectionReinforcementCount: 0,
+    patientReportDismissalCount: 0,
+    overclassificationPressureCount: 0,
+    materialOutcomeSuppressionCount: 0,
+    supportAccessRestrictionCount: 0,
+    highAlignmentPoorOutcomePressureCount: 0,
+    insufficientEvidenceCount: 0,
+  }
+}
+
+function buildSummary(
+  rows: readonly InstitutionalDenialDoctrinePressureRow[],
+  findings: readonly InstitutionalDenialDoctrinePressureFinding[]
+): InstitutionalDenialDoctrinePressureReport['summary'] {
+  const summary = emptySummary()
+  summary.rowCount = rows.length
+  for (const finding of findings) {
+    switch (finding.kind) {
+      case 'approved_language_pressure':
+        summary.approvedLanguagePressureCount += 1
+        break
+      case 'care_mode_discussion_restriction':
+        summary.careModeDiscussionRestrictionCount += 1
+        break
+      case 'dissenting_staff_exclusion_pressure':
+        summary.dissentingStaffExclusionPressureCount += 1
+        break
+      case 'treatment_limitation_suppression':
+        summary.treatmentLimitationSuppressionCount += 1
+        break
+      case 'subject_deflection_reinforcement':
+        summary.subjectDeflectionReinforcementCount += 1
+        break
+      case 'patient_report_dismissal':
+        summary.patientReportDismissalCount += 1
+        break
+      case 'overclassification_pressure':
+        summary.overclassificationPressureCount += 1
+        break
+      case 'material_outcome_suppression':
+        summary.materialOutcomeSuppressionCount += 1
+        break
+      case 'support_access_restriction':
+        summary.supportAccessRestrictionCount += 1
+        break
+      case 'high_alignment_poor_outcome_pressure':
+        summary.highAlignmentPoorOutcomePressureCount += 1
+        break
+      case 'insufficient_pressure_evidence':
+        summary.insufficientEvidenceCount += 1
+        break
+      default:
+        break
+    }
+  }
+  return summary
+}
+
+export function buildInstitutionalDenialDoctrinePressureReport(input: {
+  doctrinePressureSignals?: readonly InstitutionalDenialDoctrinePressureSignal[]
+  staffTelemetryFindings?: readonly StaffTreatmentTelemetryFinding[]
+  medicalDeviationFindings?: readonly MedicalOutcomeDeviationFinding[]
+  blameRoutingFindings?: readonly TreatmentFailureBlameRoutingFinding[]
+  medicalScorecardFindings?: readonly MedicalAccountabilityScorecardFinding[]
+  accommodationFindings?: readonly AccommodationAccessAuditFinding[]
+  options?: InstitutionalDenialDoctrinePressureOptions
+}): InstitutionalDenialDoctrinePressureReport {
+  const options = resolveOptions(input.options)
+  const signals = dedupeSignals(input.doctrinePressureSignals ?? [])
+  const staffFindings = input.staffTelemetryFindings ?? []
+  const deviationFindings = input.medicalDeviationFindings ?? []
+  const blameFindings = input.blameRoutingFindings ?? []
+  const scorecardFindings = input.medicalScorecardFindings ?? []
+  const accommodationFindings = input.accommodationFindings ?? []
+
+  if (
+    signals.length === 0 &&
+    staffFindings.length === 0 &&
+    deviationFindings.length === 0 &&
+    blameFindings.length === 0 &&
+    scorecardFindings.length === 0 &&
+    accommodationFindings.length === 0
+  ) {
+    return {
+      rows: [],
+      findings: [],
+      summary: emptySummary(),
+      lines: formatReportLines([], []),
+    }
+  }
+
+  const buckets = new Map<string, RowBucket>()
+
+  for (const signal of signals) {
+    const bucket = getOrCreateBucket(buckets, resolveSignalKey(signal))
+    bucket.signals.push(signal)
+    if (signal.siteId && bucket.siteId === undefined) {
+      bucket.siteId = signal.siteId
+    }
+    if (signal.staffId && bucket.staffId === undefined) {
+      bucket.staffId = signal.staffId
+    }
+    if (signal.subjectId && bucket.subjectId === undefined) {
+      bucket.subjectId = signal.subjectId
+    }
+    if (signal.protocolId && bucket.protocolId === undefined) {
+      bucket.protocolId = signal.protocolId
+    }
+    if (signal.doctrineId && bucket.doctrineId === undefined) {
+      bucket.doctrineId = signal.doctrineId
+    }
+  }
+
+  for (const finding of staffFindings) {
+    getOrCreateBucket(buckets, resolveStaffFindingKey(finding)).staffFindings.push(finding)
+  }
+
+  for (const finding of deviationFindings) {
+    getOrCreateBucket(
+      buckets,
+      resolveSubjectProtocolFindingKey(finding)
+    ).deviationFindings.push(finding)
+  }
+
+  for (const finding of blameFindings) {
+    getOrCreateBucket(
+      buckets,
+      resolveSubjectProtocolFindingKey(finding)
+    ).blameFindings.push(finding)
+  }
+
+  for (const finding of scorecardFindings) {
+    getOrCreateBucket(buckets, resolveScorecardFindingKey(finding)).scorecardFindings.push(
+      finding
+    )
+  }
+
+  for (const finding of accommodationFindings) {
+    getOrCreateBucket(
+      buckets,
+      resolveSubjectProtocolFindingKey(finding)
+    ).accommodationFindings.push(finding)
+  }
+
+  const bucketByRowId = new Map(
+    [...buckets.values()].map((bucket) => [bucket.rowId, bucket] as const)
+  )
+  const rows = [...buckets.values()].map(buildRow).sort(compareRows)
+  const findings = rows
+    .flatMap((row) => {
+      const bucket = bucketByRowId.get(row.rowId)
+      if (bucket === undefined) {
+        return []
+      }
+      return buildRowFindings(row, bucket, options)
+    })
+    .sort(compareFindings)
+
+  const summary = buildSummary(rows, findings)
+  const lines = formatReportLines(rows, findings)
+
+  return { rows, findings, summary, lines }
+}

--- a/src/domain/institutionalDenialDoctrinePressure.ts
+++ b/src/domain/institutionalDenialDoctrinePressure.ts
@@ -110,6 +110,16 @@ export interface InstitutionalDenialDoctrinePressureOptions {
   minimumEvidenceCount?: number
 }
 
+export interface InstitutionalDenialDoctrinePressureInput {
+  doctrinePressureSignals?: readonly InstitutionalDenialDoctrinePressureSignal[]
+  staffTelemetryFindings?: readonly StaffTreatmentTelemetryFinding[]
+  medicalDeviationFindings?: readonly MedicalOutcomeDeviationFinding[]
+  blameRoutingFindings?: readonly TreatmentFailureBlameRoutingFinding[]
+  medicalScorecardFindings?: readonly MedicalAccountabilityScorecardFinding[]
+  accommodationFindings?: readonly AccommodationAccessAuditFinding[]
+  options?: InstitutionalDenialDoctrinePressureOptions
+}
+
 const DEFAULT_OPTIONS: Required<InstitutionalDenialDoctrinePressureOptions> = {
   highPressureThreshold: 70,
   criticalPressureThreshold: 90,
@@ -207,6 +217,29 @@ function normalizeWeek(value: number | undefined): number | undefined {
   return Math.max(0, Math.trunc(value))
 }
 
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function isValidSignalKind(value: unknown): value is InstitutionalDenialDoctrinePressureSignalKind {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(SIGNAL_TO_FINDING, value)
+  )
+}
+
+function encodeRowSegment(value: string): string {
+  return encodeURIComponent(value)
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
+}
+
 function normalizeMinimumEvidenceCount(value: number | undefined): number {
   if (value === undefined || !Number.isFinite(value)) {
     return DEFAULT_OPTIONS.minimumEvidenceCount
@@ -251,6 +284,16 @@ function staffWeekKey(staffId: string, week: number | undefined): string {
   return `staff\0${staffId}\0${weekPart}`
 }
 
+function staffSubjectProtocolWeekKey(
+  staffId: string,
+  subjectId: string,
+  protocolId: string,
+  week: number | undefined
+): string {
+  const weekPart = week !== undefined ? String(week) : ''
+  return `staff-subject\0${staffId}\0${subjectId}\0${protocolId}\0${weekPart}`
+}
+
 function siteWeekKey(siteId: string, week: number | undefined): string {
   const weekPart = week !== undefined ? String(week) : ''
   return `site\0${siteId}\0${weekPart}`
@@ -260,23 +303,10 @@ function rowIdForKey(key: string): string {
   if (key === AGGREGATE_KEY) {
     return 'row:aggregate'
   }
-  if (key.startsWith('subject\0')) {
-    const parts = key.split('\0')
-    return `row:subject:${parts[1] ?? ''}:${parts[2] ?? ''}:${parts[3] ?? ''}`
-  }
-  if (key.startsWith('staff-doctrine\0')) {
-    const parts = key.split('\0')
-    return `row:staff-doctrine:${parts[1] ?? ''}:${parts[2] ?? ''}:${parts[3] ?? ''}`
-  }
-  if (key.startsWith('staff\0')) {
-    const parts = key.split('\0')
-    return `row:staff:${parts[1] ?? ''}:${parts[2] ?? ''}`
-  }
-  if (key.startsWith('site\0')) {
-    const parts = key.split('\0')
-    return `row:site:${parts[1] ?? ''}:${parts[2] ?? ''}`
-  }
-  return `row:unknown:${key}`
+  const parts = key.split('\0')
+  const type = parts[0] ?? 'unknown'
+  const segments = parts.slice(1).map(encodeRowSegment)
+  return `row:${type}/${segments.join('/')}`
 }
 
 function parseSubjectProtocolWeekKey(key: string): {
@@ -323,8 +353,33 @@ function parseStaffDoctrineWeekKey(key: string): {
   }
 }
 
+function parseStaffSubjectProtocolWeekKey(key: string): {
+  staffId?: string
+  subjectId?: string
+  protocolId?: string
+  week?: number
+} {
+  if (!key.startsWith('staff-subject\0')) {
+    return {}
+  }
+  const parts = key.split('\0')
+  const staffId = parts[1]
+  const subjectId = parts[2]
+  const protocolId = parts[3]
+  const weekPart = parts[4]
+  if (!staffId || !subjectId || !protocolId) {
+    return {}
+  }
+  return {
+    staffId,
+    subjectId,
+    protocolId,
+    week: weekPart && weekPart.length > 0 ? Number(weekPart) : undefined,
+  }
+}
+
 function parseStaffWeekKey(key: string): { staffId?: string; week?: number } {
-  if (!key.startsWith('staff\0') || key.startsWith('staff-doctrine\0')) {
+  if (!key.startsWith('staff\0') || key.startsWith('staff-doctrine\0') || key.startsWith('staff-subject\0')) {
     return {}
   }
   const parts = key.split('\0')
@@ -363,6 +418,7 @@ function getOrCreateBucket(buckets: Map<string, RowBucket>, key: string): RowBuc
 
   const subjectFields = parseSubjectProtocolWeekKey(key)
   const staffDoctrineFields = parseStaffDoctrineWeekKey(key)
+  const staffSubjectFields = parseStaffSubjectProtocolWeekKey(key)
   const staffFields = parseStaffWeekKey(key)
   const siteFields = parseSiteWeekKey(key)
 
@@ -370,12 +426,14 @@ function getOrCreateBucket(buckets: Map<string, RowBucket>, key: string): RowBuc
     key,
     rowId: rowIdForKey(key),
     siteId: siteFields.siteId,
-    staffId: staffDoctrineFields.staffId ?? staffFields.staffId,
-    subjectId: subjectFields.subjectId,
-    protocolId: subjectFields.protocolId,
+    staffId:
+      staffSubjectFields.staffId ?? staffDoctrineFields.staffId ?? staffFields.staffId,
+    subjectId: staffSubjectFields.subjectId ?? subjectFields.subjectId,
+    protocolId: staffSubjectFields.protocolId ?? subjectFields.protocolId,
     doctrineId: staffDoctrineFields.doctrineId,
     week:
       subjectFields.week ??
+      staffSubjectFields.week ??
       staffDoctrineFields.week ??
       staffFields.week ??
       siteFields.week,
@@ -391,20 +449,20 @@ function getOrCreateBucket(buckets: Map<string, RowBucket>, key: string): RowBuc
 }
 
 function resolveSignalKey(signal: InstitutionalDenialDoctrinePressureSignal): string {
-  const subjectId = signal.subjectId?.trim()
-  const protocolId = signal.protocolId?.trim()
-  const week = normalizeWeek(signal.week)
+  const subjectId = signal.subjectId
+  const protocolId = signal.protocolId
+  const week = signal.week
   if (subjectId && protocolId) {
     return subjectProtocolWeekKey(subjectId, protocolId, week)
   }
 
-  const staffId = signal.staffId?.trim()
-  const doctrineId = signal.doctrineId?.trim()
+  const staffId = signal.staffId
+  const doctrineId = signal.doctrineId
   if (staffId && doctrineId) {
     return staffDoctrineWeekKey(staffId, doctrineId, week)
   }
 
-  const siteId = signal.siteId?.trim()
+  const siteId = signal.siteId
   if (siteId) {
     return siteWeekKey(siteId, week)
   }
@@ -421,8 +479,8 @@ function resolveSubjectProtocolFindingKey(input: {
   protocolId?: string
   week?: number
 }): string {
-  const subjectId = input.subjectId?.trim()
-  const protocolId = input.protocolId?.trim()
+  const subjectId = normalizeOptionalString(input.subjectId)
+  const protocolId = normalizeOptionalString(input.protocolId)
   const week = normalizeWeek(input.week)
   if (subjectId && protocolId) {
     return subjectProtocolWeekKey(subjectId, protocolId, week)
@@ -431,9 +489,16 @@ function resolveSubjectProtocolFindingKey(input: {
 }
 
 function resolveStaffFindingKey(finding: StaffTreatmentTelemetryFinding): string {
-  const subjectId = finding.subjectId?.trim()
-  const protocolId = finding.protocolId?.trim()
+  const staffId = normalizeOptionalString(finding.staffId)
+  const subjectId = normalizeOptionalString(finding.subjectId)
+  const protocolId = normalizeOptionalString(finding.protocolId)
   const week = normalizeWeek(finding.week)
+  if (staffId && subjectId && protocolId) {
+    return staffSubjectProtocolWeekKey(staffId, subjectId, protocolId, week)
+  }
+  if (staffId) {
+    return staffWeekKey(staffId, week)
+  }
   if (subjectId && protocolId) {
     return subjectProtocolWeekKey(subjectId, protocolId, week)
   }
@@ -445,11 +510,11 @@ function resolveScorecardFindingKey(finding: MedicalAccountabilityScorecardFindi
   if (subjectKey !== AGGREGATE_KEY) {
     return subjectKey
   }
-  const staffId = finding.staffId?.trim()
+  const staffId = normalizeOptionalString(finding.staffId)
   if (staffId) {
     return staffWeekKey(staffId, normalizeWeek(finding.week))
   }
-  const siteId = finding.siteId?.trim()
+  const siteId = normalizeOptionalString(finding.siteId)
   if (siteId) {
     return siteWeekKey(siteId, normalizeWeek(finding.week))
   }
@@ -462,9 +527,9 @@ function dedupeSignals(
   const seen = new Set<string>()
   const deduped: InstitutionalDenialDoctrinePressureSignal[] = []
   for (const signal of signals) {
-    const signalId = signal.signalId.trim()
-    const kind = signal.kind
-    if (signalId.length === 0 || !(kind in SIGNAL_TO_FINDING)) {
+    const signalId = normalizeOptionalString(signal.signalId)
+    const kind = isValidSignalKind(signal.kind) ? signal.kind : undefined
+    if (signalId === undefined || kind === undefined) {
       continue
     }
     if (seen.has(signalId)) {
@@ -474,15 +539,16 @@ function dedupeSignals(
     deduped.push({
       ...signal,
       signalId,
-      siteId: signal.siteId?.trim() || undefined,
-      staffId: signal.staffId?.trim() || undefined,
-      subjectId: signal.subjectId?.trim() || undefined,
-      protocolId: signal.protocolId?.trim() || undefined,
-      doctrineId: signal.doctrineId?.trim() || undefined,
+      kind,
+      siteId: normalizeOptionalString(signal.siteId),
+      staffId: normalizeOptionalString(signal.staffId),
+      subjectId: normalizeOptionalString(signal.subjectId),
+      protocolId: normalizeOptionalString(signal.protocolId),
+      doctrineId: normalizeOptionalString(signal.doctrineId),
       week: normalizeWeek(signal.week),
       pressureScore:
         signal.pressureScore === undefined ? undefined : clampScore(signal.pressureScore),
-      detail: signal.detail?.trim() || undefined,
+      detail: normalizeOptionalString(signal.detail),
     })
   }
   return deduped
@@ -598,6 +664,51 @@ function upstreamEvidenceCount(bucket: RowBucket): number {
   )
 }
 
+function contributesDeviationEvidence(
+  finding: MedicalOutcomeDeviationFinding,
+  bucket: RowBucket
+): boolean {
+  if (finding.kind === 'governance_notification_candidate') {
+    return true
+  }
+  return (
+    finding.severity === 'critical' &&
+    CRITICAL_DEVIATION_KINDS.has(finding.kind) &&
+    hasExplicitDoctrineSignal(bucket)
+  )
+}
+
+function contributesBlameEvidence(
+  finding: TreatmentFailureBlameRoutingFinding,
+  bucket: RowBucket
+): boolean {
+  if (finding.kind === 'prohibited_subject_deflection') {
+    return true
+  }
+  if (finding.kind === 'missing_treatment_limitation_acknowledgment') {
+    return true
+  }
+  if (finding.kind === 'institutional_accountability_required') {
+    return hasMedicalAccountabilityContext(bucket)
+  }
+  return false
+}
+
+function contributesAccommodationEvidence(
+  finding: AccommodationAccessAuditFinding,
+  bucket: RowBucket
+): boolean {
+  if (finding.kind === 'cure_only_pressure_high') {
+    return hasExplicitDoctrineSignal(bucket)
+  }
+  return (
+    finding.kind === 'care_mode_unavailable' ||
+    finding.kind === 'treatment_limitation_unacknowledged' ||
+    finding.kind === 'outcome_worsened_without_accommodation_review' ||
+    finding.kind === 'accountability_route_conflicts_with_limitation'
+  )
+}
+
 function contributingEvidenceCount(bucket: RowBucket): number {
   let count = bucket.signals.length
   for (const finding of bucket.staffFindings) {
@@ -606,16 +717,12 @@ function contributingEvidenceCount(bucket: RowBucket): number {
     }
   }
   for (const finding of bucket.deviationFindings) {
-    if (finding.kind !== 'missing_observation') {
+    if (contributesDeviationEvidence(finding, bucket)) {
       count += 1
     }
   }
   for (const finding of bucket.blameFindings) {
-    if (
-      finding.kind === 'prohibited_subject_deflection' ||
-      finding.kind === 'missing_treatment_limitation_acknowledgment' ||
-      finding.kind === 'institutional_accountability_required'
-    ) {
+    if (contributesBlameEvidence(finding, bucket)) {
       count += 1
     }
   }
@@ -625,17 +732,57 @@ function contributingEvidenceCount(bucket: RowBucket): number {
     }
   }
   for (const finding of bucket.accommodationFindings) {
-    if (
-      finding.kind === 'care_mode_unavailable' ||
-      finding.kind === 'treatment_limitation_unacknowledged' ||
-      finding.kind === 'outcome_worsened_without_accommodation_review' ||
-      finding.kind === 'accountability_route_conflicts_with_limitation' ||
-      finding.kind === 'cure_only_pressure_high'
-    ) {
+    if (contributesAccommodationEvidence(finding, bucket)) {
       count += 1
     }
   }
   return count
+}
+
+function resolveEnrichedRowMetadata(
+  bucket: RowBucket
+): Pick<
+  InstitutionalDenialDoctrinePressureRow,
+  'siteId' | 'staffId' | 'subjectId' | 'protocolId' | 'doctrineId' | 'week'
+> {
+  if (bucket.key === AGGREGATE_KEY) {
+    return { week: bucket.week }
+  }
+
+  const metadata = {
+    siteId: bucket.siteId,
+    staffId: bucket.staffId,
+    subjectId: bucket.subjectId,
+    protocolId: bucket.protocolId,
+    doctrineId: bucket.doctrineId,
+    week: bucket.week,
+  }
+
+  if (metadata.staffId === undefined) {
+    const staffIds = uniqueSorted(
+      [
+        ...bucket.staffFindings.map((finding) => normalizeOptionalString(finding.staffId)),
+        ...bucket.scorecardFindings.map((finding) => normalizeOptionalString(finding.staffId)),
+      ].filter((staffId): staffId is string => staffId !== undefined)
+    )
+    if (staffIds.length === 1) {
+      metadata.staffId = staffIds[0]
+    }
+  }
+
+  if (metadata.siteId === undefined) {
+    const siteIds = uniqueSorted(
+      [
+        ...bucket.accommodationFindings.map((finding) => normalizeOptionalString(finding.siteId)),
+        ...bucket.scorecardFindings.map((finding) => normalizeOptionalString(finding.siteId)),
+      ].filter((siteId): siteId is string => siteId !== undefined)
+    )
+    if (siteIds.length === 1) {
+      metadata.siteId = siteIds[0]
+    }
+  }
+
+  return metadata
 }
 
 function buildRow(bucket: RowBucket): InstitutionalDenialDoctrinePressureRow {
@@ -650,12 +797,7 @@ function buildRow(bucket: RowBucket): InstitutionalDenialDoctrinePressureRow {
 
   return {
     rowId: bucket.rowId,
-    siteId: bucket.siteId,
-    staffId: bucket.staffId,
-    subjectId: bucket.subjectId,
-    protocolId: bucket.protocolId,
-    doctrineId: bucket.doctrineId,
-    week: bucket.week,
+    ...resolveEnrichedRowMetadata(bucket),
     pressureScore,
     signalCount: bucket.signals.length,
     upstreamFindingCount: upstreamEvidenceCount(bucket),
@@ -910,14 +1052,31 @@ function buildRowFindings(
     }
   }
 
+  const pressureFindings = findings.filter(
+    (finding) => finding.kind !== 'insufficient_pressure_evidence'
+  )
   const evidenceCount = contributingEvidenceCount(bucket)
-  if (evidenceCount < options.minimumEvidenceCount) {
+  const hasRowEvidence =
+    bucket.signals.length > 0 ||
+    bucket.staffFindings.length > 0 ||
+    bucket.deviationFindings.length > 0 ||
+    bucket.blameFindings.length > 0 ||
+    bucket.scorecardFindings.length > 0 ||
+    bucket.accommodationFindings.length > 0
+
+  if (
+    evidenceCount < options.minimumEvidenceCount ||
+    (hasRowEvidence && pressureFindings.length === 0)
+  ) {
     pushFinding(findings, {
       kind: 'insufficient_pressure_evidence',
       row,
       bucket,
       options,
-      detail: `Fewer than ${options.minimumEvidenceCount} evidence item(s) support this doctrine-pressure row.`,
+      detail:
+        pressureFindings.length === 0 && hasRowEvidence
+          ? 'Upstream evidence is present but none is eligible for doctrine-pressure findings on this row.'
+          : `Fewer than ${options.minimumEvidenceCount} evidence item(s) support this doctrine-pressure row.`,
     })
   }
 
@@ -1145,15 +1304,22 @@ function buildSummary(
   return summary
 }
 
-export function buildInstitutionalDenialDoctrinePressureReport(input: {
-  doctrinePressureSignals?: readonly InstitutionalDenialDoctrinePressureSignal[]
-  staffTelemetryFindings?: readonly StaffTreatmentTelemetryFinding[]
-  medicalDeviationFindings?: readonly MedicalOutcomeDeviationFinding[]
-  blameRoutingFindings?: readonly TreatmentFailureBlameRoutingFinding[]
-  medicalScorecardFindings?: readonly MedicalAccountabilityScorecardFinding[]
-  accommodationFindings?: readonly AccommodationAccessAuditFinding[]
-  options?: InstitutionalDenialDoctrinePressureOptions
-}): InstitutionalDenialDoctrinePressureReport {
+function emptyReport(): InstitutionalDenialDoctrinePressureReport {
+  return {
+    rows: [],
+    findings: [],
+    summary: emptySummary(),
+    lines: formatReportLines([], []),
+  }
+}
+
+export function buildInstitutionalDenialDoctrinePressureReport(
+  input?: InstitutionalDenialDoctrinePressureInput | null
+): InstitutionalDenialDoctrinePressureReport {
+  if (input == null) {
+    return emptyReport()
+  }
+
   const options = resolveOptions(input.options)
   const signals = dedupeSignals(input.doctrinePressureSignals ?? [])
   const staffFindings = input.staffTelemetryFindings ?? []
@@ -1170,34 +1336,13 @@ export function buildInstitutionalDenialDoctrinePressureReport(input: {
     scorecardFindings.length === 0 &&
     accommodationFindings.length === 0
   ) {
-    return {
-      rows: [],
-      findings: [],
-      summary: emptySummary(),
-      lines: formatReportLines([], []),
-    }
+    return emptyReport()
   }
 
   const buckets = new Map<string, RowBucket>()
 
   for (const signal of signals) {
-    const bucket = getOrCreateBucket(buckets, resolveSignalKey(signal))
-    bucket.signals.push(signal)
-    if (signal.siteId && bucket.siteId === undefined) {
-      bucket.siteId = signal.siteId
-    }
-    if (signal.staffId && bucket.staffId === undefined) {
-      bucket.staffId = signal.staffId
-    }
-    if (signal.subjectId && bucket.subjectId === undefined) {
-      bucket.subjectId = signal.subjectId
-    }
-    if (signal.protocolId && bucket.protocolId === undefined) {
-      bucket.protocolId = signal.protocolId
-    }
-    if (signal.doctrineId && bucket.doctrineId === undefined) {
-      bucket.doctrineId = signal.doctrineId
-    }
+    getOrCreateBucket(buckets, resolveSignalKey(signal)).signals.push(signal)
   }
 
   for (const finding of staffFindings) {
@@ -1231,22 +1376,22 @@ export function buildInstitutionalDenialDoctrinePressureReport(input: {
     ).accommodationFindings.push(finding)
   }
 
-  const bucketByRowId = new Map(
-    [...buckets.values()].map((bucket) => [bucket.rowId, bucket] as const)
+  const sortedBuckets = [...buckets.values()].sort((left, right) =>
+    compareRows(buildRow(left), buildRow(right))
   )
-  const rows = [...buckets.values()].map(buildRow).sort(compareRows)
-  const findings = rows
-    .flatMap((row) => {
-      const bucket = bucketByRowId.get(row.rowId)
-      if (bucket === undefined) {
-        return []
-      }
-      return buildRowFindings(row, bucket, options)
-    })
-    .sort(compareFindings)
 
-  const summary = buildSummary(rows, findings)
-  const lines = formatReportLines(rows, findings)
+  const rows: InstitutionalDenialDoctrinePressureRow[] = []
+  const findings: InstitutionalDenialDoctrinePressureFinding[] = []
 
-  return { rows, findings, summary, lines }
+  for (const bucket of sortedBuckets) {
+    const row = buildRow(bucket)
+    rows.push(row)
+    findings.push(...buildRowFindings(row, bucket, options))
+  }
+
+  const sortedFindings = findings.sort(compareFindings)
+  const summary = buildSummary(rows, sortedFindings)
+  const lines = formatReportLines(rows, sortedFindings)
+
+  return { rows, findings: sortedFindings, summary, lines }
 }

--- a/src/domain/institutionalDenialDoctrinePressure.ts
+++ b/src/domain/institutionalDenialDoctrinePressure.ts
@@ -739,6 +739,35 @@ function contributingEvidenceCount(bucket: RowBucket): number {
   return count
 }
 
+function resolveUnambiguousOptionalId(
+  keyDefined: string | undefined,
+  explicitValues: readonly (string | undefined)[],
+  upstreamValues: readonly (string | undefined)[]
+): string | undefined {
+  if (keyDefined !== undefined) {
+    return keyDefined
+  }
+
+  const explicit = uniqueSorted(
+    explicitValues.filter((value): value is string => value !== undefined)
+  )
+  if (explicit.length > 1) {
+    return undefined
+  }
+  if (explicit.length === 1) {
+    return explicit[0]
+  }
+
+  const upstream = uniqueSorted(
+    upstreamValues.filter((value): value is string => value !== undefined)
+  )
+  if (upstream.length === 1) {
+    return upstream[0]
+  }
+
+  return undefined
+}
+
 function resolveEnrichedRowMetadata(
   bucket: RowBucket
 ): Pick<
@@ -749,40 +778,25 @@ function resolveEnrichedRowMetadata(
     return { week: bucket.week }
   }
 
-  const metadata = {
-    siteId: bucket.siteId,
-    staffId: bucket.staffId,
+  const signalStaffIds = bucket.signals.map((signal) => signal.staffId)
+  const signalSiteIds = bucket.signals.map((signal) => signal.siteId)
+  const upstreamStaffIds = [
+    ...bucket.staffFindings.map((finding) => normalizeOptionalString(finding.staffId)),
+    ...bucket.scorecardFindings.map((finding) => normalizeOptionalString(finding.staffId)),
+  ]
+  const upstreamSiteIds = [
+    ...bucket.accommodationFindings.map((finding) => normalizeOptionalString(finding.siteId)),
+    ...bucket.scorecardFindings.map((finding) => normalizeOptionalString(finding.siteId)),
+  ]
+
+  return {
+    siteId: resolveUnambiguousOptionalId(bucket.siteId, signalSiteIds, upstreamSiteIds),
+    staffId: resolveUnambiguousOptionalId(bucket.staffId, signalStaffIds, upstreamStaffIds),
     subjectId: bucket.subjectId,
     protocolId: bucket.protocolId,
     doctrineId: bucket.doctrineId,
     week: bucket.week,
   }
-
-  if (metadata.staffId === undefined) {
-    const staffIds = uniqueSorted(
-      [
-        ...bucket.staffFindings.map((finding) => normalizeOptionalString(finding.staffId)),
-        ...bucket.scorecardFindings.map((finding) => normalizeOptionalString(finding.staffId)),
-      ].filter((staffId): staffId is string => staffId !== undefined)
-    )
-    if (staffIds.length === 1) {
-      metadata.staffId = staffIds[0]
-    }
-  }
-
-  if (metadata.siteId === undefined) {
-    const siteIds = uniqueSorted(
-      [
-        ...bucket.accommodationFindings.map((finding) => normalizeOptionalString(finding.siteId)),
-        ...bucket.scorecardFindings.map((finding) => normalizeOptionalString(finding.siteId)),
-      ].filter((siteId): siteId is string => siteId !== undefined)
-    )
-    if (siteIds.length === 1) {
-      metadata.siteId = siteIds[0]
-    }
-  }
-
-  return metadata
 }
 
 function buildRow(bucket: RowBucket): InstitutionalDenialDoctrinePressureRow {

--- a/src/test/institutionalDenialDoctrinePressure.test.ts
+++ b/src/test/institutionalDenialDoctrinePressure.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   buildInstitutionalDenialDoctrinePressureReport,
+  type InstitutionalDenialDoctrinePressureInput,
   type InstitutionalDenialDoctrinePressureSignal,
 } from '../domain/institutionalDenialDoctrinePressure'
 import type { AccommodationAccessAuditFinding } from '../domain/accommodationAccessAudit'
@@ -102,14 +103,20 @@ describe('institutionalDenialDoctrinePressure (SPE-2001)', () => {
       ],
     })
     expect(report.rows).toHaveLength(1)
-    expect(report.rows[0]?.rowId).toBe('row:staff-doctrine:staff:alpha:doctrine:denial:2')
+    expect(report.rows[0]?.rowId).toBe(
+      'row:staff-doctrine/staff%3Aalpha/doctrine%3Adenial/2'
+    )
     expect(report.rows[0]?.signalCount).toBe(1)
   })
 
-  it('skips invalid blank signalId/kind signals', () => {
+  it('skips invalid blank signalId and invalid kind signals', () => {
     const report = buildInstitutionalDenialDoctrinePressureReport({
       doctrinePressureSignals: [
         doctrineSignal({ signalId: '  ', kind: 'approved_language_requirement' }),
+        doctrineSignal({
+          signalId: 'invalid-kind',
+          kind: 'not_a_real_kind' as InstitutionalDenialDoctrinePressureSignal['kind'],
+        }),
         doctrineSignal({ signalId: 'valid', kind: 'support_access_restricted', siteId: 'site:1' }),
       ],
     })
@@ -397,7 +404,7 @@ describe('institutionalDenialDoctrinePressure (SPE-2001)', () => {
     expect(report.findings.some((f) => f.kind === 'treatment_limitation_suppression')).toBe(true)
   })
 
-  it('sparse upstream findings go to deterministic aggregate rows without throwing', () => {
+  it('sparse upstream findings go to deterministic staff rows without throwing', () => {
     const report = buildInstitutionalDenialDoctrinePressureReport({
       staffTelemetryFindings: [
         staffFinding({
@@ -408,7 +415,8 @@ describe('institutionalDenialDoctrinePressure (SPE-2001)', () => {
       ],
     })
     expect(report.rows).toHaveLength(1)
-    expect(report.rows[0]?.rowId).toBe('row:aggregate')
+    expect(report.rows[0]?.rowId).toBe('row:staff/staff%3Asparse/')
+    expect(report.rows[0]?.staffId).toBe('staff:sparse')
   })
 
   it('threshold overrides affect severity', () => {
@@ -569,11 +577,272 @@ describe('institutionalDenialDoctrinePressure (SPE-2001)', () => {
     expect(source).toMatch(/import type \{ TreatmentFailureBlameRoutingFinding \}/)
     expect(source).toMatch(/import type \{ MedicalAccountabilityScorecardFinding \}/)
     expect(source).toMatch(/import type \{ AccommodationAccessAuditFinding \}/)
+    expect(source).toMatch(/export interface InstitutionalDenialDoctrinePressureInput/)
     expect(source.includes('buildStaffTreatmentTelemetryReport')).toBe(false)
     expect(source.includes('buildMedicalOutcomeDeviationAuditReport')).toBe(false)
     expect(source.includes('buildTreatmentFailureBlameRoutingReport')).toBe(false)
     expect(source.includes('buildMedicalAccountabilityScorecard')).toBe(false)
     expect(source.includes('buildAccommodationAccessAuditReport')).toBe(false)
+  })
+
+  it('distinct colon-containing buckets produce distinct rows and findings', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'sig-a',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:a:b',
+          protocolId: 'protocol:c',
+          detail: 'Bucket A.',
+        }),
+        doctrineSignal({
+          signalId: 'sig-b',
+          kind: 'overclassification_pressure',
+          subjectId: 'agent:a',
+          protocolId: 'protocol:b:c',
+          detail: 'Bucket B.',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(2)
+    expect(report.rows[0]?.rowId).not.toBe(report.rows[1]?.rowId)
+    const rowA = report.rows.find((row) => row.subjectId === 'agent:a:b')
+    const rowB = report.rows.find((row) => row.protocolId === 'protocol:b:c')
+    expect(rowA).toBeDefined()
+    expect(rowB).toBeDefined()
+    expect(
+      report.findings.find(
+        (finding) => finding.rowId === rowA?.rowId && finding.kind === 'patient_report_dismissal'
+      )?.detail
+    ).toBe('Bucket A.')
+    expect(
+      report.findings.find(
+        (finding) =>
+          finding.rowId === rowB?.rowId && finding.kind === 'overclassification_pressure'
+      )?.detail
+    ).toBe('Bucket B.')
+  })
+
+  it('keeps distinct staff telemetry rows for same subject/protocol/week', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:one',
+          subjectId: 'agent:shared',
+          protocolId: 'protocol:shared',
+          week: 2,
+          detail: 'Staff one pressure.',
+        }),
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:two',
+          subjectId: 'agent:shared',
+          protocolId: 'protocol:shared',
+          week: 2,
+          detail: 'Staff two pressure.',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(2)
+    expect(report.rows.map((row) => row.staffId).sort()).toEqual(['staff:one', 'staff:two'])
+    expect(
+      report.findings.filter((finding) => finding.kind === 'high_alignment_poor_outcome_pressure')
+    ).toHaveLength(2)
+  })
+
+  it('skips malformed runtime signals without throwing', () => {
+    expect(() =>
+      buildInstitutionalDenialDoctrinePressureReport({
+        doctrinePressureSignals: [
+          { signalId: null, kind: 'approved_language_requirement' } as never,
+          { signalId: 'null-kind', kind: null } as never,
+          {
+            signalId: 'bad-ids',
+            kind: 'approved_language_requirement',
+            staffId: 42,
+            subjectId: false,
+          } as never,
+          doctrineSignal({
+            signalId: 'good',
+            kind: 'support_access_restricted',
+            siteId: 'site:safe',
+          }),
+        ],
+      })
+    ).not.toThrow()
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        { signalId: null, kind: 'approved_language_requirement' } as never,
+        { signalId: 'null-kind', kind: null } as never,
+        {
+          signalId: 'bad-ids',
+          kind: 'approved_language_requirement',
+          staffId: 42,
+          subjectId: false,
+        } as never,
+        doctrineSignal({
+          signalId: 'good',
+          kind: 'support_access_restricted',
+          siteId: 'site:safe',
+        }),
+      ],
+    })
+    const siteRow = report.rows.find((row) => row.siteId === 'site:safe')
+    expect(siteRow).toBeDefined()
+    expect(siteRow?.staffId).toBeUndefined()
+    expect(siteRow?.subjectId).toBeUndefined()
+    const aggregateRow = report.rows.find((row) => row.rowId === 'row:aggregate')
+    expect(aggregateRow?.siteId).toBeUndefined()
+    expect(aggregateRow?.staffId).toBeUndefined()
+  })
+
+  it('skips prototype-like signal kinds such as toString', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        { signalId: 'proto', kind: 'toString' } as never,
+        doctrineSignal({
+          signalId: 'valid',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:proto',
+          protocolId: 'protocol:proto',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.findings.some((finding) => finding.kind === 'patient_report_dismissal')).toBe(
+      true
+    )
+  })
+
+  it('emits insufficient evidence for gated-only upstream rows', () => {
+    const institutionalOnly = buildInstitutionalDenialDoctrinePressureReport({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'institutional_accountability_required',
+          severity: 'warning',
+          subjectId: 'agent:gate',
+          protocolId: 'protocol:gate',
+          detail: 'Institutional accountability only.',
+        }),
+      ],
+    })
+    expect(
+      institutionalOnly.findings.some((finding) => finding.kind === 'insufficient_pressure_evidence')
+    ).toBe(true)
+    expect(
+      institutionalOnly.findings.some((finding) => finding.kind === 'material_outcome_suppression')
+    ).toBe(false)
+
+    const cureOnly = buildInstitutionalDenialDoctrinePressureReport({
+      accommodationFindings: [
+        accommodationFinding({
+          kind: 'cure_only_pressure_high',
+          severity: 'warning',
+          rowId: 'row:acc-gate',
+          subjectId: 'agent:gate',
+          protocolId: 'protocol:gate',
+          detail: 'Cure-only pressure only.',
+        }),
+      ],
+    })
+    expect(cureOnly.findings.some((finding) => finding.kind === 'insufficient_pressure_evidence')).toBe(
+      true
+    )
+    expect(
+      cureOnly.findings.some((finding) => finding.kind === 'care_mode_discussion_restriction')
+    ).toBe(false)
+
+    const withContext = buildInstitutionalDenialDoctrinePressureReport({
+      accommodationFindings: [
+        accommodationFinding({
+          kind: 'cure_only_pressure_high',
+          severity: 'warning',
+          rowId: 'row:acc-gate',
+          subjectId: 'agent:gate',
+          protocolId: 'protocol:gate',
+          detail: 'Cure-only pressure only.',
+        }),
+      ],
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'doctrine',
+          kind: 'care_mode_discussion_restricted',
+          subjectId: 'agent:gate',
+          protocolId: 'protocol:gate',
+        }),
+      ],
+    })
+    expect(
+      withContext.findings.some((finding) => finding.kind === 'care_mode_discussion_restriction')
+    ).toBe(true)
+  })
+
+  it('does not misattribute conflicting optional IDs on aggregate buckets', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'site-only',
+          kind: 'support_access_restricted',
+          siteId: 'site:aggregate',
+        }),
+        doctrineSignal({
+          signalId: 'staff-only',
+          kind: 'dissenting_staff_exclusion_pressure',
+          staffId: 'staff:other',
+          doctrineId: 'doctrine:other',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(2)
+    const siteRow = report.rows.find((row) => row.siteId === 'site:aggregate')
+    const staffRow = report.rows.find((row) => row.staffId === 'staff:other')
+    expect(siteRow?.subjectId).toBeUndefined()
+    expect(siteRow?.staffId).toBeUndefined()
+    expect(staffRow?.siteId).toBeUndefined()
+    expect(staffRow?.subjectId).toBeUndefined()
+  })
+
+  it('preserves unambiguous scorecard and accommodation metadata on subject rows', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      medicalScorecardFindings: [
+        scorecardFinding({
+          kind: 'high_alignment_poor_outcome',
+          severity: 'warning',
+          rowId: 'row:score-meta',
+          subjectId: 'agent:meta',
+          protocolId: 'protocol:meta',
+          staffId: 'staff:meta',
+          siteId: 'site:meta',
+          detail: 'Scorecard metadata.',
+        }),
+      ],
+      accommodationFindings: [
+        accommodationFinding({
+          kind: 'care_mode_unavailable',
+          severity: 'warning',
+          rowId: 'row:acc-meta',
+          subjectId: 'agent:meta',
+          protocolId: 'protocol:meta',
+          siteId: 'site:meta',
+          detail: 'Accommodation metadata.',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]?.staffId).toBe('staff:meta')
+    expect(report.rows[0]?.siteId).toBe('site:meta')
+  })
+
+  it('returns empty deterministic report for nullish runtime input', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport(
+      null as unknown as InstitutionalDenialDoctrinePressureInput
+    )
+    expect(report.rows).toEqual([])
+    expect(report.findings).toEqual([])
+    expect(report.lines[0]).toBe(
+      'Institutional denial doctrine pressure: rows=0, findings=0, critical=0'
+    )
   })
 
   it('has no reverse imports from upstream modules', () => {

--- a/src/test/institutionalDenialDoctrinePressure.test.ts
+++ b/src/test/institutionalDenialDoctrinePressure.test.ts
@@ -1,0 +1,592 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  buildInstitutionalDenialDoctrinePressureReport,
+  type InstitutionalDenialDoctrinePressureSignal,
+} from '../domain/institutionalDenialDoctrinePressure'
+import type { AccommodationAccessAuditFinding } from '../domain/accommodationAccessAudit'
+import type { MedicalAccountabilityScorecardFinding } from '../domain/medicalAccountabilityScorecard'
+import type { MedicalOutcomeDeviationFinding } from '../domain/medicalOutcomeDeviationAudit'
+import type { StaffTreatmentTelemetryFinding } from '../domain/staffTreatmentTelemetry'
+import type { TreatmentFailureBlameRoutingFinding } from '../domain/treatmentFailureBlameRouting'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function doctrineSignal(
+  overrides: Partial<InstitutionalDenialDoctrinePressureSignal> &
+    Pick<InstitutionalDenialDoctrinePressureSignal, 'signalId' | 'kind'>
+): InstitutionalDenialDoctrinePressureSignal {
+  return { ...overrides }
+}
+
+function staffFinding(
+  overrides: Partial<StaffTreatmentTelemetryFinding> &
+    Pick<StaffTreatmentTelemetryFinding, 'kind' | 'staffId' | 'detail'>
+): StaffTreatmentTelemetryFinding {
+  return { ...overrides }
+}
+
+function deviationFinding(
+  overrides: Partial<MedicalOutcomeDeviationFinding> &
+    Pick<
+      MedicalOutcomeDeviationFinding,
+      'kind' | 'severity' | 'subjectId' | 'protocolId' | 'detail'
+    >
+): MedicalOutcomeDeviationFinding {
+  return { ...overrides }
+}
+
+function blameFinding(
+  overrides: Partial<TreatmentFailureBlameRoutingFinding> &
+    Pick<
+      TreatmentFailureBlameRoutingFinding,
+      'kind' | 'severity' | 'subjectId' | 'protocolId' | 'detail'
+    >
+): TreatmentFailureBlameRoutingFinding {
+  return { ...overrides }
+}
+
+function scorecardFinding(
+  overrides: Partial<MedicalAccountabilityScorecardFinding> &
+    Pick<MedicalAccountabilityScorecardFinding, 'kind' | 'severity' | 'rowId' | 'detail'>
+): MedicalAccountabilityScorecardFinding {
+  return { ...overrides }
+}
+
+function accommodationFinding(
+  overrides: Partial<AccommodationAccessAuditFinding> &
+    Pick<
+      AccommodationAccessAuditFinding,
+      'kind' | 'severity' | 'rowId' | 'subjectId' | 'protocolId' | 'detail'
+    >
+): AccommodationAccessAuditFinding {
+  return { ...overrides }
+}
+
+describe('institutionalDenialDoctrinePressure (SPE-2001)', () => {
+  it('returns empty report for empty input without throwing', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({})
+    expect(report.rows).toEqual([])
+    expect(report.findings).toEqual([])
+    expect(report.summary).toEqual({
+      rowCount: 0,
+      approvedLanguagePressureCount: 0,
+      careModeDiscussionRestrictionCount: 0,
+      dissentingStaffExclusionPressureCount: 0,
+      treatmentLimitationSuppressionCount: 0,
+      subjectDeflectionReinforcementCount: 0,
+      patientReportDismissalCount: 0,
+      overclassificationPressureCount: 0,
+      materialOutcomeSuppressionCount: 0,
+      supportAccessRestrictionCount: 0,
+      highAlignmentPoorOutcomePressureCount: 0,
+      insufficientEvidenceCount: 0,
+    })
+    expect(report.lines[0]).toBe(
+      'Institutional denial doctrine pressure: rows=0, findings=0, critical=0'
+    )
+  })
+
+  it('builds row from explicit doctrine-pressure signal', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'sig-1',
+          kind: 'approved_language_requirement',
+          staffId: 'staff:alpha',
+          doctrineId: 'doctrine:denial',
+          week: 2,
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]?.rowId).toBe('row:staff-doctrine:staff:alpha:doctrine:denial:2')
+    expect(report.rows[0]?.signalCount).toBe(1)
+  })
+
+  it('skips invalid blank signalId/kind signals', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({ signalId: '  ', kind: 'approved_language_requirement' }),
+        doctrineSignal({ signalId: 'valid', kind: 'support_access_restricted', siteId: 'site:1' }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]?.siteId).toBe('site:1')
+  })
+
+  it('deduplicates duplicate signalId deterministically', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'dup',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:1',
+          protocolId: 'protocol:1',
+          detail: 'First wins.',
+        }),
+        doctrineSignal({
+          signalId: 'dup',
+          kind: 'overclassification_pressure',
+          subjectId: 'agent:2',
+          protocolId: 'protocol:2',
+          detail: 'Second ignored.',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.findings.some((f) => f.kind === 'patient_report_dismissal')).toBe(true)
+    expect(report.findings.some((f) => f.kind === 'overclassification_pressure')).toBe(false)
+  })
+
+  it('approved-language signal emits approved_language_pressure', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'lang',
+          kind: 'approved_language_requirement',
+          staffId: 'staff:lang',
+          doctrineId: 'doctrine:lang',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'approved_language_pressure')).toBe(true)
+  })
+
+  it('care-mode discussion restriction signal emits care_mode_discussion_restriction', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'care',
+          kind: 'care_mode_discussion_restricted',
+          siteId: 'site:care',
+          week: 1,
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'care_mode_discussion_restriction')).toBe(true)
+  })
+
+  it('dissenting staff exclusion signal emits dissenting_staff_exclusion_pressure', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'dissent',
+          kind: 'dissenting_staff_exclusion_pressure',
+          staffId: 'staff:dissent',
+          doctrineId: 'doctrine:dissent',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'dissenting_staff_exclusion_pressure')).toBe(
+      true
+    )
+  })
+
+  it('treatment-limitation suppression signal emits treatment_limitation_suppression', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'limit',
+          kind: 'treatment_limitation_suppressed',
+          subjectId: 'agent:limit',
+          protocolId: 'protocol:limit',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'treatment_limitation_suppression')).toBe(true)
+  })
+
+  it('subject-side deflection signal emits subject_deflection_reinforcement', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'deflect',
+          kind: 'subject_side_deflection_reinforced',
+          subjectId: 'agent:deflect',
+          protocolId: 'protocol:deflect',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'subject_deflection_reinforcement')).toBe(true)
+  })
+
+  it('patient-report dismissal signal emits patient_report_dismissal', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'patient',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:patient',
+          protocolId: 'protocol:patient',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'patient_report_dismissal')).toBe(true)
+  })
+
+  it('overclassification signal emits overclassification_pressure', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'over',
+          kind: 'overclassification_pressure',
+          subjectId: 'agent:over',
+          protocolId: 'protocol:over',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'overclassification_pressure')).toBe(true)
+  })
+
+  it('material outcome suppression signal emits material_outcome_suppression', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'material',
+          kind: 'material_outcome_suppressed',
+          subjectId: 'agent:material',
+          protocolId: 'protocol:material',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'material_outcome_suppression')).toBe(true)
+  })
+
+  it('support access restriction signal emits support_access_restriction', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'support',
+          kind: 'support_access_restricted',
+          siteId: 'site:support',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'support_access_restriction')).toBe(true)
+  })
+
+  it('SPE-2010 high_alignment_low_efficacy fixture emits high_alignment_poor_outcome_pressure', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'high_alignment_low_efficacy',
+          staffId: 'staff:telemetry',
+          subjectId: 'agent:telemetry',
+          protocolId: 'protocol:telemetry',
+          week: 4,
+          detail: 'Alignment high, efficacy low.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'high_alignment_poor_outcome_pressure')).toBe(
+      true
+    )
+  })
+
+  it('SPE-2006 prohibited_subject_deflection fixture emits subject_deflection_reinforcement', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'prohibited_subject_deflection',
+          severity: 'warning',
+          subjectId: 'agent:blame',
+          protocolId: 'protocol:blame',
+          detail: 'Subject deflection prohibited.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'subject_deflection_reinforcement')).toBe(true)
+  })
+
+  it('SPE-2006 missing_treatment_limitation_acknowledgment fixture emits treatment_limitation_suppression', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'missing_treatment_limitation_acknowledgment',
+          severity: 'warning',
+          subjectId: 'agent:ack',
+          protocolId: 'protocol:ack',
+          detail: 'Limitation acknowledgment missing.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'treatment_limitation_suppression')).toBe(true)
+  })
+
+  it('SPE-2003 governance_notification_candidate fixture emits material_outcome_suppression', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'governance_notification_candidate',
+          severity: 'warning',
+          subjectId: 'agent:gov',
+          protocolId: 'protocol:gov',
+          detail: 'Governance notification candidate.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'material_outcome_suppression')).toBe(true)
+  })
+
+  it('SPE-2003 missing_observation alone does not emit doctrine pressure', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      medicalDeviationFindings: [
+        deviationFinding({
+          kind: 'missing_observation',
+          severity: 'info',
+          subjectId: 'agent:missing',
+          protocolId: 'protocol:missing',
+          detail: 'Observation missing.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'material_outcome_suppression')).toBe(false)
+    expect(report.findings.some((f) => f.kind === 'insufficient_pressure_evidence')).toBe(true)
+  })
+
+  it('SPE-2008 high_alignment_poor_outcome fixture emits high_alignment_poor_outcome_pressure', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      medicalScorecardFindings: [
+        scorecardFinding({
+          kind: 'high_alignment_poor_outcome',
+          severity: 'warning',
+          rowId: 'row:score',
+          subjectId: 'agent:score',
+          protocolId: 'protocol:score',
+          detail: 'High alignment with poor outcome.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'high_alignment_poor_outcome_pressure')).toBe(
+      true
+    )
+  })
+
+  it('SPE-2011 care_mode_unavailable fixture emits care_mode_discussion_restriction', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      accommodationFindings: [
+        accommodationFinding({
+          kind: 'care_mode_unavailable',
+          severity: 'warning',
+          rowId: 'row:acc',
+          subjectId: 'agent:acc',
+          protocolId: 'protocol:acc',
+          detail: 'Requested care mode unavailable.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'care_mode_discussion_restriction')).toBe(true)
+  })
+
+  it('SPE-2011 treatment_limitation_unacknowledged fixture emits treatment_limitation_suppression', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      accommodationFindings: [
+        accommodationFinding({
+          kind: 'treatment_limitation_unacknowledged',
+          severity: 'warning',
+          rowId: 'row:acc-limit',
+          subjectId: 'agent:acc-limit',
+          protocolId: 'protocol:acc-limit',
+          detail: 'Treatment limitation unacknowledged.',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'treatment_limitation_suppression')).toBe(true)
+  })
+
+  it('sparse upstream findings go to deterministic aggregate rows without throwing', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      staffTelemetryFindings: [
+        staffFinding({
+          kind: 'outcome_below_expected',
+          staffId: 'staff:sparse',
+          detail: 'Sparse staff finding.',
+        }),
+      ],
+    })
+    expect(report.rows).toHaveLength(1)
+    expect(report.rows[0]?.rowId).toBe('row:aggregate')
+  })
+
+  it('threshold overrides affect severity', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'pressure',
+          kind: 'approved_language_requirement',
+          staffId: 'staff:thresh',
+          doctrineId: 'doctrine:thresh',
+          pressureScore: 95,
+        }),
+      ],
+      options: {
+        highPressureThreshold: 50,
+        criticalPressureThreshold: 90,
+      },
+    })
+    const finding = report.findings.find((f) => f.kind === 'approved_language_pressure')
+    expect(finding?.severity).toBe('critical')
+  })
+
+  it('minimum evidence option emits insufficient_pressure_evidence for sparse rows', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      options: { minimumEvidenceCount: 3 },
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'one',
+          kind: 'support_access_restricted',
+          siteId: 'site:sparse',
+        }),
+      ],
+    })
+    expect(report.findings.some((f) => f.kind === 'insufficient_pressure_evidence')).toBe(true)
+  })
+
+  it('rows/findings/lines sorted deterministically', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'b',
+          kind: 'support_access_restricted',
+          siteId: 'site:z',
+          week: 2,
+        }),
+        doctrineSignal({
+          signalId: 'a',
+          kind: 'approved_language_requirement',
+          siteId: 'site:a',
+          week: 1,
+        }),
+      ],
+    })
+    expect(report.rows.map((row) => row.siteId)).toEqual(['site:a', 'site:z'])
+    const findingKinds = report.findings.map((finding) => finding.kind)
+    expect(findingKinds.indexOf('approved_language_pressure')).toBeLessThan(
+      findingKinds.indexOf('support_access_restriction')
+    )
+  })
+
+  it('frozen inputs are not mutated', () => {
+    const signals = Object.freeze([
+      doctrineSignal({
+        signalId: 'frozen',
+        kind: 'patient_report_dismissed',
+        subjectId: 'agent:frozen',
+        protocolId: 'protocol:frozen',
+      }),
+    ])
+    const staff = Object.freeze([
+      staffFinding({
+        kind: 'high_alignment_low_efficacy',
+        staffId: 'staff:frozen',
+        subjectId: 'agent:frozen',
+        protocolId: 'protocol:frozen',
+        detail: 'Frozen.',
+      }),
+    ])
+    buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: signals,
+      staffTelemetryFindings: staff,
+    })
+    expect(Object.isFrozen(signals)).toBe(true)
+    expect(Object.isFrozen(staff)).toBe(true)
+  })
+
+  it('summary counts match findings', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 's1',
+          kind: 'approved_language_requirement',
+          staffId: 'staff:sum',
+          doctrineId: 'doctrine:sum',
+        }),
+        doctrineSignal({
+          signalId: 's2',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:sum',
+          protocolId: 'protocol:sum',
+        }),
+      ],
+    })
+    expect(report.summary.approvedLanguagePressureCount).toBe(
+      report.findings.filter((f) => f.kind === 'approved_language_pressure').length
+    )
+    expect(report.summary.patientReportDismissalCount).toBe(
+      report.findings.filter((f) => f.kind === 'patient_report_dismissal').length
+    )
+    expect(report.summary.rowCount).toBe(report.rows.length)
+  })
+
+  it('lines contain no SCP/source strings', () => {
+    const report = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'lines',
+          kind: 'subject_side_deflection_reinforced',
+          subjectId: 'agent:lines',
+          protocolId: 'protocol:lines',
+          detail: 'Audit line test.',
+        }),
+      ],
+      blameRoutingFindings: [
+        blameFinding({
+          kind: 'prohibited_subject_deflection',
+          severity: 'warning',
+          subjectId: 'agent:lines',
+          protocolId: 'protocol:lines',
+          detail: 'Blame routing lines test.',
+        }),
+      ],
+    })
+    const joined = report.lines.join('\n').toLowerCase()
+    expect(joined).not.toContain('scp-')
+    expect(joined).not.toContain('scp ')
+    expect(joined).not.toContain('9977')
+    expect(report.lines.join('\n')).not.toContain('row:row:')
+  })
+
+  it('does not import GameState or UI modules', () => {
+    const source = readFileSync(
+      path.join(__dirname, '../domain/institutionalDenialDoctrinePressure.ts'),
+      'utf8'
+    )
+    expect(source.includes("from './models'")).toBe(false)
+    expect(source.includes('gameStore')).toBe(false)
+    expect(source.includes('/features/')).toBe(false)
+  })
+
+  it('uses type-only imports from upstream pure helper modules', () => {
+    const source = readFileSync(
+      path.join(__dirname, '../domain/institutionalDenialDoctrinePressure.ts'),
+      'utf8'
+    )
+    expect(source).toMatch(/import type \{ StaffTreatmentTelemetryFinding \}/)
+    expect(source).toMatch(/import type \{ MedicalOutcomeDeviationFinding \}/)
+    expect(source).toMatch(/import type \{ TreatmentFailureBlameRoutingFinding \}/)
+    expect(source).toMatch(/import type \{ MedicalAccountabilityScorecardFinding \}/)
+    expect(source).toMatch(/import type \{ AccommodationAccessAuditFinding \}/)
+    expect(source.includes('buildStaffTreatmentTelemetryReport')).toBe(false)
+    expect(source.includes('buildMedicalOutcomeDeviationAuditReport')).toBe(false)
+    expect(source.includes('buildTreatmentFailureBlameRoutingReport')).toBe(false)
+    expect(source.includes('buildMedicalAccountabilityScorecard')).toBe(false)
+    expect(source.includes('buildAccommodationAccessAuditReport')).toBe(false)
+  })
+
+  it('has no reverse imports from upstream modules', () => {
+    const upstreamFiles = [
+      'staffTreatmentTelemetry.ts',
+      'medicalOutcomeDeviationAudit.ts',
+      'treatmentFailureBlameRouting.ts',
+      'medicalAccountabilityScorecard.ts',
+      'accommodationAccessAudit.ts',
+    ]
+    for (const file of upstreamFiles) {
+      const source = readFileSync(path.join(__dirname, '../domain', file), 'utf8')
+      expect(source.includes('institutionalDenialDoctrinePressure')).toBe(false)
+    }
+  })
+})

--- a/src/test/institutionalDenialDoctrinePressure.test.ts
+++ b/src/test/institutionalDenialDoctrinePressure.test.ts
@@ -778,6 +778,100 @@ describe('institutionalDenialDoctrinePressure (SPE-2001)', () => {
     ).toBe(true)
   })
 
+  it('preserves unambiguous staffId from signal-only subject/protocol rows', () => {
+    const singleStaff = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'sig-staff',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:signal-staff',
+          protocolId: 'protocol:signal-staff',
+          staffId: 'staff:signal-only',
+          detail: 'Signal-only staff attribution.',
+        }),
+      ],
+    })
+    expect(singleStaff.rows[0]?.staffId).toBe('staff:signal-only')
+    expect(singleStaff.findings[0]?.staffId).toBe('staff:signal-only')
+
+    const matchingStaff = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'sig-a',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:shared-signal',
+          protocolId: 'protocol:shared-signal',
+          staffId: 'staff:same',
+        }),
+        doctrineSignal({
+          signalId: 'sig-b',
+          kind: 'overclassification_pressure',
+          subjectId: 'agent:shared-signal',
+          protocolId: 'protocol:shared-signal',
+          staffId: 'staff:same',
+        }),
+      ],
+    })
+    expect(matchingStaff.rows).toHaveLength(1)
+    expect(matchingStaff.rows[0]?.staffId).toBe('staff:same')
+
+    const conflictingStaff = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'sig-conflict-a',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:conflict-signal',
+          protocolId: 'protocol:conflict-signal',
+          staffId: 'staff:alpha',
+        }),
+        doctrineSignal({
+          signalId: 'sig-conflict-b',
+          kind: 'material_outcome_suppressed',
+          subjectId: 'agent:conflict-signal',
+          protocolId: 'protocol:conflict-signal',
+          staffId: 'staff:beta',
+        }),
+      ],
+    })
+    expect(conflictingStaff.rows[0]?.staffId).toBeUndefined()
+    expect(conflictingStaff.findings.every((finding) => finding.staffId === undefined)).toBe(true)
+  })
+
+  it('preserves unambiguous siteId from signal-only subject/protocol rows', () => {
+    const singleSite = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'sig-site',
+          kind: 'material_outcome_suppressed',
+          subjectId: 'agent:signal-site',
+          protocolId: 'protocol:signal-site',
+          siteId: 'site:signal-only',
+        }),
+      ],
+    })
+    expect(singleSite.rows[0]?.siteId).toBe('site:signal-only')
+
+    const conflictingSite = buildInstitutionalDenialDoctrinePressureReport({
+      doctrinePressureSignals: [
+        doctrineSignal({
+          signalId: 'sig-site-a',
+          kind: 'patient_report_dismissed',
+          subjectId: 'agent:conflict-site',
+          protocolId: 'protocol:conflict-site',
+          siteId: 'site:alpha',
+        }),
+        doctrineSignal({
+          signalId: 'sig-site-b',
+          kind: 'support_access_restricted',
+          subjectId: 'agent:conflict-site',
+          protocolId: 'protocol:conflict-site',
+          siteId: 'site:beta',
+        }),
+      ],
+    })
+    expect(conflictingSite.rows[0]?.siteId).toBeUndefined()
+  })
+
   it('does not misattribute conflicting optional IDs on aggregate buckets', () => {
     const report = buildInstitutionalDenialDoctrinePressureReport({
       doctrinePressureSignals: [


### PR DESCRIPTION
## Summary

- Adds pure deterministic `buildInstitutionalDenialDoctrinePressureReport` helper (SPE-2001).
- Composes explicit doctrine-pressure signals with type-only upstream findings from SPE-2010, SPE-2003, SPE-2006, SPE-2008, SPE-2011.
- Linear: [SPE-2001](https://linear.app/spectranoir/issue/SPE-2001/batch-9977-institutional-denial-doctrine-enforcement-model)

## Smallest boundary

Pure report helper + focused tests only. No GameState persistence, weekly tick, runtime enforcement, UI, doctrine/taboo validation, policy selector, campaign ledger, pressure/faction/legitimacy/procurement gates, or upstream module changes.

## Files changed

- `src/domain/institutionalDenialDoctrinePressure.ts`
- `src/test/institutionalDenialDoctrinePressure.test.ts`

## Review hardening (53124b4)

- Collision-safe row IDs via encoded bucket keys; rows/findings built together from bucket iteration (no `rowId` lookup map).
- Staff telemetry buckets include `staffId` (staff+subject+protocol+week) so staff attribution is preserved.
- Defensive runtime signal normalization (`null`/non-string skipped; own-property kind guard).
- Contributing evidence mirrors finding eligibility (gated upstream no longer satisfies threshold alone).
- Metadata from bucket keys + unanimous enrichment only (no first-writer signal copying).
- Exported `InstitutionalDenialDoctrinePressureInput`; nullish runtime input returns empty report.
- 39 focused tests including colon-ID collision, staff split, gated evidence, metadata, and malformed input cases.

## Validation run

- `npm run test:run -- src/test/institutionalDenialDoctrinePressure.test.ts` (39 tests)
- Adjacent upstream helper tests (145 tests)
- `npm run lint`
- `git diff --check`
- `npm run test:run` (332 files, 3247 tests)

## Gap / edge-case / boundary audit

1. **Runtime input safety** — malformed signals skipped; null input empty report; colon IDs collision-safe.
2. **Report correctness** — conservative upstream maps preserved; staff identity retained; no silent empty rows.
3. **Metadata correctness** — no first-writer misattribution; unanimous staff/site enrichment only.
4. **Upstream deps** — type-only imports; no builders; no reverse imports.
5. **Determinism** — stable sort; inputs not mutated.
6. **Boundary** — pure helper only; no persistence/tick/UI/enforcement/planning edits.

## Explicitly out of scope

Runtime doctrine enforcement, staff exclusion mechanics, policy selector, doctrine/taboo validation engine, Front Desk overlay, GameState integration, SPE-2011 changes, campaign gates, real-world encoding, planning/backlog updates.
