### PR TITLE
feat(SPE-2248): Operations UI route drill-down (event feed ↔ case/report)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -17,7 +17,7 @@ From `README.md` **Current design notes**:
 
 1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, and activation event feed shipped (SPE-2107 / SPE-2113); **next:** [SPE-2249](https://linear.app/spectranoir/issue/SPE-2249/concealmenttriggers-migration-batch-4-remaining-templates) (content-only `concealmentTriggers` on remaining templates).
 2. **Infiltration and access follow-through** — [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) (encounter/content depth on shipped SPE-521 substrate; not new probe mechanics).
-3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); **next:** [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248/operations-ui-route-drill-down-event-feed-casereport-cross-links) (event feed ↔ case/report cross-links).
+3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
 4. **Core UX specs** — Finish or refresh core UX specs so surfaces match canonical domain outputs (`planning/roadmap.md` §15).
 5. **Tuning and QA references** — Complete tuning references and QA references, then use them to harden implementation sequencing (same roadmap section).
 6. **MVP loop proof** — Drive implementation toward trustworthy end-to-end weekly loop proof before broadening (`planning/roadmap.md` phases 1–2).

--- a/planning/operations-route-drill-down-slice.md
+++ b/planning/operations-route-drill-down-slice.md
@@ -1,0 +1,47 @@
+# Operations route drill-down (SPE-2248)
+
+## Goal
+
+Tighten cross-links between the event feed, case detail, and weekly reports for long-run QA and player legibility.
+
+## Scope (this slice)
+
+- Event feed: consistent primary `href` per event type; drill-down links preserve active feed filters when set.
+- Case detail: weekly report links for weeks that reference the case.
+- Report detail: case ids in snapshot sections (existing `reportDetailHelpers` links — verified, no change).
+- Documented event-type → drill-down matrix (below).
+
+## Out of scope
+
+- Report prev/next week navigation (shipped PR #2329).
+- Multi-week timeline scrubber.
+- Map / anomalous route graphs (SPE-765).
+
+## Event type → primary drill-down
+
+| Event type | Primary target |
+| --- | --- |
+| `assignment.*` | Case detail |
+| `case.*` | Case detail |
+| `intel.report_generated` | Report week |
+| `concealment.activated` | Report week |
+| `infiltration.*` | Report week |
+| `agent.*` / `progression.xp_gained` | Agent detail |
+| `recruitment.*` | Recruitment |
+| `directive.applied` | Operations desk |
+| `support.shortfall` | Case detail |
+| `faction.unlock_available` | Factions |
+| `faction.standing_changed` | Case detail when `caseId` set; else none |
+| `production.*` / `market.*` / `agency.containment_updated` / `agency.front_business.*` / `system.equipment_recovered` / `system.party_cards_drawn` | None (desk-level or aggregate) |
+
+## Acceptance
+
+- [x] Matrix documented in this file.
+- [x] RTL/component tests for representative links and feed filter preservation.
+- [x] No broken `APP_ROUTES` hrefs on updated surfaces.
+
+## See also
+
+- `src/features/dashboard/eventFeedView.ts`
+- `src/features/operations/operationsRouteDrillDown.ts`
+- Linear SPE-2248 / GitHub issue #2330

--- a/planning/operations-route-drill-down-slice.md
+++ b/planning/operations-route-drill-down-slice.md
@@ -7,7 +7,7 @@ Tighten cross-links between the event feed, case detail, and weekly reports for 
 ## Scope (this slice)
 
 - Event feed: consistent primary `href` per event type; drill-down links preserve active feed filters when set.
-- Case detail: weekly report links for weeks that reference the case.
+- Case detail: weekly report links for weeks that reference the case (report lists, team status, or note `metadata.caseId`).
 - Report detail: case ids in snapshot sections (existing `reportDetailHelpers` links — verified, no change).
 - Documented event-type → drill-down matrix (below).
 

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -475,6 +475,9 @@ export const CASE_UI_LABELS: Record<string, string> = {
   oddsFailAbbr: 'F',
   removeTeam: 'Remove',
   tags: 'Tags',
+  caseWeeklyReports: 'Weekly reports',
+  caseWeeklyReportsHint: 'After-action reports that reference this case or its weekly notes.',
+  caseWeeklyReportLink: 'Week {week} report',
   loreStub: 'Intelligence stub',
 }
 

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -389,3 +389,41 @@ it('shows pre-commit injury, death, and downtime warnings for available teams', 
     within(oddsPanel).getAllByText(/survivability|balanced formation|Fatigue is driving/i).length
   ).toBeGreaterThan(0)
 })
