### PR TITLE
SPE-2250: infiltration encounter content slice 1 (ops-005, psi-001, info-001)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -15,8 +15,8 @@ From `README.md` **Current design notes**:
 
 ## Queue (highest leverage first — reorder as needed)
 
-1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, activation event feed, and batch-4 template migration shipped (`planning/concealment-triggers-migration-batch-4-slice.md`, SPE-2249); **next:** [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) (encounter/content depth on SPE-521 substrate).
-2. **Infiltration and access follow-through** — [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) (encounter/content depth on shipped SPE-521 substrate; not new probe mechanics).
+1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, activation event feed, and batch-4 concealment migration shipped (`planning/concealment-triggers-migration-batch-4-slice.md`, SPE-2249); infiltration content slice 1 shipped (`planning/infiltration-encounter-content-slice-1.md`, SPE-2250) for `ops-005`, `psi-001`, `info-001`.
+2. **Infiltration and access follow-through** — [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) slice 2+: remaining batch-4 templates and encounter depth on shipped SPE-521 substrate (not new probe mechanics).
 3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
 4. **Core UX specs** — Finish or refresh core UX specs so surfaces match canonical domain outputs (`planning/roadmap.md` §15).
 5. **Tuning and QA references** — Complete tuning references and QA references, then use them to harden implementation sequencing (same roadmap section).

--- a/planning/infiltration-encounter-content-slice-1.md
+++ b/planning/infiltration-encounter-content-slice-1.md
@@ -1,0 +1,32 @@
+# Infiltration encounter/content slice 1 (SPE-2250)
+
+## Goal
+
+Content-only follow-through on the shipped SPE-521 substrate: add authored `infiltrationProbePlan`, `infiltrationCoverProfile`, and `stealthLeaveBehindId` to batch-4 templates that already have `concealmentTriggers` but lacked a full infiltration stack.
+
+No new probe mechanics, domain kernel changes, or UI work in this slice.
+
+## Migrated templates (`INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS`)
+
+| Template | Cover role | Default probe | Leave-behind |
+| --- | --- | --- | --- |
+| `ops-005` | maintenance | `probe_access` (+ route fallback, cleanup at 0.55 awareness) | `leave-behind:risk-discovery` |
+| `psi-001` | civilian_staff | `probe_route` (+ access fallback) | `leave-behind:risk-discovery` |
+| `info-001` | courier | `probe_route` (+ access fallback) | `leave-behind:burn-tool` |
+
+## Intentionally deferred (same issue, later slices)
+
+Remaining batch-4 templates with triggers only (`bio-forensics-001`, `occult-001`–`007`, `psi-004`, `psi-006`, `followup_psi_aftermath`) and encounter-depth beyond probe/cover/leave-behind.
+
+## Acceptance
+
+- [x] `INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS` catalog test
+- [x] Probe-plan count ≥ 24 (was 21)
+- [x] `advanceWeek` integration: `ops-005` hidden + probe tick
+- [x] `npm run test:run` green
+
+## See also
+
+- `planning/concealment-triggers-migration-batch-4-slice.md` (SPE-2249)
+- `src/test/infiltrationEncounterContentSlice.test.ts`
+- Linear SPE-2250

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -196,8 +196,6 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 2,
     tags: ['occult', 'signal', 'seal', 'tier-2'],
