### PR TITLE
fix(SPE-2248): operations drill-down gap hardening

### DIFF
--- a/planning/operations-route-drill-down-slice.md
+++ b/planning/operations-route-drill-down-slice.md
@@ -34,6 +34,13 @@ Tighten cross-links between the event feed, case detail, and weekly reports for 
 | `faction.standing_changed` | Case detail when `caseId` set; else none |
 | `production.*` / `market.*` / `agency.containment_updated` / `agency.front_business.*` / `system.equipment_recovered` / `system.party_cards_drawn` | None (desk-level or aggregate) |
 
+## Gap hardening (post-merge)
+
+- Report-week feed hrefs fall back to case detail when that week's report is not in state.
+- `getCaseWeeklyReportWeeks` includes `caseSnapshots` keys, not only list columns.
+- Case, report, and agent detail show a desk back link when opened with feed filter params.
+- `buildDrillDownHrefWithFeedContext` preserves pre-existing query strings on targets.
+
 ## Acceptance
 
 - [x] Matrix documented in this file.

--- a/src/features/agents/AgentDetailPage.tsx
+++ b/src/features/agents/AgentDetailPage.tsx
@@ -12,6 +12,7 @@ import { useGameStore } from '../../app/store/gameStore'
 import { NAVIGATION_ROUTES, SHELL_UI_TEXT } from '../../data/copy'
 import { AgentEntityPanel } from './AgentEntityPanel'
 import { AGENT_DETAIL_TABS, DEFAULT_AGENT_DETAIL_TAB, type TabType } from './agentTabsModel'
