### PR TITLE
SPE-2247: Wire leave-behind custodyLossRefs into investigation markers

### DIFF
--- a/src/domain/investigationCustodyLoss.ts
+++ b/src/domain/investigationCustodyLoss.ts
@@ -1,0 +1,194 @@
+/**
+ * SPE-2247 slice 4: investigation-facing custody-loss markers from stealth leave-behinds.
+ *
+ * Maps registry `custodyLossRefs` onto persistent per-case flags and readable markers.
+ * Distinct from SPE-809 `CustodyChain` / `CustodyMarker` pipeline data (not yet wired in sim).
+ */
+
+import { readPersistentFlag, selectPersistentFlags, setPersistentFlag } from './flagSystem'
+import type { GameFlagValue, GameState } from './models'
+import type { StealthLeaveBehindKind } from './stealthLeaveBehindRegistry'
+
+export interface InvestigationCustodyLossMarker {
+  readonly ref: string
+  readonly leaveBehindId: string
+  readonly kind: StealthLeaveBehindKind
+  readonly label: string
+  readonly appliedWeek: number
+}
+
+export interface ApplyStealthLeaveBehindInvestigationCustodyLossInput {
+  readonly state: GameState
+  readonly caseId: string
+  readonly leaveBehindId: string
+  readonly leaveBehindKind: StealthLeaveBehindKind
+  readonly leaveBehindLabel: string
+  readonly custodyLossRefs: readonly string[]
+  readonly week: number
+}
+
+export interface ApplyStealthLeaveBehindInvestigationCustodyLossResult {
+  readonly state: GameState
+  readonly appliedRefs: readonly string[]
+  readonly resolutionNote?: string
+}
+
+function sanitizeCaseId(caseId: string) {
+  return caseId.trim()
+}
+
+function sanitizeCustodyRef(ref: string) {
+  return ref.trim()
+}
+
+function normalizeRefForFlag(ref: string) {
+  return sanitizeCustodyRef(ref).replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '')
+}
+
+export function buildInvestigationCustodyLossFlagId(caseId: string, custodyLossRef: string) {
+  const normalizedCaseId = sanitizeCaseId(caseId)
+  const normalizedRef = normalizeRefForFlag(custodyLossRef)
+
+  return `investigation.case.${normalizedCaseId}.custody-loss.${normalizedRef}`
+}
+
+const CUSTODY_LOSS_MARKER_PREFIX = 'investigation-custody-loss:v1:'
+
+function buildMarkerPayload(input: {
+  ref: string
+  leaveBehindId: string
+  kind: StealthLeaveBehindKind
+  label: string
+  appliedWeek: number
+}): InvestigationCustodyLossMarker {
+  return Object.freeze({
+    ref: input.ref,
+    leaveBehindId: input.leaveBehindId,
+    kind: input.kind,
+    label: input.label,
+    appliedWeek: input.appliedWeek,
+  })
+}
+
+function serializeInvestigationCustodyLossMarker(marker: InvestigationCustodyLossMarker): string {
+  return `${CUSTODY_LOSS_MARKER_PREFIX}${JSON.stringify({
+    ref: marker.ref,
+    leaveBehindId: marker.leaveBehindId,
+    kind: marker.kind,
+    label: marker.label,
+    appliedWeek: marker.appliedWeek,
+  })}`
+}
+
+function parseInvestigationCustodyLossMarker(value: GameFlagValue | undefined) {
+  if (typeof value !== 'string' || !value.startsWith(CUSTODY_LOSS_MARKER_PREFIX)) {
+    return undefined
+  }
+
+  try {
+    const parsed = JSON.parse(value.slice(CUSTODY_LOSS_MARKER_PREFIX.length)) as Partial<
+      InvestigationCustodyLossMarker
+    >
+    if (
+      typeof parsed.ref !== 'string' ||
+      typeof parsed.leaveBehindId !== 'string' ||
+      typeof parsed.kind !== 'string' ||
+      typeof parsed.label !== 'string' ||
+      typeof parsed.appliedWeek !== 'number'
+    ) {
+      return undefined
+    }
+
+    return buildMarkerPayload({
+      ref: parsed.ref,
+      leaveBehindId: parsed.leaveBehindId,
+      kind: parsed.kind as StealthLeaveBehindKind,
+      label: parsed.label,
+      appliedWeek: parsed.appliedWeek,
+    })
+  } catch {
+    return undefined
+  }
+}
+
+export function readInvestigationCustodyLossMarker(
+  state: GameState,
+  caseId: string,
+  custodyLossRef: string
+): InvestigationCustodyLossMarker | undefined {
+  const flagId = buildInvestigationCustodyLossFlagId(caseId, custodyLossRef)
+  return parseInvestigationCustodyLossMarker(readPersistentFlag(state, flagId))
+}
+
+export function listInvestigationCustodyLossMarkers(
+  state: GameState,
+  caseId: string
+): readonly InvestigationCustodyLossMarker[] {
+  const normalizedCaseId = sanitizeCaseId(caseId)
+  const prefix = `investigation.case.${normalizedCaseId}.custody-loss.`
+  const flags = selectPersistentFlags(state, prefix)
+
+  return Object.values(flags)
+    .map((value) => parseInvestigationCustodyLossMarker(value))
+    .filter((marker): marker is InvestigationCustodyLossMarker => marker !== undefined)
+    .sort((left, right) => left.ref.localeCompare(right.ref))
+}
+
+export function countInvestigationCustodyLossRefs(state: GameState, caseId: string) {
+  return listInvestigationCustodyLossMarkers(state, caseId).length
+}
+
+export function applyStealthLeaveBehindInvestigationCustodyLoss(
+  input: ApplyStealthLeaveBehindInvestigationCustodyLossInput
+): ApplyStealthLeaveBehindInvestigationCustodyLossResult {
+  const normalizedCaseId = sanitizeCaseId(input.caseId)
+
+  if (normalizedCaseId.length === 0 || input.custodyLossRefs.length === 0) {
+    return {
+      state: input.state,
+      appliedRefs: [],
+    }
+  }
+
+  let nextState = input.state
+  const appliedRefs: string[] = []
+
+  for (const ref of input.custodyLossRefs) {
+    const normalizedRef = sanitizeCustodyRef(ref)
+    if (!normalizedRef) {
+      continue
+    }
+
+    if (readInvestigationCustodyLossMarker(nextState, normalizedCaseId, normalizedRef)) {
+      continue
+    }
+
+    const marker = buildMarkerPayload({
+      ref: normalizedRef,
+      leaveBehindId: input.leaveBehindId,
+      kind: input.leaveBehindKind,
+      label: input.leaveBehindLabel,
+      appliedWeek: input.week,
+    })
+    nextState = setPersistentFlag(
+      nextState,
+      buildInvestigationCustodyLossFlagId(normalizedCaseId, normalizedRef),
+      serializeInvestigationCustodyLossMarker(marker)
+    )
+    appliedRefs.push(normalizedRef)
+  }
+
+  if (appliedRefs.length === 0) {
+    return {
+      state: nextState,
+      appliedRefs: [],
+    }
+  }
+
+  const refSummary = appliedRefs.join(', ')
+  return {
+    state: nextState,
+    appliedRefs,
+    resolutionNote: `Investigation custody strain (${input.leaveBehindLabel}): lost ${refSummary}.`,
+  }
+}

