### PR TITLE
SPE-2101: Add institutional automation registry

### DIFF
--- a/src/domain/institutionalAutomationRegistry.ts
+++ b/src/domain/institutionalAutomationRegistry.ts
@@ -1,0 +1,806 @@
+/**
+ * SPE-2101: pure institutional automation registry.
+ *
+ * Fixture-only slice for fallible institutional automation agents: role class,
+ * authority tier, audit trail, conflict resolution, and operator projection.
+ *
+ * Non-goals: GameState persistence, UI, live entity registry integration,
+ * authority-graph owner edge wiring, specialist unit integration, alert-center
+ * runtime, autonomous actuation, distributed perception runtime, or franchise
+ * source-canon import.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type InstitutionalAutomationId = string
+
+export type AutomationRoleClass =
+  | 'observe'
+  | 'retrieve'
+  | 'classify'
+  | 'patrol'
+  | 'contain'
+  | 'decontaminate'
+  | 'archive'
+  | 'translate'
+  | 'escort'
+  | 'misdirect'
+  | 'censor'
+  | 'repair'
+  | 'warn'
+
+export type AutomationAuthorityTier =
+  | 'advisory'
+  | 'task_execution'
+  | 'field_autonomy'
+  | 'emergency_override'
+  | 'records_alteration'
+  | 'command_escalation'
+
+export type AutomationPersonhoodStatus =
+  | 'tool'
+  | 'agent'
+  | 'assistant'
+  | 'legal_person'
+  | 'captive_intelligence'
+  | 'emergent_mind'
+
+export type AutomationCompromiseStatus =
+  | 'none'
+  | 'suspected'
+  | 'confirmed'
+  | 'contained'
+  | 'isolated'
+
+export type AutomationFailureMode =
+  | 'silent'
+  | 'false_negative'
+  | 'false_positive'
+  | 'over_actuation'
+  | 'records_drift'
+  | 'coordination_loss'
+
+export type AutomationAuditState =
+  | 'seed'
+  | 'provisional'
+  | 'active'
+  | 'suspended'
+  | 'decommissioned'
+
+export type AutomationActionConfidence =
+  | 'rumor'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'verified'
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface AutomationSensorCapability {
+  sensorId: string
+  channel: string
+  reliability: number
+}
+
+export interface AutomationOverridePath {
+  requiresHumanAck: boolean
+  escalationNodeIds: readonly string[]
+  lockoutReasonCode?: string
+}
+
+export interface AutomationSensorInputRef {
+  sensorId: string
+  readingCode: string
+  strength?: number
+}
+
+export interface AutomationActionRecord {
+  actionId: string
+  automationId: InstitutionalAutomationId
+  week?: number
+  triggerRuleId: string
+  operatorId?: string
+  confidence: AutomationActionConfidence
+  sensorInputs: readonly AutomationSensorInputRef[]
+  actionTaken: string
+  reviewed: boolean
+  assertsObjectiveTruth?: boolean
+  provenanceTag?: string
+}
+
+export interface InstitutionalAutomationEntry {
+  id: InstitutionalAutomationId
+  label: string
+  roleClass: AutomationRoleClass
+  authorityTier: AutomationAuthorityTier
+  personhoodStatus: AutomationPersonhoodStatus
+  sensorSuite: readonly AutomationSensorCapability[]
+  overridePath: AutomationOverridePath
+  ownerNodeId: string
+  trustScore: number
+  compromiseStatus: AutomationCompromiseStatus
+  failureMode: AutomationFailureMode
+  auditState: AutomationAuditState
+  actionLog: readonly AutomationActionRecord[]
+  dueProcessHookIds?: readonly string[]
+  seedRecord?: boolean
+  metadata?: Readonly<Record<string, string | number | boolean>>
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type AutomationRegistryValidationIssueCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'duplicate_action_id'
+  | 'invalid_trust_score'
+  | 'invalid_sensor_reliability'
+  | 'missing_owner_node_id'
+  | 'empty_sensor_suite'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_field'
+  | 'non_seed_missing_audit_trail'
+  | 'objective_truth_without_confidence'
+  | 'action_missing_required_fields'
+  | 'action_automation_id_mismatch'
+  | 'surveillance_tier_missing_due_process'
+  | 'emergency_tier_missing_due_process'
+
+export interface AutomationRegistryValidationIssue {
+  code: AutomationRegistryValidationIssueCode
+  detail: string
+  severity: 'error' | 'warning'
+  relatedIds?: readonly string[]
+}
+
+export interface AutomationRegistryValidationResult {
+  valid: boolean
+  issues: readonly AutomationRegistryValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Conflict resolution
+// ---------------------------------------------------------------------------
+
+export type AutomationConflictClaimSource = 'records' | 'sensors'
+
+export interface AutomationConflictClaim {
+  claimId: string
+  subjectRef: string
+  source: AutomationConflictClaimSource
+  assertedSummary: string
+  confidence: AutomationActionConfidence
+  week?: number
+}
+
+export interface AutomationConflictClaimOutcome {
+  claimId: string
+  preferred: boolean
+  reasonCode: string
+}
+
+export interface AutomationConflictResolution {
+  winnerBotId: InstitutionalAutomationId
+  loserBotId: InstitutionalAutomationId
+  reasonCode: string
+  claims: readonly AutomationConflictClaim[]
+  claimOutcomes: readonly AutomationConflictClaimOutcome[]
+}
+
+// ---------------------------------------------------------------------------
+// Operator feed projection
+// ---------------------------------------------------------------------------
+
+export type AutomationFeedRedactionReason =
+  | 'policy_withhold_confidence'
+  | 'policy_withhold_sensor_inputs'
+  | 'policy_withhold_operator'
+  | 'policy_withhold_action_detail'
+  | 'policy_unreviewed_action'
+
+export interface AutomationFeedProjectionPolicy {
+  minimumConfidence?: AutomationActionConfidence
+  redactSensorInputs?: boolean
+  redactOperatorIds?: boolean
+  redactUnreviewed?: boolean
+  redactActionDetailBelowConfidence?: AutomationActionConfidence
+}
+
+export interface ProjectedAutomationAction {
+  actionId: string
+  automationId: InstitutionalAutomationId
+  week?: number
+  triggerRuleId: string
+  operatorId?: string
+  actionTaken: string | null
+  confidence?: AutomationActionConfidence
+  sensorInputs?: readonly AutomationSensorInputRef[]
+  reviewed: boolean
+  redacted: boolean
+  redactionReasons: readonly AutomationFeedRedactionReason[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const AUTHORITY_TIER_ORDER: readonly AutomationAuthorityTier[] = [
+  'advisory',
+  'task_execution',
+  'field_autonomy',
+  'emergency_override',
+  'records_alteration',
+  'command_escalation',
+]
+
+const CONFIDENCE_ORDER: readonly AutomationActionConfidence[] = [
+  'rumor',
+  'low',
+  'medium',
+  'high',
+  'verified',
+]
+
+const COMPROMISE_SEVERITY: Readonly<Record<AutomationCompromiseStatus, number>> = {
+  none: 0,
+  suspected: 1,
+  contained: 2,
+  confirmed: 3,
+  isolated: 4,
+}
+
+const RECORDS_ROLE_CLASSES: ReadonlySet<AutomationRoleClass> = new Set([
+  'archive',
+  'classify',
+  'retrieve',
+])
+
+const SENSOR_ROLE_CLASSES: ReadonlySet<AutomationRoleClass> = new Set(['observe', 'patrol', 'warn'])
+
+const SURVEILLANCE_ROLE_CLASSES: ReadonlySet<AutomationRoleClass> = new Set(['observe', 'censor'])
+
+const HIGH_SURVEILLANCE_TIERS: ReadonlySet<AutomationAuthorityTier> = new Set([
+  'field_autonomy',
+  'emergency_override',
+  'records_alteration',
+  'command_escalation',
+])
+
+const DUE_PROCESS_TIERS: ReadonlySet<AutomationAuthorityTier> = new Set([
+  'emergency_override',
+  'records_alteration',
+])
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest)\b/i
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function uniqueSorted(values: readonly string[]) {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))].sort(
+    (left, right) => left.localeCompare(right)
+  )
+}
+
+function normalizeToken(value: string) {
+  return value.trim()
+}
+
+function normalizeReliability(value: number) {
+  if (!Number.isFinite(value)) {
+    return Number.NaN
+  }
+
+  return Number(Math.max(0, Math.min(1, value)).toFixed(4))
+}
+
+function authorityTierRank(tier: AutomationAuthorityTier) {
+  return AUTHORITY_TIER_ORDER.indexOf(tier)
+}
+
+function confidenceRank(confidence: AutomationActionConfidence) {
+  const rank = CONFIDENCE_ORDER.indexOf(confidence)
+  return rank >= 0 ? rank : -1
+}
+
+function isValidConfidence(confidence: AutomationActionConfidence | undefined) {
+  return confidence !== undefined && confidenceRank(confidence) >= 0
+}
+
+function pushIssue(
+  issues: AutomationRegistryValidationIssue[],
+  issue: AutomationRegistryValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: AutomationRegistryValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function tokenContainsFranchiseReference(token: string) {
+  return FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function auditTrailExempt(entry: InstitutionalAutomationEntry) {
+  return (
+    entry.seedRecord === true ||
+    entry.auditState === 'seed' ||
+    entry.auditState === 'provisional'
+  )
+}
+
+function requiresDueProcessHooks(entry: InstitutionalAutomationEntry) {
+  if (DUE_PROCESS_TIERS.has(entry.authorityTier)) {
+    return true
+  }
+
+  return (
+    SURVEILLANCE_ROLE_CLASSES.has(entry.roleClass) &&
+    HIGH_SURVEILLANCE_TIERS.has(entry.authorityTier)
+  )
+}
+
+function hasDueProcessHooks(entry: InstitutionalAutomationEntry) {
+  return (entry.dueProcessHookIds?.length ?? 0) > 0
+}
+
+function botSourceLean(
+  bot: InstitutionalAutomationEntry
+): AutomationConflictClaimSource {
+  if (RECORDS_ROLE_CLASSES.has(bot.roleClass)) {
+    return 'records'
+  }
+
+  if (SENSOR_ROLE_CLASSES.has(bot.roleClass)) {
+    return 'sensors'
+  }
+
+  return 'records'
+}
+
+function compareBotsForConflict(
+  botA: InstitutionalAutomationEntry,
+  botB: InstitutionalAutomationEntry
+): {
+  winner: InstitutionalAutomationEntry
+  loser: InstitutionalAutomationEntry
+  reasonCode: string
+} {
+  const tierDelta = authorityTierRank(botA.authorityTier) - authorityTierRank(botB.authorityTier)
+  if (tierDelta !== 0) {
+    return tierDelta > 0
+      ? { winner: botA, loser: botB, reasonCode: 'higher_authority_tier' }
+      : { winner: botB, loser: botA, reasonCode: 'higher_authority_tier' }
+  }
+
+  const leanA = botSourceLean(botA)
+  const leanB = botSourceLean(botB)
+  if (leanA === 'records' && leanB === 'sensors') {
+    return { winner: botA, loser: botB, reasonCode: 'records_over_sensors' }
+  }
+  if (leanB === 'records' && leanA === 'sensors') {
+    return { winner: botB, loser: botA, reasonCode: 'records_over_sensors' }
+  }
+
+  const trustDelta = botA.trustScore - botB.trustScore
+  if (trustDelta !== 0) {
+    return trustDelta > 0
+      ? { winner: botA, loser: botB, reasonCode: 'higher_trust_score' }
+      : { winner: botB, loser: botA, reasonCode: 'higher_trust_score' }
+  }
+
+  const compromiseDelta =
+    COMPROMISE_SEVERITY[botA.compromiseStatus] - COMPROMISE_SEVERITY[botB.compromiseStatus]
+  if (compromiseDelta !== 0) {
+    return compromiseDelta < 0
+      ? { winner: botA, loser: botB, reasonCode: 'lower_compromise_severity' }
+      : { winner: botB, loser: botA, reasonCode: 'lower_compromise_severity' }
+  }
+
+  const idCompare = botA.id.localeCompare(botB.id)
+  if (idCompare <= 0) {
+    return { winner: botA, loser: botB, reasonCode: 'stable_id_tiebreak' }
+  }
+
+  return { winner: botB, loser: botA, reasonCode: 'stable_id_tiebreak' }
+}
+
+function collectStringTokensFromEntry(entry: InstitutionalAutomationEntry, tokens: string[]) {
+  tokens.push(entry.id, entry.label, entry.ownerNodeId)
+
+  for (const sensor of entry.sensorSuite) {
+    tokens.push(sensor.sensorId, sensor.channel)
+  }
+
+  if (entry.overridePath.lockoutReasonCode) {
+    tokens.push(entry.overridePath.lockoutReasonCode)
+  }
+
+  for (const nodeId of entry.overridePath.escalationNodeIds) {
+    tokens.push(nodeId)
+  }
+
+  for (const hookId of entry.dueProcessHookIds ?? []) {
+    tokens.push(hookId)
+  }
+
+  for (const action of entry.actionLog) {
+    tokens.push(
+      action.actionId,
+      action.automationId,
+      action.triggerRuleId,
+      action.actionTaken
+    )
+    if (action.operatorId) {
+      tokens.push(action.operatorId)
+    }
+    if (action.provenanceTag) {
+      tokens.push(action.provenanceTag)
+    }
+    for (const input of action.sensorInputs) {
+      tokens.push(input.sensorId, input.readingCode)
+    }
+  }
+
+  for (const value of Object.values(entry.metadata ?? {})) {
+    if (typeof value === 'string') {
+      tokens.push(value)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateAutomationEntry(
+  entry: InstitutionalAutomationEntry
+): AutomationRegistryValidationResult {
+  const issues: AutomationRegistryValidationIssue[] = []
+  const id = normalizeToken(entry.id)
+  const label = normalizeToken(entry.label)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Automation entry is missing id.',
+    })
+  } else if (tokenContainsFranchiseReference(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Automation id ${id} contains a franchise or source-literal token.`,
+      relatedIds: [id],
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Automation entry is missing label.',
+      relatedIds: id ? [id] : undefined,
+    })
+  } else if (tokenContainsFranchiseReference(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Automation label ${label} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!normalizeToken(entry.ownerNodeId)) {
+    pushIssue(issues, {
+      code: 'missing_owner_node_id',
+      severity: 'error',
+      detail: `Automation ${id || '(unknown)'} is missing ownerNodeId.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const trustScore = entry.trustScore
+  if (
+    !Number.isFinite(trustScore) ||
+    trustScore < 0 ||
+    trustScore > 100 ||
+    trustScore !== Math.trunc(trustScore)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_trust_score',
+      severity: 'error',
+      detail: `Automation ${id || '(unknown)'} trustScore must be a finite integer between 0 and 100.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (entry.sensorSuite.length === 0) {
+    pushIssue(issues, {
+      code: 'empty_sensor_suite',
+      severity: 'error',
+      detail: `Automation ${id || '(unknown)'} requires at least one sensor capability.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const sensor of entry.sensorSuite) {
+    const reliability = normalizeReliability(sensor.reliability)
+    if (!Number.isFinite(reliability)) {
+      pushIssue(issues, {
+        code: 'invalid_sensor_reliability',
+        severity: 'error',
+        detail: `Sensor ${sensor.sensorId} reliability must be a finite number between 0 and 1.`,
+        relatedIds: uniqueSorted([id, sensor.sensorId]),
+      })
+    }
+
+    for (const token of [sensor.sensorId, sensor.channel]) {
+      if (tokenContainsFranchiseReference(token)) {
+        pushIssue(issues, {
+          code: 'franchise_token_in_field',
+          severity: 'error',
+          detail: `Sensor field ${token} contains a franchise or source-literal token.`,
+          relatedIds: uniqueSorted([id, sensor.sensorId]),
+        })
+      }
+    }
+  }
+
+  if (!auditTrailExempt(entry) && entry.actionLog.length === 0) {
+    pushIssue(issues, {
+      code: 'non_seed_missing_audit_trail',
+      severity: 'error',
+      detail: `Automation ${id || '(unknown)'} requires an audit actionLog unless seed/provisional.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const seenActionIds = new Set<string>()
+  for (const action of entry.actionLog) {
+    const actionId = normalizeToken(action.actionId)
+    if (!actionId) {
+      pushIssue(issues, {
+        code: 'action_missing_required_fields',
+        severity: 'error',
+        detail: 'Automation action is missing actionId.',
+        relatedIds: id ? [id] : undefined,
+      })
+    } else if (seenActionIds.has(actionId)) {
+      pushIssue(issues, {
+        code: 'duplicate_action_id',
+        severity: 'error',
+        detail: `Duplicate action id ${actionId}.`,
+        relatedIds: uniqueSorted([id, actionId]),
+      })
+    } else {
+      seenActionIds.add(actionId)
+    }
+
+    if (id && normalizeToken(action.automationId) !== id) {
+      pushIssue(issues, {
+        code: 'action_automation_id_mismatch',
+        severity: 'error',
+        detail: `Action ${actionId || '(unknown)'} automationId does not match entry id ${id}.`,
+        relatedIds: uniqueSorted([id, actionId]),
+      })
+    }
+
+    const missingFields: string[] = []
+    if (!normalizeToken(action.triggerRuleId)) {
+      missingFields.push('triggerRuleId')
+    }
+    if (!normalizeToken(action.actionTaken)) {
+      missingFields.push('actionTaken')
+    }
+    if (action.reviewed !== true && action.reviewed !== false) {
+      missingFields.push('reviewed')
+    }
+    if (!Array.isArray(action.sensorInputs)) {
+      missingFields.push('sensorInputs')
+    }
+
+    if (missingFields.length > 0) {
+      pushIssue(issues, {
+        code: 'action_missing_required_fields',
+        severity: 'error',
+        detail: `Action ${actionId || '(unknown)'} is missing required fields: ${missingFields.join(', ')}.`,
+        relatedIds: uniqueSorted([id, actionId]),
+      })
+    }
+
+    if (action.assertsObjectiveTruth === true && !isValidConfidence(action.confidence)) {
+      pushIssue(issues, {
+        code: 'objective_truth_without_confidence',
+        severity: 'error',
+        detail: `Action ${actionId || '(unknown)'} asserts objective truth without valid confidence.`,
+        relatedIds: uniqueSorted([id, actionId]),
+      })
+    }
+
+    for (const token of [action.actionTaken, action.triggerRuleId, action.provenanceTag ?? '']) {
+      if (token && tokenContainsFranchiseReference(token)) {
+        pushIssue(issues, {
+          code: 'franchise_token_in_field',
+          severity: 'error',
+          detail: `Action field for ${actionId || '(unknown)'} contains a franchise or source-literal token.`,
+          relatedIds: uniqueSorted([id, actionId]),
+        })
+      }
+    }
+  }
+
+  if (requiresDueProcessHooks(entry) && !hasDueProcessHooks(entry)) {
+    const code = DUE_PROCESS_TIERS.has(entry.authorityTier)
+      ? 'emergency_tier_missing_due_process'
+      : 'surveillance_tier_missing_due_process'
+
+    pushIssue(issues, {
+      code,
+      severity: 'warning',
+      detail: `Automation ${id || '(unknown)'} requires dueProcessHookIds for its authority/surveillance posture.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+export function resolveAutomationConflict(
+  botA: InstitutionalAutomationEntry,
+  botB: InstitutionalAutomationEntry,
+  claims: readonly AutomationConflictClaim[]
+): AutomationConflictResolution {
+  const sortedClaims = Object.freeze(
+    [...claims]
+      .sort((left, right) => left.claimId.localeCompare(right.claimId))
+      .map((claim) => Object.freeze({ ...claim }))
+  )
+
+  const { winner, loser, reasonCode } = compareBotsForConflict(botA, botB)
+  const winnerLean = botSourceLean(winner)
+
+  const claimOutcomes = sortedClaims.map((claim) => {
+    const preferred = claim.source === winnerLean
+    return Object.freeze({
+      claimId: claim.claimId,
+      preferred,
+      reasonCode: preferred ? 'winner_source_aligned' : 'winner_source_opposed',
+    })
+  })
+
+  return Object.freeze({
+    winnerBotId: winner.id,
+    loserBotId: loser.id,
+    reasonCode,
+    claims: sortedClaims,
+    claimOutcomes: Object.freeze(claimOutcomes),
+  })
+}
+
+export function projectAutomationFeedForOperator(
+  actions: readonly AutomationActionRecord[],
+  policy: AutomationFeedProjectionPolicy
+): readonly ProjectedAutomationAction[] {
+  const sortedActions = [...actions].sort((left, right) => {
+    const weekLeft = left.week ?? 0
+    const weekRight = right.week ?? 0
+    if (weekLeft !== weekRight) {
+      return weekLeft - weekRight
+    }
+
+    return left.actionId.localeCompare(right.actionId)
+  })
+
+  const projected = sortedActions.map((action) => {
+    const redactionReasons: AutomationFeedRedactionReason[] = []
+
+    const minimumRank = policy.minimumConfidence
+      ? confidenceRank(policy.minimumConfidence)
+      : undefined
+    const actionRank = confidenceRank(action.confidence)
+    const redactDetailRank = policy.redactActionDetailBelowConfidence
+      ? confidenceRank(policy.redactActionDetailBelowConfidence)
+      : undefined
+
+    let actionTaken: string | null = action.actionTaken
+    let confidence: AutomationActionConfidence | undefined = action.confidence
+    let operatorId: string | undefined = action.operatorId
+    let includeSensorInputs = action.sensorInputs.length > 0
+
+    if (minimumRank !== undefined && actionRank < minimumRank) {
+      redactionReasons.push('policy_withhold_confidence')
+      confidence = undefined
+    }
+
+    if (redactDetailRank !== undefined && actionRank < redactDetailRank) {
+      redactionReasons.push('policy_withhold_action_detail')
+      actionTaken = null
+    }
+
+    if (policy.redactUnreviewed && !action.reviewed) {
+      redactionReasons.push('policy_unreviewed_action')
+      actionTaken = null
+    }
+
+    if (policy.redactOperatorIds) {
+      redactionReasons.push('policy_withhold_operator')
+      operatorId = undefined
+    }
+
+    if (policy.redactSensorInputs) {
+      redactionReasons.push('policy_withhold_sensor_inputs')
+      includeSensorInputs = false
+    }
+
+    const uniqueReasons = uniqueSorted(redactionReasons) as AutomationFeedRedactionReason[]
+    const redacted = uniqueReasons.length > 0
+
+    return Object.freeze({
+      actionId: action.actionId,
+      automationId: action.automationId,
+      ...(action.week !== undefined ? { week: action.week } : {}),
+      triggerRuleId: action.triggerRuleId,
+      ...(operatorId ? { operatorId } : {}),
+      actionTaken,
+      ...(confidence ? { confidence } : {}),
+      ...(includeSensorInputs
+        ? { sensorInputs: Object.freeze([...action.sensorInputs]) }
+        : {}),
+      reviewed: action.reviewed,
+      redacted,
+      redactionReasons: Object.freeze(uniqueReasons),
+    })
+  })
+
+  return Object.freeze(projected)
+}
+
+export function collectInstitutionalAutomationTokens(
+  entry: InstitutionalAutomationEntry
+): readonly string[] {
+  const tokens: string[] = []
+  collectStringTokensFromEntry(entry, tokens)
+  return uniqueSorted(tokens)
+}
+
+export function institutionalAutomationTokensContainFranchiseReferences(
+  tokens: readonly string[]
+) {
+  return tokens.some((token) => tokenContainsFranchiseReference(token))
+}

--- a/src/domain/institutionalAutomationRegistry.ts
+++ b/src/domain/institutionalAutomationRegistry.ts
@@ -295,12 +295,8 @@ function normalizeToken(value: string) {
   return value.trim()
 }
 
-function normalizeReliability(value: number) {
-  if (!Number.isFinite(value)) {
-    return Number.NaN
-  }
-
-  return Number(Math.max(0, Math.min(1, value)).toFixed(4))
+function isRawReliabilityValid(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
 }
 
 function authorityTierRank(tier: AutomationAuthorityTier) {
@@ -547,14 +543,14 @@ export function validateAutomationEntry(
   }
 
   for (const sensor of entry.sensorSuite) {
-    const reliability = normalizeReliability(sensor.reliability)
-    if (!Number.isFinite(reliability)) {
+    if (!isRawReliabilityValid(sensor.reliability)) {
       pushIssue(issues, {
         code: 'invalid_sensor_reliability',
         severity: 'error',
         detail: `Sensor ${sensor.sensorId} reliability must be a finite number between 0 and 1.`,
         relatedIds: uniqueSorted([id, sensor.sensorId]),
       })
+      continue
     }
 
     for (const token of [sensor.sensorId, sensor.channel]) {

--- a/src/test/institutionalAutomationRegistry.test.ts
+++ b/src/test/institutionalAutomationRegistry.test.ts
@@ -1,0 +1,389 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type {
+  AutomationActionRecord,
+  AutomationConflictClaim,
+  InstitutionalAutomationEntry,
+} from '../domain/institutionalAutomationRegistry'
+import {
+  collectInstitutionalAutomationTokens,
+  institutionalAutomationTokensContainFranchiseReferences,
+  projectAutomationFeedForOperator,
+  resolveAutomationConflict,
+  validateAutomationEntry,
+} from '../domain/institutionalAutomationRegistry'
+
+function baseAction(
+  overrides: Partial<AutomationActionRecord> = {}
+): AutomationActionRecord {
+  return {
+    actionId: 'act-base',
+    automationId: 'auto:perimeter-scan-1',
+    week: 4,
+    triggerRuleId: 'rule:corridor-threshold',
+    operatorId: 'operator:shift-lead',
+    confidence: 'medium',
+    sensorInputs: [{ sensorId: 'sensor:thermal-1', readingCode: 'heat_spike', strength: 0.72 }],
+    actionTaken: 'Issued corridor hold advisory',
+    reviewed: true,
+    provenanceTag: 'dispatch_log',
+    ...overrides,
+  }
+}
+
+function baseEntry(
+  overrides: Partial<InstitutionalAutomationEntry> = {}
+): InstitutionalAutomationEntry {
+  return {
+    id: 'auto:perimeter-scan-1',
+    label: 'Perimeter Scan Agent',
+    roleClass: 'observe',
+    authorityTier: 'task_execution',
+    personhoodStatus: 'tool',
+    sensorSuite: [{ sensorId: 'sensor:thermal-1', channel: 'thermal', reliability: 0.85 }],
+    overridePath: {
+      requiresHumanAck: true,
+      escalationNodeIds: ['node:perimeter-ops'],
+    },
+    ownerNodeId: 'node:perimeter-ops',
+    trustScore: 72,
+    compromiseStatus: 'none',
+    failureMode: 'false_negative',
+    auditState: 'active',
+    actionLog: [baseAction()],
+    ...overrides,
+  }
+}
+
+describe('institutionalAutomationRegistry slice 1 (SPE-2101)', () => {
+  it('1. two bots with different roleClass + authorityTier validate independently', () => {
+    const patrolBot = baseEntry({
+      id: 'auto:patrol-relay-1',
+      label: 'Corridor Patrol Relay',
+      roleClass: 'patrol',
+      authorityTier: 'field_autonomy',
+      dueProcessHookIds: ['hook:patrol-oversight'],
+      actionLog: [
+        baseAction({
+          actionId: 'act-patrol-1',
+          automationId: 'auto:patrol-relay-1',
+        }),
+      ],
+    })
+    const archiveBot = baseEntry({
+      id: 'auto:records-index-1',
+      label: 'Records Index Automaton',
+      roleClass: 'archive',
+      authorityTier: 'records_alteration',
+      dueProcessHookIds: ['hook:records-review'],
+      actionLog: [
+        baseAction({
+          actionId: 'act-records-1',
+          automationId: 'auto:records-index-1',
+          actionTaken: 'Reindexed corridor incident packet',
+        }),
+      ],
+    })
+
+    expect(validateAutomationEntry(patrolBot).valid).toBe(true)
+    expect(validateAutomationEntry(archiveBot).valid).toBe(true)
+  })
+
+  it('2. seed entry may lack action audit trail when explicitly marked seed/provisional', () => {
+    const seedEntry = baseEntry({
+      auditState: 'seed',
+      seedRecord: true,
+      actionLog: [],
+    })
+    const provisionalEntry = baseEntry({
+      id: 'auto:provisional-1',
+      auditState: 'provisional',
+      actionLog: [],
+    })
+
+    expect(validateAutomationEntry(seedEntry).valid).toBe(true)
+    expect(validateAutomationEntry(provisionalEntry).valid).toBe(true)
+  })
+
+  it('3. non-seed entry without audit trail errors', () => {
+    const result = validateAutomationEntry(
+      baseEntry({
+        auditState: 'active',
+        actionLog: [],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'non_seed_missing_audit_trail')).toBe(true)
+  })
+
+  it('4. franchise/source-like bot name pattern errors', () => {
+    const result = validateAutomationEntry(
+      baseEntry({
+        id: 'auto:mobile-task-force-scanner',
+        label: 'Mobile Task Force Scanner',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.issues.some(
+        (issue) =>
+          issue.code === 'franchise_token_in_id' || issue.code === 'franchise_token_in_label'
+      )
+    ).toBe(true)
+  })
+
+  it('5. objective-truth output without confidence errors', () => {
+    const validObjective = validateAutomationEntry(
+      baseEntry({
+        actionLog: [
+          baseAction({
+            actionId: 'act-objective-valid',
+            assertsObjectiveTruth: true,
+            confidence: 'verified',
+          }),
+        ],
+      })
+    )
+
+    expect(validObjective.valid).toBe(true)
+    expect(
+      validObjective.issues.some((issue) => issue.code === 'objective_truth_without_confidence')
+    ).toBe(false)
+
+    const invalidAction = baseAction({
+      actionId: 'act-invalid-confidence',
+      assertsObjectiveTruth: true,
+      confidence: 'verified',
+    })
+    ;(invalidAction as { confidence: string }).confidence = 'invalid-confidence'
+
+    const badResult = validateAutomationEntry(
+      baseEntry({
+        actionLog: [invalidAction],
+      })
+    )
+
+    expect(badResult.valid).toBe(false)
+    expect(badResult.issues.some((issue) => issue.code === 'objective_truth_without_confidence')).toBe(
+      true
+    )
+  })
+
+  it('6. surveillance/emergency tier without due-process hook IDs warns', () => {
+    const surveillanceWarning = validateAutomationEntry(
+      baseEntry({
+        roleClass: 'observe',
+        authorityTier: 'field_autonomy',
+        dueProcessHookIds: [],
+      })
+    )
+
+    expect(surveillanceWarning.valid).toBe(true)
+    expect(
+      surveillanceWarning.issues.some((issue) => issue.code === 'surveillance_tier_missing_due_process')
+    ).toBe(true)
+
+    const emergencyWarning = validateAutomationEntry(
+      baseEntry({
+        roleClass: 'archive',
+        authorityTier: 'emergency_override',
+        dueProcessHookIds: undefined,
+      })
+    )
+
+    expect(
+      emergencyWarning.issues.some((issue) => issue.code === 'emergency_tier_missing_due_process')
+    ).toBe(true)
+  })
+
+  it('7. audit action record includes trigger, operator, confidence, sensor inputs, action taken, and reviewed flag', () => {
+    const entry = baseEntry()
+    const action = entry.actionLog[0]
+
+    expect(action?.triggerRuleId).toBe('rule:corridor-threshold')
+    expect(action?.operatorId).toBe('operator:shift-lead')
+    expect(action?.confidence).toBe('medium')
+    expect(action?.sensorInputs.length).toBeGreaterThan(0)
+    expect(action?.actionTaken.length).toBeGreaterThan(0)
+    expect(action?.reviewed).toBe(true)
+    expect(validateAutomationEntry(entry).valid).toBe(true)
+  })
+
+  it('8. conflict resolver returns deterministic winner metadata', () => {
+    const recordsBot = baseEntry({
+      id: 'auto:records-bot',
+      roleClass: 'archive',
+      authorityTier: 'records_alteration',
+      trustScore: 60,
+    })
+    const sensorBot = baseEntry({
+      id: 'auto:sensor-bot',
+      roleClass: 'observe',
+      authorityTier: 'task_execution',
+      trustScore: 90,
+    })
+    const claims: AutomationConflictClaim[] = [
+      {
+        claimId: 'claim-b',
+        subjectRef: 'corridor-7',
+        source: 'sensors',
+        assertedSummary: 'Heat anomaly detected',
+        confidence: 'high',
+      },
+      {
+        claimId: 'claim-a',
+        subjectRef: 'corridor-7',
+        source: 'records',
+        assertedSummary: 'Corridor already cleared in records',
+        confidence: 'medium',
+      },
+    ]
+
+    const first = resolveAutomationConflict(recordsBot, sensorBot, claims)
+    const second = resolveAutomationConflict(recordsBot, sensorBot, claims)
+
+    expect(first).toEqual(second)
+    expect(first.winnerBotId).toBe('auto:records-bot')
+    expect(first.reasonCode).toBe('higher_authority_tier')
+  })
+
+  it('9. conflict resolver preserves both claims in output', () => {
+    const botA = baseEntry({ id: 'auto:a', roleClass: 'archive', authorityTier: 'advisory' })
+    const botB = baseEntry({
+      id: 'auto:b',
+      roleClass: 'observe',
+      authorityTier: 'advisory',
+      trustScore: 50,
+    })
+    const claims: AutomationConflictClaim[] = [
+      {
+        claimId: 'c-2',
+        subjectRef: 'wing-3',
+        source: 'sensors',
+        assertedSummary: 'Motion trace',
+        confidence: 'low',
+      },
+      {
+        claimId: 'c-1',
+        subjectRef: 'wing-3',
+        source: 'records',
+        assertedSummary: 'Wing sealed',
+        confidence: 'low',
+      },
+    ]
+
+    const resolution = resolveAutomationConflict(botA, botB, claims)
+
+    expect(resolution.claims).toHaveLength(2)
+    expect(resolution.claimOutcomes).toHaveLength(2)
+    expect(resolution.claims.map((claim) => claim.claimId)).toEqual(['c-1', 'c-2'])
+  })
+
+  it('10. operator projection redacts per policy', () => {
+    const projected = projectAutomationFeedForOperator(
+      [
+        baseAction({ actionId: 'act-1', confidence: 'low', reviewed: false }),
+        baseAction({ actionId: 'act-2', confidence: 'high', reviewed: true }),
+      ],
+      {
+        minimumConfidence: 'medium',
+        redactUnreviewed: true,
+        redactOperatorIds: true,
+        redactSensorInputs: true,
+      }
+    )
+
+    const low = projected.find((item) => item.actionId === 'act-1')
+    const high = projected.find((item) => item.actionId === 'act-2')
+
+    expect(low?.redacted).toBe(true)
+    expect(low?.confidence).toBeUndefined()
+    expect(low?.operatorId).toBeUndefined()
+    expect(low?.sensorInputs).toBeUndefined()
+    expect(low?.actionTaken).toBeNull()
+
+    expect(high?.confidence).toBe('high')
+    expect(high?.operatorId).toBeUndefined()
+    expect(high?.sensorInputs).toBeUndefined()
+  })
+
+  it('11. operator projection can include reason codes for redaction', () => {
+    const projected = projectAutomationFeedForOperator(
+      [baseAction({ confidence: 'low', reviewed: false })],
+      {
+        redactActionDetailBelowConfidence: 'medium',
+        redactUnreviewed: true,
+      }
+    )[0]
+
+    expect(projected?.redactionReasons).toContain('policy_withhold_action_detail')
+    expect(projected?.redactionReasons).toContain('policy_unreviewed_action')
+    expect(projected?.redacted).toBe(true)
+  })
+
+  it('12. byte-stable repeated validation', () => {
+    const entry = baseEntry()
+    const first = JSON.stringify(validateAutomationEntry(entry))
+    const second = JSON.stringify(validateAutomationEntry(entry))
+
+    expect(first).toBe(second)
+  })
+
+  it('13. inputs are not mutated', () => {
+    const entry = structuredClone(baseEntry())
+    const claims: AutomationConflictClaim[] = [
+      {
+        claimId: 'claim-1',
+        subjectRef: 'zone-a',
+        source: 'records',
+        assertedSummary: 'Seal intact',
+        confidence: 'medium',
+      },
+    ]
+    const actions = structuredClone([baseAction()])
+    const botB = structuredClone(
+      baseEntry({ id: 'auto:sensor-bot', roleClass: 'observe', authorityTier: 'advisory' })
+    )
+
+    const entryBefore = structuredClone(entry)
+    const claimsBefore = structuredClone(claims)
+    const actionsBefore = structuredClone(actions)
+
+    validateAutomationEntry(entry)
+    resolveAutomationConflict(entry, botB, claims)
+    projectAutomationFeedForOperator(actions, { redactOperatorIds: true })
+
+    expect(entry).toEqual(entryBefore)
+    expect(claims).toEqual(claimsBefore)
+    expect(actions).toEqual(actionsBefore)
+  })
+
+  it('14. module does not import GameState, React/UI, or live registry modules', () => {
+    const source = readFileSync(resolve('src/domain/institutionalAutomationRegistry.ts'), 'utf8')
+
+    expect(source).not.toMatch(/^import\b/m)
+    expect(source).not.toMatch(/from ['"]react/)
+    expect(source).not.toMatch(/liveRegistry/)
+    expect(source).not.toMatch(/authorityGraph/)
+    expect(source).not.toMatch(/specialistUnits/)
+  })
+
+  it('15. fixture labels and ids contain no source/franchise tokens', () => {
+    const entries = [
+      baseEntry(),
+      baseEntry({
+        id: 'auto:records-index-1',
+        label: 'Records Index Automaton',
+        roleClass: 'archive',
+      }),
+    ]
+
+    for (const entry of entries) {
+      const tokens = collectInstitutionalAutomationTokens(entry)
+      expect(institutionalAutomationTokensContainFranchiseReferences(tokens)).toBe(false)
+    }
+  })
+})

--- a/src/test/institutionalAutomationRegistry.test.ts
+++ b/src/test/institutionalAutomationRegistry.test.ts
@@ -135,6 +135,54 @@ describe('institutionalAutomationRegistry slice 1 (SPE-2101)', () => {
     ).toBe(true)
   })
 
+  it('rejects sensor reliability below 0 before normalization', () => {
+    const result = validateAutomationEntry(
+      baseEntry({
+        sensorSuite: [{ sensorId: 'sensor:thermal-1', channel: 'thermal', reliability: -0.2 }],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'invalid_sensor_reliability')).toBe(true)
+  })
+
+  it('rejects sensor reliability above 1 before normalization', () => {
+    for (const reliability of [1.5, 1.8]) {
+      const result = validateAutomationEntry(
+        baseEntry({
+          sensorSuite: [{ sensorId: 'sensor:thermal-1', channel: 'thermal', reliability }],
+        })
+      )
+
+      expect(result.valid).toBe(false)
+      expect(result.issues.some((issue) => issue.code === 'invalid_sensor_reliability')).toBe(true)
+    }
+  })
+
+  it('accepts sensor reliability at 0 and 1', () => {
+    for (const reliability of [0, 1]) {
+      const result = validateAutomationEntry(
+        baseEntry({
+          sensorSuite: [{ sensorId: 'sensor:thermal-1', channel: 'thermal', reliability }],
+        })
+      )
+
+      expect(result.issues.some((issue) => issue.code === 'invalid_sensor_reliability')).toBe(false)
+    }
+  })
+
+  it('rejects malformed non-number sensor reliability without throwing', () => {
+    const entry = baseEntry({
+      sensorSuite: [{ sensorId: 'sensor:thermal-1', channel: 'thermal', reliability: 0.5 }],
+    })
+    ;(entry.sensorSuite[0] as { reliability: unknown }).reliability = 'bad'
+
+    expect(() => validateAutomationEntry(entry)).not.toThrow()
+    const result = validateAutomationEntry(entry)
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'invalid_sensor_reliability')).toBe(true)
+  })
+
   it('5. objective-truth output without confidence errors', () => {
     const validObjective = validateAutomationEntry(
       baseEntry({


### PR DESCRIPTION
## Summary

Adds a pure deterministic institutional automation registry (SPE-2101 slice 1) for fallible institutional automation agents: role class, authority tier, audit trail, conflict resolution, and operator feed projection.

- Linear: https://linear.app/spectranoir/issue/SPE-2101/institutional-automation-registry-roles-authority-tiers-audit-trail
- Harvest traceability: `foundation-bots-provisional-30` (provisional source; structural patterns only)

## Smallest boundary

Fixture-only domain module with no runtime wiring. Validates registry entries, resolves records-vs-sensors conflicts deterministically, and projects a redacted operator action feed from policy.

## Files changed (SPE-2101 only)

- `src/domain/institutionalAutomationRegistry.ts` — types, `validateAutomationEntry`, `resolveAutomationConflict`, `projectAutomationFeedForOperator`, franchise token lint
- `src/test/institutionalAutomationRegistry.test.ts` — acceptance + reliability regression tests

**Scope note:** Branch was rebased onto latest `main` (includes merged SPE-788 #2155/#2156). PR no longer carries authorityGraph/authorityNegotiation diffs.

## Review hardening (379ea5c)

- Validate **raw** `sensor.reliability` before any clamp/normalize; emit `invalid_sensor_reliability` for out-of-range finite values
- Regression tests for `< 0`, `> 1`, boundary `0`/`1`, and malformed non-number runtime values

## Dispositions (out of scope for SPE-2101)

- **Franchise regex centralization:** deferred follow-up; local helper kept to avoid cross-module refactor
- **SPE-788 authorityNegotiation/graph threads:** outdated after rebase; no longer in this PR diff

## Validation run

- `npm run test:run -- src/test/institutionalAutomationRegistry.test.ts` — 19/19 passed
- `npm run lint` — passed
- `git diff --check` — passed
- `npm run test:run` — 337 files, 3344 tests passed
- `npm run build` — fails on known baseline TS drift outside this PR (e.g. `branchContinuity.ts`, `capabilityGap.ts`, `procurementEmergency.ts`); **no errors in SPE-2101 files**

## Gap / edge-case / boundary audit

- `ownerNodeId` is opaque; not validated against `authorityGraph` in this slice
- Conflict resolver is pairwise; multi-bot conflicts are caller-chained
- Seed/provisional entries may omit `actionLog`; active entries require audit trail
- Operator projection is separate from SPE-1045 live registry / alert-center worklist

## Explicit out of scope

- GameState persistence
- UI
- alert-center wire-up
- liveRegistry / live entity registry integration
- authorityGraph owner-edge integration
- specialist unit integration
- autonomous containment actuation runtime
- distributed perception runtime
- culpability investigation workflow
- real departments, franchise bot names, wiki canon, or source-literal labels

## Test plan

- [x] Targeted SPE-2101 test file (19 cases)
- [x] Full test suite
- [x] ESLint