### PR TITLE
Emit concealment activation events on first weekly apply

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -15,7 +15,7 @@ From `README.md` **Current design notes**:
 
 ## Queue (highest leverage first — reorder as needed)
 
-1. **Hidden / disguised activation** — Runtime + authored triggers shipped (SPE-2107 / SPE-2113); **next slice:** concealment case prep UI (`planning/concealment-case-prep-slice.md`) so players can preview activation and set `conceal.case.{id}` before weekly resolution.
+1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, and activation event feed shipped (SPE-2107 / SPE-2113); **next:** content batches for templates without `concealmentTriggers`, or infiltration follow-through (backlog #2).
 2. **Infiltration and access follow-through** — Expand follow-on infiltration and access work that consumes hidden-state and behavior-validation surfaces (keeps one rules substrate).
 3. **Route and week navigation** — Extend route-level drill-down and multi-week navigation coverage (legibility and QA for long runs).
 4. **Core UX specs** — Finish or refresh core UX specs so surfaces match canonical domain outputs (`planning/roadmap.md` §15).

--- a/planning/concealment-activation-event-feed-slice.md
+++ b/planning/concealment-activation-event-feed-slice.md
@@ -1,0 +1,30 @@
+# Concealment activation event feed (SPE-2107 follow-up)
+
+## Goal
+
+When weekly `applyConcealmentActivationToCase` first applies hidden or displaced presence on an in-progress case, emit a deterministic operation event and weekly report note that surfaces `activation.reason` for the front desk / event feed.
+
+## Scope
+
+- `concealment.activated` event draft from `advanceWeek` when `hiddenState` transitions from unset to `hidden` or `displaced`
+- Human-readable `summary` derived from `reason` (authored trigger, per-case flag, tag bridge, recon bridge)
+- Event feed + report note wiring (mirror infiltration probe events)
+
+## Out of scope
+
+- Re-activation when already concealed
+- Case prep UI changes (shipped in weekly prep panel)
+- Full SPE-781 modality matrix
+
+## Acceptance
+
+- [x] `advanceWeek` emits `concealment.activated` with `mode`, `reason`, and `summary` on first activation
+- [x] Event appears in `game.events` and weekly `report.notes`
+- [x] Event feed renders title/detail with case link
+- [x] Tests: summary formatter + integration on conceal flags and authored triggers
+
+## See also
+
+- `planning/concealment-case-prep-slice.md` (prep UI + consolidation done)
+- `src/domain/hiddenStateActivation.ts`
+- `src/test/advanceWeek.concealmentActivation.integration.test.ts`

--- a/planning/concealment-case-prep-slice.md
+++ b/planning/concealment-case-prep-slice.md
@@ -177,7 +177,7 @@ Optional thin domain file: `src/domain/concealmentCasePrep.ts` if eligibility is
 ## Follow-ups (after this slice)
 
 1. ~~**Covert ops prep consolidation**~~ — shipped (`WeeklyCasePrepPanel`, collapsible sections, shared forensic strip).
-2. **Concealment event feed** — surface `activation.reason` on first weekly apply (if not already in event payload).
+2. ~~**Concealment event feed**~~ — shipped (`concealment.activated` event + report notes; `planning/concealment-activation-event-feed-slice.md`).
 3. **Remaining templates** without `concealmentTriggers` — content-only batches, not UI.
 
 ---

--- a/src/domain/concealmentActivationFeed.ts
+++ b/src/domain/concealmentActivationFeed.ts
@@ -1,0 +1,41 @@
+import type { ConcealmentActivationMode } from './hiddenStateActivation'
+
+/**
+ * Player-facing one-line summary for concealment activation events.
+ * `reason` values come from `resolveConcealmentActivation`.
+ */
+export function formatConcealmentActivationSummary(
+  mode: ConcealmentActivationMode,
+  reason: string
+): string {
+  if (reason.startsWith('authored-trigger:')) {
+    const triggerId = reason.slice('authored-trigger:'.length)
+    return mode === 'displaced'
+      ? `Displaced cover activated (${triggerId}).`
+      : `Hidden presence activated (${triggerId}).`
+  }
+
+  if (reason.startsWith('global-flag:conceal.displace.')) {
+    return 'Displaced cover activated from weekly displacement flag.'
+  }
+
+  if (reason.startsWith('global-flag:conceal.case.')) {
+    return 'Hidden presence activated from weekly covert posture flag.'
+  }
+
+  if (reason.startsWith('global-flag-prefix:')) {
+    return 'Hidden presence activated from shared conceal directive.'
+  }
+
+  if (reason === 'case-tag') {
+    return 'Hidden presence activated from concealment-tagged operation.'
+  }
+
+  if (reason === 'recon-hidden-modifiers') {
+    return 'Hidden presence activated from recon modifier threshold.'
+  }
+
+  return mode === 'displaced'
+    ? `Displaced cover activated (${reason}).`
+    : `Hidden presence activated (${reason}).`
+}

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -584,6 +584,19 @@ const infiltrationProbeEventSchema = z
   })
   .strict()
 
