### PR TITLE
feat(SPE-521): infiltration case prep panel with weekly probe override

### DIFF
--- a/planning/infiltration-case-prep-slice.md
+++ b/planning/infiltration-case-prep-slice.md
@@ -1,0 +1,27 @@
+# SPE-521 deferred UX — Infiltration case prep panel
+
+## Goal
+
+Case-detail prep for covert infiltration: probe/awareness tracks, cover posture summary, and optional weekly probe action override before `advanceWeek`.
+
+## Shipped
+
+| Area | Files |
+| --- | --- |
+| Override domain | `src/domain/infiltrationProbeOverride.ts`, `CaseInstance.infiltrationWeeklyProbeActionOverride` |
+| Weekly tick | `applyWeeklyInfiltrationProbeTick` prefers override → plan |
+| View | `src/features/cases/infiltrationCasePrepView.ts` |
+| UI | `src/features/cases/InfiltrationCasePrepPanel.tsx` |
+| Page | `src/features/cases/CaseDetailPage.tsx` (above leave-behind + investigation prep) |
+| Store | `setInfiltrationWeeklyProbeAction` |
+
+## Acceptance
+
+- In-progress hidden infiltration-tagged cases show probe %, awareness %, stage, cover role/tiers, strain notes.
+- Player can select `probe_access` / `probe_route` / `cleanup` or clear to plan default.
+- Next weekly tick uses override when set (tests in `infiltrationProbe.test.ts`, `infiltrationProbeOverride.test.ts`).
+
+## See also
+
+- `src/domain/infiltrationProbe.ts`, `src/domain/infiltrationCover.ts`
+- `planning/investigation-question-case-prep-slice.md` (SPE-626 UI, merged)

--- a/planning/investigation-question-case-prep-slice.md
+++ b/planning/investigation-question-case-prep-slice.md
@@ -113,7 +113,7 @@ askInvestigationQuestion: (caseId, domain, questionId) => void
 
 ## Runner-up (next after this)
 
-1. **Infiltration case prep panel** — probe progress, awareness, stage, cover posture summary, optional weekly probe action override (SPE-521 deferred UX).
+1. ~~**Infiltration case prep panel**~~ — shipped; see `planning/infiltration-case-prep-slice.md`.
 2. **SPE-1464** — branch/path continuity validation (backlog near-term hint).
 3. **Hidden activation expansion** — backlog #1; broader than case-detail slice.
 

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -7,6 +7,7 @@ import {
   buildInvestigationAskedFlagId,
 } from '../../domain/investigationEconomy'
 import { readPersistentFlag } from '../../domain/flagSystem'
+import { copyInfiltrationProbePlan } from '../../domain/infiltrationProbe'
 import { createStarterCase } from '../../domain/templates/startingCases'
 import { buildWeeklyReportTutorialChoices } from '../../features/operations/frontDeskChoices'
 import type { AgentData, Candidate } from '../../domain/models'
@@ -207,6 +208,38 @@ describe('gameStore', () => {
         buildInvestigationAskedFlagId('case-investigation-store', 'forensic.missing-proof')
       )
     ).toBeUndefined()
