### PR TITLE
SPE-2093: Branch continuity structured seed prerequisite validation

### DIFF
--- a/src/domain/branchContinuity.ts
+++ b/src/domain/branchContinuity.ts
@@ -16,7 +16,7 @@ export interface BranchSimulationTruth {
 export interface BranchPathFacts {
   pathId: string
   acquiredItemIds: readonly string[]
-  seedValues: Readonly<Record<string, string | number | boolean>>
+  seedValues: Readonly<Record<string, BranchSeedValue>>
   roomOfOriginId?: string
   companionStatusById: Readonly<Record<string, BranchCompanionStatus>>
   injuryStatusBySubjectId: Readonly<Record<string, BranchInjuryStatus>>
@@ -214,28 +214,55 @@ function hasPriorChoice(pathFacts: BranchPathFacts, choiceId: string) {
   return pathFacts.priorChoiceIds.includes(choiceId)
 }
 
-function isBranchSeedValue(value: unknown): value is BranchSeedValue {
+export function isBranchSeedNumber(value: number): boolean {
+  return Number.isFinite(value) && Number.isInteger(value)
+}
+
+export function isBranchSeedValue(value: unknown): value is BranchSeedValue {
   return (
     typeof value === 'string' ||
     typeof value === 'boolean' ||
-    (typeof value === 'number' && Number.isFinite(value))
+    (typeof value === 'number' && isBranchSeedNumber(value))
   )
 }
 
+/** Coerces JSON/runtime values into a comparable seed value; non-integer numbers are rejected. */
+export function normalizeBranchSeedValue(value: unknown): BranchSeedValue | undefined {
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'number' && isBranchSeedNumber(value)) {
+    return value
+  }
+
+  return undefined
+}
+
 function seedValuesMatch(actual: BranchSeedValue | undefined, required: BranchSeedValue) {
-  if (actual === undefined) {
-    return false
+  return actual !== undefined && actual === required
+}
+
+function buildRequiredSeedEntries(
+  requiredSeedValues: Readonly<Record<string, BranchSeedValue>> | undefined
+): ReadonlyArray<readonly [string, BranchSeedValue]> {
+  const merged: Record<string, BranchSeedValue> = {}
+
+  for (const [rawKey, rawValue] of Object.entries(requiredSeedValues ?? {})) {
+    const seedKey = normalizeString(rawKey)
+    if (seedKey.length === 0) {
+      continue
+    }
+
+    const normalizedValue = normalizeBranchSeedValue(rawValue)
+    if (normalizedValue === undefined) {
+      continue
+    }
+
+    merged[seedKey] = normalizedValue
   }
 
-  if (typeof actual !== typeof required) {
-    return false
-  }
-
-  if (typeof required === 'number') {
-    return Math.trunc(actual as number) === Math.trunc(required)
-  }
-
-  return actual === required
+  return Object.entries(merged).sort(([left], [right]) => left.localeCompare(right))
 }
 
 function hasSeedKey(pathFacts: BranchPathFacts, seedKey: string) {
@@ -469,16 +496,7 @@ function validateRequires(
     }
   }
 
-  const requiredSeedEntries = Object.entries(requires.requiredSeedValues ?? {})
-    .map(([seedKey, seedValue]) => [normalizeString(seedKey), seedValue] as const)
-    .filter(([seedKey]) => seedKey.length > 0)
-    .sort(([left], [right]) => left.localeCompare(right))
-
-  for (const [seedKey, requiredValue] of requiredSeedEntries) {
-    if (!isBranchSeedValue(requiredValue)) {
-      continue
-    }
-
+  for (const [seedKey, requiredValue] of buildRequiredSeedEntries(requires.requiredSeedValues)) {
     const actualValue = pathFacts.seedValues[seedKey]
     if (seedValuesMatch(actualValue, requiredValue)) {
       continue
@@ -503,18 +521,21 @@ function validateRequires(
   }
 
   const anyRequiredSeedKeys = normalizeStringList(requires.anyRequiredSeedKeys)
+  const sortedAnyRequiredSeedKeys = [...anyRequiredSeedKeys].sort((left, right) =>
+    left.localeCompare(right)
+  )
   if (
-    anyRequiredSeedKeys.length > 0 &&
-    !anyRequiredSeedKeys.some((seedKey) => hasSeedKey(pathFacts, seedKey))
+    sortedAnyRequiredSeedKeys.length > 0 &&
+    !sortedAnyRequiredSeedKeys.some((seedKey) => hasSeedKey(pathFacts, seedKey))
   ) {
     pushWarning(warnings, {
       pathId,
       nodeId,
       warningClass: 'missing_seed_prerequisite',
       audience: 'simulation',
-      summary: `Node requires at least one seed key among ${anyRequiredSeedKeys.join(', ')}, but the path has none.`,
-      relatedIds: anyRequiredSeedKeys,
-      detailKey: `any-seed:${anyRequiredSeedKeys.join('|')}`,
+      summary: `Node requires at least one seed key among ${sortedAnyRequiredSeedKeys.join(', ')}, but the path has none.`,
+      relatedIds: sortedAnyRequiredSeedKeys,
+      detailKey: `any-seed:${sortedAnyRequiredSeedKeys.join('|')}`,
     })
   }
 }

--- a/src/domain/branchContinuity.ts
+++ b/src/domain/branchContinuity.ts
@@ -26,6 +26,8 @@ export interface BranchPathFacts {
   simulationTruth?: BranchSimulationTruth
 }
 
+export type BranchSeedValue = string | number | boolean
+
 export interface BranchNodeRequirements {
   anyItemIds?: readonly string[]
   allItemIds?: readonly string[]
@@ -36,6 +38,17 @@ export interface BranchNodeRequirements {
   learnedClueIds?: readonly string[]
   priorChoiceIds?: readonly string[]
   requiredRecordRevisionIds?: readonly string[]
+  /**
+   * Exact key→value match against `BranchPathFacts.seedValues`.
+   * Use full global-flag ids (e.g. `branch.seed.doorCode`) when auditing from GameState projection.
+   */
+  requiredSeedValues?: Readonly<Record<string, BranchSeedValue>>
+  /**
+   * At least one listed key must exist in `BranchPathFacts.seedValues` (presence only).
+   * Does not require truthy values — `false` or `0` still satisfies. Prefer `requiredSeedValues`
+   * when the node needs a specific flag value.
+   */
+  anyRequiredSeedKeys?: readonly string[]
 }
 
 export interface BranchPlayerKnowledgeAssumption {
@@ -66,6 +79,7 @@ export interface BranchCorrectedRecord {
 
 export type BranchContinuityWarningClass =
   | 'missing_item'
+  | 'missing_seed_prerequisite'
   | 'companion_status_mismatch'
   | 'missing_prior_choice'
   | 'injury_contradiction'
@@ -110,6 +124,7 @@ export interface BranchContinuityValidationInput {
 
 const ERROR_WARNING_CLASSES = new Set<BranchContinuityWarningClass>([
   'missing_item',
+  'missing_seed_prerequisite',
   'companion_status_mismatch',
   'missing_prior_choice',
   'injury_contradiction',
@@ -119,6 +134,7 @@ const ERROR_WARNING_CLASSES = new Set<BranchContinuityWarningClass>([
 
 const WARNING_CLASS_ORDER: readonly BranchContinuityWarningClass[] = [
   'missing_item',
+  'missing_seed_prerequisite',
   'companion_status_mismatch',
   'missing_prior_choice',
   'injury_contradiction',
@@ -196,6 +212,34 @@ function hasLearnedClue(pathFacts: BranchPathFacts, clueId: string) {
 
 function hasPriorChoice(pathFacts: BranchPathFacts, choiceId: string) {
   return pathFacts.priorChoiceIds.includes(choiceId)
+}
+
+function isBranchSeedValue(value: unknown): value is BranchSeedValue {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  )
+}
+
+function seedValuesMatch(actual: BranchSeedValue | undefined, required: BranchSeedValue) {
+  if (actual === undefined) {
+    return false
+  }
+
+  if (typeof actual !== typeof required) {
+    return false
+  }
+
+  if (typeof required === 'number') {
+    return Math.trunc(actual as number) === Math.trunc(required)
+  }
+
+  return actual === required
+}
+
+function hasSeedKey(pathFacts: BranchPathFacts, seedKey: string) {
+  return Object.prototype.hasOwnProperty.call(pathFacts.seedValues, seedKey)
 }
 
 function isHiddenSimulationEvent(pathFacts: BranchPathFacts, eventId: string) {
@@ -423,6 +467,55 @@ function validateRequires(
         detailKey: `revision:${revisionId}`,
       })
     }
+  }
+
+  const requiredSeedEntries = Object.entries(requires.requiredSeedValues ?? {})
+    .map(([seedKey, seedValue]) => [normalizeString(seedKey), seedValue] as const)
+    .filter(([seedKey]) => seedKey.length > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+
+  for (const [seedKey, requiredValue] of requiredSeedEntries) {
+    if (!isBranchSeedValue(requiredValue)) {
+      continue
+    }
+
+    const actualValue = pathFacts.seedValues[seedKey]
+    if (seedValuesMatch(actualValue, requiredValue)) {
+      continue
+    }
+
+    const actualLabel =
+      actualValue === undefined
+        ? 'unset'
+        : typeof actualValue === 'string'
+          ? actualValue
+          : String(actualValue)
+
+    pushWarning(warnings, {
+      pathId,
+      nodeId,
+      warningClass: 'missing_seed_prerequisite',
+      audience: 'simulation',
+      summary: `Node requires seed ${seedKey}=${String(requiredValue)}, but the path has ${actualLabel}.`,
+      relatedIds: [seedKey],
+      detailKey: `seed:${seedKey}`,
+    })
+  }
+
+  const anyRequiredSeedKeys = normalizeStringList(requires.anyRequiredSeedKeys)
+  if (
+    anyRequiredSeedKeys.length > 0 &&
+    !anyRequiredSeedKeys.some((seedKey) => hasSeedKey(pathFacts, seedKey))
+  ) {
+    pushWarning(warnings, {
+      pathId,
+      nodeId,
+      warningClass: 'missing_seed_prerequisite',
+      audience: 'simulation',
+      summary: `Node requires at least one seed key among ${anyRequiredSeedKeys.join(', ')}, but the path has none.`,
+      relatedIds: anyRequiredSeedKeys,
+      detailKey: `any-seed:${anyRequiredSeedKeys.join('|')}`,
+    })
   }
 }
 

--- a/src/domain/branchContinuityAuthoring.ts
+++ b/src/domain/branchContinuityAuthoring.ts
@@ -21,6 +21,7 @@ import type {
   BranchContinuityNode,
   BranchNodeRequirements,
   BranchPlayerKnowledgeAssumption,
+  BranchSeedValue,
 } from './branchContinuity'
 
 export interface AuthoredBranchContinuityNode {
@@ -77,6 +78,34 @@ function copyRecordIfNonEmpty(value: unknown): Record<string, unknown> | undefin
   return { ...record }
 }
 
+function isBranchSeedValue(value: unknown): value is BranchSeedValue {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  )
+}
+
+function copyRequiredSeedValues(
+  value: unknown
+): Readonly<Record<string, BranchSeedValue>> | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+
+  const out: Record<string, BranchSeedValue> = {}
+  for (const [rawKey, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof rawKey !== 'string' || rawKey.trim().length === 0 || !isBranchSeedValue(rawValue)) {
+      continue
+    }
+
+    out[rawKey.trim()] =
+      typeof rawValue === 'number' ? Math.trunc(rawValue) : rawValue
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
 function slimRequires(requires: BranchNodeRequirements | null | undefined): BranchNodeRequirements | undefined {
   if (requires == null) {
     return undefined
@@ -131,6 +160,16 @@ function slimRequires(requires: BranchNodeRequirements | null | undefined): Bran
   const requiredRecordRevisionIds = copyNonEmptyStringList(requires.requiredRecordRevisionIds)
   if (requiredRecordRevisionIds !== undefined) {
     out.requiredRecordRevisionIds = requiredRecordRevisionIds
+  }
+
+  const requiredSeedValues = copyRequiredSeedValues(requires.requiredSeedValues)
+  if (requiredSeedValues !== undefined) {
+    out.requiredSeedValues = requiredSeedValues
+  }
+
+  const anyRequiredSeedKeys = copyNonEmptyStringList(requires.anyRequiredSeedKeys)
+  if (anyRequiredSeedKeys !== undefined) {
+    out.anyRequiredSeedKeys = anyRequiredSeedKeys
   }
 
   return Object.keys(out).length > 0 ? out : undefined

--- a/src/domain/branchContinuityAuthoring.ts
+++ b/src/domain/branchContinuityAuthoring.ts
@@ -17,11 +17,12 @@
  * never read on invalid rows.
  */
 
-import type {
-  BranchContinuityNode,
-  BranchNodeRequirements,
-  BranchPlayerKnowledgeAssumption,
-  BranchSeedValue,
+import {
+  normalizeBranchSeedValue,
+  type BranchContinuityNode,
+  type BranchNodeRequirements,
+  type BranchPlayerKnowledgeAssumption,
+  type BranchSeedValue,
 } from './branchContinuity'
 
 export interface AuthoredBranchContinuityNode {
@@ -78,14 +79,6 @@ function copyRecordIfNonEmpty(value: unknown): Record<string, unknown> | undefin
   return { ...record }
 }
 
-function isBranchSeedValue(value: unknown): value is BranchSeedValue {
-  return (
-    typeof value === 'string' ||
-    typeof value === 'boolean' ||
-    (typeof value === 'number' && Number.isFinite(value))
-  )
-}
-
 function copyRequiredSeedValues(
   value: unknown
 ): Readonly<Record<string, BranchSeedValue>> | undefined {
@@ -95,12 +88,16 @@ function copyRequiredSeedValues(
 
   const out: Record<string, BranchSeedValue> = {}
   for (const [rawKey, rawValue] of Object.entries(value as Record<string, unknown>)) {
-    if (typeof rawKey !== 'string' || rawKey.trim().length === 0 || !isBranchSeedValue(rawValue)) {
+    if (typeof rawKey !== 'string' || rawKey.trim().length === 0) {
       continue
     }
 
-    out[rawKey.trim()] =
-      typeof rawValue === 'number' ? Math.trunc(rawValue) : rawValue
+    const normalizedValue = normalizeBranchSeedValue(rawValue)
+    if (normalizedValue === undefined) {
+      continue
+    }
+
+    out[rawKey.trim()] = normalizedValue
   }
 
   return Object.keys(out).length > 0 ? out : undefined

--- a/src/test/branchContinuity.test.ts
+++ b/src/test/branchContinuity.test.ts
@@ -84,6 +84,231 @@ describe('branchContinuity', () => {
     expect(report.summary.byClass.missing_item).toBe(1)
   })
 
+  it('flags missing_seed_prerequisite when a required seed is absent', () => {
+    const report = validateNodes([
+      {
+        nodeId: 'node:needs-door-code',
+        requires: { requiredSeedValues: { 'branch.seed.doorCode': 417 } },
+      },
+    ])
+
+    const warning = findWarning(report, 'node:needs-door-code', 'missing_seed_prerequisite')
+    expect(warning).toMatchObject({
+      severity: 'error',
+      audience: 'simulation',
+      relatedIds: ['branch.seed.doorCode'],
+    })
+    expect(warning?.id).toContain('seed:branch.seed.doorCode')
+    expect(report.summary.byClass.missing_seed_prerequisite).toBe(1)
+  })
+
+  it('flags missing_seed_prerequisite when a required seed value mismatches', () => {
+    const report = validateNodes(
+      [
+        {
+          nodeId: 'node:needs-door-code',
+          requires: { requiredSeedValues: { doorCode: 417 } },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { doorCode: 999 },
+      })
+    )
+
+    const warning = findWarning(report, 'node:needs-door-code', 'missing_seed_prerequisite')
+    expect(warning).toMatchObject({
+      severity: 'error',
+      audience: 'simulation',
+      relatedIds: ['doorCode'],
+    })
+  })
+
+  it('produces no missing_seed_prerequisite when required seeds match the path', () => {
+    const report = validateNodes([
+      {
+        nodeId: 'node:door-ok',
+        requires: { requiredSeedValues: { doorCode: 417 } },
+      },
+    ])
+
+    expect(findWarning(report, 'node:door-ok', 'missing_seed_prerequisite')).toBeUndefined()
+    expect(report.summary.byClass.missing_seed_prerequisite).toBeUndefined()
+  })
+
+  it('flags missing_seed_prerequisite when anyRequiredSeedKeys has no matching path keys', () => {
+    const report = validateNodes([
+      {
+        nodeId: 'node:needs-exploit-flag',
+        requires: { anyRequiredSeedKeys: ['branch.seed.exploitA', 'branch.seed.exploitB'] },
+      },
+    ])
+
+    const warning = findWarning(report, 'node:needs-exploit-flag', 'missing_seed_prerequisite')
+    expect(warning).toMatchObject({
+      severity: 'error',
+      audience: 'simulation',
+    })
+    expect(warning?.id).toContain('any-seed:')
+  })
+
+  it('produces no warning when anyRequiredSeedKeys is satisfied by one path seed', () => {
+    const report = validateNodes(
+      [
+        {
+          nodeId: 'node:exploit-ok',
+          requires: { anyRequiredSeedKeys: ['branch.seed.exploitA', 'branch.seed.exploitB'] },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { 'branch.seed.exploitB': true },
+      })
+    )
+
+    expect(findWarning(report, 'node:exploit-ok', 'missing_seed_prerequisite')).toBeUndefined()
+  })
+
+  it('treats anyRequiredSeedKeys as presence-only when the path seed value is false', () => {
+    const report = validateNodes(
+      [
+        {
+          nodeId: 'node:exploit-false',
+          requires: { anyRequiredSeedKeys: ['branch.seed.exploitA'] },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { 'branch.seed.exploitA': false },
+      })
+    )
+
+    expect(findWarning(report, 'node:exploit-false', 'missing_seed_prerequisite')).toBeUndefined()
+  })
+
+  it('flags string seed mismatch and accepts an exact string match', () => {
+    const mismatch = validateNodes(
+      [
+        {
+          nodeId: 'node:passphrase',
+          requires: { requiredSeedValues: { 'branch.seed.passphrase': 'omega' } },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { 'branch.seed.passphrase': 'alpha' },
+      })
+    )
+    expect(findWarning(mismatch, 'node:passphrase', 'missing_seed_prerequisite')).toBeDefined()
+
+    const match = validateNodes(
+      [
+        {
+          nodeId: 'node:passphrase',
+          requires: { requiredSeedValues: { 'branch.seed.passphrase': 'omega' } },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { 'branch.seed.passphrase': 'omega' },
+      })
+    )
+    expect(findWarning(match, 'node:passphrase', 'missing_seed_prerequisite')).toBeUndefined()
+  })
+
+  it('flags boolean seed mismatch and accepts an exact boolean match', () => {
+    const mismatch = validateNodes(
+      [
+        {
+          nodeId: 'node:gate',
+          requires: { requiredSeedValues: { 'branch.seed.gateOpen': true } },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { 'branch.seed.gateOpen': false },
+      })
+    )
+    expect(findWarning(mismatch, 'node:gate', 'missing_seed_prerequisite')).toBeDefined()
+
+    const match = validateNodes(
+      [
+        {
+          nodeId: 'node:gate',
+          requires: { requiredSeedValues: { 'branch.seed.gateOpen': true } },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { 'branch.seed.gateOpen': true },
+      })
+    )
+    expect(findWarning(match, 'node:gate', 'missing_seed_prerequisite')).toBeUndefined()
+  })
+
+  it('flags type mismatch when the path stores a string but the node requires a number', () => {
+    const report = validateNodes(
+      [
+        {
+          nodeId: 'node:typed-code',
+          requires: { requiredSeedValues: { doorCode: 417 } },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { doorCode: '417' },
+      })
+    )
+
+    expect(findWarning(report, 'node:typed-code', 'missing_seed_prerequisite')).toBeDefined()
+  })
+
+  it('emits required and any seed warnings independently on the same node', () => {
+    const report = validateNodes(
+      [
+        {
+          nodeId: 'node:combo',
+          requires: {
+            requiredSeedValues: { 'branch.seed.doorCode': 417 },
+            anyRequiredSeedKeys: ['branch.seed.exploitA', 'branch.seed.exploitB'],
+          },
+        },
+      ],
+      createRavenloftPathFacts({
+        seedValues: { 'branch.seed.doorCode': 999, 'branch.seed.exploitA': true },
+      })
+    )
+
+    const seedWarnings = report.warnings.filter(
+      (warning) =>
+        warning.nodeId === 'node:combo' && warning.warningClass === 'missing_seed_prerequisite'
+    )
+    expect(seedWarnings).toHaveLength(1)
+    expect(seedWarnings[0]?.id).toContain('seed:branch.seed.doorCode')
+  })
+
+  it('orders multiple missing seed warnings deterministically by seed key', () => {
+    const report = validateNodes([
+      {
+        nodeId: 'node:multi-seed',
+        requires: {
+          requiredSeedValues: {
+            'branch.seed.zeta': 1,
+            'branch.seed.alpha': 2,
+            'branch.seed.middle': 3,
+          },
+        },
+      },
+    ])
+
+    const seedWarnings = report.warnings
+      .filter(
+        (warning) =>
+          warning.nodeId === 'node:multi-seed' &&
+          warning.warningClass === 'missing_seed_prerequisite' &&
+          warning.id.includes(':seed:')
+      )
+      .map((warning) => warning.id)
+
+    expect(seedWarnings).toEqual([
+      `${PATH_ID}:node:multi-seed:missing_seed_prerequisite:seed:branch.seed.alpha`,
+      `${PATH_ID}:node:multi-seed:missing_seed_prerequisite:seed:branch.seed.middle`,
+      `${PATH_ID}:node:multi-seed:missing_seed_prerequisite:seed:branch.seed.zeta`,
+    ])
+  })
+
   it('flags wounded requirement when the path records healed instead of wounded', () => {
     const report = validateNodes(
       [

--- a/src/test/branchContinuity.test.ts
+++ b/src/test/branchContinuity.test.ts
@@ -279,6 +279,38 @@ describe('branchContinuity', () => {
     expect(seedWarnings[0]?.id).toContain('seed:branch.seed.doorCode')
   })
 
+  it('collapses duplicate normalized seed keys with last value winning in the validator', () => {
+    const report = validateNodes([
+      {
+        nodeId: 'node:dup-key',
+        requires: {
+          requiredSeedValues: {
+            'branch.seed.alpha': 1,
+            ' branch.seed.alpha ': 2,
+          },
+        },
+      },
+    ])
+
+    expect(report.warnings).toHaveLength(1)
+    expect(findWarning(report, 'node:dup-key', 'missing_seed_prerequisite')).toMatchObject({
+      summary: expect.stringContaining('branch.seed.alpha=2'),
+    })
+  })
+
+  it('ignores non-integer numeric seed requirements in direct validator input', () => {
+    const report = validateNodes([
+      {
+        nodeId: 'node:non-integer',
+        requires: {
+          requiredSeedValues: { 'branch.seed.alpha': 1.9 },
+        },
+      },
+    ])
+
+    expect(report.warnings).toHaveLength(0)
+  })
+
   it('orders multiple missing seed warnings deterministically by seed key', () => {
     const report = validateNodes([
       {

--- a/src/test/branchContinuityAuthoring.test.ts
+++ b/src/test/branchContinuityAuthoring.test.ts
@@ -480,6 +480,20 @@ describe('branchContinuityAuthoring', () => {
     expect(report.validation.warnings).toHaveLength(0)
   })
 
+  it('drops non-integer numeric seed requirements from the adapter', () => {
+    const authored = [
+      {
+        id: 'node:float-seed',
+        continuity: {
+          requires: { requiredSeedValues: { 'branch.seed.alpha': 1.9 } },
+        },
+      },
+    ] as AuthoredBranchContinuityNode[]
+
+    const [node] = buildBranchContinuityNodesFromAuthoredGraph(authored)
+    expect(node.requires).toBeUndefined()
+  })
+
   it('keeps the last trimmed duplicate key when authored requiredSeedValues collide', () => {
     const authored = [
       {

--- a/src/test/branchContinuityAuthoring.test.ts
+++ b/src/test/branchContinuityAuthoring.test.ts
@@ -409,6 +409,96 @@ describe('branchContinuityAuthoring', () => {
     expect(warning).toMatchObject({ severity: 'error', audience: 'simulation' })
   })
 
+  it('maps requiredSeedValues through the adapter and surfaces missing_seed_prerequisite', () => {
+    const game = createStartingState()
+    const nodes = buildBranchContinuityNodesFromAuthoredGraph([
+      {
+        id: 'node:needs-seed',
+        continuity: {
+          requires: { requiredSeedValues: { 'branch.seed.doorCode': 417 } },
+        },
+      },
+    ])
+
+    const [node] = nodes
+    expect(node.requires?.requiredSeedValues).toEqual({ 'branch.seed.doorCode': 417 })
+
+    const report = buildBranchContinuityAuditReport({ game, nodes })
+    const warning = report.validation.warnings.find(
+      (entry) =>
+        entry.nodeId === 'node:needs-seed' && entry.warningClass === 'missing_seed_prerequisite'
+    )
+
+    expect(warning).toMatchObject({ severity: 'error', audience: 'simulation' })
+  })
+
+  it('produces no missing_seed_prerequisite when authored seed matches projected global flags', () => {
+    let game = createStartingState()
+    game = setGlobalFlag(game, 'branch.seed.doorCode', 417)
+
+    const nodes = buildBranchContinuityNodesFromAuthoredGraph([
+      {
+        id: 'node:seed-match',
+        continuity: {
+          requires: { requiredSeedValues: { 'branch.seed.doorCode': 417 } },
+        },
+      },
+    ])
+
+    const report = buildBranchContinuityAuditReport({ game, nodes })
+
+    expect(
+      report.validation.warnings.some(
+        (entry) => entry.warningClass === 'missing_seed_prerequisite'
+      )
+    ).toBe(false)
+  })
+
+  it('drops invalid requiredSeedValues entries from the adapter without surfacing seed warnings', () => {
+    const authored = [
+      {
+        id: 'node:bad-seed',
+        continuity: {
+          requires: {
+            requiredSeedValues: {
+              'branch.seed.doorCode': null,
+              'branch.seed.nan': Number.NaN,
+            },
+          },
+        },
+      },
+    ] as unknown as AuthoredBranchContinuityNode[]
+
+    const [node] = buildBranchContinuityNodesFromAuthoredGraph(authored)
+    expect(node.requires).toBeUndefined()
+
+    const game = createStartingState()
+    const report = buildBranchContinuityAuditReport({
+      game,
+      nodes: buildBranchContinuityNodesFromAuthoredGraph(authored),
+    })
+    expect(report.validation.warnings).toHaveLength(0)
+  })
+
+  it('keeps the last trimmed duplicate key when authored requiredSeedValues collide', () => {
+    const authored = [
+      {
+        id: 'node:dup-key',
+        continuity: {
+          requires: {
+            requiredSeedValues: {
+              'branch.seed.alpha': 1,
+              ' branch.seed.alpha ': 2,
+            },
+          },
+        },
+      },
+    ] as AuthoredBranchContinuityNode[]
+
+    const [node] = buildBranchContinuityNodesFromAuthoredGraph(authored)
+    expect(node.requires?.requiredSeedValues).toEqual({ 'branch.seed.alpha': 2 })
+  })
+
   it('produces zero warnings when requires match starting inventory projection', () => {
     const game = createStartingState()
     expect(game.inventory.electronic_parts).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary
- Extends branch continuity validation with `requiredSeedValues` (exact key/value match) and `anyRequiredSeedKeys` (presence-only) on `BranchPathFacts.seedValues`.
- Adds `missing_seed_prerequisite` error warnings in the validator and passes seed requirements through the SPE-1811 authoring adapter.
- Documents seed-key semantics (full global-flag ids for GameState audits; `anyRequiredSeedKeys` does not require truthy values).
- Adds unit and authoring/audit integration tests, including edge cases (type mismatch, boolean/string seeds, invalid JSON entries dropped, deterministic multi-seed ordering).

## Test plan
- [x] `npm run test:run -- src/test/branchContinuity.test.ts src/test/branchContinuityAuthoring.test.ts` (64 tests)
- [ ] CI green on PR

Closes SPE-2093.

Made with [Cursor](https://cursor.com)