+import { resolveOperationsBackTarget } from '../operations/operationsRouteDrillDown'
 import { getAgentView } from './agentView'
 
 interface AgentDetailLocationState {
@@ -39,7 +40,14 @@ export default function AgentDetailPage() {
   const backSearch = toSearchString(backParams)
   const fallbackRegistrySearch =
     isRegistryDetailRoute && !backSearch ? (locationState?.registrySearch ?? '') : ''
-  const backTo = `${backSystemRoute}${backSearch || fallbackRegistrySearch}`
+  const defaultBack = `${backSystemRoute}${backSearch || fallbackRegistrySearch}`
+  const feedBackTarget = resolveOperationsBackTarget(
+    new URLSearchParams(location.search),
+    defaultBack
+  )
+  const backTo = feedBackTarget.href
+  const backLabel =
+    feedBackTarget.label || SHELL_UI_TEXT.backToTemplate.replace('{label}', backSystemLabel)
 
   useEffect(() => {
     const normalizedParams = cloneSearchParams(searchParams)
@@ -64,7 +72,7 @@ export default function AgentDetailPage() {
         title={SHELL_UI_TEXT.agentNotFoundTitle}
         message={SHELL_UI_TEXT.agentNotFoundMessage}
         backTo={backTo}
-        backLabel={SHELL_UI_TEXT.backToTemplate.replace('{label}', backSystemLabel)}
+        backLabel={backLabel}
       />
     )
   }
@@ -77,7 +85,7 @@ export default function AgentDetailPage() {
       headerActions={
         <>
           <Link to={backTo} className="btn btn-sm btn-ghost">
-            {`Back to ${backSystemLabel.toLowerCase()}`}
+            {backLabel}
           </Link>
           <Link to={view.squadBuilderLink} className="btn btn-sm btn-ghost">
             {view.squadBuilderLabel}

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -427,3 +427,12 @@ it('returns to the operations desk when opened from a filtered feed', () => {
     '/?feedQ=raid'
   )
 })
+
+it('shows a desk back link on case detail when opened from a filtered feed', () => {
+  renderCaseDetail('/cases/case-001?feedQ=raid')
+
+  expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+    'href',
+    '/?feedQ=raid'
+  )
+})

--- a/src/features/cases/CaseDetailPage.tsx
+++ b/src/features/cases/CaseDetailPage.tsx
@@ -82,6 +82,11 @@ export default function CaseDetailPage() {
 
   return (
     <section className="space-y-4">
+      {backTarget.label ? (
+        <Link to={backTarget.href} className="btn btn-sm btn-ghost w-fit">
+          {backTarget.label}
+        </Link>
+      ) : null}
       <article className="panel panel-primary space-y-4" role="region" aria-label="Case dossier">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">

--- a/src/features/dashboard/eventFeedView.ts
+++ b/src/features/dashboard/eventFeedView.ts
@@ -1148,6 +1148,38 @@ export function getAvailableEventCategories(events: OperationEvent[]) {
   )
 }
 
+function hasWeeklyReport(reports: GameState['reports'], week: number): boolean {
+  return reports.some((report) => report.week === week)
+}
+
+function getEventPayloadCaseId(event: OperationEvent): string | undefined {
+  const caseId = (event.payload as { caseId?: string }).caseId
+
+  return typeof caseId === 'string' && caseId.length > 0 ? caseId : undefined
+}
+
+/** Report-week feed links fall back to case detail when that week's report is absent. */
+export function refineEventFeedDrillDownHref(
+  view: EventFeedView,
+  reports: GameState['reports']
+): EventFeedView {
+  if (!view.href?.startsWith(`${APP_ROUTES.report}/`)) {
+    return view
+  }
+
+  if (hasWeeklyReport(reports, view.week)) {
+    return view
+  }
+
+  const caseId = getEventPayloadCaseId(view.event)
+
+  if (!caseId) {
+    return { ...view, href: undefined }
+  }
+
+  return { ...view, href: APP_ROUTES.caseDetail(caseId) }
+}
+
 export function getFilteredEventFeedViews(
   game: GameState,
   filters: EventFeedFilters = DEFAULT_EVENT_FEED_FILTERS
@@ -1162,7 +1194,10 @@ export function getFilteredEventFeedViews(
     entityId: filters.entityId,
   })
 
-  const mapped = filteredEvents.map(buildEventFeedView).filter((view) => {
+  const mapped = filteredEvents
+    .map(buildEventFeedView)
+    .map((view) => refineEventFeedDrillDownHref(view, game.reports))
+    .filter((view) => {
     if (filters.category !== 'all' && EVENT_TYPE_CATEGORIES[view.event.type] !== filters.category) {
       return false
     }

--- a/src/features/operations/operationsRouteDrillDown.ts
+++ b/src/features/operations/operationsRouteDrillDown.ts
@@ -15,7 +15,8 @@ function reportListsCase(report: WeeklyReport, caseId: string): boolean {
     report.partialCases.includes(caseId) ||
     report.unresolvedTriggers.includes(caseId) ||
     report.spawnedCases.includes(caseId) ||
-    report.teamStatus.some((entry) => entry.assignedCaseId === caseId)
+    report.teamStatus.some((entry) => entry.assignedCaseId === caseId) ||
+    caseId in (report.caseSnapshots ?? {})
   )
 }
 
@@ -57,7 +58,9 @@ export function buildDrillDownHrefWithFeedContext(
     return href
   }
 
-  const [pathname, existingSearch = ''] = href.split('?')
+  const questionIndex = href.indexOf('?')
+  const pathname = questionIndex === -1 ? href : href.slice(0, questionIndex)
+  const existingSearch = questionIndex === -1 ? '' : href.slice(questionIndex + 1)
   const merged = writeEventFeedFilters(
     readEventFeedFilters(searchParams),
     new URLSearchParams(existingSearch)

--- a/src/features/report/ReportDetailPage.tsx
+++ b/src/features/report/ReportDetailPage.tsx
@@ -105,6 +105,7 @@ export default function ReportDetailPage() {
   const noteCategoryOptions = getAvailableReportNoteCategories(report.notes)
   const filteredNotes = filterReportNotesByCategory(report.notes, selectedNoteCategory)
   const weekNavigation = buildReportWeekNavigation(game.reports, report.week)
+  const reportBackTarget = resolveOperationsBackTarget(locationSearch, APP_ROUTES.report)
 
   // --- Real-data knowledge/relay/ladder UI wiring ---
   // For each team in the report, show knowledge ladders and relay/decay/fusion for each anomaly/hazard
@@ -123,6 +124,11 @@ export default function ReportDetailPage() {
 
   return (
     <section className="space-y-4">
+      {reportBackTarget.label ? (
+        <Link to={reportBackTarget.href} className="btn btn-sm btn-ghost w-fit">
+          {reportBackTarget.label}
+        </Link>
+      ) : null}
       <article className="panel panel-primary space-y-4" role="region" aria-label="Weekly report dossier">
         {/* Real-data knowledge ladders and relay/decay/fusion status */}
         <div className="my-2 p-2 bg-blue-50 rounded text-xs">

--- a/src/test/eventFeedView.test.ts
+++ b/src/test/eventFeedView.test.ts
@@ -9,6 +9,7 @@ import {
   getAvailableEventSources,
   getAvailableEventTypes,
   getFilteredEventFeedViews,
+  refineEventFeedDrillDownHref,
 } from '../features/dashboard/eventFeedView'
 
 // ---------------------------------------------------------------------------
@@ -1224,6 +1225,21 @@ describe('buildEventFeedView href', () => {
       infiltrationStage: 'probing',
     })
     expect(buildEventFeedView(infiltration).href).toBe('/report/5')
+  })
+
+  it('refineEventFeedDrillDownHref falls back to case when report week is missing', () => {
+    const concealment = makeEvent('concealment.activated', {
+      week: 9,
+      caseId: 'case-a',
+      caseTitle: 'Hidden op',
+      mode: 'hidden',
+      reason: 'authored',
+      summary: 'Cover engaged',
+    })
+    const view = buildEventFeedView(concealment)
+
+    expect(refineEventFeedDrillDownHref(view, []).href).toBe('/cases/case-a')
+    expect(refineEventFeedDrillDownHref(view, [{ week: 9 } as never]).href).toBe('/report/9')
   })
 })
 

--- a/src/test/operationsRouteDrillDown.test.ts
+++ b/src/test/operationsRouteDrillDown.test.ts
@@ -28,6 +28,29 @@ function emptyReport(week: number): WeeklyReport {
 }
 
 describe('getCaseWeeklyReportWeeks', () => {
+  it('collects weeks from caseSnapshots when case lists are empty', () => {
+    const reports: WeeklyReport[] = [
+      {
+        ...emptyReport(2),
+        caseSnapshots: {
+          'case-a': {
+            caseId: 'case-a',
+            title: 'Snapshot only',
+            kind: 'case',
+            mode: 'containment',
+            status: 'in_progress',
+            stage: 1,
+            deadlineRemaining: 2,
+            durationWeeks: 3,
+            assignedTeamIds: [],
+          },
+        },
+      },
+    ]
+
+    expect(getCaseWeeklyReportWeeks(reports, 'case-a')).toEqual([2])
+  })
+
   it('collects weeks from case lists and note metadata.caseId', () => {
     const reports: WeeklyReport[] = [
       {
@@ -77,6 +100,16 @@ describe('event feed return navigation', () => {
     expect(href).toContain('/cases/case-a')
     expect(href).toContain('feedQ=raid')
     expect(href).toContain('feedCategory=incident_response')
+  })
+
+  it('preserves existing query strings on drill-down hrefs', () => {
+    const href = buildDrillDownHrefWithFeedContext(
+      '/cases/case-a?tab=timeline',
+      new URLSearchParams('feedQ=raid')
+    )
+
+    expect(href).toContain('tab=timeline')
+    expect(href).toContain('feedQ=raid')
   })
 
   it('returns operations desk when feed filters are present', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-merge audit passes for SPE-2248 (#2333). Addresses edge cases that should have been caught before the original PR shipped.

## Fixes

| Pass | Issue | Fix |
|------|--------|-----|
| Edge cases | Feed links to `/report/N` when report N absent | `refineEventFeedDrillDownHref` → case detail fallback |
| Edge cases | Cases only in `caseSnapshots` omitted from weekly report links | `reportListsCase` checks snapshot keys |
| Scope / integration | No visible back path from case/report detail when drilled from feed | Desk back link when feed params present |
| Scope / integration | Agent drill-down from feed returned to agents list with feed params | `resolveOperationsBackTarget` on agent detail |
| Determinism | `href.split('?')` broke targets with multiple query segments | First-`?` split in `buildDrillDownHrefWithFeedContext` |

## Tests

- `operationsRouteDrillDown.test.ts` — snapshots, query preservation
- `eventFeedView.test.ts` — report href fallback
- `CaseDetailPage.test.tsx` — visible desk back link

## Verification

- `npm run lint`
- `npm run test:run` (3544 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

