### PR TITLE
SPE-2107: Runtime concealment activation resolver (slice 1)

### DIFF
--- a/src/domain/hiddenStateActivation.ts
+++ b/src/domain/hiddenStateActivation.ts
@@ -63,12 +63,17 @@ function hasConcealmentActivationTag(caseData: CaseInstance) {
   return CONCEALMENT_ACTIVATION_TAGS.some((tag) => caseTags.includes(tag))
 }
 
-function hasTruthyGlobalFlagWithPrefix(
-  globalFlags: Readonly<Record<string, GameFlagValue>>,
-  prefix: string
-) {
+function isSharedConcealGlobalFlag(flagId: string) {
+  return (
+    flagId.startsWith(GLOBAL_CONCEAL_PREFIX) &&
+    !flagId.startsWith(GLOBAL_CONCEAL_CASE_PREFIX) &&
+    !flagId.startsWith(GLOBAL_CONCEAL_DISPLACE_PREFIX)
+  )
+}
+
+function hasSharedConcealGlobalFlag(globalFlags: Readonly<Record<string, GameFlagValue>>) {
   return Object.entries(globalFlags).some(
-    ([flagId, value]) => flagId.startsWith(prefix) && isTruthyGameFlag(value)
+    ([flagId, value]) => isSharedConcealGlobalFlag(flagId) && isTruthyGameFlag(value)
   )
 }
 
@@ -142,7 +147,7 @@ export function resolveConcealmentActivation(
     }
   }
 
