### PR TITLE
feat(SPE-70): concealment case prep panel on case detail

### DIFF
--- a/planning/concealment-case-prep-slice.md
+++ b/planning/concealment-case-prep-slice.md
@@ -145,11 +145,11 @@ Guard: only when `canPlayerSetConcealCaseFlag(case)`; no-op otherwise (mirror in
 
 ## Acceptance criteria
 
-- [ ] In-progress eligible case shows concealment prep with activation preview reason.
-- [ ] Player can set/clear `conceal.case.{caseId}` from case detail; next `resolveConcealmentActivation` reflects it.
-- [ ] Already-concealed cases do not offer bogus toggles.
-- [ ] `npm run lint` + `npm run test:run` green.
-- [ ] Plan linked from `planning/backlog.md` or SPE-70 comment when PR opens.
+- [x] In-progress eligible case shows concealment prep with activation preview reason.
+- [x] Player can set/clear `conceal.case.{caseId}` from case detail; next `resolveConcealmentActivation` reflects it.
+- [x] Already-concealed cases do not offer bogus toggles (panel hidden when `hiddenState` set).
+- [x] `npm run lint` + `npm run test:run` green (3518 tests).
+- [x] Plan linked from `planning/backlog.md`.
 
 ---
 

--- a/src/domain/concealmentCasePrep.ts
+++ b/src/domain/concealmentCasePrep.ts
@@ -1,0 +1,73 @@
+/**
+ * SPE-70 / SPE-2107 slice 3: eligibility helpers for concealment case prep UI.
+ */
+
+import {
+  CONCEALMENT_ACTIVATION_TAGS,
+  type ConcealmentActivationTrigger,
+} from './hiddenStateActivation'
+import type { CaseInstance } from './models'
+
+const CONCEAL_CASE_FLAG_PREFIX = 'conceal.case.'
+
+function collectCaseTags(caseData: CaseInstance) {
+  return [...new Set([...caseData.tags, ...caseData.requiredTags, ...caseData.preferredTags])]
+}
+
+export function hasConcealmentActivationTag(caseData: CaseInstance) {
+  const caseTags = collectCaseTags(caseData)
+  return CONCEALMENT_ACTIVATION_TAGS.some((tag) => caseTags.includes(tag))
+}
+
+export function buildConcealCaseFlagId(caseId: string) {
+  return `${CONCEAL_CASE_FLAG_PREFIX}${caseId.trim()}`
+}
+
+export function canShowConcealmentCasePrepOnCase(caseData: CaseInstance) {
+  return caseData.status === 'in_progress' && caseData.hiddenState === undefined
+}
+
+export function canPlayerSetConcealCaseFlag(caseData: CaseInstance) {
+  return (
+    canShowConcealmentCasePrepOnCase(caseData) &&
+    (hasConcealmentActivationTag(caseData) || (caseData.concealmentTriggers?.length ?? 0) > 0)
+  )
+}
+
+export function listConcealmentActivationTagsOnCase(caseData: CaseInstance) {
+  const caseTags = new Set(collectCaseTags(caseData))
+  return CONCEALMENT_ACTIVATION_TAGS.filter((tag) => caseTags.has(tag))
+}
+
+export function summarizeConcealmentTriggerWhen(
+  trigger: ConcealmentActivationTrigger
+): string {
+  const when = trigger.when
+  if (when === undefined) {
+    return 'Always when open posture'
+  }
+
+  const parts: string[] = []
+
+  if (when.anyTag?.length) {
+    parts.push(`any tag: ${when.anyTag.join(', ')}`)
+  }
+
+  if (when.allTags?.length) {
+    parts.push(`all tags: ${when.allTags.join(', ')}`)
+  }
+
+  if (when.globalFlag?.trim()) {
+    parts.push(`flag: ${when.globalFlag.trim()}`)
+  }
+
+  if (when.minHiddenModifierCount !== undefined) {
+    parts.push(`hidden modifiers ≥ ${when.minHiddenModifierCount}`)
+  }
+
+  if (when.minInvestigationWeight !== undefined) {
+    parts.push(`investigation weight ≥ ${when.minInvestigationWeight}`)
+  }
+
+  return parts.length > 0 ? parts.join('; ') : 'Always when open posture'
+}

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -138,6 +138,43 @@ it('renders assignment timeline events for the selected case only', () => {
   )
 })
 
