### PR TITLE
feat(SPE-2249): ConcealmentTriggers migration batch 4 (12 templates)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -15,7 +15,7 @@ From `README.md` **Current design notes**:
 
 ## Queue (highest leverage first — reorder as needed)
 
-1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, and activation event feed shipped (SPE-2107 / SPE-2113); **next:** [SPE-2249](https://linear.app/spectranoir/issue/SPE-2249/concealmenttriggers-migration-batch-4-remaining-templates) (content-only `concealmentTriggers` on remaining templates).
+1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, activation event feed, and batch-4 template migration shipped (`planning/concealment-triggers-migration-batch-4-slice.md`, SPE-2249); **next:** [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) (encounter/content depth on SPE-521 substrate).
 2. **Infiltration and access follow-through** — [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) (encounter/content depth on shipped SPE-521 substrate; not new probe mechanics).
 3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
 4. **Core UX specs** — Finish or refresh core UX specs so surfaces match canonical domain outputs (`planning/roadmap.md` §15).

--- a/planning/concealment-case-prep-slice.md
+++ b/planning/concealment-case-prep-slice.md
@@ -178,7 +178,7 @@ Optional thin domain file: `src/domain/concealmentCasePrep.ts` if eligibility is
 
 1. ~~**Covert ops prep consolidation**~~ — shipped (`WeeklyCasePrepPanel`, collapsible sections, shared forensic strip).
 2. ~~**Concealment event feed**~~ — shipped (`concealment.activated` event + report notes; `planning/concealment-activation-event-feed-slice.md`).
-3. **Remaining templates** without `concealmentTriggers` — [SPE-2249](https://linear.app/spectranoir/issue/SPE-2249/concealmenttriggers-migration-batch-4-remaining-templates) (content-only batch 4).
+3. ~~**Remaining templates** without `concealmentTriggers`~~ — shipped batch 4 ([SPE-2249](https://linear.app/spectranoir/issue/SPE-2249), `planning/concealment-triggers-migration-batch-4-slice.md`).
 
 ---
 

--- a/planning/concealment-triggers-migration-batch-4-slice.md
+++ b/planning/concealment-triggers-migration-batch-4-slice.md
@@ -1,0 +1,44 @@
+# ConcealmentTriggers migration batch 4 (SPE-2249)
+
+## Goal
+
+Content-only follow-up after batches 1–3: add authored `concealmentTriggers[]` to remaining catalog templates where hidden/displaced activation fits the narrative.
+
+## Migrated templates (`BATCH_FOUR_TEMPLATE_IDS`)
+
+| Template | Trigger id | Mode | When |
+| --- | --- | --- | --- |
+| `ops-005` | `trigger:ops-005-chamber-approach` | hidden | `allTags: occult, seal` |
+| `bio-forensics-001` | `trigger:bio-forensics-001-vector-stakeout` | hidden | `anyTag: forensics, biological` |
+| `info-001` | `trigger:info-001-relay-infiltration` | hidden | `allTags: information, cyber` |
+| `occult-001` | `trigger:occult-001-chapel-infiltration` | hidden | `allTags: occult, chapel` |
+| `occult-002` | `trigger:occult-002-memorial-blend` | hidden | `anyTag: memorial, resonance` |
+| `occult-004` | `trigger:occult-004-vault-approach` | hidden | `allTags: reliquary, vault` |
+| `occult-005` | `trigger:occult-005-greenhouse-cover` | hidden | `anyTag: cathedral, weather` |
+| `occult-007` | `trigger:occult-007-catacomb-infiltration` | hidden | `allTags: occult, catacomb` |
+| `psi-001` | `trigger:psi-001-bleed-stakeout` | hidden | `anyTag: psionic, precognition` |
+| `psi-004` | `trigger:psi-004-station-infiltration` | hidden | `anyTag: amplifier, psionic` |
+| `psi-006` | `trigger:psi-006-reliquary-screen` | hidden | `allTags: psionic, reliquary` |
+| `followup_psi_aftermath` | `trigger:followup-psi-aftermath-residue-sweep` | hidden | `anyTag: psionic, aftermath` |
+
+## Intentionally excluded (this batch)
+
+Combat/raid generics (`combat-001`, `raid-001`, `anomaly-raid-001`, …), open-assault follow-ups (`followup_feeding_frenzy`), and templates without a credible concealed-approach narrative (`ops-006`, `ops-009`, `reward-mixed-bundle`, …). All templates with `infiltrationProbePlan` already had triggers from batches 1–3.
+
+## Out of scope
+
+- Domain kernel / UI changes
+- New activation modes
+- SPE-781 full hidden-modality matrix
+
+## Acceptance
+
+- [x] `BATCH_FOUR_TEMPLATE_IDS` catalog test
+- [x] Integration test: `ops-005` → `advanceWeek` → `hiddenState === 'hidden'`
+- [x] `npm run test:run` green
+
+## See also
+
+- Parent SPE-2155
+- `src/test/caseTemplateConcealmentMigration.test.ts`
+- Linear SPE-2249 / GitHub #2331

--- a/src/domain/templates/caseTemplates.occult.ts
+++ b/src/domain/templates/caseTemplates.occult.ts
@@ -15,6 +15,13 @@ export const occultCaseTemplates: CaseTemplate[] = [
     tags: ['occult', 'ritual', 'chapel', 'tier-2'],
     requiredTags: ['occultist'],
     preferredTags: ['holy', 'negotiator', 'ritual-kit'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:occult-001-chapel-infiltration',
+        mode: 'hidden',
+        when: { allTags: ['occult', 'chapel'] },
+      },
+    ],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -43,6 +50,13 @@ export const occultCaseTemplates: CaseTemplate[] = [
     tags: ['occult', 'resonance', 'memorial', 'tier-2'],
     requiredTags: ['scholar'],
     preferredTags: ['scholar', 'negotiator'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:occult-002-memorial-blend',
+        mode: 'hidden',
+        when: { anyTag: ['memorial', 'resonance'] },
+      },
+    ],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -116,6 +130,13 @@ export const occultCaseTemplates: CaseTemplate[] = [
     tags: ['occult', 'reliquary', 'vault', 'tier-2'],
     requiredTags: ['holy'],
     preferredTags: ['tech', 'medic'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:occult-004-vault-approach',
+        mode: 'hidden',
+        when: { allTags: ['reliquary', 'vault'] },
+      },
+    ],
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
       stageDelta: 1,
@@ -143,6 +164,13 @@ export const occultCaseTemplates: CaseTemplate[] = [
     tags: ['occult', 'weather', 'cathedral', 'tier-2'],
     requiredTags: ['scholar'],
     preferredTags: ['tech', 'negotiator'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:occult-005-greenhouse-cover',
+        mode: 'hidden',
+        when: { anyTag: ['cathedral', 'weather'] },
+      },
+    ],
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -218,6 +246,13 @@ export const occultCaseTemplates: CaseTemplate[] = [
     tags: ['occult', 'catacomb', 'raid', 'tier-3'],
     requiredTags: ['holy', 'scholar'],
     preferredTags: ['ritual-kit', 'tech', 'medic'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:occult-007-catacomb-infiltration',
+        mode: 'hidden',
+        when: { allTags: ['occult', 'catacomb'] },
+      },
+    ],
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
       stageDelta: 1,

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -198,6 +198,13 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     tags: ['occult', 'signal', 'seal', 'tier-2'],
     requiredTags: ['occultist'],
     preferredTags: ['ritual-kit', 'medium'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:ops-005-chamber-approach',
+        mode: 'hidden',
+        when: { allTags: ['occult', 'seal'] },
+      },
+    ],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -254,6 +261,13 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     tags: ['biological', 'forensics', 'triage', 'tier-2'],
     requiredTags: ['medic'],
     preferredTags: ['investigator', 'lab-kit', 'forensics'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:bio-forensics-001-vector-stakeout',
+        mode: 'hidden',
+        when: { anyTag: ['forensics', 'biological'] },
+      },
+    ],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -18,6 +18,13 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     tags: ['psionic', 'precognition', 'tier-2'],
     requiredTags: ['medium'],
     preferredTags: ['analyst', 'investigator'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:psi-001-bleed-stakeout',
+        mode: 'hidden',
+        when: { anyTag: ['psionic', 'precognition'] },
+      },
+    ],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -184,6 +191,13 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     tags: ['psionic', 'reliquary', 'memory', 'tier-2'],
     requiredTags: ['scholar'],
     preferredTags: ['medium', 'analyst', 'tech'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:psi-006-reliquary-screen',
+        mode: 'hidden',
+        when: { allTags: ['psionic', 'reliquary'] },
+      },
+    ],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -213,6 +227,13 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     tags: ['psionic', 'amplifier', 'tier-2'],
     requiredTags: ['medium'],
     preferredTags: ['tech', 'analyst', 'field-kit'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:psi-004-station-infiltration',
+        mode: 'hidden',
+        when: { anyTag: ['amplifier', 'psionic'] },
+      },
+    ],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -273,6 +294,13 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 2,
     tags: ['psionic', 'aftermath', 'tier-1'],
     preferredTags: ['medium', 'tech', 'investigator'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:followup-psi-aftermath-residue-sweep',
+        mode: 'hidden',
+        when: { anyTag: ['psionic', 'aftermath'] },
+      },
+    ],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -169,6 +169,13 @@ const baseCaseTemplates: CaseTemplate[] = [
     requiredTags: ['tech'],
     requiredRoles: ['technical', 'investigator'],
     preferredTags: ['hacker', 'analyst'],
+    concealmentTriggers: [
+      {
+        id: 'trigger:info-001-relay-infiltration',
+        mode: 'hidden',
+        when: { allTags: ['information', 'cyber'] },
+      },
+    ],
     onFail: { stageDelta: 1, spawnCount: { min: 0, max: 1 }, spawnTemplateIds: ['info-001'] },
     onUnresolved: {
       stageDelta: 2,

--- a/src/test/caseTemplateConcealmentMigration.test.ts
+++ b/src/test/caseTemplateConcealmentMigration.test.ts
@@ -31,11 +31,27 @@ const BATCH_THREE_STARTER_CHAIN_TEMPLATE_IDS = [
   'followup_targeted_abductions',
 ] as const
 
+const BATCH_FOUR_TEMPLATE_IDS = [
+  'ops-005',
+  'bio-forensics-001',
+  'info-001',
+  'occult-001',
+  'occult-002',
+  'occult-004',
+  'occult-005',
+  'occult-007',
+  'psi-001',
+  'psi-004',
+  'psi-006',
+  'followup_psi_aftermath',
+] as const
+
 describe('case template concealment migration', () => {
   it.each([
     ...BATCH_ONE_TEMPLATE_IDS,
     ...BATCH_TWO_TEMPLATE_IDS,
     ...BATCH_THREE_STARTER_CHAIN_TEMPLATE_IDS,
+    ...BATCH_FOUR_TEMPLATE_IDS,
   ])(
     'catalog template %s carries normalized concealmentTriggers',
     (templateId) => {
@@ -93,5 +109,32 @@ describe('case template concealment migration', () => {
     const activation = resolveConcealmentActivation(caseData, { globalFlags: {} })
     expect(activation.applied).toBe(true)
     expect(activation.reason).toBe('authored-trigger:trigger:occult-006-procession-blend')
+  })
+
+  it('activates hidden presence from migrated ops-005 black chamber trigger', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+    const template = caseTemplateMap['ops-005']
+    const spawned = instantiateFromTemplate(template, () => 0.42, new Set(Object.keys(state.cases)))
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = {}
+    state.cases[spawned.id] = {
+      ...spawned,
+      mode: 'probability',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+      weeksRemaining: 1,
+    }
+
+    const activation = resolveConcealmentActivation(state.cases[spawned.id], {
+      globalFlags: state.globalFlags,
+    })
+    expect(activation.applied).toBe(true)
+    expect(activation.reason).toBe('authored-trigger:trigger:ops-005-chamber-approach')
+
+    const nextState = advanceWeek(state)
+    expect(nextState.cases[spawned.id].hiddenState).toBe('hidden')
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Content-only SPE-2249: authored `concealmentTriggers[]` on 12 remaining catalog templates where hidden activation fits the narrative. No domain kernel or UI changes.

## Templates (batch 4)

`ops-005`, `bio-forensics-001`, `info-001`, `occult-001`, `occult-002`, `occult-004`, `occult-005`, `occult-007`, `psi-001`, `psi-004`, `psi-006`, `followup_psi_aftermath`

See trigger matrix in `planning/concealment-triggers-migration-batch-4-slice.md`.

## Tests

- `BATCH_FOUR_TEMPLATE_IDS` catalog coverage in `caseTemplateConcealmentMigration.test.ts`
- Integration: `ops-005` → `resolveConcealmentActivation` → `advanceWeek` → `hiddenState === 'hidden'`

## Verification

- `npm run lint`
- `npm run test:run` (3557 tests)

Linear: SPE-2249 · GitHub #2331
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

