### PR TITLE
Add prev/next navigation on weekly report detail

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -17,7 +17,7 @@ From `README.md` **Current design notes**:
 
 1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, and activation event feed shipped (SPE-2107 / SPE-2113); **next:** content batches for templates without `concealmentTriggers`, or infiltration follow-through (backlog #2).
 2. **Infiltration and access follow-through** — Expand follow-on infiltration and access work that consumes hidden-state and behavior-validation surfaces (keeps one rules substrate).
-3. **Route and week navigation** — Extend route-level drill-down and multi-week navigation coverage (legibility and QA for long runs).
+3. **Route and week navigation** — Report detail prev/next week links shipped (`planning/report-week-navigation-slice.md`); further route drill-down still open.
 4. **Core UX specs** — Finish or refresh core UX specs so surfaces match canonical domain outputs (`planning/roadmap.md` §15).
 5. **Tuning and QA references** — Complete tuning references and QA references, then use them to harden implementation sequencing (same roadmap section).
 6. **MVP loop proof** — Drive implementation toward trustworthy end-to-end weekly loop proof before broadening (`planning/roadmap.md` phases 1–2).

--- a/planning/report-week-navigation-slice.md
+++ b/planning/report-week-navigation-slice.md
@@ -1,0 +1,29 @@
+# Report week navigation (backlog #3 slice)
+
+## Goal
+
+Let players move between weekly after-action reports without returning to the list — improves legibility and QA for multi-week runs.
+
+## Scope
+
+- Pure helper: `buildReportWeekNavigation(reports, currentWeek)` → optional `previousWeek` / `nextWeek` (only when a report exists for that week)
+- `ReportDetailPage`: prev/next links in the dossier header
+- Copy in `REPORT_UI_TEXT`
+- Tests: helper + ReportDetailPage integration
+
+## Out of scope
+
+- Event feed week filters (already URL-backed)
+- Jump-to-week picker / timeline scrubber
+- Cross-linking from case detail to arbitrary report weeks
+
+## Acceptance
+
+- [x] With reports for weeks 2 and 4, week 4 shows “Previous week” → week 2 only (skips missing 3)
+- [x] First/last report omits unavailable direction
+- [x] Single-report run shows no prev/next controls
+
+## See also
+
+- `planning/backlog.md` item #3
+- `src/features/report/ReportPage.tsx`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -688,6 +688,8 @@ export const REPORT_UI_TEXT: Record<string, string> = {
   noTeamStatus: 'No team status was recorded for this week.',
   deployedRecoveryLabel: 'Deployed recovery',
   staleSnapshotSuffix: 'archived snapshot',
+  previousWeekLink: 'Previous week',
+  nextWeekLink: 'Next week',
 }
 
 export const INTEL_UI_TEXT: Record<string, string> = {

--- a/src/features/report/ReportDetailPage.tsx
+++ b/src/features/report/ReportDetailPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../domain/explanations'
 import type { KnowledgeState, KnowledgeStateMap } from '../../domain/knowledge'
 import { useState } from 'react'
-import { useParams } from 'react-router'
+import { Link, useParams } from 'react-router'
 import LocalNotFound from '../../app/LocalNotFound'
 import { APP_ROUTES } from '../../app/routes'
 import { useGameStore } from '../../app/store/gameStore'
@@ -23,6 +23,7 @@ import {
   REPORT_NOTE_CATEGORY_LABELS,
   type ReportNoteCategory,
 } from './reportNoteView'
+import { buildReportWeekNavigation } from './reportWeekNavigation'
 
 // --- Real-data knowledge/relay/fusion/decay UI helpers ---
 function getTeamKnowledgeLadder(
@@ -93,6 +94,7 @@ export default function ReportDetailPage() {
   const trendSummary = getRunTrendSummary(game, [report])
   const noteCategoryOptions = getAvailableReportNoteCategories(report.notes)
   const filteredNotes = filterReportNotesByCategory(report.notes, selectedNoteCategory)
+  const weekNavigation = buildReportWeekNavigation(game.reports, report.week)
 
   // --- Real-data knowledge/relay/ladder UI wiring ---
   // For each team in the report, show knowledge ladders and relay/decay/fusion for each anomaly/hazard
@@ -150,9 +152,35 @@ export default function ReportDetailPage() {
           </ul>
         </div>
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-sm font-medium">
-            {REPORT_LABELS.week} {report.week}
-          </p>
+          <div className="space-y-2">
+            <p className="text-sm font-medium">
+              {REPORT_LABELS.week} {report.week}
+            </p>
+            {weekNavigation.previousWeek !== undefined ||
+            weekNavigation.nextWeek !== undefined ? (
+              <nav
+                className="flex flex-wrap items-center gap-3 text-sm"
+                aria-label="Weekly report navigation"
+              >
+                {weekNavigation.previousWeek !== undefined ? (
+                  <Link
+                    to={APP_ROUTES.reportDetail(weekNavigation.previousWeek)}
+                    className="opacity-70 hover:underline"
+                  >
+                    {REPORT_UI_TEXT.previousWeekLink} ({weekNavigation.previousWeek})
+                  </Link>
+                ) : null}
+                {weekNavigation.nextWeek !== undefined ? (
+                  <Link
+                    to={APP_ROUTES.reportDetail(weekNavigation.nextWeek)}
+                    className="opacity-70 hover:underline"
+                  >
+                    {REPORT_UI_TEXT.nextWeekLink} ({weekNavigation.nextWeek})
+                  </Link>
+                ) : null}
+              </nav>
+            ) : null}
+          </div>
           <p className={`text-sm font-semibold ${weekScore >= 0 ? 'text-green-400' : 'text-red-400'}`}>
             {weekScore >= 0 ? '+' : ''}
             {weekScore} {REPORT_LABELS.points}

--- a/src/features/report/ReportFeature.test.tsx
+++ b/src/features/report/ReportFeature.test.tsx
@@ -258,6 +258,70 @@ it('filters report notes by typed note category without relying on text search',
   expect(screen.getByText(/recruitment pipeline generated 2 candidate\(s\)\./i)).toBeInTheDocument()
 })
 
+it('navigates between adjacent weekly reports from the detail header', async () => {
+  const user = userEvent.setup()
+  const game = createStartingState()
+  const emptyReport = {
+    rngStateBefore: 1,
+    rngStateAfter: 2,
+    newCases: [] as string[],
+    progressedCases: [] as string[],
+    resolvedCases: [] as string[],
+    failedCases: [] as string[],
+    partialCases: [] as string[],
+    unresolvedTriggers: [] as string[],
+    spawnedCases: [] as string[],
+    maxStage: 1,
+    avgFatigue: 0,
+    teamStatus: [],
+    notes: [],
+  }
+
+  game.reports = [
+    { ...emptyReport, week: 2 },
+    { ...emptyReport, week: 4 },
+  ]
+
+  useGameStore.setState({ game })
+  renderReportDetail('/report/4')
+
+  expect(screen.getByRole('navigation', { name: /weekly report navigation/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /previous week \(2\)/i })).toHaveAttribute('href', '/report/2')
+  expect(screen.queryByRole('link', { name: /next week/i })).not.toBeInTheDocument()
+
+  await user.click(screen.getByRole('link', { name: /previous week \(2\)/i }))
+
+  expect(screen.getByText(/^week 2$/i)).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /next week \(4\)/i })).toHaveAttribute('href', '/report/4')
+})
+
+it('omits week navigation when only one weekly report exists', () => {
+  const game = createStartingState()
+  game.reports = [
+    {
+      week: 3,
+      rngStateBefore: 1,
+      rngStateAfter: 2,
+      newCases: [],
+      progressedCases: [],
+      resolvedCases: [],
+      failedCases: [],
+      partialCases: [],
+      unresolvedTriggers: [],
+      spawnedCases: [],
+      maxStage: 1,
+      avgFatigue: 0,
+      teamStatus: [],
+      notes: [],
+    },
+  ]
+
+  useGameStore.setState({ game })
+  renderReportDetail('/report/3')
+
+  expect(screen.queryByRole('navigation', { name: /weekly report navigation/i })).not.toBeInTheDocument()
+})
+
 it('renders a local not-found state for unknown report weeks', () => {
   renderReportDetail('/report/999')
 

--- a/src/features/report/reportWeekNavigation.ts
+++ b/src/features/report/reportWeekNavigation.ts
@@ -1,0 +1,24 @@
+import type { WeeklyReport } from '../../domain/models'
+
+export interface ReportWeekNavigationView {
+  readonly previousWeek?: number
+  readonly nextWeek?: number
+}
+
+/** Adjacent report weeks that exist in `reports`, sorted ascending. */
+export function buildReportWeekNavigation(
+  reports: readonly Pick<WeeklyReport, 'week'>[],
+  currentWeek: number
+): ReportWeekNavigationView {
+  const weeks = [...new Set(reports.map((entry) => entry.week))].sort((left, right) => left - right)
+  const index = weeks.indexOf(currentWeek)
+
+  if (index === -1) {
+    return {}
+  }
+
+  return {
+    previousWeek: index > 0 ? weeks[index - 1] : undefined,
+    nextWeek: index < weeks.length - 1 ? weeks[index + 1] : undefined,
+  }
+}

--- a/src/test/reportWeekNavigation.test.ts
+++ b/src/test/reportWeekNavigation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { buildReportWeekNavigation } from '../features/report/reportWeekNavigation'
+
+describe('buildReportWeekNavigation', () => {
+  const reports = [{ week: 1 }, { week: 2 }, { week: 4 }, { week: 4 }]
+
+  it('returns adjacent weeks that have reports', () => {
+    expect(buildReportWeekNavigation(reports, 2)).toEqual({
+      previousWeek: 1,
+      nextWeek: 4,
+    })
+  })
+
+  it('omits previous on the first report and next on the last', () => {
+    expect(buildReportWeekNavigation(reports, 1)).toEqual({ nextWeek: 2 })
+    expect(buildReportWeekNavigation(reports, 4)).toEqual({ previousWeek: 2 })
+  })
+
+  it('returns empty navigation when the current week is unknown', () => {
+    expect(buildReportWeekNavigation(reports, 99)).toEqual({})
+  })
+
+  it('returns empty navigation for a single report', () => {
+    expect(buildReportWeekNavigation([{ week: 3 }], 3)).toEqual({})
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a scoped slice of backlog **#3 (route and week navigation)**: players can move between weekly after-action reports from the report detail header without returning to the list.

## Changes

- `buildReportWeekNavigation()` — finds previous/next weeks that actually have reports (skips gaps)
- `ReportDetailPage` — “Previous week (N)” / “Next week (N)” links with accessible nav region
- Copy keys in `REPORT_UI_TEXT`
- Planning: `planning/report-week-navigation-slice.md`

## Verification

- `npm run lint`
- `npm run test:run` (3529 tests)

## Context

Follows merged concealment activation event feed (#2328). Covert-ops prep arc is complete; this improves QA and long-run legibility on the reports surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

