### PR TITLE
SPE-2113: Authored concealment activation triggers (slice 2)

### DIFF
--- a/src/domain/hiddenStateActivation.ts
+++ b/src/domain/hiddenStateActivation.ts
@@ -1,11 +1,27 @@
 /**
- * SPE-2107: deterministic runtime concealment activation from tags, global flags, and recon signals.
- * Distinct from SPE-70 field propagation and behavior-weighted disguise validation.
+ * SPE-2107 / SPE-2113: deterministic concealment activation from global flags, authored triggers,
+ * tags, and recon signals. Distinct from SPE-70 field propagation and behavior-weighted disguise validation.
  */
 
 import type { CaseInstance, GameFlagValue, Id } from './models'
 
 export type ConcealmentActivationMode = 'hidden' | 'displaced'
+
+export interface ConcealmentActivationTriggerCondition {
+  readonly anyTag?: readonly string[]
+  readonly allTags?: readonly string[]
+  readonly globalFlag?: string
+  readonly minHiddenModifierCount?: number
+  readonly minInvestigationWeight?: number
+}
+
+export interface ConcealmentActivationTrigger {
+  readonly id: string
+  readonly mode: ConcealmentActivationMode
+  readonly when?: ConcealmentActivationTriggerCondition
+  readonly displacementTarget?: Id | null
+  readonly detectionConfidence?: number
+}
 
 export interface ConcealmentActivationContext {
   globalFlags: Readonly<Record<string, GameFlagValue>>
@@ -103,6 +119,103 @@ function readDisplacementTarget(
   return normalized.length > 0 ? normalized : null
 }
 
+function hasTriggerConditionFields(when: ConcealmentActivationTriggerCondition) {
+  return (
+    (when.anyTag !== undefined && when.anyTag.length > 0) ||
+    (when.allTags !== undefined && when.allTags.length > 0) ||
+    (when.globalFlag !== undefined && when.globalFlag.trim().length > 0) ||
+    when.minHiddenModifierCount !== undefined ||
+    when.minInvestigationWeight !== undefined
+  )
+}
+
+function matchesTriggerCondition(
+  caseData: CaseInstance,
+  context: ConcealmentActivationContext,
+  when: ConcealmentActivationTriggerCondition | undefined,
+  globalFlags: Readonly<Record<string, GameFlagValue>>
+) {
+  if (when === undefined) {
+    return true
+  }
+
+  if (!hasTriggerConditionFields(when)) {
+    return true
+  }
+
+  const caseTags = collectCaseTags(caseData)
+
+  if (when.anyTag !== undefined && when.anyTag.length > 0) {
+    if (!when.anyTag.some((tag) => caseTags.includes(tag))) {
+      return false
+    }
+  }
+
+  if (when.allTags !== undefined && when.allTags.length > 0) {
+    if (!when.allTags.every((tag) => caseTags.includes(tag))) {
+      return false
+    }
+  }
+
+  if (when.globalFlag !== undefined) {
+    const flagId = when.globalFlag.trim()
+    if (flagId.length === 0 || !isTruthyGameFlag(globalFlags[flagId])) {
+      return false
+    }
+  }
+
+  if (when.minHiddenModifierCount !== undefined) {
+    const count = context.hiddenModifierCount ?? 0
+    if (count < when.minHiddenModifierCount) {
+      return false
+    }
+  }
+
+  if (when.minInvestigationWeight !== undefined) {
+    if (caseData.weights.investigation < when.minInvestigationWeight) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function resolveAuthoredConcealmentActivation(
+  caseData: CaseInstance,
+  context: ConcealmentActivationContext,
+  globalFlags: Readonly<Record<string, GameFlagValue>>
+): ConcealmentActivationResult | undefined {
+  const triggers = caseData.concealmentTriggers
+  if (triggers === undefined || triggers.length === 0) {
+    return undefined
+  }
+
+  for (const trigger of triggers) {
+    if (!matchesTriggerCondition(caseData, context, trigger.when, globalFlags)) {
+      continue
+    }
+
+    if (trigger.mode === 'displaced') {
+      return {
+        applied: true,
+        mode: 'displaced',
+        reason: `authored-trigger:${trigger.id}`,
+        detectionConfidence: trigger.detectionConfidence ?? DEFAULT_DISPLACED_DETECTION_CONFIDENCE,
+        displacementTarget: trigger.displacementTarget ?? null,
+      }
+    }
+
+    return {
+      applied: true,
+      mode: 'hidden',
+      reason: `authored-trigger:${trigger.id}`,
+      detectionConfidence: trigger.detectionConfidence ?? DEFAULT_HIDDEN_DETECTION_CONFIDENCE,
+    }
+  }
+
+  return undefined
+}
+
 function matchesReconBridge(caseData: CaseInstance, hiddenModifierCount: number | undefined) {
   if (hiddenModifierCount === undefined) {
     return false
@@ -159,6 +272,11 @@ export function resolveConcealmentActivation(
       reason: `global-flag-prefix:${GLOBAL_CONCEAL_PREFIX}`,
       detectionConfidence: DEFAULT_HIDDEN_DETECTION_CONFIDENCE,
     }
+  }
+
+  const authoredActivation = resolveAuthoredConcealmentActivation(caseData, context, globalFlags)
+  if (authoredActivation !== undefined) {
+    return authoredActivation
   }
 
   if (hasConcealmentActivationTag(caseData)) {

--- a/src/domain/hiddenStateActivationAuthoring.ts
+++ b/src/domain/hiddenStateActivationAuthoring.ts
@@ -1,0 +1,177 @@
+/**
+ * SPE-2113: normalize authored concealment activation triggers for case content JSON.
+ *
+ * Does not scan content packs, register CI lint, or wire loaders — callers pass authored rows.
+ */
+
+import type {
+  ConcealmentActivationMode,
+  ConcealmentActivationTrigger,
+  ConcealmentActivationTriggerCondition,
+} from './hiddenStateActivation'
+
+export interface AuthoredConcealmentActivationTriggerCondition {
+  anyTag?: readonly string[]
+  allTags?: readonly string[]
+  globalFlag?: string
+  minHiddenModifierCount?: number
+  minInvestigationWeight?: number
+}
+
+export interface AuthoredConcealmentActivationTrigger {
+  id: string
+  mode?: ConcealmentActivationMode
+  when?: AuthoredConcealmentActivationTriggerCondition
+  displacementTarget?: string | null
+  detectionConfidence?: number
+}
+
+function isAuthoredTriggerRecord(value: unknown): value is Partial<AuthoredConcealmentActivationTrigger> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeAuthoredTriggerId(id: unknown): string | undefined {
+  if (typeof id !== 'string') {
+    return undefined
+  }
+
+  const trimmed = id.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function copyNonEmptyStringList(values: unknown): string[] | undefined {
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined
+  }
+
+  const strings = values
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+
+  return strings.length > 0 ? [...new Set(strings)] : undefined
+}
+
+function normalizeMode(mode: unknown): ConcealmentActivationMode | undefined {
+  if (mode === 'hidden' || mode === 'displaced') {
+    return mode
+  }
+
+  return undefined
+}
+
+function normalizeDetectionConfidence(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  return value >= 0 && value <= 1 ? value : undefined
+}
+
+function normalizeDisplacementTarget(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null
+  }
+
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function slimTriggerCondition(
+  when: AuthoredConcealmentActivationTriggerCondition | null | undefined
+): ConcealmentActivationTriggerCondition | undefined {
+  if (when == null) {
+    return undefined
+  }
+
+  const out: ConcealmentActivationTriggerCondition = {}
+  const anyTag = copyNonEmptyStringList(when.anyTag)
+  if (anyTag !== undefined) {
+    out.anyTag = anyTag
+  }
+
+  const allTags = copyNonEmptyStringList(when.allTags)
+  if (allTags !== undefined) {
+    out.allTags = allTags
+  }
+
+  if (typeof when.globalFlag === 'string') {
+    const flag = when.globalFlag.trim()
+    if (flag.length > 0) {
+      out.globalFlag = flag
+    }
+  }
+
+  if (
+    typeof when.minHiddenModifierCount === 'number' &&
+    Number.isFinite(when.minHiddenModifierCount) &&
+    when.minHiddenModifierCount >= 0
+  ) {
+    out.minHiddenModifierCount = when.minHiddenModifierCount
+  }
+
+  if (
+    typeof when.minInvestigationWeight === 'number' &&
+    Number.isFinite(when.minInvestigationWeight) &&
+    when.minInvestigationWeight >= 0
+  ) {
+    out.minInvestigationWeight = when.minInvestigationWeight
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function slimAuthoredTrigger(
+  authored: AuthoredConcealmentActivationTrigger
+): ConcealmentActivationTrigger | undefined {
+  const id = normalizeAuthoredTriggerId(authored.id)
+  if (id === undefined) {
+    return undefined
+  }
+
+  const mode = normalizeMode(authored.mode) ?? 'hidden'
+  const when = slimTriggerCondition(authored.when)
+  const detectionConfidence = normalizeDetectionConfidence(authored.detectionConfidence)
+  const displacementTarget = normalizeDisplacementTarget(authored.displacementTarget)
+
+  const trigger: ConcealmentActivationTrigger = { id, mode }
+
+  if (when !== undefined) {
+    trigger.when = when
+  }
+  if (detectionConfidence !== undefined) {
+    trigger.detectionConfidence = detectionConfidence
+  }
+  if (displacementTarget !== undefined) {
+    trigger.displacementTarget = displacementTarget
+  }
+
+  return trigger
+}
+
+export function buildConcealmentActivationTriggersFromAuthored(
+  authoredTriggers: readonly AuthoredConcealmentActivationTrigger[] | unknown
+): readonly ConcealmentActivationTrigger[] {
+  if (!Array.isArray(authoredTriggers)) {
+    return []
+  }
+
+  const result: ConcealmentActivationTrigger[] = []
+
+  for (const entry of authoredTriggers) {
+    if (!isAuthoredTriggerRecord(entry)) {
+      continue
+    }
+
+    const slimmed = slimAuthoredTrigger(entry as AuthoredConcealmentActivationTrigger)
+    if (slimmed !== undefined) {
+      result.push(slimmed)
+    }
+  }
+
+  return result
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1324,6 +1324,8 @@ export interface CaseInstance {
   /** SPE-521 slice 1: accumulated site awareness while infiltrating (0–1). */
   infiltrationAwareness?: number
   infiltrationStage?: 'probing' | 'exposed' | 'violent'
+  /** SPE-2113: authored concealment activation rules evaluated by `resolveConcealmentActivation`. */
+  concealmentTriggers?: readonly import('./hiddenStateActivation').ConcealmentActivationTrigger[]
 
   onFail: SpawnRule
   onUnresolved: SpawnRule

--- a/src/test/advanceWeek.concealmentActivation.integration.test.ts
+++ b/src/test/advanceWeek.concealmentActivation.integration.test.ts
@@ -55,4 +55,42 @@ describe('advanceWeek concealment activation integration', () => {
     expect(displacedResult?.hiddenState).toBe('displaced')
     expect(displacedResult?.displacementTarget).toBe('safehouse-9')
   })
+
+  it('activates hidden presence from authored concealment triggers during advanceWeek', () => {
+    const state = createStartingState()
+    const [teamA] = Object.keys(state.teams)
+
+    state.reports = []
+    state.globalFlags = { 'mission.covert-ready': true }
+
+    const authoredCase = state.cases['case-001']
+    authoredCase.status = 'open'
+    authoredCase.assignedTeamIds = []
+    authoredCase.requiredTags = []
+    authoredCase.preferredTags = []
+    authoredCase.hiddenState = undefined
+    authoredCase.counterDetection = undefined
+    authoredCase.detectionConfidence = undefined
+    authoredCase.displacementTarget = undefined
+    authoredCase.tags = ['field']
+    authoredCase.concealmentTriggers = [
+      {
+        id: 'trigger:weekly-cover',
+        mode: 'hidden',
+        when: { globalFlag: 'mission.covert-ready', anyTag: ['field'] },
+      },
+    ]
+
+    authoredCase.mode = 'deterministic'
+    authoredCase.status = 'in_progress'
+    authoredCase.assignedTeamIds = [teamA]
+    authoredCase.weeksRemaining = 1
+
+    const nextState = advanceWeek(state)
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const missionResult = lastReport.caseSnapshots?.['case-001']?.missionResult
+
+    expect(missionResult?.hiddenState).toBe('hidden')
+    expect(nextState.cases['case-001'].hiddenState).toBe('hidden')
+  })
 })

--- a/src/test/hiddenStateActivation.test.ts
+++ b/src/test/hiddenStateActivation.test.ts
@@ -144,6 +144,71 @@ describe('hiddenStateActivation', () => {
     expect(result.applied).toBe(false)
   })
 
+  it('activates from authored triggers before tag fallbacks when conditions match', () => {
+    const caseData = createActivationCase({
+      tags: ['field'],
+      concealmentTriggers: [
+        {
+          id: 'trigger:gate',
+          mode: 'hidden',
+          when: { globalFlag: 'mission.covert-ready' },
+        },
+      ],
+    })
+
+    expect(resolveConcealmentActivation(caseData, { globalFlags: {} }).applied).toBe(false)
+
+    const activated = resolveConcealmentActivation(caseData, {
+      globalFlags: { 'mission.covert-ready': true },
+    })
+    expect(activated.applied).toBe(true)
+    expect(activated.reason).toBe('authored-trigger:trigger:gate')
+  })
+
+  it('prefers authored triggers over concealment tags when both would apply', () => {
+    const caseData = createActivationCase({
+      tags: ['infiltration'],
+      concealmentTriggers: [{ id: 'trigger:authored-first', mode: 'hidden' }],
+    })
+
+    const result = resolveConcealmentActivation(caseData, { globalFlags: {} })
+    expect(result.applied).toBe(true)
+    expect(result.reason).toBe('authored-trigger:trigger:authored-first')
+  })
+
+  it('prefers global conceal flags over authored triggers', () => {
+    const caseData = createActivationCase({
+      id: 'case-authored',
+      concealmentTriggers: [{ id: 'trigger:always', mode: 'hidden' }],
+    })
+
+    const result = resolveConcealmentActivation(caseData, {
+      globalFlags: { 'conceal.case.case-authored': true },
+    })
+
+    expect(result.applied).toBe(true)
+    expect(result.reason).toBe('global-flag:conceal.case.case-authored')
+  })
+
+  it('activates displaced presence from authored trigger with displacement target', () => {
+    const caseData = createActivationCase({
+      concealmentTriggers: [
+        {
+          id: 'trigger:relocate',
+          mode: 'displaced',
+          displacementTarget: 'fallback-route',
+          when: { anyTag: ['covert'] },
+        },
+      ],
+      tags: ['covert'],
+    })
+
+    const result = resolveConcealmentActivation(caseData, { globalFlags: {} })
+    expect(result.mode).toBe('displaced')
+    expect(result.displacementTarget).toBe('fallback-route')
+    expect(result.reason).toBe('authored-trigger:trigger:relocate')
+  })
+
   it('merges activation fields through applyConcealmentActivationToCase', () => {
     const caseData = createActivationCase({ tags: ['covert'] })
     const activated = applyConcealmentActivationToCase(caseData, { globalFlags: {} })

--- a/src/test/hiddenStateActivationAuthoring.test.ts
+++ b/src/test/hiddenStateActivationAuthoring.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildConcealmentActivationTriggersFromAuthored,
+  type AuthoredConcealmentActivationTrigger,
+} from '../domain/hiddenStateActivationAuthoring'
+
+describe('hiddenStateActivationAuthoring', () => {
+  it('returns an empty array for non-array input', () => {
+    expect(buildConcealmentActivationTriggersFromAuthored(null)).toEqual([])
+    expect(buildConcealmentActivationTriggersFromAuthored({})).toEqual([])
+  })
+
+  it('maps a minimal authored trigger with default hidden mode', () => {
+    const authored: AuthoredConcealmentActivationTrigger[] = [{ id: 'trigger:cover' }]
+    expect(buildConcealmentActivationTriggersFromAuthored(authored)).toEqual([
+      { id: 'trigger:cover', mode: 'hidden' },
+    ])
+  })
+
+  it('preserves displaced mode, conditions, and optional fields', () => {
+    const authored: AuthoredConcealmentActivationTrigger[] = [
+      {
+        id: 'trigger:relocate',
+        mode: 'displaced',
+        displacementTarget: ' safehouse-3 ',
+        detectionConfidence: 0.62,
+        when: {
+          anyTag: [' covert ', 'covert'],
+          globalFlag: ' mission.phase.two ',
+          minHiddenModifierCount: 2,
+          minInvestigationWeight: 0.25,
+        },
+      },
+    ]
+
+    expect(buildConcealmentActivationTriggersFromAuthored(authored)).toEqual([
+      {
+        id: 'trigger:relocate',
+        mode: 'displaced',
+        displacementTarget: 'safehouse-3',
+        detectionConfidence: 0.62,
+        when: {
+          anyTag: ['covert'],
+          globalFlag: 'mission.phase.two',
+          minHiddenModifierCount: 2,
+          minInvestigationWeight: 0.25,
+        },
+      },
+    ])
+  })
+
+  it('skips malformed rows without throwing', () => {
+    const authored = [
+      null,
+      { id: '' },
+      { id: 'valid', mode: 'not-a-mode' },
+      { id: 'also-valid', when: { allTags: ['', '  ', null] } },
+    ] as unknown as AuthoredConcealmentActivationTrigger[]
+
+    expect(() => buildConcealmentActivationTriggersFromAuthored(authored)).not.toThrow()
+    expect(buildConcealmentActivationTriggersFromAuthored(authored)).toEqual([
+      { id: 'valid', mode: 'hidden' },
+      { id: 'also-valid', mode: 'hidden' },
+    ])
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes SPE-2107 slice 2 by wiring authored per-case `concealmentTriggers[]` into the existing weekly concealment activation path.

## Changes

- `ConcealmentActivationTrigger` + `CaseInstance.concealmentTriggers`
- `resolveConcealmentActivation` priority: global/per-case flags → first matching authored trigger → built-in tags → recon bridge
- `hiddenStateActivationAuthoring.ts` for JSON normalization (mirror branch continuity authoring)
- Unit tests + `advanceWeek` integration for authored triggers

## Verification

- `npm run lint`
- `npm run test:run -- src/test/hiddenStateActivation.test.ts src/test/hiddenStateActivationAuthoring.test.ts src/test/advanceWeek.concealmentActivation.integration.test.ts`

## Out of scope

Content migration, UI, infiltration probe state machine, full hidden-state modality matrix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

