### PR TITLE
SPE-2228: ConcealmentTriggers batch 3 (starter-chain)

### DIFF
--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -319,7 +319,14 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 2,
     tags: ['vampire', 'nest', 'night', 'tier-1'],
-    preferredTags: ['silver', 'holy'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:combat-vampire-night-stalk',
+        mode: 'hidden',
+        when: { anyTag: ['vampire', 'night'] },
+      },
+    ],
+    preferredTags: ['silver', 'holy', 'stealth', 'covert'],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -351,7 +358,14 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 1,
     tags: ['haunting', 'cognitive', 'research', 'tier-1'],
-    preferredTags: ['scholar', 'tech', 'medium'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:puzzle-archive-basement-infiltration',
+        mode: 'hidden',
+        when: { anyTag: ['haunting', 'research'] },
+      },
+    ],
+    preferredTags: ['scholar', 'tech', 'medium', 'infiltration', 'stealth'],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -383,9 +397,16 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 3,
     deadlineWeeks: 2,
     tags: ['cult', 'ritual', 'clock', 'tier-1'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:mixed-eclipse-riverfront-approach',
+        mode: 'hidden',
+        when: { allTags: ['cult', 'ritual'] },
+      },
+    ],
     requiredTags: ['occultist'],
     requiredRoles: ['containment', 'technical'],
-    preferredTags: ['holy', 'tech', 'negotiator'],
+    preferredTags: ['holy', 'tech', 'negotiator', 'covert', 'infiltration'],
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
       stageDelta: 1,
@@ -419,7 +440,14 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 1,
     deadlineWeeks: 2,
     tags: ['investigation', 'tier-1'],
-    preferredTags: ['tech', 'investigator'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:followup-missing-grid-stakeout',
+        mode: 'hidden',
+        when: { anyTag: ['investigation'] },
+      },
+    ],
+    preferredTags: ['tech', 'investigator', 'stealth', 'covert'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 0, max: 1 },
@@ -474,7 +502,14 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 1,
     deadlineWeeks: 1,
     tags: ['cognitive', 'tier-1'],
-    preferredTags: ['negotiator', 'investigator'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:followup-false-memory-screen',
+        mode: 'hidden',
+        when: { anyTag: ['cognitive'] },
+      },
+    ],
+    preferredTags: ['negotiator', 'investigator', 'disguise', 'covert'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 0, max: 1 },
@@ -500,8 +535,15 @@ const baseCaseTemplates: CaseTemplate[] = [
     weights: { combat: 0.2, investigation: 0.4, utility: 0.3, social: 0.1 },
     durationWeeks: 2,
     deadlineWeeks: 1,
-    tags: ['raid', 'tier-1'],
-    preferredTags: ['tech', 'medium'],
+    tags: ['raid', 'cognitive', 'tier-1'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:followup-campus-covert-entry',
+        mode: 'hidden',
+        when: { allTags: ['raid', 'cognitive'] },
+      },
+    ],
+    preferredTags: ['tech', 'medium', 'infiltration', 'stealth'],
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
       stageDelta: 1,
@@ -529,8 +571,15 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 1,
     tags: ['raid', 'infrastructure', 'tier-1'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:followup-blackout-chaos-cover',
+        mode: 'hidden',
+        when: { anyTag: ['infrastructure'] },
+      },
+    ],
     requiredTags: ['tech'],
-    preferredTags: ['occultist'],
+    preferredTags: ['occultist', 'covert', 'infiltration'],
     raid: { minTeams: 3, maxTeams: 5 },
     onFail: {
       stageDelta: 1,
@@ -558,7 +607,14 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 1,
     tags: ['cult', 'tier-1'],
-    preferredTags: ['negotiator', 'tech'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:followup-abduction-witness-recovery',
+        mode: 'hidden',
+        when: { anyTag: ['cult'] },
+      },
+    ],
+    preferredTags: ['negotiator', 'tech', 'infiltration', 'disguise'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 2 },

