### PR TITLE
feat(infiltration): SPE-2250 report copy, MVP slice 2, tuning/QA docs

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,22 @@ From `README.md` **Current design notes**:
 ## Queue (highest leverage first — reorder as needed)
 
 1. **Hidden / disguised activation** — Runtime, authored triggers, weekly prep UI, activation event feed, batch-4 concealment migration (SPE-2249), and full batch-4 infiltration stack (SPE-2250 slices 1–2; `planning/infiltration-encounter-content-slice-2.md`) shipped.
-2. **Infiltration and access follow-through** — [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250/infiltration-encountercontent-follow-through-post-spe-521-substrate) batch-4 probe/cover/leave-behind complete; further encounter depth beyond authored stacks is optional follow-up (not new probe mechanics).
+2. **Infiltration and access follow-through** — Batch-4 probe/cover/leave-behind complete; **report copy slice** shipped (`src/domain/infiltrationEncounterReportNotes.ts` — weekly encounter + leave-behind tradeoff notes). Further optional content depth only (not new probe mechanics).
 3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
-4. **Core UX specs** — Finish or refresh core UX specs so surfaces match canonical domain outputs (`planning/roadmap.md` §15).
-5. **Tuning and QA references** — Complete tuning references and QA references, then use them to harden implementation sequencing (same roadmap section).
-6. **MVP loop proof** — **Next implement:** slice 1 integration harness (`planning/mvp-weekly-loop-proof-slice-1.md`); then triage→prep→advanceWeek→report→drill-down hardening before broadening (`planning/roadmap.md` phases 1–2).
-7. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
-8. **Archived prototype hygiene** — Keep archived prototype code out of active runtime paths unless intentionally revived (`README.md` former “next steps”).
+4. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
+5. **Archived prototype hygiene** — Keep archived prototype code out of active runtime paths unless intentionally revived (`README.md` former “next steps”).
+
+## Shipped (May 2026 — remove from active queue when scanning)
+
+| Item | Outcome |
+| --- | --- |
+| **Core UX specs (#4)** | **Closed.** Operations Report + navigation map for batch-4 covert notes and report week prev/next (`ux/operations-report.md` §5.3.1, `ux/navigation-map.md` §3.5.1–3.5.2). Mission Triage full refresh **deferred** until triage UI is the implementation target — see `ux/mission-triage.md` spec status block (covert prep row signals, deferral vs batch-4 flags). |
+| **Tuning and QA references (#5)** | Infiltration/concealment tuning reference, QA matrix, edge-case §12.6–12.9, integration Scenario F. **SPE-25 calibration pass (May 2026):** MVP harness confirms current probe/action deltas — no constant changes; anchor `src/test/weeklyMvpLoopProof.calibration.test.ts`. |
+| **MVP loop proof (#6)** | Slice 1 (`SPE-2251`) + slice 2 persistence/4-week fixture (`weeklyMvpLoopProof.slice2.integration.test.ts`). |
+
+## Deferred UX (pick up when triage UI is next)
+
+- **`ux/mission-triage.md`** — covert prep row signals, leave-behind staging hints, deferral vs batch-4 flag UX (spec status block lists scope).
 
 ## SCP-9995 harvest — May 2026 reconciliation
 

--- a/planning/mvp-weekly-loop-proof-slice-1.md
+++ b/planning/mvp-weekly-loop-proof-slice-1.md
@@ -124,19 +124,15 @@ Reuse helpers from:
 
 ---
 
-## Runner-up slice (after loop proof)
+## Slice 2 (shipped)
 
-### Infiltration encounter report copy (SPE-2250 optional)
+Persistence reload + 4-week fixture: `src/test/weeklyMvpLoopProof.slice2.integration.test.ts`.
 
-**Goal:** Human-readable report lines for authored probe/cover/leave-behind on cases that activated concealment — e.g. “Cover strain under maintenance cover”, “Leave-behind: risk discovery applied”.
+## Related follow-up (shipped)
 
-| Area | Work |
-| --- | --- |
-| Domain | Extend existing report note builders in `advanceWeek` / event emission (no new tracks) |
-| Content | Map `infiltrationStage`, override action, selected leave-behind id → copy keys in `src/data/copy.ts` |
-| Tests | One integration test per note type; catalog guard optional |
+### Infiltration encounter report copy (SPE-2250)
 
-**Why second:** Makes the 33-template content investment visible in the operations report players already drill into.
+Shipped in `src/domain/infiltrationEncounterReportNotes.ts` with `infiltration.weekly_encounter` and `infiltration.leave_behind_tradeoff` report notes.
 
 ---
 

--- a/qa/determinism-tests.md
+++ b/qa/determinism-tests.md
@@ -10,7 +10,7 @@ This plan exists to verify that:
 
 - identical input state produces identical outcomes
 - weekly transitions are reproducible
-- report notes and surfaced outputs remain causally stable
+- report notes and surfaced outputs remain causally stable (covert-ops note families: `qa/infiltration-concealment-report-matrix.md`)
 - save/load roundtrips do not change future results
 - no hidden runtime-only state or UI-side recomputation alters behavior
 

--- a/qa/edge-case-checklist.md
+++ b/qa/edge-case-checklist.md
@@ -550,6 +550,44 @@ Validate:
 - note builder resolves conflict coherently
 - surfaced output remains causal and non-contradictory
 
+## 12.6 Infiltration routine vs threshold notes (same week)
+
+Validate:
+
+- when threshold infiltration events fire (`cover_strain`, `awareness_complication`, escalations), **no** `infiltration.weekly_encounter` note appears for that case
+- when only probe tracks move without thresholds, exactly one routine `weekly_encounter` (or intentional silence if case ineligible)
+
+See matrix row **IC-01**, **IC-02** in `qa/infiltration-concealment-report-matrix.md`.
+
+## 12.7 Leave-behind tradeoff without custody loss
+
+Validate:
+
+- mission resolves with active stealth leave-behind pressure but empty custody refs
+- `infiltration.leave_behind_tradeoff` report note and event still surface with leave-behind label
+- note does not invent custody strain text
+
+See matrix row **IC-06**.
+
+## 12.8 Probe prep override reflected in surfaced copy
+
+Validate:
+
+- `infiltrationWeeklyProbeActionOverride` set before `advanceWeek`
+- threshold or routine infiltration notes include override/action metadata (`probeAction`, `probeActionSource`)
+- enriched threshold summary mentions the selected probe action
+
+See matrix row **IC-03**.
+
+## 12.9 Concealment activates before probe tick
+
+Validate:
+
+- `concealment.activated` (when applicable) precedes infiltration probe notes in weekly ordering
+- probe eligibility requires `hiddenState === 'hidden'` after activation pass
+
+See matrix rows **IC-07**, **IC-08**.
+
 ---
 
 ## 13. Persistence edge cases

--- a/qa/infiltration-concealment-report-matrix.md
+++ b/qa/infiltration-concealment-report-matrix.md
@@ -1,0 +1,72 @@
+# Infiltration and concealment — report / event-feed QA matrix
+
+## Purpose
+
+Bounded **sign-off matrix** for batch-4 covert operations surfacing. Use during implementation review, regression after tuning constant changes, and milestone QA.
+
+**Tuning constants:** `tuning/infiltration-probe-and-concealment.md`  
+**UX contract:** `ux/operations-report.md` §5.3.1, `ux/navigation-map.md` §3.5.1
+
+---
+
+## How to use
+
+For each row:
+
+1. Set up the fixture conditions in the **Setup** column.
+2. Run `advanceWeek` (and prep helpers where noted).
+3. Assert **Report notes**, **Event feed** (if events persisted), and **Must not** columns.
+4. Prefer automated tests listed in **Test anchor**; manual check only when no test exists yet.
+
+General rules (all rows):
+
+- Report note `type` equals event `type` for infiltration family rows.
+- `metadata.probeAction` / `probeActionSource` match prep when override or authored plan applied.
+- Event feed `buildEventFeedView` returns `href` → `/report/{week}` for infiltration and concealment events.
+
+---
+
+## Matrix
+
+| ID | Invariant | Setup | Report notes (expect) | Event feed (expect) | Must not | Test anchor |
+| --- | --- | --- | --- | --- | --- | --- |
+| IC-01 | Routine week encounter | Hidden + infiltration tag; low awareness (e.g. 0.05/0.02); no threshold cross; case `in_progress` | One `infiltration.weekly_encounter`; content includes case title + probe clause + track clause | If event persisted: type `infiltration.weekly_encounter`, tone **neutral**, links to report week | Second `weekly_encounter`; threshold types same week | `infiltrationEncounterReportCopy.test.ts` (routine week) |
+| IC-02 | No duplicate routine when threshold fires | Hidden + media/public tags; awareness ~0.3; cover profile present | At least one `infiltration.cover_strain` or other threshold type; **zero** `weekly_encounter` | Threshold types warning/danger per kind; no neutral weekly duplicate | `weekly_encounter` count > 0 | `infiltrationEncounterReportCopy.test.ts` (dup check) |
+| IC-03 | Override metadata on threshold note | `applyInfiltrationWeeklyProbeActionOverride` → `probe_route`; awareness high enough for `cover_strain` | `infiltration.cover_strain` with enriched summary (route probe / override); `metadata.probeAction` = `probe_route`, `probeActionSource` = `override` | Same payload fields in feed detail | Missing `probeAction` on note metadata | `infiltrationEncounterReportCopy.test.ts` (override) |
+| IC-04 | Authored plan in routine summary | MVP fixture / ops-004 with `infiltrationProbePlan`; no threshold events | `weekly_encounter` or threshold note includes authored/access probe wording per plan | — | Client-only copy not backed by domain summary | `infiltrationEncounterReportNotes.test.ts`, `weeklyMvpLoopProof.integration.test.ts` |
+| IC-05 | Leave-behind with custody | Tuned hidden case `weeksRemaining: 1`, leave-behind id, success + active `stealthLeaveBehindMission` + non-empty `custodyLossRefs` | `infiltration.leave_behind_tradeoff`; mentions leave-behind label; optional custody strain line | `infiltration.leave_behind_tradeoff`, tone **warning**, report href | Note only in mission explanation, not report notes | `infiltrationEncounterReportCopy.test.ts` (custody), `stealthLeaveBehindMission.test.ts` |
+| IC-06 | Leave-behind without custody | Hidden resolve with `leave-behind:burn-tool` (empty registry custody refs) | Still `infiltration.leave_behind_tradeoff` with label + score reason; no fabricated custody line | Same event type emitted | Skip tradeoff note entirely; `Investigation strain:` in copy | `infiltrationEncounterReportCopy.test.ts` (IC-06); registry `leave-behind:burn-tool` |
+| IC-07 | Concealment activation note | `conceal.case.{id}` flag; eligible case not yet hidden | `concealment.activated` on activation week | `concealment.activated`, report href | Probe events before hidden state set | `advanceWeek` concealment tests; MVP slice 2 save/load |
+| IC-08 | Probe after concealment | Same week: concealment then probe | If probe runs: infiltration notes reflect **post-tick** tracks in summary | — | Pre-tick awareness in enriched threshold text | `buildInfiltrationEncounterReportContextAfterProbe` unit behavior |
+| IC-09 | Save/load prep continuity | Week 1: override + leave-behind + forensic flag; serialize/load; week 2 advance | Week 2 report includes infiltration or concealment family note | — | Lost override or leave-behind id on case | `weeklyMvpLoopProof.slice2.integration.test.ts` |
+| IC-10 | Event ↔ report parity | Any infiltration event draft in weekly batch | Matching report note with same `type` and summary substring | Feed title uses type label; detail includes awareness % when present | Report note missing for emitted infiltration event | `events.coverage.test.ts`, `buildDeterministicReportNotesFromEventDrafts` |
+| IC-11 | Non-eligible case | `hiddenState` unset and no activation; or missing infiltration-family tag | No infiltration probe notes | No infiltration events | Spurious `weekly_encounter` | `infiltrationProbe` eligibility tests |
+| IC-12 | Report week navigation | Multiple reports (non-contiguous weeks OK) | — | — | Nav shows missing week as link | `reportWeekNavigation` tests; `weeklyMvpLoopProof.slice2` (4-week) |
+
+---
+
+## Edge-case checklist crosswalk
+
+Manual regression should also walk **`qa/edge-case-checklist.md` §12.6–12.8** (infiltration-specific bullets) when changing `advanceWeek` or `reportNotes` infiltration branches.
+
+---
+
+## Failure triage
+
+| Symptom | Likely owner |
+| --- | --- |
+| Event in feed, no report note | `reportNotes.ts` missing `case` for event type |
+| Report note, no event | Event draft not pushed or filtered before persist |
+| Duplicate weekly + threshold | `applyWeeklyInfiltrationProbe` guard |
+| Override not in metadata | `pushInfiltrationEncounterEventDraft` missing `context` option |
+| Leave-behind only in mission text | Mission resolve path not calling tradeoff draft |
+| Wrong awareness in copy | Context built from pre-tick case instead of post-tick |
+
+---
+
+## See also
+
+- `tuning/infiltration-probe-and-concealment.md`
+- `qa/integration-tests.md` — Scenario F
+- `qa/edge-case-checklist.md` §12.6+
+- `qa/determinism-tests.md` — report note ordering

--- a/qa/integration-tests.md
+++ b/qa/integration-tests.md
@@ -394,6 +394,25 @@ Expected chain:
 - Hub view reflects improved faction-linked opportunity
 - report note or related surfaced signal explains the shift
 
+### Scenario F — covert infiltration prep → weekly report → event feed
+
+Fixture:
+
+- hidden case with infiltration-family tags and authored or overridden weekly probe prep
+- optional `stealthLeaveBehindId` on final resolve week
+
+Expected chain:
+
+- concealment activation (when prep flag set) before probe tick
+- infiltration report notes match event types (`weekly_encounter`, threshold kinds, or `leave_behind_tradeoff` on resolve)
+- no duplicate `weekly_encounter` when threshold notes already fired
+- event feed entries link to the same report week and carry probe metadata when override applied
+- save/load mid-campaign preserves prep; next `advanceWeek` still surfaces infiltration or concealment family notes
+
+**Sign-off matrix:** `qa/infiltration-concealment-report-matrix.md` (rows IC-01–IC-12).  
+**Constants:** `tuning/infiltration-probe-and-concealment.md`.  
+**Automated anchors:** `infiltrationEncounterReportCopy.test.ts`, `weeklyMvpLoopProof.slice2.integration.test.ts`, `eventFeedView.test.ts`.
+
 ---
 
 ## 8. Common integration failures to watch for

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -581,6 +581,19 @@ const infiltrationProbeEventSchema = z
     infiltrationAwareness: z.number().optional(),
     infiltrationProbeProgress: z.number().optional(),
     infiltrationStage: z.enum(['probing', 'exposed', 'violent']).optional(),
+    probeAction: z.enum(['probe_access', 'probe_route', 'cleanup']).optional(),
+    probeActionSource: z.enum(['override', 'authored', 'heuristic']).optional(),
+    coverRole: z
+      .enum([
+        'uniform_guard',
+        'civilian_staff',
+        'courier',
+        'maintenance',
+        'official_inspector',
+      ])
+      .optional(),
+    leaveBehindId: z.string().optional(),
+    leaveBehindLabel: z.string().optional(),
   })
   .strict()
 
@@ -672,6 +685,8 @@ export const operationEventPayloadSchemas = {
   'infiltration.escalation_exposed': infiltrationProbeEventSchema,
   'infiltration.escalation_violent': infiltrationProbeEventSchema,
   'infiltration.cover_strain': infiltrationProbeEventSchema,
+  'infiltration.weekly_encounter': infiltrationProbeEventSchema,
+  'infiltration.leave_behind_tradeoff': infiltrationProbeEventSchema,
   'concealment.activated': concealmentActivatedEventSchema,
   'system.academy_upgraded': systemAcademyUpgradedSchema,
   'system.equipment_recovered': z.object({}).passthrough(),

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -795,6 +795,8 @@ export const EVENT_TYPE_TO_SOURCE_SYSTEM: Readonly<OperationEventTypeToSourceSys
   'infiltration.escalation_exposed': 'system',
   'infiltration.escalation_violent': 'system',
   'infiltration.cover_strain': 'system',
+  'infiltration.weekly_encounter': 'system',
+  'infiltration.leave_behind_tradeoff': 'system',
   'concealment.activated': 'system',
   'system.academy_upgraded': 'system',
   'staff.coping.applied': 'agent',

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -613,6 +613,39 @@ export interface OperationEventPayloadMap {
     infiltrationAwareness?: number
     infiltrationProbeProgress?: number
     infiltrationStage?: 'probing' | 'exposed' | 'violent'
+    probeAction?: string
+    probeActionSource?: string
+    coverRole?: string
+    leaveBehindId?: string
+    leaveBehindLabel?: string
+  }
+  'infiltration.weekly_encounter': {
+    week: number
+    caseId: Id
+    caseTitle: string
+    summary: string
+    infiltrationAwareness?: number
+    infiltrationProbeProgress?: number
+    infiltrationStage?: 'probing' | 'exposed' | 'violent'
+    probeAction?: string
+    probeActionSource?: string
+    coverRole?: string
+    leaveBehindId?: string
+    leaveBehindLabel?: string
+  }
+  'infiltration.leave_behind_tradeoff': {
+    week: number
+    caseId: Id
+    caseTitle: string
+    summary: string
+    infiltrationAwareness?: number
+    infiltrationProbeProgress?: number
+    infiltrationStage?: 'probing' | 'exposed' | 'violent'
+    probeAction?: string
+    probeActionSource?: string
+    coverRole?: string
+    leaveBehindId?: string
+    leaveBehindLabel?: string
   }
   'concealment.activated': {
     week: number
@@ -704,6 +737,8 @@ export interface OperationEventTypeToSourceSystemMap {
   'infiltration.escalation_exposed': 'system'
   'infiltration.escalation_violent': 'system'
   'infiltration.cover_strain': 'system'
+  'infiltration.weekly_encounter': 'system'
+  'infiltration.leave_behind_tradeoff': 'system'
   'concealment.activated': 'system'
   'system.academy_upgraded': 'system'
   'staff.coping.applied': 'agent'

--- a/src/domain/infiltrationEncounterReportNotes.ts
+++ b/src/domain/infiltrationEncounterReportNotes.ts
@@ -1,0 +1,251 @@
+/**
+ * SPE-2250 follow-up: player-facing weekly report copy for infiltration prep and outcomes.
+ */
+
+import type { InfiltrationCoverRole } from './infiltrationCover'
+import {
+  isInfiltrationProbeEligible,
+  resolveWeeklyInfiltrationProbeAction,
+  type InfiltrationProbeAction,
+  type InfiltrationStage,
+} from './infiltrationProbe'
+import { readInfiltrationWeeklyProbeActionOverride } from './infiltrationProbeOverride'
+import type { CaseInstance, Id } from './models'
+import { getStealthLeaveBehindById, DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY } from './stealthLeaveBehindRegistry'
+
+export const INFILTRATION_PROBE_ACTION_LABELS: Record<InfiltrationProbeAction, string> = {
+  probe_access: 'access probe',
+  probe_route: 'route probe',
+  cleanup: 'cover cleanup',
+}
+
+export const INFILTRATION_COVER_ROLE_LABELS: Record<InfiltrationCoverRole, string> = {
+  uniform_guard: 'uniform guard cover',
+  civilian_staff: 'civilian staff cover',
+  courier: 'courier cover',
+  maintenance: 'maintenance cover',
+  official_inspector: 'official inspector cover',
+}
+
+export const INFILTRATION_STAGE_LABELS: Record<InfiltrationStage, string> = {
+  probing: 'probing',
+  exposed: 'cover exposed',
+  violent: 'violent escalation',
+}
+
+export type InfiltrationProbeActionSource = 'override' | 'authored' | 'heuristic'
+
+export interface InfiltrationEncounterReportContext {
+  readonly probeAction: InfiltrationProbeAction
+  readonly probeActionSource: InfiltrationProbeActionSource
+  readonly stage: InfiltrationStage
+  readonly awareness: number
+  readonly probeProgress: number
+  readonly coverRole?: InfiltrationCoverRole
+  readonly leaveBehindLabel?: string
+}
+
+export interface InfiltrationEncounterEventPayload {
+  week: number
+  caseId: Id
+  caseTitle: string
+  summary: string
+  infiltrationAwareness?: number
+  infiltrationProbeProgress?: number
+  infiltrationStage?: InfiltrationStage
+  probeAction?: InfiltrationProbeAction
+  probeActionSource?: InfiltrationProbeActionSource
+  coverRole?: InfiltrationCoverRole
+  leaveBehindId?: string
+  leaveBehindLabel?: string
+}
+
+function roundBand(value: number) {
+  return Math.round(value * 1000) / 1000
+}
+
+export function resolveInfiltrationProbeActionSource(
+  caseData: CaseInstance
+): InfiltrationProbeActionSource {
+  if (readInfiltrationWeeklyProbeActionOverride(caseData) !== undefined) {
+    return 'override'
+  }
+
+  if (caseData.infiltrationProbePlan !== undefined) {
+    return 'authored'
+  }
+
+  return 'heuristic'
+}
+
+/** Probe action that will run (or ran) this week — mirrors `applyWeeklyInfiltrationProbeTick`. */
+export function resolveWeeklyInfiltrationProbeActionUsed(
+  caseData: CaseInstance
+): InfiltrationProbeAction | undefined {
+  if (!isInfiltrationProbeEligible(caseData)) {
+    return undefined
+  }
+
+  return (
+    readInfiltrationWeeklyProbeActionOverride(caseData) ??
+    resolveWeeklyInfiltrationProbeAction(caseData)
+  )
+}
+
+export function readInfiltrationLeaveBehindLabel(caseData: CaseInstance): string | undefined {
+  const leaveBehindId = caseData.stealthLeaveBehindId?.trim()
+  if (!leaveBehindId) {
+    return undefined
+  }
+
+  const definition = getStealthLeaveBehindById(
+    DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY,
+    leaveBehindId
+  )
+  return definition?.label
+}
+
+export function buildInfiltrationEncounterReportContext(
+  caseData: CaseInstance
+): InfiltrationEncounterReportContext | undefined {
+  const probeAction = resolveWeeklyInfiltrationProbeActionUsed(caseData)
+  if (probeAction === undefined) {
+    return undefined
+  }
+
+  return {
+    probeAction,
+    probeActionSource: resolveInfiltrationProbeActionSource(caseData),
+    stage: caseData.infiltrationStage ?? 'probing',
+    awareness: roundBand(caseData.infiltrationAwareness ?? 0),
+    probeProgress: roundBand(caseData.infiltrationProbeProgress ?? 0),
+    coverRole: caseData.infiltrationCoverProfile?.claimedRole,
+    leaveBehindLabel: readInfiltrationLeaveBehindLabel(caseData),
+  }
+}
+
+function formatProbeActionClause(context: InfiltrationEncounterReportContext) {
+  const actionLabel = INFILTRATION_PROBE_ACTION_LABELS[context.probeAction]
+  if (context.probeActionSource === 'override') {
+    return `Weekly prep selected ${actionLabel} (player override).`
+  }
+
+  if (context.probeActionSource === 'authored') {
+    return `Authored probe plan ran ${actionLabel} this week.`
+  }
+
+  return `Heuristic probe plan ran ${actionLabel} this week.`
+}
+
+function formatCoverClause(context: InfiltrationEncounterReportContext) {
+  if (context.coverRole === undefined) {
+    return ''
+  }
+
+  return ` Cover posture: ${INFILTRATION_COVER_ROLE_LABELS[context.coverRole]}.`
+}
+
+function formatLeaveBehindClause(context: InfiltrationEncounterReportContext) {
+  if (!context.leaveBehindLabel) {
+    return ''
+  }
+
+  return ` Leave-behind tradeoff staged: ${context.leaveBehindLabel}.`
+}
+
+function formatTrackClause(context: InfiltrationEncounterReportContext) {
+  return ` Tracks at ${Math.round(context.probeProgress * 100)}% probe / ${Math.round(context.awareness * 100)}% awareness (${INFILTRATION_STAGE_LABELS[context.stage]}).`
+}
+
+/** Routine weekly encounter line when threshold events did not fire. */
+export function formatInfiltrationWeeklyEncounterSummary(
+  context: InfiltrationEncounterReportContext
+): string {
+  return (
+    formatProbeActionClause(context) +
+    formatCoverClause(context) +
+    formatLeaveBehindClause(context) +
+    formatTrackClause(context)
+  )
+}
+
+/** Prefix for threshold/complication summaries so cover role and prep show in reports. */
+export function enrichInfiltrationThresholdSummary(
+  baseSummary: string,
+  context: InfiltrationEncounterReportContext
+): string {
+  const prepLead = formatProbeActionClause(context).replace(/\.$/, '')
+  return `${prepLead}; ${baseSummary}${formatCoverClause(context)}${formatLeaveBehindClause(context)}${formatTrackClause(context)}`
+}
+
+export function formatInfiltrationLeaveBehindTradeoffSummary(
+  leaveBehindLabel: string,
+  options?: { custodyLossSummary?: string; scoreAdjustmentReason?: string }
+): string {
+  const parts = [`Stealth leave-behind applied — ${leaveBehindLabel}.`]
+
+  if (options?.scoreAdjustmentReason && options.scoreAdjustmentReason.length > 0) {
+    parts.push(` ${options.scoreAdjustmentReason}`)
+  }
+
+  if (options?.custodyLossSummary && options.custodyLossSummary.length > 0) {
+    parts.push(` Investigation strain: ${options.custodyLossSummary}`)
+  }
+
+  return parts.join('')
+}
+
+export function buildInfiltrationEncounterEventPayload(input: {
+  week: number
+  caseId: Id
+  caseTitle: string
+  summary: string
+  caseData: CaseInstance
+  context?: InfiltrationEncounterReportContext
+}): InfiltrationEncounterEventPayload {
+  const context = input.context ?? buildInfiltrationEncounterReportContext(input.caseData)
+
+  return {
+    week: input.week,
+    caseId: input.caseId,
+    caseTitle: input.caseTitle,
+    summary: input.summary,
+    infiltrationAwareness: context?.awareness,
+    infiltrationProbeProgress: context?.probeProgress,
+    infiltrationStage: context?.stage,
+    probeAction: context?.probeAction,
+    probeActionSource: context?.probeActionSource,
+    coverRole: context?.coverRole,
+    leaveBehindId: input.caseData.stealthLeaveBehindId,
+    leaveBehindLabel: context?.leaveBehindLabel,
+  }
+}
+
+/** True when weekly probe ticks apply (hidden + infiltration-family tags). */
+export function shouldEmitInfiltrationWeeklyEncounterNote(caseData: CaseInstance) {
+  return isInfiltrationProbeEligible(caseData)
+}
+
+/** Context after a probe tick — uses post-tick tracks and stage on the merged case. */
+export function buildInfiltrationEncounterReportContextAfterProbe(
+  caseBeforeTick: CaseInstance,
+  caseAfterTick: CaseInstance
+): InfiltrationEncounterReportContext | undefined {
+  const probeAction =
+    readInfiltrationWeeklyProbeActionOverride(caseBeforeTick) ??
+    resolveWeeklyInfiltrationProbeAction(caseBeforeTick)
+
+  if (!isInfiltrationProbeEligible(caseAfterTick)) {
+    return undefined
+  }
+
+  return {
+    probeAction,
+    probeActionSource: resolveInfiltrationProbeActionSource(caseBeforeTick),
+    stage: caseAfterTick.infiltrationStage ?? 'probing',
+    awareness: roundBand(caseAfterTick.infiltrationAwareness ?? 0),
+    probeProgress: roundBand(caseAfterTick.infiltrationProbeProgress ?? 0),
+    coverRole: caseAfterTick.infiltrationCoverProfile?.claimedRole,
+    leaveBehindLabel: readInfiltrationLeaveBehindLabel(caseAfterTick),
+  }
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1473,6 +1473,8 @@ export type ReportNoteType =
   | 'infiltration.escalation_exposed'
   | 'infiltration.escalation_violent'
   | 'infiltration.cover_strain'
+  | 'infiltration.weekly_encounter'
+  | 'infiltration.leave_behind_tradeoff'
   | 'concealment.activated'
   | 'support.restored'
   | 'hub.opportunity'
@@ -2526,6 +2528,12 @@ export interface GameState {
   squadMetadata?: Record<string, SquadMetadata>
   squadKitTemplates?: Record<string, SquadKitTemplate>
   squadKitAssignments?: Record<string, SquadKitAssignment>
+
+  /**
+   * Transitional compatibility mirror of `runtimeState.globalFlags` for weekly sim paths
+   * and legacy tests that set concealment prep flags before `advanceWeek`.
+   */
+  globalFlags?: Record<string, GameFlagValue>
 }
 
 // ---------------------------------------------------------------------------

--- a/src/domain/reportNotes.ts
+++ b/src/domain/reportNotes.ts
@@ -437,6 +437,8 @@ function buildReflectedReportNote(draft: AnyOperationEventDraft): {
     case 'infiltration.escalation_exposed':
     case 'infiltration.escalation_violent':
     case 'infiltration.cover_strain':
+    case 'infiltration.weekly_encounter':
+    case 'infiltration.leave_behind_tradeoff':
       return {
         content: `${draft.payload.caseTitle}: ${draft.payload.summary}`,
         type: draft.type,
@@ -447,6 +449,11 @@ function buildReflectedReportNote(draft: AnyOperationEventDraft): {
           infiltrationAwareness: draft.payload.infiltrationAwareness ?? null,
           infiltrationProbeProgress: draft.payload.infiltrationProbeProgress ?? null,
           infiltrationStage: draft.payload.infiltrationStage ?? null,
+          probeAction: draft.payload.probeAction ?? null,
+          probeActionSource: draft.payload.probeActionSource ?? null,
+          coverRole: draft.payload.coverRole ?? null,
+          leaveBehindId: draft.payload.leaveBehindId ?? null,
+          leaveBehindLabel: draft.payload.leaveBehindLabel ?? null,
         },
       }
 

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -183,6 +183,15 @@ import {
   mergeConcealmentActivationResult,
   resolveConcealmentActivation,
 } from '../hiddenStateActivation'
+import {
+  buildInfiltrationEncounterEventPayload,
+  buildInfiltrationEncounterReportContext,
+  buildInfiltrationEncounterReportContextAfterProbe,
+  enrichInfiltrationThresholdSummary,
+  formatInfiltrationLeaveBehindTradeoffSummary,
+  formatInfiltrationWeeklyEncounterSummary,
+  shouldEmitInfiltrationWeeklyEncounterNote,
+} from '../infiltrationEncounterReportNotes'
 import { applyWeeklyInfiltrationProbeTick } from '../infiltrationProbe'
 import {
   resolveAssignedCaseForWeek as resolveCanonicalAssignedCaseForWeek,
@@ -2124,6 +2133,36 @@ function applyWeeklyConcealmentActivation(
   return activatedCase
 }
 
+function pushInfiltrationEncounterEventDraft(
+  context: WeeklyExecutionContext,
+  caseId: string,
+  caseData: CaseInstance,
+  eventType:
+    | 'infiltration.awareness_complication'
+    | 'infiltration.escalation_exposed'
+    | 'infiltration.escalation_violent'
+    | 'infiltration.cover_strain'
+    | 'infiltration.weekly_encounter'
+    | 'infiltration.leave_behind_tradeoff',
+  summary: string,
+  options?: {
+    context?: ReturnType<typeof buildInfiltrationEncounterReportContext>
+  }
+) {
+  context.eventDrafts.push({
+    type: eventType,
+    sourceSystem: 'system',
+    payload: buildInfiltrationEncounterEventPayload({
+      week: context.sourceState.week,
+      caseId,
+      caseTitle: caseData.title,
+      summary,
+      caseData,
+      context: options?.context,
+    }),
+  })
+}
+
 function applyWeeklyInfiltrationProbe(
   context: WeeklyExecutionContext,
   caseId: string,
@@ -2132,25 +2171,56 @@ function applyWeeklyInfiltrationProbe(
   const probeResult = applyWeeklyInfiltrationProbeTick(caseData, context.sourceState.week)
 
   if (!probeResult.changed && probeResult.events.length === 0) {
+    if (shouldEmitInfiltrationWeeklyEncounterNote(caseData) && caseData.status === 'in_progress') {
+      const quietContext = buildInfiltrationEncounterReportContext(caseData)
+      if (quietContext) {
+        pushInfiltrationEncounterEventDraft(
+          context,
+          caseId,
+          caseData,
+          'infiltration.weekly_encounter',
+          formatInfiltrationWeeklyEncounterSummary(quietContext),
+          { context: quietContext }
+        )
+      }
+    }
+
     return caseData
   }
 
   context.nextState.cases[caseId] = probeResult.case
 
+  const reportContextAfterProbe =
+    buildInfiltrationEncounterReportContextAfterProbe(caseData, probeResult.case) ??
+    buildInfiltrationEncounterReportContext(probeResult.case)
+
   for (const event of probeResult.events) {
-    context.eventDrafts.push({
-      type: `infiltration.${event.kind}`,
-      sourceSystem: 'system',
-      payload: {
-        week: context.sourceState.week,
+    const summary =
+      reportContextAfterProbe !== undefined
+        ? enrichInfiltrationThresholdSummary(event.summary, reportContextAfterProbe)
+        : event.summary
+
+    pushInfiltrationEncounterEventDraft(
+      context,
+      caseId,
+      probeResult.case,
+      `infiltration.${event.kind}`,
+      summary,
+      { context: reportContextAfterProbe }
+    )
+  }
+
+  if (probeResult.events.length === 0 && shouldEmitInfiltrationWeeklyEncounterNote(probeResult.case)) {
+    if (reportContextAfterProbe && probeResult.case.status === 'in_progress') {
+      pushInfiltrationEncounterEventDraft(
+        context,
         caseId,
-        caseTitle: caseData.title,
-        summary: event.summary,
-        infiltrationAwareness: probeResult.case.infiltrationAwareness,
-        infiltrationProbeProgress: probeResult.case.infiltrationProbeProgress,
-        infiltrationStage: probeResult.case.infiltrationStage,
-      },
-    })
+        probeResult.case,
+        'infiltration.weekly_encounter',
+        formatInfiltrationWeeklyEncounterSummary(reportContextAfterProbe),
+        { context: reportContextAfterProbe }
+      )
+    }
   }
 
   return probeResult.case
@@ -2388,22 +2458,38 @@ function resolveAssignments(
       stealthLeaveBehindMission?.active &&
       stealthLeaveBehindMission.leaveBehindId &&
       stealthLeaveBehindMission.kind &&
-      stealthLeaveBehindMission.leaveBehindLabel &&
-      stealthLeaveBehindMission.custodyLossRefs.length > 0
+      stealthLeaveBehindMission.leaveBehindLabel
     ) {
-      const custodyLoss = applyStealthLeaveBehindInvestigationCustodyLoss({
-        state: context.nextState,
-        caseId,
-        leaveBehindId: stealthLeaveBehindMission.leaveBehindId,
-        leaveBehindKind: stealthLeaveBehindMission.kind,
-        leaveBehindLabel: stealthLeaveBehindMission.leaveBehindLabel,
-        custodyLossRefs: stealthLeaveBehindMission.custodyLossRefs,
-        week: context.sourceState.week,
-      })
-      context.nextState = custodyLoss.state
-      if (custodyLoss.resolutionNote) {
-        resolutionReasons.push(custodyLoss.resolutionNote)
+      let custodyLossSummary: string | undefined
+
+      if (stealthLeaveBehindMission.custodyLossRefs.length > 0) {
+        const custodyLoss = applyStealthLeaveBehindInvestigationCustodyLoss({
+          state: context.nextState,
+          caseId,
+          leaveBehindId: stealthLeaveBehindMission.leaveBehindId,
+          leaveBehindKind: stealthLeaveBehindMission.kind,
+          leaveBehindLabel: stealthLeaveBehindMission.leaveBehindLabel,
+          custodyLossRefs: stealthLeaveBehindMission.custodyLossRefs,
+          week: context.sourceState.week,
+        })
+        context.nextState = custodyLoss.state
+        if (custodyLoss.resolutionNote) {
+          resolutionReasons.push(custodyLoss.resolutionNote)
+          custodyLossSummary = custodyLoss.resolutionNote
+        }
       }
+
+      pushInfiltrationEncounterEventDraft(
+        context,
+        caseId,
+        effectiveCase,
+        'infiltration.leave_behind_tradeoff',
+        formatInfiltrationLeaveBehindTradeoffSummary(stealthLeaveBehindMission.leaveBehindLabel, {
+          custodyLossSummary,
+          scoreAdjustmentReason: stealthLeaveBehindMission.scoreAdjustmentReason,
+        }),
+        { context: buildInfiltrationEncounterReportContext(effectiveCase) }
+      )
     }
 
     const aggregateBattleCeasefireWindow =

--- a/src/domain/stealthLeaveBehindRegistry.ts
+++ b/src/domain/stealthLeaveBehindRegistry.ts
@@ -321,9 +321,10 @@ export const DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY: StealthLeaveBehindRegistry =
       id: 'leave-behind:burn-tool',
       kind: 'burn_tool',
       label: 'Burn field tool',
-      summary: 'Destroy a traceable tool rather than carry it through screening.',
+      summary:
+        'Destroy a traceable tool rather than carry it through screening. Mission score pressure only — no forensic custody chain loss.',
       discoveryRisk: 0.25,
-      custodyLossRefs: ['custody:tool-serial'],
+      custodyLossRefs: [],
     }),
     defineLeaveBehind({
       id: 'leave-behind:expose-witness',

--- a/src/features/dashboard/eventFeedView.ts
+++ b/src/features/dashboard/eventFeedView.ts
@@ -233,6 +233,8 @@ export const EVENT_TYPE_LABELS: Record<OperationEventType, string> = {
   'infiltration.escalation_exposed': 'Cover Exposed',
   'infiltration.escalation_violent': 'Violent Escalation',
   'infiltration.cover_strain': 'Cover Strain',
+  'infiltration.weekly_encounter': 'Infiltration Weekly Encounter',
+  'infiltration.leave_behind_tradeoff': 'Leave-Behind Tradeoff',
   'concealment.activated': 'Concealment Activated',
 }
 
@@ -289,6 +291,8 @@ export const EVENT_TYPE_CATEGORIES: Record<OperationEventType, EventFeedCategory
   'infiltration.escalation_exposed': 'incident_response',
   'infiltration.escalation_violent': 'incident_response',
   'infiltration.cover_strain': 'incident_response',
+  'infiltration.weekly_encounter': 'incident_response',
+  'infiltration.leave_behind_tradeoff': 'incident_response',
   'concealment.activated': 'incident_response',
 }
 
@@ -1098,7 +1102,9 @@ export function buildEventFeedView(event: OperationEvent): EventFeedView {
     case 'infiltration.awareness_complication':
     case 'infiltration.escalation_exposed':
     case 'infiltration.escalation_violent':
-    case 'infiltration.cover_strain': {
+    case 'infiltration.cover_strain':
+    case 'infiltration.weekly_encounter':
+    case 'infiltration.leave_behind_tradeoff': {
       const awarenessSuffix =
         typeof event.payload.infiltrationAwareness === 'number'
           ? ` / Awareness ${Math.round(event.payload.infiltrationAwareness * 100)}%`
@@ -1109,7 +1115,9 @@ export function buildEventFeedView(event: OperationEvent): EventFeedView {
       const tone =
         event.type === 'infiltration.escalation_violent'
           ? 'danger'
-          : 'warning'
+          : event.type === 'infiltration.weekly_encounter'
+            ? 'neutral'
+            : 'warning'
 
       return {
         event,

--- a/src/test/eventFeedView.test.ts
+++ b/src/test/eventFeedView.test.ts
@@ -1225,6 +1225,26 @@ describe('buildEventFeedView href', () => {
       infiltrationStage: 'probing',
     })
     expect(buildEventFeedView(infiltration).href).toBe('/report/5')
+
+    const weeklyEncounter = makeEvent('infiltration.weekly_encounter', {
+      week: 6,
+      caseId: 'case-a',
+      caseTitle: 'Hidden op',
+      summary: 'Weekly prep ran access probe this week.',
+      probeAction: 'probe_access',
+      probeActionSource: 'authored',
+    })
+    expect(buildEventFeedView(weeklyEncounter).tone).toBe('neutral')
+
+    const leaveBehind = makeEvent('infiltration.leave_behind_tradeoff', {
+      week: 7,
+      caseId: 'case-a',
+      caseTitle: 'Hidden op',
+      summary: 'Stealth leave-behind applied — witness exposure.',
+      leaveBehindLabel: 'witness exposure',
+    })
+    expect(buildEventFeedView(leaveBehind).href).toBe('/report/7')
+    expect(buildEventFeedView(leaveBehind).tone).toBe('warning')
   })
 
   it('refineEventFeedDrillDownHref falls back to case when report week is missing', () => {

--- a/src/test/events.coverage.test.ts
+++ b/src/test/events.coverage.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import type { OperationEventType } from '../domain/models'
+import { EVENT_TYPE_TO_SOURCE_SYSTEM, type OperationEventType } from '../domain/events/types'
 
-const EVENT_TYPE_COVERAGE_STATUS: Record<OperationEventType, 'covered' | 'future_stub'> = {
-  'assignment.team_assigned': 'covered',
+const EVENT_TYPE_COVERAGE_STATUS: Record<OperationEventType, 'covered' | 'future_stub'> = {  'assignment.team_assigned': 'covered',
   'assignment.team_unassigned': 'covered',
   'case.resolved': 'covered',
   'case.partially_resolved': 'covered',
@@ -41,17 +40,22 @@ const EVENT_TYPE_COVERAGE_STATUS: Record<OperationEventType, 'covered' | 'future
   'faction.standing_changed': 'covered',
   'faction.unlock_available': 'covered',
   'agency.containment_updated': 'covered',
+  'agency.front_business.opened': 'covered',
+  'agency.front_business.resolved': 'covered',
   'directive.applied': 'covered',
   'support.shortfall': 'covered',
   'infiltration.awareness_complication': 'covered',
   'infiltration.escalation_exposed': 'covered',
   'infiltration.escalation_violent': 'covered',
   'infiltration.cover_strain': 'covered',
+  'infiltration.weekly_encounter': 'covered',
+  'infiltration.leave_behind_tradeoff': 'covered',
   'concealment.activated': 'covered',
   'system.academy_upgraded': 'covered',
   'case.aggregate_battle': 'covered',
   'staff.coping.applied': 'covered',
   'staff.coping.misconduct': 'covered',
+  'staff.side_work.resolved': 'covered',
 }
 
 describe('event type coverage contract', () => {
@@ -64,5 +68,10 @@ describe('event type coverage contract', () => {
         .filter(([, status]) => status === 'future_stub')
         .map(([type]) => type)
     ).toEqual([])
+
+    const canonicalTypes = Object.keys(EVENT_TYPE_TO_SOURCE_SYSTEM) as OperationEventType[]
+    const classifiedTypes = Object.keys(EVENT_TYPE_COVERAGE_STATUS) as OperationEventType[]
+
+    expect(classifiedTypes.sort()).toEqual(canonicalTypes.sort())
   })
 })

--- a/src/test/helpers/weeklyMvpLoopProof.ts
+++ b/src/test/helpers/weeklyMvpLoopProof.ts
@@ -81,3 +81,14 @@ export function createWeeklyMvpLoopProofFixture(): WeeklyMvpLoopProofFixture {
 
   return { state: asked.state, teamId }
 }
+
+/** Re-applies week-open prep flags after save/load (same as fixture week 0). */
+export function applyWeeklyMvpLoopPrepFlags(state: GameState): GameState {
+  return {
+    ...state,
+    globalFlags: {
+      ...state.globalFlags,
+      [`conceal.case.${MVP_LOOP_PROOF_CASE_ID}`]: true,
+    },
+  }
+}

--- a/src/test/infiltrationEncounterReportCopy.test.ts
+++ b/src/test/infiltrationEncounterReportCopy.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  buildInfiltrationEncounterReportContext,
+  enrichInfiltrationThresholdSummary,
+  formatInfiltrationWeeklyEncounterSummary,
+  resolveInfiltrationProbeActionSource,
+} from '../domain/infiltrationEncounterReportNotes'
+import { countInvestigationCustodyLossRefs } from '../domain/investigationCustodyLoss'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyInfiltrationWeeklyProbeActionOverride } from '../domain/infiltrationProbeOverride'
+import { createStarterCase } from '../domain/templates/startingCases'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { createWeeklyMvpLoopProofFixture } from './helpers/weeklyMvpLoopProof'
+
+function createBehaviorObserver(id: string): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: { combat: 10, investigation: 50, utility: 40, social: 30 },
+    tags: ['medium', 'liaison'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+function createObserverTeam(id: string, agentId: string): Team {
+  return { id, name: id, agentIds: [agentId], tags: [] }
+}
+
+describe('infiltrationEncounterReportCopy', () => {
+  it('formats weekly encounter summary with authored plan, cover role, and leave-behind', () => {
+    const { state } = createWeeklyMvpLoopProofFixture()
+    const caseData = state.cases['case-mvp-covert']!
+    caseData.hiddenState = 'hidden'
+    caseData.tags = [...caseData.tags, 'infiltration']
+
+    const context = buildInfiltrationEncounterReportContext(caseData)
+    expect(context).toBeDefined()
+    expect(resolveInfiltrationProbeActionSource(caseData)).toBe('authored')
+    expect(context?.coverRole).toBe('uniform_guard')
+    expect(context?.leaveBehindLabel).toBe('Expose cooperating witness')
+
+    const summary = formatInfiltrationWeeklyEncounterSummary(context!)
+    expect(summary).toContain('Authored probe plan')
+    expect(summary).toContain('uniform guard cover')
+    expect(summary).toContain('Expose cooperating witness')
+    expect(summary).toContain('access probe')
+  })
+
+  it('prefixes threshold summaries with weekly prep context', () => {
+    const caseData = createStarterCase({
+      id: 'case-enrich',
+      templateId: 'ops-004',
+      status: 'in_progress',
+    })
+    caseData.hiddenState = 'hidden'
+    caseData.tags = ['infiltration', 'media', 'public']
+    caseData.infiltrationWeeklyProbeActionOverride = 'cleanup'
+    caseData.infiltrationCoverProfile = {
+      claimedRole: 'uniform_guard',
+      documentTier: 0,
+    }
+    caseData.infiltrationProbePlan = { defaultAction: 'probe_access' }
+
+    const context = buildInfiltrationEncounterReportContext(caseData)
+    expect(context).toBeDefined()
+
+    const enriched = enrichInfiltrationThresholdSummary(
+      'Cover strain is visible to local observers.',
+      context!
+    )
+    expect(enriched).toContain('cover cleanup')
+    expect(enriched).toContain('uniform guard cover')
+    expect(enriched).toContain('Cover strain is visible')
+  })
+
+  it('emits infiltration.weekly_encounter on routine covert weeks without threshold crossings', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = { 'conceal.case.case-routine': true }
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const covertCase = createStarterCase({
+      id: 'case-routine',
+      templateId: 'ops-004',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    })
+    covertCase.mode = 'deterministic'
+    covertCase.weeksRemaining = 3
+    covertCase.hiddenState = 'hidden'
+    covertCase.infiltrationAwareness = 0.05
+    covertCase.infiltrationProbeProgress = 0.02
+    covertCase.infiltrationStage = 'probing'
+    covertCase.tags = ['infiltration', 'field']
+
+    state.cases['case-routine'] = covertCase
+
+    const nextState = advanceWeek(state)
+    const report = nextState.reports[nextState.reports.length - 1]
+
+    expect(
+      report?.notes.some((note) => note.type === 'infiltration.weekly_encounter')
+    ).toBe(true)
+
+    const weeklyNote = report?.notes.find((note) => note.type === 'infiltration.weekly_encounter')
+    expect(weeklyNote?.content).toContain('Public Safety Briefing')
+    expect(weeklyNote?.metadata?.probeAction).toBeDefined()
+  })
+
+  it('emits infiltration.leave_behind_tradeoff when mission resolves with custody loss', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('agent_leave_behind_report')
+    const team = createObserverTeam('team_leave_behind_report', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    let tunedCase: CaseInstance | undefined
+
+    for (let socialDifficulty = 8; socialDifficulty <= 140; socialDifficulty += 1) {
+      const candidate: CaseInstance = {
+        ...createStarterCase({
+          id: 'case-leave',
+          templateId: 'ops-004',
+          status: 'in_progress',
+          assignedTeamIds: [team.id],
+        }),
+        mode: 'deterministic',
+        weeksRemaining: 1,
+        hiddenState: 'hidden',
+        detectionConfidence: 0.25,
+        counterDetection: false,
+        tags: ['infiltration', 'media', 'public'],
+        requiredTags: ['medium'],
+        preferredTags: [],
+        assignedTeamIds: [team.id],
+        stealthLeaveBehindId: 'leave-behind:expose-witness',
+        difficulty: {
+          combat: 0,
+          investigation: 0,
+          utility: 0,
+          social: socialDifficulty,
+        },
+        weights: { combat: 0, investigation: 0, utility: 0, social: 1 },
+      }
+
+      const resolution = resolveAssignedCaseForWeek(candidate, state, () => 0.5)
+
+      if (
+        resolution.outcome.result === 'success' &&
+        resolution.stealthLeaveBehindMission?.active &&
+        resolution.stealthLeaveBehindMission.custodyLossRefs.length > 0
+      ) {
+        tunedCase = candidate
+        break
+      }
+    }
+
+    if (tunedCase === undefined) {
+      throw new Error('Unable to tune a leave-behind mission case for report copy test.')
+    }
+
+    state.cases['case-leave'] = tunedCase
+
+    const nextState = advanceWeek(state)
+    const report = nextState.reports[nextState.reports.length - 1]
+
+    expect(
+      report?.notes.some((note) => note.type === 'infiltration.leave_behind_tradeoff')
+    ).toBe(true)
+
+    const tradeoffNote = report?.notes.find(
+      (note) => note.type === 'infiltration.leave_behind_tradeoff'
+    )
+    expect(tradeoffNote?.content).toContain('Expose cooperating witness')
+    expect(tradeoffNote?.metadata?.leaveBehindLabel).toBe('Expose cooperating witness')
+  })
+
+  it('emits infiltration.leave_behind_tradeoff without custody strain when refs are empty (IC-06)', () => {
+    const state = createStartingState()
+    const observer = createBehaviorObserver('agent_leave_behind_no_custody')
+    const team = createObserverTeam('team_leave_behind_no_custody', observer.id)
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    let tunedCase: CaseInstance | undefined
+
+    for (let socialDifficulty = 8; socialDifficulty <= 140; socialDifficulty += 1) {
+      const candidate: CaseInstance = {
+        ...createStarterCase({
+          id: 'case-leave-no-custody',
+          templateId: 'ops-004',
+          status: 'in_progress',
+          assignedTeamIds: [team.id],
+        }),
+        mode: 'deterministic',
+        weeksRemaining: 1,
+        hiddenState: 'hidden',
+        detectionConfidence: 0.25,
+        counterDetection: false,
+        tags: ['infiltration', 'media', 'public'],
+        requiredTags: ['medium'],
+        preferredTags: [],
+        assignedTeamIds: [team.id],
+        stealthLeaveBehindId: 'leave-behind:burn-tool',
+        difficulty: {
+          combat: 0,
+          investigation: 0,
+          utility: 0,
+          social: socialDifficulty,
+        },
+        weights: { combat: 0, investigation: 0, utility: 0, social: 1 },
+      }
+
+      const resolution = resolveAssignedCaseForWeek(candidate, state, () => 0.5)
+
+      if (
+        resolution.outcome.result === 'success' &&
+        resolution.stealthLeaveBehindMission?.active
+      ) {
+        tunedCase = candidate
+        break
+      }
+    }
+
+    if (tunedCase === undefined) {
+      throw new Error('Unable to tune a leave-behind mission case for no-custody report test.')
+    }
+
+    state.cases['case-leave-no-custody'] = tunedCase
+
+    const nextState = advanceWeek(state)
+    const report = nextState.reports[nextState.reports.length - 1]
+
+    expect(
+      report?.notes.some((note) => note.type === 'infiltration.leave_behind_tradeoff')
+    ).toBe(true)
+
+    const tradeoffNote = report?.notes.find(
+      (note) => note.type === 'infiltration.leave_behind_tradeoff'
+    )
+    expect(tradeoffNote?.content).toContain('Burn field tool')
+    expect(tradeoffNote?.content).toMatch(/Stealth leave-behind applied/)
+    expect(tradeoffNote?.content).not.toMatch(/Investigation strain:/i)
+    expect(tradeoffNote?.metadata?.leaveBehindLabel).toBe('Burn field tool')
+    expect(countInvestigationCustodyLossRefs(nextState, 'case-leave-no-custody')).toBe(0)
+  })
+
+  it('includes player override in enriched threshold report notes', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = { 'conceal.case.case-ops-004-cover': true }
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const covertCase = createStarterCase({
+      id: 'case-ops-004-cover',
+      templateId: 'ops-004',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    })
+    covertCase.mode = 'deterministic'
+    covertCase.weeksRemaining = 2
+    covertCase.infiltrationAwareness = 0.3
+    covertCase.infiltrationProbeProgress = 0.2
+    covertCase.hiddenState = 'hidden'
+    covertCase.tags = ['infiltration', 'media', 'public']
+    covertCase.infiltrationCoverProfile = {
+      claimedRole: 'uniform_guard',
+      documentTier: 0,
+    }
+
+    state.cases['case-ops-004-cover'] = covertCase
+
+    const withOverride = applyInfiltrationWeeklyProbeActionOverride(state, {
+      caseId: 'case-ops-004-cover',
+      action: 'probe_route',
+    })
+    expect(withOverride.applied).toBe(true)
+
+    const nextState = advanceWeek(withOverride.state)
+    const strainNote = nextState.reports
+      .flatMap((report) => report.notes)
+      .find((note) => note.type === 'infiltration.cover_strain')
+
+    expect(strainNote).toBeDefined()
+    expect(strainNote?.content).toMatch(/route probe|Weekly prep selected route probe/)
+    expect(strainNote?.content).toMatch(/player override|Weekly prep/)
+    expect(strainNote?.content).toMatch(/awareness/i)
+    expect(strainNote?.metadata?.probeAction).toBe('probe_route')
+    expect(strainNote?.metadata?.probeActionSource).toBe('override')
+    expect(typeof strainNote?.metadata?.infiltrationAwareness).toBe('number')
+  })
+
+  it('does not emit duplicate weekly_encounter when threshold events already fired', () => {
+    const state = createStartingState()
+    const [teamId] = Object.keys(state.teams)
+
+    state.reports = []
+    state.agency!.supportAvailable = 3
+    state.globalFlags = { 'conceal.case.case-ops-004-cover': true }
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const covertCase = createStarterCase({
+      id: 'case-dup-check',
+      templateId: 'ops-004',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    })
+    covertCase.mode = 'deterministic'
+    covertCase.weeksRemaining = 2
+    covertCase.hiddenState = 'hidden'
+    covertCase.tags = ['infiltration', 'media', 'public']
+    covertCase.infiltrationAwareness = 0.3
+    covertCase.infiltrationProbeProgress = 0.2
+    covertCase.infiltrationCoverProfile = {
+      claimedRole: 'uniform_guard',
+      documentTier: 0,
+    }
+
+    state.cases['case-dup-check'] = covertCase
+
+    const nextState = advanceWeek(state)
+    const report = nextState.reports[nextState.reports.length - 1]
+    const weeklyCount = report?.notes.filter(
+      (note) => note.type === 'infiltration.weekly_encounter'
+    ).length
+
+    expect(weeklyCount).toBe(0)
+    expect(
+      report?.notes.some((note) => note.type?.startsWith('infiltration.') ?? false)
+    ).toBe(true)
+  })
+})

--- a/src/test/infiltrationEncounterReportNotes.test.ts
+++ b/src/test/infiltrationEncounterReportNotes.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildInfiltrationEncounterReportContext,
+  buildInfiltrationEncounterReportContextAfterProbe,
+  enrichInfiltrationThresholdSummary,
+  formatInfiltrationLeaveBehindTradeoffSummary,
+  formatInfiltrationWeeklyEncounterSummary,
+  readInfiltrationLeaveBehindLabel,
+  resolveInfiltrationProbeActionSource,
+  shouldEmitInfiltrationWeeklyEncounterNote,
+} from '../domain/infiltrationEncounterReportNotes'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createCovertCase() {
+  const caseData = createStarterCase({
+    id: 'case-unit',
+    templateId: 'ops-004',
+    status: 'in_progress',
+  })
+  caseData.hiddenState = 'hidden'
+  caseData.tags = ['infiltration', 'media', 'public']
+  caseData.infiltrationProbePlan = { defaultAction: 'probe_access' }
+  caseData.infiltrationCoverProfile = {
+    claimedRole: 'uniform_guard',
+    documentTier: 1,
+  }
+  caseData.stealthLeaveBehindId = 'leave-behind:burn-tool'
+  caseData.infiltrationAwareness = 0.2
+  caseData.infiltrationProbeProgress = 0.1
+  caseData.infiltrationStage = 'probing'
+  return caseData
+}
+
+describe('infiltrationEncounterReportNotes', () => {
+  it('reads leave-behind labels from the registry and ignores unknown ids', () => {
+    const caseData = createCovertCase()
+    expect(readInfiltrationLeaveBehindLabel(caseData)).toBe('Burn field tool')
+    expect(readInfiltrationLeaveBehindLabel({ ...caseData, stealthLeaveBehindId: 'missing' })).toBe(
+      undefined
+    )
+  })
+
+  it('builds post-tick context with updated tracks but pre-tick probe action source', () => {
+    const before = createCovertCase()
+    before.infiltrationWeeklyProbeActionOverride = 'probe_route'
+
+    const after = {
+      ...before,
+      infiltrationAwareness: 0.62,
+      infiltrationProbeProgress: 0.35,
+      infiltrationStage: 'exposed' as const,
+    }
+
+    const context = buildInfiltrationEncounterReportContextAfterProbe(before, after)
+    expect(context?.probeAction).toBe('probe_route')
+    expect(context?.probeActionSource).toBe('override')
+    expect(context?.awareness).toBe(0.62)
+    expect(context?.stage).toBe('exposed')
+
+    const preOnly = buildInfiltrationEncounterReportContext(before)
+    expect(preOnly?.awareness).toBe(0.2)
+  })
+
+  it('enriches threshold summaries with prep, cover, leave-behind, and post-tick tracks', () => {
+    const context = buildInfiltrationEncounterReportContext(createCovertCase())!
+    const enriched = enrichInfiltrationThresholdSummary('Observers intensified scrutiny.', context)
+
+    expect(enriched).toContain('Authored probe plan')
+    expect(enriched).toContain('uniform guard cover')
+    expect(enriched).toContain('Burn field tool')
+    expect(enriched).toContain('Observers intensified scrutiny')
+    expect(enriched).toContain('10% probe / 20% awareness')
+  })
+
+  it('formats leave-behind tradeoff with score pressure and optional custody strain', () => {
+    expect(
+      formatInfiltrationLeaveBehindTradeoffSummary('Burn field tool', {
+        scoreAdjustmentReason: 'Stealth leave-behind: +1.8 (Burn field tool)',
+      })
+    ).toContain('Stealth leave-behind: +1.8')
+
+    expect(
+      formatInfiltrationLeaveBehindTradeoffSummary('Burn field tool', {
+        custodyLossSummary: 'lost custody:field-packet',
+      })
+    ).toContain('Investigation strain')
+  })
+
+  it('gates weekly encounter notes on infiltration probe eligibility only', () => {
+    const eligible = createCovertCase()
+    expect(shouldEmitInfiltrationWeeklyEncounterNote(eligible)).toBe(true)
+
+    expect(shouldEmitInfiltrationWeeklyEncounterNote({ ...eligible, hiddenState: 'revealed' })).toBe(
+      false
+    )
+    expect(
+      shouldEmitInfiltrationWeeklyEncounterNote({
+        ...eligible,
+        tags: ['media'],
+        requiredTags: [],
+        preferredTags: [],
+      })
+    ).toBe(false)
+  })
+
+  it('omits cover and leave-behind clauses when absent', () => {
+    const sparse = createCovertCase()
+    sparse.infiltrationCoverProfile = undefined
+    sparse.stealthLeaveBehindId = undefined
+
+    const summary = formatInfiltrationWeeklyEncounterSummary(
+      buildInfiltrationEncounterReportContext(sparse)!
+    )
+    expect(summary).not.toContain('Cover posture')
+    expect(summary).not.toContain('Leave-behind')
+    expect(resolveInfiltrationProbeActionSource(sparse)).toBe('authored')
+  })
+})

--- a/src/test/stealthLeaveBehindRegistry.test.ts
+++ b/src/test/stealthLeaveBehindRegistry.test.ts
@@ -42,6 +42,16 @@ describe('stealthLeaveBehindRegistry (SPE-2163 slice 1)', () => {
     expect(result.issues).toHaveLength(0)
   })
 
+  it('allows empty custodyLossRefs for score-only leave-behind tradeoffs', () => {
+    const result = validateStealthLeaveBehindDefinition(
+      baseDefinition({ custodyLossRefs: [] })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(getStealthLeaveBehindById(DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY, 'leave-behind:burn-tool')
+      ?.custodyLossRefs).toEqual([])
+  })
+
   it('rejects custody refs that collide on investigation flag suffixes', () => {
     const result = validateStealthLeaveBehindDefinition(
       baseDefinition({

--- a/src/test/stealthLeaveBehindSelectionView.test.ts
+++ b/src/test/stealthLeaveBehindSelectionView.test.ts
@@ -47,7 +47,7 @@ describe('buildStealthLeaveBehindSelectionView forensic preview', () => {
 
     expect(abandon?.projectedCustodyLossBurden).toBe(2)
     expect(abandon?.projectedForensicRemaining).toBe(1)
-    expect(burn?.projectedCustodyLossBurden).toBe(1)
-    expect(burn?.projectedForensicRemaining).toBe(2)
+    expect(burn?.projectedCustodyLossBurden).toBe(0)
+    expect(burn?.projectedForensicRemaining).toBe(3)
   })
 })

--- a/src/test/weeklyMvpLoopProof.calibration.test.ts
+++ b/src/test/weeklyMvpLoopProof.calibration.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AWARENESS_COMPLICATION_THRESHOLD,
+  VIOLENT_ESCALATION_THRESHOLD,
+} from '../domain/infiltrationProbe'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyInfiltrationWeeklyProbeActionOverride } from '../domain/infiltrationProbeOverride'
+import {
+  applyWeeklyMvpLoopPrepFlags,
+  createWeeklyMvpLoopProofFixture,
+  MVP_LOOP_PROOF_CASE_ID,
+} from './helpers/weeklyMvpLoopProof'
+
+/** SPE-25 calibration anchor: MVP fixture track bands vs tuning/infiltration-probe-and-concealment.md */
+describe('MVP weekly loop proof — infiltration calibration (SPE-25)', () => {
+  it('keeps covert tracks below violent escalation over four prep-aware weeks', () => {
+    const { state: fixtureState, teamId } = createWeeklyMvpLoopProofFixture()
+    const covertCase = fixtureState.cases[MVP_LOOP_PROOF_CASE_ID]!
+    covertCase.weeksRemaining = 5
+
+    let state: typeof fixtureState = {
+      ...fixtureState,
+      cases: { [MVP_LOOP_PROOF_CASE_ID]: covertCase },
+      teams: {
+        [teamId]: {
+          ...fixtureState.teams[teamId]!,
+          assignedCaseId: MVP_LOOP_PROOF_CASE_ID,
+        },
+      },
+      reports: [],
+      events: [],
+    }
+
+    const awarenessByWeek: number[] = []
+
+    for (let index = 0; index < 4; index += 1) {
+      state = applyWeeklyMvpLoopPrepFlags(state)
+      if (index === 1) {
+        state = applyInfiltrationWeeklyProbeActionOverride(state, {
+          caseId: MVP_LOOP_PROOF_CASE_ID,
+          action: 'cleanup',
+        }).state
+      }
+
+      state = advanceWeek(state)
+      const caseAfter = state.cases[MVP_LOOP_PROOF_CASE_ID]!
+      const awareness = caseAfter.infiltrationAwareness ?? 0
+
+      awarenessByWeek.push(awareness)
+      expect(awareness, `week index ${index} awareness`).toBeLessThan(
+        VIOLENT_ESCALATION_THRESHOLD
+      )
+      expect(caseAfter.infiltrationStage).not.toBe('violent')
+    }
+
+    expect(awarenessByWeek[1]).toBeLessThan(awarenessByWeek[0]!)
+    expect(Math.max(...awarenessByWeek)).toBeLessThan(AWARENESS_COMPLICATION_THRESHOLD + 0.2)
+  })
+})

--- a/src/test/weeklyMvpLoopProof.slice2.integration.test.ts
+++ b/src/test/weeklyMvpLoopProof.slice2.integration.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { buildReportWeekNavigation } from '../features/report/reportWeekNavigation'
+import { readPersistentFlag } from '../domain/flagSystem'
+import {
+  buildInvestigationAskedFlagId,
+  buildInvestigationLeverageFlagId,
+} from '../domain/investigationEconomy'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyInfiltrationWeeklyProbeActionOverride } from '../domain/infiltrationProbeOverride'
+import { applyStealthLeaveBehindSelection } from '../domain/stealthLeaveBehindSelection'
+import {
+  applyWeeklyMvpLoopPrepFlags,
+  createWeeklyMvpLoopProofFixture,
+  MVP_LOOP_FORENSIC_QUESTION_ID,
+  MVP_LOOP_PROOF_CASE_ID,
+} from './helpers/weeklyMvpLoopProof'
+
+describe('MVP weekly loop proof (slice 2)', () => {
+  it('preserves covert prep, flags, and report notes through save/load mid-campaign', () => {
+    const { state: week0 } = createWeeklyMvpLoopProofFixture()
+    const week1 = advanceWeek(week0)
+
+    const withOverride = applyInfiltrationWeeklyProbeActionOverride(week1, {
+      caseId: MVP_LOOP_PROOF_CASE_ID,
+      action: 'probe_route',
+    })
+    const withLeaveBehind = applyStealthLeaveBehindSelection(withOverride.state, {
+      caseId: MVP_LOOP_PROOF_CASE_ID,
+      leaveBehindId: 'leave-behind:expose-witness',
+    })
+
+    const reloaded = loadGameSave(serializeGameSave(withLeaveBehind.state))
+
+    expect(reloaded.week).toBe(week1.week)
+    expect(reloaded.reports).toHaveLength(week1.reports.length)
+    expect(reloaded.cases[MVP_LOOP_PROOF_CASE_ID]?.hiddenState).toBe('hidden')
+    expect(reloaded.cases[MVP_LOOP_PROOF_CASE_ID]?.infiltrationWeeklyProbeActionOverride).toBe(
+      'probe_route'
+    )
+    expect(reloaded.cases[MVP_LOOP_PROOF_CASE_ID]?.stealthLeaveBehindId).toBe(
+      'leave-behind:expose-witness'
+    )
+    expect(
+      readPersistentFlag(
+        reloaded,
+        buildInvestigationAskedFlagId(MVP_LOOP_PROOF_CASE_ID, MVP_LOOP_FORENSIC_QUESTION_ID)
+      )
+    ).toBe(true)
+
+    const week2 = advanceWeek(applyWeeklyMvpLoopPrepFlags(reloaded))
+    expect(week2.week).toBe(reloaded.week + 1)
+    expect(week2.reports.length).toBeGreaterThan(reloaded.reports.length)
+
+    const latestNotes = week2.reports[week2.reports.length - 1]?.notes ?? []
+    expect(
+      latestNotes.some(
+        (note) =>
+          note.type === 'infiltration.weekly_encounter' ||
+          note.type === 'infiltration.cover_strain' ||
+          note.type === 'infiltration.leave_behind_tradeoff' ||
+          note.type === 'concealment.activated'
+      )
+    ).toBe(true)
+  })
+
+  it('runs four weeks with growing report history and coherent week navigation', () => {
+    const { state: fixtureState, teamId } = createWeeklyMvpLoopProofFixture()
+    const covertCase = fixtureState.cases[MVP_LOOP_PROOF_CASE_ID]!
+    covertCase.weeksRemaining = 5
+
+    const startWeek = fixtureState.week
+    let state: typeof fixtureState = {
+      ...fixtureState,
+      cases: { [MVP_LOOP_PROOF_CASE_ID]: covertCase },
+      teams: {
+        [teamId]: {
+          ...fixtureState.teams[teamId]!,
+          assignedCaseId: MVP_LOOP_PROOF_CASE_ID,
+        },
+      },
+      reports: [],
+      events: [],
+    }
+
+    for (let index = 0; index < 4; index += 1) {
+      state = applyWeeklyMvpLoopPrepFlags(state)
+      if (index === 1) {
+        const override = applyInfiltrationWeeklyProbeActionOverride(state, {
+          caseId: MVP_LOOP_PROOF_CASE_ID,
+          action: 'cleanup',
+        })
+        state = override.state
+      }
+      const next = advanceWeek(state)
+      expect(next.gameOver, `advance ${index} should not end the run`).toBe(false)
+      state = next
+    }
+
+    expect(state.week).toBe(startWeek + 4)
+    expect(state.reports.length).toBe(4)
+
+    const weeks = state.reports.map((report) => report.week)
+    expect(new Set(weeks).size).toBe(4)
+
+    const lastReport = state.reports[state.reports.length - 1]!
+    const nav = buildReportWeekNavigation(state.reports, lastReport.week)
+    expect(nav.previousWeek).toBe(state.reports[state.reports.length - 2]?.week)
+
+    expect(
+      readPersistentFlag(
+        state,
+        buildInvestigationLeverageFlagId(MVP_LOOP_PROOF_CASE_ID, 'secure-evidence-chain')
+      )
+    ).toBe(true)
+  })
+})

--- a/systems/resolution-thresholds-tuning.md
+++ b/systems/resolution-thresholds-tuning.md
@@ -35,6 +35,8 @@ It is the tuning reference for:
 - fallout trigger bands
 - how tolerant or unforgiving the system should feel
 
+**Covert operations (separate reference):** infiltration probe awareness bands, concealment activation, and leave-behind tradeoff surfacing are tuned in `tuning/infiltration-probe-and-concealment.md` (mission score pressure from leave-behind still intersects follow-through here).
+
 This spec is for:
 
 - systems tuning

--- a/tuning/infiltration-probe-and-concealment.md
+++ b/tuning/infiltration-probe-and-concealment.md
@@ -1,0 +1,268 @@
+# Containment Protocol — Infiltration Probe and Concealment Tuning Spec
+
+## Simulation calibration passes (SPE-25)
+
+Passes such as **SPE-25 — simulation calibration** adjust **constants, bands, and thresholds only**. They do **not** redefine architecture, ownership, or weekly loop structure. Infiltration and concealment changes belong here unless an issue explicitly expands scope (new event kinds, new state owners, or new weekly phases).
+
+## Purpose
+
+This document is the **tuning reference** for batch-4 covert operations:
+
+- **Concealment activation** — when a case becomes `hidden` or `displaced` before weekly probe ticks
+- **Infiltration probe tracks** — probe progress, site awareness, stage transitions
+- **Cover posture strain** — weekly cover evaluation and threshold events
+- **Stealth leave-behind tradeoffs** — mission-resolution score pressure and optional custody fallout
+
+It is **not** the core design spec for mission resolution, disguise validation (SPE-70 field propagation), or full infiltration frameworks (SPE-522 / SPE-1007).
+
+This spec is for:
+
+- systems tuning and balance iteration
+- implementation parameterization (single source of truth in code; this doc mirrors it)
+- QA validation against `qa/infiltration-concealment-report-matrix.md`
+- campaign feel review for covert-ops weeks
+
+---
+
+## Design goals
+
+Infiltration and concealment tuning should:
+
+- make weekly prep (probe action override, leave-behind selection, conceal flag) **visible in reports and events**
+- cross **awareness bands** with deterministic threshold events before hard failure
+- keep **partial success under authority scrutiny** meaningfully worse than clean success when leave-behind is staged
+- preserve **eligibility gates** (`hidden` + infiltration-family tags) so probes do not run on exposed operations by accident
+
+Infiltration and concealment tuning should not:
+
+- introduce client-side re-simulation of probe math
+- duplicate threshold logic in UX copy with different numbers than domain constants
+- emit **routine** and **threshold** infiltration notes for the same cause in one week
+
+---
+
+## 1. Canonical code owners (implementation)
+
+| Concern | Module | Weekly hook |
+| --- | --- | --- |
+| Probe tracks, action deltas, awareness thresholds | `src/domain/infiltrationProbe.ts` | `applyWeeklyInfiltrationProbeTick` via `advanceWeek` → `applyWeeklyInfiltrationProbe` |
+| Player-facing report copy and event payload enrichment | `src/domain/infiltrationEncounterReportNotes.ts` | Same weekly hook + mission resolve for leave-behind |
+| Weekly prep override | `src/domain/infiltrationProbeOverride.ts` | Pre-week flag on case |
+| Cover posture / `cover_strain` events | `src/domain/infiltrationCover.ts` | Chained after probe action in `applyWeeklyInfiltrationProbeTick` |
+| Concealment activation | `src/domain/hiddenStateActivation.ts` | `applyWeeklyConcealmentActivation` in `advanceWeek` (before probe) |
+| Concealment prep UI eligibility | `src/domain/concealmentCasePrep.ts` | Flags `conceal.case.{caseId}` |
+| Leave-behind registry and mission pressure | `src/domain/stealthLeaveBehindRegistry.ts` | `resolveAssignedCaseForWeek` → `stealthLeaveBehindMission` |
+| Report notes from events | `src/domain/reportNotes.ts` | `buildDeterministicReportNotesFromEventDrafts` |
+| Event feed labels / drill-down | `src/features/dashboard/eventFeedView.ts` | Consumes persisted `OperationEvent` records |
+
+**Related tuning (not duplicated here):** mission resolution bands and follow-through breakpoints remain in `systems/resolution-thresholds-tuning.md`. Escalation/fallout tier selection remains in `tuning/escalation-and-fallout.md`.
+
+---
+
+## 2. Concealment activation
+
+### 2.1 Eligibility tags
+
+Cases can activate concealed presence when tags include one of (`hiddenStateActivation.ts`):
+
+`infiltration`, `disguise`, `stealth`, `concealment`, `covert`
+
+Authored `concealmentTriggers` on templates may also apply without manual tag assignment.
+
+### 2.2 Prep flags
+
+| Flag pattern | Effect |
+| --- | --- |
+| `conceal.case.{caseId}` | Player opted into hidden activation for that case this week |
+| `conceal.displace.{caseId}` | Displaced mode when configured |
+
+### 2.3 Default detection confidence on activation
+
+| Mode | Default `detectionConfidence` |
+| --- | --- |
+| `hidden` | `0.25` |
+| `displaced` | `0.55` |
+
+### 2.4 Recon bridge (authored triggers)
+
+When triggers require recon signal:
+
+- `minHiddenModifierCount`: **2**
+- `minInvestigationWeight`: **0.3**
+
+Tune only with integration fixtures that include recon modifiers; changing these without fixture updates will break concealment trigger tests.
+
+---
+
+## 3. Infiltration probe eligibility
+
+Weekly probe ticks run only when **both** are true (`isInfiltrationProbeEligible`):
+
+1. `case.hiddenState === 'hidden'`
+2. Case tags (including `requiredTags` / `preferredTags`) include at least one of: `infiltration`, `disguise`, `covert`
+
+**Tuning implication:** lowering awareness on a non-hidden case must **not** expect probe events; activation order in `advanceWeek` is concealment **then** probe.
+
+---
+
+## 4. Probe action deltas (per week)
+
+Canonical deltas (`ACTION_DELTAS` in `infiltrationProbe.ts`):
+
+| Action | Δ probe progress | Δ awareness |
+| --- | ---: | ---: |
+| `probe_access` | +0.15 | +0.12 |
+| `probe_route` | +0.10 | +0.18 |
+| `cleanup` | +0.02 | −0.15 |
+
+Values are clamped to `[0, 1]` after each tick. Rounding uses three decimal places (`roundBand`).
+
+### 4.1 Action resolution order
+
+1. Player override: `infiltrationWeeklyProbeActionOverride` (if set)
+2. Authored `infiltrationProbePlan` (default, progress rules, `cleanupWhenAwarenessAtLeast`)
+3. Tag heuristics (`probe_route` vs `cleanup` vs `probe_access` from case tags)
+4. Fallback: `probe_access`
+
+Tag heuristic uses `cleanup` when awareness ≥ **complication threshold** (0.55) and case has cleanup-family tags (`media`, `court`, `public`, …).
+
+---
+
+## 5. Awareness and stage thresholds
+
+| Constant | Value | Effect |
+| --- | ---: | --- |
+| `AWARENESS_COMPLICATION_THRESHOLD` | **0.55** | Cross band → `awareness_complication` event; may promote stage `probing` → `exposed` |
+| `VIOLENT_ESCALATION_THRESHOLD` | **0.80** | Cross band → `escalation_violent` when stage becomes `violent` |
+| `EXPOSED_DETECTION_CONFIDENCE` | **0.55** | Floor on `detectionConfidence` when stage is `exposed` |
+| `VIOLENT_DETECTION_CONFIDENCE` | **0.75** | Floor when stage is `violent`; enables `counterDetection` |
+
+### 5.1 Threshold events (emitted kinds)
+
+| Event kind | Typical trigger |
+| --- | --- |
+| `awareness_complication` | Awareness crosses 0.55 upward |
+| `escalation_exposed` | Same crossing while stage becomes `exposed` from `probing` |
+| `escalation_violent` | Awareness ≥ 0.80 and stage `violent` |
+| `cover_strain` | Weekly cover posture evaluation (`infiltrationCover.ts`) |
+
+**Report copy:** threshold summaries are **enriched** with weekly prep context (probe action, cover role, leave-behind label, track percentages) via `enrichInfiltrationThresholdSummary`.
+
+### 5.2 Routine weekly encounter
+
+`infiltration.weekly_encounter` emits when:
+
+- Case remains infiltration-eligible and `in_progress`
+- Probe tick produced **no** threshold events
+- (Typical) probe still changed tracks **or** truly quiet week with no tick change
+
+**Must not** emit in the same week as any threshold infiltration event for that case (duplicate guard in `applyWeeklyInfiltrationProbe`).
+
+---
+
+## 6. Cover posture tuning (awareness bumps)
+
+Weekly cover evaluation adds awareness when strain applies (`infiltrationCover.ts`):
+
+| Strain source | Typical Δ awareness |
+| --- | ---: |
+| Role mismatch with case tags | +0.08 |
+| Route violation tags | +0.06 |
+| Weak document tier | +0.05 |
+| Weak doctrine band | +0.04 |
+
+`COVER_STRAIN_BAND` (**0.35**) participates in strain visibility logic alongside authority/procedural scrutiny tag sets (`public`, `media`, `court`, …).
+
+Stage mission score adjustments for `exposed` / `violent` stages are owned by infiltration stage mission pressure in `infiltrationProbe.ts` (mission resolution orchestration); tune alongside `systems/resolution-thresholds-tuning.md` § follow-through, not in isolation.
+
+---
+
+## 7. Stealth leave-behind tradeoff
+
+### 7.1 Selection
+
+Player selects `stealthLeaveBehindId` before resolve; registry definitions live in `stealthLeaveBehindRegistry.ts`.
+
+### 7.2 Mission pressure
+
+`stealthLeaveBehindMission.active` when hidden case resolves successfully under configured scrutiny/discovery rules. `shouldDegradeSuccessToPartial` is **registry- and tag-driven** (authority scrutiny + discovery risk), not a single global constant.
+
+### 7.3 Report and event
+
+On mission resolve, when leave-behind mission is active:
+
+- Emit `infiltration.leave_behind_tradeoff` report note and matching event
+- **Custody loss optional:** note still emits when `custodyLossRefs` is empty but mission pressure is active (canonical example: `leave-behind:burn-tool` — score malus only, no forensic custody chain)
+- When custody refs exist, apply `applyStealthLeaveBehindInvestigationCustodyLoss` and include resolution text in the note
+
+**Tuning workflow:** use social difficulty sweep in `stealthLeaveBehindMission.test.ts` / `infiltrationEncounterReportCopy.test.ts` patterns—do not hard-code a single difficulty in specs without verifying `stealthLeaveBehindMission.active`.
+
+---
+
+## 8. Surfacing contract (reports + event feed)
+
+| Surface | Contract |
+| --- | --- |
+| Report note `type` | Matches event `type` for infiltration family (`infiltration.*`) |
+| Note `content` | `{caseTitle}: {summary}` where `summary` is domain-authored |
+| Note `metadata` | Includes `probeAction`, `probeActionSource`, `coverRole`, `leaveBehindLabel` when context exists |
+| Event feed | Same payload fields; `weekly_encounter` tone **neutral**; other infiltration types **warning** except `escalation_violent` **danger** |
+| Drill-down | Infiltration and concealment events link to `/report/{week}` |
+
+Full invariant matrix: **`qa/infiltration-concealment-report-matrix.md`**.
+
+---
+
+## 9. Calibration workflow
+
+1. Change constant in the owning `.ts` file (never only in this doc).
+2. Run unit tests: `infiltrationEncounterReportNotes.test.ts`, `infiltrationProbe.test.ts` (if present), `infiltrationEncounterReportCopy.test.ts`.
+3. Run integration: `advanceWeek.infiltrationProbe.integration.test.ts`, `stealthLeaveBehindMission.test.ts`, `weeklyMvpLoopProof.slice2.integration.test.ts`.
+4. Update **this file** threshold tables to match.
+5. Update QA matrix expected columns if surfacing rules change.
+
+---
+
+## 10. QA and balancing review questions
+
+- Does crossing **0.55** awareness feel like complication before failure?
+- Is **cleanup** attractive enough when awareness is high on media/public cases?
+- Does **probe_route** materially raise awareness versus **probe_access** on the same fixture?
+- After leave-behind selection, does a **successful** resolve still show tradeoff copy when scrutiny applies?
+- Does the player see **one** infiltration explanation per week per case (no duplicate routine + threshold)?
+- Do override prep choices appear in **both** report metadata and readable summary text?
+
+**Determinism:** same case snapshot + same week + same RNG stream → same probe action, same events, same ordered report notes.
+
+---
+
+## 11. Acceptance criteria
+
+Infiltration and concealment tuning is aligned when:
+
+- Code constants and this document match
+- QA matrix rows pass in CI fixtures
+- Reports and event feed agree on prep context and awareness/stage bands
+- Concealment activation always precedes probe ticks in the weekly pipeline
+- Leave-behind tradeoff is visible even when custody loss does not fire
+
+---
+
+## 12. Calibration history
+
+| Pass | Date | Harness | Result |
+| --- | --- | --- | --- |
+| SPE-25 MVP anchor | May 2026 | `weeklyMvpLoopProof.calibration.test.ts` (4-week loop, cleanup prep week 2) | **No constant changes.** Awareness stays below `VIOLENT_ESCALATION_THRESHOLD` (0.80); cleanup week reduces awareness vs prior week; peak stays within ~0.20 of complication band (0.55). |
+
+When changing `ACTION_DELTAS` or awareness thresholds, re-run this test and update the matrix if bands shift.
+
+---
+
+## See also
+
+- `qa/infiltration-concealment-report-matrix.md` — report/event invariants
+- `ux/operations-report.md` §5.3.1 — player-facing note families
+- `ux/navigation-map.md` §3.5 — report week navigation
+- `planning/infiltration-encounter-content-slice-2.md` — shipped batch-4 scope
+- `systems/resolution-thresholds-tuning.md` — mission outcome bands
+- `tuning/escalation-and-fallout.md` — fallout tiers after partial/failed resolve

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -26,6 +26,20 @@ This spec is for:
 
 ---
 
+## Spec status (May 2026)
+
+**Partial refresh shipped elsewhere:** batch-4 covert operations surfacing (concealment activation, infiltration report note types, leave-behind tradeoff copy, report week prev/next) is specified in `ux/operations-report.md` §5.3.1 and `ux/navigation-map.md` §3.5.1–3.5.2. Weekly prep UI behavior lives in domain helpers and case prep views — not re-specified here yet.
+
+**Deferred until triage UI is next:**
+
+- triage row signals for hidden/concealment-eligible cases and staged leave-behind
+- comparison columns for infiltration prep cost vs deferral risk
+- cross-links from triage deferral to escalation carryover (see comparison table and escalation carryover risk rows below)
+
+Do not treat this document as stale for core prioritization UX; treat covert-prep surfacing as **out of scope** until the deferred block is picked up (`planning/backlog.md` item #4).
+
+---
+
 ## Design goals
 
 The Mission Triage view should:

--- a/ux/navigation-map.md
+++ b/ux/navigation-map.md
@@ -414,9 +414,28 @@ review latest week
 
 browse prior reports
 
+move to previous or next stored report week from report detail (skip weeks without a report)
+
 inspect cause summaries
 
 jump from report items to relevant agency or operations surfaces
+
+#### 3.5.1 Report week navigation (prev / next)
+
+When viewing a weekly report dossier:
+
+- show **Previous week** only if an earlier report exists in `state.reports`
+- show **Next week** only if a later report exists
+- skip week indices that have no report artifact (non-contiguous history is normal)
+- hide both controls when only one report exists
+
+This is **not** a second global week control—it reuses the canonical report list ordering. See `planning/report-week-navigation-slice.md` and `ux/operations-report.md` (Report week navigation).
+
+#### 3.5.2 Covert ops notes and event feed drill-down
+
+Report notes for `concealment.activated` and `infiltration.*` types should be readable in the report body; matching **OperationEvent** rows in the dashboard feed link back to the same report week.
+
+Event feed tone guidance: routine `infiltration.weekly_encounter` is low alarm; threshold and leave-behind types read as warnings unless violent escalation (danger). Details: `ux/operations-report.md` §5.3.1.
 
 Should not contain
 

--- a/ux/operations-report.md
+++ b/ux/operations-report.md
@@ -246,6 +246,38 @@ Recon gaps increased avoidable exposure.
 
 This is one of the most important sections in the entire view.
 
+### 5.3.1 Covert infiltration and concealment note families (batch 4)
+
+#### Purpose
+
+Surface deterministic covert-ops outcomes from the same weekly pipeline as other report notes—**no client-side probe math**.
+
+#### Note types (canonical `type` strings)
+
+| Report / event `type` | When it appears | Player takeaway |
+| --- | --- | --- |
+| `concealment.activated` | Case enters `hidden` or `displaced` from prep flag or authored trigger | Cover is now active for this operation |
+| `infiltration.weekly_encounter` | Eligible hidden case; probe tick ran; **no** threshold events that week | What prep ran (access/route/cleanup), cover role, staged leave-behind, track bands |
+| `infiltration.awareness_complication` | Site awareness crosses complication band (~55%) | Patrol/staff pressure may intensify |
+| `infiltration.escalation_exposed` | Stage moves to exposed on complication cross | Visible cover strain; higher detection pressure |
+| `infiltration.escalation_violent` | Violent stage from very high awareness (~80%+) | Overt escalation / emergency escape risk |
+| `infiltration.cover_strain` | Weekly cover posture evaluation fires strain | Role/document/route mismatch under scrutiny |
+| `infiltration.leave_behind_tradeoff` | Mission resolve with active stealth leave-behind pressure | Extraction tradeoff label; optional custody strain; may fire **without** custody loss |
+
+#### Content and metadata rules
+
+- **Content shape:** `{caseTitle}: {summary}` where `summary` is produced in domain (`infiltrationEncounterReportNotes.ts`, concealment activation feed).
+- **Threshold summaries** are prefixed with weekly prep context (probe action, cover role, leave-behind label, track clause)—do not strip prefixes in UI.
+- **Metadata** (when present on note): `probeAction`, `probeActionSource` (`override` | `authored` | `heuristic`), `coverRole`, `leaveBehindLabel`, `infiltrationAwareness`, `infiltrationProbeProgress`, `infiltrationStage`.
+- **Duplicate guard:** at most one `infiltration.weekly_encounter` per case per week; never alongside threshold infiltration notes for the same case in the same week.
+
+#### Event feed parity
+
+Dashboard event feed must show the same infiltration/concealment types with labels from `eventFeedView.ts`, link to `/report/{week}`, and use tone **neutral** for `weekly_encounter`, **warning** for most other infiltration types, **danger** for `escalation_violent`.
+
+**QA matrix:** `qa/infiltration-concealment-report-matrix.md`  
+**Tuning bands:** `tuning/infiltration-probe-and-concealment.md`
+
 ### 5.4 Fallout and pressure changes
 
 #### Purpose — Fallout and pressure changes
@@ -435,6 +467,19 @@ Should show:
 
 Drilldowns should move the player from understanding to action.
 
+### Report week navigation (prev / next)
+
+When multiple weekly reports exist, the report detail header exposes **Previous week** / **Next week** links that jump only to weeks with a stored report (gaps are skipped).
+
+Rules:
+
+- Omit prev when viewing the earliest available report week.
+- Omit next when viewing the latest available report week.
+- Single-report campaigns show no prev/next chrome.
+- Navigation is **read-only**; it does not change simulation state.
+
+Implementation: `buildReportWeekNavigation` in `src/features/report/reportWeekNavigation.ts`; copy in `REPORT_UI_TEXT`. Spec slice: `planning/report-week-navigation-slice.md`.
+
 ---
 
 ## 10. Relationship to other views
@@ -454,6 +499,10 @@ The report may link indirectly when fallout changes rumor quality, access, or fa
 ### Procurement
 
 The report should link there only when a real equipment or recovery bottleneck is involved.
+
+### Event feed (dashboard)
+
+Infiltration and concealment events in the global feed must agree with this report’s notes for the same week (type, summary, awareness/stage when shown). Drill-down from feed items should land on this report week, not a parallel explanation.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds infiltration weekly encounter and leave-behind tradeoff report notes with event-feed parity (`infiltrationEncounterReportNotes.ts`, `advanceWeek` wiring).
- Ships MVP loop proof slice 2: save/load mid-campaign + 4-week fixture + SPE-25 calibration anchor test.
- Adds infiltration/concealment tuning reference, QA matrix, and UX spec updates (operations report + navigation map; mission triage deferred).
- Makes `leave-behind:burn-tool` score-only (empty custody refs); IC-06 integration test covers tradeoff without custody strain.
- Audit fix: extends `ReportNoteType` and event coverage contract for new infiltration event/note types.

## Test plan

- [x] `npm run test:run -- src/test/infiltrationEncounterReportCopy.test.ts src/test/weeklyMvpLoopProof.slice2.integration.test.ts src/test/weeklyMvpLoopProof.calibration.test.ts`
- [x] `npm run test:run -- src/test/events.coverage.test.ts src/test/eventFeedView.test.ts`
- [x] `npm run lint`
