### PR TITLE
SPE-2155: Case template concealmentTriggers content migration

### DIFF
--- a/src/domain/hiddenStateActivationAuthoring.ts
+++ b/src/domain/hiddenStateActivationAuthoring.ts
@@ -1,7 +1,7 @@
 /**
  * SPE-2113: normalize authored concealment activation triggers for case content JSON.
  *
- * Does not scan content packs, register CI lint, or wire loaders — callers pass authored rows.
+ * Case templates normalize authored rows in `buildCaseTemplateCatalog`; spawn copies them onto cases.
  */
 
 import type {
@@ -151,6 +151,18 @@ function slimAuthoredTrigger(
   }
 
   return trigger
+}
+
+/** Normalizes optional template-authored rows; returns `undefined` when the catalog omits triggers. */
+export function resolveConcealmentTriggersForTemplate(
+  authoredTriggers: readonly AuthoredConcealmentActivationTrigger[] | undefined
+): readonly ConcealmentActivationTrigger[] | undefined {
+  if (authoredTriggers === undefined) {
+    return undefined
+  }
+
+  const normalized = buildConcealmentActivationTriggersFromAuthored(authoredTriggers)
+  return normalized.length > 0 ? normalized : undefined
 }
 
 export function buildConcealmentActivationTriggersFromAuthored(

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1249,6 +1249,12 @@ export interface CaseTemplate {
 
   /** Only relevant when kind === "raid". */
   raid?: { minTeams: number; maxTeams: number }
+
+  /**
+   * SPE-2113: authored concealment activation rows (normalized in `buildCaseTemplateCatalog`).
+   * Copied onto spawned `CaseInstance` records for weekly `resolveConcealmentActivation`.
+   */
+  concealmentTriggers?: readonly import('./hiddenStateActivation').ConcealmentActivationTrigger[]
 }
 
 /** SPE-1701: deterministic deployment carry-in stamped at team→case assignment. */

--- a/src/domain/sim/spawn.ts
+++ b/src/domain/sim/spawn.ts
@@ -129,6 +129,8 @@ export function instantiateFromTemplate(
   usedIds: Set<string> = new Set(),
   week = 1
 ): CaseInstance {
+  const concealmentTriggers = template.concealmentTriggers
+
   const instantiated: CaseInstance = {
     id: nextId(usedIds, rng),
     templateId: template.templateId,
@@ -156,6 +158,10 @@ export function instantiateFromTemplate(
     onFail: { ...template.onFail },
     onUnresolved: { ...template.onUnresolved },
     raid: template.raid,
+    concealmentTriggers:
+      concealmentTriggers !== undefined && concealmentTriggers.length > 0
+        ? [...concealmentTriggers]
+        : undefined,
   }
 
   return applySiteGenerationToCase({

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -16,6 +16,13 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 3,
     tags: ['cyber', 'relay', 'evidence', 'tier-2'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:ops-001-ghost-relay',
+        mode: 'hidden',
+        when: { anyTag: ['relay', 'cyber'] },
+      },
+    ],
     requiredTags: ['tech'],
     preferredTags: ['analyst', 'field-kit'],
     onFail: {
@@ -44,8 +51,15 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 2,
     tags: ['interview', 'memory', 'civilian', 'tier-2'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:ops-002-disinfo-cover',
+        mode: 'hidden',
+        when: { anyTag: ['interview', 'memory'] },
+      },
+    ],
     requiredTags: ['negotiator'],
-    preferredTags: ['medium', 'investigator'],
+    preferredTags: ['medium', 'investigator', 'disguise'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -72,8 +86,15 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 3,
     tags: ['archive', 'records', 'forensics', 'tier-2'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:ops-003-vault-approach',
+        mode: 'hidden',
+        when: { allTags: ['archive', 'records'] },
+      },
+    ],
     requiredTags: ['investigator'],
-    preferredTags: ['tech', 'forensics'],
+    preferredTags: ['tech', 'forensics', 'stealth'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -99,9 +120,16 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     weights: { combat: 0.05, investigation: 0.2, utility: 0.15, social: 0.6 },
     durationWeeks: 1,
     deadlineWeeks: 2,
-    tags: ['media', 'public', 'containment', 'tier-1'],
+    tags: ['media', 'public', 'containment', 'covert', 'tier-1'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:ops-004-briefing-cover',
+        mode: 'hidden',
+        when: { anyTag: ['media', 'public'] },
+      },
+    ],
     requiredTags: ['medium'],
-    preferredTags: ['negotiator', 'liaison'],
+    preferredTags: ['negotiator', 'liaison', 'infiltration'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -1,4 +1,8 @@
 // cspell:words cataloguers cutovers exfiltration psionic
+import {
+  buildConcealmentActivationTriggersFromAuthored,
+  type AuthoredConcealmentActivationTrigger,
+} from '../hiddenStateActivationAuthoring'
 import { TEAM_COVERAGE_ROLES, type CaseTemplate, type TeamCoverageRole } from '../models'
 import { normalizeSpawnRule } from '../spawnRules'
 import { occultCaseTemplates } from './caseTemplates.occult'
@@ -589,9 +593,16 @@ function normalizeRequiredRoles(roles: TeamCoverageRole[] | undefined) {
   ]
 }
 
-function cloneTemplate(template: CaseTemplate): CaseTemplate {
+function cloneTemplate(
+  template: CaseTemplate & {
+    concealmentTriggers?: readonly AuthoredConcealmentActivationTrigger[]
+  }
+): CaseTemplate {
   const onFail = normalizeSpawnRule(template.onFail)
   const onUnresolved = normalizeSpawnRule(template.onUnresolved)
+  const concealmentTriggers = buildConcealmentActivationTriggersFromAuthored(
+    template.concealmentTriggers ?? []
+  )
 
   return {
     ...template,
@@ -612,6 +623,8 @@ function cloneTemplate(template: CaseTemplate): CaseTemplate {
       spawnCount: { ...onUnresolved.spawnCount },
       spawnTemplateIds: normalizeTagList(onUnresolved.spawnTemplateIds),
     },
+    concealmentTriggers:
+      concealmentTriggers.length > 0 ? concealmentTriggers : undefined,
   }
 }
 
@@ -661,6 +674,28 @@ export function getCaseTemplateCatalogErrors(templates: CaseTemplate[]) {
 
     if ((template.requiredRoles ?? []).some((role) => !TEAM_COVERAGE_ROLES.includes(role))) {
       errors.push(`Template ${template.templateId} has invalid required roles.`)
+    }
+
+    if (template.concealmentTriggers !== undefined) {
+      if (template.concealmentTriggers.length === 0) {
+        errors.push(`Template ${template.templateId} declares empty concealmentTriggers.`)
+      }
+
+      const triggerIds = new Set<string>()
+      for (const trigger of template.concealmentTriggers) {
+        if (triggerIds.has(trigger.id)) {
+          errors.push(
+            `Template ${template.templateId} has duplicate concealment trigger id: ${trigger.id}`
+          )
+        }
+        triggerIds.add(trigger.id)
+
+        if (trigger.mode === 'displaced' && trigger.displacementTarget === undefined) {
+          errors.push(
+            `Template ${template.templateId} trigger ${trigger.id} is displaced without displacementTarget.`
+          )
+        }
+      }
     }
 
     const canConvertToRaid =

--- a/src/domain/templates/startingCases.ts
+++ b/src/domain/templates/startingCases.ts
@@ -103,6 +103,10 @@ export function createStarterCase(seed: StarterCaseSeed): CaseInstance {
       spawnTemplateIds: [...onUnresolved.spawnTemplateIds],
     },
     raid: template.raid ? { ...template.raid } : undefined,
+    concealmentTriggers:
+      template.concealmentTriggers !== undefined && template.concealmentTriggers.length > 0
+        ? [...template.concealmentTriggers]
+        : undefined,
   }
 
   return applySiteGenerationToCase({

--- a/src/test/caseTemplateConcealmentMigration.test.ts
+++ b/src/test/caseTemplateConcealmentMigration.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { caseTemplateMap } from '../data/caseTemplates'
+import { createStartingState } from '../data/startingState'
+import { resolveConcealmentActivation } from '../domain/hiddenStateActivation'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { instantiateFromTemplate } from '../domain/sim/spawn'
+
+const MIGRATED_TEMPLATE_IDS = ['ops-001', 'ops-002', 'ops-003', 'ops-004'] as const
+
+describe('case template concealment migration', () => {
+  it.each(MIGRATED_TEMPLATE_IDS)('catalog template %s carries normalized concealmentTriggers', (templateId) => {
+    const template = caseTemplateMap[templateId]
+    expect(template?.concealmentTriggers?.length).toBeGreaterThan(0)
+  })
+
+  it('activates hidden presence from migrated ops-004 without global conceal flags', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+    const template = caseTemplateMap['ops-004']
+    const spawned = instantiateFromTemplate(template, () => 0.42, new Set(Object.keys(state.cases)))
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = {}
+    state.cases[spawned.id] = {
+      ...spawned,
+      mode: 'deterministic',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+      weeksRemaining: 1,
+    }
+
+    const activation = resolveConcealmentActivation(state.cases[spawned.id], {
+      globalFlags: state.globalFlags,
+    })
+    expect(activation.applied).toBe(true)
+    expect(activation.reason).toBe('authored-trigger:trigger:ops-004-briefing-cover')
+
+    const nextState = advanceWeek(state)
+    const resolved = nextState.cases[spawned.id]
+    expect(resolved.hiddenState).toBe('hidden')
+  })
+})

--- a/src/test/hiddenStateActivation.test.ts
+++ b/src/test/hiddenStateActivation.test.ts
@@ -11,8 +11,9 @@ function createActivationCase(overrides: Partial<CaseInstance> = {}): CaseInstan
   return {
     ...createStarterCase({
       id: 'case-conceal',
-      templateId: 'ops-004',
+      templateId: 'chem-001',
     }),
+    concealmentTriggers: undefined,
     mode: 'threshold',
     assignedTeamIds: [],
     requiredTags: [],

--- a/src/test/sim.spawn.test.ts
+++ b/src/test/sim.spawn.test.ts
@@ -44,6 +44,21 @@ describe('spawn flows', () => {
     expect(caseA.stage).toBe(1)
   })
 
+  it('copies normalized concealment triggers from catalog templates onto spawned cases', () => {
+    const state = createStartingState()
+    const template = state.templates['ops-004']
+
+    const caseInstance = instantiateFromTemplate(template, () => 0.25, new Set())
+
+    expect(caseInstance.concealmentTriggers).toEqual([
+      {
+        id: 'trigger:ops-004-briefing-cover',
+        mode: 'hidden',
+        when: { anyTag: ['media', 'public'] },
+      },
+    ])
+  })
+
   it('fills missing optional tag lists when instantiating a template', () => {
     const template: CaseTemplate = {
       templateId: 'custom-001',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the operations case template pack to authored `concealmentTriggers`, normalized at catalog build and copied onto spawned cases.

## Changes

- `buildCaseTemplateCatalog` normalizes authored trigger rows via `buildConcealmentActivationTriggersFromAuthored`
- `instantiateFromTemplate` copies triggers onto `CaseInstance`
- Catalog validation for duplicate trigger ids and displaced targets
- Migrated templates: `ops-001`, `ops-002`, `ops-003`, `ops-004`
- Tests: spawn copy, catalog presence, resolver + advanceWeek for `ops-004`

## Verification

- `npm run lint`
- `npm run test:run -- src/test/sim.spawn.test.ts src/test/caseTemplateConcealmentMigration.test.ts src/test/starterContent.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

