### PR TITLE
SPE-2251: MVP weekly loop proof integration harness (slice 1)

### DIFF
--- a/planning/mvp-weekly-loop-proof-slice-1.md
+++ b/planning/mvp-weekly-loop-proof-slice-1.md
@@ -108,11 +108,19 @@ Reuse helpers from:
 
 ## Acceptance criteria
 
-- [ ] `weeklyMvpLoopProof.integration.test.ts` runs in CI (`npm run test:run`)
-- [ ] Test covers: prep mutations → `advanceWeek` → report notes + event feed href sanity + week navigation
-- [ ] No new persistence shapes; uses existing store flags and case fields
-- [ ] `npm run lint` green
-- [ ] Plan linked from backlog #6
+- [x] `weeklyMvpLoopProof.integration.test.ts` runs in CI (`npm run test:run`)
+- [x] Test covers: prep mutations → `advanceWeek` → report notes + event feed href sanity + week navigation
+- [x] No new persistence shapes; uses existing domain prep APIs and case fields
+- [x] `npm run lint` green
+- [x] Plan linked from backlog #6
+
+## Shipped artifacts
+
+| Area | Files |
+| --- | --- |
+| Fixture | `src/test/helpers/weeklyMvpLoopProof.ts` |
+| Integration tests | `src/test/weeklyMvpLoopProof.integration.test.ts` |
+| Linear | SPE-2251 |
 
 ---
 

--- a/src/test/helpers/weeklyMvpLoopProof.ts
+++ b/src/test/helpers/weeklyMvpLoopProof.ts
@@ -1,0 +1,83 @@
+import { createStartingState } from '../../data/startingState'
+import { caseTemplateMap } from '../../data/caseTemplates'
+import {
+  applySuccessfulInvestigation,
+  askInvestigationQuestion,
+} from '../../domain/investigationEconomy'
+import type { GameState } from '../../domain/models'
+import { assignTeam } from '../../domain/sim/assign'
+import { createStarterCase } from '../../domain/templates/startingCases'
+
+export const MVP_LOOP_PROOF_CASE_ID = 'case-mvp-covert'
+export const MVP_LOOP_PROOF_TEMPLATE_ID = 'ops-004'
+export const MVP_LOOP_FORENSIC_QUESTION_ID = 'forensic.present-signature'
+
+export interface WeeklyMvpLoopProofFixture {
+  readonly state: GameState
+  readonly teamId: string
+}
+
+/** Deterministic starting state with covert case assigned and week-0 prep applied. */
+export function createWeeklyMvpLoopProofFixture(): WeeklyMvpLoopProofFixture {
+  const [teamId] = Object.keys(createStartingState().teams)
+  const template = caseTemplateMap[MVP_LOOP_PROOF_TEMPLATE_ID]
+
+  let state = createStartingState()
+  state.reports = []
+  state.events = []
+  state.agency!.supportAvailable = 3
+  state.globalFlags = {}
+
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+  }
+
+  for (const team of Object.values(state.teams)) {
+    team.assignedCaseId = undefined
+    if (team.status) {
+      team.status = { ...team.status, assignedCaseId: null }
+    }
+  }
+
+  const covertCase = createStarterCase({
+    id: MVP_LOOP_PROOF_CASE_ID,
+    templateId: MVP_LOOP_PROOF_TEMPLATE_ID,
+    status: 'in_progress',
+  })
+  covertCase.mode = 'deterministic'
+  covertCase.weeksRemaining = 2
+  covertCase.requiredTags = []
+  covertCase.preferredTags = []
+  covertCase.stealthLeaveBehindId = template.stealthLeaveBehindId
+  covertCase.infiltrationAwareness = 0.3
+  covertCase.infiltrationProbeProgress = 0.2
+
+  state.cases[MVP_LOOP_PROOF_CASE_ID] = covertCase
+  state = assignTeam(state, MVP_LOOP_PROOF_CASE_ID, teamId)
+
+  if (state.cases[MVP_LOOP_PROOF_CASE_ID]?.assignedTeamIds.length !== 1) {
+    throw new Error('Expected covert case team assignment before weekly resolve')
+  }
+
+  state.globalFlags[`conceal.case.${MVP_LOOP_PROOF_CASE_ID}`] = true
+
+  state = applySuccessfulInvestigation(state, {
+    caseId: MVP_LOOP_PROOF_CASE_ID,
+    forensicBudget: 1,
+    tacticalBudget: 0,
+  })
+
+  const asked = askInvestigationQuestion(state, {
+    caseId: MVP_LOOP_PROOF_CASE_ID,
+    domain: 'forensic',
+    questionId: MVP_LOOP_FORENSIC_QUESTION_ID,
+  })
+  if (!asked.applied) {
+    throw new Error(`Expected forensic question prep to apply: ${asked.reason ?? 'unknown'}`)
+  }
+
+  return { state: asked.state, teamId }
+}

