### PR TITLE
SPE-788: Add authority graph consequence resolver

### DIFF
--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -1,0 +1,1057 @@
+/**
+ * SPE-788 slice 1: authority relationship graph — pure types, validation,
+ * alias normalization, and deterministic consequence resolution.
+ *
+ * Fixture-only contract; no runtime game state, mission runtime, UI, negotiation engine,
+ * or ethics/obedience integration in this slice.
+ */
+
+// ---------------------------------------------------------------------------
+// Unions
+// ---------------------------------------------------------------------------
+
+export type AuthorityNodeType =
+  | 'agency'
+  | 'department'
+  | 'faction'
+  | 'institution'
+  | 'site'
+  | 'public_office'
+  | 'sponsor_group'
+  | 'patron'
+  | 'proxy'
+  | 'coalition'
+  | 'hidden_network'
+  | 'symbolic_anchor'
+  | 'constituency'
+  | 'external_regime'
+  | 'media_actor'
+  | 'contractor'
+  | 'population_group_reference'
+
+export type AuthorityRelationshipKind =
+  | 'alliance'
+  | 'rivalry'
+  | 'subordination'
+  | 'dependency'
+  | 'hidden_agenda'
+  | 'patronage'
+  | 'proxy_representation'
+  | 'front'
+  | 'splinter'
+  | 'shared_authority'
+  | 'information_gate'
+  | 'cell'
+  | 'subsidiary'
+  | 'precursor'
+  | 'successor'
+  | 'remnant'
+  | 'jurisdiction_claim'
+  | 'resource_control'
+  | 'media_leverage'
+  | 'legal_leverage'
+  | 'donor_pressure'
+  | 'operational_bottleneck'
+  | 'embedded_enforcement'
+  | 'narrative_control'
+
+export type AuthorityRelationshipStatus =
+  | 'current'
+  | 'hidden'
+  | 'disputed'
+  | 'severed'
+  | 'inherited'
+  | 'newly_formed'
+  | 'outdated'
+  | 'contradicted'
+
+export type AuthoritySourceConfidence =
+  | 'verified'
+  | 'probable'
+  | 'rumor'
+  | 'hostile_dossier'
+  | 'public_cover'
+  | 'redacted'
+  | 'contradicted'
+  | 'unknown'
+
+export type AuthorityPressureChannel =
+  | 'mission_access'
+  | 'aid'
+  | 'hostility'
+  | 'permission'
+  | 'surveillance'
+  | 'information_flow'
+  | 'secrecy'
+  | 'delay'
+  | 'narrative_control'
+  | 'resource_release'
+  | 'reporting_pressure'
+  | 'contradiction_flag'
+  | 'local_compliance'
+
+export type AuthorityConsequenceEffect = 'grant' | 'deny' | 'modify' | 'delay' | 'flag'
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface AuthoritySourceProvenance {
+  sourceTag: string
+  recordedWeek?: number
+  recorderId?: string
+}
+
+export interface AuthorityNodeAlias {
+  aliasId: string
+  label: string
+  confidence: AuthoritySourceConfidence
+}
+
+export interface AuthorityGraphNode {
+  id: string
+  nodeType: AuthorityNodeType
+  label: string
+  aliases?: readonly AuthorityNodeAlias[]
+  factionClass?: string
+  linkedFactionIds?: readonly string[]
+  linkedPopulationIds?: readonly string[]
+  linkedDepartmentIds?: readonly string[]
+  linkedSiteIds?: readonly string[]
+  metadata?: Readonly<Record<string, string | number | boolean>>
+}
+
+export interface AuthorityGraphEdge {
+  id: string
+  kind: AuthorityRelationshipKind
+  fromNodeId: string
+  toNodeId: string
+  status: AuthorityRelationshipStatus
+  sourceConfidence: AuthoritySourceConfidence
+  provenance: AuthoritySourceProvenance
+  strength?: number
+  volatility?: number
+  pressureChannels?: readonly AuthorityPressureChannel[]
+  representsNodeId?: string
+  hiddenUntilWeek?: number
+  notes?: string
+}
+
+export interface AuthorityGraph {
+  nodes: readonly AuthorityGraphNode[]
+  edges: readonly AuthorityGraphEdge[]
+}
+
+export interface AuthorityGraphQuery {
+  actorNodeId: string
+  counterpartyNodeId?: string
+  channel: AuthorityPressureChannel
+  asOfWeek: number
+  viewerConfidenceFloor?: AuthoritySourceConfidence
+  includeContradictedClaims?: boolean
+}
+
+export interface AuthorityConsequence {
+  channel: AuthorityPressureChannel
+  effect: AuthorityConsequenceEffect
+  magnitude: number
+  reasonCode: string
+  edgeIds: readonly string[]
+  confidenceApplied: AuthoritySourceConfidence
+  delayed: boolean
+  contradicted: boolean
+}
+
+export type AuthorityGraphValidationIssueCode =
+  | 'duplicate_node_id'
+  | 'duplicate_edge_id'
+  | 'unknown_from_node'
+  | 'unknown_to_node'
+  | 'missing_proxy_represents_node'
+  | 'unknown_represents_node'
+  | 'self_loop_edge'
+  | 'missing_provenance_source_tag'
+  | 'population_faction_collapse'
+  | 'contradictory_current_claims'
+  | 'perfect_dossier_unlikely'
+  | 'unmapped_relationship_kind'
+  | 'proxy_representation_cycle'
+
+export interface AuthorityGraphValidationIssue {
+  code: AuthorityGraphValidationIssueCode
+  detail: string
+  severity: 'error' | 'warning'
+  relatedIds?: readonly string[]
+}
+
+export interface AuthorityGraphValidationResult {
+  valid: boolean
+  issues: readonly AuthorityGraphValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Slice-1 resolver coverage
+// ---------------------------------------------------------------------------
+
+const SLICE1_RESOLVER_KINDS: ReadonlySet<AuthorityRelationshipKind> = new Set([
+  'alliance',
+  'rivalry',
+  'subordination',
+  'dependency',
+  'hidden_agenda',
+  'patronage',
+  'proxy_representation',
+  'front',
+  'splinter',
+  'shared_authority',
+  'information_gate',
+])
+
+const CONFIDENCE_WEIGHT: Readonly<Record<AuthoritySourceConfidence, number>> = {
+  verified: 100,
+  probable: 80,
+  rumor: 50,
+  hostile_dossier: 40,
+  public_cover: 60,
+  redacted: 30,
+  contradicted: 0,
+  unknown: 20,
+}
+
+const CONFIDENCE_FLOOR_ORDER: readonly AuthoritySourceConfidence[] = [
+  'contradicted',
+  'unknown',
+  'redacted',
+  'hostile_dossier',
+  'rumor',
+  'public_cover',
+  'probable',
+  'verified',
+]
+
+const FRANCHISE_TOKEN_PATTERN =
+  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest)\b/i
+
+const ACTIVE_STATUSES: ReadonlySet<AuthorityRelationshipStatus> = new Set(['current', 'hidden'])
+
+function uniqueSorted(values: readonly string[]) {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))].sort(
+    (left, right) => left.localeCompare(right)
+  )
+}
+
+function normalizeToken(value: string) {
+  return value.trim()
+}
+
+function confidenceRank(confidence: AuthoritySourceConfidence) {
+  return CONFIDENCE_FLOOR_ORDER.indexOf(confidence)
+}
+
+function meetsConfidenceFloor(
+  edgeConfidence: AuthoritySourceConfidence,
+  floor: AuthoritySourceConfidence | undefined
+) {
+  if (!floor) {
+    return edgeConfidence !== 'contradicted'
+  }
+
+  return confidenceRank(edgeConfidence) >= confidenceRank(floor)
+}
+
+function scaleMagnitude(base: number, confidence: AuthoritySourceConfidence) {
+  return Math.trunc((base * CONFIDENCE_WEIGHT[confidence]) / 100)
+}
+
+function edgeIsActive(edge: AuthorityGraphEdge, asOfWeek: number) {
+  if (edge.status === 'severed' || edge.status === 'outdated' || edge.status === 'contradicted') {
+    return false
+  }
+
+  if (edge.status === 'hidden') {
+    const hiddenUntil = edge.hiddenUntilWeek ?? Number.POSITIVE_INFINITY
+    return asOfWeek >= hiddenUntil
+  }
+
+  return ACTIVE_STATUSES.has(edge.status)
+}
+
+function edgeIsDelayed(edge: AuthorityGraphEdge, asOfWeek: number) {
+  if (edge.status !== 'hidden') {
+    return false
+  }
+
+  const hiddenUntil = edge.hiddenUntilWeek ?? Number.POSITIVE_INFINITY
+  return asOfWeek < hiddenUntil
+}
+
+function buildNodeIndex(graph: AuthorityGraph) {
+  const byId = new Map<string, AuthorityGraphNode>()
+  for (const node of graph.nodes) {
+    byId.set(node.id, node)
+  }
+  return byId
+}
+
+function buildAliasIndex(graph: AuthorityGraph) {
+  const aliasToNodeId = new Map<string, string>()
+
+  for (const node of graph.nodes) {
+    const aliases = [...(node.aliases ?? [])].sort((left, right) =>
+      left.aliasId.localeCompare(right.aliasId)
+    )
+
+    for (const alias of aliases) {
+      const keys = uniqueSorted([alias.aliasId, alias.label])
+      for (const key of keys) {
+        if (!aliasToNodeId.has(key)) {
+          aliasToNodeId.set(key, node.id)
+        }
+      }
+    }
+  }
+
+  return aliasToNodeId
+}
+
+export function normalizeAuthorityNodeId(graph: AuthorityGraph, ref: string): string | undefined {
+  const token = normalizeToken(ref)
+  if (!token) {
+    return undefined
+  }
+
+  const byId = buildNodeIndex(graph)
+  if (byId.has(token)) {
+    return token
+  }
+
+  return buildAliasIndex(graph).get(token)
+}
+
+function pushIssue(
+  issues: AuthorityGraphValidationIssue[],
+  issue: AuthorityGraphValidationIssue
+) {
+  issues.push(issue)
+}
+
+function edgeTripleKey(edge: Pick<AuthorityGraphEdge, 'fromNodeId' | 'toNodeId' | 'kind'>) {
+  return `${edge.fromNodeId}::${edge.toNodeId}::${edge.kind}`
+}
+
+function detectContradictoryCurrentClaims(
+  edges: readonly AuthorityGraphEdge[]
+): Array<{ edgeIds: string[]; detail: string }> {
+  const contradictions: Array<{ edgeIds: string[]; detail: string }> = []
+  const currentByTriple = new Map<string, AuthorityGraphEdge[]>()
+  const subordinationByChild = new Map<string, AuthorityGraphEdge[]>()
+
+  for (const edge of edges) {
+    if (edge.status !== 'current') {
+      continue
+    }
+
+    const triple = edgeTripleKey(edge)
+    const group = currentByTriple.get(triple) ?? []
+    group.push(edge)
+    currentByTriple.set(triple, group)
+
+    if (edge.kind === 'subordination') {
+      const childGroup = subordinationByChild.get(edge.fromNodeId) ?? []
+      childGroup.push(edge)
+      subordinationByChild.set(edge.fromNodeId, childGroup)
+    }
+  }
+
+  for (const [triple, group] of currentByTriple) {
+    if (group.length < 2) {
+      continue
+    }
+
+    const confidences = new Set(group.map((edge) => edge.sourceConfidence))
+    if (confidences.size > 1) {
+      contradictions.push({
+        edgeIds: uniqueSorted(group.map((edge) => edge.id)),
+        detail: `Conflicting current claims for ${triple}.`,
+      })
+    }
+  }
+
+  for (const [childId, group] of subordinationByChild) {
+    const superiors = new Set(group.map((edge) => edge.toNodeId))
+    if (superiors.size > 1) {
+      contradictions.push({
+        edgeIds: uniqueSorted(group.map((edge) => edge.id)),
+        detail: `Node ${childId} has competing subordination parents.`,
+      })
+    }
+  }
+
+  for (const edge of edges) {
+    if (edge.status !== 'current') {
+      continue
+    }
+
+    if (edge.kind === 'front' || edge.kind === 'alliance') {
+      const counterpart =
+        edge.kind === 'front'
+          ? edges.find(
+              (candidate) =>
+                candidate.status === 'current' &&
+                candidate.kind === 'alliance' &&
+                candidate.fromNodeId === edge.fromNodeId &&
+                candidate.toNodeId === edge.toNodeId
+            )
+          : edges.find(
+              (candidate) =>
+                candidate.status === 'current' &&
+                candidate.kind === 'front' &&
+                candidate.fromNodeId === edge.fromNodeId &&
+                candidate.toNodeId === edge.toNodeId
+            )
+
+      if (counterpart) {
+        contradictions.push({
+          edgeIds: uniqueSorted([edge.id, counterpart.id]),
+          detail: `Front and alliance both current between ${edge.fromNodeId} and ${edge.toNodeId}.`,
+        })
+      }
+    }
+  }
+
+  return contradictions
+}
+
+export function validateAuthorityGraph(graph: AuthorityGraph): AuthorityGraphValidationResult {
+  const issues: AuthorityGraphValidationIssue[] = []
+  const nodeIds = new Set<string>()
+  const edgeIds = new Set<string>()
+  const nodeById = buildNodeIndex(graph)
+
+  for (const node of graph.nodes) {
+    const id = normalizeToken(node.id)
+    if (!id) {
+      pushIssue(issues, {
+        code: 'duplicate_node_id',
+        severity: 'error',
+        detail: 'Node is missing id.',
+      })
+      continue
+    }
+
+    if (nodeIds.has(id)) {
+      pushIssue(issues, {
+        code: 'duplicate_node_id',
+        severity: 'error',
+        detail: `Duplicate node id ${id}.`,
+        relatedIds: [id],
+      })
+    } else {
+      nodeIds.add(id)
+    }
+
+    if (node.nodeType === 'population_group_reference') {
+      const hasFactionLink = (node.linkedFactionIds?.length ?? 0) > 0
+      const hasPoliticalEdge = graph.edges.some(
+        (edge) =>
+          edge.status === 'current' &&
+          SLICE1_RESOLVER_KINDS.has(edge.kind) &&
+          (edge.fromNodeId === id || edge.toNodeId === id) &&
+          edge.kind !== 'proxy_representation'
+      )
+
+      if (!hasFactionLink && hasPoliticalEdge) {
+        pushIssue(issues, {
+          code: 'population_faction_collapse',
+          severity: 'warning',
+          detail: `Population reference ${id} acts as political faction without linkedFactionIds.`,
+          relatedIds: [id],
+        })
+      }
+    }
+  }
+
+  const verifiedEdgeCount = graph.edges.filter(
+    (edge) => edge.sourceConfidence === 'verified' && edge.status === 'current'
+  ).length
+
+  if (graph.edges.length > 0 && verifiedEdgeCount === graph.edges.length) {
+    pushIssue(issues, {
+      code: 'perfect_dossier_unlikely',
+      severity: 'warning',
+      detail: 'All edges are verified and current; dossier may be unrealistically complete.',
+    })
+  }
+
+  for (const edge of graph.edges) {
+    if (edgeIds.has(edge.id)) {
+      pushIssue(issues, {
+        code: 'duplicate_edge_id',
+        severity: 'error',
+        detail: `Duplicate edge id ${edge.id}.`,
+        relatedIds: [edge.id],
+      })
+    } else {
+      edgeIds.add(edge.id)
+    }
+
+    if (!normalizeToken(edge.provenance?.sourceTag ?? '')) {
+      pushIssue(issues, {
+        code: 'missing_provenance_source_tag',
+        severity: 'error',
+        detail: `Edge ${edge.id} is missing provenance.sourceTag.`,
+        relatedIds: [edge.id],
+      })
+    }
+
+    if (!nodeById.has(edge.fromNodeId)) {
+      pushIssue(issues, {
+        code: 'unknown_from_node',
+        severity: 'error',
+        detail: `Edge ${edge.id} references unknown fromNodeId ${edge.fromNodeId}.`,
+        relatedIds: [edge.id, edge.fromNodeId],
+      })
+    }
+
+    if (!nodeById.has(edge.toNodeId)) {
+      pushIssue(issues, {
+        code: 'unknown_to_node',
+        severity: 'error',
+        detail: `Edge ${edge.id} references unknown toNodeId ${edge.toNodeId}.`,
+        relatedIds: [edge.id, edge.toNodeId],
+      })
+    }
+
+    if (edge.fromNodeId === edge.toNodeId) {
+      const nodeType = nodeById.get(edge.fromNodeId)?.nodeType
+      if (nodeType !== 'symbolic_anchor') {
+        pushIssue(issues, {
+          code: 'self_loop_edge',
+          severity: 'warning',
+          detail: `Edge ${edge.id} is a self-loop.`,
+          relatedIds: [edge.id],
+        })
+      }
+    }
+
+    if (edge.kind === 'proxy_representation') {
+      if (!edge.representsNodeId) {
+        pushIssue(issues, {
+          code: 'missing_proxy_represents_node',
+          severity: 'error',
+          detail: `Edge ${edge.id} requires representsNodeId.`,
+          relatedIds: [edge.id],
+        })
+      } else if (!nodeById.has(edge.representsNodeId)) {
+        pushIssue(issues, {
+          code: 'unknown_represents_node',
+          severity: 'error',
+          detail: `Edge ${edge.id} references unknown representsNodeId ${edge.representsNodeId}.`,
+          relatedIds: [edge.id, edge.representsNodeId],
+        })
+      }
+    }
+
+    if (edge.status === 'current' && !SLICE1_RESOLVER_KINDS.has(edge.kind)) {
+      pushIssue(issues, {
+        code: 'unmapped_relationship_kind',
+        severity: 'warning',
+        detail: `Edge ${edge.id} uses deferred kind ${edge.kind} with status current.`,
+        relatedIds: [edge.id],
+      })
+    }
+  }
+
+  const proxyCycles = new Set<string>()
+  for (const edge of graph.edges) {
+    if (edge.kind !== 'proxy_representation' || !edge.representsNodeId) {
+      continue
+    }
+
+    const visited = new Set<string>([edge.fromNodeId])
+    let cursor: string | undefined = edge.representsNodeId
+
+    while (cursor) {
+      if (visited.has(cursor)) {
+        proxyCycles.add(edge.id)
+        break
+      }
+
+      visited.add(cursor)
+      const next = graph.edges.find(
+        (candidate) =>
+          candidate.kind === 'proxy_representation' &&
+          candidate.fromNodeId === cursor &&
+          candidate.representsNodeId
+      )
+
+      cursor = next?.representsNodeId
+    }
+  }
+
+  for (const edgeId of proxyCycles) {
+    pushIssue(issues, {
+      code: 'proxy_representation_cycle',
+      severity: 'error',
+      detail: `Proxy representation cycle detected at edge ${edgeId}.`,
+      relatedIds: [edgeId],
+    })
+  }
+
+  for (const contradiction of detectContradictoryCurrentClaims(graph.edges)) {
+    pushIssue(issues, {
+      code: 'contradictory_current_claims',
+      severity: 'warning',
+      detail: contradiction.detail,
+      relatedIds: contradiction.edgeIds,
+    })
+  }
+
+  const hasError = issues.some((issue) => issue.severity === 'error')
+
+  return {
+    valid: !hasError,
+    issues: Object.freeze(
+      [...issues].sort((left, right) => {
+        const codeCompare = left.code.localeCompare(right.code)
+        if (codeCompare !== 0) {
+          return codeCompare
+        }
+
+        return left.detail.localeCompare(right.detail)
+      })
+    ),
+  }
+}
+
+function sortConsequences(consequences: AuthorityConsequence[]) {
+  consequences.sort((left, right) => {
+    const channelCompare = left.channel.localeCompare(right.channel)
+    if (channelCompare !== 0) {
+      return channelCompare
+    }
+
+    const reasonCompare = left.reasonCode.localeCompare(right.reasonCode)
+    if (reasonCompare !== 0) {
+      return reasonCompare
+    }
+
+    const edgeCompare = (left.edgeIds[0] ?? '').localeCompare(right.edgeIds[0] ?? '')
+    if (edgeCompare !== 0) {
+      return edgeCompare
+    }
+
+    return left.magnitude - right.magnitude
+  })
+}
+
+function addConsequence(
+  consequences: AuthorityConsequence[],
+  input: Omit<AuthorityConsequence, 'edgeIds'> & { edgeIds: readonly string[] }
+) {
+  const existing = consequences.find(
+    (consequence) =>
+      consequence.channel === input.channel &&
+      consequence.reasonCode === input.reasonCode &&
+      consequence.effect === input.effect
+  )
+
+  if (existing) {
+    existing.magnitude = Math.trunc(existing.magnitude + input.magnitude)
+    return
+  }
+
+  consequences.push({
+    channel: input.channel,
+    effect: input.effect,
+    magnitude: input.magnitude,
+    reasonCode: input.reasonCode,
+    edgeIds: [...input.edgeIds],
+    confidenceApplied: input.confidenceApplied,
+    delayed: input.delayed,
+    contradicted: input.contradicted,
+  })
+}
+
+function resolveProxyTargetNodeId(
+  graph: AuthorityGraph,
+  edge: AuthorityGraphEdge,
+  nodeById: Map<string, AuthorityGraphNode>
+) {
+  if (edge.kind !== 'proxy_representation') {
+    return edge.toNodeId
+  }
+
+  const represents = edge.representsNodeId
+  if (represents && nodeById.has(represents)) {
+    return represents
+  }
+
+  return edge.toNodeId
+}
+
+function edgeAppliesToQuery(
+  edge: AuthorityGraphEdge,
+  query: AuthorityGraphQuery,
+  actorId: string,
+  counterpartyId: string | undefined
+) {
+  const involvesActor = edge.fromNodeId === actorId || edge.toNodeId === actorId
+  if (!involvesActor) {
+    return false
+  }
+
+  if (counterpartyId) {
+    const involvesCounterparty =
+      edge.fromNodeId === counterpartyId || edge.toNodeId === counterpartyId
+
+    if (!involvesCounterparty) {
+      const proxyTarget = edge.representsNodeId
+      if (proxyTarget !== counterpartyId) {
+        return false
+      }
+    }
+  }
+
+  if (edge.pressureChannels && edge.pressureChannels.length > 0) {
+    if (!edge.pressureChannels.includes(query.channel)) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function mapEdgeToConsequences(
+  graph: AuthorityGraph,
+  edge: AuthorityGraphEdge,
+  query: AuthorityGraphQuery,
+  actorId: string,
+  nodeById: Map<string, AuthorityGraphNode>,
+  consequences: AuthorityConsequence[],
+  contradictionEdgeIds: ReadonlySet<string>
+) {
+  if (!SLICE1_RESOLVER_KINDS.has(edge.kind)) {
+    return
+  }
+
+  const delayed = edgeIsDelayed(edge, query.asOfWeek)
+  if (!edgeIsActive(edge, query.asOfWeek) && !delayed) {
+    return
+  }
+
+  const includeContradicted = query.includeContradictedClaims === true
+  if (edge.sourceConfidence === 'contradicted' && !includeContradicted) {
+    return
+  }
+
+  if (!meetsConfidenceFloor(edge.sourceConfidence, query.viewerConfidenceFloor)) {
+    return
+  }
+
+  const contradicted =
+    contradictionEdgeIds.has(edge.id) || edge.sourceConfidence === 'contradicted'
+  const effectiveTargetId = resolveProxyTargetNodeId(graph, edge, nodeById)
+  const peerId =
+    edge.fromNodeId === actorId
+      ? effectiveTargetId
+      : edge.fromNodeId === effectiveTargetId
+        ? actorId
+        : edge.toNodeId
+
+  const baseStrength = clampStrength(edge.strength ?? 50)
+  const weighted = scaleMagnitude(baseStrength, edge.sourceConfidence)
+
+  const emit = (
+    channel: AuthorityPressureChannel,
+    effect: AuthorityConsequenceEffect,
+    magnitude: number,
+    reasonCode: string
+  ) => {
+    if (query.channel !== channel) {
+      return
+    }
+
+    addConsequence(consequences, {
+      channel,
+      effect,
+      magnitude,
+      reasonCode,
+      edgeIds: [edge.id],
+      confidenceApplied: edge.sourceConfidence,
+      delayed,
+      contradicted,
+    })
+  }
+
+  switch (edge.kind) {
+    case 'dependency': {
+      if (query.channel === 'mission_access') {
+        emit(
+          'mission_access',
+          delayed || weighted < 40 ? 'delay' : weighted < 60 ? 'deny' : 'grant',
+          delayed ? 30 : weighted < 60 ? -weighted : weighted,
+          delayed ? 'dependency_hidden_delay' : 'dependency_access'
+        )
+      }
+
+      if (query.channel === 'permission') {
+        emit(
+          'permission',
+          weighted < 50 ? 'deny' : 'modify',
+          weighted < 50 ? -weighted : Math.trunc(weighted / 2),
+          'dependency_permission'
+        )
+      }
+      break
+    }
+
+    case 'rivalry': {
+      if (query.channel === 'hostility') {
+        emit('hostility', 'modify', weighted, 'rivalry_hostility')
+      }
+
+      if (query.channel === 'aid') {
+        emit('aid', 'deny', -Math.max(weighted, 20), 'rivalry_blocks_aid')
+      }
+      break
+    }
+
+    case 'alliance': {
+      if (query.channel === 'aid') {
+        emit('aid', weighted >= 40 ? 'grant' : 'modify', weighted, 'alliance_aid')
+      }
+
+      if (query.channel === 'hostility') {
+        emit('hostility', 'modify', -Math.trunc(weighted / 2), 'alliance_reduces_hostility')
+      }
+      break
+    }
+
+    case 'hidden_agenda': {
+      if (query.channel === 'information_flow') {
+        emit(
+          'information_flow',
+          delayed ? 'delay' : 'modify',
+          delayed ? 25 : -Math.trunc(weighted * 0.6),
+          delayed ? 'hidden_agenda_delayed' : 'hidden_agenda_filters_intel'
+        )
+      }
+
+      if (query.channel === 'delay') {
+        emit('delay', 'delay', delayed ? 40 : 20, 'hidden_agenda_delay_channel')
+      }
+      break
+    }
+
+    case 'proxy_representation': {
+      const represented = nodeById.get(effectiveTargetId)
+      if (query.channel === 'permission' || query.channel === 'aid') {
+        emit(
+          query.channel,
+          'modify',
+          Math.trunc(weighted * 0.7),
+          represented
+            ? `proxy_routes_${represented.nodeType}`
+            : 'proxy_routes_represented_bloc'
+        )
+      }
+      break
+    }
+
+    case 'shared_authority': {
+      if (query.channel === 'permission') {
+        emit('permission', 'modify', Math.trunc(weighted / 2), 'shared_authority_permission')
+      }
+
+      if (query.channel === 'secrecy') {
+        emit('secrecy', 'modify', Math.trunc(weighted / 3), 'shared_authority_secrecy')
+      }
+
+      if (query.channel === 'local_compliance') {
+        emit('local_compliance', 'modify', Math.trunc(weighted / 2), 'shared_authority_compliance')
+      }
+      break
+    }
+
+    case 'splinter':
+    case 'front': {
+      if (query.channel === 'permission') {
+        emit('permission', 'flag', 15, `${edge.kind}_nonmonolithic_permission`)
+      }
+
+      if (query.channel === 'contradiction_flag') {
+        emit('contradiction_flag', 'flag', 10, `${edge.kind}_internal_division`)
+      }
+      break
+    }
+
+    case 'subordination': {
+      if (query.channel === 'permission') {
+        const superiorIsPeer = peerId === edge.toNodeId
+        emit(
+          'permission',
+          superiorIsPeer ? 'grant' : 'modify',
+          superiorIsPeer ? weighted : Math.trunc(weighted / 3),
+          'subordination_permission'
+        )
+      }
+      break
+    }
+
+    case 'patronage': {
+      if (query.channel === 'aid') {
+        emit('aid', 'grant', weighted, 'patronage_aid')
+      }
+
+      if (query.channel === 'resource_release') {
+        emit('resource_release', 'grant', Math.trunc(weighted / 2), 'patronage_resource_release')
+      }
+      break
+    }
+
+    case 'information_gate': {
+      if (query.channel === 'information_flow') {
+        emit(
+          'information_flow',
+          weighted >= 50 ? 'deny' : 'modify',
+          weighted >= 50 ? -weighted : -Math.trunc(weighted / 2),
+          'information_gate'
+        )
+      }
+      break
+    }
+
+    default:
+      break
+  }
+}
+
+function clampStrength(value: number) {
+  if (!Number.isFinite(value)) {
+    return 50
+  }
+
+  return Math.max(0, Math.min(100, Math.trunc(value)))
+}
+
+function collectContradictionEdgeIds(graph: AuthorityGraph) {
+  const ids = new Set<string>()
+  for (const contradiction of detectContradictoryCurrentClaims(graph.edges)) {
+    for (const edgeId of contradiction.edgeIds) {
+      ids.add(edgeId)
+    }
+  }
+  return ids
+}
+
+export function resolveAuthorityGraphConsequences(
+  graph: AuthorityGraph,
+  query: AuthorityGraphQuery
+): readonly AuthorityConsequence[] {
+  const actorId = normalizeAuthorityNodeId(graph, query.actorNodeId)
+  if (!actorId) {
+    return Object.freeze([])
+  }
+
+  const counterpartyId = query.counterpartyNodeId
+    ? normalizeAuthorityNodeId(graph, query.counterpartyNodeId)
+    : undefined
+
+  const nodeById = buildNodeIndex(graph)
+  const consequences: AuthorityConsequence[] = []
+  const contradictionEdgeIds = collectContradictionEdgeIds(graph)
+
+  if (query.channel === 'contradiction_flag' && contradictionEdgeIds.size > 0) {
+    for (const edgeId of uniqueSorted([...contradictionEdgeIds])) {
+      addConsequence(consequences, {
+        channel: 'contradiction_flag',
+        effect: 'flag',
+        magnitude: 50,
+        reasonCode: 'conflicting_current_claims',
+        edgeIds: [edgeId],
+        confidenceApplied: 'probable',
+        delayed: false,
+        contradicted: true,
+      })
+    }
+  }
+
+  for (const edge of graph.edges) {
+    if (!edgeAppliesToQuery(edge, query, actorId, counterpartyId)) {
+      continue
+    }
+
+    mapEdgeToConsequences(
+      graph,
+      edge,
+      query,
+      actorId,
+      nodeById,
+      consequences,
+      contradictionEdgeIds
+    )
+  }
+
+  if (
+    query.channel !== 'contradiction_flag' &&
+    contradictionEdgeIds.size > 0 &&
+    consequences.every((consequence) => consequence.channel !== 'contradiction_flag')
+  ) {
+    addConsequence(consequences, {
+      channel: 'contradiction_flag',
+      effect: 'flag',
+      magnitude: 25,
+      reasonCode: 'conflicting_current_claims',
+      edgeIds: uniqueSorted([...contradictionEdgeIds]),
+      confidenceApplied: 'probable',
+      delayed: false,
+      contradicted: true,
+    })
+  }
+
+  sortConsequences(consequences)
+
+  return Object.freeze(
+    consequences.map((consequence) =>
+      Object.freeze({
+        ...consequence,
+        edgeIds: Object.freeze([...consequence.edgeIds]),
+      })
+    )
+  )
+}
+
+export function collectAuthorityGraphTokens(graph: AuthorityGraph): readonly string[] {
+  const tokens: string[] = []
+
+  for (const node of graph.nodes) {
+    tokens.push(node.id, node.label, node.nodeType)
+    if (node.factionClass) {
+      tokens.push(node.factionClass)
+    }
+
+    for (const alias of node.aliases ?? []) {
+      tokens.push(alias.aliasId, alias.label)
+    }
+
+    for (const value of Object.values(node.metadata ?? {})) {
+      if (typeof value === 'string') {
+        tokens.push(value)
+      }
+    }
+  }
+
+  for (const edge of graph.edges) {
+    tokens.push(edge.id, edge.kind, edge.fromNodeId, edge.toNodeId, edge.provenance.sourceTag)
+    if (edge.notes) {
+      tokens.push(edge.notes)
+    }
+  }
+
+  return uniqueSorted(tokens)
+}
+
+export function authorityGraphTokensContainFranchiseReferences(tokens: readonly string[]) {
+  return tokens.some((token) => FRANCHISE_TOKEN_PATTERN.test(token))
+}

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -576,6 +576,10 @@ export function validateAuthorityGraph(graph: AuthorityGraph): AuthorityGraphVal
     }
   }
 
