### PR TITLE
feat(SPE-2163): stealth tradeoff leave-behind registry (slice 1)

### DIFF
--- a/src/domain/stealthLeaveBehindRegistry.ts
+++ b/src/domain/stealthLeaveBehindRegistry.ts
@@ -1,0 +1,241 @@
+/**
+ * SPE-2163 slice 1: authored stealth tradeoff leave-behind catalog.
+ *
+ * Pure registry for field-stealth fallout kinds (abandon evidence, burn tool, etc.)
+ * with bounded discovery risk and custody-loss references. No weekly hook or UI yet.
+ */
+
+import { clamp } from './math'
+
+export type StealthLeaveBehindKind =
+  | 'abandon_evidence'
+  | 'burn_tool'
+  | 'expose_witness'
+  | 'leave_trace'
+  | 'risk_discovery'
+
+export const STEALTH_LEAVE_BEHIND_KINDS: readonly StealthLeaveBehindKind[] = [
+  'abandon_evidence',
+  'burn_tool',
+  'expose_witness',
+  'leave_trace',
+  'risk_discovery',
+] as const
+
+export interface StealthLeaveBehindDefinition {
+  readonly id: string
+  readonly kind: StealthLeaveBehindKind
+  readonly label: string
+  readonly discoveryRisk: number
+  readonly custodyLossRefs: readonly string[]
+  readonly summary?: string
+}
+
+export interface StealthLeaveBehindRegistry {
+  readonly entries: readonly StealthLeaveBehindDefinition[]
+}
+
+export type StealthLeaveBehindValidationCode =
+  | 'missing_id'
+  | 'duplicate_id'
+  | 'missing_label'
+  | 'invalid_kind'
+  | 'invalid_discovery_risk'
+  | 'empty_custody_loss_ref'
+  | 'duplicate_custody_loss_ref'
+
+export interface StealthLeaveBehindValidationIssue {
+  readonly code: StealthLeaveBehindValidationCode
+  readonly detail: string
+  readonly relatedIds?: readonly string[]
+}
+
+export interface StealthLeaveBehindValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly StealthLeaveBehindValidationIssue[]
+}
+
+const KIND_SET = new Set<string>(STEALTH_LEAVE_BEHIND_KINDS)
+
+export function isStealthLeaveBehindKind(value: string): value is StealthLeaveBehindKind {
+  return KIND_SET.has(value)
+}
+
+function normalizeToken(value: string) {
+  return value.trim()
+}
+
+function pushIssue(
+  issues: StealthLeaveBehindValidationIssue[],
+  issue: StealthLeaveBehindValidationIssue
+) {
+  issues.push(issue)
+}
+
+export function validateStealthLeaveBehindDefinition(
+  definition: StealthLeaveBehindDefinition
+): StealthLeaveBehindValidationResult {
+  const issues: StealthLeaveBehindValidationIssue[] = []
+  const id = normalizeToken(definition.id)
+  const label = normalizeToken(definition.label)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      detail: 'Leave-behind definition is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      detail: 'Leave-behind definition is missing label.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isStealthLeaveBehindKind(definition.kind)) {
+    pushIssue(issues, {
+      code: 'invalid_kind',
+      detail: `Leave-behind ${id || '(unknown)'} has invalid kind ${String(definition.kind)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const discoveryRisk = definition.discoveryRisk
+  if (!Number.isFinite(discoveryRisk) || discoveryRisk < 0 || discoveryRisk > 1) {
+    pushIssue(issues, {
+      code: 'invalid_discovery_risk',
+      detail: `Leave-behind ${id || '(unknown)'} discoveryRisk must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const seenCustodyRefs = new Set<string>()
+  for (const ref of definition.custodyLossRefs) {
+    const normalized = normalizeToken(ref)
+    if (!normalized) {
+      pushIssue(issues, {
+        code: 'empty_custody_loss_ref',
+        detail: `Leave-behind ${id || '(unknown)'} declares an empty custodyLossRef.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
+    if (seenCustodyRefs.has(normalized)) {
+      pushIssue(issues, {
+        code: 'duplicate_custody_loss_ref',
+        detail: `Leave-behind ${id || '(unknown)'} repeats custodyLossRef ${normalized}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    } else {
+      seenCustodyRefs.add(normalized)
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  }
+}
+
+export function validateStealthLeaveBehindRegistry(
+  registry: StealthLeaveBehindRegistry
+): StealthLeaveBehindValidationResult {
+  const issues: StealthLeaveBehindValidationIssue[] = []
+  const seenIds = new Set<string>()
+
+  for (const entry of registry.entries) {
+    const entryResult = validateStealthLeaveBehindDefinition(entry)
+    issues.push(...entryResult.issues)
+
+    const id = normalizeToken(entry.id)
+    if (!id) {
+      continue
+    }
+
+    if (seenIds.has(id)) {
+      pushIssue(issues, {
+        code: 'duplicate_id',
+        detail: `Duplicate leave-behind id ${id}.`,
+        relatedIds: [id],
+      })
+    } else {
+      seenIds.add(id)
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  }
+}
+
+export function getStealthLeaveBehindById(
+  registry: StealthLeaveBehindRegistry,
+  id: string
+): StealthLeaveBehindDefinition | undefined {
+  const normalized = normalizeToken(id)
+  if (!normalized) {
+    return undefined
+  }
+
+  return registry.entries.find((entry) => entry.id === normalized)
+}
+
+function defineLeaveBehind(
+  input: StealthLeaveBehindDefinition
+): StealthLeaveBehindDefinition {
+  return Object.freeze({
+    ...input,
+    discoveryRisk: clamp(input.discoveryRisk, 0, 1),
+    custodyLossRefs: Object.freeze([...input.custodyLossRefs]),
+  })
+}
+
+/** Baseline catalog: one authored tradeoff row per canonical kind. */
+export const DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY: StealthLeaveBehindRegistry = Object.freeze({
+  entries: Object.freeze([
+    defineLeaveBehind({
+      id: 'leave-behind:abandon-evidence',
+      kind: 'abandon_evidence',
+      label: 'Abandon compromised evidence',
+      summary: 'Drop tainted packets to break the custody chain before exit.',
+      discoveryRisk: 0.35,
+      custodyLossRefs: ['custody:field-packet', 'custody:chain-seal'],
+    }),
+    defineLeaveBehind({
+      id: 'leave-behind:burn-tool',
+      kind: 'burn_tool',
+      label: 'Burn field tool',
+      summary: 'Destroy a traceable tool rather than carry it through screening.',
+      discoveryRisk: 0.25,
+      custodyLossRefs: ['custody:tool-serial'],
+    }),
+    defineLeaveBehind({
+      id: 'leave-behind:expose-witness',
+      kind: 'expose_witness',
+      label: 'Expose cooperating witness',
+      summary: 'Redirect scrutiny onto a witness contact to buy extraction time.',
+      discoveryRisk: 0.55,
+      custodyLossRefs: ['custody:witness-credential'],
+    }),
+    defineLeaveBehind({
+      id: 'leave-behind:leave-trace',
+      kind: 'leave_trace',
+      label: 'Leave forensic trace',
+      summary: 'Accept a discoverable trace to preserve cover on the primary route.',
+      discoveryRisk: 0.45,
+      custodyLossRefs: ['custody:trace-sample'],
+    }),
+    defineLeaveBehind({
+      id: 'leave-behind:risk-discovery',
+      kind: 'risk_discovery',
+      label: 'Risk delayed discovery',
+      summary: 'Stay in place and accept elevated discovery rather than abandon the objective.',
+      discoveryRisk: 0.7,
+      custodyLossRefs: ['custody:mission-window'],
+    }),
+  ]),
+})

--- a/src/test/stealthLeaveBehindRegistry.test.ts
+++ b/src/test/stealthLeaveBehindRegistry.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY,
+  STEALTH_LEAVE_BEHIND_KINDS,
+  getStealthLeaveBehindById,
+  isStealthLeaveBehindKind,
+  validateStealthLeaveBehindDefinition,
+  validateStealthLeaveBehindRegistry,
+  type StealthLeaveBehindDefinition,
+} from '../domain/stealthLeaveBehindRegistry'
+
+function baseDefinition(
+  overrides: Partial<StealthLeaveBehindDefinition> = {}
+): StealthLeaveBehindDefinition {
+  return {
+    id: 'leave-behind:abandon-evidence',
+    kind: 'abandon_evidence',
+    label: 'Abandon compromised evidence',
+    discoveryRisk: 0.35,
+    custodyLossRefs: ['custody:packet-alpha'],
+    ...overrides,
+  }
+}
+
+describe('stealthLeaveBehindRegistry (SPE-2163 slice 1)', () => {
+  it('exposes the five canonical leave-behind kinds', () => {
+    expect(STEALTH_LEAVE_BEHIND_KINDS).toEqual([
+      'abandon_evidence',
+      'burn_tool',
+      'expose_witness',
+      'leave_trace',
+      'risk_discovery',
+    ])
+    expect(isStealthLeaveBehindKind('abandon_evidence')).toBe(true)
+    expect(isStealthLeaveBehindKind('unknown_kind')).toBe(false)
+  })
+
+  it('validates a well-formed definition', () => {
+    const result = validateStealthLeaveBehindDefinition(baseDefinition())
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toHaveLength(0)
+  })
+
+  it('rejects invalid discovery risk, ids, kinds, and custody refs', () => {
+    const result = validateStealthLeaveBehindDefinition(
+      baseDefinition({
+        id: '',
+        kind: 'not_a_kind' as StealthLeaveBehindDefinition['kind'],
+        label: '   ',
+        discoveryRisk: 1.5,
+        custodyLossRefs: ['', 'custody:ok', 'custody:ok'],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.map((issue) => issue.code).sort()).toEqual(
+      [
+        'duplicate_custody_loss_ref',
+        'empty_custody_loss_ref',
+        'invalid_discovery_risk',
+        'invalid_kind',
+        'missing_id',
+        'missing_label',
+      ].sort()
+    )
+  })
+
+  it('validates the default registry with one entry per kind and unique ids', () => {
+    const result = validateStealthLeaveBehindRegistry(DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY)
+
+    expect(result.valid).toBe(true)
+    expect(DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY.entries).toHaveLength(
+      STEALTH_LEAVE_BEHIND_KINDS.length
+    )
+
+    for (const kind of STEALTH_LEAVE_BEHIND_KINDS) {
+      const matches = DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY.entries.filter(
+        (entry) => entry.kind === kind
+      )
+      expect(matches).toHaveLength(1)
+    }
+  })
+
+  it('rejects duplicate ids across registry entries', () => {
+    const duplicate = baseDefinition({ id: 'leave-behind:dup' })
+    const result = validateStealthLeaveBehindRegistry({
+      entries: [duplicate, { ...duplicate, label: 'Second copy' }],
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'duplicate_id')).toBe(true)
+  })
+
+  it('looks up entries by id', () => {
+    const entry = getStealthLeaveBehindById(
+      DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY,
+      'leave-behind:risk-discovery'
+    )
+
+    expect(entry?.kind).toBe('risk_discovery')
+    expect(entry?.discoveryRisk).toBeGreaterThan(0)
+    expect(getStealthLeaveBehindById(DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY, 'missing')).toBe(
+      undefined
+    )
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pure stealth leave-behind catalog for field tradeoffs (abandon evidence, burn tool, expose witness, leave trace, risk discovery).

## Changes

- `src/domain/stealthLeaveBehindRegistry.ts` — kinds, `discoveryRisk`, `custodyLossRefs[]`, validation, lookup, default one-per-kind catalog
- `src/test/stealthLeaveBehindRegistry.test.ts` — validation and registry coverage

## Out of scope

- Weekly resolution wiring
- UI
- Template authoring migration
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