-    requiredTags: ['occultist'],
-    preferredTags: ['ritual-kit', 'medium'],
     concealmentTriggers: [
       {
         id: 'trigger:ops-005-chamber-approach',
@@ -205,6 +203,19 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['occult', 'seal'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_route' }],
+      cleanupWhenAwarenessAtLeast: 0.55,
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 0,
+      doctrineBand: 0.4,
+    },
+    stealthLeaveBehindId: 'leave-behind:risk-discovery',
+    requiredTags: ['occultist'],
+    preferredTags: ['ritual-kit', 'medium', 'covert', 'infiltration', 'stealth'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -16,8 +16,6 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 3,
     tags: ['psionic', 'precognition', 'tier-2'],
-    requiredTags: ['medium'],
-    preferredTags: ['analyst', 'investigator'],
     concealmentTriggers: [
       {
         id: 'trigger:psi-001-bleed-stakeout',
@@ -25,6 +23,18 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['psionic', 'precognition'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
+    stealthLeaveBehindId: 'leave-behind:risk-discovery',
+    requiredTags: ['medium'],
+    preferredTags: ['analyst', 'investigator', 'covert', 'infiltration'],
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/domain/templates/caseTemplates.ts
+++ b/src/domain/templates/caseTemplates.ts
@@ -166,9 +166,6 @@ const baseCaseTemplates: CaseTemplate[] = [
     durationWeeks: 2,
     deadlineWeeks: 3,
     tags: ['information', 'cyber', 'tier-3'],
-    requiredTags: ['tech'],
-    requiredRoles: ['technical', 'investigator'],
-    preferredTags: ['hacker', 'analyst'],
     concealmentTriggers: [
       {
         id: 'trigger:info-001-relay-infiltration',
@@ -176,6 +173,19 @@ const baseCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['information', 'cyber'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.5, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'courier',
+      documentTier: 2,
+      doctrineBand: 0.65,
+    },
+    stealthLeaveBehindId: 'leave-behind:burn-tool',
+    requiredTags: ['tech'],
+    requiredRoles: ['technical', 'investigator'],
+    preferredTags: ['hacker', 'analyst', 'covert', 'infiltration'],
     onFail: { stageDelta: 1, spawnCount: { min: 0, max: 1 }, spawnTemplateIds: ['info-001'] },
     onUnresolved: {
       stageDelta: 2,

--- a/src/test/advanceWeek.infiltrationProbe.integration.test.ts
+++ b/src/test/advanceWeek.infiltrationProbe.integration.test.ts
@@ -147,4 +147,42 @@ describe('advanceWeek infiltration probe integration', () => {
     expect(updatedCase.infiltrationProbeProgress).toBeCloseTo(0.7, 3)
     expect(updatedCase.infiltrationAwareness).toBeCloseTo(0.38, 3)
   })
+
+  it('ticks probe progress for batch-4 ops-005 after authored concealment activation', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = {}
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const chamberCase = instantiateFromTemplate(
+      caseTemplateMap['ops-005'],
+      () => 0.42,
+      new Set(Object.keys(state.cases))
+    )
+    chamberCase.id = 'case-ops-005'
+    chamberCase.tags = [...chamberCase.tags, 'infiltration', 'covert']
+    chamberCase.status = 'in_progress'
+    chamberCase.assignedTeamIds = [teamId]
+    chamberCase.weeksRemaining = 2
+    chamberCase.mode = 'probability'
+    chamberCase.infiltrationProbeProgress = 0.15
+    chamberCase.infiltrationAwareness = 0.2
+
+    state.cases['case-ops-005'] = chamberCase
+
+    const nextState = advanceWeek(state)
+    const updatedCase = nextState.cases['case-ops-005']
+
+    expect(updatedCase.hiddenState).toBe('hidden')
+    expect(updatedCase.infiltrationProbeProgress).toBeGreaterThan(0.15)
+    expect(updatedCase.infiltrationCoverProfile?.claimedRole).toBe('maintenance')
+    expect(updatedCase.stealthLeaveBehindId).toBe('leave-behind:risk-discovery')
+  })
 })

--- a/src/test/infiltrationCover.test.ts
+++ b/src/test/infiltrationCover.test.ts
@@ -228,7 +228,7 @@ describe('infiltrationCover', () => {
       .filter((template) => template.infiltrationProbePlan)
       .map((template) => template.templateId)
 
-    expect(templateIds.length).toBeGreaterThanOrEqual(21)
+    expect(templateIds.length).toBeGreaterThanOrEqual(24)
 
     for (const templateId of templateIds) {
       expect(caseTemplateMap[templateId].infiltrationCoverProfile?.claimedRole).toBeTruthy()

--- a/src/test/infiltrationEncounterContentSlice.test.ts
+++ b/src/test/infiltrationEncounterContentSlice.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { caseTemplateMap, caseTemplates } from '../domain/templates/caseTemplates'
+
+/** SPE-2250 slice 1: batch-4 templates that gained full infiltration stack. */
+export const INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS = [
+  'ops-005',
+  'psi-001',
+  'info-001',
+] as const
+
+describe('infiltration encounter content slice 1', () => {
+  it.each(INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS)(
+    'catalog template %s declares probe plan, cover profile, and leave-behind',
+    (templateId) => {
+      const template = caseTemplateMap[templateId]
+
+      expect(template?.infiltrationProbePlan?.defaultAction).toBeTruthy()
+      expect(template?.infiltrationCoverProfile?.claimedRole).toBeTruthy()
+      expect(template?.stealthLeaveBehindId?.trim()).toBeTruthy()
+      expect(template?.concealmentTriggers?.length).toBeGreaterThan(0)
+    }
+  )
+
+  it('extends probe-plan catalog count beyond batch 1–3 baseline', () => {
+    const probePlanIds = caseTemplates
+      .filter((template) => template.infiltrationProbePlan)
+      .map((template) => template.templateId)
+
+    expect(probePlanIds.length).toBeGreaterThanOrEqual(24)
+    for (const templateId of INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS) {
+      expect(probePlanIds).toContain(templateId)
+    }
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Content-only follow-through on the shipped SPE-521 substrate (SPE-2250 slice 1). Adds authored `infiltrationProbePlan`, `infiltrationCoverProfile`, and `stealthLeaveBehindId` to three batch-4 templates that already had `concealmentTriggers` but no infiltration stack.

## Templates

| Template | Cover | Default probe | Leave-behind |
| --- | --- | --- | --- |
| `ops-005` | maintenance | `probe_access` (+ route fallback, cleanup ≥0.55 awareness) | `leave-behind:risk-discovery` |
| `psi-001` | civilian_staff | `probe_route` (+ access fallback) | `leave-behind:risk-discovery` |
| `info-001` | courier | `probe_route` (+ access fallback) | `leave-behind:burn-tool` |

## Tests

- `src/test/infiltrationEncounterContentSlice.test.ts` — `INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS` catalog guard; probe-plan count ≥ 24
- `advanceWeek.infiltrationProbe.integration.test.ts` — `ops-005` hidden + probe tick after authored concealment
- `infiltrationCover.test.ts` — raised probe-plan baseline to 24

## Docs

- `planning/infiltration-encounter-content-slice-1.md`
- `planning/backlog.md` queue note for slice 1 shipped / slice 2+ deferred

## Validation

- `npm run lint` — pass
- `npm run test:run` — 3562 tests pass

## Out of scope

- No new probe mechanics, domain kernel, or UI
- Remaining batch-4 trigger-only templates (`bio-forensics-001`, occult/psi follow-ups) → SPE-2250 slice 2+
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