--- a/src/test/weeklyMvpLoopProof.integration.test.ts
+++ b/src/test/weeklyMvpLoopProof.integration.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { APP_ROUTES } from '../app/routes'
+import { buildEventFeedView, refineEventFeedDrillDownHref } from '../features/dashboard/eventFeedView'
+import { getCaseWeeklyReportWeeks } from '../features/operations/operationsRouteDrillDown'
+import { buildReportWeekNavigation } from '../features/report/reportWeekNavigation'
+import { readPersistentFlag } from '../domain/flagSystem'
+import {
+  buildInvestigationAskedFlagId,
+  buildInvestigationLeverageFlagId,
+} from '../domain/investigationEconomy'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyInfiltrationWeeklyProbeActionOverride } from '../domain/infiltrationProbeOverride'
+import { applyStealthLeaveBehindSelection } from '../domain/stealthLeaveBehindSelection'
+import {
+  createWeeklyMvpLoopProofFixture,
+  MVP_LOOP_FORENSIC_QUESTION_ID,
+  MVP_LOOP_PROOF_CASE_ID,
+} from './helpers/weeklyMvpLoopProof'
+
+function isCovertReportNoteType(type: string | undefined) {
+  return type === 'concealment.activated' || (type?.startsWith('infiltration.') ?? false)
+}
+
+function isCovertOperationEventType(type: string) {
+  return type === 'concealment.activated' || type.startsWith('infiltration.')
+}
+
+describe('MVP weekly loop proof', () => {
+  it('carries weekly prep through advanceWeek into covert posture and reports', () => {
+    const { state: week0 } = createWeeklyMvpLoopProofFixture()
+
+    expect(
+      readPersistentFlag(
+        week0,
+        buildInvestigationAskedFlagId(MVP_LOOP_PROOF_CASE_ID, MVP_LOOP_FORENSIC_QUESTION_ID)
+      )
+    ).toBe(true)
+    expect(week0.globalFlags[`conceal.case.${MVP_LOOP_PROOF_CASE_ID}`]).toBe(true)
+
+    const week1 = advanceWeek(week0)
+    expect(week1.week).toBe(week0.week + 1)
+    expect(week1.reports).toHaveLength(1)
+
+    const caseAfterWeek1 = week1.cases[MVP_LOOP_PROOF_CASE_ID]
+    expect(caseAfterWeek1.hiddenState).toBe('hidden')
+
+    const report1 = week1.reports[0]!
+    const reportNoteTypes = report1.notes.map((note) => note.type)
+    const hasCovertReportNote = reportNoteTypes.some((type) => isCovertReportNoteType(type))
+    const hasCovertEvent = week1.events.some((event) => isCovertOperationEventType(event.type))
+
+    expect(hasCovertReportNote || hasCovertEvent).toBe(true)
+    expect(
+      readPersistentFlag(
+        week1,
+        buildInvestigationAskedFlagId(MVP_LOOP_PROOF_CASE_ID, MVP_LOOP_FORENSIC_QUESTION_ID)
+      )
+    ).toBe(true)
+    expect(
+      readPersistentFlag(
+        week1,
+        buildInvestigationLeverageFlagId(MVP_LOOP_PROOF_CASE_ID, 'secure-evidence-chain')
+      )
+    ).toBe(true)
+
+    expect(caseAfterWeek1.status).toBe('in_progress')
+
+    const override = applyInfiltrationWeeklyProbeActionOverride(week1, {
+      caseId: MVP_LOOP_PROOF_CASE_ID,
+      action: 'probe_route',
+    })
+    expect(override.applied).toBe(true)
+
+    const leaveBehind = applyStealthLeaveBehindSelection(override.state, {
+      caseId: MVP_LOOP_PROOF_CASE_ID,
+      leaveBehindId: 'leave-behind:expose-witness',
+    })
+    expect(leaveBehind.applied).toBe(true)
+    expect(leaveBehind.state.cases[MVP_LOOP_PROOF_CASE_ID]?.stealthLeaveBehindId).toBe(
+      'leave-behind:expose-witness'
+    )
+
+    const week2 = advanceWeek(leaveBehind.state)
+    expect(week2.week).toBe(week1.week + 1)
+    expect(week2.reports.length).toBeGreaterThanOrEqual(2)
+
+    const latestReport = week2.reports[week2.reports.length - 1]!
+    const priorReport = week2.reports[week2.reports.length - 2]!
+
+    expect(buildReportWeekNavigation(week2.reports, latestReport.week)).toEqual({
+      previousWeek: priorReport.week,
+    })
+    expect(getCaseWeeklyReportWeeks(week2.reports, MVP_LOOP_PROOF_CASE_ID).length).toBeGreaterThan(0)
+  })
+
+  it('keeps event feed drill-down hrefs coherent with generated reports', () => {
+    const { state: week0 } = createWeeklyMvpLoopProofFixture()
+    const week1 = advanceWeek(week0)
+    const reportWeek = week1.reports[0]?.week
+
+    expect(reportWeek).toBeDefined()
+
+    const covertEvent = week1.events.find(
+      (event) =>
+        isCovertOperationEventType(event.type) &&
+        (event.payload as { caseId?: string }).caseId === MVP_LOOP_PROOF_CASE_ID
+    )
+
+    expect(covertEvent).toBeDefined()
+
+    const feedView = refineEventFeedDrillDownHref(buildEventFeedView(covertEvent!), week1.reports)
+
+    expect(feedView.href).toBe(APP_ROUTES.reportDetail(reportWeek!))
+
+    const missingReportView = refineEventFeedDrillDownHref(buildEventFeedView(covertEvent!), [])
+    expect(missingReportView.href).toBe(APP_ROUTES.caseDetail(MVP_LOOP_PROOF_CASE_ID))
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the slice 1 **MVP weekly loop proof** integration harness recommended in `planning/mvp-weekly-loop-proof-slice-1.md` (Linear SPE-2251).

Proves a minimal multi-week path:

1. **Week-0 prep** — `conceal.case.*` flag, forensic investigation question, team assignment
2. **`advanceWeek`** — hidden posture, covert report notes / events, persisted investigation flags
3. **Week-1 prep** — infiltration probe override + stealth leave-behind selection (post-activation)
4. **Second `advanceWeek`** — growing report history + `buildReportWeekNavigation`
5. **Event feed** — `refineEventFeedDrillDownHref` uses report week when present, case detail fallback when not

## Files

| File | Role |
| --- | --- |
| `src/test/helpers/weeklyMvpLoopProof.ts` | Deterministic fixture (`ops-004` covert case) |
| `src/test/weeklyMvpLoopProof.integration.test.ts` | Two integration tests |

## Validation

- `npm run lint` — pass
- `npm run test:run` — 3576 tests pass (+2)

## Out of scope

- Playwright / browser E2E
- New domain mechanics or persistence shapes
- Store-layer duplicate tests (domain prep APIs mirror store behavior)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-496a35db-7242-4b4c-854a-1e4ff6280a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

