### PR TITLE
feat(SPE-521): infiltration cover profiles for remaining probe-plan templates

### DIFF
--- a/src/domain/templates/caseTemplates.occult.ts
+++ b/src/domain/templates/caseTemplates.occult.ts
@@ -76,8 +76,17 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['mirror', 'possession'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 0,
+      doctrineBand: 0.4,
+    },
     requiredTags: ['holy'],
-    preferredTags: ['investigator', 'tech', 'ritual-kit', 'stealth'],
+    preferredTags: ['investigator', 'tech', 'ritual-kit', 'stealth', 'covert', 'infiltration'],
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
       stageDelta: 1,

--- a/src/domain/templates/caseTemplates.occult.ts
+++ b/src/domain/templates/caseTemplates.occult.ts
@@ -241,6 +241,16 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['ritual', 'civilian'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.45, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.5,
+      routeViolationTags: ['ritual'],
+    },
     preferredTags: ['negotiator', 'medium', 'holy', 'covert', 'infiltration'],
     pressureValue: 8,
     regionTag: 'occult_district',

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -111,8 +111,17 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['archive', 'records'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.35, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
     requiredTags: ['investigator'],
-    preferredTags: ['tech', 'forensics', 'stealth'],
+    preferredTags: ['tech', 'forensics', 'stealth', 'covert', 'infiltration'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -67,6 +67,15 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['interview', 'memory'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.35,
+    },
     requiredTags: ['negotiator'],
     preferredTags: ['medium', 'investigator', 'disguise'],
     onFail: {
@@ -266,6 +275,15 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['court', 'witness'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'official_inspector',
+      documentTier: 2,
+      doctrineBand: 0.65,
+    },
     requiredTags: ['negotiator'],
     preferredTags: ['medium', 'occult', 'covert', 'disguise'],
     raid: { minTeams: 2, maxTeams: 3 },
@@ -332,6 +350,15 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['logistics', 'supply-chain'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.5, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'courier',
+      documentTier: 1,
+      doctrineBand: 0.5,
+    },
     preferredTags: ['medic', 'forensics', 'lab-kit', 'stealth', 'infiltration'],
     pressureValue: 7,
     regionTag: 'bio_containment',

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -51,6 +51,15 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['psionic', 'compulsion'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
     requiredTags: ['investigator'],
     preferredTags: ['medium', 'tech', 'negotiator', 'infiltration', 'covert'],
     onFail: {
@@ -86,6 +95,15 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['psionic', 'memory'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 2,
+      doctrineBand: 0.5,
+    },
     requiredTags: ['negotiator'],
     preferredTags: ['medium', 'investigator', 'analyst', 'disguise'],
     onFail: {
@@ -121,6 +139,15 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['psionic', 'occult'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.55,
+    },
     requiredTags: ['medium', 'scholar'],
     preferredTags: ['ritual-kit', 'investigator', 'tech', 'covert', 'infiltration'],
     raid: { minTeams: 2, maxTeams: 3 },

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -140,8 +140,8 @@ export const psionicCaseTemplates: CaseTemplate[] = [
       },
     ],
     infiltrationProbePlan: {
-      defaultAction: 'probe_access',
-      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_route' }],
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
     },
     infiltrationCoverProfile: {
       claimedRole: 'civilian_staff',

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -147,6 +147,7 @@ export const psionicCaseTemplates: CaseTemplate[] = [
       claimedRole: 'civilian_staff',
       documentTier: 1,
       doctrineBand: 0.55,
+      routeViolationTags: ['occult', 'psionic'],
     },
     requiredTags: ['medium', 'scholar'],
     preferredTags: ['ritual-kit', 'investigator', 'tech', 'covert', 'infiltration'],

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -438,7 +438,7 @@ const baseCaseTemplates: CaseTemplate[] = [
       claimedRole: 'civilian_staff',
       documentTier: 0,
       doctrineBand: 0.4,
-      routeViolationTags: ['cult'],
+      routeViolationTags: ['cult', 'ritual'],
     },
     requiredTags: ['occultist'],
     requiredRoles: ['containment', 'technical'],

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -334,6 +334,15 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['vampire', 'night'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.5, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 0,
+      doctrineBand: 0.35,
+    },
     preferredTags: ['silver', 'holy', 'stealth', 'covert'],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
@@ -421,6 +430,16 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['cult', 'ritual'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.45, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 0,
+      doctrineBand: 0.4,
+      routeViolationTags: ['cult'],
+    },
     requiredTags: ['occultist'],
     requiredRoles: ['containment', 'technical'],
     preferredTags: ['holy', 'tech', 'negotiator', 'covert', 'infiltration'],
@@ -464,6 +483,15 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['investigation'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 1,
+      doctrineBand: 0.4,
+    },
     preferredTags: ['tech', 'investigator', 'stealth', 'covert'],
     onFail: {
       stageDelta: 1,
@@ -526,6 +554,15 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['cognitive'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.3,
+    },
     preferredTags: ['negotiator', 'investigator', 'disguise', 'covert'],
     onFail: {
       stageDelta: 1,
@@ -560,6 +597,15 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['raid', 'cognitive'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'courier',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
     preferredTags: ['tech', 'medium', 'infiltration', 'stealth'],
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
@@ -595,6 +641,15 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['infrastructure'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.45, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 0,
+      doctrineBand: 0.35,
+    },
     requiredTags: ['tech'],
     preferredTags: ['occultist', 'covert', 'infiltration'],
     raid: { minTeams: 3, maxTeams: 5 },

--- a/src/features/dashboard/eventFeedView.ts
+++ b/src/features/dashboard/eventFeedView.ts
@@ -229,6 +229,10 @@ export const EVENT_TYPE_LABELS: Record<OperationEventType, string> = {
   'staff.coping.applied': 'Coping Applied',
   'staff.coping.misconduct': 'Coping Misconduct',
   'staff.side_work.resolved': 'Side Work Resolved',
+  'infiltration.awareness_complication': 'Infiltration Complication',
+  'infiltration.escalation_exposed': 'Cover Exposed',
+  'infiltration.escalation_violent': 'Violent Escalation',
+  'infiltration.cover_strain': 'Cover Strain',
 }
 
 export const EVENT_TYPE_CATEGORIES: Record<OperationEventType, EventFeedCategory> = {
@@ -280,6 +284,10 @@ export const EVENT_TYPE_CATEGORIES: Record<OperationEventType, EventFeedCategory
   'staff.coping.applied': 'personnel',
   'staff.coping.misconduct': 'personnel',
   'staff.side_work.resolved': 'personnel',
+  'infiltration.awareness_complication': 'incident_response',
+  'infiltration.escalation_exposed': 'incident_response',
+  'infiltration.escalation_violent': 'incident_response',
+  'infiltration.cover_strain': 'incident_response',
 }
 
 const EVENT_FEED_CATEGORIES = Object.keys(EVENT_CATEGORY_LABELS) as EventFeedCategory[]
@@ -1059,6 +1067,37 @@ export function buildEventFeedView(event: OperationEvent): EventFeedView {
         searchText:
           `side work ${event.payload.optionId} ${event.payload.outcome} agent ${event.payload.agentId}`.toLowerCase(),
       }
+
+    case 'infiltration.awareness_complication':
+    case 'infiltration.escalation_exposed':
+    case 'infiltration.escalation_violent':
+    case 'infiltration.cover_strain': {
+      const awarenessSuffix =
+        typeof event.payload.infiltrationAwareness === 'number'
+          ? ` / Awareness ${Math.round(event.payload.infiltrationAwareness * 100)}%`
+          : ''
+      const stageSuffix = event.payload.infiltrationStage
+        ? ` / Stage ${event.payload.infiltrationStage}`
+        : ''
+      const tone =
+        event.type === 'infiltration.escalation_violent'
+          ? 'danger'
+          : 'warning'
+
+      return {
+        event,
+        week: event.payload.week,
+        title: `${event.payload.caseTitle}: ${typeLabel}`,
+        detail: `Week ${event.payload.week}${awarenessSuffix}${stageSuffix} / ${event.payload.summary}`,
+        sourceLabel,
+        typeLabel,
+        timestampLabel,
+        tone,
+        href: APP_ROUTES.caseDetail(event.payload.caseId),
+        searchText:
+          `${event.payload.caseTitle} ${event.payload.caseId} ${event.payload.summary} infiltration`.toLowerCase(),
+      }
+    }
   }
 
   throw new Error(`Unhandled event feed type: ${(event as OperationEvent).type}`)

--- a/src/test/infiltrationCover.test.ts
+++ b/src/test/infiltrationCover.test.ts
@@ -11,7 +11,7 @@ import {
   applyWeeklyInfiltrationProbeTick,
 } from '../domain/infiltrationProbe'
 import type { Agent, CaseInstance } from '../domain/models'
-import { caseTemplateMap } from '../domain/templates/caseTemplates'
+import { caseTemplateMap, caseTemplates } from '../domain/templates/caseTemplates'
 
 function createCoverCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
   return {
@@ -131,15 +131,20 @@ describe('infiltrationCover', () => {
     expect(weekly.events.some((event) => event.kind === 'cover_strain')).toBe(true)
   })
 
-  it('copies cover profiles on seeded infiltration templates', () => {
-    const templateIds = [
-      'ops-001',
-      'ops-004',
-      'occult-006',
-      'puzzle_whispering_archive',
-      'psi-007',
-      'followup_targeted_abductions',
-    ] as const
+  it('requires a cover profile on every template with a probe plan', () => {
+    const missingCover = caseTemplates
+      .filter((template) => template.infiltrationProbePlan && !template.infiltrationCoverProfile)
+      .map((template) => template.templateId)
+
+    expect(missingCover).toEqual([])
+  })
+
+  it('copies cover profiles on all probe-plan templates', () => {
+    const templateIds = caseTemplates
+      .filter((template) => template.infiltrationProbePlan)
+      .map((template) => template.templateId)
+
+    expect(templateIds.length).toBeGreaterThanOrEqual(19)
 
     for (const templateId of templateIds) {
       expect(caseTemplateMap[templateId].infiltrationCoverProfile?.claimedRole).toBeTruthy()

--- a/src/test/infiltrationCover.test.ts
+++ b/src/test/infiltrationCover.test.ts
@@ -144,7 +144,7 @@ describe('infiltrationCover', () => {
       .filter((template) => template.infiltrationProbePlan)
       .map((template) => template.templateId)
 
-    expect(templateIds.length).toBeGreaterThanOrEqual(19)
+    expect(templateIds.length).toBeGreaterThanOrEqual(21)
 
     for (const templateId of templateIds) {
       expect(caseTemplateMap[templateId].infiltrationCoverProfile?.claimedRole).toBeTruthy()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends SPE-521 slice 3 content to covert/concealment templates that lacked authored probe plans and cover profiles.

**21 templates** now declare both `infiltrationProbePlan` and `infiltrationCoverProfile` (up from 6). Every template with `concealmentTriggers` is included.

## New templates (15)

| Template | Cover role | Probe default |
|----------|------------|---------------|
| `ops-002` | civilian_staff | probe_access + cleanup |
| `ops-003` | maintenance | probe_access → probe_route |
| `ops-007` | official_inspector | probe_access + cleanup |
| `ops-008` | courier | probe_route |
| `psi-002` | civilian_staff | probe_route |
| `psi-003` | civilian_staff | probe_access + cleanup |
| `psi-occ-001` | civilian_staff | probe_access |
| `occult-003` | maintenance | probe_access → probe_route |
| `occult-008` | civilian_staff | probe_route |
| `combat_vampire_nest` | maintenance | probe_route |
| `mixed_eclipse_ritual` | civilian_staff | probe_route |
| `followup_missing_persons` | maintenance | probe_route |
| `followup_false_memories` | civilian_staff | probe_access + cleanup |
| `followup_campus_outbreak` | courier | probe_route |
| `followup_blackout` | maintenance | probe_route |

`ops-003` and `occult-003` add `covert` / `infiltration` to preferred tags so weekly probe eligibility matches other concealment missions.

## Also in this PR

- Front-desk event feed handlers for `infiltration.*` event types (including `cover_strain`).

## Tests

- `infiltrationCover.test.ts` asserts **every** probe-plan template has a cover profile (catalog-wide), with `>= 21` templates.

## Parent

SPE-521 — infiltration probe awareness (slice 3 landed in #2307).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