--- a/src/test/caseTemplateConcealmentMigration.test.ts
+++ b/src/test/caseTemplateConcealmentMigration.test.ts
@@ -3,6 +3,7 @@ import { caseTemplateMap } from '../data/caseTemplates'
 import { createStartingState } from '../data/startingState'
 import { resolveConcealmentActivation } from '../domain/hiddenStateActivation'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { createStarterCase } from '../domain/templates/startingCases'
 import { instantiateFromTemplate } from '../domain/sim/spawn'
 
 const BATCH_ONE_TEMPLATE_IDS = ['ops-001', 'ops-002', 'ops-003', 'ops-004'] as const
@@ -19,8 +20,23 @@ const BATCH_TWO_TEMPLATE_IDS = [
   'ops-008',
 ] as const
 
+const BATCH_THREE_STARTER_CHAIN_TEMPLATE_IDS = [
+  'combat_vampire_nest',
+  'puzzle_whispering_archive',
+  'mixed_eclipse_ritual',
+  'followup_missing_persons',
+  'followup_false_memories',
+  'followup_campus_outbreak',
+  'followup_blackout',
+  'followup_targeted_abductions',
+] as const
+
 describe('case template concealment migration', () => {
-  it.each([...BATCH_ONE_TEMPLATE_IDS, ...BATCH_TWO_TEMPLATE_IDS])(
+  it.each([
+    ...BATCH_ONE_TEMPLATE_IDS,
+    ...BATCH_TWO_TEMPLATE_IDS,
+    ...BATCH_THREE_STARTER_CHAIN_TEMPLATE_IDS,
+  ])(
     'catalog template %s carries normalized concealmentTriggers',
     (templateId) => {
     const template = caseTemplateMap[templateId]
@@ -53,6 +69,21 @@ describe('case template concealment migration', () => {
     const nextState = advanceWeek(state)
     const resolved = nextState.cases[spawned.id]
     expect(resolved.hiddenState).toBe('hidden')
+  })
+
+  it('copies starter-chain triggers onto cases created via createStarterCase', () => {
+    const starterCase = createStarterCase({
+      id: 'case-starter-test',
+      templateId: 'puzzle_whispering_archive',
+    })
+
+    expect(starterCase.concealmentTriggers).toEqual([
+      {
+        id: 'trigger:puzzle-archive-basement-infiltration',
+        mode: 'hidden',
+        when: { anyTag: ['haunting', 'research'] },
+      },
+    ])
   })
 
   it('activates hidden presence from migrated occult-006 procession blend trigger', () => {

--- a/src/test/starterContent.test.ts
+++ b/src/test/starterContent.test.ts
@@ -242,13 +242,13 @@ describe('starter content contracts', () => {
       title: caseTemplateMap['combat_vampire_nest'].title,
       deadlineRemaining: caseTemplateMap['combat_vampire_nest'].deadlineWeeks,
       requiredTags: [],
-      preferredTags: ['silver', 'holy'],
+      preferredTags: ['silver', 'holy', 'stealth', 'covert'],
     })
 
     expect(starterCases['case-002']).toMatchObject({
       templateId: 'puzzle_whispering_archive',
       title: caseTemplateMap['puzzle_whispering_archive'].title,
-      preferredTags: ['scholar', 'tech', 'medium'],
+      preferredTags: ['scholar', 'tech', 'medium', 'infiltration', 'stealth'],
     })
 
     expect(starterCases['case-003']).toMatchObject({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Third content-pack slice: authored `concealmentTriggers` on the tier-1 **base starter-chain** in `caseTemplates.ts` (quest roots + follow-ups).

## Migrated templates (8)

**Quest roots**
- `combat_vampire_nest` — night stalk before dawn relocation
- `puzzle_whispering_archive` — sub-basement infiltration
- `mixed_eclipse_ritual` — riverfront cult approach under cover

**Follow-ups**
- `followup_missing_persons` — grid stakeout without alerting nest
- `followup_false_memories` — screen contaminated witness interviews
- `followup_campus_outbreak` — covert entry during cognitive spread (added `cognitive` tag)
- `followup_blackout` — operate inside blackout chaos
- `followup_targeted_abductions` — covert witness recovery

**Skipped:** `followup_feeding_frenzy` (open-air combat raid; no concealment fit).

## Starter cases

`createStarterCase` copies triggers; `starterContent` expectations updated for extended `preferredTags`.

## Verification

- `npm run lint`
- `npm run test:run -- src/test/caseTemplateConcealmentMigration.test.ts src/test/starterContent.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

