### PR TITLE
feat(SPE-2247): stealth leave-behind tradeoff selection (slice 5)

### DIFF
--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -86,6 +86,7 @@ import { applyChapterBreakAttritionReset } from '../../domain/agent/attritionRes
 import { applyRotatingRosterContinuityReconciliation } from '../../domain/agent/rosterContinuity'
 import { advanceWeek } from '../../domain/sim/advanceWeek'
 import { assignTeam, launchMajorIncident, unassignTeam } from '../../domain/sim/assign'
+import { applyStealthLeaveBehindSelection } from '../../domain/stealthLeaveBehindSelection'
 import { queueFabrication } from '../../domain/sim/production'
 import { invokeEmergencyGrayMarketWaiver } from '../../domain/procurementEmergency'
 import {
@@ -220,6 +221,8 @@ interface GameStore {
   ) => void
   assign: (caseId: Id, teamId: Id) => void
   unassign: (caseId: Id, teamId?: Id) => void
+  /** SPE-2247: set stealth leave-behind tradeoff on an eligible in-progress infiltration case. */
+  selectStealthLeaveBehind: (caseId: Id, leaveBehindId: string) => void
   hireCandidate: (candidateId: Id) => void
   scoutCandidate: (candidateId: Id) => void
   transitionCandidateFunnel: (
@@ -1122,6 +1125,16 @@ export const useGameStore = create<GameStore>()(
       assign: (caseId, teamId) => set((s) => ({ game: assignTeam(s.game, caseId, teamId) })),
 
       unassign: (caseId, teamId) => set((s) => ({ game: unassignTeam(s.game, caseId, teamId) })),
+
+      selectStealthLeaveBehind: (caseId, leaveBehindId) =>
+        set((s) => {
+          const result = applyStealthLeaveBehindSelection(s.game, { caseId, leaveBehindId })
+          if (!result.applied) {
+            return { game: s.game }
+          }
+
+          return { game: result.state }
+        }),
 
       hireCandidate: (candidateId) => set((s) => ({ game: hireCandidate(s.game, candidateId) })),
 

--- a/src/domain/investigationCustodyLoss.ts
+++ b/src/domain/investigationCustodyLoss.ts
@@ -139,6 +139,43 @@ export function countInvestigationCustodyLossRefs(state: GameState, caseId: stri
   return listInvestigationCustodyLossMarkers(state, caseId).length
 }
 
+/**
+ * Project forensic custody burden after leave-behind refs would be applied at resolution.
+ * Mirrors apply dedupe: skips empty refs, colliding flag suffixes, and existing markers.
+ */
+export function projectInvestigationCustodyLossBurdenAfterRefs(
+  state: GameState,
+  caseId: string,
+  custodyLossRefs: readonly string[]
+): number {
+  const normalizedCaseId = sanitizeCaseId(caseId)
+  if (normalizedCaseId.length === 0) {
+    return 0
+  }
+
+  const appliedFlagSuffixes = new Set(
+    listInvestigationCustodyLossMarkers(state, normalizedCaseId).map((marker) =>
+      normalizeInvestigationCustodyLossRefForFlag(marker.ref)
+    )
+  )
+
+  for (const ref of custodyLossRefs) {
+    const normalizedRef = sanitizeCustodyRef(ref)
+    if (!normalizedRef) {
+      continue
+    }
+
+    const flagSuffix = normalizeInvestigationCustodyLossRefForFlag(normalizedRef)
+    if (!flagSuffix || appliedFlagSuffixes.has(flagSuffix)) {
+      continue
+    }
+
+    appliedFlagSuffixes.add(flagSuffix)
+  }
+
+  return appliedFlagSuffixes.size
+}
+
 export function applyStealthLeaveBehindInvestigationCustodyLoss(
   input: ApplyStealthLeaveBehindInvestigationCustodyLossInput
 ): ApplyStealthLeaveBehindInvestigationCustodyLossResult {

--- a/src/domain/stealthLeaveBehindSelection.ts
+++ b/src/domain/stealthLeaveBehindSelection.ts
@@ -1,0 +1,111 @@
+/**
+ * SPE-2247 slice 5: player selection of stealth leave-behind tradeoffs on eligible cases.
+ */
+
+import type { CaseInstance, GameState } from './models'
+import {
+  DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY,
+  getStealthLeaveBehindById,
+  isStealthLeaveBehindMissionEligible,
+  type StealthLeaveBehindDefinition,
+  type StealthLeaveBehindRegistry,
+} from './stealthLeaveBehindRegistry'
+
+export type StealthLeaveBehindSelectionFailureReason =
+  | 'invalid_case'
+  | 'ineligible'
+  | 'unknown_id'
+
+export interface ApplyStealthLeaveBehindSelectionInput {
+  readonly caseId: string
+  readonly leaveBehindId: string
+}
+
+export interface ApplyStealthLeaveBehindSelectionResult {
+  readonly state: GameState
+  readonly applied: boolean
+  readonly reason?: StealthLeaveBehindSelectionFailureReason
+  readonly leaveBehindId?: string
+}
+
+function sanitizeCaseId(caseId: string) {
+  return caseId.trim()
+}
+
+/** Case is open for weekly play and eligible for leave-behind mission pressure. */
+export function canSelectStealthLeaveBehindOnCase(caseData: CaseInstance) {
+  return caseData.status === 'in_progress' && isStealthLeaveBehindMissionEligible(caseData)
+}
+
+export function listSelectableStealthLeaveBehinds(
+  caseData: CaseInstance,
+  registry: StealthLeaveBehindRegistry = DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY
+): readonly StealthLeaveBehindDefinition[] {
+  if (!canSelectStealthLeaveBehindOnCase(caseData)) {
+    return []
+  }
+
+  return registry.entries
+}
+
+export function readStealthLeaveBehindSelection(
+  state: GameState,
+  caseId: string
+): string | undefined {
+  const normalizedCaseId = sanitizeCaseId(caseId)
+  if (normalizedCaseId.length === 0) {
+    return undefined
+  }
+
+  const leaveBehindId = state.cases[normalizedCaseId]?.stealthLeaveBehindId?.trim()
+  return leaveBehindId && leaveBehindId.length > 0 ? leaveBehindId : undefined
+}
+
+export function applyStealthLeaveBehindSelection(
+  state: GameState,
+  input: ApplyStealthLeaveBehindSelectionInput,
+  registry: StealthLeaveBehindRegistry = DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY
+): ApplyStealthLeaveBehindSelectionResult {
+  const normalizedCaseId = sanitizeCaseId(input.caseId)
+  const currentCase = normalizedCaseId.length > 0 ? state.cases[normalizedCaseId] : undefined
+
+  if (!currentCase) {
+    return {
+      state,
+      applied: false,
+      reason: 'invalid_case',
+    }
+  }
+
+  if (!canSelectStealthLeaveBehindOnCase(currentCase)) {
+    return {
+      state,
+      applied: false,
+      reason: 'ineligible',
+    }
+  }
+
+  const definition = getStealthLeaveBehindById(registry, input.leaveBehindId)
+  if (!definition) {
+    return {
+      state,
+      applied: false,
+      reason: 'unknown_id',
+    }
+  }
+
+  return {
+    state: {
+      ...state,
+      cases: {
+        ...state.cases,
+        [normalizedCaseId]: {
+          ...currentCase,
+          stealthLeaveBehindId: definition.id,
+        },
+      },
+    },
+    applied: true,
+    leaveBehindId: definition.id,
+  }
+}

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -154,6 +154,7 @@ it('shows stealth leave-behind tradeoff selection for eligible in-progress hidde
   const panel = screen.getByRole('region', { name: /stealth leave-behind tradeoff/i })
 
   expect(within(panel).getByRole('heading', { name: /stealth leave-behind/i })).toBeInTheDocument()
+  expect(within(panel).getByLabelText(/forensic investigation budget/i)).toBeInTheDocument()
   expect(within(panel).getByText(/leave forensic trace/i)).toBeInTheDocument()
   expect(within(panel).getByRole('button', { name: /selected/i })).toBeInTheDocument()
 

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { createStartingState } from '../../data/startingState'
 import { useGameStore } from '../../app/store/gameStore'
+import { createStarterCase } from '../../domain/templates/startingCases'
 import CaseDetailPage from './CaseDetailPage'
 
 function renderCaseDetail(route = '/cases/case-001') {
@@ -128,6 +129,63 @@ it('renders assignment timeline events for the selected case only', () => {
     'href',
     '/teams/t_nightwatch'
   )
+})
+
+it('shows stealth leave-behind tradeoff selection for eligible in-progress hidden cases', async () => {
+  const user = userEvent.setup()
+  const game = createStartingState()
+
+  game.cases['case-stealth-ui'] = {
+    ...createStarterCase({ id: 'case-stealth-ui', templateId: 'ops-003' }),
+    title: 'Archive Access Siege',
+    status: 'in_progress',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.25,
+    counterDetection: false,
+    tags: ['infiltration', 'archive', 'records'],
+    requiredTags: [],
+    preferredTags: [],
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
+  }
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-stealth-ui')
+
+  const panel = screen.getByRole('region', { name: /stealth leave-behind tradeoff/i })
+
+  expect(within(panel).getByRole('heading', { name: /stealth leave-behind/i })).toBeInTheDocument()
+  expect(within(panel).getByText(/leave forensic trace/i)).toBeInTheDocument()
+  expect(within(panel).getByRole('button', { name: /selected/i })).toBeInTheDocument()
+
+  const burnRow = within(panel).getByText(/burn field tool/i).closest('li')
+  expect(burnRow).not.toBeNull()
+  await user.click(within(burnRow as HTMLElement).getByRole('button', { name: /^select$/i }))
+
+  expect(within(panel).getByText(/burn field tool/i)).toBeInTheDocument()
+  expect(within(panel).getAllByRole('button', { name: /selected/i })).toHaveLength(1)
+  expect(useGameStore.getState().game.cases['case-stealth-ui']?.stealthLeaveBehindId).toBe(
+    'leave-behind:burn-tool'
+  )
+})
+
+it('hides stealth leave-behind tradeoff when the case is not eligible', () => {
+  const game = createStartingState()
+
+  game.cases['case-stealth-ui'] = {
+    ...createStarterCase({ id: 'case-stealth-ui', templateId: 'ops-003' }),
+    title: 'Archive Access Siege',
+    status: 'open',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.25,
+    counterDetection: false,
+    tags: ['infiltration', 'archive', 'records'],
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
+  }
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-stealth-ui')
+
+  expect(screen.queryByRole('region', { name: /stealth leave-behind tradeoff/i })).not.toBeInTheDocument()
 })
 
 it('shows pre-commit injury, death, and downtime warnings for available teams', () => {

--- a/src/features/cases/CaseDetailPage.tsx
+++ b/src/features/cases/CaseDetailPage.tsx
@@ -22,6 +22,7 @@ import { type CaseInstance, type GameState, type Team } from '../../domain/model
 import { getCaseTemplateIntelView } from './caseIntelProjection'
 import { getCaseAssignmentInsights } from './caseInsights'
 import { getCaseListItemView } from './caseView'
+import { StealthLeaveBehindSelectionPanel } from './StealthLeaveBehindSelectionPanel'
 
 export default function CaseDetailPage() {
   const { caseId } = useParams()
@@ -324,6 +325,8 @@ export default function CaseDetailPage() {
               </p>
             )}
           </article>
+
+          <StealthLeaveBehindSelectionPanel caseData={currentCase} />
 
           <article
             className="panel panel-support space-y-3"

--- a/src/features/cases/StealthLeaveBehindSelectionPanel.tsx
+++ b/src/features/cases/StealthLeaveBehindSelectionPanel.tsx
@@ -30,6 +30,23 @@ export function StealthLeaveBehindSelectionPanel({ caseData }: { caseData: CaseI
         pressure; custody refs strain forensic investigation budget after resolution.
       </p>
 
+      <div
+        className="rounded border border-sky-400/25 bg-sky-500/6 px-3 py-2 text-sm"
+        aria-label="Forensic investigation budget"
+      >
+        <p className="text-xs uppercase tracking-wide opacity-60">Forensic investigation budget</p>
+        <p className="mt-1">
+          <span className="opacity-60">Remaining:</span>{' '}
+          <span className="font-medium">{view.forensicBudget.remaining}</span>
+          <span className="opacity-50">
+            {' '}
+            (granted {view.forensicBudget.granted}, spent {view.forensicBudget.spent}, custody
+            burden {view.forensicBudget.custodyLossBurden}
+            {view.forensicBudget.markerCount === 1 ? ' marker' : ' markers'})
+          </span>
+        </p>
+      </div>
+
       <ul className="space-y-2">
         {view.options.map((option) => (
           <li
@@ -81,6 +98,10 @@ function StealthLeaveBehindOptionBody({ option }: { option: StealthLeaveBehindOp
       <p className="text-xs opacity-55">
         Discovery risk {Math.round(option.discoveryRisk * 100)}% / Mission malus +
         {option.scoreAdjustmentPreview.toFixed(1)} / Custody refs {option.custodyLossRefCount}
+      </p>
+      <p className="text-xs opacity-55">
+        If resolved with this tradeoff: forensic custody burden {option.projectedCustodyLossBurden}{' '}
+        / {option.projectedForensicRemaining} forensic questions remaining
       </p>
     </div>
   )

--- a/src/features/cases/StealthLeaveBehindSelectionPanel.tsx
+++ b/src/features/cases/StealthLeaveBehindSelectionPanel.tsx
@@ -1,0 +1,87 @@
+import { useGameStore } from '../../app/store/gameStore'
+import type { CaseInstance } from '../../domain/models'
+import {
+  buildStealthLeaveBehindSelectionView,
+  type StealthLeaveBehindOptionView,
+} from './stealthLeaveBehindSelectionView'
+
+export function StealthLeaveBehindSelectionPanel({ caseData }: { caseData: CaseInstance }) {
+  const game = useGameStore((state) => state.game)
+  const selectStealthLeaveBehind = useGameStore((state) => state.selectStealthLeaveBehind)
+  const view = buildStealthLeaveBehindSelectionView(caseData, game)
+
+  if (!view.visible) {
+    return null
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-3"
+      role="region"
+      aria-label="Stealth leave-behind tradeoff"
+    >
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold">Stealth leave-behind</h3>
+        <p className="text-xs uppercase tracking-wide opacity-50">Extraction tradeoff</p>
+      </div>
+
+      <p className="text-sm opacity-60">
+        Choose the extraction tradeoff before weekly resolution. Discovery risk feeds mission score
+        pressure; custody refs strain forensic investigation budget after resolution.
+      </p>
+
+      <ul className="space-y-2">
+        {view.options.map((option) => (
+          <li
+            key={option.id}
+            className={`rounded border px-3 py-2 ${
+              option.selected
+                ? 'border-amber-400/40 bg-amber-500/10'
+                : 'border-white/10 bg-white/5'
+            }`}
+          >
+            <StealthLeaveBehindOptionRow
+              option={option}
+              onSelect={() => selectStealthLeaveBehind(caseData.id, option.id)}
+            />
+          </li>
+        ))}
+      </ul>
+    </article>
+  )
+}
+
+function StealthLeaveBehindOptionRow({
+  option,
+  onSelect,
+}: {
+  option: StealthLeaveBehindOptionView
+  onSelect: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <StealthLeaveBehindOptionBody option={option} />
+      <button
+        type="button"
+        className="btn btn-sm"
+        aria-pressed={option.selected}
+        onClick={onSelect}
+      >
+        {option.selected ? 'Selected' : 'Select'}
+      </button>
+    </div>
+  )
+}
+
+function StealthLeaveBehindOptionBody({ option }: { option: StealthLeaveBehindOptionView }) {
+  return (
+    <div className="space-y-1">
+      <p className="font-medium">{option.label}</p>
+      {option.summary ? <p className="text-xs opacity-60">{option.summary}</p> : null}
+      <p className="text-xs opacity-55">
+        Discovery risk {Math.round(option.discoveryRisk * 100)}% / Mission malus +
+        {option.scoreAdjustmentPreview.toFixed(1)} / Custody refs {option.custodyLossRefCount}
+      </p>
+    </div>
+  )
+}

--- a/src/features/cases/stealthLeaveBehindSelectionView.ts
+++ b/src/features/cases/stealthLeaveBehindSelectionView.ts
@@ -4,12 +4,22 @@ import {
   listSelectableStealthLeaveBehinds,
   readStealthLeaveBehindSelection,
 } from '../../domain/stealthLeaveBehindSelection'
+import { projectInvestigationCustodyLossBurdenAfterRefs } from '../../domain/investigationCustodyLoss'
+import { readInvestigationBudget } from '../../domain/investigationEconomy'
 import {
   evaluateStealthLeaveBehindMissionPressure,
   getStealthLeaveBehindById,
   DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY,
 } from '../../domain/stealthLeaveBehindRegistry'
 import type { CaseInstance, GameState } from '../../domain/models'
+
+export interface StealthLeaveBehindForensicBudgetPreview {
+  readonly granted: number
+  readonly spent: number
+  readonly custodyLossBurden: number
+  readonly remaining: number
+  readonly markerCount: number
+}
 
 export interface StealthLeaveBehindOptionView {
   readonly id: string
@@ -19,6 +29,8 @@ export interface StealthLeaveBehindOptionView {
   readonly summary?: string
   readonly selected: boolean
   readonly scoreAdjustmentPreview: number
+  readonly projectedCustodyLossBurden: number
+  readonly projectedForensicRemaining: number
 }
 
 export interface StealthLeaveBehindSelectionView {
@@ -26,6 +38,23 @@ export interface StealthLeaveBehindSelectionView {
   readonly selectedLeaveBehindId?: string
   readonly options: readonly StealthLeaveBehindOptionView[]
   readonly activePressurePreview: boolean
+  readonly forensicBudget: StealthLeaveBehindForensicBudgetPreview
+}
+
+function projectForensicRemaining(granted: number, spent: number, custodyLossBurden: number) {
+  return Math.max(0, granted - spent - custodyLossBurden)
+}
+
+function buildForensicBudgetPreview(game: GameState, caseId: string): StealthLeaveBehindForensicBudgetPreview {
+  const budget = readInvestigationBudget(game, caseId, 'forensic')
+
+  return {
+    granted: budget.granted,
+    spent: budget.spent,
+    custodyLossBurden: budget.custodyLossBurden,
+    remaining: budget.remaining,
+    markerCount: budget.custodyLossBurden,
+  }
 }
 
 export function buildStealthLeaveBehindSelectionView(
@@ -37,9 +66,17 @@ export function buildStealthLeaveBehindSelectionView(
       visible: false,
       options: [],
       activePressurePreview: false,
+      forensicBudget: {
+        granted: 0,
+        spent: 0,
+        custodyLossBurden: 0,
+        remaining: 0,
+        markerCount: 0,
+      },
     }
   }
 
+  const forensicBudget = buildForensicBudgetPreview(game, caseData.id)
   const selectedLeaveBehindId = readStealthLeaveBehindSelection(game, caseData.id)
   const options = listSelectableStealthLeaveBehinds(caseData).map((definition) => {
     const previewCase: CaseInstance = {
@@ -47,6 +84,11 @@ export function buildStealthLeaveBehindSelectionView(
       stealthLeaveBehindId: definition.id,
     }
     const pressure = evaluateStealthLeaveBehindMissionPressure(previewCase)
+    const projectedCustodyLossBurden = projectInvestigationCustodyLossBurdenAfterRefs(
+      game,
+      caseData.id,
+      definition.custodyLossRefs
+    )
 
     return {
       id: definition.id,
@@ -56,6 +98,12 @@ export function buildStealthLeaveBehindSelectionView(
       summary: definition.summary,
       selected: selectedLeaveBehindId === definition.id,
       scoreAdjustmentPreview: pressure.scoreAdjustment,
+      projectedCustodyLossBurden,
+      projectedForensicRemaining: projectForensicRemaining(
+        forensicBudget.granted,
+        forensicBudget.spent,
+        projectedCustodyLossBurden
+      ),
     }
   })
 
@@ -66,6 +114,7 @@ export function buildStealthLeaveBehindSelectionView(
     selectedLeaveBehindId,
     options,
     activePressurePreview,
+    forensicBudget,
   }
 }
 

--- a/src/features/cases/stealthLeaveBehindSelectionView.ts
+++ b/src/features/cases/stealthLeaveBehindSelectionView.ts
@@ -1,0 +1,91 @@
+import {
+  applyStealthLeaveBehindSelection,
+  canSelectStealthLeaveBehindOnCase,
+  listSelectableStealthLeaveBehinds,
+  readStealthLeaveBehindSelection,
+} from '../../domain/stealthLeaveBehindSelection'
+import {
+  evaluateStealthLeaveBehindMissionPressure,
+  getStealthLeaveBehindById,
+  DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY,
+} from '../../domain/stealthLeaveBehindRegistry'
+import type { CaseInstance, GameState } from '../../domain/models'
+
+export interface StealthLeaveBehindOptionView {
+  readonly id: string
+  readonly label: string
+  readonly discoveryRisk: number
+  readonly custodyLossRefCount: number
+  readonly summary?: string
+  readonly selected: boolean
+  readonly scoreAdjustmentPreview: number
+}
+
+export interface StealthLeaveBehindSelectionView {
+  readonly visible: boolean
+  readonly selectedLeaveBehindId?: string
+  readonly options: readonly StealthLeaveBehindOptionView[]
+  readonly activePressurePreview: boolean
+}
+
+export function buildStealthLeaveBehindSelectionView(
+  caseData: CaseInstance,
+  game: GameState
+): StealthLeaveBehindSelectionView {
+  if (!canSelectStealthLeaveBehindOnCase(caseData)) {
+    return {
+      visible: false,
+      options: [],
+      activePressurePreview: false,
+    }
+  }
+
+  const selectedLeaveBehindId = readStealthLeaveBehindSelection(game, caseData.id)
+  const options = listSelectableStealthLeaveBehinds(caseData).map((definition) => {
+    const previewCase: CaseInstance = {
+      ...caseData,
+      stealthLeaveBehindId: definition.id,
+    }
+    const pressure = evaluateStealthLeaveBehindMissionPressure(previewCase)
+
+    return {
+      id: definition.id,
+      label: definition.label,
+      discoveryRisk: definition.discoveryRisk,
+      custodyLossRefCount: definition.custodyLossRefs.length,
+      summary: definition.summary,
+      selected: selectedLeaveBehindId === definition.id,
+      scoreAdjustmentPreview: pressure.scoreAdjustment,
+    }
+  })
+
+  const activePressurePreview = evaluateStealthLeaveBehindMissionPressure(caseData).active
+
+  return {
+    visible: true,
+    selectedLeaveBehindId,
+    options,
+    activePressurePreview,
+  }
+}
+
+export function selectStealthLeaveBehindOnCase(
+  game: GameState,
+  caseId: string,
+  leaveBehindId: string
+) {
+  return applyStealthLeaveBehindSelection(game, { caseId, leaveBehindId })
+}
+
+export function describeStealthLeaveBehindSelection(
+  game: GameState,
+  caseId: string
+): string | undefined {
+  const selectedId = readStealthLeaveBehindSelection(game, caseId)
+  if (!selectedId) {
+    return undefined
+  }
+
+  const definition = getStealthLeaveBehindById(DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY, selectedId)
+  return definition?.label
+}

--- a/src/test/investigationCustodyLoss.test.ts
+++ b/src/test/investigationCustodyLoss.test.ts
@@ -6,6 +6,7 @@ import {
   countInvestigationCustodyLossRefs,
   listInvestigationCustodyLossMarkers,
   normalizeInvestigationCustodyLossRefForFlag,
+  projectInvestigationCustodyLossBurdenAfterRefs,
   readInvestigationCustodyLossMarker,
 } from '../domain/investigationCustodyLoss'
 import { askInvestigationQuestion, grantInvestigationQuestionBudget } from '../domain/investigationEconomy'
@@ -70,6 +71,37 @@ describe('investigationCustodyLoss', () => {
 
     expect(second.appliedRefs).toEqual([])
     expect(countInvestigationCustodyLossRefs(second.state, 'case-001')).toBe(1)
+  })
+
+  it('projects forensic custody burden after leave-behind refs with apply-equivalent dedupe', () => {
+    const state = createStartingState()
+
+    expect(
+      projectInvestigationCustodyLossBurdenAfterRefs(state, 'case-001', [
+        'custody:field-packet',
+        'custody:chain-seal',
+      ])
+    ).toBe(2)
+
+    const withMarker = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: 'case-001',
+      leaveBehindId: 'leave-behind:burn-tool',
+      leaveBehindKind: 'burn_tool',
+      leaveBehindLabel: 'Burn field tool',
+      custodyLossRefs: ['custody:tool-serial'],
+      week: 1,
+    }).state
+
+    expect(
+      projectInvestigationCustodyLossBurdenAfterRefs(withMarker, 'case-001', [
+        'custody:tool-serial',
+        'custody:field-packet',
+      ])
+    ).toBe(2)
+    expect(
+      projectInvestigationCustodyLossBurdenAfterRefs(withMarker, 'case-001', ['!!!', 'custody:field-packet'])
+    ).toBe(2)
   })
 
   it('skips symbolic-only custody refs that do not yield a flag suffix', () => {

--- a/src/test/stealthLeaveBehindSelection.test.ts
+++ b/src/test/stealthLeaveBehindSelection.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { evaluateStealthLeaveBehindMissionPressure } from '../domain/stealthLeaveBehindRegistry'
+import {
+  applyStealthLeaveBehindSelection,
+  canSelectStealthLeaveBehindOnCase,
+  listSelectableStealthLeaveBehinds,
+  readStealthLeaveBehindSelection,
+} from '../domain/stealthLeaveBehindSelection'
+import { STEALTH_LEAVE_BEHIND_KINDS } from '../domain/stealthLeaveBehindRegistry'
+import { instantiateFromTemplate } from '../domain/sim/spawn'
+import { caseTemplateMap } from '../domain/templates/caseTemplates'
+import { createStarterCase } from '../domain/templates/startingCases'
+import type { CaseInstance } from '../domain/models'
+
+function createEligibleCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({ id: 'case-stealth-select', templateId: 'ops-003' }),
+    status: 'in_progress',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.25,
+    counterDetection: false,
+    tags: ['infiltration', 'archive', 'records'],
+    requiredTags: [],
+    preferredTags: [],
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
+    ...overrides,
+  }
+}
+
+describe('stealthLeaveBehindSelection', () => {
+  it('lists all catalog rows only for in-progress eligible hidden cases', () => {
+    const eligible = createEligibleCase()
+    expect(listSelectableStealthLeaveBehinds(eligible)).toHaveLength(STEALTH_LEAVE_BEHIND_KINDS.length)
+    expect(listSelectableStealthLeaveBehinds({ ...eligible, hiddenState: 'revealed' })).toEqual([])
+    expect(listSelectableStealthLeaveBehinds({ ...eligible, status: 'open' })).toEqual([])
+    expect(
+      listSelectableStealthLeaveBehinds({
+        ...eligible,
+        tags: ['archive', 'records'],
+      })
+    ).toEqual([])
+  })
+
+  it('applies a valid selection to the case instance and rejects invalid input', () => {
+    const state = createStartingState()
+    state.cases['case-stealth-select'] = createEligibleCase()
+
+    const applied = applyStealthLeaveBehindSelection(state, {
+      caseId: 'case-stealth-select',
+      leaveBehindId: 'leave-behind:risk-discovery',
+    })
+
+    expect(applied.applied).toBe(true)
+    expect(applied.leaveBehindId).toBe('leave-behind:risk-discovery')
+    expect(readStealthLeaveBehindSelection(applied.state, 'case-stealth-select')).toBe(
+      'leave-behind:risk-discovery'
+    )
+
+    const unknown = applyStealthLeaveBehindSelection(applied.state, {
+      caseId: 'case-stealth-select',
+      leaveBehindId: 'leave-behind:missing',
+    })
+    expect(unknown.applied).toBe(false)
+    expect(unknown.reason).toBe('unknown_id')
+
+    const resolvedState = {
+      ...state,
+      cases: {
+        ...state.cases,
+        'case-stealth-select': { ...createEligibleCase(), status: 'resolved' as const },
+      },
+    }
+    expect(
+      applyStealthLeaveBehindSelection(resolvedState, {
+        caseId: 'case-stealth-select',
+        leaveBehindId: 'leave-behind:burn-tool',
+      }).reason
+    ).toBe('ineligible')
+
+    expect(
+      applyStealthLeaveBehindSelection(state, {
+        caseId: 'missing-case',
+        leaveBehindId: 'leave-behind:burn-tool',
+      }).reason
+    ).toBe('invalid_case')
+  })
+
+  it('drives mission pressure from the selected leave-behind id', () => {
+    const state = createStartingState()
+    state.cases['case-stealth-select'] = createEligibleCase({
+      stealthLeaveBehindId: 'leave-behind:burn-tool',
+    })
+
+    const next = applyStealthLeaveBehindSelection(state, {
+      caseId: 'case-stealth-select',
+      leaveBehindId: 'leave-behind:expose-witness',
+    }).state
+
+    const caseData = next.cases['case-stealth-select']!
+    const pressure = evaluateStealthLeaveBehindMissionPressure(caseData)
+
+    expect(pressure.active).toBe(true)
+    expect(pressure.leaveBehindId).toBe('leave-behind:expose-witness')
+    expect(pressure.scoreAdjustment).toBe(2.8)
+    expect(pressure.custodyLossRefs).toEqual(['custody:witness-credential'])
+  })
+
+  it('keeps template default on spawn when the player never selects', () => {
+    const spawned = instantiateFromTemplate(caseTemplateMap['ops-003'], () => 0.2, new Set())
+
+    expect(spawned.stealthLeaveBehindId).toBe('leave-behind:leave-trace')
+
+    const state = createStartingState()
+    state.cases[spawned.id] = spawned
+
+    expect(readStealthLeaveBehindSelection(state, spawned.id)).toBe('leave-behind:leave-trace')
+  })
+
+  it('canSelectStealthLeaveBehindOnCase requires in_progress and concealment eligibility', () => {
+    const eligible = createEligibleCase()
+    expect(canSelectStealthLeaveBehindOnCase(eligible)).toBe(true)
+    expect(canSelectStealthLeaveBehindOnCase({ ...eligible, status: 'open' })).toBe(false)
+    expect(canSelectStealthLeaveBehindOnCase({ ...eligible, hiddenState: 'displaced' })).toBe(false)
+  })
+})

--- a/src/test/stealthLeaveBehindSelectionView.test.ts
+++ b/src/test/stealthLeaveBehindSelectionView.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { grantInvestigationQuestionBudget } from '../domain/investigationEconomy'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { buildStealthLeaveBehindSelectionView } from '../features/cases/stealthLeaveBehindSelectionView'
+import type { CaseInstance } from '../domain/models'
+
+function createEligibleCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({ id: 'case-stealth-forensic', templateId: 'ops-003' }),
+    status: 'in_progress',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.25,
+    counterDetection: false,
+    tags: ['infiltration', 'archive', 'records'],
+    requiredTags: [],
+    preferredTags: [],
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
+    ...overrides,
+  }
+}
+
+describe('buildStealthLeaveBehindSelectionView forensic preview', () => {
+  it('includes current forensic budget and per-option projected burden', () => {
+    let state = createStartingState()
+    state.cases['case-stealth-forensic'] = createEligibleCase()
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: 'case-stealth-forensic',
+      domain: 'forensic',
+      amount: 3,
+    })
+
+    const caseData = state.cases['case-stealth-forensic']!
+    const view = buildStealthLeaveBehindSelectionView(caseData, state)
+
+    expect(view.visible).toBe(true)
+    expect(view.forensicBudget).toMatchObject({
+      granted: 3,
+      spent: 0,
+      custodyLossBurden: 0,
+      remaining: 3,
+      markerCount: 0,
+    })
+
+    const abandon = view.options.find((option) => option.id === 'leave-behind:abandon-evidence')
+    const burn = view.options.find((option) => option.id === 'leave-behind:burn-tool')
+
+    expect(abandon?.projectedCustodyLossBurden).toBe(2)
+    expect(abandon?.projectedForensicRemaining).toBe(1)
+    expect(burn?.projectedCustodyLossBurden).toBe(1)
+    expect(burn?.projectedForensicRemaining).toBe(2)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **SPE-2247 slice 5**: players can choose `stealthLeaveBehindId` on eligible in-progress hidden infiltration cases before weekly resolution. Template defaults on spawn are unchanged when the player never selects.

## Changes

- **Domain** (`stealthLeaveBehindSelection.ts`): eligibility (`in_progress` + existing concealment rules), list/read/apply selection with structured failure reasons.
- **Store** (`selectStealthLeaveBehind`): applies selection via domain helper; no-op on invalid input.
- **UI**: `StealthLeaveBehindSelectionPanel` on case detail with catalog previews (discovery risk, mission malus, custody ref counts).
- **Forensic preview**: current forensic budget snapshot plus per-option projected `custodyLossBurden` and remaining question headroom after resolution (`projectInvestigationCustodyLossBurdenAfterRefs`).
- **Tests**: domain, view projection, Case detail panel visibility/selection, spawn default regression.

## Verification

- `npm run lint`
- `npm run test:run` (full suite on branch)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

