### PR TITLE
feat(SPE-2237): authored infiltration probe plans and weekly action selection

### DIFF
--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -10,6 +10,43 @@ export type InfiltrationStage = 'probing' | 'exposed' | 'violent'
 
 export type InfiltrationProbeAction = 'probe_access' | 'probe_route' | 'cleanup'
 
+const INFILTRATION_PROBE_ACTIONS: readonly InfiltrationProbeAction[] = [
+  'probe_access',
+  'probe_route',
+  'cleanup',
+]
+
+export function isInfiltrationProbeAction(value: string): value is InfiltrationProbeAction {
+  return (INFILTRATION_PROBE_ACTIONS as readonly string[]).includes(value)
+}
+
+export interface InfiltrationProbeProgressActionRule {
+  readonly belowProbeProgress: number
+  readonly action: InfiltrationProbeAction
+}
+
+export interface InfiltrationProbePlan {
+  readonly defaultAction?: InfiltrationProbeAction
+  /** First rule where current probe progress is strictly below `belowProbeProgress` (rules sorted ascending). */
+  readonly actionWhenProbeProgressBelow?: readonly InfiltrationProbeProgressActionRule[]
+  readonly cleanupWhenAwarenessAtLeast?: number
+}
+
+export function copyInfiltrationProbePlan(
+  plan: InfiltrationProbePlan | undefined
+): InfiltrationProbePlan | undefined {
+  if (plan === undefined) {
+    return undefined
+  }
+
+  return {
+    ...plan,
+    actionWhenProbeProgressBelow: plan.actionWhenProbeProgressBelow
+      ? [...plan.actionWhenProbeProgressBelow]
+      : undefined,
+  }
+}
+
 export interface InfiltrationProbeState {
   probeProgress: number
   awareness: number
@@ -54,13 +91,72 @@ const ACTION_DELTAS: Record<
   cleanup: { probeProgress: 0.02, awareness: -0.15 },
 }
 
