### PR TITLE
SPE-2250 slice 2: infiltration stack for remaining nine batch-4 templates

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -15,8 +15,8 @@ From `README.md` **Current design notes**:
 
 ## Queue (highest leverage first — reorder as needed)
 
-1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, activation event feed, and batch-4 concealment migration shipped (`planning/concealment-triggers-migration-batch-4-slice.md`, SPE-2249); infiltration content slice 1 shipped (`planning/infiltration-encounter-content-slice-1.md`, SPE-2250) for `ops-005`, `psi-001`, `info-001`.
-2. **Infiltration and access follow-through** — [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) slice 2+: remaining batch-4 templates and encounter depth on shipped SPE-521 substrate (not new probe mechanics).
+1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, activation event feed, batch-4 concealment migration (SPE-2249), and full batch-4 infiltration stack (SPE-2250 slices 1–2; `planning/infiltration-encounter-content-slice-2.md`) shipped.
+2. **Infiltration and access follow-through** — [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) batch-4 probe/cover/leave-behind complete; further encounter depth beyond authored stacks is optional follow-up (not new probe mechanics).
 3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
 4. **Core UX specs** — Finish or refresh core UX specs so surfaces match canonical domain outputs (`planning/roadmap.md` §15).
 5. **Tuning and QA references** — Complete tuning references and QA references, then use them to harden implementation sequencing (same roadmap section).

--- a/planning/infiltration-encounter-content-slice-1.md
+++ b/planning/infiltration-encounter-content-slice-1.md
@@ -14,9 +14,9 @@ No new probe mechanics, domain kernel changes, or UI work in this slice.
 | `psi-001` | civilian_staff | `probe_route` (+ access fallback) | `leave-behind:risk-discovery` |
 | `info-001` | courier | `probe_route` (+ access fallback) | `leave-behind:burn-tool` |
 
-## Intentionally deferred (same issue, later slices)
+## Follow-up
 
-Remaining batch-4 templates with triggers only (`bio-forensics-001`, `occult-001`–`007`, `psi-004`, `psi-006`, `followup_psi_aftermath`) and encounter-depth beyond probe/cover/leave-behind.
+Remaining nine batch-4 templates shipped in slice 2 (`planning/infiltration-encounter-content-slice-2.md`).
 
 ## Acceptance
 

--- a/planning/infiltration-encounter-content-slice-2.md
+++ b/planning/infiltration-encounter-content-slice-2.md
@@ -1,0 +1,41 @@
+# Infiltration encounter/content slice 2 (SPE-2250)
+
+## Goal
+
+Complete batch-4 infiltration follow-through: add authored `infiltrationProbePlan`, `infiltrationCoverProfile`, and `stealthLeaveBehindId` to the nine remaining batch-4 templates that had `concealmentTriggers` only after SPE-2249.
+
+Content-only on the shipped SPE-521 substrate — no new probe mechanics.
+
+## Migrated templates (`INFILTRATION_CONTENT_SLICE_2_TEMPLATE_IDS`)
+
+| Template | Cover role | Default probe | Leave-behind |
+| --- | --- | --- | --- |
+| `bio-forensics-001` | maintenance | `probe_access` (+ route fallback) | `leave-behind:leave-trace` |
+| `occult-001` | maintenance | `probe_access` (+ route fallback) | `leave-behind:risk-discovery` |
+| `occult-002` | civilian_staff | `probe_route` (+ access fallback) | `leave-behind:leave-trace` |
+| `occult-004` | maintenance | `probe_access` (+ route fallback) | `leave-behind:leave-trace` |
+| `occult-005` | civilian_staff | `probe_access` (cleanup ≥0.55 awareness) | `leave-behind:leave-trace` |
+| `occult-007` | maintenance | `probe_access` (+ route fallback) | `leave-behind:risk-discovery` |
+| `psi-004` | civilian_staff | `probe_route` (+ access fallback) | `leave-behind:risk-discovery` |
+| `psi-006` | maintenance | `probe_access` (+ route fallback) | `leave-behind:risk-discovery` |
+| `followup_psi_aftermath` | maintenance | `probe_route` (+ access fallback) | `leave-behind:leave-trace` |
+
+Slice 1 (`ops-005`, `psi-001`, `info-001`) documented in `planning/infiltration-encounter-content-slice-1.md`.
+
+## Batch-4 completion
+
+All twelve `BATCH_FOUR_TEMPLATE_IDS` from SPE-2249 now carry the full infiltration stack (`INFILTRATION_CONTENT_BATCH_FOUR_TEMPLATE_IDS` in tests).
+
+## Acceptance
+
+- [x] `INFILTRATION_CONTENT_SLICE_2_TEMPLATE_IDS` catalog test
+- [x] All twelve batch-4 templates have probe + cover + leave-behind
+- [x] Probe-plan count ≥ 33 (was 24 after slice 1)
+- [x] `advanceWeek` integration: `psi-004` hidden + probe tick
+- [x] `npm run test:run` green
+
+## See also
+
+- `planning/infiltration-encounter-content-slice-1.md`
+- `planning/concealment-triggers-migration-batch-4-slice.md`
+- Linear SPE-2250