+const concealmentActivatedEventSchema = z
+  .object({
+    week: weekSchema,
+    caseId: idSchema,
+    caseTitle: z.string(),
+    mode: z.enum(['hidden', 'displaced']),
+    reason: z.string(),
+    summary: z.string(),
+    detectionConfidence: z.number().optional(),
+    displacementTarget: idSchema.nullable().optional(),
+  })
+  .strict()
+
 const systemAcademyUpgradedSchema = z
   .object({
     week: weekSchema,
@@ -659,6 +672,7 @@ export const operationEventPayloadSchemas = {
   'infiltration.escalation_exposed': infiltrationProbeEventSchema,
   'infiltration.escalation_violent': infiltrationProbeEventSchema,
   'infiltration.cover_strain': infiltrationProbeEventSchema,
+  'concealment.activated': concealmentActivatedEventSchema,
   'system.academy_upgraded': systemAcademyUpgradedSchema,
   'system.equipment_recovered': z.object({}).passthrough(),
   'case.aggregate_battle': z.object({}).passthrough(),

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -614,6 +614,16 @@ export interface OperationEventPayloadMap {
     infiltrationProbeProgress?: number
     infiltrationStage?: 'probing' | 'exposed' | 'violent'
   }
+  'concealment.activated': {
+    week: number
+    caseId: Id
+    caseTitle: string
+    mode: 'hidden' | 'displaced'
+    reason: string
+    summary: string
+    detectionConfidence?: number
+    displacementTarget?: Id | null
+  }
   'system.academy_upgraded': {
     week: number
     tierBefore: number
@@ -694,6 +704,7 @@ export interface OperationEventTypeToSourceSystemMap {
   'infiltration.escalation_exposed': 'system'
   'infiltration.escalation_violent': 'system'
   'infiltration.cover_strain': 'system'
+  'concealment.activated': 'system'
   'system.academy_upgraded': 'system'
   'staff.coping.applied': 'agent'
   'staff.coping.misconduct': 'agent'
@@ -749,6 +760,7 @@ export const EVENT_TYPE_TO_SOURCE_SYSTEM: Readonly<OperationEventTypeToSourceSys
   'infiltration.escalation_exposed': 'system',
   'infiltration.escalation_violent': 'system',
   'infiltration.cover_strain': 'system',
+  'concealment.activated': 'system',
   'system.academy_upgraded': 'system',
   'staff.coping.applied': 'agent',
   'staff.coping.misconduct': 'agent',

--- a/src/domain/hiddenStateActivation.ts
+++ b/src/domain/hiddenStateActivation.ts
@@ -300,12 +300,11 @@ export function resolveConcealmentActivation(
   return { applied: false }
 }
 
-/** Merges activation fields onto a case when {@link resolveConcealmentActivation} applies. */
-export function applyConcealmentActivationToCase(
+/** Merges a pre-resolved activation onto a case without re-running resolution. */
+export function mergeConcealmentActivationResult(
   caseData: CaseInstance,
-  context: ConcealmentActivationContext
+  activation: ConcealmentActivationResult
 ): CaseInstance {
-  const activation = resolveConcealmentActivation(caseData, context)
   if (!activation.applied || !activation.mode) {
     return caseData
   }
@@ -326,4 +325,12 @@ export function applyConcealmentActivationToCase(
     detectionConfidence: activation.detectionConfidence,
     counterDetection: caseData.counterDetection ?? false,
   }
+}
+
+/** Merges activation fields onto a case when {@link resolveConcealmentActivation} applies. */
+export function applyConcealmentActivationToCase(
+  caseData: CaseInstance,
+  context: ConcealmentActivationContext
+): CaseInstance {
+  return mergeConcealmentActivationResult(caseData, resolveConcealmentActivation(caseData, context))
 }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1473,6 +1473,7 @@ export type ReportNoteType =
   | 'infiltration.escalation_exposed'
   | 'infiltration.escalation_violent'
   | 'infiltration.cover_strain'
+  | 'concealment.activated'
   | 'support.restored'
   | 'hub.opportunity'
   | 'hub.rumor'

--- a/src/domain/reportNotes.ts
+++ b/src/domain/reportNotes.ts
@@ -450,6 +450,20 @@ function buildReflectedReportNote(draft: AnyOperationEventDraft): {
         },
       }
 
+    case 'concealment.activated':
+      return {
+        content: `${draft.payload.caseTitle}: ${draft.payload.summary}`,
+        type: 'concealment.activated',
+        metadata: {
+          caseId: draft.payload.caseId,
+          caseTitle: draft.payload.caseTitle,
+          mode: draft.payload.mode,
+          reason: draft.payload.reason,
+          summary: draft.payload.summary,
+          displacementTarget: draft.payload.displacementTarget ?? null,
+        },
+      }
+
     case 'system.equipment_recovered':
       return {
         content: draft.payload.content,

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -178,7 +178,11 @@ import {
   buildExecutionInstabilityRouteShift,
 } from '../executionInstability'
 import { buildMissionRewardBreakdown } from '../missionResults'
-import { applyConcealmentActivationToCase } from '../hiddenStateActivation'
+import { formatConcealmentActivationSummary } from '../concealmentActivationFeed'
+import {
+  applyConcealmentActivationToCase,
+  resolveConcealmentActivation,
+} from '../hiddenStateActivation'
 import { applyWeeklyInfiltrationProbeTick } from '../infiltrationProbe'
 import {
   resolveAssignedCaseForWeek as resolveCanonicalAssignedCaseForWeek,
@@ -2091,13 +2095,30 @@ function applyWeeklyConcealmentActivation(
   caseData: CaseInstance
 ): CaseInstance {
   const globalFlags = context.nextState.globalFlags ?? context.sourceState.globalFlags ?? {}
-  const activatedCase = applyConcealmentActivationToCase(caseData, {
+  const activationContext = {
     globalFlags,
     hiddenModifierCount: countCaseHiddenModifiers(caseData, caseData.mapLayer),
-  })
+  }
+  const activation = resolveConcealmentActivation(caseData, activationContext)
+  const activatedCase = applyConcealmentActivationToCase(caseData, activationContext)
 
-  if (activatedCase !== caseData) {
+  if (activatedCase !== caseData && activation.applied && activation.mode) {
     context.nextState.cases[caseId] = activatedCase
+    const reason = activation.reason ?? 'unknown'
+    context.eventDrafts.push({
+      type: 'concealment.activated',
+      sourceSystem: 'system',
+      payload: {
+        week: context.sourceState.week,
+        caseId,
+        caseTitle: caseData.title,
+        mode: activation.mode,
+        reason,
+        summary: formatConcealmentActivationSummary(activation.mode, reason),
+        detectionConfidence: activation.detectionConfidence,
+        displacementTarget: activation.displacementTarget ?? null,
+      },
+    })
   }
 
   return activatedCase

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -180,7 +180,7 @@ import {
 import { buildMissionRewardBreakdown } from '../missionResults'
 import { formatConcealmentActivationSummary } from '../concealmentActivationFeed'
 import {
-  applyConcealmentActivationToCase,
+  mergeConcealmentActivationResult,
   resolveConcealmentActivation,
 } from '../hiddenStateActivation'
 import { applyWeeklyInfiltrationProbeTick } from '../infiltrationProbe'
@@ -2100,7 +2100,7 @@ function applyWeeklyConcealmentActivation(
     hiddenModifierCount: countCaseHiddenModifiers(caseData, caseData.mapLayer),
   }
   const activation = resolveConcealmentActivation(caseData, activationContext)
-  const activatedCase = applyConcealmentActivationToCase(caseData, activationContext)
+  const activatedCase = mergeConcealmentActivationResult(caseData, activation)
 
   if (activatedCase !== caseData && activation.applied && activation.mode) {
     context.nextState.cases[caseId] = activatedCase

--- a/src/features/dashboard/eventFeedView.ts
+++ b/src/features/dashboard/eventFeedView.ts
@@ -233,6 +233,7 @@ export const EVENT_TYPE_LABELS: Record<OperationEventType, string> = {
   'infiltration.escalation_exposed': 'Cover Exposed',
   'infiltration.escalation_violent': 'Violent Escalation',
   'infiltration.cover_strain': 'Cover Strain',
+  'concealment.activated': 'Concealment Activated',
 }
 
 export const EVENT_TYPE_CATEGORIES: Record<OperationEventType, EventFeedCategory> = {
@@ -288,6 +289,7 @@ export const EVENT_TYPE_CATEGORIES: Record<OperationEventType, EventFeedCategory
   'infiltration.escalation_exposed': 'incident_response',
   'infiltration.escalation_violent': 'incident_response',
   'infiltration.cover_strain': 'incident_response',
+  'concealment.activated': 'incident_response',
 }
 
 const EVENT_FEED_CATEGORIES = Object.keys(EVENT_CATEGORY_LABELS) as EventFeedCategory[]
@@ -1067,6 +1069,28 @@ export function buildEventFeedView(event: OperationEvent): EventFeedView {
         searchText:
           `side work ${event.payload.optionId} ${event.payload.outcome} agent ${event.payload.agentId}`.toLowerCase(),
       }
+
+    case 'concealment.activated': {
+      const modeLabel = event.payload.mode === 'displaced' ? 'Displaced cover' : 'Hidden presence'
+      const targetSuffix =
+        event.payload.mode === 'displaced' && event.payload.displacementTarget
+          ? ` / Target ${event.payload.displacementTarget}`
+          : ''
+
+      return {
+        event,
+        week: event.payload.week,
+        title: `${event.payload.caseTitle}: ${typeLabel}`,
+        detail: `Week ${event.payload.week} / ${modeLabel}${targetSuffix} / ${event.payload.summary}`,
+        sourceLabel,
+        typeLabel,
+        timestampLabel,
+        tone: 'neutral',
+        href: APP_ROUTES.caseDetail(event.payload.caseId),
+        searchText:
+          `${event.payload.caseTitle} ${event.payload.caseId} ${event.payload.summary} ${event.payload.reason} concealment`.toLowerCase(),
+      }
+    }
 
     case 'infiltration.awareness_complication':
     case 'infiltration.escalation_exposed':

--- a/src/test/advanceWeek.concealmentActivation.integration.test.ts
+++ b/src/test/advanceWeek.concealmentActivation.integration.test.ts
@@ -54,6 +54,30 @@ describe('advanceWeek concealment activation integration', () => {
     expect(revealedResult?.hiddenState).toBe('revealed')
     expect(displacedResult?.hiddenState).toBe('displaced')
     expect(displacedResult?.displacementTarget).toBe('safehouse-9')
+
+    const activationEvents = nextState.events.filter((event) => event.type === 'concealment.activated')
+    expect(activationEvents).toHaveLength(3)
+    expect(
+      activationEvents.map((event) => (event.payload as { caseId: string }).caseId).sort()
+    ).toEqual(['case-001', 'case-002', 'case-003'])
+
+    const hiddenEvent = activationEvents.find(
+      (event) => (event.payload as { caseId: string }).caseId === 'case-001'
+    )
+    expect(hiddenEvent?.payload).toMatchObject({
+      mode: 'hidden',
+      reason: 'global-flag:conceal.case.case-001',
+    })
+
+    const displacedEvent = activationEvents.find(
+      (event) => (event.payload as { caseId: string }).caseId === 'case-003'
+    )
+    expect(displacedEvent?.payload).toMatchObject({
+      mode: 'displaced',
+      displacementTarget: 'safehouse-9',
+    })
+
+    expect(lastReport.notes.some((note) => note.type === 'concealment.activated')).toBe(true)
   })
 
   it('activates hidden presence from authored concealment triggers during advanceWeek', () => {
@@ -92,5 +116,35 @@ describe('advanceWeek concealment activation integration', () => {
 
     expect(missionResult?.hiddenState).toBe('hidden')
     expect(nextState.cases['case-001'].hiddenState).toBe('hidden')
+
+    const activationEvent = nextState.events.find((event) => event.type === 'concealment.activated')
+    expect(activationEvent?.payload).toMatchObject({
+      caseId: 'case-001',
+      mode: 'hidden',
+      reason: 'authored-trigger:trigger:weekly-cover',
+    })
+    expect(lastReport.notes.some((note) => note.type === 'concealment.activated')).toBe(true)
+  })
+
+  it('does not emit concealment activation when the case is already concealed', () => {
+    const state = createStartingState()
+    const [teamA] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = { 'conceal.case.case-001': true }
+
+    const currentCase = state.cases['case-001']
+    currentCase.mode = 'deterministic'
+    currentCase.status = 'in_progress'
+    currentCase.assignedTeamIds = [teamA]
+    currentCase.weeksRemaining = 1
+    currentCase.hiddenState = 'hidden'
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.events.some((event) => event.type === 'concealment.activated')).toBe(false)
   })
 })

--- a/src/test/concealmentActivationFeed.test.ts
+++ b/src/test/concealmentActivationFeed.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { formatConcealmentActivationSummary } from '../domain/concealmentActivationFeed'
+
+describe('formatConcealmentActivationSummary', () => {
+  it('formats authored trigger reasons', () => {
+    expect(
+      formatConcealmentActivationSummary('hidden', 'authored-trigger:trigger:ops-003-vault-approach')
+    ).toBe('Hidden presence activated (trigger:ops-003-vault-approach).')
+    expect(
+      formatConcealmentActivationSummary('displaced', 'authored-trigger:trigger:cover-shift')
+    ).toBe('Displaced cover activated (trigger:cover-shift).')
+  })
+
+  it('formats global flag and bridge reasons', () => {
+    expect(formatConcealmentActivationSummary('hidden', 'global-flag:conceal.case.case-001')).toBe(
+      'Hidden presence activated from weekly covert posture flag.'
+    )
+    expect(
+      formatConcealmentActivationSummary('displaced', 'global-flag:conceal.displace.case-003')
+    ).toBe('Displaced cover activated from weekly displacement flag.')
+    expect(formatConcealmentActivationSummary('hidden', 'global-flag-prefix:conceal.')).toBe(
+      'Hidden presence activated from shared conceal directive.'
+    )
+    expect(formatConcealmentActivationSummary('hidden', 'case-tag')).toBe(
+      'Hidden presence activated from concealment-tagged operation.'
+    )
+    expect(formatConcealmentActivationSummary('hidden', 'recon-hidden-modifiers')).toBe(
+      'Hidden presence activated from recon modifier threshold.'
+    )
+  })
+})

--- a/src/test/events.coverage.test.ts
+++ b/src/test/events.coverage.test.ts
@@ -47,6 +47,7 @@ const EVENT_TYPE_COVERAGE_STATUS: Record<OperationEventType, 'covered' | 'future
   'infiltration.escalation_exposed': 'covered',
   'infiltration.escalation_violent': 'covered',
   'infiltration.cover_strain': 'covered',
+  'concealment.activated': 'covered',
   'system.academy_upgraded': 'covered',
   'case.aggregate_battle': 'covered',
   'staff.coping.applied': 'covered',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the concealment prep follow-up: when weekly resolution first applies hidden or displaced presence on an in-progress case, the game now emits a `concealment.activated` operation event and weekly report note with a human-readable summary derived from `activation.reason`.

## Changes

- `formatConcealmentActivationSummary()` for authored triggers, flags, tag bridge, and recon bridge reasons
- `applyWeeklyConcealmentActivation` pushes event drafts (skips cases already concealed)
- Event validation, feed labels, and report note reflection for `concealment.activated`
- Planning/backlog updates; slice doc `planning/concealment-activation-event-feed-slice.md`

## Verification

- `npm run lint`
- `npm run test:run` (3523 tests)

## Reviewer notes

- Mirrors infiltration probe event pattern (`summary` + case link in event feed).
- Three activation events expected in the global-flag integration fixture (cases 001–003); no event when `hiddenState` is already set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

