### PR TITLE
feat(SPE-2240): infiltration cover profile and weekly posture (slice 3)

### DIFF
--- a/src/domain/disguiseValidation.ts
+++ b/src/domain/disguiseValidation.ts
@@ -1,5 +1,6 @@
 import { clamp } from './math'
 import type { Agent, CaseInstance, Id } from './models'
+import type { InfiltrationCoverRole } from './infiltrationCover'
 import {
   getInfiltrationAwarenessPressure,
   getInfiltrationStagePressure,
@@ -30,6 +31,9 @@ export interface BehaviorWeightedDisguiseValidationContext {
   leaderId?: Id | null
   /** SPE-521: optional override; defaults to case infiltration awareness when present. */
   infiltrationAwareness?: number
+  /** SPE-521 slice 3: optional override; defaults to case cover profile when present. */
+  coverRole?: InfiltrationCoverRole
+  documentTier?: number
 }
 
 export interface BehaviorWeightedDisguiseValidationResult {
@@ -64,6 +68,21 @@ function roundTo(value: number, digits = 1) {
 
 function collectCaseTags(caseData: CaseInstance) {
   return [...new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])]
+}
+
+export function resolveDisguiseValidationContextFromCase(
+  caseData: CaseInstance,
+  context: BehaviorWeightedDisguiseValidationContext = {}
+): BehaviorWeightedDisguiseValidationContext {
+  const profile = caseData.infiltrationCoverProfile
+
+  return {
+    ...context,
+    infiltrationAwareness:
+      context.infiltrationAwareness ?? getInfiltrationAwarenessPressure(caseData),
+    coverRole: context.coverRole ?? profile?.claimedRole,
+    documentTier: context.documentTier ?? profile?.documentTier,
+  }
 }
 
 function collectObserverTags(
@@ -101,6 +120,7 @@ export function evaluateBehaviorWeightedDisguiseValidation(
     return INACTIVE_BEHAVIOR_VALIDATION
   }
 
+  const resolvedContext = resolveDisguiseValidationContextFromCase(caseData, context)
   const caseTags = collectCaseTags(caseData)
   const authorityScrutiny = hasAnyTag(caseTags, AUTHORITY_SCRUTINY_TAGS)
   const proceduralScrutiny = hasAnyTag(caseTags, PROCEDURAL_SCRUTINY_TAGS)
@@ -111,7 +131,7 @@ export function evaluateBehaviorWeightedDisguiseValidation(
     return INACTIVE_BEHAVIOR_VALIDATION
   }
 
-  const observerTags = collectObserverTags(agents, context)
+  const observerTags = collectObserverTags(agents, resolvedContext)
   const averageSocial = averageStat(agents, 'social')
   const averageInvestigation = averageStat(agents, 'investigation')
   const evidenceSignals: string[] = []
@@ -153,19 +173,23 @@ export function evaluateBehaviorWeightedDisguiseValidation(
     typeof caseData.detectionConfidence === 'number'
       ? clamp(caseData.detectionConfidence, 0, 1)
       : 0
-  const infiltrationAwareness = clamp(
-    context.infiltrationAwareness ?? getInfiltrationAwarenessPressure(caseData),
-    0,
-    1
-  )
+  const infiltrationAwareness = clamp(resolvedContext.infiltrationAwareness ?? 0, 0, 1)
   const infiltrationStagePressure = getInfiltrationStagePressure(
     caseData,
     infiltrationAwareness
   )
+  const documentTier = resolvedContext.documentTier ?? 2
+  const documentScrutinyPressure =
+    authorityScrutiny && documentTier <= 0
+      ? 0.35
+      : authorityScrutiny && documentTier === 1
+        ? 0.15
+        : 0
   const counterDetectionPressure =
     (caseData.counterDetection ? 1 : 0) +
     (priorDetectionConfidence >= DETECTION_CONFIDENCE_PRESSURE_THRESHOLD ? 1 : 0) +
     infiltrationStagePressure +
+    documentScrutinyPressure +
     (hasEffectiveCountermeasure({ family: 'deception', presentTags: observerTags }) ? 0.5 : 0)
 
   if (validationScore < ESCALATION_VALIDATION_SCORE_THRESHOLD) {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -658,6 +658,7 @@ export const operationEventPayloadSchemas = {
   'infiltration.awareness_complication': infiltrationProbeEventSchema,
   'infiltration.escalation_exposed': infiltrationProbeEventSchema,
   'infiltration.escalation_violent': infiltrationProbeEventSchema,
+  'infiltration.cover_strain': infiltrationProbeEventSchema,
   'system.academy_upgraded': systemAcademyUpgradedSchema,
   'system.equipment_recovered': z.object({}).passthrough(),
   'case.aggregate_battle': z.object({}).passthrough(),

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -605,6 +605,15 @@ export interface OperationEventPayloadMap {
     infiltrationProbeProgress?: number
     infiltrationStage?: 'probing' | 'exposed' | 'violent'
   }
+  'infiltration.cover_strain': {
+    week: number
+    caseId: Id
+    caseTitle: string
+    summary: string
+    infiltrationAwareness?: number
+    infiltrationProbeProgress?: number
+    infiltrationStage?: 'probing' | 'exposed' | 'violent'
+  }
   'system.academy_upgraded': {
     week: number
     tierBefore: number
@@ -684,6 +693,7 @@ export interface OperationEventTypeToSourceSystemMap {
   'infiltration.awareness_complication': 'system'
   'infiltration.escalation_exposed': 'system'
   'infiltration.escalation_violent': 'system'
+  'infiltration.cover_strain': 'system'
   'system.academy_upgraded': 'system'
   'staff.coping.applied': 'agent'
   'staff.coping.misconduct': 'agent'
@@ -738,6 +748,7 @@ export const EVENT_TYPE_TO_SOURCE_SYSTEM: Readonly<OperationEventTypeToSourceSys
   'infiltration.awareness_complication': 'system',
   'infiltration.escalation_exposed': 'system',
   'infiltration.escalation_violent': 'system',
+  'infiltration.cover_strain': 'system',
   'system.academy_upgraded': 'system',
   'staff.coping.applied': 'agent',
   'staff.coping.misconduct': 'agent',

--- a/src/domain/infiltrationCover.ts
+++ b/src/domain/infiltrationCover.ts
@@ -6,12 +6,12 @@ import { clamp } from './math'
 import type { CaseInstance } from './models'
 import {
   AWARENESS_COMPLICATION_THRESHOLD,
-  type InfiltrationProbeState,
   type InfiltrationThresholdEvent,
   isInfiltrationProbeEligible,
   mergeInfiltrationProbeStateIntoCase,
   readInfiltrationProbeState,
-  VIOLENT_ESCALATION_THRESHOLD,
+  resolveInfiltrationStageAfterAwareness,
+  resolveInfiltrationThresholdEvents,
 } from './infiltrationProbe'
 
 export type InfiltrationCoverRole =
@@ -95,44 +95,6 @@ export function copyInfiltrationCoverProfile(
     ...profile,
     routeViolationTags: profile.routeViolationTags ? [...profile.routeViolationTags] : undefined,
   }
-}
-
-function resolveThresholdEvents(
-  priorState: InfiltrationProbeState,
-  nextState: InfiltrationProbeState
-): InfiltrationThresholdEvent[] {
-  const events: InfiltrationThresholdEvent[] = []
-  const priorAwareness = priorState.awareness
-  const priorStage = priorState.stage
-  const { awareness, stage } = nextState
-
-  if (
-    awareness >= AWARENESS_COMPLICATION_THRESHOLD &&
-    priorAwareness < AWARENESS_COMPLICATION_THRESHOLD
-  ) {
-    events.push({
-      kind: 'awareness_complication',
-      summary:
-        'Site awareness crossed the complication band; patrol focus or staff challenges may intensify without ending the operation.',
-    })
-    if (stage === 'exposed' && priorStage === 'probing') {
-      events.push({
-        kind: 'escalation_exposed',
-        summary:
-          'Cover strain is visible to local observers; behavior scrutiny and detection pressure increase.',
-      })
-    }
-  }
-
-  if (awareness >= VIOLENT_ESCALATION_THRESHOLD && priorStage !== 'violent' && stage === 'violent') {
-    events.push({
-      kind: 'escalation_violent',
-      summary:
-        'Infiltrator shifted from probing to overt violence or emergency escape as discovery risk spiked.',
-    })
-  }
-
-  return events
 }
 
 /**
@@ -237,27 +199,18 @@ export function applyWeeklyInfiltrationCoverPostureToCase(
   const nextAwareness = roundBand(
     clamp(priorState.awareness + posture.awarenessDelta, 0, 1)
   )
-  let stage = priorState.stage
-
-  if (
-    nextAwareness >= AWARENESS_COMPLICATION_THRESHOLD &&
-    priorState.awareness < AWARENESS_COMPLICATION_THRESHOLD &&
-    stage === 'probing'
-  ) {
-    stage = 'exposed'
-  }
-
-  if (nextAwareness >= VIOLENT_ESCALATION_THRESHOLD && priorState.stage !== 'violent') {
-    stage = 'violent'
-  }
-
-  const nextState: InfiltrationProbeState = {
+  const stage = resolveInfiltrationStageAfterAwareness(
+    priorState.stage,
+    priorState.awareness,
+    nextAwareness
+  )
+  const nextState = {
     probeProgress: priorState.probeProgress,
     awareness: nextAwareness,
     stage,
   }
 
-  const thresholdEvents = resolveThresholdEvents(priorState, nextState)
+  const thresholdEvents = resolveInfiltrationThresholdEvents(priorState, nextState)
   const merged = mergeInfiltrationProbeStateIntoCase(caseData, nextState)
   const events = [...posture.events, ...thresholdEvents]
   const changed =

--- a/src/domain/infiltrationCover.ts
+++ b/src/domain/infiltrationCover.ts
@@ -180,7 +180,7 @@ export function evaluateWeeklyInfiltrationCoverPosture(
 
   const doctrineBand = profile.doctrineBand ?? 1
 
-  if (proceduralScrutiny && doctrineBand < 0.35) {
+  if (proceduralScrutiny && doctrineBand < COVER_STRAIN_BAND) {
     awarenessDelta += WEAK_DOCTRINE_AWARENESS
     strainReasons.push('cover doctrine slips under procedural questioning')
   }

--- a/src/domain/infiltrationCover.ts
+++ b/src/domain/infiltrationCover.ts
@@ -199,14 +199,12 @@ export function evaluateWeeklyInfiltrationCoverPosture(
   const events: InfiltrationThresholdEvent[] = []
   const strainSummary =
     strainReasons.join('; ') ||
-    'Weekly cover posture review flagged visible mismatch between role and site expectations.'
+    'Cover posture strain accumulated; observers may begin treating the infiltrator as out of role.'
 
   if (priorAwareness < COVER_STRAIN_BAND && nextAwareness >= COVER_STRAIN_BAND) {
     events.push({
       kind: 'cover_strain',
-      summary:
-        strainReasons[0] ??
-        'Cover posture strain accumulated; observers may begin treating the infiltrator as out of role.',
+      summary: strainSummary,
     })
   } else if (
     effectiveDelta >= ROUTE_VIOLATION_AWARENESS &&

--- a/src/domain/infiltrationCover.ts
+++ b/src/domain/infiltrationCover.ts
@@ -1,0 +1,257 @@
+/**
+ * SPE-521 slice 3: authored cover identity profile and weekly posture evaluation.
+ */
+
+import { clamp } from './math'
+import type { CaseInstance } from './models'
+import {
+  AWARENESS_COMPLICATION_THRESHOLD,
+  type InfiltrationProbeState,
+  type InfiltrationThresholdEvent,
+  isInfiltrationProbeEligible,
+  mergeInfiltrationProbeStateIntoCase,
+  readInfiltrationProbeState,
+  VIOLENT_ESCALATION_THRESHOLD,
+} from './infiltrationProbe'
+
+export type InfiltrationCoverRole =
+  | 'uniform_guard'
+  | 'civilian_staff'
+  | 'courier'
+  | 'maintenance'
+  | 'official_inspector'
+
+const INFILTRATION_COVER_ROLES: readonly InfiltrationCoverRole[] = [
+  'uniform_guard',
+  'civilian_staff',
+  'courier',
+  'maintenance',
+  'official_inspector',
+]
+
+export function isInfiltrationCoverRole(value: string): value is InfiltrationCoverRole {
+  return (INFILTRATION_COVER_ROLES as readonly string[]).includes(value)
+}
+
+export interface InfiltrationCoverProfile {
+  readonly claimedRole: InfiltrationCoverRole
+  /** 0 = forged or missing, 1 = plausible, 2 = strong institutional backing. */
+  readonly documentTier?: number
+  /** 0–1 doctrine or cover-story fluency for scripted checks. */
+  readonly doctrineBand?: number
+  /** Case tags that spike awareness when present alongside this cover. */
+  readonly routeViolationTags?: readonly string[]
+}
+
+export interface InfiltrationCoverPostureEvaluation {
+  awarenessDelta: number
+  events: readonly InfiltrationThresholdEvent[]
+  summary?: string
+}
+
+export interface WeeklyInfiltrationCoverPostureResult {
+  case: CaseInstance
+  events: readonly InfiltrationThresholdEvent[]
+  changed: boolean
+}
+
+const AUTHORITY_SCRUTINY_TAGS = ['public', 'media', 'court'] as const
+const PROCEDURAL_SCRUTINY_TAGS = ['witness', 'interview', 'civilian', 'court'] as const
+
+const ROLE_INCOMPATIBLE_CASE_TAGS: Record<InfiltrationCoverRole, readonly string[]> = {
+  uniform_guard: ['media', 'public', 'interview'],
+  civilian_staff: ['military', 'parade'],
+  courier: ['court', 'media'],
+  maintenance: ['media', 'public', 'court'],
+  official_inspector: ['covert', 'infiltration'],
+}
+
+const ROLE_MISMATCH_AWARENESS = 0.08
+const ROUTE_VIOLATION_AWARENESS = 0.06
+const WEAK_DOCUMENT_AWARENESS = 0.05
+const WEAK_DOCTRINE_AWARENESS = 0.04
+const COVER_STRAIN_BAND = 0.35
+
+function collectCaseTags(caseData: CaseInstance): Set<string> {
+  return new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])
+}
+
+function hasAnyTag(caseTags: Set<string>, candidates: readonly string[]) {
+  return candidates.some((tag) => caseTags.has(tag))
+}
+
+function roundBand(value: number) {
+  return Math.round(value * 1000) / 1000
+}
+
+export function copyInfiltrationCoverProfile(
+  profile: InfiltrationCoverProfile | undefined
+): InfiltrationCoverProfile | undefined {
+  if (profile === undefined) {
+    return undefined
+  }
+
+  return {
+    ...profile,
+    routeViolationTags: profile.routeViolationTags ? [...profile.routeViolationTags] : undefined,
+  }
+}
+
+function resolveThresholdEvents(
+  priorState: InfiltrationProbeState,
+  nextState: InfiltrationProbeState
+): InfiltrationThresholdEvent[] {
+  const events: InfiltrationThresholdEvent[] = []
+  const priorAwareness = priorState.awareness
+  const priorStage = priorState.stage
+  const { awareness, stage } = nextState
+
+  if (
+    awareness >= AWARENESS_COMPLICATION_THRESHOLD &&
+    priorAwareness < AWARENESS_COMPLICATION_THRESHOLD
+  ) {
+    events.push({
+      kind: 'awareness_complication',
+      summary:
+        'Site awareness crossed the complication band; patrol focus or staff challenges may intensify without ending the operation.',
+    })
+    if (stage === 'exposed' && priorStage === 'probing') {
+      events.push({
+        kind: 'escalation_exposed',
+        summary:
+          'Cover strain is visible to local observers; behavior scrutiny and detection pressure increase.',
+      })
+    }
+  }
+
+  if (awareness >= VIOLENT_ESCALATION_THRESHOLD && priorStage !== 'violent' && stage === 'violent') {
+    events.push({
+      kind: 'escalation_violent',
+      summary:
+        'Infiltrator shifted from probing to overt violence or emergency escape as discovery risk spiked.',
+    })
+  }
+
+  return events
+}
+
+/**
+ * Deterministic weekly cover posture pressure from authored profile vs case context.
+ */
+export function evaluateWeeklyInfiltrationCoverPosture(
+  caseData: CaseInstance
+): InfiltrationCoverPostureEvaluation {
+  const profile = caseData.infiltrationCoverProfile
+
+  if (!isInfiltrationProbeEligible(caseData) || profile === undefined) {
+    return { awarenessDelta: 0, events: [] }
+  }
+
+  const caseTags = collectCaseTags(caseData)
+  const priorAwareness = clamp(caseData.infiltrationAwareness ?? 0, 0, 1)
+  let awarenessDelta = 0
+  const strainReasons: string[] = []
+
+  const incompatibleTags = ROLE_INCOMPATIBLE_CASE_TAGS[profile.claimedRole]
+  if (hasAnyTag(caseTags, incompatibleTags)) {
+    awarenessDelta += ROLE_MISMATCH_AWARENESS
+    strainReasons.push(`claimed ${profile.claimedRole} clashes with site context`)
+  }
+
+  if (profile.routeViolationTags !== undefined && hasAnyTag(caseTags, profile.routeViolationTags)) {
+    awarenessDelta += ROUTE_VIOLATION_AWARENESS
+    strainReasons.push('movement or venue tags contradict the cover story')
+  }
+
+  const authorityScrutiny = hasAnyTag(caseTags, AUTHORITY_SCRUTINY_TAGS)
+  const proceduralScrutiny = hasAnyTag(caseTags, PROCEDURAL_SCRUTINY_TAGS)
+  const documentTier = profile.documentTier ?? 2
+
+  if (authorityScrutiny && documentTier <= 0) {
+    awarenessDelta += WEAK_DOCUMENT_AWARENESS
+    strainReasons.push('paperwork cannot survive authority scrutiny')
+  }
+
+  const doctrineBand = profile.doctrineBand ?? 1
+
+  if (proceduralScrutiny && doctrineBand < 0.35) {
+    awarenessDelta += WEAK_DOCTRINE_AWARENESS
+    strainReasons.push('cover doctrine slips under procedural questioning')
+  }
+
+  if (awarenessDelta <= 0) {
+    return { awarenessDelta: 0, events: [] }
+  }
+
+  const events: InfiltrationThresholdEvent[] = []
+  const nextAwareness = roundBand(clamp(priorAwareness + awarenessDelta, 0, 1))
+
+  if (priorAwareness < COVER_STRAIN_BAND && nextAwareness >= COVER_STRAIN_BAND) {
+    events.push({
+      kind: 'cover_strain',
+      summary:
+        strainReasons[0] ??
+        'Cover posture strain accumulated; observers may begin treating the infiltrator as out of role.',
+    })
+  } else if (awarenessDelta >= ROUTE_VIOLATION_AWARENESS) {
+    events.push({
+      kind: 'cover_strain',
+      summary:
+        strainReasons.join('; ') ||
+        'Weekly cover posture review flagged visible mismatch between role and site expectations.',
+    })
+  }
+
+  return {
+    awarenessDelta: roundBand(awarenessDelta),
+    events,
+    summary: strainReasons.join('; ') || undefined,
+  }
+}
+
+/** Merges cover posture awareness delta and threshold follow-ups onto the case. */
+export function applyWeeklyInfiltrationCoverPostureToCase(
+  caseData: CaseInstance
+): WeeklyInfiltrationCoverPostureResult {
+  const posture = evaluateWeeklyInfiltrationCoverPosture(caseData)
+
+  if (posture.awarenessDelta <= 0) {
+    return { case: caseData, events: [], changed: false }
+  }
+
+  const priorState = readInfiltrationProbeState(caseData)
+  const nextAwareness = roundBand(clamp(priorState.awareness + posture.awarenessDelta, 0, 1))
+  let stage = priorState.stage
+
+  if (
+    nextAwareness >= AWARENESS_COMPLICATION_THRESHOLD &&
+    priorState.awareness < AWARENESS_COMPLICATION_THRESHOLD &&
+    stage === 'probing'
+  ) {
+    stage = 'exposed'
+  }
+
+  if (nextAwareness >= VIOLENT_ESCALATION_THRESHOLD && priorState.stage !== 'violent') {
+    stage = 'violent'
+  }
+
+  const nextState: InfiltrationProbeState = {
+    probeProgress: priorState.probeProgress,
+    awareness: nextAwareness,
+    stage,
+  }
+
+  const thresholdEvents = resolveThresholdEvents(priorState, nextState)
+  const merged = mergeInfiltrationProbeStateIntoCase(caseData, nextState)
+  const changed =
+    merged.infiltrationAwareness !== caseData.infiltrationAwareness ||
+    merged.infiltrationStage !== caseData.infiltrationStage ||
+    merged.detectionConfidence !== caseData.detectionConfidence ||
+    merged.counterDetection !== caseData.counterDetection
+
+  return {
+    case: merged,
+    events: [...posture.events, ...thresholdEvents],
+    changed,
+  }
+}

--- a/src/domain/infiltrationCover.ts
+++ b/src/domain/infiltrationCover.ts
@@ -63,7 +63,7 @@ const ROLE_INCOMPATIBLE_CASE_TAGS: Record<InfiltrationCoverRole, readonly string
   civilian_staff: ['military', 'parade'],
   courier: ['court', 'media'],
   maintenance: ['media', 'public', 'court'],
-  official_inspector: ['covert', 'infiltration'],
+  official_inspector: ['covert'],
 }
 
 const ROLE_MISMATCH_AWARENESS = 0.08

--- a/src/domain/infiltrationCover.ts
+++ b/src/domain/infiltrationCover.ts
@@ -63,7 +63,7 @@ const ROLE_INCOMPATIBLE_CASE_TAGS: Record<InfiltrationCoverRole, readonly string
   civilian_staff: ['military', 'parade'],
   courier: ['court', 'media'],
   maintenance: ['media', 'public', 'court'],
-  official_inspector: ['covert'],
+  official_inspector: [],
 }
 
 const ROLE_MISMATCH_AWARENESS = 0.08

--- a/src/domain/infiltrationCover.ts
+++ b/src/domain/infiltrationCover.ts
@@ -158,7 +158,13 @@ export function evaluateWeeklyInfiltrationCoverPosture(
     strainReasons.push(`claimed ${profile.claimedRole} clashes with site context`)
   }
 
-  if (profile.routeViolationTags !== undefined && hasAnyTag(caseTags, profile.routeViolationTags)) {
+  const incompatibleTagSet = new Set(incompatibleTags)
+  const extraRouteViolations =
+    profile.routeViolationTags?.filter(
+      (tag) => caseTags.has(tag) && !incompatibleTagSet.has(tag)
+    ) ?? []
+
+  if (extraRouteViolations.length > 0) {
     awarenessDelta += ROUTE_VIOLATION_AWARENESS
     strainReasons.push('movement or venue tags contradict the cover story')
   }
@@ -183,8 +189,17 @@ export function evaluateWeeklyInfiltrationCoverPosture(
     return { awarenessDelta: 0, events: [] }
   }
 
-  const events: InfiltrationThresholdEvent[] = []
   const nextAwareness = roundBand(clamp(priorAwareness + awarenessDelta, 0, 1))
+  const effectiveDelta = roundBand(nextAwareness - priorAwareness)
+
+  if (effectiveDelta <= 0) {
+    return { awarenessDelta: 0, events: [] }
+  }
+
+  const events: InfiltrationThresholdEvent[] = []
+  const strainSummary =
+    strainReasons.join('; ') ||
+    'Weekly cover posture review flagged visible mismatch between role and site expectations.'
 
   if (priorAwareness < COVER_STRAIN_BAND && nextAwareness >= COVER_STRAIN_BAND) {
     events.push({
@@ -193,17 +208,18 @@ export function evaluateWeeklyInfiltrationCoverPosture(
         strainReasons[0] ??
         'Cover posture strain accumulated; observers may begin treating the infiltrator as out of role.',
     })
-  } else if (awarenessDelta >= ROUTE_VIOLATION_AWARENESS) {
+  } else if (
+    effectiveDelta >= ROUTE_VIOLATION_AWARENESS &&
+    priorAwareness < AWARENESS_COMPLICATION_THRESHOLD
+  ) {
     events.push({
       kind: 'cover_strain',
-      summary:
-        strainReasons.join('; ') ||
-        'Weekly cover posture review flagged visible mismatch between role and site expectations.',
+      summary: strainSummary,
     })
   }
 
   return {
-    awarenessDelta: roundBand(awarenessDelta),
+    awarenessDelta: effectiveDelta,
     events,
     summary: strainReasons.join('; ') || undefined,
   }
@@ -220,7 +236,9 @@ export function applyWeeklyInfiltrationCoverPostureToCase(
   }
 
   const priorState = readInfiltrationProbeState(caseData)
-  const nextAwareness = roundBand(clamp(priorState.awareness + posture.awarenessDelta, 0, 1))
+  const nextAwareness = roundBand(
+    clamp(priorState.awareness + posture.awarenessDelta, 0, 1)
+  )
   let stage = priorState.stage
 
   if (
@@ -243,15 +261,17 @@ export function applyWeeklyInfiltrationCoverPostureToCase(
 
   const thresholdEvents = resolveThresholdEvents(priorState, nextState)
   const merged = mergeInfiltrationProbeStateIntoCase(caseData, nextState)
+  const events = [...posture.events, ...thresholdEvents]
   const changed =
     merged.infiltrationAwareness !== caseData.infiltrationAwareness ||
     merged.infiltrationStage !== caseData.infiltrationStage ||
     merged.detectionConfidence !== caseData.detectionConfidence ||
-    merged.counterDetection !== caseData.counterDetection
+    merged.counterDetection !== caseData.counterDetection ||
+    events.length > 0
 
   return {
     case: merged,
-    events: [...posture.events, ...thresholdEvents],
+    events,
     changed,
   }
 }

--- a/src/domain/infiltrationCoverAuthoring.ts
+++ b/src/domain/infiltrationCoverAuthoring.ts
@@ -30,6 +30,10 @@ function normalizeDocumentTier(value: unknown): number | undefined {
     return undefined
   }
 
+  if (value < 0) {
+    return undefined
+  }
+
   const tier = Math.trunc(value)
   return tier >= 0 && tier <= 2 ? tier : undefined
 }

--- a/src/domain/infiltrationCoverAuthoring.ts
+++ b/src/domain/infiltrationCoverAuthoring.ts
@@ -1,0 +1,96 @@
+/**
+ * SPE-521 slice 3: normalize authored infiltration cover profiles for case templates.
+ */
+
+import type { InfiltrationCoverProfile, InfiltrationCoverRole } from './infiltrationCover'
+import { isInfiltrationCoverRole } from './infiltrationCover'
+
+export interface AuthoredInfiltrationCoverProfile {
+  claimedRole?: string
+  documentTier?: number
+  doctrineBand?: number
+  routeViolationTags?: readonly string[]
+}
+
+function isAuthoredProfileRecord(value: unknown): value is Partial<AuthoredInfiltrationCoverProfile> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeCoverRole(role: unknown): InfiltrationCoverRole | undefined {
+  if (typeof role !== 'string') {
+    return undefined
+  }
+
+  const trimmed = role.trim() as InfiltrationCoverRole
+  return isInfiltrationCoverRole(trimmed) ? trimmed : undefined
+}
+
+function normalizeDocumentTier(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  const tier = Math.trunc(value)
+  return tier >= 0 && tier <= 2 ? tier : undefined
+}
+
+function normalizeDoctrineBand(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  return value >= 0 && value <= 1 ? value : undefined
+}
+
+function normalizeRouteViolationTags(tags: readonly string[] | undefined): readonly string[] | undefined {
+  if (!Array.isArray(tags) || tags.length === 0) {
+    return undefined
+  }
+
+  const normalized = [
+    ...new Set(tags.map((tag) => (typeof tag === 'string' ? tag.trim() : '')).filter(Boolean)),
+  ]
+
+  return normalized.length > 0 ? normalized : undefined
+}
+
+export function buildInfiltrationCoverProfileFromAuthored(
+  authored: AuthoredInfiltrationCoverProfile | undefined | null
+): InfiltrationCoverProfile | undefined {
+  if (authored == null) {
+    return undefined
+  }
+
+  const claimedRole = normalizeCoverRole(authored.claimedRole)
+  const documentTier = normalizeDocumentTier(authored.documentTier)
+  const doctrineBand = normalizeDoctrineBand(authored.doctrineBand)
+  const routeViolationTags = normalizeRouteViolationTags(authored.routeViolationTags)
+
+  if (claimedRole === undefined) {
+    return undefined
+  }
+
+  const profile: InfiltrationCoverProfile = { claimedRole }
+
+  if (documentTier !== undefined) {
+    profile.documentTier = documentTier
+  }
+  if (doctrineBand !== undefined) {
+    profile.doctrineBand = doctrineBand
+  }
+  if (routeViolationTags !== undefined) {
+    profile.routeViolationTags = routeViolationTags
+  }
+
+  return profile
+}
+
+export function buildInfiltrationCoverProfileFromAuthoredRecord(
+  authored: unknown
+): InfiltrationCoverProfile | undefined {
+  if (!isAuthoredProfileRecord(authored)) {
+    return undefined
+  }
+
+  return buildInfiltrationCoverProfileFromAuthored(authored as AuthoredInfiltrationCoverProfile)
+}

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -194,21 +194,38 @@ function roundBand(value: number) {
   return Math.round(value * 1000) / 1000
 }
 
-/**
- * Applies one infiltration action to probe/awareness tracks and returns threshold events.
- */
-export function evaluateInfiltrationProbe(
-  state: InfiltrationProbeState,
-  action: InfiltrationProbeAction
-): InfiltrationProbeEvaluation {
-  const events: InfiltrationThresholdEvent[] = []
-  const priorAwareness = state.awareness
-  const priorStage = state.stage
-  const delta = ACTION_DELTAS[action]
+/** Resolves infiltration stage after an awareness change (probe actions or cover posture). */
+export function resolveInfiltrationStageAfterAwareness(
+  priorStage: InfiltrationStage,
+  priorAwareness: number,
+  nextAwareness: number
+): InfiltrationStage {
+  let stage = priorStage
 
-  const probeProgress = roundBand(clamp(state.probeProgress + delta.probeProgress, 0, 1))
-  const awareness = roundBand(clamp(state.awareness + delta.awareness, 0, 1))
-  let stage = state.stage
+  if (
+    nextAwareness >= AWARENESS_COMPLICATION_THRESHOLD &&
+    priorAwareness < AWARENESS_COMPLICATION_THRESHOLD &&
+    stage === 'probing'
+  ) {
+    stage = 'exposed'
+  }
+
+  if (nextAwareness >= VIOLENT_ESCALATION_THRESHOLD && priorStage !== 'violent') {
+    stage = 'violent'
+  }
+
+  return stage
+}
+
+/** Emits threshold events when awareness or stage cross configured bands. */
+export function resolveInfiltrationThresholdEvents(
+  priorState: InfiltrationProbeState,
+  nextState: InfiltrationProbeState
+): InfiltrationThresholdEvent[] {
+  const events: InfiltrationThresholdEvent[] = []
+  const priorAwareness = priorState.awareness
+  const priorStage = priorState.stage
+  const { awareness, stage } = nextState
 
   if (
     awareness >= AWARENESS_COMPLICATION_THRESHOLD &&
@@ -219,8 +236,7 @@ export function evaluateInfiltrationProbe(
       summary:
         'Site awareness crossed the complication band; patrol focus or staff challenges may intensify without ending the operation.',
     })
-    if (stage === 'probing') {
-      stage = 'exposed'
+    if (stage === 'exposed' && priorStage === 'probing') {
       events.push({
         kind: 'escalation_exposed',
         summary:
@@ -229,8 +245,7 @@ export function evaluateInfiltrationProbe(
     }
   }
 
-  if (awareness >= VIOLENT_ESCALATION_THRESHOLD && priorStage !== 'violent') {
-    stage = 'violent'
+  if (awareness >= VIOLENT_ESCALATION_THRESHOLD && priorStage !== 'violent' && stage === 'violent') {
     events.push({
       kind: 'escalation_violent',
       summary:
@@ -238,9 +253,25 @@ export function evaluateInfiltrationProbe(
     })
   }
 
+  return events
+}
+
+/**
+ * Applies one infiltration action to probe/awareness tracks and returns threshold events.
+ */
+export function evaluateInfiltrationProbe(
+  state: InfiltrationProbeState,
+  action: InfiltrationProbeAction
+): InfiltrationProbeEvaluation {
+  const delta = ACTION_DELTAS[action]
+  const probeProgress = roundBand(clamp(state.probeProgress + delta.probeProgress, 0, 1))
+  const awareness = roundBand(clamp(state.awareness + delta.awareness, 0, 1))
+  const stage = resolveInfiltrationStageAfterAwareness(state.stage, state.awareness, awareness)
+  const nextState: InfiltrationProbeState = { probeProgress, awareness, stage }
+
   return {
-    nextState: { probeProgress, awareness, stage },
-    events,
+    nextState,
+    events: resolveInfiltrationThresholdEvents(state, nextState),
   }
 }
 

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -3,22 +3,9 @@
  * Progress and awareness advance independently; thresholds emit complications before hard failure.
  */
 
+import { applyWeeklyInfiltrationCoverPostureToCase } from './infiltrationCover'
 import { clamp } from './math'
 import type { CaseInstance } from './models'
-
-type ApplyWeeklyInfiltrationCoverPostureToCase = typeof import('./infiltrationCover').applyWeeklyInfiltrationCoverPostureToCase
-
-let applyWeeklyInfiltrationCoverPostureToCase: ApplyWeeklyInfiltrationCoverPostureToCase = ((..._args) => {
-  throw new Error(
-    'applyWeeklyInfiltrationCoverPostureToCase has not been registered in infiltrationProbe.'
-  )
-}) as ApplyWeeklyInfiltrationCoverPostureToCase
-
-export function setApplyWeeklyInfiltrationCoverPostureToCase(
-  applyCoverPosture: ApplyWeeklyInfiltrationCoverPostureToCase
-): void {
-  applyWeeklyInfiltrationCoverPostureToCase = applyCoverPosture
-}
 
 export type InfiltrationStage = 'probing' | 'exposed' | 'violent'
 

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -3,9 +3,22 @@
  * Progress and awareness advance independently; thresholds emit complications before hard failure.
  */
 
-import { applyWeeklyInfiltrationCoverPostureToCase } from './infiltrationCover'
 import { clamp } from './math'
 import type { CaseInstance } from './models'
+
+type ApplyWeeklyInfiltrationCoverPostureToCase = typeof import('./infiltrationCover').applyWeeklyInfiltrationCoverPostureToCase
+
+let applyWeeklyInfiltrationCoverPostureToCase: ApplyWeeklyInfiltrationCoverPostureToCase = ((..._args) => {
+  throw new Error(
+    'applyWeeklyInfiltrationCoverPostureToCase has not been registered in infiltrationProbe.'
+  )
+}) as ApplyWeeklyInfiltrationCoverPostureToCase
+
+export function setApplyWeeklyInfiltrationCoverPostureToCase(
+  applyCoverPosture: ApplyWeeklyInfiltrationCoverPostureToCase
+): void {
+  applyWeeklyInfiltrationCoverPostureToCase = applyCoverPosture
+}
 
 export type InfiltrationStage = 'probing' | 'exposed' | 'violent'
 

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -3,6 +3,7 @@
  * Progress and awareness advance independently; thresholds emit complications before hard failure.
  */
 
+import { applyWeeklyInfiltrationCoverPostureToCase } from './infiltrationCover'
 import { clamp } from './math'
 import type { CaseInstance } from './models'
 
@@ -57,6 +58,7 @@ export type InfiltrationThresholdEventKind =
   | 'awareness_complication'
   | 'escalation_exposed'
   | 'escalation_violent'
+  | 'cover_strain'
 
 export interface InfiltrationThresholdEvent {
   kind: InfiltrationThresholdEventKind
@@ -308,7 +310,14 @@ export function applyWeeklyInfiltrationProbeTick(
   }
 
   const resolvedAction = action ?? resolveWeeklyInfiltrationProbeAction(caseData)
-  return applyInfiltrationProbeActionToCase(caseData, resolvedAction)
+  const probeResult = applyInfiltrationProbeActionToCase(caseData, resolvedAction)
+  const coverResult = applyWeeklyInfiltrationCoverPostureToCase(probeResult.case)
+
+  return {
+    case: coverResult.case,
+    events: [...probeResult.events, ...coverResult.events],
+    changed: probeResult.changed || coverResult.changed,
+  }
 }
 
 export function getInfiltrationAwarenessPressure(caseData: CaseInstance) {

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -287,7 +287,8 @@ export function applyInfiltrationProbeActionToCase(
     merged.infiltrationAwareness !== caseData.infiltrationAwareness ||
     merged.infiltrationStage !== caseData.infiltrationStage ||
     merged.detectionConfidence !== caseData.detectionConfidence ||
-    merged.counterDetection !== caseData.counterDetection
+    merged.counterDetection !== caseData.counterDetection ||
+    evaluation.events.length > 0
 
   return {
     case: merged,
@@ -313,10 +314,12 @@ export function applyWeeklyInfiltrationProbeTick(
   const probeResult = applyInfiltrationProbeActionToCase(caseData, resolvedAction)
   const coverResult = applyWeeklyInfiltrationCoverPostureToCase(probeResult.case)
 
+  const events = [...probeResult.events, ...coverResult.events]
+
   return {
     case: coverResult.case,
-    events: [...probeResult.events, ...coverResult.events],
-    changed: probeResult.changed || coverResult.changed,
+    events,
+    changed: probeResult.changed || coverResult.changed || events.length > 0,
   }
 }
 

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1258,6 +1258,9 @@ export interface CaseTemplate {
 
   /** SPE-521 slice 2: authored weekly infiltration probe action plan (normalized in catalog build). */
   infiltrationProbePlan?: import('./infiltrationProbe').InfiltrationProbePlan
+
+  /** SPE-521 slice 3: authored cover identity profile (normalized in catalog build). */
+  infiltrationCoverProfile?: import('./infiltrationCover').InfiltrationCoverProfile
 }
 
 /** SPE-1701: deterministic deployment carry-in stamped at team→case assignment. */
@@ -1337,6 +1340,8 @@ export interface CaseInstance {
   concealmentTriggers?: readonly import('./hiddenStateActivation').ConcealmentActivationTrigger[]
   /** SPE-521 slice 2: weekly infiltration probe action plan copied from template at spawn. */
   infiltrationProbePlan?: import('./infiltrationProbe').InfiltrationProbePlan
+  /** SPE-521 slice 3: cover identity profile copied from template at spawn. */
+  infiltrationCoverProfile?: import('./infiltrationCover').InfiltrationCoverProfile
 
   onFail: SpawnRule
   onUnresolved: SpawnRule
@@ -1457,6 +1462,10 @@ export type ReportNoteType =
   | 'directive.applied'
   // Add support.shortfall for fallout reporting
   | 'support.shortfall'
+  | 'infiltration.awareness_complication'
+  | 'infiltration.escalation_exposed'
+  | 'infiltration.escalation_violent'
+  | 'infiltration.cover_strain'
   | 'support.restored'
   | 'hub.opportunity'
   | 'hub.rumor'

--- a/src/domain/reportNotes.ts
+++ b/src/domain/reportNotes.ts
@@ -433,6 +433,23 @@ function buildReflectedReportNote(draft: AnyOperationEventDraft): {
         },
       }
 
+    case 'infiltration.awareness_complication':
+    case 'infiltration.escalation_exposed':
+    case 'infiltration.escalation_violent':
+    case 'infiltration.cover_strain':
+      return {
+        content: `${draft.payload.caseTitle}: ${draft.payload.summary}`,
+        type: draft.type,
+        metadata: {
+          caseId: draft.payload.caseId,
+          caseTitle: draft.payload.caseTitle,
+          summary: draft.payload.summary,
+          infiltrationAwareness: draft.payload.infiltrationAwareness ?? null,
+          infiltrationProbeProgress: draft.payload.infiltrationProbeProgress ?? null,
+          infiltrationStage: draft.payload.infiltrationStage ?? null,
+        },
+      }
+
     case 'system.equipment_recovered':
       return {
         content: draft.payload.content,

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -2102,9 +2102,7 @@ function applyWeeklyInfiltrationProbe(
     return caseData
   }
 
-  if (probeResult.changed || probeResult.events.length > 0) {
-    context.nextState.cases[caseId] = probeResult.case
-  }
+  context.nextState.cases[caseId] = probeResult.case
 
   for (const event of probeResult.events) {
     context.eventDrafts.push({
@@ -2122,7 +2120,7 @@ function applyWeeklyInfiltrationProbe(
     })
   }
 
-  return probeResult.changed || probeResult.events.length > 0 ? probeResult.case : caseData
+  return probeResult.case
 }
 
 // Accept timingCheckState as parameter for shared cadence

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -2098,11 +2098,13 @@ function applyWeeklyInfiltrationProbe(
 ): CaseInstance {
   const probeResult = applyWeeklyInfiltrationProbeTick(caseData, context.sourceState.week)
 
-  if (!probeResult.changed) {
+  if (!probeResult.changed && probeResult.events.length === 0) {
     return caseData
   }
 
-  context.nextState.cases[caseId] = probeResult.case
+  if (probeResult.changed || probeResult.events.length > 0) {
+    context.nextState.cases[caseId] = probeResult.case
+  }
 
   for (const event of probeResult.events) {
     context.eventDrafts.push({
@@ -2120,7 +2122,7 @@ function applyWeeklyInfiltrationProbe(
     })
   }
 
-  return probeResult.case
+  return probeResult.changed || probeResult.events.length > 0 ? probeResult.case : caseData
 }
 
 // Accept timingCheckState as parameter for shared cadence

--- a/src/domain/sim/spawn.ts
+++ b/src/domain/sim/spawn.ts
@@ -4,6 +4,7 @@ import { createMissionIntelState } from '../intel'
 import { type CaseInstance, type CaseTemplate, type CompromisedAuthorityState, type GameState, type SpawnRule } from '../models'
 import { inferCasePressureValue, inferCaseRegionTag } from '../pressure'
 import { normalizeSpawnRule } from '../spawnRules'
+import { copyInfiltrationCoverProfile } from '../infiltrationCover'
 import { copyInfiltrationProbePlan } from '../infiltrationProbe'
 import { applySiteGenerationToCase } from '../siteGeneration'
 import { SIM_NOTES } from '../../data/copy'
@@ -164,6 +165,7 @@ export function instantiateFromTemplate(
         ? [...concealmentTriggers]
         : undefined,
     infiltrationProbePlan: copyInfiltrationProbePlan(template.infiltrationProbePlan),
+    infiltrationCoverProfile: copyInfiltrationCoverProfile(template.infiltrationCoverProfile),
   }
 
   return applySiteGenerationToCase({

--- a/src/domain/templates/caseTemplates.occult.ts
+++ b/src/domain/templates/caseTemplates.occult.ts
@@ -170,6 +170,11 @@ export const occultCaseTemplates: CaseTemplate[] = [
       defaultAction: 'probe_route',
       actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.45, action: 'probe_access' }],
     },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 2,
+      doctrineBand: 0.55,
+    },
     requiredTags: ['negotiator'],
     preferredTags: ['medium', 'investigator', 'disguise', 'infiltration'],
     raid: { minTeams: 2, maxTeams: 4 },

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -145,7 +145,6 @@ export const operationsCaseTemplates: CaseTemplate[] = [
       claimedRole: 'uniform_guard',
       documentTier: 1,
       doctrineBand: 0.4,
-      routeViolationTags: ['media', 'public'],
     },
     requiredTags: ['medium'],
     preferredTags: ['negotiator', 'liaison', 'infiltration'],

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -27,6 +27,11 @@ export const operationsCaseTemplates: CaseTemplate[] = [
       defaultAction: 'probe_route',
       actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.5, action: 'probe_access' }],
     },
+    infiltrationCoverProfile: {
+      claimedRole: 'courier',
+      documentTier: 2,
+      doctrineBand: 0.65,
+    },
     requiredTags: ['tech'],
     preferredTags: ['analyst', 'field-kit'],
     onFail: {
@@ -135,6 +140,12 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     infiltrationProbePlan: {
       defaultAction: 'probe_access',
       cleanupWhenAwarenessAtLeast: 0.55,
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'uniform_guard',
+      documentTier: 1,
+      doctrineBand: 0.4,
+      routeViolationTags: ['media', 'public'],
     },
     requiredTags: ['medium'],
     preferredTags: ['negotiator', 'liaison', 'infiltration'],

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -278,6 +278,11 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     infiltrationProbePlan: {
       defaultAction: 'probe_route',
     },
+    infiltrationCoverProfile: {
+      claimedRole: 'official_inspector',
+      documentTier: 2,
+      doctrineBand: 0.7,
+    },
     requiredTags: ['negotiator'],
     preferredTags: ['medium', 'analyst', 'infiltration', 'disguise'],
     pressureValue: 9,

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -767,6 +767,12 @@ export function getCaseTemplateCatalogErrors(templates: CaseTemplate[]) {
       errors.push(`Template ${template.templateId} has invalid required roles.`)
     }
 
+    if (template.infiltrationProbePlan !== undefined && template.infiltrationCoverProfile === undefined) {
+      errors.push(
+        `Template ${template.templateId} declares infiltrationProbePlan without a valid infiltrationCoverProfile.`
+      )
+    }
+
     if (template.concealmentTriggers !== undefined) {
       if (template.concealmentTriggers.length === 0) {
         errors.push(`Template ${template.templateId} declares empty concealmentTriggers.`)

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -4,6 +4,10 @@ import {
   type AuthoredConcealmentActivationTrigger,
 } from '../hiddenStateActivationAuthoring'
 import {
+  buildInfiltrationCoverProfileFromAuthored,
+  type AuthoredInfiltrationCoverProfile,
+} from '../infiltrationCoverAuthoring'
+import {
   buildInfiltrationProbePlanFromAuthored,
   type AuthoredInfiltrationProbePlan,
 } from '../infiltrationProbeAuthoring'
@@ -373,6 +377,11 @@ const baseCaseTemplates: CaseTemplate[] = [
       defaultAction: 'probe_access',
       actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.35, action: 'probe_route' }],
     },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 1,
+      doctrineBand: 0.5,
+    },
     preferredTags: ['scholar', 'tech', 'medium', 'infiltration', 'stealth'],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
@@ -626,6 +635,12 @@ const baseCaseTemplates: CaseTemplate[] = [
       defaultAction: 'probe_route',
       actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
     },
+    infiltrationCoverProfile: {
+      claimedRole: 'courier',
+      documentTier: 1,
+      doctrineBand: 0.45,
+      routeViolationTags: ['cult'],
+    },
     preferredTags: ['negotiator', 'tech', 'infiltration', 'disguise'],
     onFail: {
       stageDelta: 1,
@@ -665,6 +680,7 @@ function cloneTemplate(
   template: CaseTemplate & {
     concealmentTriggers?: readonly AuthoredConcealmentActivationTrigger[]
     infiltrationProbePlan?: AuthoredInfiltrationProbePlan
+    infiltrationCoverProfile?: AuthoredInfiltrationCoverProfile
   }
 ): CaseTemplate {
   const onFail = normalizeSpawnRule(template.onFail)
@@ -673,6 +689,9 @@ function cloneTemplate(
     template.concealmentTriggers ?? []
   )
   const infiltrationProbePlan = buildInfiltrationProbePlanFromAuthored(template.infiltrationProbePlan)
+  const infiltrationCoverProfile = buildInfiltrationCoverProfileFromAuthored(
+    template.infiltrationCoverProfile
+  )
 
   return {
     ...template,
@@ -696,6 +715,7 @@ function cloneTemplate(
     concealmentTriggers:
       concealmentTriggers.length > 0 ? concealmentTriggers : undefined,
     infiltrationProbePlan,
+    infiltrationCoverProfile,
   }
 }
 

--- a/src/domain/templates/startingCases.ts
+++ b/src/domain/templates/startingCases.ts
@@ -3,6 +3,7 @@ import { inferFactionIdFromCaseTags } from '../factions'
 import { createMissionIntelState } from '../intel'
 import { inferCasePressureValue, inferCaseRegionTag } from '../pressure'
 import { normalizeSpawnRule } from '../spawnRules'
+import { copyInfiltrationCoverProfile } from '../infiltrationCover'
 import { copyInfiltrationProbePlan } from '../infiltrationProbe'
 import { applySiteGenerationToCase } from '../siteGeneration'
 import { caseTemplateMap } from './caseTemplates'
@@ -109,6 +110,7 @@ export function createStarterCase(seed: StarterCaseSeed): CaseInstance {
         ? [...template.concealmentTriggers]
         : undefined,
     infiltrationProbePlan: copyInfiltrationProbePlan(template.infiltrationProbePlan),
+    infiltrationCoverProfile: copyInfiltrationCoverProfile(template.infiltrationCoverProfile),
   }
 
   return applySiteGenerationToCase({

--- a/src/test/advanceWeek.infiltrationProbe.integration.test.ts
+++ b/src/test/advanceWeek.infiltrationProbe.integration.test.ts
@@ -43,6 +43,41 @@ describe('advanceWeek infiltration probe integration', () => {
     expect(updatedCase.detectionConfidence).toBeGreaterThanOrEqual(0.55)
   })
 
+  it('emits cover strain when media briefing cover clashes with guard role', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = { 'conceal.case.case-ops-004-cover': true }
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const covertCase = createStarterCase({
+      id: 'case-ops-004-cover',
+      templateId: 'ops-004',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    })
+    covertCase.mode = 'deterministic'
+    covertCase.weeksRemaining = 2
+    covertCase.infiltrationAwareness = 0.3
+    covertCase.infiltrationProbeProgress = 0.2
+
+    state.cases['case-ops-004-cover'] = covertCase
+
+    const nextState = advanceWeek(state)
+    const updatedCase = nextState.cases['case-ops-004-cover']
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+
+    expect(updatedCase.hiddenState).toBe('hidden')
+    expect(updatedCase.infiltrationAwareness).toBeGreaterThan(0.42)
+    expect(lastReport.notes.some((note) => note.type === 'infiltration.cover_strain')).toBe(true)
+  })
+
   it('uses authored cleanup when awareness crosses the plan threshold', () => {
     const state = createStartingState()
     const [teamId] = Object.keys(state.teams)

--- a/src/test/events.coverage.test.ts
+++ b/src/test/events.coverage.test.ts
@@ -46,6 +46,7 @@ const EVENT_TYPE_COVERAGE_STATUS: Record<OperationEventType, 'covered' | 'future
   'infiltration.awareness_complication': 'covered',
   'infiltration.escalation_exposed': 'covered',
   'infiltration.escalation_violent': 'covered',
+  'infiltration.cover_strain': 'covered',
   'system.academy_upgraded': 'covered',
   'case.aggregate_battle': 'covered',
   'staff.coping.applied': 'covered',

--- a/src/test/infiltrationCover.test.ts
+++ b/src/test/infiltrationCover.test.ts
@@ -41,6 +41,25 @@ describe('infiltrationCover', () => {
     expect(posture.events.some((event) => event.kind === 'cover_strain')).toBe(true)
   })
 
+  it('joins all strain reasons when crossing the cover strain band', () => {
+    const posture = evaluateWeeklyInfiltrationCoverPosture(
+      createCoverCase({
+        tags: ['infiltration', 'covert', 'media', 'public', 'witness', 'interview'],
+        infiltrationAwareness: 0.28,
+        infiltrationCoverProfile: {
+          claimedRole: 'uniform_guard',
+          documentTier: 0,
+          doctrineBand: 0.2,
+        },
+      })
+    )
+
+    const coverStrain = posture.events.find((event) => event.kind === 'cover_strain')
+    expect(coverStrain?.summary).toContain('claimed uniform_guard clashes with site context')
+    expect(coverStrain?.summary).toContain('paperwork cannot survive authority scrutiny')
+    expect(coverStrain?.summary).toContain('cover doctrine slips under procedural questioning')
+  })
+
   it('applies posture after weekly probe tick', () => {
     const weekly = applyWeeklyInfiltrationProbeTick(createCoverCase(), 3)
 

--- a/src/test/infiltrationCover.test.ts
+++ b/src/test/infiltrationCover.test.ts
@@ -6,7 +6,10 @@ import {
   evaluateWeeklyInfiltrationCoverPosture,
 } from '../domain/infiltrationCover'
 import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
-import { applyWeeklyInfiltrationProbeTick } from '../domain/infiltrationProbe'
+import {
+  applyInfiltrationProbeActionToCase,
+  applyWeeklyInfiltrationProbeTick,
+} from '../domain/infiltrationProbe'
 import type { Agent, CaseInstance } from '../domain/models'
 import { caseTemplateMap } from '../domain/templates/caseTemplates'
 
@@ -71,5 +74,56 @@ describe('infiltrationCover', () => {
 
     expect(result.changed).toBe(false)
     expect(result.events).toEqual([])
+  })
+
+  it('does not double-count route violations already covered by role mismatch', () => {
+    const posture = evaluateWeeklyInfiltrationCoverPosture(
+      createCoverCase({
+        infiltrationCoverProfile: {
+          claimedRole: 'uniform_guard',
+          routeViolationTags: ['media', 'public'],
+        },
+      })
+    )
+
+    expect(posture.awarenessDelta).toBe(0.08)
+  })
+
+  it('applies no posture pressure when awareness is already capped', () => {
+    const posture = evaluateWeeklyInfiltrationCoverPosture(
+      createCoverCase({
+        infiltrationAwareness: 1,
+        infiltrationStage: 'violent',
+      })
+    )
+
+    expect(posture.awarenessDelta).toBe(0)
+    expect(posture.events).toEqual([])
+  })
+
+  it('runs cover posture only on the weekly tick, not a single probe action', () => {
+    const baseline = createCoverCase({ infiltrationAwareness: 0.3 })
+    const actionOnly = applyInfiltrationProbeActionToCase(baseline, 'probe_access')
+    const weekly = applyWeeklyInfiltrationProbeTick(baseline, 3)
+
+    expect(actionOnly.case.infiltrationAwareness).toBeLessThan(
+      weekly.case.infiltrationAwareness ?? 0
+    )
+    expect(weekly.events.some((event) => event.kind === 'cover_strain')).toBe(true)
+  })
+
+  it('copies cover profiles on seeded infiltration templates', () => {
+    const templateIds = [
+      'ops-001',
+      'ops-004',
+      'occult-006',
+      'puzzle_whispering_archive',
+      'psi-007',
+      'followup_targeted_abductions',
+    ] as const
+
+    for (const templateId of templateIds) {
+      expect(caseTemplateMap[templateId].infiltrationCoverProfile?.claimedRole).toBeTruthy()
+    }
   })
 })

--- a/src/test/infiltrationCover.test.ts
+++ b/src/test/infiltrationCover.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { createStarterCase } from '../domain/templates/startingCases'
+import {
+  applyWeeklyInfiltrationCoverPostureToCase,
+  copyInfiltrationCoverProfile,
+  evaluateWeeklyInfiltrationCoverPosture,
+} from '../domain/infiltrationCover'
+import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
+import { applyWeeklyInfiltrationProbeTick } from '../domain/infiltrationProbe'
+import type { Agent, CaseInstance } from '../domain/models'
+import { caseTemplateMap } from '../domain/templates/caseTemplates'
+
+function createCoverCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-cover',
+      templateId: 'ops-004',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    tags: ['infiltration', 'covert', 'media', 'public'],
+    infiltrationCoverProfile: copyInfiltrationCoverProfile(
+      caseTemplateMap['ops-004'].infiltrationCoverProfile
+    ),
+    infiltrationAwareness: 0.3,
+    infiltrationProbeProgress: 0.2,
+    infiltrationStage: 'probing',
+    assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+describe('infiltrationCover', () => {
+  it('adds awareness when claimed role clashes with site tags', () => {
+    const posture = evaluateWeeklyInfiltrationCoverPosture(createCoverCase())
+
+    expect(posture.awarenessDelta).toBeGreaterThan(0)
+    expect(posture.events.some((event) => event.kind === 'cover_strain')).toBe(true)
+  })
+
+  it('applies posture after weekly probe tick', () => {
+    const weekly = applyWeeklyInfiltrationProbeTick(createCoverCase(), 3)
+
+    expect(weekly.changed).toBe(true)
+    expect(weekly.case.infiltrationAwareness).toBeGreaterThan(0.3)
+    expect(weekly.events.some((event) => event.kind === 'cover_strain')).toBe(true)
+  })
+
+  it('raises disguise pressure when authority scrutiny meets weak documents', () => {
+    const observer: Agent = {
+      id: 'a_cover_reader',
+      name: 'a_cover_reader',
+      role: 'liaison',
+      baseStats: { combat: 10, investigation: 50, utility: 40, social: 58 },
+      tags: ['medium', 'liaison'],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    }
+
+    const validation = evaluateBehaviorWeightedDisguiseValidation(createCoverCase(), [observer])
+
+    expect(validation.active).toBe(true)
+    expect(validation.level).toBe('strong')
+  })
+
+  it('skips posture when case is not infiltration-eligible', () => {
+    const result = applyWeeklyInfiltrationCoverPostureToCase(
+      createCoverCase({ hiddenState: undefined })
+    )
+
+    expect(result.changed).toBe(false)
+    expect(result.events).toEqual([])
+  })
+})

--- a/src/test/infiltrationCoverAuthoring.test.ts
+++ b/src/test/infiltrationCoverAuthoring.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildInfiltrationCoverProfileFromAuthored,
+  buildInfiltrationCoverProfileFromAuthoredRecord,
   type AuthoredInfiltrationCoverProfile,
 } from '../domain/infiltrationCoverAuthoring'
 
@@ -24,6 +25,19 @@ describe('infiltrationCoverAuthoring', () => {
       documentTier: 1,
       doctrineBand: 0.42,
       routeViolationTags: ['media', 'public'],
+    })
+  })
+
+  it('buildInfiltrationCoverProfileFromAuthoredRecord rejects non-objects', () => {
+    expect(buildInfiltrationCoverProfileFromAuthoredRecord('uniform_guard')).toBeUndefined()
+    expect(
+      buildInfiltrationCoverProfileFromAuthoredRecord({
+        claimedRole: 'courier',
+        documentTier: 2,
+      })
+    ).toEqual({
+      claimedRole: 'courier',
+      documentTier: 2,
     })
   })
 })

--- a/src/test/infiltrationCoverAuthoring.test.ts
+++ b/src/test/infiltrationCoverAuthoring.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildInfiltrationCoverProfileFromAuthored,
+  type AuthoredInfiltrationCoverProfile,
+} from '../domain/infiltrationCoverAuthoring'
+
+describe('infiltrationCoverAuthoring', () => {
+  it('returns undefined for empty authored profiles', () => {
+    expect(buildInfiltrationCoverProfileFromAuthored(null)).toBeUndefined()
+    expect(buildInfiltrationCoverProfileFromAuthored({})).toBeUndefined()
+    expect(buildInfiltrationCoverProfileFromAuthored({ claimedRole: 'not-a-role' })).toBeUndefined()
+  })
+
+  it('normalizes claimed role, document tier, doctrine band, and route tags', () => {
+    const authored: AuthoredInfiltrationCoverProfile = {
+      claimedRole: ' uniform_guard ',
+      documentTier: 1,
+      doctrineBand: 0.42,
+      routeViolationTags: [' media ', 'public', ''],
+    }
+
+    expect(buildInfiltrationCoverProfileFromAuthored(authored)).toEqual({
+      claimedRole: 'uniform_guard',
+      documentTier: 1,
+      doctrineBand: 0.42,
+      routeViolationTags: ['media', 'public'],
+    })
+  })
+})

--- a/src/test/infiltrationProbe.test.ts
+++ b/src/test/infiltrationProbe.test.ts
@@ -8,6 +8,7 @@ import {
   getInfiltrationStagePressure,
   isInfiltrationProbeEligible,
   readInfiltrationProbeState,
+  resolveInfiltrationThresholdEvents,
   resolveWeeklyInfiltrationProbeAction,
 } from '../domain/infiltrationProbe'
 import { caseTemplateMap } from '../domain/templates/caseTemplates'
@@ -53,6 +54,14 @@ describe('infiltrationProbe', () => {
     expect(access.nextState.awareness).toBeGreaterThan(baseline.awareness)
     expect(route.nextState.probeProgress).toBeGreaterThan(access.nextState.probeProgress)
     expect(route.nextState.awareness).toBeGreaterThan(access.nextState.awareness)
+  })
+
+  it('resolveInfiltrationThresholdEvents matches probe evaluation threshold summaries', () => {
+    const priorState = { probeProgress: 0.2, awareness: 0.5, stage: 'probing' as const }
+    const evaluation = evaluateInfiltrationProbe(priorState, 'probe_access')
+    const fromResolver = resolveInfiltrationThresholdEvents(priorState, evaluation.nextState)
+
+    expect(fromResolver).toEqual(evaluation.events)
   })
 
   it('fires awareness complication without requiring violent escalation', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **SPE-521 slice 3**: authored cover identity profiles on infiltrating cases, deterministic weekly posture evaluation after probe ticks, and a disguise-validation bridge for weak paperwork under authority scrutiny.

## Behavior

- **`InfiltrationCoverProfile`** on templates/cases: `claimedRole`, optional `documentTier`, `doctrineBand`, `routeViolationTags`.
- **Weekly posture** runs after probe action resolution; bumps awareness when role/tags/documents/doctrine clash with site context; emits `infiltration.cover_strain` (and threshold follow-ups when bands cross).
- **Disguise validation** reads cover profile via `resolveDisguiseValidationContextFromCase`; weak `documentTier` under media/public/court tags increases counter-detection pressure.
- **Report notes** now reflect all infiltration event types (including cover strain).

## Content

Cover profiles seeded on the six templates that already have `infiltrationProbePlan` (`ops-001`, `ops-004`, `occult-006`, `puzzle_whispering_archive`, `psi-007`, `followup_targeted_abductions`).

## Tests

- `infiltrationCoverAuthoring.test.ts`, `infiltrationCover.test.ts`
- Extended `advanceWeek.infiltrationProbe.integration.test.ts` (ops-004 guard vs media briefing)
- Event coverage map updated for `infiltration.cover_strain`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