+function collectCaseTags(caseData: CaseInstance) {
+  return [...new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])]
+}
+
 export function hasInfiltrationProbeTag(caseData: CaseInstance) {
-  return INFILTRATION_PROBE_TAGS.some(
-    (tag) =>
-      caseData.tags.includes(tag) ||
-      caseData.requiredTags.includes(tag) ||
-      caseData.preferredTags.includes(tag)
-  )
+  return INFILTRATION_PROBE_TAGS.some((tag) => collectCaseTags(caseData).includes(tag))
+}
+
+const ROUTE_PROBE_TAGS = ['logistics', 'relay', 'supply-chain', 'cyber', 'parade', 'market'] as const
+const CLEANUP_PROBE_TAGS = ['media', 'court', 'public', 'interview', 'civilian'] as const
+const TAG_HEURISTIC_CLEANUP_AWARENESS = AWARENESS_COMPLICATION_THRESHOLD
+
+function matchesAnyTag(caseTags: readonly string[], candidates: readonly string[]) {
+  return candidates.some((tag) => caseTags.includes(tag))
+}
+
+function resolveProgressRuleAction(
+  probeProgress: number,
+  rules: readonly InfiltrationProbeProgressActionRule[]
+): InfiltrationProbeAction | undefined {
+  for (const rule of rules) {
+    if (probeProgress < rule.belowProbeProgress) {
+      return rule.action
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Deterministic weekly probe action: authored plan → progress rules → tag heuristics → default.
+ */
+export function resolveWeeklyInfiltrationProbeAction(caseData: CaseInstance): InfiltrationProbeAction {
+  const state = readInfiltrationProbeState(caseData)
+  const plan = caseData.infiltrationProbePlan
+  const caseTags = collectCaseTags(caseData)
+
+  if (plan?.cleanupWhenAwarenessAtLeast !== undefined) {
+    if (state.awareness >= plan.cleanupWhenAwarenessAtLeast) {
+      return 'cleanup'
+    }
+  }
+
+  if (plan?.actionWhenProbeProgressBelow !== undefined) {
+    const ruled = resolveProgressRuleAction(state.probeProgress, plan.actionWhenProbeProgressBelow)
+    if (ruled !== undefined) {
+      return ruled
+    }
+  }
+
+  if (plan?.defaultAction !== undefined) {
+    return plan.defaultAction
+  }
+
+  if (
+    matchesAnyTag(caseTags, CLEANUP_PROBE_TAGS) &&
+    state.awareness >= TAG_HEURISTIC_CLEANUP_AWARENESS
+  ) {
+    return 'cleanup'
+  }
+
+  if (matchesAnyTag(caseTags, ROUTE_PROBE_TAGS)) {
+    return 'probe_route'
+  }
+
+  return 'probe_access'
 }
 
 /** Counter-detection pressure contribution from infiltration tracks for disguise validation. */
@@ -171,13 +267,10 @@ export function mergeInfiltrationProbeStateIntoCase(
   }
 }
 
-/**
- * One weekly probe tick for assigned in-progress covert cases (defaults to access probing).
- */
-export function applyWeeklyInfiltrationProbeTick(
+/** Applies a single probe action and merges track state onto the case. */
+export function applyInfiltrationProbeActionToCase(
   caseData: CaseInstance,
-  _week: number,
-  action: InfiltrationProbeAction = 'probe_access'
+  action: InfiltrationProbeAction
 ): WeeklyInfiltrationProbeResult {
   if (!isInfiltrationProbeEligible(caseData)) {
     return { case: caseData, events: [], changed: false }
@@ -198,6 +291,23 @@ export function applyWeeklyInfiltrationProbeTick(
     events: evaluation.events,
     changed,
   }
+}
+
+/**
+ * One weekly probe tick for assigned in-progress covert cases.
+ * Uses {@link resolveWeeklyInfiltrationProbeAction} unless `action` is overridden.
+ */
+export function applyWeeklyInfiltrationProbeTick(
+  caseData: CaseInstance,
+  _week: number,
+  action?: InfiltrationProbeAction
+): WeeklyInfiltrationProbeResult {
+  if (!isInfiltrationProbeEligible(caseData)) {
+    return { case: caseData, events: [], changed: false }
+  }
+
+  const resolvedAction = action ?? resolveWeeklyInfiltrationProbeAction(caseData)
+  return applyInfiltrationProbeActionToCase(caseData, resolvedAction)
 }
 
 export function getInfiltrationAwarenessPressure(caseData: CaseInstance) {

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -91,12 +91,13 @@ const ACTION_DELTAS: Record<
   cleanup: { probeProgress: 0.02, awareness: -0.15 },
 }
 
-function collectCaseTags(caseData: CaseInstance) {
-  return [...new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])]
+function collectCaseTags(caseData: CaseInstance): Set<string> {
+  return new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])
 }
 
 export function hasInfiltrationProbeTag(caseData: CaseInstance) {
-  return INFILTRATION_PROBE_TAGS.some((tag) => collectCaseTags(caseData).includes(tag))
+  const caseTags = collectCaseTags(caseData)
+  return INFILTRATION_PROBE_TAGS.some((tag) => caseTags.has(tag))
 }
 
 const ROUTE_PROBE_TAGS = ['logistics', 'relay', 'supply-chain', 'cyber', 'parade', 'market'] as const

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -103,8 +103,8 @@ const ROUTE_PROBE_TAGS = ['logistics', 'relay', 'supply-chain', 'cyber', 'parade
 const CLEANUP_PROBE_TAGS = ['media', 'court', 'public', 'interview', 'civilian'] as const
 const TAG_HEURISTIC_CLEANUP_AWARENESS = AWARENESS_COMPLICATION_THRESHOLD
 
-function matchesAnyTag(caseTags: readonly string[], candidates: readonly string[]) {
-  return candidates.some((tag) => caseTags.includes(tag))
+function matchesAnyTag(caseTags: Set<string>, candidates: readonly string[]) {
+  return candidates.some((tag) => caseTags.has(tag))
 }
 
 function resolveProgressRuleAction(

--- a/src/domain/infiltrationProbeAuthoring.ts
+++ b/src/domain/infiltrationProbeAuthoring.ts
@@ -1,0 +1,109 @@
+/**
+ * SPE-521 slice 2: normalize authored infiltration probe plans for case templates.
+ */
+
+import type {
+  InfiltrationProbeAction,
+  InfiltrationProbePlan,
+  InfiltrationProbeProgressActionRule,
+} from './infiltrationProbe'
+import { isInfiltrationProbeAction } from './infiltrationProbe'
+
+export interface AuthoredInfiltrationProbeProgressActionRule {
+  belowProbeProgress?: number
+  action?: string
+}
+
+export interface AuthoredInfiltrationProbePlan {
+  defaultAction?: string
+  actionWhenProbeProgressBelow?: readonly AuthoredInfiltrationProbeProgressActionRule[]
+  cleanupWhenAwarenessAtLeast?: number
+}
+
+function isAuthoredPlanRecord(value: unknown): value is Partial<AuthoredInfiltrationProbePlan> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeProbeAction(action: unknown): InfiltrationProbeAction | undefined {
+  if (typeof action !== 'string') {
+    return undefined
+  }
+
+  const trimmed = action.trim() as InfiltrationProbeAction
+  return isInfiltrationProbeAction(trimmed) ? trimmed : undefined
+}
+
+function normalizeProgressThreshold(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  return value >= 0 && value <= 1 ? value : undefined
+}
+
+function normalizeProgressRules(
+  rules: readonly AuthoredInfiltrationProbeProgressActionRule[] | undefined
+): readonly InfiltrationProbeProgressActionRule[] | undefined {
+  if (!Array.isArray(rules) || rules.length === 0) {
+    return undefined
+  }
+
+  const normalized: InfiltrationProbeProgressActionRule[] = []
+
+  for (const entry of rules) {
+    if (typeof entry !== 'object' || entry === null) {
+      continue
+    }
+
+    const belowProbeProgress = normalizeProgressThreshold(entry.belowProbeProgress)
+    const action = normalizeProbeAction(entry.action)
+
+    if (belowProbeProgress === undefined || action === undefined) {
+      continue
+    }
+
+    normalized.push({ belowProbeProgress, action })
+  }
+
+  if (normalized.length === 0) {
+    return undefined
+  }
+
+  return [...normalized].sort((left, right) => left.belowProbeProgress - right.belowProbeProgress)
+}
+
+export function buildInfiltrationProbePlanFromAuthored(
+  authored: AuthoredInfiltrationProbePlan | undefined | null
+): InfiltrationProbePlan | undefined {
+  if (authored == null) {
+    return undefined
+  }
+
+  const defaultAction = normalizeProbeAction(authored.defaultAction)
+  const actionWhenProbeProgressBelow = normalizeProgressRules(authored.actionWhenProbeProgressBelow)
+  const cleanupWhenAwarenessAtLeast = normalizeProgressThreshold(authored.cleanupWhenAwarenessAtLeast)
+
+  const plan: InfiltrationProbePlan = {}
+
+  if (defaultAction !== undefined) {
+    plan.defaultAction = defaultAction
+  }
+  if (actionWhenProbeProgressBelow !== undefined) {
+    plan.actionWhenProbeProgressBelow = actionWhenProbeProgressBelow
+  }
+  if (cleanupWhenAwarenessAtLeast !== undefined) {
+    plan.cleanupWhenAwarenessAtLeast = cleanupWhenAwarenessAtLeast
+  }
+
+  return Object.keys(plan).length > 0 ? plan : undefined
+}
+
+export function buildInfiltrationProbePlanFromAuthoredRecord(
+  authored: unknown
+): InfiltrationProbePlan | undefined {
+  if (!isAuthoredPlanRecord(authored)) {
+    return undefined
+  }
+
+  return buildInfiltrationProbePlanFromAuthored(authored as AuthoredInfiltrationProbePlan)
+}

--- a/src/domain/infiltrationProbeAuthoring.ts
+++ b/src/domain/infiltrationProbeAuthoring.ts
@@ -69,7 +69,7 @@ function normalizeProgressRules(
     return undefined
   }
 
-  return [...normalized].sort((left, right) => left.belowProbeProgress - right.belowProbeProgress)
+  return normalized.sort((left, right) => left.belowProbeProgress - right.belowProbeProgress)
 }
 
 export function buildInfiltrationProbePlanFromAuthored(

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1255,6 +1255,9 @@ export interface CaseTemplate {
    * Copied onto spawned `CaseInstance` records for weekly `resolveConcealmentActivation`.
    */
   concealmentTriggers?: readonly import('./hiddenStateActivation').ConcealmentActivationTrigger[]
+
+  /** SPE-521 slice 2: authored weekly infiltration probe action plan (normalized in catalog build). */
+  infiltrationProbePlan?: import('./infiltrationProbe').InfiltrationProbePlan
 }
 
 /** SPE-1701: deterministic deployment carry-in stamped at team→case assignment. */
@@ -1332,6 +1335,8 @@ export interface CaseInstance {
   infiltrationStage?: 'probing' | 'exposed' | 'violent'
   /** SPE-2113: authored concealment activation rules evaluated by `resolveConcealmentActivation`. */
   concealmentTriggers?: readonly import('./hiddenStateActivation').ConcealmentActivationTrigger[]
+  /** SPE-521 slice 2: weekly infiltration probe action plan copied from template at spawn. */
+  infiltrationProbePlan?: import('./infiltrationProbe').InfiltrationProbePlan
 
   onFail: SpawnRule
   onUnresolved: SpawnRule

--- a/src/domain/sim/spawn.ts
+++ b/src/domain/sim/spawn.ts
@@ -4,6 +4,7 @@ import { createMissionIntelState } from '../intel'
 import { type CaseInstance, type CaseTemplate, type CompromisedAuthorityState, type GameState, type SpawnRule } from '../models'
 import { inferCasePressureValue, inferCaseRegionTag } from '../pressure'
 import { normalizeSpawnRule } from '../spawnRules'
+import { copyInfiltrationProbePlan } from '../infiltrationProbe'
 import { applySiteGenerationToCase } from '../siteGeneration'
 import { SIM_NOTES } from '../../data/copy'
 import { EVENT_NOTE_BUILDERS } from './eventNoteBuilders'
@@ -162,6 +163,7 @@ export function instantiateFromTemplate(
       concealmentTriggers !== undefined && concealmentTriggers.length > 0
         ? [...concealmentTriggers]
         : undefined,
+    infiltrationProbePlan: copyInfiltrationProbePlan(template.infiltrationProbePlan),
   }
 
   return applySiteGenerationToCase({

--- a/src/domain/templates/caseTemplates.occult.ts
+++ b/src/domain/templates/caseTemplates.occult.ts
@@ -166,6 +166,10 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['parade', 'social'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.45, action: 'probe_access' }],
+    },
     requiredTags: ['negotiator'],
     preferredTags: ['medium', 'investigator', 'disguise', 'infiltration'],
     raid: { minTeams: 2, maxTeams: 4 },

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -23,6 +23,10 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['relay', 'cyber'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.5, action: 'probe_access' }],
+    },
     requiredTags: ['tech'],
     preferredTags: ['analyst', 'field-kit'],
     onFail: {
@@ -128,6 +132,10 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['media', 'public'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    },
     requiredTags: ['medium'],
     preferredTags: ['negotiator', 'liaison', 'infiltration'],
     onFail: {

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -275,6 +275,9 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['market', 'compulsion'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+    },
     requiredTags: ['negotiator'],
     preferredTags: ['medium', 'analyst', 'infiltration', 'disguise'],
     pressureValue: 9,

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -3,6 +3,10 @@ import {
   buildConcealmentActivationTriggersFromAuthored,
   type AuthoredConcealmentActivationTrigger,
 } from '../hiddenStateActivationAuthoring'
+import {
+  buildInfiltrationProbePlanFromAuthored,
+  type AuthoredInfiltrationProbePlan,
+} from '../infiltrationProbeAuthoring'
 import { TEAM_COVERAGE_ROLES, type CaseTemplate, type TeamCoverageRole } from '../models'
 import { normalizeSpawnRule } from '../spawnRules'
 import { occultCaseTemplates } from './caseTemplates.occult'
@@ -365,6 +369,10 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['haunting', 'research'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.35, action: 'probe_route' }],
+    },
     preferredTags: ['scholar', 'tech', 'medium', 'infiltration', 'stealth'],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
@@ -614,6 +622,10 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['cult'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
+    },
     preferredTags: ['negotiator', 'tech', 'infiltration', 'disguise'],
     onFail: {
       stageDelta: 1,
@@ -652,6 +664,7 @@ function normalizeRequiredRoles(roles: TeamCoverageRole[] | undefined) {
 function cloneTemplate(
   template: CaseTemplate & {
     concealmentTriggers?: readonly AuthoredConcealmentActivationTrigger[]
+    infiltrationProbePlan?: AuthoredInfiltrationProbePlan
   }
 ): CaseTemplate {
   const onFail = normalizeSpawnRule(template.onFail)
@@ -659,6 +672,7 @@ function cloneTemplate(
   const concealmentTriggers = buildConcealmentActivationTriggersFromAuthored(
     template.concealmentTriggers ?? []
   )
+  const infiltrationProbePlan = buildInfiltrationProbePlanFromAuthored(template.infiltrationProbePlan)
 
   return {
     ...template,
@@ -681,6 +695,7 @@ function cloneTemplate(
     },
     concealmentTriggers:
       concealmentTriggers.length > 0 ? concealmentTriggers : undefined,
+    infiltrationProbePlan,
   }
 }
 

--- a/src/domain/templates/startingCases.ts
+++ b/src/domain/templates/startingCases.ts
@@ -3,6 +3,7 @@ import { inferFactionIdFromCaseTags } from '../factions'
 import { createMissionIntelState } from '../intel'
 import { inferCasePressureValue, inferCaseRegionTag } from '../pressure'
 import { normalizeSpawnRule } from '../spawnRules'
+import { copyInfiltrationProbePlan } from '../infiltrationProbe'
 import { applySiteGenerationToCase } from '../siteGeneration'
 import { caseTemplateMap } from './caseTemplates'
 
@@ -107,6 +108,7 @@ export function createStarterCase(seed: StarterCaseSeed): CaseInstance {
       template.concealmentTriggers !== undefined && template.concealmentTriggers.length > 0
         ? [...template.concealmentTriggers]
         : undefined,
+    infiltrationProbePlan: copyInfiltrationProbePlan(template.infiltrationProbePlan),
   }
 
   return applySiteGenerationToCase({

--- a/src/test/advanceWeek.infiltrationProbe.integration.test.ts
+++ b/src/test/advanceWeek.infiltrationProbe.integration.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { caseTemplateMap } from '../data/caseTemplates'
 import { createStartingState } from '../data/startingState'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { instantiateFromTemplate } from '../domain/sim/spawn'
+import { createStarterCase } from '../domain/templates/startingCases'
 
 describe('advanceWeek infiltration probe integration', () => {
   it('ticks probe tracks under cover and emits awareness complication events', () => {
@@ -38,5 +41,75 @@ describe('advanceWeek infiltration probe integration', () => {
     expect(updatedCase.infiltrationAwareness).toBeGreaterThan(0.48)
     expect(updatedCase.infiltrationStage).toBe('exposed')
     expect(updatedCase.detectionConfidence).toBeGreaterThanOrEqual(0.55)
+  })
+
+  it('uses authored cleanup when awareness crosses the plan threshold', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = { 'conceal.case.case-ops-004': true }
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const covertCase = createStarterCase({
+      id: 'case-ops-004',
+      templateId: 'ops-004',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    })
+    covertCase.mode = 'deterministic'
+    covertCase.weeksRemaining = 2
+    covertCase.infiltrationAwareness = 0.56
+    covertCase.infiltrationProbeProgress = 0.25
+
+    state.cases['case-ops-004'] = covertCase
+
+    const nextState = advanceWeek(state)
+    const updatedCase = nextState.cases['case-ops-004']
+
+    expect(updatedCase.hiddenState).toBe('hidden')
+    expect(updatedCase.infiltrationAwareness).toBeLessThan(0.56)
+    expect(updatedCase.infiltrationProbeProgress).toBeGreaterThan(0.25)
+  })
+
+  it('uses authored probe_route default for relay templates at high progress', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = { 'conceal.case.case-ops-001': true }
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const relayCase = instantiateFromTemplate(
+      caseTemplateMap['ops-001'],
+      () => 0.25,
+      new Set(Object.keys(state.cases))
+    )
+    relayCase.id = 'case-ops-001'
+    relayCase.tags = [...relayCase.tags, 'infiltration']
+    relayCase.status = 'in_progress'
+    relayCase.assignedTeamIds = [teamId]
+    relayCase.weeksRemaining = 2
+    relayCase.mode = 'deterministic'
+    relayCase.infiltrationProbeProgress = 0.6
+    relayCase.infiltrationAwareness = 0.2
+
+    state.cases['case-ops-001'] = relayCase
+
+    const nextState = advanceWeek(state)
+    const updatedCase = nextState.cases['case-ops-001']
+
+    expect(updatedCase.infiltrationProbeProgress).toBeCloseTo(0.7, 3)
+    expect(updatedCase.infiltrationAwareness).toBeCloseTo(0.38, 3)
   })
 })

--- a/src/test/infiltrationProbe.test.ts
+++ b/src/test/infiltrationProbe.test.ts
@@ -3,11 +3,14 @@ import { createStarterCase } from '../domain/templates/startingCases'
 import {
   AWARENESS_COMPLICATION_THRESHOLD,
   applyWeeklyInfiltrationProbeTick,
+  copyInfiltrationProbePlan,
   evaluateInfiltrationProbe,
   getInfiltrationStagePressure,
   isInfiltrationProbeEligible,
   readInfiltrationProbeState,
+  resolveWeeklyInfiltrationProbeAction,
 } from '../domain/infiltrationProbe'
+import { caseTemplateMap } from '../domain/templates/caseTemplates'
 import type { CaseInstance } from '../domain/models'
 
 function createInfiltrationCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
@@ -98,6 +101,72 @@ describe('infiltrationProbe', () => {
         AWARENESS_COMPLICATION_THRESHOLD - 0.2
       )
     ).toBe(0.5)
+  })
+
+  it('resolves weekly action from authored plan before tag heuristics', () => {
+    const ops004Plan = copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan)
+    const ops001Plan = copyInfiltrationProbePlan(caseTemplateMap['ops-001'].infiltrationProbePlan)
+
+    expect(
+      resolveWeeklyInfiltrationProbeAction(
+        createInfiltrationCase({
+          infiltrationProbePlan: ops004Plan,
+          infiltrationAwareness: 0.56,
+        })
+      )
+    ).toBe('cleanup')
+
+    expect(
+      resolveWeeklyInfiltrationProbeAction(
+        createInfiltrationCase({
+          infiltrationProbePlan: ops004Plan,
+          infiltrationAwareness: 0.4,
+        })
+      )
+    ).toBe('probe_access')
+
+    expect(
+      resolveWeeklyInfiltrationProbeAction(
+        createInfiltrationCase({
+          infiltrationProbePlan: ops001Plan,
+          infiltrationProbeProgress: 0.6,
+        })
+      )
+    ).toBe('probe_route')
+
+    expect(
+      resolveWeeklyInfiltrationProbeAction(
+        createInfiltrationCase({
+          infiltrationProbePlan: ops001Plan,
+          infiltrationProbeProgress: 0.2,
+        })
+      )
+    ).toBe('probe_access')
+  })
+
+  it('selects probe_route via tag heuristics when no plan is present', () => {
+    expect(
+      resolveWeeklyInfiltrationProbeAction(
+        createInfiltrationCase({
+          infiltrationProbePlan: undefined,
+          tags: ['infiltration', 'cyber'],
+        })
+      )
+    ).toBe('probe_route')
+  })
+
+  it('applies resolved weekly action when action override is omitted', () => {
+    const weekly = applyWeeklyInfiltrationProbeTick(
+      createInfiltrationCase({
+        infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+        infiltrationAwareness: 0.56,
+        infiltrationProbeProgress: 0.3,
+      }),
+      2
+    )
+
+    expect(weekly.changed).toBe(true)
+    expect(weekly.case.infiltrationAwareness).toBeLessThan(0.56)
   })
 
   it('merges violent escalation into case counter-detection fields', () => {

--- a/src/test/infiltrationProbeAuthoring.test.ts
+++ b/src/test/infiltrationProbeAuthoring.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildInfiltrationProbePlanFromAuthored,
+  buildInfiltrationProbePlanFromAuthoredRecord,
+  type AuthoredInfiltrationProbePlan,
+} from '../domain/infiltrationProbeAuthoring'
+
+describe('infiltrationProbeAuthoring', () => {
+  it('returns undefined for null or empty authored plans', () => {
+    expect(buildInfiltrationProbePlanFromAuthored(null)).toBeUndefined()
+    expect(buildInfiltrationProbePlanFromAuthored({})).toBeUndefined()
+    expect(buildInfiltrationProbePlanFromAuthoredRecord(null)).toBeUndefined()
+    expect(buildInfiltrationProbePlanFromAuthoredRecord('not-an-object')).toBeUndefined()
+  })
+
+  it('normalizes default action and awareness cleanup threshold', () => {
+    const authored: AuthoredInfiltrationProbePlan = {
+      defaultAction: ' probe_route ',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    }
+
+    expect(buildInfiltrationProbePlanFromAuthored(authored)).toEqual({
+      defaultAction: 'probe_route',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    })
+  })
+
+  it('sorts progress rules and drops invalid rows', () => {
+    const authored: AuthoredInfiltrationProbePlan = {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [
+        { belowProbeProgress: 0.5, action: 'probe_route' },
+        { belowProbeProgress: 0.2, action: 'cleanup' },
+        { belowProbeProgress: 1.5, action: 'probe_access' },
+        { belowProbeProgress: 0.35, action: 'not-valid' },
+        null as unknown as AuthoredInfiltrationProbePlan,
+      ],
+    }
+
+    expect(buildInfiltrationProbePlanFromAuthored(authored)).toEqual({
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [
+        { belowProbeProgress: 0.2, action: 'cleanup' },
+        { belowProbeProgress: 0.5, action: 'probe_route' },
+      ],
+    })
+  })
+
+  it('skips unknown default actions without throwing', () => {
+    expect(() =>
+      buildInfiltrationProbePlanFromAuthored({ defaultAction: 'probe_everything' })
+    ).not.toThrow()
+    expect(buildInfiltrationProbePlanFromAuthored({ defaultAction: 'probe_everything' })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements infiltration probe **slice 2**: per-case authored `infiltrationProbePlan` on templates, normalization at catalog build, copy onto spawned/starter cases, and deterministic weekly action selection before tag heuristics.

## Behavior

- **Plan fields:** `defaultAction`, `actionWhenProbeProgressBelow` (sorted ascending; first match where progress is strictly below threshold), `cleanupWhenAwarenessAtLeast`.
- **Resolver order:** cleanup threshold → progress rules → default action → tag heuristics (`media`/`public`/… cleanup at ≥0.55 awareness, logistics/cyber/… → `probe_route`) → `probe_access`.
- **`applyWeeklyInfiltrationProbeTick`** uses the resolver when no action override is passed.

## Content

Plans added for: `ops-001`, `ops-004`, `occult-006`, `puzzle_whispering_archive`, `psi-007`, `followup_targeted_abductions`.

## Tests

- `infiltrationProbeAuthoring.test.ts`
- Resolver + auto-tick coverage in `infiltrationProbe.test.ts`
- `advanceWeek.infiltrationProbe.integration.test.ts` (ops-004 cleanup, ops-001 `probe_route`)

## Parent epic

Part of infiltration probe awareness (parent backlog); slice 1 tracks remain unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

