### PR TITLE
feat(SPE-626): investigation question case prep UI

### DIFF
--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -2,6 +2,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { caseTemplateMap } from '../../data/caseTemplates'
 import { createStartingState } from '../../data/startingState'
+import {
+  applySuccessfulInvestigation,
+  buildInvestigationAskedFlagId,
+} from '../../domain/investigationEconomy'
+import { readPersistentFlag } from '../../domain/flagSystem'
+import { createStarterCase } from '../../domain/templates/startingCases'
 import { buildWeeklyReportTutorialChoices } from '../../features/operations/frontDeskChoices'
 import type { AgentData, Candidate } from '../../domain/models'
 import { advanceWeek as advanceWeekDomain } from '../../domain/sim/advanceWeek'
@@ -124,6 +130,85 @@ beforeEach(() => {
 })
 
 describe('gameStore', () => {
+  it('asks investigation questions only for in-progress cases with budget', () => {
+    let game = createStartingState()
+    game.cases['case-investigation-store'] = {
+      ...createStarterCase({ id: 'case-investigation-store', templateId: 'ops-003' }),
+      status: 'in_progress',
+      weeksRemaining: 2,
+      assignedTeamIds: [],
+      requiredTags: [],
+      preferredTags: [],
+    }
+    game = applySuccessfulInvestigation(game, {
+      caseId: 'case-investigation-store',
+      forensicBudget: 1,
+      tacticalBudget: 0,
+    })
+
+    useGameStore.setState({ game })
+    const before = useGameStore.getState().game
+
+    useGameStore
+      .getState()
+      .askInvestigationQuestion(
+        'case-investigation-store',
+        'forensic',
+        'forensic.present-signature'
+      )
+
+    expect(
+      readPersistentFlag(
+        useGameStore.getState().game,
+        buildInvestigationAskedFlagId('case-investigation-store', 'forensic.present-signature')
+      )
+    ).toBe(true)
+    expect(useGameStore.getState().game).not.toBe(before)
+
+    const afterFirstAsk = useGameStore.getState().game
+
+    useGameStore
+      .getState()
+      .askInvestigationQuestion(
+        'case-investigation-store',
+        'forensic',
+        'forensic.present-signature'
+      )
+
+    expect(useGameStore.getState().game).toBe(afterFirstAsk)
+
+    useGameStore.getState().askInvestigationQuestion('missing-case', 'forensic', 'forensic.present-signature')
+
+    expect(useGameStore.getState().game).toBe(afterFirstAsk)
+
+    useGameStore.setState({
+      game: {
+        ...afterFirstAsk,
+        cases: {
+          ...afterFirstAsk.cases,
+          'case-investigation-store': {
+            ...afterFirstAsk.cases['case-investigation-store']!,
+            status: 'resolved',
+          },
+        },
+      },
+    })
+
+    const resolvedSnapshot = useGameStore.getState().game
+
+    useGameStore
+      .getState()
+      .askInvestigationQuestion('case-investigation-store', 'forensic', 'forensic.missing-proof')
+
+    expect(useGameStore.getState().game).toBe(resolvedSnapshot)
+    expect(
+      readPersistentFlag(
+        useGameStore.getState().game,
+        buildInvestigationAskedFlagId('case-investigation-store', 'forensic.missing-proof')
+      )
+    ).toBeUndefined()
+  })
+
   it('assigns and unassigns teams through the store actions', () => {
     useGameStore.getState().assign('case-001', 't_nightwatch')
 

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -90,6 +90,7 @@ import {
   askInvestigationQuestion as applyAskInvestigationQuestion,
   type InvestigationQuestionDomain,
 } from '../../domain/investigationEconomy'
+import { canAskInvestigationQuestionOnCase } from '../../features/cases/investigationCasePrepView'
 import { applyStealthLeaveBehindSelection } from '../../domain/stealthLeaveBehindSelection'
 import { queueFabrication } from '../../domain/sim/production'
 import { invokeEmergencyGrayMarketWaiver } from '../../domain/procurementEmergency'
@@ -1148,6 +1149,11 @@ export const useGameStore = create<GameStore>()(
 
       askInvestigationQuestion: (caseId, domain, questionId) =>
         set((s) => {
+          const caseData = s.game.cases[caseId]
+          if (!canAskInvestigationQuestionOnCase(caseData)) {
+            return { game: s.game }
+          }
+
           const result = applyAskInvestigationQuestion(s.game, {
             caseId,
             domain,

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -86,6 +86,10 @@ import { applyChapterBreakAttritionReset } from '../../domain/agent/attritionRes
 import { applyRotatingRosterContinuityReconciliation } from '../../domain/agent/rosterContinuity'
 import { advanceWeek } from '../../domain/sim/advanceWeek'
 import { assignTeam, launchMajorIncident, unassignTeam } from '../../domain/sim/assign'
+import {
+  askInvestigationQuestion as applyAskInvestigationQuestion,
+  type InvestigationQuestionDomain,
+} from '../../domain/investigationEconomy'
 import { applyStealthLeaveBehindSelection } from '../../domain/stealthLeaveBehindSelection'
 import { queueFabrication } from '../../domain/sim/production'
 import { invokeEmergencyGrayMarketWaiver } from '../../domain/procurementEmergency'
@@ -223,6 +227,12 @@ interface GameStore {
   unassign: (caseId: Id, teamId?: Id) => void
   /** SPE-2247: set stealth leave-behind tradeoff on an eligible in-progress infiltration case. */
   selectStealthLeaveBehind: (caseId: Id, leaveBehindId: string) => void
+  /** SPE-626: ask a forensic or tactical investigation question on an in-progress case. */
+  askInvestigationQuestion: (
+    caseId: Id,
+    domain: InvestigationQuestionDomain,
+    questionId: string
+  ) => void
   hireCandidate: (candidateId: Id) => void
   scoutCandidate: (candidateId: Id) => void
   transitionCandidateFunnel: (
@@ -1129,6 +1139,20 @@ export const useGameStore = create<GameStore>()(
       selectStealthLeaveBehind: (caseId, leaveBehindId) =>
         set((s) => {
           const result = applyStealthLeaveBehindSelection(s.game, { caseId, leaveBehindId })
+          if (!result.applied) {
+            return { game: s.game }
+          }
+
+          return { game: result.state }
+        }),
+
+      askInvestigationQuestion: (caseId, domain, questionId) =>
+        set((s) => {
+          const result = applyAskInvestigationQuestion(s.game, {
+            caseId,
+            domain,
+            questionId,
+          })
           if (!result.applied) {
             return { game: s.game }
           }

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -219,6 +219,28 @@ it('shows investigation question prep and asks a forensic question', async () =>
   ).toBe(true)
 })
 
+it('shows investigation prep empty state when no budget is granted yet', () => {
+  const game = createStartingState()
+
+  game.cases['case-investigation-ui'] = {
+    ...createStarterCase({ id: 'case-investigation-ui', templateId: 'ops-003' }),
+    title: 'Investigation Prep Case',
+    status: 'in_progress',
+    weeksRemaining: 2,
+    assignedTeamIds: [],
+    requiredTags: [],
+    preferredTags: [],
+  }
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-investigation-ui')
+
+  const panel = screen.getByRole('region', { name: /investigation question prep/i })
+
+  expect(within(panel).getByText(/no investigation budget on this case yet/i)).toBeInTheDocument()
+  expect(within(panel).queryByRole('region', { name: /forensic inquiry/i })).not.toBeInTheDocument()
+})
+
 it('hides investigation question prep when the case is not in progress', () => {
   const game = createStartingState()
 

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -5,6 +5,11 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { createStartingState } from '../../data/startingState'
 import { useGameStore } from '../../app/store/gameStore'
+import { readPersistentFlag } from '../../domain/flagSystem'
+import {
+  applySuccessfulInvestigation,
+  buildInvestigationAskedFlagId,
+} from '../../domain/investigationEconomy'
 import { createStarterCase } from '../../domain/templates/startingCases'
 import CaseDetailPage from './CaseDetailPage'
 
@@ -167,6 +172,67 @@ it('shows stealth leave-behind tradeoff selection for eligible in-progress hidde
   expect(useGameStore.getState().game.cases['case-stealth-ui']?.stealthLeaveBehindId).toBe(
     'leave-behind:burn-tool'
   )
+})
+
+it('shows investigation question prep and asks a forensic question', async () => {
+  const user = userEvent.setup()
+  let game = createStartingState()
+
+  game.cases['case-investigation-ui'] = {
+    ...createStarterCase({ id: 'case-investigation-ui', templateId: 'ops-003' }),
+    title: 'Investigation Prep Case',
+    status: 'in_progress',
+    weeksRemaining: 2,
+    assignedTeamIds: [],
+    requiredTags: [],
+    preferredTags: [],
+  }
+
+  game = applySuccessfulInvestigation(game, {
+    caseId: 'case-investigation-ui',
+    forensicBudget: 1,
+    tacticalBudget: 1,
+  })
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-investigation-ui')
+
+  const panel = screen.getByRole('region', { name: /investigation question prep/i })
+
+  expect(within(panel).getByRole('heading', { name: /investigation questions/i })).toBeInTheDocument()
+  expect(within(panel).getByText(/concrete signature is present/i)).toBeInTheDocument()
+
+  const forensicSection = within(panel).getByRole('region', { name: /forensic inquiry/i })
+  const signatureRow = within(forensicSection)
+    .getByText(/concrete signature is present/i)
+    .closest('li')
+  expect(signatureRow).not.toBeNull()
+  await user.click(within(signatureRow as HTMLElement).getByRole('button', { name: /^ask$/i }))
+
+  expect(within(forensicSection).getByRole('button', { name: /asked/i })).toBeInTheDocument()
+  expect(within(forensicSection).getByText(/primary residue signature is real/i)).toBeInTheDocument()
+  expect(
+    readPersistentFlag(
+      useGameStore.getState().game,
+      buildInvestigationAskedFlagId('case-investigation-ui', 'forensic.present-signature')
+    )
+  ).toBe(true)
+})
+
+it('hides investigation question prep when the case is not in progress', () => {
+  const game = createStartingState()
+
+  game.cases['case-investigation-ui'] = {
+    ...createStarterCase({ id: 'case-investigation-ui', templateId: 'ops-003' }),
+    status: 'resolved',
+    weeksRemaining: 0,
+    assignedTeamIds: [],
+  }
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-investigation-ui')
+
+  expect(screen.queryByRole('region', { name: /investigation question prep/i })).not.toBeInTheDocument()
 })
 
 it('hides stealth leave-behind tradeoff when the case is not eligible', () => {

--- a/src/features/cases/CaseDetailPage.tsx
+++ b/src/features/cases/CaseDetailPage.tsx
@@ -22,6 +22,7 @@ import { type CaseInstance, type GameState, type Team } from '../../domain/model
 import { getCaseTemplateIntelView } from './caseIntelProjection'
 import { getCaseAssignmentInsights } from './caseInsights'
 import { getCaseListItemView } from './caseView'
+import { InvestigationCasePrepPanel } from './InvestigationCasePrepPanel'
 import { StealthLeaveBehindSelectionPanel } from './StealthLeaveBehindSelectionPanel'
 
 export default function CaseDetailPage() {
@@ -327,6 +328,8 @@ export default function CaseDetailPage() {
           </article>
 
           <StealthLeaveBehindSelectionPanel caseData={currentCase} />
+
+          <InvestigationCasePrepPanel caseData={currentCase} />
 
           <article
             className="panel panel-support space-y-3"

--- a/src/features/cases/InvestigationCasePrepPanel.tsx
+++ b/src/features/cases/InvestigationCasePrepPanel.tsx
@@ -1,0 +1,183 @@
+import { useGameStore } from '../../app/store/gameStore'
+import type { CaseInstance } from '../../domain/models'
+import {
+  buildInvestigationCasePrepView,
+  type InvestigationBudgetView,
+  type InvestigationDomainPrepView,
+  type InvestigationQuestionRowView,
+} from './investigationCasePrepView'
+
+export function InvestigationCasePrepPanel({ caseData }: { caseData: CaseInstance }) {
+  const game = useGameStore((state) => state.game)
+  const askInvestigationQuestion = useGameStore((state) => state.askInvestigationQuestion)
+  const view = buildInvestigationCasePrepView(caseData, game)
+
+  if (!view.visible) {
+    return null
+  }
+
+  const hasAnyBudget =
+    view.forensic.budget.granted > 0 ||
+    view.forensic.budget.spent > 0 ||
+    view.tactical.budget.granted > 0 ||
+    view.tactical.budget.spent > 0
+
+  return (
+    <article
+      className="panel panel-support space-y-4"
+      role="region"
+      aria-label="Investigation question prep"
+    >
+      <PanelHeader />
+
+      <p className="text-sm opacity-60">
+        Spend investigation question budget before weekly resolution. Forensic custody strain from
+        leave-behind fallout reduces forensic headroom.
+      </p>
+
+      {!hasAnyBudget ? (
+        <p className="text-sm opacity-50">
+          No investigation budget on this case yet. Successful investigation during weekly
+          resolution grants forensic and tactical questions.
+        </p>
+      ) : null}
+
+      <InvestigationDomainSection
+        domainView={view.forensic}
+        showCustodyBurden
+        onAsk={(questionId) => askInvestigationQuestion(caseData.id, 'forensic', questionId)}
+      />
+
+      <InvestigationDomainSection
+        domainView={view.tactical}
+        onAsk={(questionId) => askInvestigationQuestion(caseData.id, 'tactical', questionId)}
+      />
+
+      {view.custodyMarkers.length > 0 ? (
+        <section className="space-y-2" aria-label="Investigation custody strain">
+          <p className="text-xs uppercase tracking-wide opacity-50">Custody strain markers</p>
+          <ul className="space-y-2">
+            {view.custodyMarkers.map((marker) => (
+              <li
+                key={marker.ref}
+                className="rounded border border-rose-400/25 bg-rose-500/6 px-3 py-2 text-sm"
+              >
+                <p className="font-medium">{marker.ref}</p>
+                <p className="text-xs opacity-60">
+                  {marker.leaveBehindLabel} / applied week {marker.appliedWeek}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </article>
+  )
+}
+
+function PanelHeader() {
+  return (
+    <div className="space-y-1">
+      <h3 className="text-lg font-semibold">Investigation questions</h3>
+      <p className="text-xs uppercase tracking-wide opacity-50">Case prep</p>
+    </div>
+  )
+}
+
+function InvestigationDomainSection({
+  domainView,
+  showCustodyBurden = false,
+  onAsk,
+}: {
+  domainView: InvestigationDomainPrepView
+  showCustodyBurden?: boolean
+  onAsk: (questionId: string) => void
+}) {
+  return (
+    <section className="space-y-2" aria-label={domainView.domainLabel}>
+      <DomainHeader domainView={domainView} showCustodyBurden={showCustodyBurden} />
+
+      <ul className="space-y-2">
+        {domainView.questions.map((question) => (
+          <li
+            key={question.id}
+            className={`rounded border px-3 py-2 ${
+              question.asked
+                ? 'border-emerald-400/30 bg-emerald-500/8'
+                : 'border-white/10 bg-white/5'
+            }`}
+          >
+            <InvestigationQuestionRow question={question} onAsk={() => onAsk(question.id)} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function DomainHeader({
+  domainView,
+  showCustodyBurden,
+}: {
+  domainView: InvestigationDomainPrepView
+  showCustodyBurden: boolean
+}) {
+  return (
+    <div className="space-y-1">
+      <h4 className="font-semibold">{domainView.domainLabel}</h4>
+      <BudgetLine budget={domainView.budget} showCustodyBurden={showCustodyBurden} />
+    </div>
+  )
+}
+
+function BudgetLine({
+  budget,
+  showCustodyBurden,
+}: {
+  budget: InvestigationBudgetView
+  showCustodyBurden: boolean
+}) {
+  return (
+    <p className="text-xs opacity-55">
+      Remaining {budget.remaining} (granted {budget.granted}, spent {budget.spent}
+      {showCustodyBurden ? `, custody burden ${budget.custodyLossBurden}` : ''}
+      )
+    </p>
+  )
+}
+
+function InvestigationQuestionRow({
+  question,
+  onAsk,
+}: {
+  question: InvestigationQuestionRowView
+  onAsk: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{question.prompt}</p>
+        {question.asked ? (
+          <>
+            <p className="text-xs opacity-70">{question.answer}</p>
+            {question.leverageLabel ? (
+              <p className="text-xs text-sky-200/90">
+                Leverage: {question.leverageLabel}
+                {question.leverageDescription ? ` — ${question.leverageDescription}` : ''}
+              </p>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="btn btn-sm"
+        disabled={!question.canAsk}
+        aria-pressed={question.asked}
+        onClick={onAsk}
+      >
+        {question.asked ? 'Asked' : 'Ask'}
+      </button>
+    </div>
+  )
+}

--- a/src/features/cases/InvestigationCasePrepPanel.tsx
+++ b/src/features/cases/InvestigationCasePrepPanel.tsx
@@ -40,18 +40,20 @@ export function InvestigationCasePrepPanel({ caseData }: { caseData: CaseInstanc
           No investigation budget on this case yet. Successful investigation during weekly
           resolution grants forensic and tactical questions.
         </p>
-      ) : null}
+      ) : (
+        <>
+          <InvestigationDomainSection
+            domainView={view.forensic}
+            showCustodyBurden
+            onAsk={(questionId) => askInvestigationQuestion(caseData.id, 'forensic', questionId)}
+          />
 
-      <InvestigationDomainSection
-        domainView={view.forensic}
-        showCustodyBurden
-        onAsk={(questionId) => askInvestigationQuestion(caseData.id, 'forensic', questionId)}
-      />
-
-      <InvestigationDomainSection
-        domainView={view.tactical}
-        onAsk={(questionId) => askInvestigationQuestion(caseData.id, 'tactical', questionId)}
-      />
+          <InvestigationDomainSection
+            domainView={view.tactical}
+            onAsk={(questionId) => askInvestigationQuestion(caseData.id, 'tactical', questionId)}
+          />
+        </>
+      )}
 
       {view.custodyMarkers.length > 0 ? (
         <section className="space-y-2" aria-label="Investigation custody strain">
@@ -107,7 +109,14 @@ function InvestigationDomainSection({
                 : 'border-white/10 bg-white/5'
             }`}
           >
-            <InvestigationQuestionRow question={question} onAsk={() => onAsk(question.id)} />
+            <InvestigationQuestionRow
+              question={question}
+              onAsk={() => {
+                if (question.canAsk) {
+                  onAsk(question.id)
+                }
+              }}
+            />
           </li>
         ))}
       </ul>

--- a/src/features/cases/investigationCasePrepView.ts
+++ b/src/features/cases/investigationCasePrepView.ts
@@ -2,7 +2,6 @@ import { readPersistentFlag } from '../../domain/flagSystem'
 import { listInvestigationCustodyLossMarkers } from '../../domain/investigationCustodyLoss'
 import {
   buildInvestigationAskedFlagId,
-  buildInvestigationLeverageFlagId,
   listInvestigationQuestionSet,
   readInvestigationBudget,
   type InvestigationQuestionDomain,
@@ -51,6 +50,10 @@ export function canShowInvestigationCasePrepOnCase(caseData: CaseInstance) {
   return caseData.status === 'in_progress'
 }
 
+export function canAskInvestigationQuestionOnCase(caseData: CaseInstance | undefined) {
+  return caseData !== undefined && canShowInvestigationCasePrepOnCase(caseData)
+}
+
 function buildDomainPrepView(
   game: GameState,
   caseId: string,
@@ -59,9 +62,6 @@ function buildDomainPrepView(
   const budget = readInvestigationBudget(game, caseId, domain)
   const questions = listInvestigationQuestionSet(domain).map((question) => {
     const asked = Boolean(readPersistentFlag(game, buildInvestigationAskedFlagId(caseId, question.id)))
-    const leverageActive = asked
-      ? Boolean(readPersistentFlag(game, buildInvestigationLeverageFlagId(caseId, question.leverage.id)))
-      : false
 
     return {
       id: question.id,
@@ -69,8 +69,8 @@ function buildDomainPrepView(
       answer: question.answer,
       asked,
       canAsk: !asked && budget.remaining > 0,
-      leverageLabel: leverageActive ? question.leverage.label : undefined,
-      leverageDescription: leverageActive ? question.leverage.description : undefined,
+      leverageLabel: asked ? question.leverage.label : undefined,
+      leverageDescription: asked ? question.leverage.description : undefined,
     }
   })
 

--- a/src/features/cases/investigationCasePrepView.ts
+++ b/src/features/cases/investigationCasePrepView.ts
@@ -1,0 +1,130 @@
+import { readPersistentFlag } from '../../domain/flagSystem'
+import { listInvestigationCustodyLossMarkers } from '../../domain/investigationCustodyLoss'
+import {
+  buildInvestigationAskedFlagId,
+  buildInvestigationLeverageFlagId,
+  listInvestigationQuestionSet,
+  readInvestigationBudget,
+  type InvestigationQuestionDomain,
+} from '../../domain/investigationEconomy'
+import type { CaseInstance, GameState } from '../../domain/models'
+
+export interface InvestigationBudgetView {
+  readonly granted: number
+  readonly spent: number
+  readonly custodyLossBurden: number
+  readonly remaining: number
+  readonly maxBudget: number
+}
+
+export interface InvestigationQuestionRowView {
+  readonly id: string
+  readonly prompt: string
+  readonly answer: string
+  readonly asked: boolean
+  readonly canAsk: boolean
+  readonly leverageLabel?: string
+  readonly leverageDescription?: string
+}
+
+export interface InvestigationDomainPrepView {
+  readonly domain: InvestigationQuestionDomain
+  readonly domainLabel: string
+  readonly budget: InvestigationBudgetView
+  readonly questions: readonly InvestigationQuestionRowView[]
+}
+
+export interface InvestigationCustodyMarkerView {
+  readonly ref: string
+  readonly leaveBehindLabel: string
+  readonly appliedWeek: number
+}
+
+export interface InvestigationCasePrepView {
+  readonly visible: boolean
+  readonly forensic: InvestigationDomainPrepView
+  readonly tactical: InvestigationDomainPrepView
+  readonly custodyMarkers: readonly InvestigationCustodyMarkerView[]
+}
+
+export function canShowInvestigationCasePrepOnCase(caseData: CaseInstance) {
+  return caseData.status === 'in_progress'
+}
+
+function buildDomainPrepView(
+  game: GameState,
+  caseId: string,
+  domain: InvestigationQuestionDomain
+): InvestigationDomainPrepView {
+  const budget = readInvestigationBudget(game, caseId, domain)
+  const questions = listInvestigationQuestionSet(domain).map((question) => {
+    const asked = Boolean(readPersistentFlag(game, buildInvestigationAskedFlagId(caseId, question.id)))
+    const leverageActive = asked
+      ? Boolean(readPersistentFlag(game, buildInvestigationLeverageFlagId(caseId, question.leverage.id)))
+      : false
+
+    return {
+      id: question.id,
+      prompt: question.prompt,
+      answer: question.answer,
+      asked,
+      canAsk: !asked && budget.remaining > 0,
+      leverageLabel: leverageActive ? question.leverage.label : undefined,
+      leverageDescription: leverageActive ? question.leverage.description : undefined,
+    }
+  })
+
+  return {
+    domain,
+    domainLabel: domain === 'forensic' ? 'Forensic inquiry' : 'Tactical read',
+    budget: {
+      granted: budget.granted,
+      spent: budget.spent,
+      custodyLossBurden: budget.custodyLossBurden,
+      remaining: budget.remaining,
+      maxBudget: budget.maxBudget,
+    },
+    questions,
+  }
+}
+
+const EMPTY_DOMAIN_VIEW: InvestigationDomainPrepView = {
+  domain: 'forensic',
+  domainLabel: 'Forensic inquiry',
+  budget: {
+    granted: 0,
+    spent: 0,
+    custodyLossBurden: 0,
+    remaining: 0,
+    maxBudget: 6,
+  },
+  questions: [],
+}
+
+export function buildInvestigationCasePrepView(
+  caseData: CaseInstance,
+  game: GameState
+): InvestigationCasePrepView {
+  if (!canShowInvestigationCasePrepOnCase(caseData)) {
+    return {
+      visible: false,
+      forensic: EMPTY_DOMAIN_VIEW,
+      tactical: { ...EMPTY_DOMAIN_VIEW, domain: 'tactical', domainLabel: 'Tactical read' },
+      custodyMarkers: [],
+    }
+  }
+
+  const caseId = caseData.id
+  const custodyMarkers = listInvestigationCustodyLossMarkers(game, caseId).map((marker) => ({
+    ref: marker.ref,
+    leaveBehindLabel: marker.label,
+    appliedWeek: marker.appliedWeek,
+  }))
+
+  return {
+    visible: true,
+    forensic: buildDomainPrepView(game, caseId, 'forensic'),
+    tactical: buildDomainPrepView(game, caseId, 'tactical'),
+    custodyMarkers,
+  }
+}

--- a/src/test/investigationCasePrepView.test.ts
+++ b/src/test/investigationCasePrepView.test.ts
@@ -9,6 +9,7 @@ import {
 import { createStarterCase } from '../domain/templates/startingCases'
 import {
   buildInvestigationCasePrepView,
+  canAskInvestigationQuestionOnCase,
   canShowInvestigationCasePrepOnCase,
 } from '../features/cases/investigationCasePrepView'
 
@@ -34,6 +35,13 @@ describe('investigationCasePrepView', () => {
 
     const hidden = buildInvestigationCasePrepView({ ...inProgress, status: 'open' }, createStartingState())
     expect(hidden.visible).toBe(false)
+  })
+
+  it('allows asks only for defined in-progress cases', () => {
+    const inProgress = createInProgressCase()
+    expect(canAskInvestigationQuestionOnCase(inProgress)).toBe(true)
+    expect(canAskInvestigationQuestionOnCase(undefined)).toBe(false)
+    expect(canAskInvestigationQuestionOnCase({ ...inProgress, status: 'resolved' })).toBe(false)
   })
 
   it('shows forensic and tactical budgets after investigation grant', () => {

--- a/src/test/investigationCasePrepView.test.ts
+++ b/src/test/investigationCasePrepView.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { applyStealthLeaveBehindInvestigationCustodyLoss } from '../domain/investigationCustodyLoss'
+import {
+  applySuccessfulInvestigation,
+  askInvestigationQuestion,
+  grantInvestigationQuestionBudget,
+} from '../domain/investigationEconomy'
+import { createStarterCase } from '../domain/templates/startingCases'
+import {
+  buildInvestigationCasePrepView,
+  canShowInvestigationCasePrepOnCase,
+} from '../features/cases/investigationCasePrepView'
+
+function createInProgressCase(id = 'case-investigation-prep') {
+  return {
+    ...createStarterCase({ id, templateId: 'ops-003' }),
+    status: 'in_progress' as const,
+    hiddenState: 'hidden' as const,
+    detectionConfidence: 0.25,
+    counterDetection: false,
+    tags: ['infiltration', 'archive'],
+    requiredTags: [],
+    preferredTags: [],
+  }
+}
+
+describe('investigationCasePrepView', () => {
+  it('is visible only for in-progress cases', () => {
+    const inProgress = createInProgressCase()
+    expect(canShowInvestigationCasePrepOnCase(inProgress)).toBe(true)
+    expect(canShowInvestigationCasePrepOnCase({ ...inProgress, status: 'open' })).toBe(false)
+    expect(canShowInvestigationCasePrepOnCase({ ...inProgress, status: 'resolved' })).toBe(false)
+
+    const hidden = buildInvestigationCasePrepView({ ...inProgress, status: 'open' }, createStartingState())
+    expect(hidden.visible).toBe(false)
+  })
+
+  it('shows forensic and tactical budgets after investigation grant', () => {
+    let state = createStartingState()
+    state.cases['case-investigation-prep'] = createInProgressCase()
+
+    state = applySuccessfulInvestigation(state, {
+      caseId: 'case-investigation-prep',
+      forensicBudget: 2,
+      tacticalBudget: 1,
+    })
+
+    const view = buildInvestigationCasePrepView(state.cases['case-investigation-prep']!, state)
+
+    expect(view.visible).toBe(true)
+    expect(view.forensic.budget).toMatchObject({ granted: 2, spent: 0, remaining: 2 })
+    expect(view.tactical.budget).toMatchObject({ granted: 1, spent: 0, remaining: 1 })
+    expect(view.forensic.questions.length).toBe(3)
+    expect(view.tactical.questions.length).toBe(3)
+  })
+
+  it('marks asked questions and reflects spent budget', () => {
+    let state = createStartingState()
+    state.cases['case-investigation-prep'] = createInProgressCase()
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: 'case-investigation-prep',
+      domain: 'forensic',
+      amount: 1,
+    })
+
+    state = askInvestigationQuestion(state, {
+      caseId: 'case-investigation-prep',
+      domain: 'forensic',
+      questionId: 'forensic.present-signature',
+    }).state
+
+    const view = buildInvestigationCasePrepView(state.cases['case-investigation-prep']!, state)
+    const asked = view.forensic.questions.find((q) => q.id === 'forensic.present-signature')
+
+    expect(asked?.asked).toBe(true)
+    expect(asked?.canAsk).toBe(false)
+    expect(asked?.leverageLabel).toBe('Secure evidence chain')
+    expect(view.forensic.budget.spent).toBe(1)
+    expect(view.forensic.budget.remaining).toBe(0)
+
+    const unasked = view.forensic.questions.find((q) => q.id === 'forensic.missing-proof')
+    expect(unasked?.canAsk).toBe(false)
+  })
+
+  it('lists custody strain markers and reduces forensic remaining', () => {
+    let state = createStartingState()
+    state.cases['case-investigation-prep'] = createInProgressCase()
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: 'case-investigation-prep',
+      domain: 'forensic',
+      amount: 3,
+    })
+
+    state = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: 'case-investigation-prep',
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      leaveBehindKind: 'abandon_evidence',
+      leaveBehindLabel: 'Abandon compromised evidence',
+      custodyLossRefs: ['custody:field-packet', 'custody:chain-seal'],
+      week: 2,
+    }).state
+
+    const view = buildInvestigationCasePrepView(state.cases['case-investigation-prep']!, state)
+
+    expect(view.custodyMarkers).toHaveLength(2)
+    expect(view.custodyMarkers[0]?.ref).toBe('custody:chain-seal')
+    expect(view.forensic.budget.custodyLossBurden).toBe(2)
+    expect(view.forensic.budget.remaining).toBe(1)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **SPE-626 UI slice**: players on in-progress cases can spend forensic and tactical investigation question budget, see answers and leverage, and review custody-strain markers from leave-behind fallout.

## Changes

- **View** (`investigationCasePrepView.ts`) — budgets, question rows (asked / canAsk), custody markers
- **Panel** (`InvestigationCasePrepPanel.tsx`) on case detail (below stealth leave-behind)
- **Store** — `askInvestigationQuestion(caseId, domain, questionId)` wrapping domain helper
- **Tests** — view builder, Case detail interaction, regression on `investigationEconomy`

## Plan

`planning/investigation-question-case-prep-slice.md`

## Verification

- `npm run lint`
- `npm run test:run` (targeted + investigation economy regression)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