+it('shows concealment prep and toggles covert posture flag', async () => {
+  const user = userEvent.setup()
+  const game = createStartingState()
+
+  game.cases['case-conceal-ui'] = {
+    ...createStarterCase({ id: 'case-conceal-ui', templateId: 'ops-003' }),
+    title: 'Covert Access',
+    status: 'in_progress',
+    tags: ['infiltration', 'archive'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+  }
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-conceal-ui')
+
+  const panel = screen.getByRole('region', { name: /concealment case prep/i })
+
+  expect(within(panel).getByRole('heading', { name: /concealment prep/i })).toBeInTheDocument()
+  expect(within(panel).getByText(/next weekly tick will mark this case as hidden/i)).toBeInTheDocument()
+
+  await user.click(within(panel).getByRole('button', { name: /request covert posture/i }))
+
+  expect(
+    useGameStore.getState().game.runtimeState?.globalFlags?.['conceal.case.case-conceal-ui'] ??
+      useGameStore.getState().game.globalFlags?.['conceal.case.case-conceal-ui']
+  ).toBeTruthy()
+
+  await user.click(within(panel).getByRole('button', { name: /clear covert request/i }))
+
+  const flag =
+    useGameStore.getState().game.runtimeState?.globalFlags?.['conceal.case.case-conceal-ui'] ??
+    useGameStore.getState().game.globalFlags?.['conceal.case.case-conceal-ui']
+  expect(flag === false || flag === undefined).toBe(true)
+})
+
 it('shows infiltration prep and sets weekly probe action override', async () => {
   const user = userEvent.setup()
   const game = createStartingState()

--- a/src/features/cases/CaseDetailPage.tsx
+++ b/src/features/cases/CaseDetailPage.tsx
@@ -22,6 +22,7 @@ import { type CaseInstance, type GameState, type Team } from '../../domain/model
 import { getCaseTemplateIntelView } from './caseIntelProjection'
 import { getCaseAssignmentInsights } from './caseInsights'
 import { getCaseListItemView } from './caseView'
+import { ConcealmentCasePrepPanel } from './ConcealmentCasePrepPanel'
 import { InfiltrationCasePrepPanel } from './InfiltrationCasePrepPanel'
 import { InvestigationCasePrepPanel } from './InvestigationCasePrepPanel'
 import { StealthLeaveBehindSelectionPanel } from './StealthLeaveBehindSelectionPanel'
@@ -327,6 +328,8 @@ export default function CaseDetailPage() {
               </p>
             )}
           </article>
+
+          <ConcealmentCasePrepPanel caseData={currentCase} />
 
           <InfiltrationCasePrepPanel caseData={currentCase} />
 

--- a/src/features/cases/ConcealmentCasePrepPanel.tsx
+++ b/src/features/cases/ConcealmentCasePrepPanel.tsx
@@ -1,0 +1,116 @@
+import { useGameStore } from '../../app/store/gameStore'
+import { buildConcealCaseFlagId } from '../../domain/concealmentCasePrep'
+import type { CaseInstance } from '../../domain/models'
+import {
+  buildConcealmentCasePrepView,
+  type ConcealmentCasePrepView,
+  type ConcealmentTriggerRowView,
+} from './concealmentCasePrepView'
+
+export function ConcealmentCasePrepPanel({ caseData }: { caseData: CaseInstance }) {
+  const game = useGameStore((state) => state.game)
+  const setGlobalFlag = useGameStore((state) => state.setGlobalFlag)
+  const view = buildConcealmentCasePrepView(caseData, game)
+
+  if (!view.visible) {
+    return null
+  }
+
+  const concealFlagId = buildConcealCaseFlagId(caseData.id)
+
+  return (
+    <article
+      className="panel panel-support space-y-4"
+      role="region"
+      aria-label="Concealment case prep"
+    >
+      <PanelHeader />
+
+      <p className="text-sm opacity-60">
+        Preview how concealment rules resolve before weekly resolution. Request covert posture to
+        set the per-case flag used by weekly activation.
+      </p>
+
+      <PreviewSection view={view} />
+
+      {view.activationTags.length > 0 ? (
+        <section className="space-y-1" aria-label="Concealment activation tags">
+          <p className="text-xs uppercase tracking-wide opacity-50">Activation tags</p>
+          <p className="text-sm">{view.activationTags.join(', ')}</p>
+        </section>
+      ) : null}
+
+      {view.triggerRows.length > 0 ? (
+        <section className="space-y-2" aria-label="Authored concealment triggers">
+          <p className="text-xs uppercase tracking-wide opacity-50">Authored triggers</p>
+          <ul className="space-y-2">
+            {view.triggerRows.map((row) => (
+              <TriggerRow key={row.id} row={row} />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {view.hiddenModifierCount !== undefined && view.hiddenModifierCount > 0 ? (
+        <p className="text-xs opacity-55">
+          Hidden map modifiers on case: {view.hiddenModifierCount}
+        </p>
+      ) : null}
+
+      {view.canToggleConcealFlag ? (
+        <section className="space-y-2" aria-label="Covert posture request">
+          <button
+            type="button"
+            className="btn btn-sm"
+            aria-pressed={view.playerConcealFlagActive}
+            onClick={() =>
+              setGlobalFlag(concealFlagId, view.playerConcealFlagActive ? false : true)
+            }
+          >
+            {view.playerConcealFlagActive ? 'Clear covert request' : 'Request covert posture'}
+          </button>
+          <p className="text-xs opacity-55">
+            Sets <span className="font-mono text-[0.7rem]">{concealFlagId}</span> for the next
+            weekly tick.
+          </p>
+        </section>
+      ) : null}
+    </article>
+  )
+}
+
+function PanelHeader() {
+  return (
+    <div className="space-y-1">
+      <h3 className="text-lg font-semibold">Concealment prep</h3>
+      <p className="text-xs uppercase tracking-wide opacity-50">Covert activation</p>
+    </div>
+  )
+}
+
+function PreviewSection({ view }: { view: ConcealmentCasePrepView }) {
+  return (
+    <section
+      className={`rounded border px-3 py-2 text-sm ${
+        view.previewApplied
+          ? 'border-violet-400/35 bg-violet-500/8'
+          : 'border-white/10 bg-white/5'
+      }`}
+      aria-label="Concealment activation preview"
+    >
+      <p className="font-medium">{view.previewStatusLabel}</p>
+      <p className="mt-1 text-xs opacity-70">{view.previewReasonLabel}</p>
+    </section>
+  )
+}
+
+function TriggerRow({ row }: { row: ConcealmentTriggerRowView }) {
+  return (
+    <li className="rounded border border-white/10 bg-white/5 px-3 py-2 text-sm">
+      <p className="font-medium">{row.id}</p>
+      <p className="text-xs opacity-60">
+        {row.modeLabel} — {row.whenSummary}
+      </p>
+    </li>
+  )
+}

--- a/src/features/cases/concealmentCasePrepView.ts
+++ b/src/features/cases/concealmentCasePrepView.ts
@@ -1,0 +1,132 @@
+import {
+  buildConcealCaseFlagId,
+  canPlayerSetConcealCaseFlag,
+  canShowConcealmentCasePrepOnCase,
+  listConcealmentActivationTagsOnCase,
+  summarizeConcealmentTriggerWhen,
+} from '../../domain/concealmentCasePrep'
+import { isPersistentFlagSet } from '../../domain/flagSystem'
+import { readGameStateManager } from '../../domain/gameStateManager'
+import {
+  resolveConcealmentActivation,
+  type ConcealmentActivationMode,
+} from '../../domain/hiddenStateActivation'
+import { countCaseHiddenModifiers } from '../../domain/recon'
+import type { CaseInstance, GameState } from '../../domain/models'
+
+export interface ConcealmentTriggerRowView {
+  readonly id: string
+  readonly modeLabel: string
+  readonly whenSummary: string
+}
+
+export interface ConcealmentCasePrepView {
+  readonly visible: boolean
+  readonly activationTags: readonly string[]
+  readonly triggerRows: readonly ConcealmentTriggerRowView[]
+  readonly previewApplied: boolean
+  readonly previewMode?: ConcealmentActivationMode
+  readonly previewReason?: string
+  readonly previewReasonLabel: string
+  readonly previewStatusLabel: string
+  readonly playerConcealFlagActive: boolean
+  readonly canToggleConcealFlag: boolean
+  readonly hiddenModifierCount?: number
+}
+
+const MODE_LABELS: Record<ConcealmentActivationMode, string> = {
+  hidden: 'Hidden presence',
+  displaced: 'Displaced cover',
+}
+
+function humanizePreviewReason(reason: string | undefined): string {
+  if (reason === undefined || reason.length === 0) {
+    return 'No activation rule matched yet'
+  }
+
+  if (reason.startsWith('global-flag:conceal.case.')) {
+    return 'Covert request flag on this case'
+  }
+
+  if (reason.startsWith('global-flag:conceal.displace.')) {
+    return 'Displacement flag on this case'
+  }
+
+  if (reason === 'global-flag-prefix:conceal.') {
+    return 'Agency-wide covert activation flag'
+  }
+
+  if (reason === 'case-tag') {
+    return 'Concealment activation tags on the case'
+  }
+
+  if (reason.startsWith('authored-trigger:')) {
+    return `Authored trigger (${reason.slice('authored-trigger:'.length)})`
+  }
+
+  if (reason === 'recon-hidden-modifiers') {
+    return 'Recon hidden-modifier bridge'
+  }
+
+  return reason
+}
+
+function buildPreviewStatusLabel(applied: boolean, mode?: ConcealmentActivationMode) {
+  if (!applied) {
+    return 'Open posture — no covert activation on the next weekly tick'
+  }
+
+  if (mode === 'displaced') {
+    return 'Next weekly tick will mark this case as displaced cover'
+  }
+
+  return 'Next weekly tick will mark this case as hidden presence'
+}
+
+export function buildConcealmentCasePrepView(
+  caseData: CaseInstance,
+  game: GameState
+): ConcealmentCasePrepView {
+  const emptyView: ConcealmentCasePrepView = {
+    visible: false,
+    activationTags: [],
+    triggerRows: [],
+    previewApplied: false,
+    previewReasonLabel: 'No activation rule matched yet',
+    previewStatusLabel: 'Open posture — no covert activation on the next weekly tick',
+    playerConcealFlagActive: false,
+    canToggleConcealFlag: false,
+  }
+
+  if (!canShowConcealmentCasePrepOnCase(caseData)) {
+    return emptyView
+  }
+
+  const globalFlags = readGameStateManager(game).globalFlags
+  const hiddenModifierCount = countCaseHiddenModifiers(caseData, caseData.mapLayer)
+  const preview = resolveConcealmentActivation(caseData, {
+    globalFlags,
+    hiddenModifierCount,
+  })
+
+  const concealFlagId = buildConcealCaseFlagId(caseData.id)
+  const playerConcealFlagActive = isPersistentFlagSet(game, concealFlagId)
+
+  return {
+    visible: true,
+    activationTags: listConcealmentActivationTagsOnCase(caseData),
+    triggerRows: (caseData.concealmentTriggers ?? []).map((trigger) => ({
+      id: trigger.id,
+      modeLabel: MODE_LABELS[trigger.mode ?? 'hidden'],
+      whenSummary: summarizeConcealmentTriggerWhen(trigger),
+    })),
+    previewApplied: preview.applied,
+    previewMode: preview.mode,
+    previewReason: preview.reason,
+    previewReasonLabel: humanizePreviewReason(preview.reason),
+    previewStatusLabel: buildPreviewStatusLabel(preview.applied, preview.mode),
+    playerConcealFlagActive,
+    canToggleConcealFlag: canPlayerSetConcealCaseFlag(caseData),
+    hiddenModifierCount,
+  }
+}

--- a/src/test/concealmentCasePrepView.test.ts
+++ b/src/test/concealmentCasePrepView.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  buildConcealCaseFlagId,
+  canShowConcealmentCasePrepOnCase,
+} from '../domain/concealmentCasePrep'
+import { setPersistentFlag } from '../domain/flagSystem'
+import { buildConcealmentCasePrepView } from '../features/cases/concealmentCasePrepView'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createOpenCase(overrides: Record<string, unknown> = {}) {
+  return {
+    ...createStarterCase({ id: 'case-conceal-prep', templateId: 'ops-003' }),
+    status: 'in_progress' as const,
+    tags: ['infiltration'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+describe('concealmentCasePrepView', () => {
+  it('is visible only for in-progress cases without hidden state', () => {
+    const open = createOpenCase()
+    expect(canShowConcealmentCasePrepOnCase(open)).toBe(true)
+    expect(canShowConcealmentCasePrepOnCase({ ...open, status: 'resolved' })).toBe(false)
+    expect(canShowConcealmentCasePrepOnCase({ ...open, hiddenState: 'hidden' })).toBe(false)
+
+    const hidden = buildConcealmentCasePrepView(
+      { ...open, hiddenState: 'hidden' },
+      createStartingState()
+    )
+    expect(hidden.visible).toBe(false)
+  })
+
+  it('previews case-tag activation', () => {
+    const view = buildConcealmentCasePrepView(createOpenCase(), createStartingState())
+
+    expect(view.visible).toBe(true)
+    expect(view.previewApplied).toBe(true)
+    expect(view.previewReason).toBe('case-tag')
+    expect(view.previewReasonLabel).toContain('tags')
+    expect(view.activationTags).toContain('infiltration')
+  })
+
+  it('previews per-case conceal flag', () => {
+    let state = createStartingState()
+    state.cases['case-conceal-prep'] = createOpenCase({ tags: [] })
+
+    state = setPersistentFlag(state, buildConcealCaseFlagId('case-conceal-prep'), true)
+
+    const view = buildConcealmentCasePrepView(state.cases['case-conceal-prep']!, state)
+
+    expect(view.previewApplied).toBe(true)
+    expect(view.previewReason).toContain('conceal.case.')
+    expect(view.playerConcealFlagActive).toBe(true)
+  })
+
+  it('lists authored triggers and allows flag toggle when triggers exist', () => {
+    const caseData = createOpenCase({
+      tags: [],
+      concealmentTriggers: [
+        {
+          id: 'trigger:test-cover',
+          mode: 'hidden',
+          when: { anyTag: ['media'] },
+        },
+      ],
+    })
+
+    const view = buildConcealmentCasePrepView(caseData, createStartingState())
+
+    expect(view.triggerRows).toHaveLength(1)
+    expect(view.triggerRows[0]?.id).toBe('trigger:test-cover')
+    expect(view.canToggleConcealFlag).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the SPE-70 / SPE-2107 slice 3 case-detail prep surface for covert concealment activation.

## Changes

- **Preview** next-week `resolveConcealmentActivation` (hidden/displaced, reason label)
- **Authored triggers** list with mode and condition summaries
- **Player prep:** request/clear `conceal.case.{caseId}` via existing `setGlobalFlag` when case has concealment tags or triggers
- Panel is **first** in the weekly prep stack (concealment → infiltration → leave-behind → investigation)

## Verification

- `npm run lint`
- `npm run test:run` (3518 tests)

## Docs

- `planning/concealment-case-prep-slice.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

