### PR TITLE
feat(SPE-2244): stealth leave-behind mission-resolution fallout (slice 2)

### DIFF
--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -13,6 +13,10 @@ import {
   evaluateInfiltrationStageMissionPressure,
   type InfiltrationStageMissionPressureResult,
 } from './infiltrationProbe'
+import {
+  evaluateStealthLeaveBehindMissionPressure,
+  type StealthLeaveBehindMissionPressureResult,
+} from './stealthLeaveBehindRegistry'
 import { buildAgencyProtocolState } from './protocols'
 import { computeTeamScore, computeRequiredScore } from './sim/scoring'
 import { applyExecutionInstabilityOverlay } from './executionInstability'
@@ -29,12 +33,14 @@ export interface WeeklyCaseResolutionStrategy {
   outcome: ResolutionOutcome
   behaviorValidation?: BehaviorWeightedDisguiseValidationResult
   infiltrationStageMission?: InfiltrationStageMissionPressureResult
+  stealthLeaveBehindMission?: StealthLeaveBehindMissionPressureResult
   weakestLinkResult?: import('./weakestLinkResolution').WeakestLinkMissionResolutionResult
 }
 
 export function resolveMissionSuccessDegradeHint(input: {
   behaviorValidation?: BehaviorWeightedDisguiseValidationResult
   infiltrationStageMission?: InfiltrationStageMissionPressureResult
+  stealthLeaveBehindMission?: StealthLeaveBehindMissionPressureResult
 }): { shouldDegrade: boolean; reason?: string } {
   if (
     input.behaviorValidation?.shouldDegradeSuccessToPartial &&
@@ -53,6 +59,16 @@ export function resolveMissionSuccessDegradeHint(input: {
     return {
       shouldDegrade: true,
       reason: input.infiltrationStageMission.degradeSuccessReason,
+    }
+  }
+
+  if (
+    input.stealthLeaveBehindMission?.shouldDegradeSuccessToPartial &&
+    input.stealthLeaveBehindMission.degradeSuccessReason
+  ) {
+    return {
+      shouldDegrade: true,
+      reason: input.stealthLeaveBehindMission.degradeSuccessReason,
     }
   }
 
@@ -129,14 +145,17 @@ export function resolveAssignedCaseForWeek(
     behaviorValidation
   )
   const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(resolvedEffectiveCase)
+  const stealthLeaveBehindMission = evaluateStealthLeaveBehindMissionPressure(resolvedEffectiveCase)
   const scoreAdjustment =
     factionContext.scoreAdjustment +
     behaviorValidation.scoreAdjustment +
-    infiltrationStageMission.scoreAdjustment
+    infiltrationStageMission.scoreAdjustment +
+    stealthLeaveBehindMission.scoreAdjustment
   const scoreAdjustmentReason = [
     ...factionContext.reasons,
     behaviorValidation.scoreAdjustmentReason,
     infiltrationStageMission.scoreAdjustmentReason,
+    stealthLeaveBehindMission.scoreAdjustmentReason,
   ]
     .filter(Boolean)
     .join(' / ')
@@ -216,6 +235,9 @@ export function resolveAssignedCaseForWeek(
         ...(infiltrationStageMission.scoreAdjustmentReason
           ? [infiltrationStageMission.scoreAdjustmentReason]
           : []),
+        ...(stealthLeaveBehindMission.scoreAdjustmentReason
+          ? [stealthLeaveBehindMission.scoreAdjustmentReason]
+          : []),
         `Weakest-link outcome: ${weakestLinkResult.outcomeCategory}`,
         ...weakestLinkResult.weakestLinkNarrativeReasonCodes,
         ...instabilityReasons,
@@ -259,6 +281,7 @@ export function resolveAssignedCaseForWeek(
     outcome,
     behaviorValidation,
     infiltrationStageMission,
+    stealthLeaveBehindMission,
     weakestLinkResult,
   }
 }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1261,6 +1261,9 @@ export interface CaseTemplate {
 
   /** SPE-521 slice 3: authored cover identity profile (normalized in catalog build). */
   infiltrationCoverProfile?: import('./infiltrationCover').InfiltrationCoverProfile
+
+  /** SPE-2163 slice 2: registry id for mission-resolution stealth tradeoff fallout. */
+  stealthLeaveBehindId?: string
 }
 
 /** SPE-1701: deterministic deployment carry-in stamped at team→case assignment. */
@@ -1342,6 +1345,8 @@ export interface CaseInstance {
   infiltrationProbePlan?: import('./infiltrationProbe').InfiltrationProbePlan
   /** SPE-521 slice 3: cover identity profile copied from template at spawn. */
   infiltrationCoverProfile?: import('./infiltrationCover').InfiltrationCoverProfile
+  /** SPE-2163 slice 2: stealth tradeoff row copied from template at spawn. */
+  stealthLeaveBehindId?: string
 
   onFail: SpawnRule
   onUnresolved: SpawnRule

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -1562,6 +1562,9 @@ interface WeeklyCaseResolutionStrategy {
   infiltrationStageMission?: ReturnType<
     typeof resolveCanonicalAssignedCaseForWeek
   >['infiltrationStageMission']
+  stealthLeaveBehindMission?: ReturnType<
+    typeof resolveCanonicalAssignedCaseForWeek
+  >['stealthLeaveBehindMission']
   weakestLinkResult?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['weakestLinkResult']
 }
 
@@ -1699,6 +1702,7 @@ function resolveAssignedCaseForWeek(
     aggregateBattleSummary,
     behaviorValidation: canonicalResolution.behaviorValidation,
     infiltrationStageMission: canonicalResolution.infiltrationStageMission,
+    stealthLeaveBehindMission: canonicalResolution.stealthLeaveBehindMission,
     weakestLinkResult: canonicalResolution.weakestLinkResult,
     campaignToIncident,
     incidentToCampaign,
@@ -2298,12 +2302,14 @@ function resolveAssignments(
       aggregateBattleSummary,
       behaviorValidation,
       infiltrationStageMission,
+      stealthLeaveBehindMission,
       weakestLinkResult,
     } = weeklyResolution
 
     const missionSuccessDegrade = resolveMissionSuccessDegradeHint({
       behaviorValidation,
       infiltrationStageMission,
+      stealthLeaveBehindMission,
     })
 
     Object.assign(context.activeTeamStressModifiers, activeTeamStressModifiers)

--- a/src/domain/sim/resolve.ts
+++ b/src/domain/sim/resolve.ts
@@ -17,6 +17,7 @@ import { buildFactionMissionContext } from '../factions'
 import { evaluateContractRoleFit } from '../contractsRuntime'
 import { evaluateBehaviorWeightedDisguiseValidation } from '../disguiseValidation'
 import { evaluateInfiltrationStageMissionPressure } from '../infiltrationProbe'
+import { evaluateStealthLeaveBehindMissionPressure } from '../stealthLeaveBehindRegistry'
 import {
   buildAggregatedLeaderBonus,
   createDefaultPerformanceMetricSummary,
@@ -112,18 +113,21 @@ function buildTeamScoreContextForTeamIds(
         : null,
   })
   const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(c)
+  const stealthLeaveBehindMission = evaluateStealthLeaveBehindMissionPressure(c)
   const baseScoreAdjustment =
     (coordination?.scoreAdjustment ?? 0) +
     factionContext.scoreAdjustment +
     (contractFit?.scoreAdjustment ?? 0) +
     behaviorValidation.scoreAdjustment +
-    infiltrationStageMission.scoreAdjustment
+    infiltrationStageMission.scoreAdjustment +
+    stealthLeaveBehindMission.scoreAdjustment
   const scoreAdjustmentReason = [
     coordination?.reason,
     ...factionContext.reasons,
     ...(contractFit?.reasons ?? []),
     behaviorValidation.scoreAdjustmentReason,
     infiltrationStageMission.scoreAdjustmentReason,
+    stealthLeaveBehindMission.scoreAdjustmentReason,
   ]
     .filter(Boolean)
     .join(' / ')

--- a/src/domain/sim/spawn.ts
+++ b/src/domain/sim/spawn.ts
@@ -166,6 +166,7 @@ export function instantiateFromTemplate(
         : undefined,
     infiltrationProbePlan: copyInfiltrationProbePlan(template.infiltrationProbePlan),
     infiltrationCoverProfile: copyInfiltrationCoverProfile(template.infiltrationCoverProfile),
+    stealthLeaveBehindId: template.stealthLeaveBehindId?.trim() || undefined,
   }
 
   return applySiteGenerationToCase({

--- a/src/domain/stealthLeaveBehindRegistry.ts
+++ b/src/domain/stealthLeaveBehindRegistry.ts
@@ -5,7 +5,10 @@
  * with bounded discovery risk and custody-loss references. No weekly hook or UI yet.
  */
 
+import { CONCEALMENT_ACTIVATION_TAGS } from './hiddenStateActivation'
+import { INFILTRATION_AUTHORITY_SCRUTINY_TAGS } from './infiltrationCover'
 import { clamp } from './math'
+import type { CaseInstance } from './models'
 
 export type StealthLeaveBehindKind =
   | 'abandon_evidence'
@@ -192,6 +195,85 @@ function defineLeaveBehind(
     discoveryRisk: clamp(input.discoveryRisk, 0, 1),
     custodyLossRefs: Object.freeze([...input.custodyLossRefs]),
   })
+}
+
+const DISCOVERY_RISK_MISSION_SCORE_SCALE = 5
+const HIGH_LEAVE_BEHIND_DISCOVERY_THRESHOLD = 0.55
+
+export interface StealthLeaveBehindMissionPressureResult {
+  active: boolean
+  leaveBehindId?: string
+  kind?: StealthLeaveBehindKind
+  scoreAdjustment: number
+  scoreAdjustmentReason?: string
+  shouldDegradeSuccessToPartial: boolean
+  degradeSuccessReason?: string
+}
+
+const INACTIVE_LEAVE_BEHIND_MISSION_PRESSURE: StealthLeaveBehindMissionPressureResult = {
+  active: false,
+  scoreAdjustment: 0,
+  shouldDegradeSuccessToPartial: false,
+}
+
+function collectCaseTags(caseData: CaseInstance) {
+  return [...new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])]
+}
+
+function hasAuthorityScrutiny(caseTags: readonly string[]) {
+  const tagSet = new Set(caseTags)
+  return INFILTRATION_AUTHORITY_SCRUTINY_TAGS.some((tag) => tagSet.has(tag))
+}
+
+export function isStealthLeaveBehindMissionEligible(caseData: CaseInstance) {
+  if (caseData.hiddenState !== 'hidden') {
+    return false
+  }
+
+  const caseTags = collectCaseTags(caseData)
+  return CONCEALMENT_ACTIVATION_TAGS.some((tag) => caseTags.includes(tag))
+}
+
+/**
+ * Bounded mission-resolution malus from an authored stealth leave-behind tradeoff.
+ */
+export function evaluateStealthLeaveBehindMissionPressure(
+  caseData: CaseInstance,
+  registry: StealthLeaveBehindRegistry = DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY
+): StealthLeaveBehindMissionPressureResult {
+  if (!isStealthLeaveBehindMissionEligible(caseData)) {
+    return INACTIVE_LEAVE_BEHIND_MISSION_PRESSURE
+  }
+
+  const leaveBehindId = normalizeToken(caseData.stealthLeaveBehindId ?? '')
+  if (!leaveBehindId) {
+    return INACTIVE_LEAVE_BEHIND_MISSION_PRESSURE
+  }
+
+  const definition = getStealthLeaveBehindById(registry, leaveBehindId)
+  if (!definition) {
+    return INACTIVE_LEAVE_BEHIND_MISSION_PRESSURE
+  }
+
+  const scoreAdjustment =
+    Math.round(definition.discoveryRisk * DISCOVERY_RISK_MISSION_SCORE_SCALE * 10) / 10
+  const caseTags = collectCaseTags(caseData)
+  const authorityScrutiny = hasAuthorityScrutiny(caseTags)
+  const highDiscoveryRisk = definition.discoveryRisk >= HIGH_LEAVE_BEHIND_DISCOVERY_THRESHOLD
+  const scoreAdjustmentReason = `Stealth leave-behind: +${scoreAdjustment.toFixed(1)} (${definition.label})`
+
+  return {
+    active: true,
+    leaveBehindId: definition.id,
+    kind: definition.kind,
+    scoreAdjustment,
+    scoreAdjustmentReason,
+    shouldDegradeSuccessToPartial: highDiscoveryRisk && authorityScrutiny,
+    degradeSuccessReason:
+      highDiscoveryRisk && authorityScrutiny
+        ? 'Stealth extraction tradeoff under authority scrutiny prevented a clean resolution.'
+        : undefined,
+  }
 }
 
 /** Baseline catalog: one authored tradeoff row per canonical kind. */

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -120,6 +120,7 @@ export const operationsCaseTemplates: CaseTemplate[] = [
       documentTier: 1,
       doctrineBand: 0.45,
     },
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
     requiredTags: ['investigator'],
     preferredTags: ['tech', 'forensics', 'stealth', 'covert', 'infiltration'],
     onFail: {
@@ -164,6 +165,7 @@ export const operationsCaseTemplates: CaseTemplate[] = [
       documentTier: 1,
       doctrineBand: 0.4,
     },
+    stealthLeaveBehindId: 'leave-behind:expose-witness',
     requiredTags: ['medium'],
     preferredTags: ['negotiator', 'liaison', 'infiltration'],
     onFail: {

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -11,6 +11,7 @@ import {
   buildInfiltrationProbePlanFromAuthored,
   type AuthoredInfiltrationProbePlan,
 } from '../infiltrationProbeAuthoring'
+import { getStealthLeaveBehindById, DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY } from '../stealthLeaveBehindRegistry'
 import { TEAM_COVERAGE_ROLES, type CaseTemplate, type TeamCoverageRole } from '../models'
 import { normalizeSpawnRule } from '../spawnRules'
 import { occultCaseTemplates } from './caseTemplates.occult'
@@ -771,6 +772,7 @@ function cloneTemplate(
       concealmentTriggers.length > 0 ? concealmentTriggers : undefined,
     infiltrationProbePlan,
     infiltrationCoverProfile,
+    stealthLeaveBehindId: template.stealthLeaveBehindId?.trim() || undefined,
   }
 }
 
@@ -826,6 +828,19 @@ export function getCaseTemplateCatalogErrors(templates: CaseTemplate[]) {
       errors.push(
         `Template ${template.templateId} declares infiltrationProbePlan without a valid infiltrationCoverProfile.`
       )
+    }
+
+    if (template.stealthLeaveBehindId !== undefined) {
+      const leaveBehindId = template.stealthLeaveBehindId.trim()
+      if (!leaveBehindId) {
+        errors.push(`Template ${template.templateId} declares blank stealthLeaveBehindId.`)
+      } else if (
+        !getStealthLeaveBehindById(DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY, leaveBehindId)
+      ) {
+        errors.push(
+          `Template ${template.templateId} references unknown stealthLeaveBehindId ${leaveBehindId}.`
+        )
+      }
     }
 
     if (template.concealmentTriggers !== undefined) {

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -11,6 +11,7 @@ import {
   buildInfiltrationProbePlanFromAuthored,
   type AuthoredInfiltrationProbePlan,
 } from '../infiltrationProbeAuthoring'
+import { CONCEALMENT_ACTIVATION_TAGS } from '../hiddenStateActivation'
 import { getStealthLeaveBehindById, DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY } from '../stealthLeaveBehindRegistry'
 import { TEAM_COVERAGE_ROLES, type CaseTemplate, type TeamCoverageRole } from '../models'
 import { normalizeSpawnRule } from '../spawnRules'
@@ -840,6 +841,17 @@ export function getCaseTemplateCatalogErrors(templates: CaseTemplate[]) {
         errors.push(
           `Template ${template.templateId} references unknown stealthLeaveBehindId ${leaveBehindId}.`
         )
+      } else {
+        const tagUnion = [
+          ...template.tags,
+          ...(template.requiredTags ?? []),
+          ...(template.preferredTags ?? []),
+        ]
+        if (!CONCEALMENT_ACTIVATION_TAGS.some((tag) => tagUnion.includes(tag))) {
+          errors.push(
+            `Template ${template.templateId} declares stealthLeaveBehindId without a concealment activation tag.`
+          )
+        }
       }
     }
 

--- a/src/test/stealthLeaveBehindMission.test.ts
+++ b/src/test/stealthLeaveBehindMission.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  resolveAssignedCaseForWeek,
+  resolveMissionSuccessDegradeHint,
+} from '../domain/caseResolutionOrchestration'
+import { evaluateStealthLeaveBehindMissionPressure } from '../domain/stealthLeaveBehindRegistry'
+import { previewResolutionForTeamIds } from '../domain/sim/resolve'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createBehaviorObserver(id: string) {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation: 50,
+      utility: 40,
+      social: 30,
+    },
+    tags: ['medium', 'liaison'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  } satisfies Agent
+}
+
+function createObserverTeam(id: string, agentId: string) {
+  return {
+    id,
+    name: id,
+    agentIds: [agentId],
+    tags: [],
+  } satisfies Team
+}
+
+function createStealthCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-stealth-leave-behind',
+      templateId: 'ops-004',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['infiltration', 'media', 'public'],
+    requiredTags: ['medium'],
+    preferredTags: [],
+    assignedTeamIds: [],
+    stealthLeaveBehindId: 'leave-behind:burn-tool',
+    ...overrides,
+  }
+}
+
+describe('evaluateStealthLeaveBehindMissionPressure', () => {
+  it('is inactive without hidden state, concealment tags, or leave-behind id', () => {
+    const base = createStealthCase()
+
+    expect(evaluateStealthLeaveBehindMissionPressure({ ...base, hiddenState: 'revealed' }).active).toBe(
+      false
+    )
+    expect(
+      evaluateStealthLeaveBehindMissionPressure({
+        ...base,
+        tags: ['media', 'public'],
+      }).active
+    ).toBe(false)
+    expect(
+      evaluateStealthLeaveBehindMissionPressure({ ...base, stealthLeaveBehindId: undefined }).active
+    ).toBe(false)
+    expect(
+      evaluateStealthLeaveBehindMissionPressure({
+        ...base,
+        stealthLeaveBehindId: 'leave-behind:missing',
+      }).active
+    ).toBe(false)
+  })
+
+  it('scales score malus from registry discoveryRisk', () => {
+    const burnTool = evaluateStealthLeaveBehindMissionPressure(createStealthCase())
+    const riskDiscovery = evaluateStealthLeaveBehindMissionPressure(
+      createStealthCase({ stealthLeaveBehindId: 'leave-behind:risk-discovery' })
+    )
+
+    expect(burnTool.active).toBe(true)
+    expect(burnTool.scoreAdjustment).toBe(1.3)
+    expect(riskDiscovery.scoreAdjustment).toBe(3.5)
+    expect(riskDiscovery.scoreAdjustment).toBeGreaterThan(burnTool.scoreAdjustment)
+  })
+
+  it('requests partial degrade only for high discovery risk under authority scrutiny', () => {
+    const lowRisk = evaluateStealthLeaveBehindMissionPressure(createStealthCase())
+    const highRiskNoAuthority = evaluateStealthLeaveBehindMissionPressure(
+      createStealthCase({
+        stealthLeaveBehindId: 'leave-behind:risk-discovery',
+        tags: ['infiltration', 'interview', 'civilian'],
+      })
+    )
+    const highRiskAuthority = evaluateStealthLeaveBehindMissionPressure(
+      createStealthCase({
+        stealthLeaveBehindId: 'leave-behind:expose-witness',
+        tags: ['infiltration', 'media', 'public'],
+      })
+    )
+
+    expect(lowRisk.shouldDegradeSuccessToPartial).toBe(false)
+    expect(highRiskNoAuthority.shouldDegradeSuccessToPartial).toBe(false)
+    expect(highRiskAuthority.shouldDegradeSuccessToPartial).toBe(true)
+  })
+})
+
+describe('resolveMissionSuccessDegradeHint leave-behind priority', () => {
+  it('prefers infiltration stage degrade over leave-behind degrade', () => {
+    const stageReason = 'Violent infiltration escalation under authority scrutiny prevented a clean resolution.'
+    const leaveBehindReason =
+      'Stealth extraction tradeoff under authority scrutiny prevented a clean resolution.'
+
+    const hint = resolveMissionSuccessDegradeHint({
+      infiltrationStageMission: {
+        active: true,
+        scoreAdjustment: 4.5,
+        shouldDegradeSuccessToPartial: true,
+        degradeSuccessReason: stageReason,
+      },
+      stealthLeaveBehindMission: {
+        active: true,
+        scoreAdjustment: 3.5,
+        shouldDegradeSuccessToPartial: true,
+        degradeSuccessReason: leaveBehindReason,
+      },
+    })
+
+    expect(hint.shouldDegrade).toBe(true)
+    expect(hint.reason).toBe(stageReason)
+  })
+})
+
+describe('stealth leave-behind mission-resolution fallout', () => {
+  it('applies leave-behind malus through live case resolution orchestration', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('a_leave_behind_orchestration')
+    const team = createObserverTeam('t_leave_behind_orchestration', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    const without = createStealthCase({
+      assignedTeamIds: [team.id],
+      stealthLeaveBehindId: undefined,
+    })
+    const withLeaveBehind = createStealthCase({
+      assignedTeamIds: [team.id],
+      stealthLeaveBehindId: 'leave-behind:risk-discovery',
+    })
+
+    const inactive = resolveAssignedCaseForWeek(without, state, () => 0.5)
+    const active = resolveAssignedCaseForWeek(withLeaveBehind, state, () => 0.5)
+
+    expect(inactive.stealthLeaveBehindMission?.active).toBe(false)
+    expect(active.stealthLeaveBehindMission?.active).toBe(true)
+    expect(active.stealthLeaveBehindMission?.scoreAdjustment).toBe(3.5)
+    expect(
+      active.outcome.reasons.some((reason) => reason.includes('Stealth leave-behind:'))
+    ).toBe(true)
+  })
+
+  it('matches preview and live score context for authored leave-behind', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('a_preview_leave_behind')
+    const team = createObserverTeam('t_preview_leave_behind', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    const stealthCase = createStealthCase({
+      assignedTeamIds: [team.id],
+      stealthLeaveBehindId: 'leave-behind:expose-witness',
+    })
+    const baselineCase = { ...stealthCase, stealthLeaveBehindId: undefined }
+
+    const previewActive = previewResolutionForTeamIds(stealthCase, state, [team.id])
+    const previewBaseline = previewResolutionForTeamIds(baselineCase, state, [team.id])
+    const liveActive = resolveAssignedCaseForWeek(stealthCase, state, () => 0.5)
+
+    expect(liveActive.stealthLeaveBehindMission?.scoreAdjustment).toBe(2.8)
+    expect(previewActive.odds.success).toBeLessThanOrEqual(previewBaseline.odds.success)
+  })
+})

