### PR TITLE
Consolidate covert ops case prep into weekly panel

### DIFF
--- a/planning/concealment-case-prep-slice.md
+++ b/planning/concealment-case-prep-slice.md
@@ -7,7 +7,7 @@ After the infiltration + investigation + leave-behind prep stack on case detail,
 | Candidate | Why / why not |
 | --- | --- |
 | **Concealment case prep (this plan)** | Domain shipped (`hiddenStateActivation.ts`, weekly wire in `advanceWeek`); **zero** case-detail UI today; closes backlog #1 player-facing gap; same patterns as SPE-626 / SPE-521 / SPE-2247 prep slices. |
-| Case prep consolidation | Good polish after concealment panel exists (shared forensic strip, collapsible sections). |
+| Case prep consolidation | **Done** — `WeeklyCasePrepPanel` on case detail (`weeklyCasePrepView.ts`). |
 | Backlog #1 “full” hidden modalities | Too broad (SPE-781, modality matrix); defer. |
 | SPE-1464 branch continuity | **Done** in repo + Linear; no new slice. |
 | Route / multi-week navigation (backlog #3) | High value but different surface; does not complete covert-ops prep arc. |
@@ -170,13 +170,13 @@ Optional thin domain file: `src/domain/concealmentCasePrep.ts` if eligibility is
 
 - **Flag namespace collision:** only touch `conceal.case.{caseId}`; never write `conceal.` prefix from UI without explicit product decision.
 - **Preview drift:** preview must use same `globalFlags` source as `applyWeeklyConcealmentActivation` in `advanceWeek` — verify call site when wiring.
-- **Panel clutter:** four prep panels on full covert cases — consolidation is a follow-up, not a blocker.
+- **Panel clutter:** addressed via weekly prep consolidation on case detail.
 
 ---
 
 ## Follow-ups (after this slice)
 
-1. **Covert ops prep consolidation** — single “Weekly prep” region with subsections.
+1. ~~**Covert ops prep consolidation**~~ — shipped (`WeeklyCasePrepPanel`, collapsible sections, shared forensic strip).
 2. **Concealment event feed** — surface `activation.reason` on first weekly apply (if not already in event payload).
 3. **Remaining templates** without `concealmentTriggers` — content-only batches, not UI.
 

--- a/planning/investigation-question-case-prep-slice.md
+++ b/planning/investigation-question-case-prep-slice.md
@@ -108,14 +108,14 @@ askInvestigationQuestion: (caseId, domain, questionId) => void
 ## Risks
 
 - **Double spend:** store must use domain result; do not decrement clocks locally
-- **Panel clutter:** three panels on infiltration cases — acceptable for slice; consolidate budget strip in follow-up
+- **Panel clutter:** addressed via `WeeklyCasePrepPanel` consolidation on case detail.
 - **SPE-626 Linear status:** domain AC largely met in repo; close parent or add child issue when UI ships
 
 ## Runner-up (next after this)
 
 1. ~~**Infiltration case prep panel**~~ — shipped; see `planning/infiltration-case-prep-slice.md`.
 2. **Concealment case prep panel** — `planning/concealment-case-prep-slice.md` (SPE-70 / SPE-2107 slice 3 UX; backlog #1 player-facing gap).
-3. **Covert ops prep consolidation** — merge forensic strip / collapse four prep panels on infiltration cases.
+3. ~~**Covert ops prep consolidation**~~ — shipped (`WeeklyCasePrepPanel` on case detail).
 4. ~~**SPE-1464**~~ — done in repo; branch continuity validator shipped.
 
 ## See also

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -155,19 +155,18 @@ it('shows concealment prep and toggles covert posture flag', async () => {
   useGameStore.setState({ game })
   renderCaseDetail('/cases/case-conceal-ui')
 
-  const panel = screen.getByRole('region', { name: /concealment case prep/i })
+  const weeklyPrep = screen.getByRole('region', { name: /weekly case prep/i })
 
-  expect(within(panel).getByRole('heading', { name: /concealment prep/i })).toBeInTheDocument()
-  expect(within(panel).getByText(/next weekly tick will mark this case as hidden/i)).toBeInTheDocument()
+  expect(within(weeklyPrep).getByText(/next weekly tick will mark this case as hidden/i)).toBeInTheDocument()
 
-  await user.click(within(panel).getByRole('button', { name: /request covert posture/i }))
+  await user.click(within(weeklyPrep).getByRole('button', { name: /request covert posture/i }))
 
   expect(
     useGameStore.getState().game.runtimeState?.globalFlags?.['conceal.case.case-conceal-ui'] ??
       useGameStore.getState().game.globalFlags?.['conceal.case.case-conceal-ui']
   ).toBeTruthy()
 
-  await user.click(within(panel).getByRole('button', { name: /clear covert request/i }))
+  await user.click(within(weeklyPrep).getByRole('button', { name: /clear covert request/i }))
 
   const flag =
     useGameStore.getState().game.runtimeState?.globalFlags?.['conceal.case.case-conceal-ui'] ??
@@ -199,20 +198,19 @@ it('shows infiltration prep and sets weekly probe action override', async () => 
   useGameStore.setState({ game })
   renderCaseDetail('/cases/case-stealth-ui')
 
-  const panel = screen.getByRole('region', { name: /infiltration case prep/i })
+  const weeklyPrep = screen.getByRole('region', { name: /weekly case prep/i })
 
-  expect(within(panel).getByRole('heading', { name: /infiltration prep/i })).toBeInTheDocument()
-  expect(within(panel).getByText(/probe progress 20%/i)).toBeInTheDocument()
-  expect(within(panel).getByText(/uniform guard/i)).toBeInTheDocument()
+  expect(within(weeklyPrep).getByText(/probe progress 20%/i)).toBeInTheDocument()
+  expect(within(weeklyPrep).getByText(/uniform guard/i)).toBeInTheDocument()
 
-  const cleanupRow = within(panel).getByText(/clean up cover/i).closest('li')
+  const cleanupRow = within(weeklyPrep).getByText(/clean up cover/i).closest('li')
   expect(cleanupRow).not.toBeNull()
   await user.click(within(cleanupRow as HTMLElement).getByRole('button', { name: /^select$/i }))
 
   expect(
     useGameStore.getState().game.cases['case-stealth-ui']?.infiltrationWeeklyProbeActionOverride
   ).toBe('cleanup')
-  expect(within(panel).getByRole('button', { name: /use plan default/i })).toBeInTheDocument()
+  expect(within(weeklyPrep).getByRole('button', { name: /use plan default/i })).toBeInTheDocument()
 })
 
 it('shows stealth leave-behind tradeoff selection for eligible in-progress hidden cases', async () => {
@@ -235,19 +233,18 @@ it('shows stealth leave-behind tradeoff selection for eligible in-progress hidde
   useGameStore.setState({ game })
   renderCaseDetail('/cases/case-stealth-ui')
 
-  const panel = screen.getByRole('region', { name: /stealth leave-behind tradeoff/i })
+  const weeklyPrep = screen.getByRole('region', { name: /weekly case prep/i })
 
-  expect(within(panel).getByRole('heading', { name: /stealth leave-behind/i })).toBeInTheDocument()
-  expect(within(panel).getByLabelText(/forensic investigation budget/i)).toBeInTheDocument()
-  expect(within(panel).getByText(/leave forensic trace/i)).toBeInTheDocument()
-  expect(within(panel).getByRole('button', { name: /selected/i })).toBeInTheDocument()
+  expect(within(weeklyPrep).getAllByLabelText(/forensic investigation budget/i)).toHaveLength(1)
+  expect(within(weeklyPrep).getByText(/leave forensic trace/i)).toBeInTheDocument()
+  expect(within(weeklyPrep).getByRole('button', { name: /selected/i })).toBeInTheDocument()
 
-  const burnRow = within(panel).getByText(/burn field tool/i).closest('li')
+  const burnRow = within(weeklyPrep).getByText(/burn field tool/i).closest('li')
   expect(burnRow).not.toBeNull()
   await user.click(within(burnRow as HTMLElement).getByRole('button', { name: /^select$/i }))
 
-  expect(within(panel).getByText(/burn field tool/i)).toBeInTheDocument()
-  expect(within(panel).getAllByRole('button', { name: /selected/i })).toHaveLength(1)
+  expect(within(weeklyPrep).getByText(/burn field tool/i)).toBeInTheDocument()
+  expect(within(weeklyPrep).getAllByRole('button', { name: /selected/i })).toHaveLength(1)
   expect(useGameStore.getState().game.cases['case-stealth-ui']?.stealthLeaveBehindId).toBe(
     'leave-behind:burn-tool'
   )
@@ -276,9 +273,9 @@ it('shows investigation question prep and asks a forensic question', async () =>
   useGameStore.setState({ game })
   renderCaseDetail('/cases/case-investigation-ui')
 
-  const panel = screen.getByRole('region', { name: /investigation question prep/i })
+  const weeklyPrep = screen.getByRole('region', { name: /weekly case prep/i })
+  const panel = within(weeklyPrep).getByRole('group', { name: /investigation question prep/i })
 
-  expect(within(panel).getByRole('heading', { name: /investigation questions/i })).toBeInTheDocument()
   expect(within(panel).getByText(/concrete signature is present/i)).toBeInTheDocument()
 
   const forensicSection = within(panel).getByRole('region', { name: /forensic inquiry/i })
@@ -314,7 +311,8 @@ it('shows investigation prep empty state when no budget is granted yet', () => {
   useGameStore.setState({ game })
   renderCaseDetail('/cases/case-investigation-ui')
 
-  const panel = screen.getByRole('region', { name: /investigation question prep/i })
+  const weeklyPrep = screen.getByRole('region', { name: /weekly case prep/i })
+  const panel = within(weeklyPrep).getByRole('group', { name: /investigation question prep/i })
 
   expect(within(panel).getByText(/no investigation budget on this case yet/i)).toBeInTheDocument()
   expect(within(panel).queryByRole('region', { name: /forensic inquiry/i })).not.toBeInTheDocument()
@@ -333,7 +331,7 @@ it('hides investigation question prep when the case is not in progress', () => {
   useGameStore.setState({ game })
   renderCaseDetail('/cases/case-investigation-ui')
 
-  expect(screen.queryByRole('region', { name: /investigation question prep/i })).not.toBeInTheDocument()
+  expect(screen.queryByRole('group', { name: /investigation question prep/i })).not.toBeInTheDocument()
 })
 
 it('hides stealth leave-behind tradeoff when the case is not eligible', () => {
@@ -353,7 +351,7 @@ it('hides stealth leave-behind tradeoff when the case is not eligible', () => {
   useGameStore.setState({ game })
   renderCaseDetail('/cases/case-stealth-ui')
 
-  expect(screen.queryByRole('region', { name: /stealth leave-behind tradeoff/i })).not.toBeInTheDocument()
+  expect(screen.queryByRole('group', { name: /stealth leave-behind tradeoff/i })).not.toBeInTheDocument()
 })
 
 it('shows pre-commit injury, death, and downtime warnings for available teams', () => {

--- a/src/features/cases/CaseDetailPage.tsx
+++ b/src/features/cases/CaseDetailPage.tsx
@@ -22,10 +22,7 @@ import { type CaseInstance, type GameState, type Team } from '../../domain/model
 import { getCaseTemplateIntelView } from './caseIntelProjection'
 import { getCaseAssignmentInsights } from './caseInsights'
 import { getCaseListItemView } from './caseView'
-import { ConcealmentCasePrepPanel } from './ConcealmentCasePrepPanel'
-import { InfiltrationCasePrepPanel } from './InfiltrationCasePrepPanel'
-import { InvestigationCasePrepPanel } from './InvestigationCasePrepPanel'
-import { StealthLeaveBehindSelectionPanel } from './StealthLeaveBehindSelectionPanel'
+import { WeeklyCasePrepPanel } from './WeeklyCasePrepPanel'
 
 export default function CaseDetailPage() {
   const { caseId } = useParams()
@@ -329,13 +326,7 @@ export default function CaseDetailPage() {
             )}
           </article>
 
-          <ConcealmentCasePrepPanel caseData={currentCase} />
-
-          <InfiltrationCasePrepPanel caseData={currentCase} />
-
-          <StealthLeaveBehindSelectionPanel caseData={currentCase} />
-
-          <InvestigationCasePrepPanel caseData={currentCase} />
+          <WeeklyCasePrepPanel caseData={currentCase} />
 
           <article
             className="panel panel-support space-y-3"

--- a/src/features/cases/ConcealmentCasePrepPanel.tsx
+++ b/src/features/cases/ConcealmentCasePrepPanel.tsx
@@ -7,7 +7,15 @@ import {
   type ConcealmentTriggerRowView,
 } from './concealmentCasePrepView'
 
-export function ConcealmentCasePrepPanel({ caseData }: { caseData: CaseInstance }) {
+import type { CasePrepPanelLayout } from './casePrepPanelLayout'
+
+export function ConcealmentCasePrepPanel({
+  caseData,
+  layout = 'standalone',
+}: {
+  caseData: CaseInstance
+  layout?: CasePrepPanelLayout
+}) {
   const game = useGameStore((state) => state.game)
   const setGlobalFlag = useGameStore((state) => state.setGlobalFlag)
   const view = buildConcealmentCasePrepView(caseData, game)
@@ -17,14 +25,11 @@ export function ConcealmentCasePrepPanel({ caseData }: { caseData: CaseInstance 
   }
 
   const concealFlagId = buildConcealCaseFlagId(caseData.id)
+  const embedded = layout === 'embedded'
 
-  return (
-    <article
-      className="panel panel-support space-y-4"
-      role="region"
-      aria-label="Concealment case prep"
-    >
-      <PanelHeader />
+  const content = (
+    <>
+      {embedded ? null : <PanelHeader />}
 
       <p className="text-sm opacity-60">
         Preview how concealment rules resolve before weekly resolution. Request covert posture to
@@ -75,6 +80,24 @@ export function ConcealmentCasePrepPanel({ caseData }: { caseData: CaseInstance 
           </p>
         </section>
       ) : null}
+    </>
+  )
+
+  if (embedded) {
+    return (
+      <div className="space-y-4" role="group" aria-label="Concealment case prep">
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-4"
+      role="region"
+      aria-label="Concealment case prep"
+    >
+      {content}
     </article>
   )
 }

--- a/src/features/cases/ForensicInvestigationBudgetStrip.tsx
+++ b/src/features/cases/ForensicInvestigationBudgetStrip.tsx
@@ -1,0 +1,28 @@
+import type { InvestigationBudgetView } from './investigationCasePrepView'
+
+export function ForensicInvestigationBudgetStrip({
+  budget,
+  custodyMarkerCount,
+}: {
+  budget: InvestigationBudgetView
+  custodyMarkerCount: number
+}) {
+  return (
+    <div
+      className="rounded border border-sky-400/25 bg-sky-500/6 px-3 py-2 text-sm"
+      aria-label="Forensic investigation budget"
+    >
+      <p className="text-xs uppercase tracking-wide opacity-60">Forensic investigation budget</p>
+      <p className="mt-1">
+        <span className="opacity-60">Remaining:</span>{' '}
+        <span className="font-medium">{budget.remaining}</span>
+        <span className="opacity-50">
+          {' '}
+          (granted {budget.granted}, spent {budget.spent}, custody burden {budget.custodyLossBurden}
+          {custodyMarkerCount === 1 ? ' / 1 marker' : custodyMarkerCount > 1 ? ` / ${custodyMarkerCount} markers` : ''}
+          )
+        </span>
+      </p>
+    </div>
+  )
+}

--- a/src/features/cases/InfiltrationCasePrepPanel.tsx
+++ b/src/features/cases/InfiltrationCasePrepPanel.tsx
@@ -6,7 +6,15 @@ import {
   type InfiltrationProbeActionOptionView,
 } from './infiltrationCasePrepView'
 
-export function InfiltrationCasePrepPanel({ caseData }: { caseData: CaseInstance }) {
+import type { CasePrepPanelLayout } from './casePrepPanelLayout'
+
+export function InfiltrationCasePrepPanel({
+  caseData,
+  layout = 'standalone',
+}: {
+  caseData: CaseInstance
+  layout?: CasePrepPanelLayout
+}) {
   const setInfiltrationWeeklyProbeAction = useGameStore(
     (state) => state.setInfiltrationWeeklyProbeAction
   )
@@ -16,13 +24,11 @@ export function InfiltrationCasePrepPanel({ caseData }: { caseData: CaseInstance
     return null
   }
 
-  return (
-    <article
-      className="panel panel-support space-y-4"
-      role="region"
-      aria-label="Infiltration case prep"
-    >
-      <PanelHeader />
+  const embedded = layout === 'embedded'
+
+  const content = (
+    <>
+      {embedded ? null : <PanelHeader />}
 
       <p className="text-sm opacity-60">
         Review probe tracks and cover posture before weekly resolution. Override the next weekly
@@ -77,6 +83,24 @@ export function InfiltrationCasePrepPanel({ caseData }: { caseData: CaseInstance
           </button>
         ) : null}
       </section>
+    </>
+  )
+
+  if (embedded) {
+    return (
+      <div className="space-y-4" role="group" aria-label="Infiltration case prep">
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-4"
+      role="region"
+      aria-label="Infiltration case prep"
+    >
+      {content}
     </article>
   )
 }

--- a/src/features/cases/InvestigationCasePrepPanel.tsx
+++ b/src/features/cases/InvestigationCasePrepPanel.tsx
@@ -7,7 +7,15 @@ import {
   type InvestigationQuestionRowView,
 } from './investigationCasePrepView'
 
-export function InvestigationCasePrepPanel({ caseData }: { caseData: CaseInstance }) {
+import type { CasePrepPanelLayout } from './casePrepPanelLayout'
+
+export function InvestigationCasePrepPanel({
+  caseData,
+  layout = 'standalone',
+}: {
+  caseData: CaseInstance
+  layout?: CasePrepPanelLayout
+}) {
   const game = useGameStore((state) => state.game)
   const askInvestigationQuestion = useGameStore((state) => state.askInvestigationQuestion)
   const view = buildInvestigationCasePrepView(caseData, game)
@@ -16,19 +24,16 @@ export function InvestigationCasePrepPanel({ caseData }: { caseData: CaseInstanc
     return null
   }
 
+  const embedded = layout === 'embedded'
   const hasAnyBudget =
     view.forensic.budget.granted > 0 ||
     view.forensic.budget.spent > 0 ||
     view.tactical.budget.granted > 0 ||
     view.tactical.budget.spent > 0
 
-  return (
-    <article
-      className="panel panel-support space-y-4"
-      role="region"
-      aria-label="Investigation question prep"
-    >
-      <PanelHeader />
+  const content = (
+    <>
+      {embedded ? null : <PanelHeader />}
 
       <p className="text-sm opacity-60">
         Spend investigation question budget before weekly resolution. Forensic custody strain from
@@ -44,7 +49,7 @@ export function InvestigationCasePrepPanel({ caseData }: { caseData: CaseInstanc
         <>
           <InvestigationDomainSection
             domainView={view.forensic}
-            showCustodyBurden
+            showCustodyBurden={!embedded}
             onAsk={(questionId) => askInvestigationQuestion(caseData.id, 'forensic', questionId)}
           />
 
@@ -73,6 +78,24 @@ export function InvestigationCasePrepPanel({ caseData }: { caseData: CaseInstanc
           </ul>
         </section>
       ) : null}
+    </>
+  )
+
+  if (embedded) {
+    return (
+      <div className="space-y-4" role="group" aria-label="Investigation question prep">
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-4"
+      role="region"
+      aria-label="Investigation question prep"
+    >
+      {content}
     </article>
   )
 }

--- a/src/features/cases/StealthLeaveBehindSelectionPanel.tsx
+++ b/src/features/cases/StealthLeaveBehindSelectionPanel.tsx
@@ -1,11 +1,18 @@
 import { useGameStore } from '../../app/store/gameStore'
 import type { CaseInstance } from '../../domain/models'
+import type { CasePrepPanelLayout } from './casePrepPanelLayout'
 import {
   buildStealthLeaveBehindSelectionView,
   type StealthLeaveBehindOptionView,
 } from './stealthLeaveBehindSelectionView'
 
-export function StealthLeaveBehindSelectionPanel({ caseData }: { caseData: CaseInstance }) {
+export function StealthLeaveBehindSelectionPanel({
+  caseData,
+  layout = 'standalone',
+}: {
+  caseData: CaseInstance
+  layout?: CasePrepPanelLayout
+}) {
   const game = useGameStore((state) => state.game)
   const selectStealthLeaveBehind = useGameStore((state) => state.selectStealthLeaveBehind)
   const view = buildStealthLeaveBehindSelectionView(caseData, game)
@@ -14,38 +21,40 @@ export function StealthLeaveBehindSelectionPanel({ caseData }: { caseData: CaseI
     return null
   }
 
-  return (
-    <article
-      className="panel panel-support space-y-3"
-      role="region"
-      aria-label="Stealth leave-behind tradeoff"
-    >
-      <div className="space-y-1">
-        <h3 className="text-lg font-semibold">Stealth leave-behind</h3>
-        <p className="text-xs uppercase tracking-wide opacity-50">Extraction tradeoff</p>
-      </div>
+  const embedded = layout === 'embedded'
+
+  const content = (
+    <>
+      {embedded ? null : (
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold">Stealth leave-behind</h3>
+          <p className="text-xs uppercase tracking-wide opacity-50">Extraction tradeoff</p>
+        </div>
+      )}
 
       <p className="text-sm opacity-60">
         Choose the extraction tradeoff before weekly resolution. Discovery risk feeds mission score
         pressure; custody refs strain forensic investigation budget after resolution.
       </p>
 
-      <div
-        className="rounded border border-sky-400/25 bg-sky-500/6 px-3 py-2 text-sm"
-        aria-label="Forensic investigation budget"
-      >
-        <p className="text-xs uppercase tracking-wide opacity-60">Forensic investigation budget</p>
-        <p className="mt-1">
-          <span className="opacity-60">Remaining:</span>{' '}
-          <span className="font-medium">{view.forensicBudget.remaining}</span>
-          <span className="opacity-50">
-            {' '}
-            (granted {view.forensicBudget.granted}, spent {view.forensicBudget.spent}, custody
-            burden {view.forensicBudget.custodyLossBurden}
-            {view.forensicBudget.markerCount === 1 ? ' marker' : ' markers'})
-          </span>
-        </p>
-      </div>
+      {embedded ? null : (
+        <div
+          className="rounded border border-sky-400/25 bg-sky-500/6 px-3 py-2 text-sm"
+          aria-label="Forensic investigation budget"
+        >
+          <p className="text-xs uppercase tracking-wide opacity-60">Forensic investigation budget</p>
+          <p className="mt-1">
+            <span className="opacity-60">Remaining:</span>{' '}
+            <span className="font-medium">{view.forensicBudget.remaining}</span>
+            <span className="opacity-50">
+              {' '}
+              (granted {view.forensicBudget.granted}, spent {view.forensicBudget.spent}, custody
+              burden {view.forensicBudget.custodyLossBurden}
+              {view.forensicBudget.markerCount === 1 ? ' marker' : ' markers'})
+            </span>
+          </p>
+        </div>
+      )}
 
       <ul className="space-y-2">
         {view.options.map((option) => (
@@ -64,6 +73,24 @@ export function StealthLeaveBehindSelectionPanel({ caseData }: { caseData: CaseI
           </li>
         ))}
       </ul>
+    </>
+  )
+
+  if (embedded) {
+    return (
+      <div className="space-y-3" role="group" aria-label="Stealth leave-behind tradeoff">
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-3"
+      role="region"
+      aria-label="Stealth leave-behind tradeoff"
+    >
+      {content}
     </article>
   )
 }

--- a/src/features/cases/WeeklyCasePrepPanel.tsx
+++ b/src/features/cases/WeeklyCasePrepPanel.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from 'react'
+import { useGameStore } from '../../app/store/gameStore'
+import type { CaseInstance } from '../../domain/models'
+import { ConcealmentCasePrepPanel } from './ConcealmentCasePrepPanel'
+import { ForensicInvestigationBudgetStrip } from './ForensicInvestigationBudgetStrip'
+import { InfiltrationCasePrepPanel } from './InfiltrationCasePrepPanel'
+import { InvestigationCasePrepPanel } from './InvestigationCasePrepPanel'
+import { StealthLeaveBehindSelectionPanel } from './StealthLeaveBehindSelectionPanel'
+import { buildWeeklyCasePrepView } from './weeklyCasePrepView'
+
+export function WeeklyCasePrepPanel({ caseData }: { caseData: CaseInstance }) {
+  const game = useGameStore((state) => state.game)
+  const view = buildWeeklyCasePrepView(caseData, game)
+
+  if (!view.visible) {
+    return null
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-4"
+      role="region"
+      aria-label="Weekly case prep"
+    >
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold">Weekly prep</h3>
+        <p className="text-xs uppercase tracking-wide opacity-50">Covert operations</p>
+      </div>
+
+      <p className="text-sm opacity-60">
+        Configure concealment, infiltration, extraction tradeoffs, and investigation questions before
+        weekly resolution. Sections collapse for a shorter dossier view.
+      </p>
+
+      {view.showSharedForensicBudget ? (
+        <ForensicInvestigationBudgetStrip
+          budget={view.forensicBudget}
+          custodyMarkerCount={view.custodyMarkerCount}
+        />
+      ) : null}
+
+      <div className="space-y-3">
+        {view.sections.concealment ? (
+          <WeeklyPrepSection title="Concealment" defaultOpen>
+            <ConcealmentCasePrepPanel caseData={caseData} layout="embedded" />
+          </WeeklyPrepSection>
+        ) : null}
+
+        {view.sections.infiltration ? (
+          <WeeklyPrepSection title="Infiltration" defaultOpen>
+            <InfiltrationCasePrepPanel caseData={caseData} layout="embedded" />
+          </WeeklyPrepSection>
+        ) : null}
+
+        {view.sections.stealthLeaveBehind ? (
+          <WeeklyPrepSection title="Stealth leave-behind" defaultOpen>
+            <StealthLeaveBehindSelectionPanel caseData={caseData} layout="embedded" />
+          </WeeklyPrepSection>
+        ) : null}
+
+        {view.sections.investigation ? (
+          <WeeklyPrepSection title="Investigation questions" defaultOpen>
+            <InvestigationCasePrepPanel caseData={caseData} layout="embedded" />
+          </WeeklyPrepSection>
+        ) : null}
+      </div>
+    </article>
+  )
+}
+
+function WeeklyPrepSection({
+  title,
+  defaultOpen,
+  children,
+}: {
+  title: string
+  defaultOpen?: boolean
+  children: ReactNode
+}) {
+  return (
+    <details className="weekly-prep-section rounded border border-white/10 bg-white/[0.03]" open={defaultOpen}>
+      <summary className="cursor-pointer px-3 py-2 text-sm font-semibold marker:opacity-60">
+        {title}
+      </summary>
+      <div className="space-y-4 border-t border-white/10 px-3 py-3">{children}</div>
+    </details>
+  )
+}

--- a/src/features/cases/casePrepPanelLayout.ts
+++ b/src/features/cases/casePrepPanelLayout.ts
@@ -1,0 +1,1 @@
+export type CasePrepPanelLayout = 'standalone' | 'embedded'

--- a/src/features/cases/weeklyCasePrepView.ts
+++ b/src/features/cases/weeklyCasePrepView.ts
@@ -1,0 +1,60 @@
+import { listInvestigationCustodyLossMarkers } from '../../domain/investigationCustodyLoss'
+import { readInvestigationBudget } from '../../domain/investigationEconomy'
+import type { CaseInstance, GameState } from '../../domain/models'
+import { buildConcealmentCasePrepView } from './concealmentCasePrepView'
+import { buildInfiltrationCasePrepView } from './infiltrationCasePrepView'
+import {
+  buildInvestigationCasePrepView,
+  type InvestigationBudgetView,
+} from './investigationCasePrepView'
+import { buildStealthLeaveBehindSelectionView } from './stealthLeaveBehindSelectionView'
+
+export interface WeeklyCasePrepSectionsView {
+  readonly concealment: boolean
+  readonly infiltration: boolean
+  readonly stealthLeaveBehind: boolean
+  readonly investigation: boolean
+}
+
+export interface WeeklyCasePrepView {
+  readonly visible: boolean
+  readonly sections: WeeklyCasePrepSectionsView
+  readonly showSharedForensicBudget: boolean
+  readonly forensicBudget: InvestigationBudgetView
+  readonly custodyMarkerCount: number
+}
+
+export function buildWeeklyCasePrepView(
+  caseData: CaseInstance,
+  game: GameState
+): WeeklyCasePrepView {
+  const concealment = buildConcealmentCasePrepView(caseData, game)
+  const infiltration = buildInfiltrationCasePrepView(caseData)
+  const stealth = buildStealthLeaveBehindSelectionView(caseData, game)
+  const investigation = buildInvestigationCasePrepView(caseData, game)
+
+  const sections: WeeklyCasePrepSectionsView = {
+    concealment: concealment.visible,
+    infiltration: infiltration.visible,
+    stealthLeaveBehind: stealth.visible,
+    investigation: investigation.visible,
+  }
+
+  const visible = Object.values(sections).some(Boolean)
+  const forensicBudget = readInvestigationBudget(game, caseData.id, 'forensic')
+  const custodyMarkerCount = listInvestigationCustodyLossMarkers(game, caseData.id).length
+
+  return {
+    visible,
+    sections,
+    showSharedForensicBudget: sections.stealthLeaveBehind || sections.investigation,
+    forensicBudget: {
+      granted: forensicBudget.granted,
+      spent: forensicBudget.spent,
+      custodyLossBurden: forensicBudget.custodyLossBurden,
+      remaining: forensicBudget.remaining,
+      maxBudget: forensicBudget.maxBudget,
+    },
+    custodyMarkerCount,
+  }
+}

--- a/src/test/weeklyCasePrepView.test.ts
+++ b/src/test/weeklyCasePrepView.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { applySuccessfulInvestigation } from '../domain/investigationEconomy'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { buildWeeklyCasePrepView } from '../features/cases/weeklyCasePrepView'
+
+describe('weeklyCasePrepView', () => {
+  it('is visible when any prep subsection applies', () => {
+    const state = createStartingState()
+    state.cases['case-weekly-prep'] = {
+      ...createStarterCase({ id: 'case-weekly-prep', templateId: 'ops-003' }),
+      status: 'in_progress',
+      tags: ['infiltration'],
+      requiredTags: [],
+      preferredTags: [],
+    }
+
+    const view = buildWeeklyCasePrepView(state.cases['case-weekly-prep']!, state)
+
+    expect(view.visible).toBe(true)
+    expect(view.sections.concealment).toBe(true)
+    expect(view.sections.infiltration).toBe(false)
+  })
+
+  it('shows shared forensic budget when stealth or investigation prep applies', () => {
+    let state = createStartingState()
+    state.cases['case-weekly-prep'] = {
+      ...createStarterCase({ id: 'case-weekly-prep', templateId: 'ops-003' }),
+      status: 'in_progress',
+      hiddenState: 'hidden',
+      tags: ['infiltration', 'archive', 'records'],
+      stealthLeaveBehindId: 'leave-behind:leave-trace',
+      requiredTags: [],
+      preferredTags: [],
+    }
+
+    state = applySuccessfulInvestigation(state, {
+      caseId: 'case-weekly-prep',
+      forensicBudget: 1,
+      tacticalBudget: 1,
+    })
+
+    const view = buildWeeklyCasePrepView(state.cases['case-weekly-prep']!, state)
+
+    expect(view.showSharedForensicBudget).toBe(true)
+    expect(view.forensicBudget.remaining).toBeGreaterThan(0)
+    expect(view.sections.stealthLeaveBehind).toBe(true)
+    expect(view.sections.investigation).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces four separate case-detail prep articles (concealment, infiltration, stealth leave-behind, investigation) with a single **Weekly prep** region. Subsections use collapsible `<details>` blocks; stealth and investigation share one **Forensic investigation budget** strip at the top when either section is visible.

## Changes

- `WeeklyCasePrepPanel` + `buildWeeklyCasePrepView()` orchestrate section visibility and shared budget.
- `ForensicInvestigationBudgetStrip` extracted for the shared strip.
- Sub-panels accept `layout="embedded"` (`role="group"`, no duplicate headers or forensic strip).
- `CaseDetailPage` renders only `WeeklyCasePrepPanel`.
- Tests updated for weekly prep scoping; `weeklyCasePrepView.test.ts` added.
- Planning docs mark consolidation follow-up as shipped.

## Verification

- `npm run lint`
- `npm run test:run` (3520 tests)

## Reviewer notes

- Section order: Concealment → Infiltration → Stealth leave-behind → Investigation.
- Standalone layout remains on sub-panels for potential reuse; case detail uses embedded only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