+
+it('links to weekly reports that reference the case', () => {
+  const game = createStartingState()
+
+  game.reports = [
+    {
+      week: 2,
+      rngStateBefore: 1,
+      rngStateAfter: 2,
+      newCases: [],
+      progressedCases: ['case-001'],
+      resolvedCases: [],
+      failedCases: [],
+      partialCases: [],
+      unresolvedTriggers: [],
+      spawnedCases: [],
+      maxStage: 1,
+      avgFatigue: 0,
+      teamStatus: [],
+      notes: [],
+    },
+  ]
+
+  useGameStore.setState({ game })
+  renderCaseDetail('/cases/case-001')
+
+  expect(screen.getByRole('region', { name: /weekly reports/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /week 2 report/i })).toHaveAttribute('href', '/report/2')
+})
+
+it('returns to the operations desk when opened from a filtered feed', () => {
+  renderCaseDetail('/cases/missing-case?feedQ=raid')
+
+  expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+    'href',
+    '/?feedQ=raid'
+  )
+})

--- a/src/features/cases/CaseDetailPage.tsx
+++ b/src/features/cases/CaseDetailPage.tsx
@@ -22,22 +22,28 @@ import { type CaseInstance, type GameState, type Team } from '../../domain/model
 import { getCaseTemplateIntelView } from './caseIntelProjection'
 import { getCaseAssignmentInsights } from './caseInsights'
 import { getCaseListItemView } from './caseView'
+import { CaseWeeklyReportsPanel } from './CaseWeeklyReportsPanel'
 import { WeeklyCasePrepPanel } from './WeeklyCasePrepPanel'
+import { resolveOperationsBackTarget } from '../operations/operationsRouteDrillDown'
 
 export default function CaseDetailPage() {
   const { caseId } = useParams()
   const location = useLocation()
   const { game, assign, unassign, playPartyCard } = useGameStore()
   const currentCase = caseId ? game.cases[caseId] : undefined
-  const backTo = `${APP_ROUTES.cases}${location.search}`
+  const locationSearch = new URLSearchParams(location.search)
+  const defaultBack = `${APP_ROUTES.cases}${location.search}`
+  const backTarget = resolveOperationsBackTarget(locationSearch, defaultBack)
 
   if (!currentCase) {
     return (
       <LocalNotFound
         title={SHELL_UI_TEXT.caseNotFoundTitle}
         message={SHELL_UI_TEXT.caseNotFoundMessage}
-        backTo={backTo}
-        backLabel={SHELL_UI_TEXT.backToTemplate.replace('{label}', 'Cases')}
+        backTo={backTarget.href}
+        backLabel={
+          backTarget.label || SHELL_UI_TEXT.backToTemplate.replace('{label}', 'Cases')
+        }
       />
     )
   }
@@ -325,6 +331,8 @@ export default function CaseDetailPage() {
               </p>
             )}
           </article>
+
+          <CaseWeeklyReportsPanel caseId={currentCase.id} />
 
           <WeeklyCasePrepPanel caseData={currentCase} />
 