+  for (const nextNodeIds of proxyRepresentationAdjacency.values()) {
+    nextNodeIds.sort((left, right) => left.localeCompare(right))
+  }
+
   const proxyCycles = new Set<string>()
   for (const edge of graph.edges) {
     if (edge.kind !== 'proxy_representation' || !edge.representsNodeId) {
@@ -603,8 +607,7 @@ export function validateAuthorityGraph(graph: AuthorityGraph): AuthorityGraphVal
       const nextVisited = new Set(current.visited)
       nextVisited.add(current.nodeId)
 
-      const nextNodeIds =
-        proxyRepresentationAdjacency.get(current.nodeId) ?? []
+      const nextNodeIds = proxyRepresentationAdjacency.get(current.nodeId) ?? []
       for (const nextNodeId of nextNodeIds) {
         stack.push({
           nodeId: nextNodeId,

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -310,18 +310,36 @@ function buildAliasIndex(graph: AuthorityGraph) {
   return aliasToNodeId
 }
 
-export function normalizeAuthorityNodeId(graph: AuthorityGraph, ref: string): string | undefined {
+interface AuthorityGraphIndices {
+  nodeById: Map<string, AuthorityGraphNode>
+  aliasToNodeId: Map<string, string>
+}
+
+function buildAuthorityGraphIndices(graph: AuthorityGraph): AuthorityGraphIndices {
+  return {
+    nodeById: buildNodeIndex(graph),
+    aliasToNodeId: buildAliasIndex(graph),
+  }
+}
+
+function normalizeAuthorityNodeIdWithIndices(
+  ref: string,
+  indices: AuthorityGraphIndices
+): string | undefined {
   const token = normalizeToken(ref)
   if (!token) {
     return undefined
   }
 
-  const byId = buildNodeIndex(graph)
-  if (byId.has(token)) {
+  if (indices.nodeById.has(token)) {
     return token
   }
 
-  return buildAliasIndex(graph).get(token)
+  return indices.aliasToNodeId.get(token)
+}
+
+export function normalizeAuthorityNodeId(graph: AuthorityGraph, ref: string): string | undefined {
+  return normalizeAuthorityNodeIdWithIndices(ref, buildAuthorityGraphIndices(graph))
 }
 
 function pushIssue(
@@ -1015,7 +1033,8 @@ export function resolveAuthorityGraphConsequences(
   graph: AuthorityGraph,
   query: AuthorityGraphQuery
 ): readonly AuthorityConsequence[] {
-  const actorId = normalizeAuthorityNodeId(graph, query.actorNodeId)
+  const indices = buildAuthorityGraphIndices(graph)
+  const actorId = normalizeAuthorityNodeIdWithIndices(query.actorNodeId, indices)
   if (!actorId) {
     return Object.freeze([])
   }
@@ -1027,13 +1046,13 @@ export function resolveAuthorityGraphConsequences(
       return Object.freeze([])
     }
 
-    counterpartyId = normalizeAuthorityNodeId(graph, counterpartyRef)
+    counterpartyId = normalizeAuthorityNodeIdWithIndices(counterpartyRef, indices)
     if (!counterpartyId) {
       return Object.freeze([])
     }
   }
 
-  const nodeById = buildNodeIndex(graph)
+  const nodeById = indices.nodeById
   const consequences: AuthorityConsequence[] = []
   const contradictionEdgeIds = collectContradictionEdgeIds(graph)
 

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -346,6 +346,65 @@ interface FrontAlliancePairClaims {
   alliance: AuthorityGraphEdge[]
 }
 
+function detectProxyRepresentationCycles(
+  proxyOutgoingByFromNode: ReadonlyMap<string, ReadonlyArray<{ targetNodeId: string; edgeId: string }>>
+): Set<string> {
+  const cycles = new Set<string>()
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+
+  function markCyclePath(path: ReadonlyArray<{ targetNodeId: string; edgeId: string }>, cycleNodeId: string) {
+    const cycleStart = path.findIndex((hop) => hop.targetNodeId === cycleNodeId)
+    const cycleHops = cycleStart >= 0 ? path.slice(cycleStart) : path
+
+    for (const hop of cycleHops) {
+      cycles.add(hop.edgeId)
+    }
+  }
+
+  function visitNode(nodeId: string, path: Array<{ targetNodeId: string; edgeId: string }>) {
+    if (visiting.has(nodeId)) {
+      markCyclePath(path, nodeId)
+      return
+    }
+
+    if (visited.has(nodeId)) {
+      return
+    }
+
+    visiting.add(nodeId)
+
+    for (const hop of proxyOutgoingByFromNode.get(nodeId) ?? []) {
+      if (visiting.has(hop.targetNodeId)) {
+        cycles.add(hop.edgeId)
+        markCyclePath(path, hop.targetNodeId)
+        continue
+      }
+
+      visitNode(hop.targetNodeId, [...path, hop])
+    }
+
+    visiting.delete(nodeId)
+    visited.add(nodeId)
+  }
+
+  const proxyNodeIds = new Set<string>()
+  for (const [fromNodeId, hops] of proxyOutgoingByFromNode) {
+    proxyNodeIds.add(fromNodeId)
+    for (const hop of hops) {
+      proxyNodeIds.add(hop.targetNodeId)
+    }
+  }
+
+  for (const nodeId of uniqueSorted([...proxyNodeIds])) {
+    if (!visited.has(nodeId)) {
+      visitNode(nodeId, [])
+    }
+  }
+
+  return cycles
+}
+
 function detectContradictoryCurrentClaims(
   edges: readonly AuthorityGraphEdge[]
 ): Array<{ edgeIds: string[]; detail: string }> {
@@ -569,60 +628,29 @@ export function validateAuthorityGraph(graph: AuthorityGraph): AuthorityGraphVal
     }
   }
 
-  const proxyRepresentationAdjacency = new Map<string, string[]>()
+  const proxyOutgoingByFromNode = new Map<
+    string,
+    Array<{ targetNodeId: string; edgeId: string }>
+  >()
+
   for (const edge of graph.edges) {
     if (edge.kind !== 'proxy_representation' || !edge.representsNodeId) {
       continue
     }
 
-    const nextNodeIds = proxyRepresentationAdjacency.get(edge.fromNodeId)
-    if (nextNodeIds) {
-      nextNodeIds.push(edge.representsNodeId)
-    } else {
-      proxyRepresentationAdjacency.set(edge.fromNodeId, [edge.representsNodeId])
-    }
+    const hops = proxyOutgoingByFromNode.get(edge.fromNodeId) ?? []
+    hops.push({ targetNodeId: edge.representsNodeId, edgeId: edge.id })
+    proxyOutgoingByFromNode.set(edge.fromNodeId, hops)
   }
 
-  for (const nextNodeIds of proxyRepresentationAdjacency.values()) {
-    nextNodeIds.sort((left, right) => left.localeCompare(right))
+  for (const hops of proxyOutgoingByFromNode.values()) {
+    hops.sort((left, right) => {
+      const targetCompare = left.targetNodeId.localeCompare(right.targetNodeId)
+      return targetCompare !== 0 ? targetCompare : left.edgeId.localeCompare(right.edgeId)
+    })
   }
 
-  const proxyCycles = new Set<string>()
-  for (const edge of graph.edges) {
-    if (edge.kind !== 'proxy_representation' || !edge.representsNodeId) {
-      continue
-    }
-
-    const stack: Array<{ nodeId: string; visited: Set<string> }> = [
-      {
-        nodeId: edge.representsNodeId,
-        visited: new Set<string>([edge.fromNodeId]),
-      },
-    ]
-
-    while (stack.length > 0) {
-      const current = stack.pop()
-      if (!current) {
-        continue
-      }
-
-      if (current.visited.has(current.nodeId)) {
-        proxyCycles.add(edge.id)
-        break
-      }
-
-      const nextVisited = new Set(current.visited)
-      nextVisited.add(current.nodeId)
-
-      const nextNodeIds = proxyRepresentationAdjacency.get(current.nodeId) ?? []
-      for (const nextNodeId of nextNodeIds) {
-        stack.push({
-          nodeId: nextNodeId,
-          visited: nextVisited,
-        })
-      }
-    }
-  }
+  const proxyCycles = detectProxyRepresentationCycles(proxyOutgoingByFromNode)
 
   for (const edgeId of proxyCycles) {
     pushIssue(issues, {

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -297,11 +297,7 @@ function buildAliasIndex(graph: AuthorityGraph) {
   const aliasToNodeId = new Map<string, string>()
 
   for (const node of graph.nodes) {
-    const aliases = [...(node.aliases ?? [])].sort((left, right) =>
-      left.aliasId.localeCompare(right.aliasId)
-    )
-
-    for (const alias of aliases) {
+    for (const alias of node.aliases ?? []) {
       const keys = uniqueSorted([alias.aliasId, alias.label])
       for (const key of keys) {
         if (!aliasToNodeId.has(key)) {

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -686,6 +686,9 @@ function addConsequence(
 
   if (existing) {
     existing.magnitude = Math.trunc(existing.magnitude + input.magnitude)
+    existing.edgeIds = uniqueSorted([...existing.edgeIds, ...input.edgeIds])
+    existing.contradicted = existing.contradicted || input.contradicted
+    existing.delayed = existing.delayed || input.delayed
     return
   }
 

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -335,12 +335,24 @@ function edgeTripleKey(edge: Pick<AuthorityGraphEdge, 'fromNodeId' | 'toNodeId' 
   return `${edge.fromNodeId}::${edge.toNodeId}::${edge.kind}`
 }
 
+function edgePairKey(edge: Pick<AuthorityGraphEdge, 'fromNodeId' | 'toNodeId'>) {
+  return `${edge.fromNodeId}::${edge.toNodeId}`
+}
+
+interface FrontAlliancePairClaims {
+  fromNodeId: string
+  toNodeId: string
+  front: AuthorityGraphEdge[]
+  alliance: AuthorityGraphEdge[]
+}
+
 function detectContradictoryCurrentClaims(
   edges: readonly AuthorityGraphEdge[]
 ): Array<{ edgeIds: string[]; detail: string }> {
   const contradictions: Array<{ edgeIds: string[]; detail: string }> = []
   const currentByTriple = new Map<string, AuthorityGraphEdge[]>()
   const subordinationByChild = new Map<string, AuthorityGraphEdge[]>()
+  const frontAllianceByPair = new Map<string, FrontAlliancePairClaims>()
 
   for (const edge of edges) {
     if (edge.status !== 'current') {
@@ -356,6 +368,24 @@ function detectContradictoryCurrentClaims(
       const childGroup = subordinationByChild.get(edge.fromNodeId) ?? []
       childGroup.push(edge)
       subordinationByChild.set(edge.fromNodeId, childGroup)
+    }
+
+    if (edge.kind === 'front' || edge.kind === 'alliance') {
+      const pairKey = edgePairKey(edge)
+      const pairClaims = frontAllianceByPair.get(pairKey) ?? {
+        fromNodeId: edge.fromNodeId,
+        toNodeId: edge.toNodeId,
+        front: [],
+        alliance: [],
+      }
+
+      if (edge.kind === 'front') {
+        pairClaims.front.push(edge)
+      } else {
+        pairClaims.alliance.push(edge)
+      }
+
+      frontAllianceByPair.set(pairKey, pairClaims)
     }
   }
 
@@ -383,36 +413,17 @@ function detectContradictoryCurrentClaims(
     }
   }
 
-  for (const edge of edges) {
-    if (edge.status !== 'current') {
+  for (const pairClaims of frontAllianceByPair.values()) {
+    if (pairClaims.front.length === 0 || pairClaims.alliance.length === 0) {
       continue
     }
 
-    if (edge.kind === 'front' || edge.kind === 'alliance') {
-      const counterpart =
-        edge.kind === 'front'
-          ? edges.find(
-              (candidate) =>
-                candidate.status === 'current' &&
-                candidate.kind === 'alliance' &&
-                candidate.fromNodeId === edge.fromNodeId &&
-                candidate.toNodeId === edge.toNodeId
-            )
-          : edges.find(
-              (candidate) =>
-                candidate.status === 'current' &&
-                candidate.kind === 'front' &&
-                candidate.fromNodeId === edge.fromNodeId &&
-                candidate.toNodeId === edge.toNodeId
-            )
-
-      if (counterpart) {
-        contradictions.push({
-          edgeIds: uniqueSorted([edge.id, counterpart.id]),
-          detail: `Front and alliance both current between ${edge.fromNodeId} and ${edge.toNodeId}.`,
-        })
-      }
-    }
+    contradictions.push({
+      edgeIds: uniqueSorted(
+        [...pairClaims.front, ...pairClaims.alliance].map((edge) => edge.id)
+      ),
+      detail: `Front and alliance both current between ${pairClaims.fromNodeId} and ${pairClaims.toNodeId}.`,
+    })
   }
 
   return contradictions

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -674,7 +674,7 @@ function addConsequence(
 }
 
 function resolveProxyTargetNodeId(
-  graph: AuthorityGraph,
+  _graph: AuthorityGraph,
   edge: AuthorityGraphEdge,
   nodeById: Map<string, AuthorityGraphNode>
 ) {

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -954,9 +954,18 @@ export function resolveAuthorityGraphConsequences(
     return Object.freeze([])
   }
 
-  const counterpartyId = query.counterpartyNodeId
-    ? normalizeAuthorityNodeId(graph, query.counterpartyNodeId)
-    : undefined
+  let counterpartyId: string | undefined
+  if (query.counterpartyNodeId !== undefined) {
+    const counterpartyRef = normalizeToken(query.counterpartyNodeId)
+    if (!counterpartyRef) {
+      return Object.freeze([])
+    }
+
+    counterpartyId = normalizeAuthorityNodeId(graph, counterpartyRef)
+    if (!counterpartyId) {
+      return Object.freeze([])
+    }
+  }
 
   const nodeById = buildNodeIndex(graph)
   const consequences: AuthorityConsequence[] = []

--- a/src/domain/authorityGraph.ts
+++ b/src/domain/authorityGraph.ts
@@ -562,30 +562,55 @@ export function validateAuthorityGraph(graph: AuthorityGraph): AuthorityGraphVal
     }
   }
 
+  const proxyRepresentationAdjacency = new Map<string, string[]>()
+  for (const edge of graph.edges) {
+    if (edge.kind !== 'proxy_representation' || !edge.representsNodeId) {
+      continue
+    }
+
+    const nextNodeIds = proxyRepresentationAdjacency.get(edge.fromNodeId)
+    if (nextNodeIds) {
+      nextNodeIds.push(edge.representsNodeId)
+    } else {
+      proxyRepresentationAdjacency.set(edge.fromNodeId, [edge.representsNodeId])
+    }
+  }
+
   const proxyCycles = new Set<string>()
   for (const edge of graph.edges) {
     if (edge.kind !== 'proxy_representation' || !edge.representsNodeId) {
       continue
     }
 
-    const visited = new Set<string>([edge.fromNodeId])
-    let cursor: string | undefined = edge.representsNodeId
+    const stack: Array<{ nodeId: string; visited: Set<string> }> = [
+      {
+        nodeId: edge.representsNodeId,
+        visited: new Set<string>([edge.fromNodeId]),
+      },
+    ]
 
-    while (cursor) {
-      if (visited.has(cursor)) {
+    while (stack.length > 0) {
+      const current = stack.pop()
+      if (!current) {
+        continue
+      }
+
+      if (current.visited.has(current.nodeId)) {
         proxyCycles.add(edge.id)
         break
       }
 
-      visited.add(cursor)
-      const next = graph.edges.find(
-        (candidate) =>
-          candidate.kind === 'proxy_representation' &&
-          candidate.fromNodeId === cursor &&
-          candidate.representsNodeId
-      )
+      const nextVisited = new Set(current.visited)
+      nextVisited.add(current.nodeId)
 
-      cursor = next?.representsNodeId
+      const nextNodeIds =
+        proxyRepresentationAdjacency.get(current.nodeId) ?? []
+      for (const nextNodeId of nextNodeIds) {
+        stack.push({
+          nodeId: nextNodeId,
+          visited: nextVisited,
+        })
+      }
     }
   }
 

--- a/src/test/authorityGraph.test.ts
+++ b/src/test/authorityGraph.test.ts
@@ -596,4 +596,43 @@ describe('authorityGraph slice 1 (SPE-788)', () => {
     expect(validation.issues.some((issue) => issue.code === 'missing_proxy_represents_node')).toBe(true)
     expect(validation.issues.some((issue) => issue.code === 'unmapped_relationship_kind')).toBe(true)
   })
+
+  it('14b. proxy cycle detection follows all branches, not only the first outgoing edge', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'proxy-root', nodeType: 'proxy', label: 'Root Liaison' }),
+        node({ id: 'constituency-a', nodeType: 'constituency', label: 'Ward Bloc A' }),
+        node({ id: 'constituency-b', nodeType: 'constituency', label: 'Ward Bloc B' }),
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+      ],
+      edges: [
+        edge({
+          id: 'proxy-a',
+          kind: 'proxy_representation',
+          fromNodeId: 'proxy-root',
+          toNodeId: 'agency-core',
+          representsNodeId: 'constituency-a',
+        }),
+        edge({
+          id: 'proxy-b',
+          kind: 'proxy_representation',
+          fromNodeId: 'proxy-root',
+          toNodeId: 'agency-core',
+          representsNodeId: 'constituency-b',
+        }),
+        edge({
+          id: 'proxy-cycle',
+          kind: 'proxy_representation',
+          fromNodeId: 'constituency-b',
+          toNodeId: 'agency-core',
+          representsNodeId: 'proxy-root',
+        }),
+      ],
+    }
+
+    const validation = validateAuthorityGraph(graph)
+    expect(validation.valid).toBe(false)
+    expect(validation.issues.some((issue) => issue.code === 'proxy_representation_cycle')).toBe(true)
+    expect(validation.issues.some((issue) => issue.relatedIds?.includes('proxy-b'))).toBe(true)
+  })
 })

--- a/src/test/authorityGraph.test.ts
+++ b/src/test/authorityGraph.test.ts
@@ -597,6 +597,44 @@ describe('authorityGraph slice 1 (SPE-788)', () => {
     expect(validation.issues.some((issue) => issue.code === 'unmapped_relationship_kind')).toBe(true)
   })
 
+  it('10b. merged consequences retain all contributing edge ids and merged flags', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'faction-a', nodeType: 'faction', label: 'Archive Bloc' }),
+        node({ id: 'faction-b', nodeType: 'faction', label: 'Security Bloc' }),
+        node({ id: 'faction-c', nodeType: 'faction', label: 'Logistics Bloc' }),
+      ],
+      edges: [
+        edge({
+          id: 'all-ab',
+          kind: 'alliance',
+          fromNodeId: 'faction-a',
+          toNodeId: 'faction-b',
+          sourceConfidence: 'verified',
+        }),
+        edge({
+          id: 'all-ac',
+          kind: 'alliance',
+          fromNodeId: 'faction-a',
+          toNodeId: 'faction-c',
+          sourceConfidence: 'rumor',
+          status: 'hidden',
+          hiddenUntilWeek: 20,
+        }),
+      ],
+    }
+
+    const consequences = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'faction-a', channel: 'hostility', asOfWeek: 10 })
+    )
+
+    const merged = consequences.find((item) => item.reasonCode === 'alliance_reduces_hostility')
+    expect(merged).toBeDefined()
+    expect(merged?.edgeIds).toEqual(['all-ab', 'all-ac'])
+    expect(merged?.delayed).toBe(true)
+  })
+
   it('14b. proxy cycle detection follows all branches, not only the first outgoing edge', () => {
     const graph: AuthorityGraph = {
       nodes: [

--- a/src/test/authorityGraph.test.ts
+++ b/src/test/authorityGraph.test.ts
@@ -435,6 +435,57 @@ describe('authorityGraph slice 1 (SPE-788)', () => {
     expect(first).toEqual(second)
   })
 
+  it('11a. unresolved counterparty id returns no consequences instead of all actor edges', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'faction-a', nodeType: 'faction', label: 'Archive Bloc' }),
+        node({ id: 'faction-b', nodeType: 'faction', label: 'Security Bloc' }),
+        node({ id: 'faction-c', nodeType: 'faction', label: 'Logistics Bloc' }),
+      ],
+      edges: [
+        edge({
+          id: 'riv-ab',
+          kind: 'rivalry',
+          fromNodeId: 'faction-a',
+          toNodeId: 'faction-b',
+        }),
+        edge({
+          id: 'all-ac',
+          kind: 'alliance',
+          fromNodeId: 'faction-a',
+          toNodeId: 'faction-c',
+        }),
+      ],
+    }
+
+    const pairwise = resolveAuthorityGraphConsequences(
+      graph,
+      query({
+        actorNodeId: 'faction-a',
+        counterpartyNodeId: 'faction-b',
+        channel: 'hostility',
+      })
+    )
+
+    const unresolvedCounterparty = resolveAuthorityGraphConsequences(
+      graph,
+      query({
+        actorNodeId: 'faction-a',
+        counterpartyNodeId: 'stale-alias-typo',
+        channel: 'hostility',
+      })
+    )
+
+    const allActorEdges = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'faction-a', channel: 'hostility' })
+    )
+
+    expect(pairwise.length).toBeGreaterThan(0)
+    expect(unresolvedCounterparty).toEqual([])
+    expect(allActorEdges.length).toBeGreaterThan(pairwise.length)
+  })
+
   it('11. inputs are not mutated', () => {
     const graph: AuthorityGraph = structuredClone({
       nodes: [node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' })],

--- a/src/test/authorityGraph.test.ts
+++ b/src/test/authorityGraph.test.ts
@@ -1,0 +1,548 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type {
+  AuthorityGraph,
+  AuthorityGraphEdge,
+  AuthorityGraphNode,
+  AuthorityGraphQuery,
+} from '../domain/authorityGraph'
+import {
+  authorityGraphTokensContainFranchiseReferences,
+  collectAuthorityGraphTokens,
+  normalizeAuthorityNodeId,
+  resolveAuthorityGraphConsequences,
+  validateAuthorityGraph,
+} from '../domain/authorityGraph'
+
+function provenance(sourceTag: string) {
+  return { sourceTag }
+}
+
+function node(overrides: Partial<AuthorityGraphNode> & Pick<AuthorityGraphNode, 'id' | 'nodeType' | 'label'>): AuthorityGraphNode {
+  return {
+    id: overrides.id,
+    nodeType: overrides.nodeType,
+    label: overrides.label,
+    aliases: overrides.aliases,
+    factionClass: overrides.factionClass,
+    linkedFactionIds: overrides.linkedFactionIds,
+    linkedPopulationIds: overrides.linkedPopulationIds,
+    linkedDepartmentIds: overrides.linkedDepartmentIds,
+    linkedSiteIds: overrides.linkedSiteIds,
+    metadata: overrides.metadata,
+  }
+}
+
+function edge(overrides: Partial<AuthorityGraphEdge> & Pick<AuthorityGraphEdge, 'id' | 'kind' | 'fromNodeId' | 'toNodeId'>): AuthorityGraphEdge {
+  return {
+    status: 'current',
+    sourceConfidence: 'verified',
+    ...overrides,
+    provenance: overrides.provenance ?? provenance('field_report'),
+  }
+}
+
+function query(overrides: Partial<AuthorityGraphQuery> & Pick<AuthorityGraphQuery, 'actorNodeId' | 'channel'>): AuthorityGraphQuery {
+  return {
+    asOfWeek: 10,
+    ...overrides,
+  }
+}
+
+describe('authorityGraph slice 1 (SPE-788)', () => {
+  it('1. dependency edge changes mission access or permission', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+        node({ id: 'inst-partner', nodeType: 'institution', label: 'Regional Oversight Institute' }),
+      ],
+      edges: [
+        edge({
+          id: 'dep-1',
+          kind: 'dependency',
+          fromNodeId: 'agency-core',
+          toNodeId: 'inst-partner',
+          sourceConfidence: 'rumor',
+        }),
+      ],
+    }
+
+    const access = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'agency-core', counterpartyNodeId: 'inst-partner', channel: 'mission_access' })
+    )
+
+    expect(access.length).toBeGreaterThan(0)
+    expect(access[0]?.channel).toBe('mission_access')
+    expect(['deny', 'delay']).toContain(access[0]?.effect)
+
+    const permission = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'agency-core', counterpartyNodeId: 'inst-partner', channel: 'permission' })
+    )
+
+    expect(permission.some((item) => item.reasonCode === 'dependency_permission')).toBe(true)
+  })
+
+  it('2. rivalry edge increases hostility or blocks aid', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'faction-a', nodeType: 'faction', label: 'North Archive Bloc' }),
+        node({ id: 'faction-b', nodeType: 'faction', label: 'Perimeter Security Bloc' }),
+      ],
+      edges: [
+        edge({
+          id: 'riv-1',
+          kind: 'rivalry',
+          fromNodeId: 'faction-a',
+          toNodeId: 'faction-b',
+          strength: 80,
+        }),
+      ],
+    }
+
+    const hostility = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'faction-a', counterpartyNodeId: 'faction-b', channel: 'hostility' })
+    )
+
+    expect(hostility[0]?.magnitude).toBeGreaterThan(0)
+
+    const aid = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'faction-a', counterpartyNodeId: 'faction-b', channel: 'aid' })
+    )
+
+    expect(aid[0]?.effect).toBe('deny')
+    expect(aid[0]?.reasonCode).toBe('rivalry_blocks_aid')
+  })
+
+  it('3. hidden agenda / hidden network edge produces delayed or contradicted consequences', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+        node({ id: 'net-veil', nodeType: 'hidden_network', label: 'Veil Broker Network' }),
+      ],
+      edges: [
+        edge({
+          id: 'hid-1',
+          kind: 'hidden_agenda',
+          fromNodeId: 'agency-core',
+          toNodeId: 'net-veil',
+          status: 'hidden',
+          hiddenUntilWeek: 12,
+          sourceConfidence: 'hostile_dossier',
+        }),
+      ],
+    }
+
+    const early = resolveAuthorityGraphConsequences(
+      graph,
+      query({
+        actorNodeId: 'agency-core',
+        counterpartyNodeId: 'net-veil',
+        channel: 'information_flow',
+        asOfWeek: 8,
+      })
+    )
+
+    expect(early.some((item) => item.delayed && item.effect === 'delay')).toBe(true)
+
+    const late = resolveAuthorityGraphConsequences(
+      graph,
+      query({
+        actorNodeId: 'agency-core',
+        counterpartyNodeId: 'net-veil',
+        channel: 'information_flow',
+        asOfWeek: 14,
+      })
+    )
+
+    expect(late.some((item) => !item.delayed)).toBe(true)
+    expect(late.some((item) => item.confidenceApplied === 'hostile_dossier')).toBe(true)
+  })
+
+  it('4. proxy-representation edge routes consequence through represented constituency or bloc', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'proxy-liaison', nodeType: 'proxy', label: 'District Liaison Proxy' }),
+        node({ id: 'constituency-ward', nodeType: 'constituency', label: 'Industrial Ward Bloc' }),
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+      ],
+      edges: [
+        edge({
+          id: 'proxy-1',
+          kind: 'proxy_representation',
+          fromNodeId: 'proxy-liaison',
+          toNodeId: 'agency-core',
+          representsNodeId: 'constituency-ward',
+        }),
+      ],
+    }
+
+    const consequences = resolveAuthorityGraphConsequences(
+      graph,
+      query({
+        actorNodeId: 'proxy-liaison',
+        counterpartyNodeId: 'agency-core',
+        channel: 'permission',
+      })
+    )
+
+    expect(consequences.some((item) => item.reasonCode === 'proxy_routes_constituency')).toBe(true)
+  })
+
+  it('5. shared-authority edge changes permission, secrecy, or local compliance', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+        node({ id: 'regime-host', nodeType: 'external_regime', label: 'Host Perimeter Authority' }),
+        node({ id: 'site-alpha', nodeType: 'site', label: 'Co-managed Site Alpha' }),
+      ],
+      edges: [
+        edge({
+          id: 'shared-1',
+          kind: 'shared_authority',
+          fromNodeId: 'agency-core',
+          toNodeId: 'site-alpha',
+          strength: 70,
+        }),
+        edge({
+          id: 'shared-2',
+          kind: 'shared_authority',
+          fromNodeId: 'regime-host',
+          toNodeId: 'site-alpha',
+          strength: 70,
+        }),
+      ],
+    }
+
+    const permission = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'agency-core', counterpartyNodeId: 'site-alpha', channel: 'permission' })
+    )
+    const secrecy = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'agency-core', counterpartyNodeId: 'site-alpha', channel: 'secrecy' })
+    )
+    const compliance = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'agency-core', counterpartyNodeId: 'site-alpha', channel: 'local_compliance' })
+    )
+
+    expect(permission.some((item) => item.reasonCode === 'shared_authority_permission')).toBe(true)
+    expect(secrecy.some((item) => item.reasonCode === 'shared_authority_secrecy')).toBe(true)
+    expect(compliance.some((item) => item.reasonCode === 'shared_authority_compliance')).toBe(true)
+  })
+
+  it('6. internal splinter/front edge makes an organization nonmonolithic', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'faction-umbrella', nodeType: 'faction', label: 'Unified Research Coalition' }),
+        node({ id: 'cell-pragmatic', nodeType: 'faction', label: 'Pragmatic Operations Cell' }),
+      ],
+      edges: [
+        edge({
+          id: 'spl-1',
+          kind: 'splinter',
+          fromNodeId: 'cell-pragmatic',
+          toNodeId: 'faction-umbrella',
+        }),
+        edge({
+          id: 'front-1',
+          kind: 'front',
+          fromNodeId: 'faction-umbrella',
+          toNodeId: 'cell-pragmatic',
+        }),
+      ],
+    }
+
+    const permission = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'faction-umbrella', channel: 'permission' })
+    )
+
+    expect(permission.some((item) => item.reasonCode.includes('nonmonolithic'))).toBe(true)
+  })
+
+  it('7. alias/provenance/confidence fields prevent treating the graph as perfect truth', () => {
+    const nodes = [
+      node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+      node({ id: 'inst-partner', nodeType: 'institution', label: 'Regional Oversight Institute' }),
+    ]
+
+    const rumorGraph: AuthorityGraph = {
+      nodes,
+      edges: [
+        edge({
+          id: 'dep-rumor',
+          kind: 'dependency',
+          fromNodeId: 'agency-core',
+          toNodeId: 'inst-partner',
+          sourceConfidence: 'rumor',
+          strength: 80,
+        }),
+      ],
+    }
+
+    const verifiedGraph: AuthorityGraph = {
+      nodes,
+      edges: [
+        edge({
+          id: 'dep-verified',
+          kind: 'dependency',
+          fromNodeId: 'agency-core',
+          toNodeId: 'inst-partner',
+          sourceConfidence: 'verified',
+          strength: 80,
+        }),
+      ],
+    }
+
+    const rumorView = resolveAuthorityGraphConsequences(
+      rumorGraph,
+      query({
+        actorNodeId: 'agency-core',
+        counterpartyNodeId: 'inst-partner',
+        channel: 'mission_access',
+      })
+    )
+
+    const verifiedView = resolveAuthorityGraphConsequences(
+      verifiedGraph,
+      query({
+        actorNodeId: 'agency-core',
+        counterpartyNodeId: 'inst-partner',
+        channel: 'mission_access',
+      })
+    )
+
+    expect(rumorView[0]?.confidenceApplied).toBe('rumor')
+    expect(verifiedView[0]?.confidenceApplied).toBe('verified')
+    expect(Math.abs(verifiedView[0]?.magnitude ?? 0)).toBeGreaterThan(
+      Math.abs(rumorView[0]?.magnitude ?? 0)
+    )
+
+    expect(validateAuthorityGraph(verifiedGraph).issues.some((issue) => issue.code === 'perfect_dossier_unlikely')).toBe(
+      true
+    )
+  })
+
+  it('8. conflicting current claims produce a contradiction flag', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'dept-a', nodeType: 'department', label: 'Records Directorate' }),
+        node({ id: 'dept-b', nodeType: 'department', label: 'Field Operations Directorate' }),
+        node({ id: 'dept-c', nodeType: 'department', label: 'Strategic Review Directorate' }),
+      ],
+      edges: [
+        edge({
+          id: 'sub-1',
+          kind: 'subordination',
+          fromNodeId: 'dept-a',
+          toNodeId: 'dept-b',
+          sourceConfidence: 'verified',
+        }),
+        edge({
+          id: 'sub-2',
+          kind: 'subordination',
+          fromNodeId: 'dept-a',
+          toNodeId: 'dept-c',
+          sourceConfidence: 'probable',
+        }),
+      ],
+    }
+
+    const flags = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'dept-a', channel: 'contradiction_flag' })
+    )
+
+    expect(flags.some((item) => item.channel === 'contradiction_flag')).toBe(true)
+    expect(validateAuthorityGraph(graph).issues.some((issue) => issue.code === 'contradictory_current_claims')).toBe(
+      true
+    )
+  })
+
+  it('9. group sponsor can narrow to a specific patron without losing group context', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({
+          id: 'sponsor-bloc',
+          nodeType: 'sponsor_group',
+          label: 'Industrial Patron Bloc',
+          aliases: [{ aliasId: 'alias-bloc', label: 'Industrial Patron Bloc', confidence: 'probable' }],
+        }),
+        node({ id: 'patron-veldt', nodeType: 'patron', label: 'Patron Veldt' }),
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+      ],
+      edges: [
+        edge({
+          id: 'patronage-1',
+          kind: 'patronage',
+          fromNodeId: 'sponsor-bloc',
+          toNodeId: 'patron-veldt',
+        }),
+        edge({
+          id: 'patronage-2',
+          kind: 'patronage',
+          fromNodeId: 'patron-veldt',
+          toNodeId: 'agency-core',
+        }),
+      ],
+    }
+
+    expect(normalizeAuthorityNodeId(graph, 'alias-bloc')).toBe('sponsor-bloc')
+    expect(normalizeAuthorityNodeId(graph, 'patron-veldt')).toBe('patron-veldt')
+
+    const fromPatron = resolveAuthorityGraphConsequences(
+      graph,
+      query({ actorNodeId: 'patron-veldt', counterpartyNodeId: 'agency-core', channel: 'aid' })
+    )
+
+    expect(fromPatron.some((item) => item.reasonCode === 'patronage_aid')).toBe(true)
+    expect(graph.nodes.some((item) => item.id === 'sponsor-bloc')).toBe(true)
+  })
+
+  it('10. deterministic sorting for equivalent edges/consequences', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'faction-a', nodeType: 'faction', label: 'Archive Bloc' }),
+        node({ id: 'faction-b', nodeType: 'faction', label: 'Security Bloc' }),
+      ],
+      edges: [
+        edge({
+          id: 'z-edge',
+          kind: 'rivalry',
+          fromNodeId: 'faction-a',
+          toNodeId: 'faction-b',
+        }),
+        edge({
+          id: 'a-edge',
+          kind: 'alliance',
+          fromNodeId: 'faction-a',
+          toNodeId: 'faction-b',
+          status: 'outdated',
+        }),
+      ],
+    }
+
+    const q = query({ actorNodeId: 'faction-a', counterpartyNodeId: 'faction-b', channel: 'hostility' })
+    const first = resolveAuthorityGraphConsequences(graph, q)
+    const second = resolveAuthorityGraphConsequences(graph, q)
+
+    expect(first).toEqual(second)
+  })
+
+  it('11. inputs are not mutated', () => {
+    const graph: AuthorityGraph = structuredClone({
+      nodes: [node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' })],
+      edges: [],
+    })
+    const graphBefore = structuredClone(graph)
+    const q = query({ actorNodeId: 'agency-core', channel: 'aid' })
+    const qBefore = structuredClone(q)
+
+    resolveAuthorityGraphConsequences(graph, q)
+
+    expect(graph).toEqual(graphBefore)
+    expect(q).toEqual(qBefore)
+  })
+
+  it('12. no source-specific faction names or lore strings', () => {
+    const graph: AuthorityGraph = {
+      nodes: [
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+        node({ id: 'faction-a', nodeType: 'faction', label: 'Regional Oversight Bloc' }),
+      ],
+      edges: [
+        edge({
+          id: 'all-1',
+          kind: 'alliance',
+          fromNodeId: 'agency-core',
+          toNodeId: 'faction-a',
+        }),
+      ],
+    }
+
+    const tokens = collectAuthorityGraphTokens(graph)
+    expect(authorityGraphTokensContainFranchiseReferences(tokens)).toBe(false)
+  })
+
+  it('13. module does not import GameState/UI/runtime mission modules', () => {
+    const source = readFileSync(resolve('src/domain/authorityGraph.ts'), 'utf8')
+
+    expect(source).not.toMatch(/from ['"]\.\/models['"]/)
+    expect(source).not.toMatch(/from ['"]\.\/missionIntakeRouting['"]/)
+    expect(source).not.toMatch(/from ['"]\.\/sim\/advanceWeek['"]/)
+    expect(source).not.toMatch(/from ['"]react/)
+  })
+
+  it('14. validateAuthorityGraph happy path and core validation failures', () => {
+    const valid: AuthorityGraph = {
+      nodes: [
+        node({ id: 'agency-core', nodeType: 'agency', label: 'Containment Directorate' }),
+        node({ id: 'inst-partner', nodeType: 'institution', label: 'Regional Oversight Institute' }),
+      ],
+      edges: [
+        edge({
+          id: 'all-1',
+          kind: 'alliance',
+          fromNodeId: 'agency-core',
+          toNodeId: 'inst-partner',
+          sourceConfidence: 'probable',
+        }),
+      ],
+    }
+
+    expect(validateAuthorityGraph(valid).valid).toBe(true)
+
+    const invalid: AuthorityGraph = {
+      nodes: [
+        node({ id: 'dup', nodeType: 'faction', label: 'Bloc A' }),
+        node({ id: 'dup', nodeType: 'faction', label: 'Bloc B' }),
+        node({ id: 'population-x', nodeType: 'population_group_reference', label: 'Assimilated Cohort' }),
+      ],
+      edges: [
+        edge({
+          id: 'dup-edge',
+          kind: 'alliance',
+          fromNodeId: 'dup',
+          toNodeId: 'missing-node',
+          provenance: { sourceTag: '' },
+        }),
+        edge({
+          id: 'dup-edge',
+          kind: 'proxy_representation',
+          fromNodeId: 'population-x',
+          toNodeId: 'dup',
+        }),
+        edge({
+          id: 'cell-deferred',
+          kind: 'cell',
+          fromNodeId: 'dup',
+          toNodeId: 'population-x',
+          status: 'current',
+        }),
+        edge({
+          id: 'pop-political',
+          kind: 'alliance',
+          fromNodeId: 'population-x',
+          toNodeId: 'dup',
+          status: 'current',
+        }),
+      ],
+    }
+
+    const validation = validateAuthorityGraph(invalid)
+    expect(validation.valid).toBe(false)
+    expect(validation.issues.some((issue) => issue.code === 'population_faction_collapse')).toBe(true)
+    expect(validation.issues.some((issue) => issue.code === 'duplicate_node_id')).toBe(true)
+    expect(validation.issues.some((issue) => issue.code === 'duplicate_edge_id')).toBe(true)
+    expect(validation.issues.some((issue) => issue.code === 'unknown_to_node')).toBe(true)
+    expect(validation.issues.some((issue) => issue.code === 'missing_provenance_source_tag')).toBe(true)
+    expect(validation.issues.some((issue) => issue.code === 'missing_proxy_represents_node')).toBe(true)
+    expect(validation.issues.some((issue) => issue.code === 'unmapped_relationship_kind')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds pure authority relationship graph module (SPE-788 slice 1): typed nodes/edges, validation, alias normalization, confidence-aware deterministic consequence resolution, and contradiction flags.
- Linear: https://linear.app/spectranoir/issue/SPE-788/authority-relationship-graph-and-politics-layer

## Smallest boundary

Fixture-only graph contract in src/domain/authorityGraph.ts + src/test/authorityGraph.test.ts. No GameState, mission routing, UI, negotiation, ethics, obedience, command propagation, department handoff, council-direct routing, or population registry.

## Files changed

- src/domain/authorityGraph.ts — types, alidateAuthorityGraph, 
ormalizeAuthorityNodeId, esolveAuthorityGraphConsequences, token lint helpers
- src/test/authorityGraph.test.ts — 14 acceptance scenarios

## Validation run

- 
pm run test:run -- src/test/authorityGraph.test.ts — pass (14/14)
- 
pm run test:run — pass (3296 tests)
- 
pm run lint — pass
- git diff --check — clean on touched files

## Gap / edge-case / boundary audit

- Deferred relationship kinds are declared but emit validation warnings when current; resolver does not imply behavior for unmapped kinds.
- Negotiation/bargaining, graph mutation over time, and live mission integration remain out of scope.
- Population nodes link by reference only; population_faction_collapse warns when a population reference acts as a political stand-in without linkedFactionIds.
- Hidden edges gated by hiddenUntilWeek; confidence floor and provenance attenuate magnitude.

## Explicitly out of scope

- GameState persistence, weekly tick, UI
- missionIntakeRouting, dvanceWeek, actions.ts refactor
- SPE-1047 ethics, SPE-1096 command propagation, SPE-1097 obedience
- SPE-2088 department handoff, SPE-2089 council-direct routing
- Secrecy/media/public narrative runtime, SPE-2097 population registry implementation
- Negotiation state machine and full SPE-788 acceptance (overlapping live regimes, nonmonolithic runtime beyond fixture flags)

## Test plan

- [x] Dependency, rivalry, hidden agenda, proxy, shared authority, splinter/front, confidence, contradiction, sponsor narrowing
- [x] Deterministic sort, input immutability, franchise token scan, import boundary
- [x] Validation happy path and core failures

Made with [Cursor](https://cursor.com)