--- a/src/domain/investigationCustodyLoss.ts
+++ b/src/domain/investigationCustodyLoss.ts
@@ -41,13 +41,14 @@ function sanitizeCustodyRef(ref: string) {
   return ref.trim()
 }
 
-function normalizeRefForFlag(ref: string) {
+/** Stable flag suffix for a custody-loss ref (must match registry validation). */
+export function normalizeInvestigationCustodyLossRefForFlag(ref: string) {
   return sanitizeCustodyRef(ref).replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '')
 }
 
 export function buildInvestigationCustodyLossFlagId(caseId: string, custodyLossRef: string) {
   const normalizedCaseId = sanitizeCaseId(caseId)
-  const normalizedRef = normalizeRefForFlag(custodyLossRef)
+  const normalizedRef = normalizeInvestigationCustodyLossRefForFlag(custodyLossRef)
 
   return `investigation.case.${normalizedCaseId}.custody-loss.${normalizedRef}`
 }
@@ -152,6 +153,7 @@ export function applyStealthLeaveBehindInvestigationCustodyLoss(
 
   let nextState = input.state
   const appliedRefs: string[] = []
+  const appliedFlagSuffixes = new Set<string>()
 
   for (const ref of input.custodyLossRefs) {
     const normalizedRef = sanitizeCustodyRef(ref)
@@ -159,7 +161,13 @@ export function applyStealthLeaveBehindInvestigationCustodyLoss(
       continue
     }
 
+    const flagSuffix = normalizeInvestigationCustodyLossRefForFlag(normalizedRef)
+    if (!flagSuffix || appliedFlagSuffixes.has(flagSuffix)) {
+      continue
+    }
+
     if (readInvestigationCustodyLossMarker(nextState, normalizedCaseId, normalizedRef)) {
+      appliedFlagSuffixes.add(flagSuffix)
       continue
     }
 
@@ -175,6 +183,7 @@ export function applyStealthLeaveBehindInvestigationCustodyLoss(
       buildInvestigationCustodyLossFlagId(normalizedCaseId, normalizedRef),
       serializeInvestigationCustodyLossMarker(marker)
     )
+    appliedFlagSuffixes.add(flagSuffix)
     appliedRefs.push(normalizedRef)
   }
 

--- a/src/domain/investigationEconomy.ts
+++ b/src/domain/investigationEconomy.ts
@@ -1,3 +1,4 @@
+import { countInvestigationCustodyLossRefs } from './investigationCustodyLoss'
 import { setPersistentFlag, readPersistentFlag } from './flagSystem'
 import { advanceDefinedProgressClock, readProgressClock } from './progressClocks'
 import type { GameState } from './models'
@@ -26,6 +27,8 @@ export interface InvestigationBudgetSnapshot {
   maxBudget: number
   granted: number
   spent: number
+  /** Forensic headroom reduced by one per active investigation custody-loss marker. */
+  custodyLossBurden: number
   remaining: number
 }
 
@@ -196,6 +199,9 @@ export function readInvestigationBudget(
   const spentClockId = buildInvestigationBudgetClockId(normalizedCaseId, domain, 'spent')
   const granted = readProgressClock(state, grantedClockId)?.value ?? 0
   const spent = readProgressClock(state, spentClockId)?.value ?? 0
+  const custodyLossBurden =
+    domain === 'forensic' ? countInvestigationCustodyLossRefs(state, normalizedCaseId) : 0
+  const remaining = Math.max(0, granted - spent - custodyLossBurden)
 
   return {
     caseId: normalizedCaseId,
@@ -203,7 +209,8 @@ export function readInvestigationBudget(
     maxBudget: INVESTIGATION_BUDGET_MAX,
     granted,
     spent,
-    remaining: Math.max(0, granted - spent),
+    custodyLossBurden,
+    remaining,
   }
 }
 

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -2367,7 +2367,8 @@ function resolveAssignments(
       stealthLeaveBehindMission?.active &&
       stealthLeaveBehindMission.leaveBehindId &&
       stealthLeaveBehindMission.kind &&
-      stealthLeaveBehindMission.leaveBehindLabel
+      stealthLeaveBehindMission.leaveBehindLabel &&
+      stealthLeaveBehindMission.custodyLossRefs.length > 0
     ) {
       const custodyLoss = applyStealthLeaveBehindInvestigationCustodyLoss({
         state: context.nextState,

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -276,6 +276,7 @@ import {
   isCaseUnderConstruction,
 } from '../constructionProgress'
 import { doesProgressClockMeetThreshold } from '../progressClocks'
+import { applyStealthLeaveBehindInvestigationCustodyLoss } from '../investigationCustodyLoss'
 import {
   applySuccessfulInvestigation,
   askInvestigationQuestion,
@@ -2361,6 +2362,28 @@ function resolveAssignments(
       ...outcome.reasons,
       ...buildAggregateBattleResolutionReasons(aggregateBattleSummary),
     ]
+
+    if (
+      stealthLeaveBehindMission?.active &&
+      stealthLeaveBehindMission.leaveBehindId &&
+      stealthLeaveBehindMission.kind &&
+      stealthLeaveBehindMission.leaveBehindLabel
+    ) {
+      const custodyLoss = applyStealthLeaveBehindInvestigationCustodyLoss({
+        state: context.nextState,
+        caseId,
+        leaveBehindId: stealthLeaveBehindMission.leaveBehindId,
+        leaveBehindKind: stealthLeaveBehindMission.kind,
+        leaveBehindLabel: stealthLeaveBehindMission.leaveBehindLabel,
+        custodyLossRefs: stealthLeaveBehindMission.custodyLossRefs,
+        week: context.sourceState.week,
+      })
+      context.nextState = custodyLoss.state
+      if (custodyLoss.resolutionNote) {
+        resolutionReasons.push(custodyLoss.resolutionNote)
+      }
+    }
+
     const aggregateBattleCeasefireWindow =
       buildAggregateBattleCeasefireWindowForOperation(effectiveCase)
     context.performanceByCaseId[caseId] = performanceSummary

--- a/src/domain/stealthLeaveBehindRegistry.ts
+++ b/src/domain/stealthLeaveBehindRegistry.ts
@@ -5,6 +5,7 @@
  * with bounded discovery risk and custody-loss references. No weekly hook or UI yet.
  */
 
+import { normalizeInvestigationCustodyLossRefForFlag } from './investigationCustodyLoss'
 import { CONCEALMENT_ACTIVATION_TAGS } from './hiddenStateActivation'
 import { INFILTRATION_AUTHORITY_SCRUTINY_TAGS } from './infiltrationCover'
 import { clamp } from './math'
@@ -46,6 +47,8 @@ export type StealthLeaveBehindValidationCode =
   | 'invalid_discovery_risk'
   | 'empty_custody_loss_ref'
   | 'duplicate_custody_loss_ref'
+  | 'empty_custody_loss_flag_suffix'
+  | 'colliding_custody_loss_ref'
 
 export interface StealthLeaveBehindValidationIssue {
   readonly code: StealthLeaveBehindValidationCode
@@ -115,6 +118,7 @@ export function validateStealthLeaveBehindDefinition(
   }
 
   const seenCustodyRefs = new Set<string>()
+  const seenCustodyFlagSuffixes = new Set<string>()
   for (const ref of definition.custodyLossRefs) {
     const normalized = normalizeToken(ref)
     if (!normalized) {
@@ -132,8 +136,29 @@ export function validateStealthLeaveBehindDefinition(
         detail: `Leave-behind ${id || '(unknown)'} repeats custodyLossRef ${normalized}.`,
         relatedIds: id ? [id] : undefined,
       })
+      continue
+    }
+
+    seenCustodyRefs.add(normalized)
+
+    const flagSuffix = normalizeInvestigationCustodyLossRefForFlag(normalized)
+    if (!flagSuffix) {
+      pushIssue(issues, {
+        code: 'empty_custody_loss_flag_suffix',
+        detail: `Leave-behind ${id || '(unknown)'} custodyLossRef ${normalized} does not yield a stable flag suffix.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
+    if (seenCustodyFlagSuffixes.has(flagSuffix)) {
+      pushIssue(issues, {
+        code: 'colliding_custody_loss_ref',
+        detail: `Leave-behind ${id || '(unknown)'} declares custodyLossRefs that collide on flag suffix ${flagSuffix}.`,
+        relatedIds: id ? [id] : undefined,
+      })
     } else {
-      seenCustodyRefs.add(normalized)
+      seenCustodyFlagSuffixes.add(flagSuffix)
     }
   }
 

--- a/src/domain/stealthLeaveBehindRegistry.ts
+++ b/src/domain/stealthLeaveBehindRegistry.ts
@@ -204,6 +204,8 @@ export interface StealthLeaveBehindMissionPressureResult {
   active: boolean
   leaveBehindId?: string
   kind?: StealthLeaveBehindKind
+  leaveBehindLabel?: string
+  custodyLossRefs: readonly string[]
   scoreAdjustment: number
   scoreAdjustmentReason?: string
   shouldDegradeSuccessToPartial: boolean
@@ -212,6 +214,7 @@ export interface StealthLeaveBehindMissionPressureResult {
 
 const INACTIVE_LEAVE_BEHIND_MISSION_PRESSURE: StealthLeaveBehindMissionPressureResult = {
   active: false,
+  custodyLossRefs: [],
   scoreAdjustment: 0,
   shouldDegradeSuccessToPartial: false,
 }
@@ -266,6 +269,8 @@ export function evaluateStealthLeaveBehindMissionPressure(
     active: true,
     leaveBehindId: definition.id,
     kind: definition.kind,
+    leaveBehindLabel: definition.label,
+    custodyLossRefs: definition.custodyLossRefs,
     scoreAdjustment,
     scoreAdjustmentReason,
     shouldDegradeSuccessToPartial: highDiscoveryRisk && authorityScrutiny,

--- a/src/test/investigationCustodyLoss.test.ts
+++ b/src/test/investigationCustodyLoss.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  applyStealthLeaveBehindInvestigationCustodyLoss,
+  buildInvestigationCustodyLossFlagId,
+  countInvestigationCustodyLossRefs,
+  listInvestigationCustodyLossMarkers,
+  readInvestigationCustodyLossMarker,
+} from '../domain/investigationCustodyLoss'
+import { evaluateStealthLeaveBehindMissionPressure } from '../domain/stealthLeaveBehindRegistry'
+import { readInvestigationBudget } from '../domain/investigationEconomy'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+describe('investigationCustodyLoss', () => {
+  it('builds stable per-case custody-loss flag ids', () => {
+    expect(buildInvestigationCustodyLossFlagId('case-001', 'custody:field-packet')).toBe(
+      'investigation.case.case-001.custody-loss.custody-field-packet'
+    )
+  })
+
+  it('records investigation custody-loss markers from leave-behind refs', () => {
+    const state = createStartingState()
+
+    const result = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      leaveBehindKind: 'abandon_evidence',
+      leaveBehindLabel: 'Abandon compromised evidence',
+      custodyLossRefs: ['custody:field-packet', 'custody:chain-seal'],
+      week: 3,
+    })
+
+    expect(result.appliedRefs).toEqual(['custody:field-packet', 'custody:chain-seal'])
+    expect(
+      readInvestigationCustodyLossMarker(result.state, 'case-001', 'custody:field-packet')
+    ).toMatchObject({
+      ref: 'custody:field-packet',
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      kind: 'abandon_evidence',
+      appliedWeek: 3,
+    })
+    expect(countInvestigationCustodyLossRefs(result.state, 'case-001')).toBe(2)
+    expect(listInvestigationCustodyLossMarkers(result.state, 'case-001')).toHaveLength(2)
+    expect(result.resolutionNote).toContain('custody:field-packet')
+  })
+
+  it('dedupes custody-loss markers when the same ref is applied twice', () => {
+    const first = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state: createStartingState(),
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:burn-tool',
+      leaveBehindKind: 'burn_tool',
+      leaveBehindLabel: 'Burn field tool',
+      custodyLossRefs: ['custody:tool-serial'],
+      week: 1,
+    })
+
+    const second = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state: first.state,
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:burn-tool',
+      leaveBehindKind: 'burn_tool',
+      leaveBehindLabel: 'Burn field tool',
+      custodyLossRefs: ['custody:tool-serial'],
+      week: 2,
+    })
+
+    expect(second.appliedRefs).toEqual([])
+    expect(countInvestigationCustodyLossRefs(second.state, 'case-001')).toBe(1)
+  })
+
+  it('reduces forensic investigation budget headroom by custody-loss burden', () => {
+    let state = createStartingState()
+    state = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:leave-trace',
+      leaveBehindKind: 'leave_trace',
+      leaveBehindLabel: 'Leave forensic trace',
+      custodyLossRefs: ['custody:trace-sample', 'custody:mission-window'],
+      week: 1,
+    }).state
+
+    const budget = readInvestigationBudget(state, 'case-001', 'forensic')
+
+    expect(budget.custodyLossBurden).toBe(2)
+    expect(budget.remaining).toBe(Math.max(0, budget.granted - budget.spent - 2))
+  })
+})
+
+describe('stealth leave-behind custody-loss resolution', () => {
+  it('resolves custody-loss refs when mission pressure is active', () => {
+    const caseData = {
+      ...createStarterCase({ id: 'case-x', templateId: 'ops-003' }),
+      hiddenState: 'hidden' as const,
+      tags: ['infiltration', 'archive', 'records'],
+      stealthLeaveBehindId: 'leave-behind:leave-trace',
+    }
+
+    const pressure = evaluateStealthLeaveBehindMissionPressure(caseData)
+    expect(pressure.active).toBe(true)
+    expect(pressure.custodyLossRefs).toEqual(['custody:trace-sample'])
+  })
+})

--- a/src/test/investigationCustodyLoss.test.ts
+++ b/src/test/investigationCustodyLoss.test.ts
@@ -5,8 +5,10 @@ import {
   buildInvestigationCustodyLossFlagId,
   countInvestigationCustodyLossRefs,
   listInvestigationCustodyLossMarkers,
+  normalizeInvestigationCustodyLossRefForFlag,
   readInvestigationCustodyLossMarker,
 } from '../domain/investigationCustodyLoss'
+import { askInvestigationQuestion, grantInvestigationQuestionBudget } from '../domain/investigationEconomy'
 import { evaluateStealthLeaveBehindMissionPressure } from '../domain/stealthLeaveBehindRegistry'
 import { readInvestigationBudget } from '../domain/investigationEconomy'
 import { createStarterCase } from '../domain/templates/startingCases'
@@ -68,6 +70,67 @@ describe('investigationCustodyLoss', () => {
 
     expect(second.appliedRefs).toEqual([])
     expect(countInvestigationCustodyLossRefs(second.state, 'case-001')).toBe(1)
+  })
+
+  it('skips symbolic-only custody refs that do not yield a flag suffix', () => {
+    const result = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state: createStartingState(),
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:burn-tool',
+      leaveBehindKind: 'burn_tool',
+      leaveBehindLabel: 'Burn field tool',
+      custodyLossRefs: ['!!!', 'custody:tool-serial'],
+      week: 1,
+    })
+
+    expect(result.appliedRefs).toEqual(['custody:tool-serial'])
+    expect(countInvestigationCustodyLossRefs(result.state, 'case-001')).toBe(1)
+    expect(normalizeInvestigationCustodyLossRefForFlag('!!!')).toBe('')
+  })
+
+  it('dedupes custody refs that collide on the same investigation flag suffix', () => {
+    const result = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state: createStartingState(),
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      leaveBehindKind: 'abandon_evidence',
+      leaveBehindLabel: 'Abandon compromised evidence',
+      custodyLossRefs: ['custody:field-packet', 'custody/field/packet'],
+      week: 1,
+    })
+
+    expect(result.appliedRefs).toEqual(['custody:field-packet'])
+    expect(countInvestigationCustodyLossRefs(result.state, 'case-001')).toBe(1)
+    expect(
+      normalizeInvestigationCustodyLossRefForFlag('custody:field-packet')
+    ).toBe(normalizeInvestigationCustodyLossRefForFlag('custody/field/packet'))
+  })
+
+  it('blocks forensic questions when remaining budget is consumed by custody burden only', () => {
+    let state = createStartingState()
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: 'case-001',
+      domain: 'forensic',
+      amount: 1,
+    })
+    state = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:burn-tool',
+      leaveBehindKind: 'burn_tool',
+      leaveBehindLabel: 'Burn field tool',
+      custodyLossRefs: ['custody:tool-serial'],
+      week: 1,
+    }).state
+
+    const asked = askInvestigationQuestion(state, {
+      caseId: 'case-001',
+      domain: 'forensic',
+      questionId: 'forensic.present-signature',
+    })
+
+    expect(asked.applied).toBe(false)
+    expect(asked.reason).toBe('budget_exhausted')
   })
 
   it('reduces forensic investigation budget headroom by custody-loss burden', () => {

--- a/src/test/stealthLeaveBehindMission.test.ts
+++ b/src/test/stealthLeaveBehindMission.test.ts
@@ -4,6 +4,7 @@ import {
   resolveAssignedCaseForWeek,
   resolveMissionSuccessDegradeHint,
 } from '../domain/caseResolutionOrchestration'
+import { countInvestigationCustodyLossRefs } from '../domain/investigationCustodyLoss'
 import { evaluateStealthLeaveBehindMissionPressure } from '../domain/stealthLeaveBehindRegistry'
 import { caseTemplateMap, caseTemplates } from '../data/caseTemplates'
 import { previewResolutionForTeamIds } from '../domain/sim/resolve'
@@ -136,6 +137,7 @@ describe('resolveMissionSuccessDegradeHint leave-behind priority', () => {
       },
       stealthLeaveBehindMission: {
         active: true,
+        custodyLossRefs: [],
         scoreAdjustment: 3.5,
         shouldDegradeSuccessToPartial: true,
         degradeSuccessReason: leaveBehindReason,
@@ -160,6 +162,7 @@ describe('resolveMissionSuccessDegradeHint leave-behind priority', () => {
       },
       stealthLeaveBehindMission: {
         active: true,
+        custodyLossRefs: [],
         scoreAdjustment: 3.5,
         shouldDegradeSuccessToPartial: true,
         degradeSuccessReason: leaveBehindReason,
@@ -315,6 +318,10 @@ describe('advanceWeek stealth leave-behind mission fallout', () => {
           note.includes('Stealth leave-behind:')
       )
     ).toBe(true)
+    expect(
+      notes.some((note) => note.includes('Investigation custody strain'))
+    ).toBe(true)
+    expect(countInvestigationCustodyLossRefs(nextState, 'case-001')).toBe(1)
     expect(nextState.cases['case-001'].status).toBe('open')
   })
 })

--- a/src/test/stealthLeaveBehindRegistry.test.ts
+++ b/src/test/stealthLeaveBehindRegistry.test.ts
@@ -42,6 +42,17 @@ describe('stealthLeaveBehindRegistry (SPE-2163 slice 1)', () => {
     expect(result.issues).toHaveLength(0)
   })
 
+  it('rejects custody refs that collide on investigation flag suffixes', () => {
+    const result = validateStealthLeaveBehindDefinition(
+      baseDefinition({
+        custodyLossRefs: ['custody:packet-alpha', 'custody/packet/alpha'],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.map((issue) => issue.code)).toContain('colliding_custody_loss_ref')
+  })
+
   it('rejects invalid discovery risk, ids, kinds, and custody refs', () => {
     const result = validateStealthLeaveBehindDefinition(
       baseDefinition({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes SPE-521 slice 4 by mapping stealth leave-behind registry `custodyLossRefs` onto investigation-facing custody-loss markers and forensic budget burden.

## Changes

- **`investigationCustodyLoss.ts`**: Per-case persistent flags (`investigation.case.{caseId}.custody-loss.{ref}`) with serialized marker payloads; apply/dedupe/list helpers.
- **`stealthLeaveBehindRegistry.ts`**: Active mission pressure now exposes `leaveBehindLabel` and `custodyLossRefs` from the catalog entry.
- **`investigationEconomy.ts`**: `readInvestigationBudget` reports `custodyLossBurden` and reduces forensic `remaining` by marker count.
- **`advanceWeek.ts`**: After weekly resolution, applies custody-loss markers when leave-behind mission pressure is active and surfaces a resolution note.
- **Tests**: Unit coverage for markers, budget burden, pressure refs, and `advanceWeek` integration.

## Notes

Markers use persistent string flags (not SPE-809 `CustodyChain` pipeline data). Tactical investigation budget is unchanged; only forensic headroom is burdened.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