+  })
+
+  it('sets infiltration weekly probe override only on eligible in-progress cases', () => {
+    const game = createStartingState()
+    game.cases['case-infiltration-store'] = {
+      ...createStarterCase({ id: 'case-infiltration-store', templateId: 'ops-004' }),
+      status: 'in_progress',
+      hiddenState: 'hidden',
+      tags: ['infiltration'],
+      infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    }
+
+    useGameStore.setState({ game })
+
+    useGameStore.getState().setInfiltrationWeeklyProbeAction('case-infiltration-store', 'probe_route')
+
+    expect(
+      useGameStore.getState().game.cases['case-infiltration-store']?.infiltrationWeeklyProbeActionOverride
+    ).toBe('probe_route')
+
+    useGameStore.getState().setInfiltrationWeeklyProbeAction('case-infiltration-store', null)
+
+    expect(
+      useGameStore.getState().game.cases['case-infiltration-store']?.infiltrationWeeklyProbeActionOverride
+    ).toBeUndefined()
+
+    useGameStore.getState().setInfiltrationWeeklyProbeAction('missing-case', 'cleanup')
+
+    expect(useGameStore.getState().game.cases['missing-case']).toBeUndefined()
   })
 
   it('assigns and unassigns teams through the store actions', () => {

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -91,6 +91,11 @@ import {
   type InvestigationQuestionDomain,
 } from '../../domain/investigationEconomy'
 import { canAskInvestigationQuestionOnCase } from '../../features/cases/investigationCasePrepView'
+import type { InfiltrationProbeAction } from '../../domain/infiltrationProbe'
+import {
+  applyInfiltrationWeeklyProbeActionOverride,
+  canConfigureInfiltrationWeeklyProbeOnCase,
+} from '../../domain/infiltrationProbeOverride'
 import { applyStealthLeaveBehindSelection } from '../../domain/stealthLeaveBehindSelection'
 import { queueFabrication } from '../../domain/sim/production'
 import { invokeEmergencyGrayMarketWaiver } from '../../domain/procurementEmergency'
@@ -233,6 +238,11 @@ interface GameStore {
     caseId: Id,
     domain: InvestigationQuestionDomain,
     questionId: string
+  ) => void
+  /** SPE-521 deferred UX: override or clear weekly infiltration probe action on an eligible case. */
+  setInfiltrationWeeklyProbeAction: (
+    caseId: Id,
+    action: InfiltrationProbeAction | null
   ) => void
   hireCandidate: (candidateId: Id) => void
   scoutCandidate: (candidateId: Id) => void
@@ -1158,6 +1168,24 @@ export const useGameStore = create<GameStore>()(
             caseId,
             domain,
             questionId,
+          })
+          if (!result.applied) {
+            return { game: s.game }
+          }
+
+          return { game: result.state }
+        }),
+
+      setInfiltrationWeeklyProbeAction: (caseId, action) =>
+        set((s) => {
+          const caseData = s.game.cases[caseId]
+          if (caseData === undefined || !canConfigureInfiltrationWeeklyProbeOnCase(caseData)) {
+            return { game: s.game }
+          }
+
+          const result = applyInfiltrationWeeklyProbeActionOverride(s.game, {
+            caseId,
+            action,
           })
           if (!result.applied) {
             return { game: s.game }

--- a/src/domain/infiltrationProbe.ts
+++ b/src/domain/infiltrationProbe.ts
@@ -402,7 +402,10 @@ export function applyWeeklyInfiltrationProbeTick(
     return { case: caseData, events: [], changed: false }
   }
 
-  const resolvedAction = action ?? resolveWeeklyInfiltrationProbeAction(caseData)
+  const resolvedAction =
+    action ??
+    caseData.infiltrationWeeklyProbeActionOverride ??
+    resolveWeeklyInfiltrationProbeAction(caseData)
   const probeResult = applyInfiltrationProbeActionToCase(caseData, resolvedAction)
   const coverResult = applyWeeklyInfiltrationCoverPostureToCase(probeResult.case)
 

--- a/src/domain/infiltrationProbeOverride.ts
+++ b/src/domain/infiltrationProbeOverride.ts
@@ -1,0 +1,104 @@
+/**
+ * SPE-521 deferred UX: player override for weekly infiltration probe action on case prep.
+ */
+
+import type { CaseInstance, GameState } from './models'
+import {
+  isInfiltrationProbeAction,
+  isInfiltrationProbeEligible,
+  type InfiltrationProbeAction,
+} from './infiltrationProbe'
+
+export type InfiltrationWeeklyProbeActionOverrideFailureReason =
+  | 'invalid_case'
+  | 'ineligible'
+  | 'invalid_action'
+
+export interface ApplyInfiltrationWeeklyProbeActionOverrideInput {
+  readonly caseId: string
+  /** `null` clears the override and restores authored plan resolution. */
+  readonly action: InfiltrationProbeAction | null
+}
+
+export interface ApplyInfiltrationWeeklyProbeActionOverrideResult {
+  readonly state: GameState
+  readonly applied: boolean
+  readonly reason?: InfiltrationWeeklyProbeActionOverrideFailureReason
+  readonly action?: InfiltrationProbeAction
+}
+
+function sanitizeCaseId(caseId: string) {
+  return caseId.trim()
+}
+
+export function canConfigureInfiltrationWeeklyProbeOnCase(caseData: CaseInstance) {
+  return caseData.status === 'in_progress' && isInfiltrationProbeEligible(caseData)
+}
+
+export function readInfiltrationWeeklyProbeActionOverride(
+  caseData: CaseInstance | undefined
+): InfiltrationProbeAction | undefined {
+  const action = caseData?.infiltrationWeeklyProbeActionOverride
+  return action !== undefined && isInfiltrationProbeAction(action) ? action : undefined
+}
+
+export function applyInfiltrationWeeklyProbeActionOverride(
+  state: GameState,
+  input: ApplyInfiltrationWeeklyProbeActionOverrideInput
+): ApplyInfiltrationWeeklyProbeActionOverrideResult {
+  const normalizedCaseId = sanitizeCaseId(input.caseId)
+  const currentCase = normalizedCaseId.length > 0 ? state.cases[normalizedCaseId] : undefined
+
+  if (!currentCase) {
+    return { state, applied: false, reason: 'invalid_case' }
+  }
+
+  if (!canConfigureInfiltrationWeeklyProbeOnCase(currentCase)) {
+    return { state, applied: false, reason: 'ineligible' }
+  }
+
+  if (input.action !== null && !isInfiltrationProbeAction(input.action)) {
+    return { state, applied: false, reason: 'invalid_action' }
+  }
+
+  const prior = readInfiltrationWeeklyProbeActionOverride(currentCase)
+
+  if (input.action === null) {
+    if (prior === undefined) {
+      return { state, applied: false }
+    }
+
+    const rest = { ...currentCase }
+    delete rest.infiltrationWeeklyProbeActionOverride
+
+    return {
+      state: {
+        ...state,
+        cases: {
+          ...state.cases,
+          [normalizedCaseId]: rest,
+        },
+      },
+      applied: true,
+    }
+  }
+
+  if (prior === input.action) {
+    return { state, applied: false, action: input.action }
+  }
+
+  return {
+    state: {
+      ...state,
+      cases: {
+        ...state.cases,
+        [normalizedCaseId]: {
+          ...currentCase,
+          infiltrationWeeklyProbeActionOverride: input.action,
+        },
+      },
+    },
+    applied: true,
+    action: input.action,
+  }
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1343,6 +1343,8 @@ export interface CaseInstance {
   concealmentTriggers?: readonly import('./hiddenStateActivation').ConcealmentActivationTrigger[]
   /** SPE-521 slice 2: weekly infiltration probe action plan copied from template at spawn. */
   infiltrationProbePlan?: import('./infiltrationProbe').InfiltrationProbePlan
+  /** SPE-521 deferred UX: player override for next weekly probe action (cleared when unset). */
+  infiltrationWeeklyProbeActionOverride?: import('./infiltrationProbe').InfiltrationProbeAction
   /** SPE-521 slice 3: cover identity profile copied from template at spawn. */
   infiltrationCoverProfile?: import('./infiltrationCover').InfiltrationCoverProfile
   /** SPE-2163 slice 2: stealth tradeoff row copied from template at spawn. */

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -10,7 +10,9 @@ import {
   applySuccessfulInvestigation,
   buildInvestigationAskedFlagId,
 } from '../../domain/investigationEconomy'
+import { copyInfiltrationProbePlan } from '../../domain/infiltrationProbe'
 import { createStarterCase } from '../../domain/templates/startingCases'
+import { caseTemplateMap } from '../../domain/templates/caseTemplates'
 import CaseDetailPage from './CaseDetailPage'
 
 function renderCaseDetail(route = '/cases/case-001') {
@@ -134,6 +136,46 @@ it('renders assignment timeline events for the selected case only', () => {
     'href',
     '/teams/t_nightwatch'
   )
+})
+
+it('shows infiltration prep and sets weekly probe action override', async () => {
+  const user = userEvent.setup()
+  const game = createStartingState()
+
+  game.cases['case-stealth-ui'] = {
+    ...createStarterCase({ id: 'case-stealth-ui', templateId: 'ops-004' }),
+    title: 'Archive Access Siege',
+    status: 'in_progress',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.25,
+    counterDetection: false,
+    tags: ['infiltration', 'archive', 'records'],
+    infiltrationProbeProgress: 0.2,
+    infiltrationAwareness: 0.3,
+    infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+    infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+  }
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-stealth-ui')
+
+  const panel = screen.getByRole('region', { name: /infiltration case prep/i })
+
+  expect(within(panel).getByRole('heading', { name: /infiltration prep/i })).toBeInTheDocument()
+  expect(within(panel).getByText(/probe progress 20%/i)).toBeInTheDocument()
+  expect(within(panel).getByText(/uniform guard/i)).toBeInTheDocument()
+
+  const cleanupRow = within(panel).getByText(/clean up cover/i).closest('li')
+  expect(cleanupRow).not.toBeNull()
+  await user.click(within(cleanupRow as HTMLElement).getByRole('button', { name: /^select$/i }))
+
+  expect(
+    useGameStore.getState().game.cases['case-stealth-ui']?.infiltrationWeeklyProbeActionOverride
+  ).toBe('cleanup')
+  expect(within(panel).getByRole('button', { name: /use plan default/i })).toBeInTheDocument()
 })
 
 it('shows stealth leave-behind tradeoff selection for eligible in-progress hidden cases', async () => {

--- a/src/features/cases/CaseDetailPage.tsx
+++ b/src/features/cases/CaseDetailPage.tsx
@@ -22,6 +22,7 @@ import { type CaseInstance, type GameState, type Team } from '../../domain/model
 import { getCaseTemplateIntelView } from './caseIntelProjection'
 import { getCaseAssignmentInsights } from './caseInsights'
 import { getCaseListItemView } from './caseView'
+import { InfiltrationCasePrepPanel } from './InfiltrationCasePrepPanel'
 import { InvestigationCasePrepPanel } from './InvestigationCasePrepPanel'
 import { StealthLeaveBehindSelectionPanel } from './StealthLeaveBehindSelectionPanel'
 
@@ -326,6 +327,8 @@ export default function CaseDetailPage() {
               </p>
             )}
           </article>
+
+          <InfiltrationCasePrepPanel caseData={currentCase} />
 
           <StealthLeaveBehindSelectionPanel caseData={currentCase} />
 

--- a/src/features/cases/InfiltrationCasePrepPanel.tsx
+++ b/src/features/cases/InfiltrationCasePrepPanel.tsx
@@ -112,9 +112,7 @@ function CoverSummary({ view }: { view: InfiltrationCasePrepView }) {
       <p className="text-sm">
         {view.coverRoleLabel}
         {view.documentTier !== undefined ? ` / Documents tier ${view.documentTier}` : ''}
-        {view.doctrineBand !== undefined
-          ? ` / Doctrine ${Math.round((view.doctrineBand ?? 0) * 100)}%`
-          : ''}
+        {view.doctrineBandPercent !== undefined ? ` / Doctrine ${view.doctrineBandPercent}%` : ''}
       </p>
       <ul className="list-disc space-y-1 pl-5 text-xs opacity-70">
         {view.coverStrainNotes.map((note) => (

--- a/src/features/cases/InfiltrationCasePrepPanel.tsx
+++ b/src/features/cases/InfiltrationCasePrepPanel.tsx
@@ -1,0 +1,151 @@
+import { useGameStore } from '../../app/store/gameStore'
+import type { CaseInstance } from '../../domain/models'
+import {
+  buildInfiltrationCasePrepView,
+  type InfiltrationCasePrepView,
+  type InfiltrationProbeActionOptionView,
+} from './infiltrationCasePrepView'
+
+export function InfiltrationCasePrepPanel({ caseData }: { caseData: CaseInstance }) {
+  const setInfiltrationWeeklyProbeAction = useGameStore(
+    (state) => state.setInfiltrationWeeklyProbeAction
+  )
+  const view = buildInfiltrationCasePrepView(caseData)
+
+  if (!view.visible) {
+    return null
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-4"
+      role="region"
+      aria-label="Infiltration case prep"
+    >
+      <PanelHeader />
+
+      <p className="text-sm opacity-60">
+        Review probe tracks and cover posture before weekly resolution. Override the next weekly
+        probe action or use the authored plan default.
+      </p>
+
+      <TrackSummary view={view} />
+
+      {view.coverRoleLabel ? <CoverSummary view={view} /> : null}
+
+      <section className="space-y-2" aria-label="Weekly probe action">
+        <div className="space-y-1">
+          <h4 className="font-semibold">Next weekly probe action</h4>
+          <p className="text-xs opacity-55">
+            Plan default: {view.plannedActionLabel}
+            {view.usingOverride ? (
+              <>
+                {' '}
+                / Override: <span className="text-amber-200/90">{view.overrideActionLabel}</span>
+              </>
+            ) : null}
+            {' '}
+            / Resolves as: <span className="font-medium">{view.effectiveActionLabel}</span>
+          </p>
+        </div>
+
+        <ul className="space-y-2">
+          {view.actionOptions.map((option) => (
+            <li
+              key={option.id}
+              className={`rounded border px-3 py-2 ${
+                option.selected
+                  ? 'border-amber-400/40 bg-amber-500/10'
+                  : 'border-white/10 bg-white/5'
+              }`}
+            >
+              <ProbeActionRow
+                option={option}
+                onSelect={() => setInfiltrationWeeklyProbeAction(caseData.id, option.id)}
+              />
+            </li>
+          ))}
+        </ul>
+
+        {view.usingOverride ? (
+          <button
+            type="button"
+            className="btn btn-sm"
+            onClick={() => setInfiltrationWeeklyProbeAction(caseData.id, null)}
+          >
+            Use plan default
+          </button>
+        ) : null}
+      </section>
+    </article>
+  )
+}
+
+function PanelHeader() {
+  return (
+    <div className="space-y-1">
+      <h3 className="text-lg font-semibold">Infiltration prep</h3>
+      <p className="text-xs uppercase tracking-wide opacity-50">Covert tracks</p>
+    </div>
+  )
+}
+
+function TrackSummary({ view }: { view: InfiltrationCasePrepView }) {
+  return (
+    <section className="space-y-1" aria-label="Probe and awareness tracks">
+      <p className="text-xs uppercase tracking-wide opacity-50">Tracks</p>
+      <p className="text-sm">
+        Probe progress {view.probeProgressPercent}% / Awareness {view.awarenessPercent}% (
+        {view.stageLabel})
+      </p>
+      <p className="text-xs opacity-55">
+        Complication band begins at {view.awarenessComplicationBandPercent}% awareness.
+      </p>
+    </section>
+  )
+}
+
+function CoverSummary({ view }: { view: InfiltrationCasePrepView }) {
+  return (
+    <section className="space-y-1" aria-label="Cover posture">
+      <p className="text-xs uppercase tracking-wide opacity-50">Cover posture</p>
+      <p className="text-sm">
+        {view.coverRoleLabel}
+        {view.documentTier !== undefined ? ` / Documents tier ${view.documentTier}` : ''}
+        {view.doctrineBand !== undefined
+          ? ` / Doctrine ${Math.round((view.doctrineBand ?? 0) * 100)}%`
+          : ''}
+      </p>
+      <ul className="list-disc space-y-1 pl-5 text-xs opacity-70">
+        {view.coverStrainNotes.map((note) => (
+          <li key={note}>{note}</li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function ProbeActionRow({
+  option,
+  onSelect,
+}: {
+  option: InfiltrationProbeActionOptionView
+  onSelect: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div className="space-y-1">
+        <p className="text-sm font-medium">{option.label}</p>
+        <p className="text-xs opacity-65">{option.summary}</p>
+      </div>
+      <button
+        type="button"
+        className="btn btn-sm"
+        aria-pressed={option.selected}
+        onClick={onSelect}
+      >
+        {option.selected ? 'Selected' : 'Select'}
+      </button>
+    </div>
+  )
+}

--- a/src/features/cases/infiltrationCasePrepView.ts
+++ b/src/features/cases/infiltrationCasePrepView.ts
@@ -54,7 +54,7 @@ export interface InfiltrationCasePrepView {
   readonly awarenessComplicationBandPercent: number
   readonly coverRoleLabel?: string
   readonly documentTier?: number
-  readonly doctrineBand?: number
+  readonly doctrineBandPercent?: number
   readonly coverStrainNotes: readonly string[]
   readonly plannedAction: InfiltrationProbeAction
   readonly plannedActionLabel: string

--- a/src/features/cases/infiltrationCasePrepView.ts
+++ b/src/features/cases/infiltrationCasePrepView.ts
@@ -144,7 +144,7 @@ export function buildInfiltrationCasePrepView(caseData: CaseInstance): Infiltrat
     coverRoleLabel:
       profile !== undefined ? COVER_ROLE_LABELS[profile.claimedRole] : undefined,
     documentTier: profile?.documentTier,
-    doctrineBand: profile?.doctrineBand,
+    doctrineBandPercent: profile?.doctrineBand !== undefined ? formatPercent(profile.doctrineBand) : undefined,
     coverStrainNotes: buildCoverStrainNotes(caseData),
     plannedAction,
     plannedActionLabel: INFILTRATION_PROBE_ACTION_LABELS[plannedAction],

--- a/src/features/cases/infiltrationCasePrepView.ts
+++ b/src/features/cases/infiltrationCasePrepView.ts
@@ -1,0 +1,166 @@
+import {
+  evaluateCoverRoleMismatchPressure,
+  type InfiltrationCoverRole,
+} from '../../domain/infiltrationCover'
+import {
+  AWARENESS_COMPLICATION_THRESHOLD,
+  isInfiltrationProbeEligible,
+  readInfiltrationProbeState,
+  resolveWeeklyInfiltrationProbeAction,
+  type InfiltrationProbeAction,
+  type InfiltrationStage,
+} from '../../domain/infiltrationProbe'
+import { readInfiltrationWeeklyProbeActionOverride } from '../../domain/infiltrationProbeOverride'
+import type { CaseInstance } from '../../domain/models'
+
+export const INFILTRATION_PROBE_ACTION_LABELS: Record<InfiltrationProbeAction, string> = {
+  probe_access: 'Probe access',
+  probe_route: 'Probe route',
+  cleanup: 'Clean up cover',
+}
+
+export const INFILTRATION_PROBE_ACTION_SUMMARIES: Record<InfiltrationProbeAction, string> = {
+  probe_access: 'Push objective access; moderate awareness gain.',
+  probe_route: 'Map movement and logistics; higher awareness gain.',
+  cleanup: 'Reduce awareness; minimal probe progress.',
+}
+
+const INFILTRATION_STAGE_LABELS: Record<InfiltrationStage, string> = {
+  probing: 'Probing',
+  exposed: 'Exposed',
+  violent: 'Violent escalation',
+}
+
+const COVER_ROLE_LABELS: Record<InfiltrationCoverRole, string> = {
+  uniform_guard: 'Uniform guard',
+  civilian_staff: 'Civilian staff',
+  courier: 'Courier',
+  maintenance: 'Maintenance',
+  official_inspector: 'Official inspector',
+}
+
+export interface InfiltrationProbeActionOptionView {
+  readonly id: InfiltrationProbeAction
+  readonly label: string
+  readonly summary: string
+  readonly selected: boolean
+}
+
+export interface InfiltrationCasePrepView {
+  readonly visible: boolean
+  readonly probeProgressPercent: number
+  readonly awarenessPercent: number
+  readonly stageLabel: string
+  readonly awarenessComplicationBandPercent: number
+  readonly coverRoleLabel?: string
+  readonly documentTier?: number
+  readonly doctrineBand?: number
+  readonly coverStrainNotes: readonly string[]
+  readonly plannedAction: InfiltrationProbeAction
+  readonly plannedActionLabel: string
+  readonly overrideAction?: InfiltrationProbeAction
+  readonly overrideActionLabel?: string
+  readonly effectiveAction: InfiltrationProbeAction
+  readonly effectiveActionLabel: string
+  readonly actionOptions: readonly InfiltrationProbeActionOptionView[]
+  readonly usingOverride: boolean
+}
+
+export function canShowInfiltrationCasePrepOnCase(caseData: CaseInstance) {
+  return caseData.status === 'in_progress' && isInfiltrationProbeEligible(caseData)
+}
+
+function formatPercent(value: number) {
+  return Math.round(value * 100)
+}
+
+function buildCoverStrainNotes(caseData: CaseInstance): string[] {
+  const profile = caseData.infiltrationCoverProfile
+  if (profile === undefined) {
+    return []
+  }
+
+  const notes: string[] = []
+  const mismatch = evaluateCoverRoleMismatchPressure(caseData, profile.claimedRole)
+
+  if (mismatch.hasRoleMismatch) {
+    notes.push(`Claimed ${COVER_ROLE_LABELS[profile.claimedRole]} clashes with site tags.`)
+  }
+
+  if (mismatch.hasExtraRouteViolation) {
+    notes.push('Route or venue tags contradict the cover story.')
+  }
+
+  if (notes.length === 0) {
+    notes.push('Cover posture is stable for current site context.')
+  }
+
+  return notes
+}
+
+const PROBE_ACTIONS: readonly InfiltrationProbeAction[] = [
+  'probe_access',
+  'probe_route',
+  'cleanup',
+]
+
+export function buildInfiltrationCasePrepView(caseData: CaseInstance): InfiltrationCasePrepView {
+  const emptyOptions = PROBE_ACTIONS.map((id) => ({
+    id,
+    label: INFILTRATION_PROBE_ACTION_LABELS[id],
+    summary: INFILTRATION_PROBE_ACTION_SUMMARIES[id],
+    selected: false,
+  }))
+
+  if (!canShowInfiltrationCasePrepOnCase(caseData)) {
+    return {
+      visible: false,
+      probeProgressPercent: 0,
+      awarenessPercent: 0,
+      stageLabel: INFILTRATION_STAGE_LABELS.probing,
+      awarenessComplicationBandPercent: formatPercent(AWARENESS_COMPLICATION_THRESHOLD),
+      coverStrainNotes: [],
+      plannedAction: 'probe_access',
+      plannedActionLabel: INFILTRATION_PROBE_ACTION_LABELS.probe_access,
+      effectiveAction: 'probe_access',
+      effectiveActionLabel: INFILTRATION_PROBE_ACTION_LABELS.probe_access,
+      actionOptions: emptyOptions,
+      usingOverride: false,
+    }
+  }
+
+  const tracks = readInfiltrationProbeState(caseData)
+  const plannedAction = resolveWeeklyInfiltrationProbeAction(caseData)
+  const overrideAction = readInfiltrationWeeklyProbeActionOverride(caseData)
+  const effectiveAction = overrideAction ?? plannedAction
+  const profile = caseData.infiltrationCoverProfile
+
+  return {
+    visible: true,
+    probeProgressPercent: formatPercent(tracks.probeProgress),
+    awarenessPercent: formatPercent(tracks.awareness),
+    stageLabel: INFILTRATION_STAGE_LABELS[tracks.stage],
+    awarenessComplicationBandPercent: formatPercent(AWARENESS_COMPLICATION_THRESHOLD),
+    coverRoleLabel:
+      profile !== undefined ? COVER_ROLE_LABELS[profile.claimedRole] : undefined,
+    documentTier: profile?.documentTier,
+    doctrineBand: profile?.doctrineBand,
+    coverStrainNotes: buildCoverStrainNotes(caseData),
+    plannedAction,
+    plannedActionLabel: INFILTRATION_PROBE_ACTION_LABELS[plannedAction],
+    overrideAction,
+    overrideActionLabel:
+      overrideAction !== undefined
+        ? INFILTRATION_PROBE_ACTION_LABELS[overrideAction]
+        : undefined,
+    effectiveAction,
+    effectiveActionLabel: INFILTRATION_PROBE_ACTION_LABELS[effectiveAction],
+    actionOptions: PROBE_ACTIONS.map((id) => ({
+      id,
+      label: INFILTRATION_PROBE_ACTION_LABELS[id],
+      summary: INFILTRATION_PROBE_ACTION_SUMMARIES[id],
+      selected: overrideAction === id,
+    })),
+    usingOverride: overrideAction !== undefined,
+  }
+}

--- a/src/test/infiltrationCasePrepView.test.ts
+++ b/src/test/infiltrationCasePrepView.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { copyInfiltrationProbePlan } from '../domain/infiltrationProbe'
+import {
+  buildInfiltrationCasePrepView,
+  canShowInfiltrationCasePrepOnCase,
+} from '../features/cases/infiltrationCasePrepView'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { caseTemplateMap } from '../domain/templates/caseTemplates'
+
+function createEligibleCase() {
+  return {
+    ...createStarterCase({ id: 'case-infiltration-prep', templateId: 'ops-004' }),
+    status: 'in_progress' as const,
+    hiddenState: 'hidden' as const,
+    infiltrationProbeProgress: 0.35,
+    infiltrationAwareness: 0.42,
+    infiltrationStage: 'probing' as const,
+    tags: ['infiltration'],
+    infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+    infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
+    infiltrationWeeklyProbeActionOverride: 'probe_route' as const,
+    requiredTags: [],
+    preferredTags: [],
+  }
+}
+
+describe('infiltrationCasePrepView', () => {
+  it('is visible only for in-progress eligible infiltration cases', () => {
+    const eligible = createEligibleCase()
+    expect(canShowInfiltrationCasePrepOnCase(eligible)).toBe(true)
+    expect(canShowInfiltrationCasePrepOnCase({ ...eligible, status: 'open' })).toBe(false)
+
+    const hidden = buildInfiltrationCasePrepView({ ...eligible, hiddenState: undefined })
+    expect(hidden.visible).toBe(false)
+  })
+
+  it('summarizes tracks, cover posture, and effective weekly action', () => {
+    const view = buildInfiltrationCasePrepView(createEligibleCase())
+
+    expect(view.visible).toBe(true)
+    expect(view.probeProgressPercent).toBe(35)
+    expect(view.awarenessPercent).toBe(42)
+    expect(view.stageLabel).toBe('Probing')
+    expect(view.coverRoleLabel).toBe('Uniform guard')
+    expect(view.usingOverride).toBe(true)
+    expect(view.effectiveAction).toBe('probe_route')
+    expect(view.plannedAction).toBe('probe_access')
+    expect(view.coverStrainNotes.length).toBeGreaterThan(0)
+  })
+})

--- a/src/test/infiltrationProbe.test.ts
+++ b/src/test/infiltrationProbe.test.ts
@@ -164,6 +164,21 @@ describe('infiltrationProbe', () => {
     ).toBe('probe_route')
   })
 
+  it('prefers case weekly probe override over authored plan when ticking', () => {
+    const weekly = applyWeeklyInfiltrationProbeTick(
+      createInfiltrationCase({
+        infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+        infiltrationAwareness: 0.2,
+        infiltrationProbeProgress: 0.1,
+        infiltrationWeeklyProbeActionOverride: 'cleanup',
+      }),
+      2
+    )
+
+    expect(weekly.changed).toBe(true)
+    expect(weekly.case.infiltrationAwareness).toBeLessThan(0.2)
+  })
+
   it('applies resolved weekly action when action override is omitted', () => {
     const weekly = applyWeeklyInfiltrationProbeTick(
       createInfiltrationCase({

--- a/src/test/infiltrationProbeOverride.test.ts
+++ b/src/test/infiltrationProbeOverride.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { copyInfiltrationProbePlan } from '../domain/infiltrationProbe'
+import {
+  applyInfiltrationWeeklyProbeActionOverride,
+  canConfigureInfiltrationWeeklyProbeOnCase,
+  readInfiltrationWeeklyProbeActionOverride,
+} from '../domain/infiltrationProbeOverride'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { caseTemplateMap } from '../domain/templates/caseTemplates'
+
+function createEligibleCase() {
+  return {
+    ...createStarterCase({ id: 'case-infiltration-override', templateId: 'ops-004' }),
+    status: 'in_progress' as const,
+    hiddenState: 'hidden' as const,
+    detectionConfidence: 0.25,
+    counterDetection: false,
+    tags: ['infiltration', 'covert'],
+    infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+    infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+  }
+}
+
+describe('infiltrationProbeOverride', () => {
+  it('allows override only on in-progress eligible cases', () => {
+    const eligible = createEligibleCase()
+    expect(canConfigureInfiltrationWeeklyProbeOnCase(eligible)).toBe(true)
+    expect(
+      canConfigureInfiltrationWeeklyProbeOnCase({ ...eligible, status: 'resolved' })
+    ).toBe(false)
+    expect(
+      canConfigureInfiltrationWeeklyProbeOnCase({ ...eligible, hiddenState: undefined })
+    ).toBe(false)
+  })
+
+  it('sets and clears weekly probe action override', () => {
+    let state = createStartingState()
+    state.cases['case-infiltration-override'] = createEligibleCase()
+
+    const set = applyInfiltrationWeeklyProbeActionOverride(state, {
+      caseId: 'case-infiltration-override',
+      action: 'cleanup',
+    })
+    expect(set.applied).toBe(true)
+    state = set.state
+    expect(
+      readInfiltrationWeeklyProbeActionOverride(state.cases['case-infiltration-override'])
+    ).toBe('cleanup')
+
+    const cleared = applyInfiltrationWeeklyProbeActionOverride(state, {
+      caseId: 'case-infiltration-override',
+      action: null,
+    })
+    expect(cleared.applied).toBe(true)
+    expect(
+      readInfiltrationWeeklyProbeActionOverride(cleared.state.cases['case-infiltration-override'])
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the deferred SPE-521 case-detail prep surface for covert infiltration cases.

## Changes

- **Tracks:** probe progress, awareness, and stage on in-progress hidden infiltration cases
- **Cover posture:** claimed role, document tier, doctrine band, and strain notes from mismatch evaluation
- **Weekly probe override:** player can select `probe_access`, `probe_route`, or `cleanup`, or clear back to the authored plan default
- **Simulation:** `applyWeeklyInfiltrationProbeTick` uses `infiltrationWeeklyProbeActionOverride` before `resolveWeeklyInfiltrationProbeAction`

## Panel order on case detail

1. Infiltration prep (this PR)
2. Stealth leave-behind
3. Investigation questions (SPE-626)

## Verification

- `npm run lint`
- `npm run test:run` (3513 tests)

## Docs

- `planning/infiltration-case-prep-slice.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