--- a/src/domain/templates/caseTemplates.occult.ts
+++ b/src/domain/templates/caseTemplates.occult.ts
@@ -14,7 +14,7 @@ export const occultCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 2,
     tags: ['occult', 'ritual', 'chapel', 'tier-2'],
     requiredTags: ['occultist'],
-    preferredTags: ['holy', 'negotiator', 'ritual-kit'],
+    preferredTags: ['holy', 'negotiator', 'ritual-kit', 'covert', 'infiltration', 'stealth'],
     concealmentTriggers: [
       {
         id: 'trigger:occult-001-chapel-infiltration',
@@ -22,6 +22,16 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['occult', 'chapel'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 0,
+      doctrineBand: 0.4,
+    },
+    stealthLeaveBehindId: 'leave-behind:risk-discovery',
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -49,7 +59,7 @@ export const occultCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 3,
     tags: ['occult', 'resonance', 'memorial', 'tier-2'],
     requiredTags: ['scholar'],
-    preferredTags: ['scholar', 'negotiator'],
+    preferredTags: ['scholar', 'negotiator', 'covert', 'infiltration', 'disguise'],
     concealmentTriggers: [
       {
         id: 'trigger:occult-002-memorial-blend',
@@ -57,6 +67,16 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['memorial', 'resonance'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.45, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.5,
+    },
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -129,7 +149,7 @@ export const occultCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 2,
     tags: ['occult', 'reliquary', 'vault', 'tier-2'],
     requiredTags: ['holy'],
-    preferredTags: ['tech', 'medic'],
+    preferredTags: ['tech', 'medic', 'covert', 'infiltration', 'stealth'],
     concealmentTriggers: [
       {
         id: 'trigger:occult-004-vault-approach',
@@ -137,6 +157,16 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['reliquary', 'vault'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.35, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
       stageDelta: 1,
@@ -163,7 +193,7 @@ export const occultCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 3,
     tags: ['occult', 'weather', 'cathedral', 'tier-2'],
     requiredTags: ['scholar'],
-    preferredTags: ['tech', 'negotiator'],
+    preferredTags: ['tech', 'negotiator', 'covert', 'infiltration', 'disguise'],
     concealmentTriggers: [
       {
         id: 'trigger:occult-005-greenhouse-cover',
@@ -171,6 +201,16 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['cathedral', 'weather'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      cleanupWhenAwarenessAtLeast: 0.55,
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.5,
+    },
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
     raid: { minTeams: 2, maxTeams: 3 },
     onFail: {
       stageDelta: 1,
@@ -245,7 +285,7 @@ export const occultCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 2,
     tags: ['occult', 'catacomb', 'raid', 'tier-3'],
     requiredTags: ['holy', 'scholar'],
-    preferredTags: ['ritual-kit', 'tech', 'medic'],
+    preferredTags: ['ritual-kit', 'tech', 'medic', 'covert', 'infiltration', 'stealth'],
     concealmentTriggers: [
       {
         id: 'trigger:occult-007-catacomb-infiltration',
@@ -253,6 +293,16 @@ export const occultCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['occult', 'catacomb'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 0,
+      doctrineBand: 0.4,
+    },
+    stealthLeaveBehindId: 'leave-behind:risk-discovery',
     raid: { minTeams: 2, maxTeams: 4 },
     onFail: {
       stageDelta: 1,

--- a/src/domain/templates/caseTemplates.operations.ts
+++ b/src/domain/templates/caseTemplates.operations.ts
@@ -271,7 +271,7 @@ export const operationsCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 3,
     tags: ['biological', 'forensics', 'triage', 'tier-2'],
     requiredTags: ['medic'],
-    preferredTags: ['investigator', 'lab-kit', 'forensics'],
+    preferredTags: ['investigator', 'lab-kit', 'forensics', 'covert', 'infiltration', 'stealth'],
     concealmentTriggers: [
       {
         id: 'trigger:bio-forensics-001-vector-stakeout',
@@ -279,6 +279,16 @@ export const operationsCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['forensics', 'biological'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.35, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/domain/templates/caseTemplates.psionic.ts
+++ b/src/domain/templates/caseTemplates.psionic.ts
@@ -200,7 +200,7 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 2,
     tags: ['psionic', 'reliquary', 'memory', 'tier-2'],
     requiredTags: ['scholar'],
-    preferredTags: ['medium', 'analyst', 'tech'],
+    preferredTags: ['medium', 'analyst', 'tech', 'covert', 'infiltration', 'stealth'],
     concealmentTriggers: [
       {
         id: 'trigger:psi-006-reliquary-screen',
@@ -208,6 +208,16 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { allTags: ['psionic', 'reliquary'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_access',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_route' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
+    stealthLeaveBehindId: 'leave-behind:risk-discovery',
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -236,7 +246,7 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     deadlineWeeks: 3,
     tags: ['psionic', 'amplifier', 'tier-2'],
     requiredTags: ['medium'],
-    preferredTags: ['tech', 'analyst', 'field-kit'],
+    preferredTags: ['tech', 'analyst', 'field-kit', 'covert', 'infiltration'],
     concealmentTriggers: [
       {
         id: 'trigger:psi-004-station-infiltration',
@@ -244,6 +254,16 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['amplifier', 'psionic'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'civilian_staff',
+      documentTier: 1,
+      doctrineBand: 0.45,
+    },
+    stealthLeaveBehindId: 'leave-behind:risk-discovery',
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },
@@ -303,7 +323,7 @@ export const psionicCaseTemplates: CaseTemplate[] = [
     durationWeeks: 1,
     deadlineWeeks: 2,
     tags: ['psionic', 'aftermath', 'tier-1'],
-    preferredTags: ['medium', 'tech', 'investigator'],
+    preferredTags: ['medium', 'tech', 'investigator', 'covert', 'infiltration', 'stealth'],
     concealmentTriggers: [
       {
         id: 'trigger:followup-psi-aftermath-residue-sweep',
@@ -311,6 +331,16 @@ export const psionicCaseTemplates: CaseTemplate[] = [
         when: { anyTag: ['psionic', 'aftermath'] },
       },
     ],
+    infiltrationProbePlan: {
+      defaultAction: 'probe_route',
+      actionWhenProbeProgressBelow: [{ belowProbeProgress: 0.4, action: 'probe_access' }],
+    },
+    infiltrationCoverProfile: {
+      claimedRole: 'maintenance',
+      documentTier: 1,
+      doctrineBand: 0.4,
+    },
+    stealthLeaveBehindId: 'leave-behind:leave-trace',
     onFail: {
       stageDelta: 1,
       spawnCount: { min: 1, max: 1 },

--- a/src/test/advanceWeek.infiltrationProbe.integration.test.ts
+++ b/src/test/advanceWeek.infiltrationProbe.integration.test.ts
@@ -185,4 +185,42 @@ describe('advanceWeek infiltration probe integration', () => {
     expect(updatedCase.infiltrationCoverProfile?.claimedRole).toBe('maintenance')
     expect(updatedCase.stealthLeaveBehindId).toBe('leave-behind:risk-discovery')
   })
+
+  it('ticks probe progress for batch-4 psi-004 after authored concealment activation', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = {}
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const stationCase = instantiateFromTemplate(
+      caseTemplateMap['psi-004'],
+      () => 0.42,
+      new Set(Object.keys(state.cases))
+    )
+    stationCase.id = 'case-psi-004'
+    stationCase.tags = [...stationCase.tags, 'infiltration', 'covert']
+    stationCase.status = 'in_progress'
+    stationCase.assignedTeamIds = [teamId]
+    stationCase.weeksRemaining = 2
+    stationCase.mode = 'probability'
+    stationCase.infiltrationProbeProgress = 0.1
+    stationCase.infiltrationAwareness = 0.18
+
+    state.cases['case-psi-004'] = stationCase
+
+    const nextState = advanceWeek(state)
+    const updatedCase = nextState.cases['case-psi-004']
+
+    expect(updatedCase.hiddenState).toBe('hidden')
+    expect(updatedCase.infiltrationProbeProgress).toBeGreaterThan(0.1)
+    expect(updatedCase.infiltrationCoverProfile?.claimedRole).toBe('civilian_staff')
+    expect(updatedCase.stealthLeaveBehindId).toBe('leave-behind:risk-discovery')
+  })
 })

--- a/src/test/infiltrationCover.test.ts
+++ b/src/test/infiltrationCover.test.ts
@@ -228,7 +228,7 @@ describe('infiltrationCover', () => {
       .filter((template) => template.infiltrationProbePlan)
       .map((template) => template.templateId)
 
-    expect(templateIds.length).toBeGreaterThanOrEqual(24)
+    expect(templateIds.length).toBeGreaterThanOrEqual(33)
 
     for (const templateId of templateIds) {
       expect(caseTemplateMap[templateId].infiltrationCoverProfile?.claimedRole).toBeTruthy()

--- a/src/test/infiltrationEncounterContentSlice.test.ts
+++ b/src/test/infiltrationEncounterContentSlice.test.ts
@@ -8,6 +8,24 @@ export const INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS = [
   'info-001',
 ] as const
 
+/** SPE-2250 slice 2: remaining batch-4 trigger-only templates. */
+export const INFILTRATION_CONTENT_SLICE_2_TEMPLATE_IDS = [
+  'bio-forensics-001',
+  'occult-001',
+  'occult-002',
+  'occult-004',
+  'occult-005',
+  'occult-007',
+  'psi-004',
+  'psi-006',
+  'followup_psi_aftermath',
+] as const
+
+export const INFILTRATION_CONTENT_BATCH_FOUR_TEMPLATE_IDS = [
+  ...INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS,
+  ...INFILTRATION_CONTENT_SLICE_2_TEMPLATE_IDS,
+] as const
+
 describe('infiltration encounter content slice 1', () => {
   it.each(INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS)(
     'catalog template %s declares probe plan, cover profile, and leave-behind',
@@ -28,6 +46,40 @@ describe('infiltration encounter content slice 1', () => {
 
     expect(probePlanIds.length).toBeGreaterThanOrEqual(24)
     for (const templateId of INFILTRATION_CONTENT_SLICE_1_TEMPLATE_IDS) {
+      expect(probePlanIds).toContain(templateId)
+    }
+  })
+})
+
+describe('infiltration encounter content slice 2', () => {
+  it.each(INFILTRATION_CONTENT_SLICE_2_TEMPLATE_IDS)(
+    'catalog template %s declares probe plan, cover profile, and leave-behind',
+    (templateId) => {
+      const template = caseTemplateMap[templateId]
+
+      expect(template?.infiltrationProbePlan?.defaultAction).toBeTruthy()
+      expect(template?.infiltrationCoverProfile?.claimedRole).toBeTruthy()
+      expect(template?.stealthLeaveBehindId?.trim()).toBeTruthy()
+      expect(template?.concealmentTriggers?.length).toBeGreaterThan(0)
+    }
+  )
+
+  it('completes batch-4 infiltration stack on all twelve migrated templates', () => {
+    for (const templateId of INFILTRATION_CONTENT_BATCH_FOUR_TEMPLATE_IDS) {
+      const template = caseTemplateMap[templateId]
+      expect(template?.infiltrationProbePlan?.defaultAction).toBeTruthy()
+      expect(template?.infiltrationCoverProfile?.claimedRole).toBeTruthy()
+      expect(template?.stealthLeaveBehindId?.trim()).toBeTruthy()
+    }
+  })
+
+  it('extends probe-plan catalog count to full batch-4 follow-through', () => {
+    const probePlanIds = caseTemplates
+      .filter((template) => template.infiltrationProbePlan)
+      .map((template) => template.templateId)
+
+    expect(probePlanIds.length).toBeGreaterThanOrEqual(33)
+    for (const templateId of INFILTRATION_CONTENT_SLICE_2_TEMPLATE_IDS) {
       expect(probePlanIds).toContain(templateId)
     }
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

SPE-2250 slice 2 — completes batch-4 infiltration follow-through. Adds authored `infiltrationProbePlan`, `infiltrationCoverProfile`, and `stealthLeaveBehindId` to the nine remaining batch-4 templates that had `concealmentTriggers` only.

Combined with slice 1 (#2336), all twelve `BATCH_FOUR_TEMPLATE_IDS` now carry the full infiltration stack.

## Templates (slice 2)

| Template | Cover | Default probe | Leave-behind |
| --- | --- | --- | --- |
| `bio-forensics-001` | maintenance | `probe_access` + route fallback | `leave-behind:leave-trace` |
| `occult-001` | maintenance | `probe_access` + route fallback | `leave-behind:risk-discovery` |
| `occult-002` | civilian_staff | `probe_route` + access fallback | `leave-behind:leave-trace` |
| `occult-004` | maintenance | `probe_access` + route fallback | `leave-behind:leave-trace` |
| `occult-005` | civilian_staff | `probe_access` (cleanup ≥0.55) | `leave-behind:leave-trace` |
| `occult-007` | maintenance | `probe_access` + route fallback | `leave-behind:risk-discovery` |
| `psi-004` | civilian_staff | `probe_route` + access fallback | `leave-behind:risk-discovery` |
| `psi-006` | maintenance | `probe_access` + route fallback | `leave-behind:risk-discovery` |
| `followup_psi_aftermath` | maintenance | `probe_route` + access fallback | `leave-behind:leave-trace` |

## Tests

- `INFILTRATION_CONTENT_SLICE_2_TEMPLATE_IDS` + `INFILTRATION_CONTENT_BATCH_FOUR_TEMPLATE_IDS` catalog guards
- Probe-plan count ≥ 33
- `advanceWeek` integration for `psi-004`

## Docs

- `planning/infiltration-encounter-content-slice-2.md`
- Backlog + slice 1 doc cross-links

## Validation

- `npm run lint` — pass
- `npm run test:run` — 3574 tests pass

## Out of scope

No new probe mechanics; optional encounter depth beyond authored stacks remains future work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