--- a/src/test/stealthLeaveBehindMission.test.ts
+++ b/src/test/stealthLeaveBehindMission.test.ts
@@ -5,7 +5,9 @@ import {
   resolveMissionSuccessDegradeHint,
 } from '../domain/caseResolutionOrchestration'
 import { evaluateStealthLeaveBehindMissionPressure } from '../domain/stealthLeaveBehindRegistry'
+import { caseTemplateMap } from '../data/caseTemplates'
 import { previewResolutionForTeamIds } from '../domain/sim/resolve'
+import { instantiateFromTemplate } from '../domain/sim/spawn'
 import type { Agent, CaseInstance, Team } from '../domain/models'
 import { createStarterCase } from '../domain/templates/startingCases'
 
@@ -62,6 +64,9 @@ describe('evaluateStealthLeaveBehindMissionPressure', () => {
     expect(evaluateStealthLeaveBehindMissionPressure({ ...base, hiddenState: 'revealed' }).active).toBe(
       false
     )
+    expect(evaluateStealthLeaveBehindMissionPressure({ ...base, hiddenState: 'displaced' }).active).toBe(
+      false
+    )
     expect(
       evaluateStealthLeaveBehindMissionPressure({
         ...base,
@@ -113,6 +118,33 @@ describe('evaluateStealthLeaveBehindMissionPressure', () => {
 })
 
 describe('resolveMissionSuccessDegradeHint leave-behind priority', () => {
+  it('prefers behavior-validation degrade over leave-behind degrade', () => {
+    const behaviorReason = 'Behavior mismatch blocked a clean resolution.'
+    const leaveBehindReason =
+      'Stealth extraction tradeoff under authority scrutiny prevented a clean resolution.'
+
+    const hint = resolveMissionSuccessDegradeHint({
+      behaviorValidation: {
+        active: true,
+        level: 'strong',
+        scoreAdjustment: 4.5,
+        evidenceSignals: ['hierarchy fit'],
+        counterDetection: true,
+        shouldDegradeSuccessToPartial: true,
+        degradeSuccessReason: behaviorReason,
+      },
+      stealthLeaveBehindMission: {
+        active: true,
+        scoreAdjustment: 3.5,
+        shouldDegradeSuccessToPartial: true,
+        degradeSuccessReason: leaveBehindReason,
+      },
+    })
+
+    expect(hint.shouldDegrade).toBe(true)
+    expect(hint.reason).toBe(behaviorReason)
+  })
+
   it('prefers infiltration stage degrade over leave-behind degrade', () => {
     const stageReason = 'Violent infiltration escalation under authority scrutiny prevented a clean resolution.'
     const leaveBehindReason =
@@ -183,7 +215,17 @@ describe('stealth leave-behind mission-resolution fallout', () => {
     const previewBaseline = previewResolutionForTeamIds(baselineCase, state, [team.id])
     const liveActive = resolveAssignedCaseForWeek(stealthCase, state, () => 0.5)
 
-    expect(liveActive.stealthLeaveBehindMission?.scoreAdjustment).toBe(2.8)
+    const directPressure = evaluateStealthLeaveBehindMissionPressure(stealthCase)
+    expect(liveActive.stealthLeaveBehindMission?.scoreAdjustment).toBe(directPressure.scoreAdjustment)
+    expect(directPressure.scoreAdjustment).toBe(2.8)
     expect(previewActive.odds.success).toBeLessThanOrEqual(previewBaseline.odds.success)
+  })
+
+  it('copies stealthLeaveBehindId from catalog templates at spawn', () => {
+    const ops003 = instantiateFromTemplate(caseTemplateMap['ops-003'], () => 0.2, new Set())
+    const ops004 = instantiateFromTemplate(caseTemplateMap['ops-004'], () => 0.2, new Set())
+
+    expect(ops003.stealthLeaveBehindId).toBe('leave-behind:leave-trace')
+    expect(ops004.stealthLeaveBehindId).toBe('leave-behind:expose-witness')
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires the SPE-2163 leave-behind catalog into weekly mission resolution, following the infiltration stage mission pattern.

## Changes

- `stealthLeaveBehindId` on `CaseTemplate` / `CaseInstance` (spawn + catalog validation)
- `evaluateStealthLeaveBehindMissionPressure()` — hidden + concealment tag + valid registry id; malus = `discoveryRisk × 5`; partial degrade when risk ≥ 0.55 under authority scrutiny
- `caseResolutionOrchestration`, `resolve.ts` preview, `advanceWeek` degrade hint (priority: behavior → infiltration stage → leave-behind)
- Authored ids on `ops-003` (`leave-behind:leave-trace`) and `ops-004` (`leave-behind:expose-witness`)
- `src/test/stealthLeaveBehindMission.test.ts`

## Out of scope

- Player/UI choice flow
- Auto-mapping from infiltration stage
- Custody ref side effects
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