-  if (hasTruthyGlobalFlagWithPrefix(globalFlags, GLOBAL_CONCEAL_PREFIX)) {
+  if (hasSharedConcealGlobalFlag(globalFlags)) {
     return {
       applied: true,
       mode: 'hidden',

--- a/src/domain/hiddenStateActivation.ts
+++ b/src/domain/hiddenStateActivation.ts
@@ -1,0 +1,201 @@
+/**
+ * SPE-2107: deterministic runtime concealment activation from tags, global flags, and recon signals.
+ * Distinct from SPE-70 field propagation and behavior-weighted disguise validation.
+ */
+
+import type { CaseInstance, GameFlagValue, Id } from './models'
+
+export type ConcealmentActivationMode = 'hidden' | 'displaced'
+
+export interface ConcealmentActivationContext {
+  globalFlags: Readonly<Record<string, GameFlagValue>>
+  /** From `countCaseHiddenModifiers` when a recon bridge is desired. */
+  hiddenModifierCount?: number
+}
+
+export interface ConcealmentActivationResult {
+  applied: boolean
+  mode?: ConcealmentActivationMode
+  reason?: string
+  detectionConfidence?: number
+  displacementTarget?: Id | null
+}
+
+/** Case tags that can activate concealed presence without manual `hiddenState` assignment. */
+export const CONCEALMENT_ACTIVATION_TAGS = [
+  'infiltration',
+  'disguise',
+  'stealth',
+  'concealment',
+  'covert',
+] as const
+
+const GLOBAL_CONCEAL_PREFIX = 'conceal.'
+const GLOBAL_CONCEAL_CASE_PREFIX = 'conceal.case.'
+const GLOBAL_CONCEAL_DISPLACE_PREFIX = 'conceal.displace.'
+const MIN_HIDDEN_MODIFIER_COUNT = 2
+const MIN_INVESTIGATION_WEIGHT_FOR_RECON_BRIDGE = 0.3
+const DEFAULT_HIDDEN_DETECTION_CONFIDENCE = 0.25
+const DEFAULT_DISPLACED_DETECTION_CONFIDENCE = 0.55
+
+function isTruthyGameFlag(value: GameFlagValue | undefined) {
+  if (value === undefined) {
+    return false
+  }
+
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0
+  }
+
+  return value.trim().length > 0
+}
+
+function collectCaseTags(caseData: CaseInstance) {
+  return [...new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])]
+}
+
+function hasConcealmentActivationTag(caseData: CaseInstance) {
+  const caseTags = collectCaseTags(caseData)
+  return CONCEALMENT_ACTIVATION_TAGS.some((tag) => caseTags.includes(tag))
+}
+
+function hasTruthyGlobalFlagWithPrefix(
+  globalFlags: Readonly<Record<string, GameFlagValue>>,
+  prefix: string
+) {
+  return Object.entries(globalFlags).some(
+    ([flagId, value]) => flagId.startsWith(prefix) && isTruthyGameFlag(value)
+  )
+}
+
+function readPerCaseConcealFlag(
+  globalFlags: Readonly<Record<string, GameFlagValue>>,
+  caseId: Id,
+  prefix: string
+): GameFlagValue | undefined {
+  return globalFlags[`${prefix}${caseId}`]
+}
+
+function readDisplacementTarget(
+  globalFlags: Readonly<Record<string, GameFlagValue>>,
+  caseId: Id
+): Id | null {
+  const value = readPerCaseConcealFlag(globalFlags, caseId, GLOBAL_CONCEAL_DISPLACE_PREFIX)
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function matchesReconBridge(caseData: CaseInstance, hiddenModifierCount: number | undefined) {
+  if (hiddenModifierCount === undefined) {
+    return false
+  }
+
+  return (
+    hiddenModifierCount >= MIN_HIDDEN_MODIFIER_COUNT &&
+    caseData.weights.investigation >= MIN_INVESTIGATION_WEIGHT_FOR_RECON_BRIDGE
+  )
+}
+
+function canApplyActivation(caseData: CaseInstance) {
+  return caseData.hiddenState === undefined
+}
+
+/**
+ * Resolves whether a case should enter concealed presence this week.
+ * Does not mutate the case; use {@link applyConcealmentActivationToCase} for merges.
+ */
+export function resolveConcealmentActivation(
+  caseData: CaseInstance,
+  context: ConcealmentActivationContext
+): ConcealmentActivationResult {
+  if (!canApplyActivation(caseData)) {
+    return { applied: false }
+  }
+
+  const { globalFlags } = context
+  const displacementTarget = readDisplacementTarget(globalFlags, caseData.id)
+  if (displacementTarget) {
+    return {
+      applied: true,
+      mode: 'displaced',
+      reason: `global-flag:${GLOBAL_CONCEAL_DISPLACE_PREFIX}${caseData.id}`,
+      detectionConfidence: DEFAULT_DISPLACED_DETECTION_CONFIDENCE,
+      displacementTarget,
+    }
+  }
+
+  const perCaseFlag = readPerCaseConcealFlag(globalFlags, caseData.id, GLOBAL_CONCEAL_CASE_PREFIX)
+  if (isTruthyGameFlag(perCaseFlag)) {
+    return {
+      applied: true,
+      mode: 'hidden',
+      reason: `global-flag:${GLOBAL_CONCEAL_CASE_PREFIX}${caseData.id}`,
+      detectionConfidence: DEFAULT_HIDDEN_DETECTION_CONFIDENCE,
+    }
+  }
+
+  if (hasTruthyGlobalFlagWithPrefix(globalFlags, GLOBAL_CONCEAL_PREFIX)) {
+    return {
+      applied: true,
+      mode: 'hidden',
+      reason: `global-flag-prefix:${GLOBAL_CONCEAL_PREFIX}`,
+      detectionConfidence: DEFAULT_HIDDEN_DETECTION_CONFIDENCE,
+    }
+  }
+
+  if (hasConcealmentActivationTag(caseData)) {
+    return {
+      applied: true,
+      mode: 'hidden',
+      reason: 'case-tag',
+      detectionConfidence: DEFAULT_HIDDEN_DETECTION_CONFIDENCE,
+    }
+  }
+
+  if (matchesReconBridge(caseData, context.hiddenModifierCount)) {
+    return {
+      applied: true,
+      mode: 'hidden',
+      reason: 'recon-hidden-modifiers',
+      detectionConfidence: DEFAULT_HIDDEN_DETECTION_CONFIDENCE,
+    }
+  }
+
+  return { applied: false }
+}
+
+/** Merges activation fields onto a case when {@link resolveConcealmentActivation} applies. */
+export function applyConcealmentActivationToCase(
+  caseData: CaseInstance,
+  context: ConcealmentActivationContext
+): CaseInstance {
+  const activation = resolveConcealmentActivation(caseData, context)
+  if (!activation.applied || !activation.mode) {
+    return caseData
+  }
+
+  if (activation.mode === 'displaced') {
+    return {
+      ...caseData,
+      hiddenState: 'displaced',
+      detectionConfidence: activation.detectionConfidence,
+      displacementTarget: activation.displacementTarget ?? null,
+      counterDetection: caseData.counterDetection ?? false,
+    }
+  }
+
+  return {
+    ...caseData,
+    hiddenState: 'hidden',
+    detectionConfidence: activation.detectionConfidence,
+    counterDetection: caseData.counterDetection ?? false,
+  }
+}

--- a/src/domain/hiddenStateActivation.ts
+++ b/src/domain/hiddenStateActivation.ts
@@ -39,7 +39,7 @@ const DEFAULT_HIDDEN_DETECTION_CONFIDENCE = 0.25
 const DEFAULT_DISPLACED_DETECTION_CONFIDENCE = 0.55
 
 function isTruthyGameFlag(value: GameFlagValue | undefined) {
-  if (value === undefined) {
+  if (value === undefined || value === null) {
     return false
   }
 
@@ -51,7 +51,12 @@ function isTruthyGameFlag(value: GameFlagValue | undefined) {
     return value !== 0
   }
 
-  return value.trim().length > 0
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return normalized.length > 0 && normalized !== 'false' && normalized !== '0'
+  }
+
+  return false
 }
 
 function collectCaseTags(caseData: CaseInstance) {

--- a/src/domain/recon.ts
+++ b/src/domain/recon.ts
@@ -329,6 +329,11 @@ function buildCaseHiddenModifiers(caseData: CaseInstance, mapLayer?: MapLayerRes
   return activeModifiers
 }
 
+/** SPE-2107: hidden-modifier count for concealment activation bridge (no team recon roll). */
+export function countCaseHiddenModifiers(caseData: CaseInstance, mapLayer?: MapLayerResult) {
+  return buildCaseHiddenModifiers(caseData, mapLayer).length
+}
+
 function getAgentReconContribution(
   agent: Agent,
   context?: TeamReconContext & { caseData?: CaseInstance }

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -2080,7 +2080,7 @@ function applyWeeklyConcealmentActivation(
   const globalFlags = context.nextState.globalFlags ?? context.sourceState.globalFlags ?? {}
   const activatedCase = applyConcealmentActivationToCase(caseData, {
     globalFlags,
-    hiddenModifierCount: countCaseHiddenModifiers(caseData),
+    hiddenModifierCount: countCaseHiddenModifiers(caseData, caseData.mapLayer),
   })
 
   if (activatedCase !== caseData) {

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -178,7 +178,9 @@ import {
   buildExecutionInstabilityRouteShift,
 } from '../executionInstability'
 import { buildMissionRewardBreakdown } from '../missionResults'
+import { applyConcealmentActivationToCase } from '../hiddenStateActivation'
 import { resolveAssignedCaseForWeek as resolveCanonicalAssignedCaseForWeek } from '../caseResolutionOrchestration'
+import { countCaseHiddenModifiers } from '../recon'
 import {
   buildAnchorFactionInstabilityNote,
   buildDeterministicReportNotesFromEventDrafts,
@@ -2070,6 +2072,24 @@ function applyActiveTriggerCooldowns(
   context.nextState.agents = updatedAgents
 }
 
+function applyWeeklyConcealmentActivation(
+  context: WeeklyExecutionContext,
+  caseId: string,
+  caseData: CaseInstance
+): CaseInstance {
+  const globalFlags = context.nextState.globalFlags ?? context.sourceState.globalFlags ?? {}
+  const activatedCase = applyConcealmentActivationToCase(caseData, {
+    globalFlags,
+    hiddenModifierCount: countCaseHiddenModifiers(caseData),
+  })
+
+  if (activatedCase !== caseData) {
+    context.nextState.cases[caseId] = activatedCase
+  }
+
+  return activatedCase
+}
+
 // Accept timingCheckState as parameter for shared cadence
 function resolveAssignments(
   context: WeeklyExecutionContext,
@@ -2090,7 +2110,7 @@ function resolveAssignments(
     if (context.finalizedCaseIds.has(caseId)) {
       continue
     }
-    const currentCase = context.sourceState.cases[caseId]
+    let currentCase = context.sourceState.cases[caseId]
     const existingAssignedTeamIds = currentCase.assignedTeamIds.filter((teamId) =>
       Boolean(context.nextState.teams[teamId])
     )
@@ -2112,6 +2132,8 @@ function resolveAssignments(
     recordProcessedCase(context, caseId, 'resolveAssignments')
     context.progressedCases.push(caseId)
     existingAssignedTeamIds.forEach((teamId) => context.activeTeamIds.add(teamId))
+
+    currentCase = applyWeeklyConcealmentActivation(context, caseId, currentCase)
 
     // SPE-38: Support consumption and shortage
     if (supportAvailable >= supportConsumptionPerCase) {

--- a/src/test/advanceWeek.concealmentActivation.integration.test.ts
+++ b/src/test/advanceWeek.concealmentActivation.integration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+describe('advanceWeek concealment activation integration', () => {
+  it('activates hidden mission results from global conceal flags without manual hiddenState', () => {
+    const state = createStartingState()
+    const [teamA, teamB] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = {
+      'conceal.case.case-001': true,
+      'conceal.case.case-002': true,
+      'conceal.displace.case-003': 'safehouse-9',
+    }
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+      currentCase.hiddenState = undefined
+      currentCase.counterDetection = undefined
+      currentCase.detectionConfidence = undefined
+      currentCase.displacementTarget = undefined
+    }
+
+    state.cases['case-001'].mode = 'deterministic'
+    state.cases['case-001'].status = 'in_progress'
+    state.cases['case-001'].assignedTeamIds = [teamA]
+    state.cases['case-001'].weeksRemaining = 1
+
+    state.cases['case-002'].mode = 'deterministic'
+    state.cases['case-002'].status = 'in_progress'
+    state.cases['case-002'].assignedTeamIds = [teamB]
+    state.cases['case-002'].weeksRemaining = 1
+    state.cases['case-002'].counterDetection = true
+
+    state.cases['case-003'].mode = 'deterministic'
+    state.cases['case-003'].status = 'in_progress'
+    state.cases['case-003'].assignedTeamIds = [teamA]
+    state.cases['case-003'].weeksRemaining = 1
+    state.cases['case-003'].counterDetection = true
+
+    const nextState = advanceWeek(state)
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+
+    const hiddenResult = lastReport.caseSnapshots?.['case-001']?.missionResult
+    const revealedResult = lastReport.caseSnapshots?.['case-002']?.missionResult
+    const displacedResult = lastReport.caseSnapshots?.['case-003']?.missionResult
+
+    expect(hiddenResult?.hiddenState).toBe('hidden')
+    expect(revealedResult?.hiddenState).toBe('revealed')
+    expect(displacedResult?.hiddenState).toBe('displaced')
+    expect(displacedResult?.displacementTarget).toBe('safehouse-9')
+  })
+})

--- a/src/test/behaviorDisguiseValidation.test.ts
+++ b/src/test/behaviorDisguiseValidation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
 import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
+import { applyConcealmentActivationToCase } from '../domain/hiddenStateActivation'
 import type { Agent, CaseInstance, GameState, Team } from '../domain/models'
 import { previewResolutionForTeamIds } from '../domain/sim/resolve'
 import { createStarterCase } from '../domain/templates/startingCases'
@@ -92,6 +93,24 @@ function tuneBehaviorGateCase(
 }
 
 describe('behavior-weighted disguise validation', () => {
+  it('activates behavior validation after tag-driven concealment activation', () => {
+    const observer = createBehaviorObserver('a_behavior_reader', ['liaison'], 55)
+    const hiddenCase = applyConcealmentActivationToCase(
+      createHiddenBriefingCase({
+        hiddenState: undefined,
+        detectionConfidence: undefined,
+        counterDetection: undefined,
+        tags: ['infiltration', 'public'],
+      }),
+      { globalFlags: {} }
+    )
+
+    expect(hiddenCase.hiddenState).toBe('hidden')
+    const result = evaluateBehaviorWeightedDisguiseValidation(hiddenCase, [observer])
+    expect(result.active).toBe(true)
+    expect(result.level).not.toBe('none')
+  })
+
   it('stays inactive on hidden cases without behavior-scrutiny context', () => {
     const state = createStartingState()
     const observer = state.agents.a_mina

--- a/src/test/hiddenStateActivation.test.ts
+++ b/src/test/hiddenStateActivation.test.ts
@@ -122,6 +122,15 @@ describe('hiddenStateActivation', () => {
     expect(resolveConcealmentActivation(displaced, { globalFlags: {} }).applied).toBe(false)
   })
 
+  it('does not treat per-case conceal flags as global activation for other cases', () => {
+    const caseAlpha = createActivationCase({ id: 'case-alpha' })
+    const caseBeta = createActivationCase({ id: 'case-beta' })
+    const globalFlags = { 'conceal.case.case-alpha': true }
+
+    expect(resolveConcealmentActivation(caseAlpha, { globalFlags }).applied).toBe(true)
+    expect(resolveConcealmentActivation(caseBeta, { globalFlags }).applied).toBe(false)
+  })
+
   it('ignores falsy global flag values', () => {
     const caseData = createActivationCase({ id: 'case-flag' })
     const result = resolveConcealmentActivation(caseData, {

--- a/src/test/hiddenStateActivation.test.ts
+++ b/src/test/hiddenStateActivation.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import { createStarterCase } from '../domain/templates/startingCases'
+import {
+  applyConcealmentActivationToCase,
+  CONCEALMENT_ACTIVATION_TAGS,
+  resolveConcealmentActivation,
+} from '../domain/hiddenStateActivation'
+import type { CaseInstance } from '../domain/models'
+
+function createActivationCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-conceal',
+      templateId: 'ops-004',
+    }),
+    mode: 'threshold',
+    assignedTeamIds: [],
+    requiredTags: [],
+    preferredTags: [],
+    ...overrides,
+  }
+}
+
+describe('hiddenStateActivation', () => {
+  it('activates hidden presence from concealment tags', () => {
+    const caseData = createActivationCase({
+      tags: ['infiltration', 'field'],
+    })
+
+    const result = resolveConcealmentActivation(caseData, { globalFlags: {} })
+
+    expect(result.applied).toBe(true)
+    expect(result.mode).toBe('hidden')
+    expect(result.reason).toBe('case-tag')
+    expect(result.detectionConfidence).toBe(0.25)
+  })
+
+  it.each(CONCEALMENT_ACTIVATION_TAGS)('treats %s as a concealment activation tag', (tag) => {
+    const caseData = createActivationCase({ tags: [tag] })
+    const result = resolveConcealmentActivation(caseData, { globalFlags: {} })
+    expect(result.applied).toBe(true)
+    expect(result.mode).toBe('hidden')
+  })
+
+  it('activates hidden presence from per-case and prefix global flags', () => {
+    const caseData = createActivationCase({ id: 'case-alpha' })
+
+    const perCase = resolveConcealmentActivation(caseData, {
+      globalFlags: { 'conceal.case.case-alpha': true },
+    })
+    expect(perCase.applied).toBe(true)
+    expect(perCase.mode).toBe('hidden')
+
+    const prefix = resolveConcealmentActivation(createActivationCase({ id: 'case-beta' }), {
+      globalFlags: { 'conceal.mission-ready': 1 },
+    })
+    expect(prefix.applied).toBe(true)
+    expect(prefix.reason).toBe('global-flag-prefix:conceal.')
+  })
+
+  it('activates displaced presence from per-case displace flag string value', () => {
+    const caseData = createActivationCase({ id: 'case-route' })
+    const result = resolveConcealmentActivation(caseData, {
+      globalFlags: { 'conceal.displace.case-route': 'safehouse-9' },
+    })
+
+    expect(result.applied).toBe(true)
+    expect(result.mode).toBe('displaced')
+    expect(result.displacementTarget).toBe('safehouse-9')
+    expect(result.detectionConfidence).toBe(0.55)
+  })
+
+  it('prefers displaced activation over hidden tag triggers', () => {
+    const caseData = createActivationCase({
+      id: 'case-route',
+      tags: ['stealth'],
+    })
+
+    const result = resolveConcealmentActivation(caseData, {
+      globalFlags: { 'conceal.displace.case-route': 'fallback-route' },
+    })
+
+    expect(result.mode).toBe('displaced')
+  })
+
+  it('activates from recon hidden-modifier bridge when investigation weight is high enough', () => {
+    const caseData = createActivationCase({
+      tags: ['evidence', 'archive', 'occult', 'ritual'],
+      weights: {
+        combat: 0,
+        investigation: 0.35,
+        utility: 0,
+        social: 0,
+      },
+    })
+
+    const belowThreshold = resolveConcealmentActivation(caseData, {
+      globalFlags: {},
+      hiddenModifierCount: 1,
+    })
+    expect(belowThreshold.applied).toBe(false)
+
+    const activated = resolveConcealmentActivation(caseData, {
+      globalFlags: {},
+      hiddenModifierCount: 2,
+    })
+    expect(activated.applied).toBe(true)
+    expect(activated.reason).toBe('recon-hidden-modifiers')
+  })
+
+  it('does not override revealed or displaced cases', () => {
+    const revealed = createActivationCase({
+      hiddenState: 'revealed',
+      tags: ['infiltration'],
+    })
+    const displaced = createActivationCase({
+      hiddenState: 'displaced',
+      tags: ['infiltration'],
+    })
+
+    expect(resolveConcealmentActivation(revealed, { globalFlags: {} }).applied).toBe(false)
+    expect(resolveConcealmentActivation(displaced, { globalFlags: {} }).applied).toBe(false)
+  })
+
+  it('ignores falsy global flag values', () => {
+    const caseData = createActivationCase({ id: 'case-flag' })
+    const result = resolveConcealmentActivation(caseData, {
+      globalFlags: {
+        'conceal.case.case-flag': false,
+        'conceal.mission-ready': 0,
+        'conceal.displace.case-flag': '   ',
+      },
+    })
+
+    expect(result.applied).toBe(false)
+  })
+
+  it('merges activation fields through applyConcealmentActivationToCase', () => {
+    const caseData = createActivationCase({ tags: ['covert'] })
+    const activated = applyConcealmentActivationToCase(caseData, { globalFlags: {} })
+
+    expect(activated.hiddenState).toBe('hidden')
+    expect(activated.detectionConfidence).toBe(0.25)
+    expect(activated.counterDetection).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add deterministic concealment activation (hiddenStateActivation.ts) from case tags, global conceal.* flags, per-case conceal.case.{id} / conceal.displace.{id}, and a recon hidden-modifier bridge.
- Wire activation into dvanceWeek esolveAssignments before weekly mission resolution.
- Export countCaseHiddenModifiers from econ.ts for the bridge signal.
- Add unit/integration tests; tag-driven activation now exercises behavior-weighted disguise validation without manual hiddenState assignment.

Linear: https://linear.app/spectranoir/issue/SPE-2107

## Test plan
- [x] 
pm run test:run -- src/test/hiddenStateActivation.test.ts src/test/advanceWeek.concealmentActivation.integration.test.ts src/test/behaviorDisguiseValidation.test.ts
- [ ] CI green on PR