--- a/src/features/cases/CaseWeeklyReportsPanel.tsx
+++ b/src/features/cases/CaseWeeklyReportsPanel.tsx
@@ -1,0 +1,50 @@
+import { Link, useLocation } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { CASE_UI_LABELS } from '../../data/copy'
+import {
+  buildDrillDownHrefWithFeedContext,
+  getCaseWeeklyReportWeeks,
+} from '../operations/operationsRouteDrillDown'
+
+interface CaseWeeklyReportsPanelProps {
+  caseId: string
+}
+
+export function CaseWeeklyReportsPanel({ caseId }: CaseWeeklyReportsPanelProps) {
+  const { game } = useGameStore()
+  const location = useLocation()
+  const reportWeeks = getCaseWeeklyReportWeeks(game.reports, caseId)
+
+  if (reportWeeks.length === 0) {
+    return null
+  }
+
+  return (
+    <article
+      className="panel panel-support space-y-3"
+      role="region"
+      aria-label={CASE_UI_LABELS.caseWeeklyReports}
+    >
+      <div className="space-y-1">
+        <p className="text-xs uppercase tracking-wide opacity-50">{CASE_UI_LABELS.caseWeeklyReports}</p>
+        <p className="text-sm opacity-60">{CASE_UI_LABELS.caseWeeklyReportsHint}</p>
+      </div>
+      <ul className="flex flex-wrap gap-2">
+        {reportWeeks.map((week) => (
+          <li key={week}>
+            <Link
+              to={buildDrillDownHrefWithFeedContext(
+                APP_ROUTES.reportDetail(week),
+                new URLSearchParams(location.search)
+              )}
+              className="btn btn-xs btn-ghost"
+            >
+              {CASE_UI_LABELS.caseWeeklyReportLink.replace('{week}', String(week))}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </article>
+  )
+}

--- a/src/features/cases/CaseWeeklyReportsPanel.tsx
+++ b/src/features/cases/CaseWeeklyReportsPanel.tsx
@@ -14,6 +14,7 @@ interface CaseWeeklyReportsPanelProps {
 export function CaseWeeklyReportsPanel({ caseId }: CaseWeeklyReportsPanelProps) {
   const { game } = useGameStore()
   const location = useLocation()
+  const feedContextSearch = new URLSearchParams(location.search)
   const reportWeeks = getCaseWeeklyReportWeeks(game.reports, caseId)
 
   if (reportWeeks.length === 0) {
@@ -36,7 +37,7 @@ export function CaseWeeklyReportsPanel({ caseId }: CaseWeeklyReportsPanelProps) 
             <Link
               to={buildDrillDownHrefWithFeedContext(
                 APP_ROUTES.reportDetail(week),
-                new URLSearchParams(location.search)
+                feedContextSearch
               )}
               className="btn btn-xs btn-ghost"
             >

--- a/src/features/dashboard/EventFeedPanel.tsx
+++ b/src/features/dashboard/EventFeedPanel.tsx
@@ -16,6 +16,7 @@ import {
   writeEventFeedFilters,
   type EventFeedTone,
 } from './eventFeedView'
+import { buildDrillDownHrefWithFeedContext } from '../operations/operationsRouteDrillDown'
 
 export function EventFeedPanel() {
   const { game } = useGameStore()
@@ -304,7 +305,10 @@ export function EventFeedPanel() {
                   </div>
                   <div className="space-y-1">
                     {view.href ? (
-                      <Link to={view.href} className="font-medium hover:underline">
+                      <Link
+                        to={buildDrillDownHrefWithFeedContext(view.href, searchParams)}
+                        className="font-medium hover:underline"
+                      >
                         {view.title}
                       </Link>
                     ) : (

--- a/src/features/dashboard/eventFeedView.ts
+++ b/src/features/dashboard/eventFeedView.ts
@@ -54,7 +54,7 @@ export const DEFAULT_EVENT_FEED_FILTERS: EventFeedFilters = {
   entityId: '',
 }
 
-const EVENT_FEED_PARAM_KEYS = {
+export const EVENT_FEED_PARAM_KEYS = {
   query: 'feedQ',
   category: 'feedCategory',
   sourceSystem: 'feedSource',
@@ -909,6 +909,9 @@ export function buildEventFeedView(event: OperationEvent): EventFeedView {
         typeLabel,
         timestampLabel,
         tone: event.payload.delta > 0 ? 'success' : event.payload.delta < 0 ? 'warning' : 'neutral',
+        href: event.payload.caseId
+          ? APP_ROUTES.caseDetail(event.payload.caseId)
+          : undefined,
         searchText:
           `${event.payload.factionName} ${event.payload.factionId} ${event.payload.reason} ${event.payload.caseTitle ?? ''} ${event.payload.interactionLabel ?? ''}`.toLowerCase(),
       }
@@ -1086,7 +1089,7 @@ export function buildEventFeedView(event: OperationEvent): EventFeedView {
         typeLabel,
         timestampLabel,
         tone: 'neutral',
-        href: APP_ROUTES.caseDetail(event.payload.caseId),
+        href: APP_ROUTES.reportDetail(event.payload.week),
         searchText:
           `${event.payload.caseTitle} ${event.payload.caseId} ${event.payload.summary} ${event.payload.reason} concealment`.toLowerCase(),
       }
@@ -1117,7 +1120,7 @@ export function buildEventFeedView(event: OperationEvent): EventFeedView {
         typeLabel,
         timestampLabel,
         tone,
-        href: APP_ROUTES.caseDetail(event.payload.caseId),
+        href: APP_ROUTES.reportDetail(event.payload.week),
         searchText:
           `${event.payload.caseTitle} ${event.payload.caseId} ${event.payload.summary} infiltration`.toLowerCase(),
       }

--- a/src/features/operations/operationsRouteDrillDown.ts
+++ b/src/features/operations/operationsRouteDrillDown.ts
@@ -22,11 +22,7 @@ function reportListsCase(report: WeeklyReport, caseId: string): boolean {
 function reportNoteReferencesCase(note: ReportNote, caseId: string): boolean {
   const metadataCaseId = note.metadata?.caseId
 
-  if (typeof metadataCaseId === 'string' && metadataCaseId === caseId) {
-    return true
-  }
-
-  return note.content.includes(caseId)
+  return typeof metadataCaseId === 'string' && metadataCaseId === caseId
 }
 
 /** Report weeks that mention `caseId` in lists, team status, or structured notes. */

--- a/src/features/operations/operationsRouteDrillDown.ts
+++ b/src/features/operations/operationsRouteDrillDown.ts
@@ -1,0 +1,88 @@
+import { APP_ROUTES } from '../../app/routes'
+import {
+  EVENT_FEED_PARAM_KEYS,
+  readEventFeedFilters,
+  writeEventFeedFilters,
+} from '../dashboard/eventFeedView'
+import type { ReportNote, WeeklyReport } from '../../domain/models'
+
+function reportListsCase(report: WeeklyReport, caseId: string): boolean {
+  return (
+    report.newCases.includes(caseId) ||
+    report.progressedCases.includes(caseId) ||
+    report.resolvedCases.includes(caseId) ||
+    report.failedCases.includes(caseId) ||
+    report.partialCases.includes(caseId) ||
+    report.unresolvedTriggers.includes(caseId) ||
+    report.spawnedCases.includes(caseId) ||
+    report.teamStatus.some((entry) => entry.assignedCaseId === caseId)
+  )
+}
+
+function reportNoteReferencesCase(note: ReportNote, caseId: string): boolean {
+  const metadataCaseId = note.metadata?.caseId
+
+  if (typeof metadataCaseId === 'string' && metadataCaseId === caseId) {
+    return true
+  }
+
+  return note.content.includes(caseId)
+}
+
+/** Report weeks that mention `caseId` in lists, team status, or structured notes. */
+export function getCaseWeeklyReportWeeks(
+  reports: readonly WeeklyReport[],
+  caseId: string
+): number[] {
+  const weeks = new Set<number>()
+
+  for (const report of reports) {
+    if (
+      reportListsCase(report, caseId) ||
+      report.notes.some((note) => reportNoteReferencesCase(note, caseId))
+    ) {
+      weeks.add(report.week)
+    }
+  }
+
+  return [...weeks].sort((left, right) => left - right)
+}
+
+export function hasEventFeedFilterParams(searchParams: URLSearchParams): boolean {
+  return Object.values(EVENT_FEED_PARAM_KEYS).some((key) => searchParams.has(key))
+}
+
+/** Merge active event-feed filters onto a drill-down href for return navigation. */
+export function buildDrillDownHrefWithFeedContext(
+  href: string,
+  searchParams: URLSearchParams
+): string {
+  if (!hasEventFeedFilterParams(searchParams)) {
+    return href
+  }
+
+  const [pathname, existingSearch = ''] = href.split('?')
+  const merged = writeEventFeedFilters(
+    readEventFeedFilters(searchParams),
+    new URLSearchParams(existingSearch)
+  )
+  const serialized = merged.toString()
+
+  return serialized.length > 0 ? `${pathname}?${serialized}` : pathname
+}
+
+export function resolveOperationsBackTarget(
+  searchParams: URLSearchParams,
+  defaultBack: string
+): { href: string; label: string } {
+  if (hasEventFeedFilterParams(searchParams)) {
+    const feedSearch = writeEventFeedFilters(readEventFeedFilters(searchParams)).toString()
+
+    return {
+      href: feedSearch.length > 0 ? `${APP_ROUTES.operationsDesk}?${feedSearch}` : APP_ROUTES.operationsDesk,
+      label: 'Back to operations desk',
+    }
+  }
+
+  return { href: defaultBack, label: '' }
+}

--- a/src/features/report/ReportDetailPage.tsx
+++ b/src/features/report/ReportDetailPage.tsx
@@ -76,16 +76,14 @@ export default function ReportDetailPage() {
   const [selectedNoteCategory, setSelectedNoteCategory] = useState<ReportNoteCategory | 'all'>(
     'all'
   )
+  const locationSearch = new URLSearchParams(location.search)
   const reportWeek = Number(week)
   const report = Number.isInteger(reportWeek)
     ? game.reports.find((entry) => entry.week === reportWeek)
     : undefined
 
   if (!report) {
-    const backTarget = resolveOperationsBackTarget(
-      new URLSearchParams(location.search),
-      APP_ROUTES.report
-    )
+    const backTarget = resolveOperationsBackTarget(locationSearch, APP_ROUTES.report)
 
     return (
       <LocalNotFound
@@ -178,7 +176,7 @@ export default function ReportDetailPage() {
                   <Link
                     to={buildDrillDownHrefWithFeedContext(
                       APP_ROUTES.reportDetail(weekNavigation.previousWeek),
-                      new URLSearchParams(location.search)
+                      locationSearch
                     )}
                     className="opacity-70 hover:underline"
                   >
@@ -189,7 +187,7 @@ export default function ReportDetailPage() {
                   <Link
                     to={buildDrillDownHrefWithFeedContext(
                       APP_ROUTES.reportDetail(weekNavigation.nextWeek),
-                      new URLSearchParams(location.search)
+                      locationSearch
                     )}
                     className="opacity-70 hover:underline"
                   >

--- a/src/features/report/ReportDetailPage.tsx
+++ b/src/features/report/ReportDetailPage.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../domain/explanations'
 import type { KnowledgeState, KnowledgeStateMap } from '../../domain/knowledge'
 import { useState } from 'react'
-import { Link, useParams } from 'react-router'
+import { Link, useLocation, useParams } from 'react-router'
 import LocalNotFound from '../../app/LocalNotFound'
 import { APP_ROUTES } from '../../app/routes'
 import { useGameStore } from '../../app/store/gameStore'
@@ -23,6 +23,10 @@ import {
   REPORT_NOTE_CATEGORY_LABELS,
   type ReportNoteCategory,
 } from './reportNoteView'
+import {
+  buildDrillDownHrefWithFeedContext,
+  resolveOperationsBackTarget,
+} from '../operations/operationsRouteDrillDown'
 import { buildReportWeekNavigation } from './reportWeekNavigation'
 
 // --- Real-data knowledge/relay/fusion/decay UI helpers ---
@@ -67,6 +71,7 @@ function getFusionExplanation(knowledgeState?: KnowledgeState) {
 
 export default function ReportDetailPage() {
   const { week } = useParams()
+  const location = useLocation()
   const { game } = useGameStore()
   const [selectedNoteCategory, setSelectedNoteCategory] = useState<ReportNoteCategory | 'all'>(
     'all'
@@ -77,12 +82,19 @@ export default function ReportDetailPage() {
     : undefined
 
   if (!report) {
+    const backTarget = resolveOperationsBackTarget(
+      new URLSearchParams(location.search),
+      APP_ROUTES.report
+    )
+
     return (
       <LocalNotFound
         title={SHELL_UI_TEXT.reportNotFoundTitle}
         message={SHELL_UI_TEXT.reportNotFoundMessage}
-        backTo={APP_ROUTES.report}
-        backLabel={SHELL_UI_TEXT.backToTemplate.replace('{label}', 'Reports')}
+        backTo={backTarget.href}
+        backLabel={
+          backTarget.label || SHELL_UI_TEXT.backToTemplate.replace('{label}', 'Reports')
+        }
       />
     )
   }
@@ -164,7 +176,10 @@ export default function ReportDetailPage() {
               >
                 {weekNavigation.previousWeek !== undefined ? (
                   <Link
-                    to={APP_ROUTES.reportDetail(weekNavigation.previousWeek)}
+                    to={buildDrillDownHrefWithFeedContext(
+                      APP_ROUTES.reportDetail(weekNavigation.previousWeek),
+                      new URLSearchParams(location.search)
+                    )}
                     className="opacity-70 hover:underline"
                   >
                     {REPORT_UI_TEXT.previousWeekLink} ({weekNavigation.previousWeek})
@@ -172,7 +187,10 @@ export default function ReportDetailPage() {
                 ) : null}
                 {weekNavigation.nextWeek !== undefined ? (
                   <Link
-                    to={APP_ROUTES.reportDetail(weekNavigation.nextWeek)}
+                    to={buildDrillDownHrefWithFeedContext(
+                      APP_ROUTES.reportDetail(weekNavigation.nextWeek),
+                      new URLSearchParams(location.search)
+                    )}
                     className="opacity-70 hover:underline"
                   >
                     {REPORT_UI_TEXT.nextWeekLink} ({weekNavigation.nextWeek})

--- a/src/test/eventFeedView.test.ts
+++ b/src/test/eventFeedView.test.ts
@@ -1170,8 +1170,6 @@ describe('buildEventFeedView href', () => {
         standingBefore: 0,
         standingAfter: 2,
         reason: 'case.resolved',
-        caseId: 'case-001',
-        caseTitle: 'Case 1',
       }),
       makeEvent('agency.containment_updated', {
         week: 1,
@@ -1188,6 +1186,44 @@ describe('buildEventFeedView href', () => {
     for (const event of noHrefEvents) {
       expect(buildEventFeedView(event).href).toBeUndefined()
     }
+  })
+
+  it('faction.standing_changed links to case detail when caseId is present', () => {
+    const event = makeEvent('faction.standing_changed', {
+      week: 2,
+      factionId: 'oversight',
+      factionName: 'Oversight Bureau',
+      delta: 2,
+      standingBefore: 0,
+      standingAfter: 2,
+      reason: 'case.resolved',
+      caseId: 'case-001',
+      caseTitle: 'Case 1',
+    })
+
+    expect(buildEventFeedView(event).href).toBe('/cases/case-001')
+  })
+
+  it('concealment and infiltration events link to the weekly report', () => {
+    const concealment = makeEvent('concealment.activated', {
+      week: 4,
+      caseId: 'case-a',
+      caseTitle: 'Hidden op',
+      mode: 'hidden',
+      reason: 'authored',
+      summary: 'Cover engaged',
+    })
+    expect(buildEventFeedView(concealment).href).toBe('/report/4')
+
+    const infiltration = makeEvent('infiltration.cover_strain', {
+      week: 5,
+      caseId: 'case-a',
+      caseTitle: 'Hidden op',
+      summary: 'Strain rising',
+      infiltrationAwareness: 0.4,
+      infiltrationStage: 'probing',
+    })
+    expect(buildEventFeedView(infiltration).href).toBe('/report/5')
   })
 })
 

--- a/src/test/operationsRouteDrillDown.test.ts
+++ b/src/test/operationsRouteDrillDown.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { APP_ROUTES } from '../app/routes'
+import {
+  buildDrillDownHrefWithFeedContext,
+  getCaseWeeklyReportWeeks,
+  hasEventFeedFilterParams,
+  resolveOperationsBackTarget,
+} from '../features/operations/operationsRouteDrillDown'
+import type { WeeklyReport } from '../domain/models'
+
+function emptyReport(week: number): WeeklyReport {
+  return {
+    week,
+    rngStateBefore: 1,
+    rngStateAfter: 2,
+    newCases: [],
+    progressedCases: [],
+    resolvedCases: [],
+    failedCases: [],
+    partialCases: [],
+    unresolvedTriggers: [],
+    spawnedCases: [],
+    maxStage: 1,
+    avgFatigue: 0,
+    teamStatus: [],
+    notes: [],
+  }
+}
+
+describe('getCaseWeeklyReportWeeks', () => {
+  it('collects weeks from case lists and note metadata', () => {
+    const reports: WeeklyReport[] = [
+      {
+        ...emptyReport(1),
+        progressedCases: ['case-a'],
+      },
+      {
+        ...emptyReport(3),
+        notes: [
+          {
+            id: 'n-1',
+            content: 'Probe strain',
+            timestamp: 1,
+            type: 'infiltration.cover_strain',
+            metadata: { caseId: 'case-a', week: 3 },
+          },
+        ],
+      },
+    ]
+
+    expect(getCaseWeeklyReportWeeks(reports, 'case-a')).toEqual([1, 3])
+  })
+})
+
+describe('event feed return navigation', () => {
+  it('detects feed filter params', () => {
+    expect(hasEventFeedFilterParams(new URLSearchParams('feedQ=raid'))).toBe(true)
+    expect(hasEventFeedFilterParams(new URLSearchParams('sort=name'))).toBe(false)
+  })
+
+  it('merges feed filters onto drill-down hrefs', () => {
+    const href = buildDrillDownHrefWithFeedContext(
+      APP_ROUTES.caseDetail('case-a'),
+      new URLSearchParams('feedQ=raid&feedCategory=incident_response')
+    )
+
+    expect(href).toContain('/cases/case-a')
+    expect(href).toContain('feedQ=raid')
+    expect(href).toContain('feedCategory=incident_response')
+  })
+
+  it('returns operations desk when feed filters are present', () => {
+    const target = resolveOperationsBackTarget(
+      new URLSearchParams('feedType=case.resolved'),
+      '/cases'
+    )
+
+    expect(target.href).toContain('/')
+    expect(target.href).toContain('feedType=case.resolved')
+    expect(target.label).toBe('Back to operations desk')
+  })
+})

--- a/src/test/operationsRouteDrillDown.test.ts
+++ b/src/test/operationsRouteDrillDown.test.ts
@@ -28,7 +28,7 @@ function emptyReport(week: number): WeeklyReport {
 }
 
 describe('getCaseWeeklyReportWeeks', () => {
-  it('collects weeks from case lists and note metadata', () => {
+  it('collects weeks from case lists and note metadata.caseId', () => {
     const reports: WeeklyReport[] = [
       {
         ...emptyReport(1),
@@ -39,10 +39,20 @@ describe('getCaseWeeklyReportWeeks', () => {
         notes: [
           {
             id: 'n-1',
-            content: 'Probe strain',
+            content: 'Probe strain on case-a',
             timestamp: 1,
             type: 'infiltration.cover_strain',
             metadata: { caseId: 'case-a', week: 3 },
+          },
+        ],
+      },
+      {
+        ...emptyReport(4),
+        notes: [
+          {
+            id: 'n-2',
+            content: 'Mentions case-a in prose only',
+            timestamp: 1,
           },
         ],
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements SPE-2248 / backlog item #3 (operations drill-down). Tightens cross-links between the event feed, case detail, and weekly reports.

## Changes

- **Event feed:** `concealment.activated` and `infiltration.*` rows link to the weekly report week; `faction.standing_changed` links to case detail when `caseId` is present. Drill-down links preserve active feed filter query params.
- **Case detail:** New weekly reports panel lists after-action report weeks that reference the case (lists, team status, or note metadata).
- **Report detail:** Week prev/next navigation preserves feed filters; not-found back target returns to the operations desk when opened from a filtered feed.
- **Docs:** `planning/operations-route-drill-down-slice.md` with event-type → drill-down matrix.

## Tests

- `src/test/operationsRouteDrillDown.test.ts`
- `src/test/eventFeedView.test.ts` (concealment/infiltration/faction hrefs)
- `src/features/cases/CaseDetailPage.test.tsx` (weekly report links, feed back navigation)

## Verification

- `npm run lint`
- `npm run test:run` (3540 tests)

Linear: SPE-2248 · GitHub issue #2330
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

