### PR TITLE
feat(SPE-2243): infiltration stage mission-resolution fallout (slice 5)

### DIFF
--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -32,6 +32,33 @@ export interface WeeklyCaseResolutionStrategy {
   weakestLinkResult?: import('./weakestLinkResolution').WeakestLinkMissionResolutionResult
 }
 
+export function resolveMissionSuccessDegradeHint(input: {
+  behaviorValidation?: BehaviorWeightedDisguiseValidationResult
+  infiltrationStageMission?: InfiltrationStageMissionPressureResult
+}): { shouldDegrade: boolean; reason?: string } {
+  if (
+    input.behaviorValidation?.shouldDegradeSuccessToPartial &&
+    input.behaviorValidation.degradeSuccessReason
+  ) {
+    return {
+      shouldDegrade: true,
+      reason: input.behaviorValidation.degradeSuccessReason,
+    }
+  }
+
+  if (
+    input.infiltrationStageMission?.shouldDegradeSuccessToPartial &&
+    input.infiltrationStageMission.degradeSuccessReason
+  ) {
+    return {
+      shouldDegrade: true,
+      reason: input.infiltrationStageMission.degradeSuccessReason,
+    }
+  }
+
+  return { shouldDegrade: false }
+}
+
 type SeededRng = () => number
 
 export function resolveAssignedCaseForWeek(

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -9,6 +9,10 @@ import {
   evaluateBehaviorWeightedDisguiseValidation,
   type BehaviorWeightedDisguiseValidationResult,
 } from './disguiseValidation'
+import {
+  evaluateInfiltrationStageMissionPressure,
+  type InfiltrationStageMissionPressureResult,
+} from './infiltrationProbe'
 import { buildAgencyProtocolState } from './protocols'
 import { computeTeamScore, computeRequiredScore } from './sim/scoring'
 import { applyExecutionInstabilityOverlay } from './executionInstability'
@@ -24,6 +28,7 @@ export interface WeeklyCaseResolutionStrategy {
   activeTeamStressModifiers: Record<string, number>
   outcome: ResolutionOutcome
   behaviorValidation?: BehaviorWeightedDisguiseValidationResult
+  infiltrationStageMission?: InfiltrationStageMissionPressureResult
   weakestLinkResult?: import('./weakestLinkResolution').WeakestLinkMissionResolutionResult
 }
 
@@ -96,10 +101,15 @@ export function resolveAssignedCaseForWeek(
     effectiveCase,
     behaviorValidation
   )
-  const scoreAdjustment = factionContext.scoreAdjustment + behaviorValidation.scoreAdjustment
+  const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(resolvedEffectiveCase)
+  const scoreAdjustment =
+    factionContext.scoreAdjustment +
+    behaviorValidation.scoreAdjustment +
+    infiltrationStageMission.scoreAdjustment
   const scoreAdjustmentReason = [
     ...factionContext.reasons,
     behaviorValidation.scoreAdjustmentReason,
+    infiltrationStageMission.scoreAdjustmentReason,
   ]
     .filter(Boolean)
     .join(' / ')
@@ -176,6 +186,9 @@ export function resolveAssignedCaseForWeek(
         ...(behaviorValidation.scoreAdjustmentReason
           ? [behaviorValidation.scoreAdjustmentReason]
           : []),
+        ...(infiltrationStageMission.scoreAdjustmentReason
+          ? [infiltrationStageMission.scoreAdjustmentReason]
+          : []),
         `Weakest-link outcome: ${weakestLinkResult.outcomeCategory}`,
         ...weakestLinkResult.weakestLinkNarrativeReasonCodes,
         ...instabilityReasons,
@@ -218,6 +231,7 @@ export function resolveAssignedCaseForWeek(
     activeTeamStressModifiers,
     outcome,
     behaviorValidation,
+    infiltrationStageMission,
     weakestLinkResult,
   }
 }

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -3,7 +3,10 @@
  * Progress and awareness advance independently; thresholds emit complications before hard failure.
  */
 
-import { applyWeeklyInfiltrationCoverPostureToCase } from './infiltrationCover'
+import {
+  applyWeeklyInfiltrationCoverPostureToCase,
+  INFILTRATION_AUTHORITY_SCRUTINY_TAGS,
+} from './infiltrationCover'
 import { clamp } from './math'
 import type { CaseInstance } from './models'
 
@@ -160,6 +163,64 @@ export function resolveWeeklyInfiltrationProbeAction(caseData: CaseInstance): In
   }
 
   return 'probe_access'
+}
+
+export interface InfiltrationStageMissionPressureResult {
+  active: boolean
+  scoreAdjustment: number
+  scoreAdjustmentReason?: string
+  shouldDegradeSuccessToPartial: boolean
+  degradeSuccessReason?: string
+}
+
+const INACTIVE_STAGE_MISSION_PRESSURE: InfiltrationStageMissionPressureResult = {
+  active: false,
+  scoreAdjustment: 0,
+  shouldDegradeSuccessToPartial: false,
+}
+
+const EXPOSED_STAGE_MISSION_SCORE_ADJUSTMENT = 2.5
+const VIOLENT_STAGE_MISSION_SCORE_ADJUSTMENT = 4.5
+
+function hasAuthorityScrutiny(caseTags: Set<string>) {
+  return INFILTRATION_AUTHORITY_SCRUTINY_TAGS.some((tag) => caseTags.has(tag))
+}
+
+/**
+ * Bounded mission-resolution malus from infiltration stage (distinct from weekly track deltas).
+ */
+export function evaluateInfiltrationStageMissionPressure(
+  caseData: CaseInstance
+): InfiltrationStageMissionPressureResult {
+  if (!isInfiltrationProbeEligible(caseData)) {
+    return INACTIVE_STAGE_MISSION_PRESSURE
+  }
+
+  const stage = caseData.infiltrationStage ?? 'probing'
+
+  if (stage === 'probing') {
+    return INACTIVE_STAGE_MISSION_PRESSURE
+  }
+
+  const caseTags = collectCaseTags(caseData)
+  const authorityScrutiny = hasAuthorityScrutiny(caseTags)
+  const scoreAdjustment =
+    stage === 'violent'
+      ? VIOLENT_STAGE_MISSION_SCORE_ADJUSTMENT
+      : EXPOSED_STAGE_MISSION_SCORE_ADJUSTMENT
+  const label = stage === 'violent' ? 'violent escalation' : 'exposed posture'
+  const scoreAdjustmentReason = `Infiltration stage: +${scoreAdjustment.toFixed(1)} (${label})`
+
+  return {
+    active: true,
+    scoreAdjustment,
+    scoreAdjustmentReason,
+    shouldDegradeSuccessToPartial: stage === 'violent' && authorityScrutiny,
+    degradeSuccessReason:
+      stage === 'violent' && authorityScrutiny
+        ? 'Violent infiltration escalation under authority scrutiny prevented a clean resolution.'
+        : undefined,
+  }
 }
 
 /** Counter-detection pressure contribution from infiltration tracks for disguise validation. */

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -180,7 +180,10 @@ import {
 import { buildMissionRewardBreakdown } from '../missionResults'
 import { applyConcealmentActivationToCase } from '../hiddenStateActivation'
 import { applyWeeklyInfiltrationProbeTick } from '../infiltrationProbe'
-import { resolveAssignedCaseForWeek as resolveCanonicalAssignedCaseForWeek } from '../caseResolutionOrchestration'
+import {
+  resolveAssignedCaseForWeek as resolveCanonicalAssignedCaseForWeek,
+  resolveMissionSuccessDegradeHint,
+} from '../caseResolutionOrchestration'
 import { countCaseHiddenModifiers } from '../recon'
 import {
   buildAnchorFactionInstabilityNote,
@@ -1556,6 +1559,9 @@ interface WeeklyCaseResolutionStrategy {
   outcome: ResolutionOutcomeWithDetails
   aggregateBattleSummary?: AggregateBattleCampaignSummary
   behaviorValidation?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['behaviorValidation']
+  infiltrationStageMission?: ReturnType<
+    typeof resolveCanonicalAssignedCaseForWeek
+  >['infiltrationStageMission']
   weakestLinkResult?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['weakestLinkResult']
 }
 
@@ -1692,6 +1698,7 @@ function resolveAssignedCaseForWeek(
     outcome,
     aggregateBattleSummary,
     behaviorValidation: canonicalResolution.behaviorValidation,
+    infiltrationStageMission: canonicalResolution.infiltrationStageMission,
     weakestLinkResult: canonicalResolution.weakestLinkResult,
     campaignToIncident,
     incidentToCampaign,
@@ -2290,8 +2297,14 @@ function resolveAssignments(
       outcome,
       aggregateBattleSummary,
       behaviorValidation,
+      infiltrationStageMission,
       weakestLinkResult,
     } = weeklyResolution
+
+    const missionSuccessDegrade = resolveMissionSuccessDegradeHint({
+      behaviorValidation,
+      infiltrationStageMission,
+    })
 
     Object.assign(context.activeTeamStressModifiers, activeTeamStressModifiers)
     context.nextState.teams = releaseTeams(context.nextState.teams, existingAssignedTeamIds)
@@ -2381,9 +2394,7 @@ function resolveAssignments(
         }
       }
 
-      const willDegrade = Boolean(
-        behaviorValidation?.shouldDegradeSuccessToPartial && behaviorValidation.degradeSuccessReason
-      )
+      const willDegrade = missionSuccessDegrade.shouldDegrade
 
       let rewardBreakdown = buildMissionRewardBreakdown(
         effectiveCase,
@@ -2596,11 +2607,8 @@ function resolveAssignments(
           )
         )
       }
-      if (
-        behaviorValidation?.shouldDegradeSuccessToPartial &&
-        behaviorValidation.degradeSuccessReason
-      ) {
-        downgradeResolvedCaseToPartial(context, caseId, behaviorValidation.degradeSuccessReason)
+      if (missionSuccessDegrade.shouldDegrade && missionSuccessDegrade.reason) {
+        downgradeResolvedCaseToPartial(context, caseId, missionSuccessDegrade.reason)
       }
       continue
     }

--- a/src/domain/sim/resolve.ts
+++ b/src/domain/sim/resolve.ts
@@ -16,6 +16,7 @@ import { buildAgencyProtocolState } from '../protocols'
 import { buildFactionMissionContext } from '../factions'
 import { evaluateContractRoleFit } from '../contractsRuntime'
 import { evaluateBehaviorWeightedDisguiseValidation } from '../disguiseValidation'
+import { evaluateInfiltrationStageMissionPressure } from '../infiltrationProbe'
 import {
   buildAggregatedLeaderBonus,
   createDefaultPerformanceMetricSummary,
@@ -110,15 +111,19 @@ function buildTeamScoreContextForTeamIds(
         ? (state.teams[normalizedTeamIds[0]]?.leaderId ?? null)
         : null,
   })
+  const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(c)
   const baseScoreAdjustment =
     (coordination?.scoreAdjustment ?? 0) +
     factionContext.scoreAdjustment +
-    (contractFit?.scoreAdjustment ?? 0)
+    (contractFit?.scoreAdjustment ?? 0) +
+    behaviorValidation.scoreAdjustment +
+    infiltrationStageMission.scoreAdjustment
   const scoreAdjustmentReason = [
     coordination?.reason,
     ...factionContext.reasons,
     ...(contractFit?.reasons ?? []),
     behaviorValidation.scoreAdjustmentReason,
+    infiltrationStageMission.scoreAdjustmentReason,
   ]
     .filter(Boolean)
     .join(' / ')
@@ -137,7 +142,7 @@ function buildTeamScoreContextForTeamIds(
         normalizedTeamIds.length === 1
           ? (state.teams[normalizedTeamIds[0]]?.leaderId ?? null)
           : null,
-      scoreAdjustment: baseScoreAdjustment + behaviorValidation.scoreAdjustment,
+      scoreAdjustment: baseScoreAdjustment,
       scoreAdjustmentReason,
       partyCardScoreBonus: partyCardBonus?.scoreAdjustment,
       partyCardReasons: partyCardReason,

--- a/src/test/infiltrationStageMission.test.ts
+++ b/src/test/infiltrationStageMission.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import { evaluateInfiltrationStageMissionPressure } from '../domain/infiltrationProbe'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createBehaviorObserver(id: string) {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation: 50,
+      utility: 40,
+      social: 30,
+    },
+    tags: ['medium', 'liaison'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  } satisfies Agent
+}
+
+function createObserverTeam(id: string, agentId: string) {
+  return {
+    id,
+    name: id,
+    agentIds: [agentId],
+    tags: [],
+  } satisfies Team
+}
+
+function createInfiltrationBriefingCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-infiltration-stage',
+      templateId: 'ops-004',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['infiltration', 'media', 'public'],
+    requiredTags: ['medium'],
+    preferredTags: [],
+    assignedTeamIds: [],
+    infiltrationCoverProfile: {
+      claimedRole: 'official_inspector',
+      documentTier: 2,
+      doctrineBand: 0.4,
+    },
+    ...overrides,
+  }
+}
+
+describe('infiltration stage mission-resolution fallout', () => {
+  it('orders stage malus probing < exposed < violent', () => {
+    const base = createInfiltrationBriefingCase()
+
+    expect(evaluateInfiltrationStageMissionPressure({ ...base, infiltrationStage: 'probing' }).active).toBe(
+      false
+    )
+
+    const exposed = evaluateInfiltrationStageMissionPressure({
+      ...base,
+      infiltrationStage: 'exposed',
+    })
+    const violent = evaluateInfiltrationStageMissionPressure({
+      ...base,
+      infiltrationStage: 'violent',
+    })
+
+    expect(exposed.active).toBe(true)
+    expect(violent.active).toBe(true)
+    expect(exposed.scoreAdjustment).toBeGreaterThan(0)
+    expect(violent.scoreAdjustment).toBeGreaterThan(exposed.scoreAdjustment)
+  })
+
+  it('applies violent-stage malus through live case resolution orchestration', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('a_stage_orchestration')
+    const team = createObserverTeam('t_stage_orchestration', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    const probingCase = createInfiltrationBriefingCase({
+      infiltrationStage: 'probing',
+      infiltrationAwareness: 0.3,
+      assignedTeamIds: [team.id],
+    })
+    const violentCase = createInfiltrationBriefingCase({
+      infiltrationStage: 'violent',
+      infiltrationAwareness: 0.85,
+      counterDetection: true,
+      detectionConfidence: 0.75,
+      assignedTeamIds: [team.id],
+    })
+
+    const probingResolution = resolveAssignedCaseForWeek(probingCase, state, () => 0.5)
+    const violentResolution = resolveAssignedCaseForWeek(violentCase, state, () => 0.5)
+
+    expect(probingResolution.infiltrationStageMission?.active).toBe(false)
+    expect(violentResolution.infiltrationStageMission?.active).toBe(true)
+    expect(violentResolution.infiltrationStageMission?.scoreAdjustment).toBeGreaterThan(0)
+    expect(
+      violentResolution.outcome.reasons.some((reason) => reason.includes('Infiltration stage:'))
+    ).toBe(true)
+    expect(
+      (probingResolution.infiltrationStageMission?.scoreAdjustment ?? 0) <
+        (violentResolution.infiltrationStageMission?.scoreAdjustment ?? 0)
+    ).toBe(true)
+  })
+})

--- a/src/test/infiltrationStageMission.test.ts
+++ b/src/test/infiltrationStageMission.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
-import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import {
+  resolveAssignedCaseForWeek,
+  resolveMissionSuccessDegradeHint,
+} from '../domain/caseResolutionOrchestration'
 import { evaluateInfiltrationStageMissionPressure } from '../domain/infiltrationProbe'
+import { previewResolutionForTeamIds } from '../domain/sim/resolve'
+import { advanceWeek } from '../domain/sim/advanceWeek'
 import type { Agent, CaseInstance, Team } from '../domain/models'
 import { createStarterCase } from '../domain/templates/startingCases'
 
@@ -111,5 +116,173 @@ describe('infiltration stage mission-resolution fallout', () => {
       (probingResolution.infiltrationStageMission?.scoreAdjustment ?? 0) <
         (violentResolution.infiltrationStageMission?.scoreAdjustment ?? 0)
     ).toBe(true)
+  })
+
+  it('applies exposed-stage malus between probing and violent in orchestration', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('a_exposed_orchestration')
+    const team = createObserverTeam('t_exposed_orchestration', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    const base = createInfiltrationBriefingCase({
+      infiltrationAwareness: 0.6,
+      assignedTeamIds: [team.id],
+    })
+
+    const probing = resolveAssignedCaseForWeek(
+      { ...base, infiltrationStage: 'probing' },
+      state,
+      () => 0.5
+    )
+    const exposed = resolveAssignedCaseForWeek(
+      { ...base, infiltrationStage: 'exposed', detectionConfidence: 0.55 },
+      state,
+      () => 0.5
+    )
+    const violent = resolveAssignedCaseForWeek(
+      {
+        ...base,
+        infiltrationStage: 'violent',
+        counterDetection: true,
+        detectionConfidence: 0.75,
+      },
+      state,
+      () => 0.5
+    )
+
+    expect(probing.infiltrationStageMission?.scoreAdjustment ?? 0).toBe(0)
+    expect(exposed.infiltrationStageMission?.scoreAdjustment).toBe(2.5)
+    expect(violent.infiltrationStageMission?.scoreAdjustment).toBe(4.5)
+    expect(resolveMissionSuccessDegradeHint({ infiltrationStageMission: exposed }).shouldDegrade).toBe(
+      false
+    )
+    expect(
+      resolveMissionSuccessDegradeHint({
+        infiltrationStageMission: violent.infiltrationStageMission,
+      }).shouldDegrade
+    ).toBe(true)
+  })
+
+  it('matches preview and live score context for violent infiltration stage', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('a_preview_stage')
+    const team = createObserverTeam('t_preview_stage', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    const violentCase = createInfiltrationBriefingCase({
+      infiltrationStage: 'violent',
+      infiltrationAwareness: 0.85,
+      counterDetection: true,
+      detectionConfidence: 0.75,
+      assignedTeamIds: [team.id],
+    })
+    const probingCase = { ...violentCase, infiltrationStage: 'probing' as const, counterDetection: false }
+
+    const previewViolent = previewResolutionForTeamIds(violentCase, state, [team.id])
+    const previewProbing = previewResolutionForTeamIds(probingCase, state, [team.id])
+    const liveViolent = resolveAssignedCaseForWeek(violentCase, state, () => 0.5)
+    const liveProbing = resolveAssignedCaseForWeek(probingCase, state, () => 0.5)
+
+    expect(liveViolent.infiltrationStageMission?.scoreAdjustment).toBe(4.5)
+    expect(liveProbing.infiltrationStageMission?.active).toBe(false)
+    expect(previewViolent.odds.success).toBeLessThanOrEqual(previewProbing.odds.success)
+    expect(
+      previewViolent.odds.success < previewProbing.odds.success ||
+        (liveViolent.infiltrationStageMission?.scoreAdjustment ?? 0) >
+          (liveProbing.infiltrationStageMission?.scoreAdjustment ?? 0)
+    ).toBe(true)
+  })
+})
+
+describe('advanceWeek infiltration stage mission fallout', () => {
+  it('downgrades a successful hidden infiltration when stage is violent under authority scrutiny', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('a_advance_stage')
+    const team = createObserverTeam('t_advance_stage', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+    state.agency!.supportAvailable = 2
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    let tunedCase: CaseInstance | undefined
+
+    for (let socialDifficulty = 8; socialDifficulty <= 140; socialDifficulty += 1) {
+      const candidate: CaseInstance = {
+        ...createStarterCase({ id: 'case-001', templateId: 'ops-004' }),
+        mode: 'deterministic',
+        status: 'in_progress',
+        weeksRemaining: 1,
+        hiddenState: 'hidden',
+        detectionConfidence: 0.75,
+        counterDetection: true,
+        tags: ['infiltration', 'media', 'public'],
+        requiredTags: ['medium'],
+        preferredTags: [],
+        assignedTeamIds: [team.id],
+        infiltrationStage: 'violent',
+        infiltrationAwareness: 0.85,
+        infiltrationCoverProfile: {
+          claimedRole: 'official_inspector',
+          documentTier: 2,
+          doctrineBand: 0.4,
+        },
+        difficulty: {
+          combat: 0,
+          investigation: 0,
+          utility: 0,
+          social: socialDifficulty,
+        },
+        weights: {
+          combat: 0,
+          investigation: 0,
+          utility: 0,
+          social: 1,
+        },
+      }
+
+      const resolution = resolveAssignedCaseForWeek(candidate, state, () => 0.5)
+
+      if (
+        resolution.outcome.result === 'success' &&
+        resolution.infiltrationStageMission?.shouldDegradeSuccessToPartial
+      ) {
+        tunedCase = candidate
+        break
+      }
+    }
+
+    if (tunedCase === undefined) {
+      throw new Error('Unable to tune a violent-stage infiltration success case for advanceWeek.')
+    }
+
+    state.cases['case-001'] = tunedCase
+
+    const preAdvance = resolveAssignedCaseForWeek(tunedCase, state, () => 0.5)
+    expect(preAdvance.outcome.result).toBe('success')
+    expect(preAdvance.infiltrationStageMission?.shouldDegradeSuccessToPartial).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const missionResult = nextState.reports[nextState.reports.length - 1]?.caseSnapshots?.['case-001']
+      ?.missionResult
+
+    expect(missionResult?.outcome).toBe('partial')
+    const notes = missionResult?.explanationNotes ?? []
+    expect(
+      notes.some(
+        (note) =>
+          note.includes('Violent infiltration escalation under authority scrutiny') ||
+          note.includes('Infiltration stage:')
+      )
+    ).toBe(true)
+    expect(nextState.cases['case-001'].status).toBe('open')
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mission resolution applies explicit score malus when infiltration stage is `exposed` or `violent`, with the same live/preview wiring and advanceWeek partial-degrade path as behavior-weighted disguise validation.

## Changes

- `evaluateInfiltrationStageMissionPressure` (+2.5 exposed, +4.5 violent; violent requests partial degrade under authority scrutiny)
- `resolveMissionSuccessDegradeHint` merges behavior-validation and stage degrade signals
- Wired into `resolveAssignedCaseForWeek`, preview score context, and `advanceWeek` success downgrade
- Tests: stage ordering, probing/exposed/violent orchestration, preview/live parity, advanceWeek violent downgrade

## Verification

- `npm run test:run -- src/test/infiltrationStageMission.test.ts`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

