### PR TITLE
feat(SPE-781): tiered reveal payloads — slice 1 + scouting integration

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -19,12 +19,13 @@ From `README.md` **Current design notes**:
 2. **Infiltration and access follow-through** — Batch-4 probe/cover/leave-behind complete; **report copy slice** shipped (`src/domain/infiltrationEncounterReportNotes.ts` — weekly encounter + leave-behind tradeoff notes). Further optional content depth only (not new probe mechanics).
 3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
 4. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
-5. **Archived prototype hygiene** — Keep archived prototype code out of active runtime paths unless intentionally revived (`README.md` former “next steps”).
+5. **Tiered detection / reveal payloads (SPE-781)** — Slice 1 domain resolver (`planning/reveal-payload-slice-1.md`); encounter/scan integration and full modality matrix remain follow-up.
 
 ## Shipped (May 2026 — remove from active queue when scanning)
 
 | Item | Outcome |
 | --- | --- |
+| **Archived prototype hygiene (#5)** | Guard test `src/test/archivedPrototypeHygiene.test.ts`; vitest/eslint already exclude `docs/archived/**`; no active `src` imports. |
 | **Core UX specs (#4)** | **Closed.** Operations Report + navigation map for batch-4 covert notes and report week prev/next (`ux/operations-report.md` §5.3.1, `ux/navigation-map.md` §3.5.1–3.5.2). Mission Triage full refresh **deferred** until triage UI is the implementation target — see `ux/mission-triage.md` spec status block (covert prep row signals, deferral vs batch-4 flags). |
 | **Tuning and QA references (#5)** | Infiltration/concealment tuning reference, QA matrix, edge-case §12.6–12.9, integration Scenario F. **SPE-25 calibration pass (May 2026):** MVP harness confirms current probe/action deltas — no constant changes; anchor `src/test/weeklyMvpLoopProof.calibration.test.ts`. |
 | **MVP loop proof (#6)** | Slice 1 (`SPE-2251`) + slice 2 persistence/4-week fixture (`weeklyMvpLoopProof.slice2.integration.test.ts`). |

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -25,9 +25,9 @@ From `README.md` **Current design notes**:
 
 | Item | Outcome |
 | --- | --- |
-| **Archived prototype hygiene (#5)** | Guard test `src/test/archivedPrototypeHygiene.test.ts`; vitest/eslint already exclude `docs/archived/**`; no active `src` imports. |
+| **Archived prototype hygiene** | Guard test `src/test/archivedPrototypeHygiene.test.ts`; vitest/eslint already exclude `docs/archived/**`; no active `src` imports. |
 | **Core UX specs (#4)** | **Closed.** Operations Report + navigation map for batch-4 covert notes and report week prev/next (`ux/operations-report.md` §5.3.1, `ux/navigation-map.md` §3.5.1–3.5.2). Mission Triage full refresh **deferred** until triage UI is the implementation target — see `ux/mission-triage.md` spec status block (covert prep row signals, deferral vs batch-4 flags). |
-| **Tuning and QA references (#5)** | Infiltration/concealment tuning reference, QA matrix, edge-case §12.6–12.9, integration Scenario F. **SPE-25 calibration pass (May 2026):** MVP harness confirms current probe/action deltas — no constant changes; anchor `src/test/weeklyMvpLoopProof.calibration.test.ts`. |
+| **Tuning and QA references** | Infiltration/concealment tuning reference, QA matrix, edge-case §12.6–12.9, integration Scenario F. **SPE-25 calibration pass (May 2026):** MVP harness confirms current probe/action deltas — no constant changes; anchor `src/test/weeklyMvpLoopProof.calibration.test.ts`. |
 | **MVP loop proof (#6)** | Slice 1 (`SPE-2251`) + slice 2 persistence/4-week fixture (`weeklyMvpLoopProof.slice2.integration.test.ts`). |
 
 ## Deferred UX (pick up when triage UI is next)

--- a/planning/reveal-payload-slice-1.md
+++ b/planning/reveal-payload-slice-1.md
@@ -1,0 +1,35 @@
+# Tiered detection / reveal payloads — slice 1 (SPE-781)
+
+## Goal
+
+Introduce a pure, deterministic reveal-payload resolver so scans can return **presence, category, active protection, hostility, or exact identity** in separate tiers instead of all-or-nothing truth.
+
+Slice 1 is domain-only — no UI wiring or encounter integration yet.
+
+## Shipped (slice 1 — pending merge)
+
+| Area                            | Files                                                    |
+| ------------------------------- | -------------------------------------------------------- |
+| Reveal taxonomy + scan families | `src/domain/revealPayload.ts`                            |
+| Deterministic tests             | `src/test/revealPayload.test.ts`                         |
+| Archived prototype guard        | `src/test/archivedPrototypeHygiene.test.ts` (backlog #5) |
+
+## Acceptance (Linear SPE-781 subset)
+
+- [x] Detection returns presence/category without exact identity when layers block deeper tiers
+- [x] Reveal action strips concealment layers before deeper tiers resolve
+- [x] Active-effect scan shows active effects while dormant effects stay hidden
+- [x] Targeted tests cover tier payloads, conceal reduction, ambiguous output policy, and absent/blocked edge cases
+
+## Out of scope (later slices)
+
+- Full hidden-modality matrix (`architecture/hidden-state-displacement-counter-detection.md`)
+- Encounter / equipment scan integration
+- Player-facing report copy for tiered payloads
+- False-detection / instrumentation attack modalities
+
+## See also
+
+- Linear [SPE-781](https://linear.app/spectranoir/issue/SPE-781)
+- `architecture/hidden-state-displacement-counter-detection.md` — SPE-70 modalities
+- `docs/unknown-interaction-runtime.md` — SPE-59 provisional vs confirmed identity

--- a/planning/reveal-payload-slice-1.md
+++ b/planning/reveal-payload-slice-1.md
@@ -8,8 +8,8 @@ Slice 1 is domain-only — no UI wiring or encounter integration yet.
 
 ## Shipped (slice 1 — pending merge)
 
-| Area                            | Files                                                    |
-| ------------------------------- | -------------------------------------------------------- |
+| Area | Files |
+| --- | --- |
 | Reveal taxonomy + scan families | `src/domain/revealPayload.ts`                            |
 | Deterministic tests             | `src/test/revealPayload.test.ts`                         |
 | Archived prototype guard        | `src/test/archivedPrototypeHygiene.test.ts` (backlog #5) |
@@ -21,10 +21,14 @@ Slice 1 is domain-only — no UI wiring or encounter integration yet.
 - [x] Active-effect scan shows active effects while dormant effects stay hidden
 - [x] Targeted tests cover tier payloads, conceal reduction, ambiguous output policy, and absent/blocked edge cases
 
+## Slice 2 (stacked — scouting integration)
+
+See `planning/reveal-payload-slice-2.md` — `resolveScoutingWithRevealPayload` in `src/domain/revealPayloadScoutingIntegration.ts`.
+
 ## Out of scope (later slices)
 
 - Full hidden-modality matrix (`architecture/hidden-state-displacement-counter-detection.md`)
-- Encounter / equipment scan integration
+- Encounter / equipment scan integration (beyond scouting)
 - Player-facing report copy for tiered payloads
 - False-detection / instrumentation attack modalities
 

--- a/planning/reveal-payload-slice-2.md
+++ b/planning/reveal-payload-slice-2.md
@@ -1,0 +1,34 @@
+# Tiered detection / reveal payloads — slice 2 integration (SPE-781)
+
+## Prerequisite
+
+Merge or stack on [PR #2342](https://github.com/JamesJedi420/containment-protocol/pull/2342) (slice 1 — `src/domain/revealPayload.ts`).
+
+## Goal
+
+Wire the slice-1 reveal-payload resolver into **one existing contested-resolution path** (`resolveScouting`) without changing scouting outcome bands or modifier math.
+
+Players and reports can consume tiered `DetectionScanResult` fields alongside the legacy `revealed` / `withheld` booleans.
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| `buildSubjectTruthFromScouting` — map scouting inputs to `SubjectTruthState` | Full hidden-modality matrix (SPE-70 doc) |
+| `scoutingOutcomeToDetectionScan` — derive `DetectionScanInput` from scouting outcome | UI / report copy for tier labels |
+| `resolveScoutingWithRevealPayload` — compose scouting + tiered scan | Equipment scan families |
+| Integration tests in `src/test/revealPayloadScoutingIntegration.test.ts` | Changing `resolveScouting` signature or behavior |
+
+## Acceptance
+
+- [x] Strong/success scouting yields deeper scan families than fail/catastrophic withhold paths
+- [x] High anomaly concealment adds deterministic concealment layers that block identity tiers
+- [x] `resolveScoutingWithRevealPayload` returns unchanged `outcome` / `revealed` / `withheld` vs plain `resolveScouting`
+- [x] `npm run test:run` and `npm run lint` green (integration tests only)
+
+## See also
+
+- `planning/reveal-payload-slice-1.md`
+- Linear [SPE-781](https://linear.app/spectranoir/issue/SPE-781)
+- `src/domain/scoutingResolution.ts` (SPE-59)
+- `docs/unknown-interaction-runtime.md`

--- a/src/domain/revealPayload.ts
+++ b/src/domain/revealPayload.ts
@@ -1,0 +1,231 @@
+/**
+ * SPE-781 slice 1: bounded reveal-payload layer separating internal truth from
+ * player-facing scan tiers. Deterministic conceal/reveal opposition — no universal identify.
+ */
+
+export type RevealTier =
+  | 'presence'
+  | 'category'
+  | 'hostility'
+  | 'active_protection'
+  | 'concealment_depth'
+  | 'exact_identity'
+
+export type ScanFamily = 'presence_sweep' | 'category_pass' | 'active_effects' | 'identity_probe'
+
+export type HostilityLevel = 'none' | 'latent' | 'active'
+
+export interface ConcealmentLayer {
+  readonly id: string
+  /** Tiers suppressed while this layer remains intact (outermost listed first). */
+  readonly blockedTiers: readonly RevealTier[]
+}
+
+export interface SubjectTruthState {
+  readonly present: boolean
+  readonly exactIdentity: string
+  readonly category: string
+  readonly hostility: HostilityLevel
+  readonly activeProtections: readonly string[]
+  /** Outermost concealment layer first — peel before deeper tiers unlock. */
+  readonly concealmentLayers: readonly ConcealmentLayer[]
+  readonly activeEffects: readonly string[]
+  /** Hidden from active-effect scans until an identity or deep probe succeeds. */
+  readonly dormantEffects: readonly string[]
+}
+
+export interface RevealPayloadField {
+  readonly tier: RevealTier
+  readonly internalValue: string | number | boolean | readonly string[]
+  readonly playerFacingValue: string
+  readonly ambiguous: boolean
+}
+
+export interface DetectionScanInput {
+  readonly family: ScanFamily
+  /** Reveal actions strip this many outer concealment layers before resolving tiers. */
+  readonly layersToStrip?: number
+}
+
+export interface DetectionScanResult {
+  readonly fields: readonly RevealPayloadField[]
+  readonly remainingConcealmentLayers: readonly ConcealmentLayer[]
+  readonly strippedLayerIds: readonly string[]
+}
+
+const SCAN_FAMILY_TIERS: Readonly<Record<ScanFamily, readonly RevealTier[]>> = {
+  presence_sweep: ['presence'],
+  category_pass: ['presence', 'category'],
+  active_effects: ['presence', 'active_protection'],
+  identity_probe: ['presence', 'category', 'hostility', 'concealment_depth', 'exact_identity'],
+}
+
+const CATEGORY_AMBIGUITY_LABEL = 'unclassified contact'
+
+function isTierBlocked(tier: RevealTier, layers: readonly ConcealmentLayer[]) {
+  return layers.some((layer) => layer.blockedTiers.includes(tier))
+}
+
+function normalizeLayerStripCount(count: number | undefined) {
+  if (count === undefined || !Number.isFinite(count)) {
+    return 0
+  }
+
+  return Math.max(0, Math.floor(count))
+}
+
+export function stripConcealmentLayers(
+  layers: readonly ConcealmentLayer[],
+  count: number | undefined
+): { remaining: readonly ConcealmentLayer[]; strippedIds: readonly string[] } {
+  const safeCount = Math.min(normalizeLayerStripCount(count), layers.length)
+  const strippedIds = layers.slice(0, safeCount).map((layer) => layer.id)
+  return {
+    remaining: layers.slice(safeCount),
+    strippedIds,
+  }
+}
+
+function buildPresenceField(truth: SubjectTruthState): RevealPayloadField {
+  return {
+    tier: 'presence',
+    internalValue: truth.present,
+    playerFacingValue: truth.present ? 'contact detected' : 'no contact',
+    ambiguous: false,
+  }
+}
+
+function buildCategoryField(
+  truth: SubjectTruthState,
+  layers: readonly ConcealmentLayer[]
+): RevealPayloadField | null {
+  if (isTierBlocked('category', layers)) {
+    return null
+  }
+
+  const identityBlocked = isTierBlocked('exact_identity', layers)
+  const ambiguous = identityBlocked && truth.category !== truth.exactIdentity
+
+  return {
+    tier: 'category',
+    internalValue: truth.category,
+    playerFacingValue: ambiguous ? CATEGORY_AMBIGUITY_LABEL : truth.category,
+    ambiguous,
+  }
+}
+
+function buildHostilityField(
+  truth: SubjectTruthState,
+  layers: readonly ConcealmentLayer[]
+): RevealPayloadField | null {
+  if (isTierBlocked('hostility', layers)) {
+    return null
+  }
+
+  return {
+    tier: 'hostility',
+    internalValue: truth.hostility,
+    playerFacingValue: truth.hostility,
+    ambiguous: false,
+  }
+}
+
+function buildActiveProtectionField(
+  truth: SubjectTruthState,
+  layers: readonly ConcealmentLayer[]
+): RevealPayloadField | null {
+  if (isTierBlocked('active_protection', layers)) {
+    return null
+  }
+
+  const visibleEffects = truth.activeEffects
+  const visibleProtections = truth.activeProtections
+
+  if (visibleEffects.length === 0 && visibleProtections.length === 0) {
+    return null
+  }
+
+  const combined = [...visibleProtections, ...visibleEffects]
+
+  return {
+    tier: 'active_protection',
+    internalValue: combined,
+    playerFacingValue: combined.join(', '),
+    ambiguous: false,
+  }
+}
+
+function buildConcealmentDepthField(
+  layers: readonly ConcealmentLayer[]
+): RevealPayloadField | null {
+  if (layers.length === 0) {
+    return null
+  }
+
+  return {
+    tier: 'concealment_depth',
+    internalValue: layers.length,
+    playerFacingValue: `${layers.length} concealed layer${layers.length === 1 ? '' : 's'}`,
+    ambiguous: false,
+  }
+}
+
+function buildExactIdentityField(
+  truth: SubjectTruthState,
+  layers: readonly ConcealmentLayer[]
+): RevealPayloadField | null {
+  if (isTierBlocked('exact_identity', layers)) {
+    return null
+  }
+
+  return {
+    tier: 'exact_identity',
+    internalValue: truth.exactIdentity,
+    playerFacingValue: truth.exactIdentity,
+    ambiguous: false,
+  }
+}
+
+function resolveTierField(
+  tier: RevealTier,
+  truth: SubjectTruthState,
+  layers: readonly ConcealmentLayer[]
+): RevealPayloadField | null {
+  switch (tier) {
+    case 'presence':
+      return buildPresenceField(truth)
+    case 'category':
+      return buildCategoryField(truth, layers)
+    case 'hostility':
+      return buildHostilityField(truth, layers)
+    case 'active_protection':
+      return buildActiveProtectionField(truth, layers)
+    case 'concealment_depth':
+      return buildConcealmentDepthField(layers)
+    case 'exact_identity':
+      return buildExactIdentityField(truth, layers)
+    default: {
+      const _exhaustive: never = tier
+      return _exhaustive
+    }
+  }
+}
+
+export function resolveDetectionScan(
+  truth: SubjectTruthState,
+  input: DetectionScanInput
+): DetectionScanResult {
+  const peel = stripConcealmentLayers(truth.concealmentLayers, input.layersToStrip)
+  const remainingLayers = peel.remaining
+  const requestedTiers = truth.present ? SCAN_FAMILY_TIERS[input.family] : (['presence'] as const)
+
+  const fields = requestedTiers
+    .map((tier) => resolveTierField(tier, truth, remainingLayers))
+    .filter((field): field is RevealPayloadField => field !== null)
+
+  return {
+    fields,
+    remainingConcealmentLayers: remainingLayers,
+    strippedLayerIds: peel.strippedIds,
+  }
+}

--- a/src/domain/revealPayload.ts
+++ b/src/domain/revealPayload.ts
@@ -67,7 +67,7 @@ function isTierBlocked(tier: RevealTier, layers: readonly ConcealmentLayer[]) {
 }
 
 function normalizeLayerStripCount(count: number | undefined) {
-  if (count === undefined || !Number.isFinite(count)) {
+  if (count === undefined || Number.isNaN(count)) {
     return 0
   }
 
@@ -86,7 +86,14 @@ export function stripConcealmentLayers(
   }
 }
 
-function buildPresenceField(truth: SubjectTruthState): RevealPayloadField {
+function buildPresenceField(
+  truth: SubjectTruthState,
+  layers: readonly ConcealmentLayer[]
+): RevealPayloadField | null {
+  if (truth.present && isTierBlocked('presence', layers)) {
+    return null
+  }
+
   return {
     tier: 'presence',
     internalValue: truth.present,
@@ -104,7 +111,7 @@ function buildCategoryField(
   }
 
   const identityBlocked = isTierBlocked('exact_identity', layers)
-  const ambiguous = identityBlocked && truth.category !== truth.exactIdentity
+  const ambiguous = identityBlocked
 
   return {
     tier: 'category',
@@ -145,7 +152,7 @@ function buildActiveProtectionField(
     return null
   }
 
-  const combined = [...visibleProtections, ...visibleEffects]
+  const combined = Array.from(new Set([...visibleProtections, ...visibleEffects]))
 
   return {
     tier: 'active_protection',
@@ -158,7 +165,7 @@ function buildActiveProtectionField(
 function buildConcealmentDepthField(
   layers: readonly ConcealmentLayer[]
 ): RevealPayloadField | null {
-  if (layers.length === 0) {
+  if (layers.length === 0 || isTierBlocked('concealment_depth', layers)) {
     return null
   }
 
@@ -193,7 +200,7 @@ function resolveTierField(
 ): RevealPayloadField | null {
   switch (tier) {
     case 'presence':
-      return buildPresenceField(truth)
+      return buildPresenceField(truth, layers)
     case 'category':
       return buildCategoryField(truth, layers)
     case 'hostility':
@@ -215,9 +222,18 @@ export function resolveDetectionScan(
   truth: SubjectTruthState,
   input: DetectionScanInput
 ): DetectionScanResult {
+  if (!truth.present) {
+    const presence = buildPresenceField(truth, truth.concealmentLayers)
+    return {
+      fields: presence ? [presence] : [],
+      remainingConcealmentLayers: truth.concealmentLayers,
+      strippedLayerIds: [],
+    }
+  }
+
   const peel = stripConcealmentLayers(truth.concealmentLayers, input.layersToStrip)
   const remainingLayers = peel.remaining
-  const requestedTiers = truth.present ? SCAN_FAMILY_TIERS[input.family] : (['presence'] as const)
+  const requestedTiers = SCAN_FAMILY_TIERS[input.family]
 
   const fields = requestedTiers
     .map((tier) => resolveTierField(tier, truth, remainingLayers))

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -1,0 +1,138 @@
+/**
+ * SPE-781 slice 2: compose SPE-59 scouting resolution with tiered reveal payloads.
+ *
+ * Does not alter scouting outcome bands, modifier aggregation, or legacy revealed/withheld flags.
+ */
+
+import {
+  resolveDetectionScan,
+  type ConcealmentLayer,
+  type DetectionScanInput,
+  type DetectionScanResult,
+  type HostilityLevel,
+  type RevealTier,
+  type SubjectTruthState,
+} from './revealPayload'
+import {
+  computeEffectiveScoutingConcealment,
+  resolveScouting,
+  type ScoutingInput,
+  type ScoutingResult,
+} from './scoutingResolution'
+
+export interface ScoutingRevealSubject {
+  readonly present?: boolean
+  readonly exactIdentity: string
+  readonly category: string
+  readonly hostility?: HostilityLevel
+  readonly activeProtections?: readonly string[]
+  readonly activeEffects?: readonly string[]
+  readonly dormantEffects?: readonly string[]
+}
+
+export interface ScoutingRevealIntegrationInput extends ScoutingInput {
+  readonly subject: ScoutingRevealSubject
+}
+
+export interface ScoutingRevealIntegrationResult extends ScoutingResult {
+  readonly detectionScan: DetectionScanResult
+}
+
+const GLAMOUR_LAYER: ConcealmentLayer = {
+  id: 'layer:glamour',
+  blockedTiers: ['category', 'exact_identity', 'hostility'],
+}
+
+const SIGNATURE_MASK_LAYER: ConcealmentLayer = {
+  id: 'layer:signature-mask',
+  blockedTiers: ['exact_identity'],
+}
+
+function clampConcealmentRating(rating: number) {
+  if (!Number.isFinite(rating)) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(3, Math.floor(rating)))
+}
+
+export function concealmentLayersFromRating(anomalyConcealment: number): readonly ConcealmentLayer[] {
+  const rating = clampConcealmentRating(anomalyConcealment)
+  const layers: ConcealmentLayer[] = []
+
+  if (rating >= 2) {
+    layers.push(GLAMOUR_LAYER)
+  }
+
+  if (rating >= 1) {
+    layers.push(SIGNATURE_MASK_LAYER)
+  }
+
+  return layers
+}
+
+export function buildSubjectTruthFromScouting(
+  input: ScoutingInput,
+  subject: ScoutingRevealSubject
+): SubjectTruthState {
+  const present = subject.present ?? true
+  const { concealment } = computeEffectiveScoutingConcealment(input)
+
+  return {
+    present,
+    exactIdentity: subject.exactIdentity,
+    category: subject.category,
+    hostility: subject.hostility ?? 'latent',
+    activeProtections: subject.activeProtections ?? [],
+    concealmentLayers: concealmentLayersFromRating(concealment),
+    activeEffects: subject.activeEffects ?? [],
+    dormantEffects: subject.dormantEffects ?? [],
+  }
+}
+
+export function scoutingOutcomeToDetectionScan(
+  scouting: Pick<ScoutingResult, 'outcome' | 'revealed' | 'withheld'>
+): DetectionScanInput {
+  if (scouting.withheld) {
+    return { family: 'presence_sweep' }
+  }
+
+  if (!scouting.revealed) {
+    return { family: 'presence_sweep' }
+  }
+
+  switch (scouting.outcome) {
+    case 'strong':
+      return { family: 'identity_probe', layersToStrip: 1 }
+    case 'success':
+      return { family: 'category_pass' }
+    case 'partial':
+      return { family: 'presence_sweep' }
+    case 'fail':
+    case 'catastrophic':
+      return { family: 'presence_sweep' }
+    default: {
+      const _exhaustive: never = scouting.outcome
+      return _exhaustive
+    }
+  }
+}
+
+export function resolveScoutingWithRevealPayload(
+  input: ScoutingRevealIntegrationInput
+): ScoutingRevealIntegrationResult {
+  const scouting = resolveScouting(input)
+  const truth = buildSubjectTruthFromScouting(input, input.subject)
+  const scanInput = scoutingOutcomeToDetectionScan(scouting)
+  const detectionScan = resolveDetectionScan(truth, scanInput)
+
+  return {
+    ...scouting,
+    detectionScan,
+  }
+}
+
+/** Test helper: tiers exposed on the detection scan (stable ordering). */
+export function detectionScanTierOrder(result: DetectionScanResult): readonly RevealTier[] {
+  return result.fields.map((field) => field.tier)
+}

--- a/src/domain/scoutingResolution.ts
+++ b/src/domain/scoutingResolution.ts
@@ -34,15 +34,21 @@ export interface ScoutingResult {
   withheld: boolean;
 }
 
+export interface EffectiveScoutingConcealment {
+  readonly concealment: number;
+  readonly contextExplanation: string;
+}
+
 /**
- * SPE-59: Context-sensitive scouting resolution. If containerType is 'sealed', increase concealment and alter explanation.
+ * SPE-59 / SPE-781: spatial and container adjustments applied before outcome bands.
+ * Shared with tiered reveal integration so concealment layers match scouting context.
  */
-export function resolveScouting(input: ScoutingInput): ScoutingResult {
-  // Base: team capability - anomaly concealment
+export function computeEffectiveScoutingConcealment(
+  input: ScoutingInput
+): EffectiveScoutingConcealment {
   let concealment = input.anomalyConcealment;
   let contextExplanation = '';
-  // --- Canonical spatial state effects (SPE-57) ---
-  // Visibility state
+
   if (input.visibilityState === 'obstructed') {
     concealment += 1;
     contextExplanation += 'Obstructed visibility: +1 concealment. ';
@@ -50,7 +56,7 @@ export function resolveScouting(input: ScoutingInput): ScoutingResult {
     concealment = Math.max(0, concealment - 1);
     contextExplanation += 'Exposed: -1 concealment. ';
   }
-  // Site layer
+
   if (input.siteLayer === 'exterior') {
     contextExplanation += 'Exterior: approach phase. ';
   } else if (input.siteLayer === 'transition') {
@@ -60,7 +66,7 @@ export function resolveScouting(input: ScoutingInput): ScoutingResult {
     concealment += 0.5;
     contextExplanation += 'Interior: close-quarters (+0.5 concealment). ';
   }
-  // Transition type
+
   if (input.transitionType === 'chokepoint') {
     concealment += 1;
     contextExplanation += 'Chokepoint: +1 concealment. ';
@@ -68,7 +74,7 @@ export function resolveScouting(input: ScoutingInput): ScoutingResult {
     concealment += 0.5;
     contextExplanation += 'Threshold: +0.5 concealment. ';
   }
-  // Container type (legacy)
+
   if (input.containerType === 'sealed') {
     concealment += 2;
     contextExplanation += 'Sealed container: +2 concealment penalty.';
@@ -76,6 +82,15 @@ export function resolveScouting(input: ScoutingInput): ScoutingResult {
     concealment = Math.max(0, concealment - 1);
     contextExplanation += 'Open container: -1 concealment bonus.';
   }
+
+  return { concealment, contextExplanation: contextExplanation.trim() };
+}
+
+/**
+ * SPE-59: Context-sensitive scouting resolution. If containerType is 'sealed', increase concealment and alter explanation.
+ */
+export function resolveScouting(input: ScoutingInput): ScoutingResult {
+  const { concealment, contextExplanation } = computeEffectiveScoutingConcealment(input);
   const base = input.teamCapability - concealment;
   const sources: ModifierSource[] = [
     { source: 'base', value: base }
@@ -124,7 +139,7 @@ export function resolveScouting(input: ScoutingInput): ScoutingResult {
     `Value: ${agg.capped} (${agg.total} raw)`,
     explainModifiers(agg),
     roleExplanation,
-    contextExplanation.trim()
+    contextExplanation
   ].filter(Boolean).join(' | ');
 
   // Reveal/withhold logic (example: success or strong reveals, fail/catastrophic withholds)

--- a/src/test/archivedPrototypeHygiene.test.ts
+++ b/src/test/archivedPrototypeHygiene.test.ts
@@ -3,7 +3,7 @@ import { join, relative } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const IMPORT_VIOLATION =
-  /from\s+['"][^'"]*(?:docs\/archived|incident-shell)[^'"]*['"]|import\s*\(\s*['"][^'"]*(?:docs\/archived|incident-shell)/
+  /^\s*(?:import|export)\b[^\n]*\bdocs\/archived\/incident-shell\b|import\s*\(\s*['"][^'"]*docs\/archived\/incident-shell/m
 
 function collectSourceFiles(rootDir: string, files: string[] = []): string[] {
   for (const entry of readdirSync(rootDir)) {
@@ -36,14 +36,14 @@ describe('archived prototype hygiene (backlog #5)', () => {
   it('excludes docs/archived from vitest discovery', () => {
     const configSource = readFileSync(join(process.cwd(), 'app.vite.config.ts'), 'utf8')
 
-    expect(configSource).toContain("'docs/**'")
-    expect(configSource).toContain("'**/docs/**'")
-    expect(configSource).toContain("'src/**/*.test.{ts,tsx}'")
+    expect(configSource).toMatch(/['"]docs\/\*\*['"]/)
+    expect(configSource).toMatch(/['"]\*\*\/docs\/\*\*['"]/)
+    expect(configSource).toMatch(/['"]src\/\*\*\/\*\.test\.\{ts,tsx\}['"]/)
   })
 
   it('excludes docs/archived from eslint lint targets', () => {
     const eslintSource = readFileSync(join(process.cwd(), 'eslint.config.js'), 'utf8')
 
-    expect(eslintSource).toContain("'docs/archived/**'")
+    expect(eslintSource).toMatch(/['"]docs\/archived\/\*\*['"]/)
   })
 })

--- a/src/test/archivedPrototypeHygiene.test.ts
+++ b/src/test/archivedPrototypeHygiene.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const IMPORT_VIOLATION =
+  /from\s+['"][^'"]*(?:docs\/archived|incident-shell)[^'"]*['"]|import\s*\(\s*['"][^'"]*(?:docs\/archived|incident-shell)/
+
+function collectSourceFiles(rootDir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(rootDir)) {
+    const fullPath = join(rootDir, entry)
+    const stats = statSync(fullPath)
+
+    if (stats.isDirectory()) {
+      collectSourceFiles(fullPath, files)
+      continue
+    }
+
+    if (/\.(ts|tsx)$/.test(entry)) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+describe('archived prototype hygiene (backlog #5)', () => {
+  it('keeps docs/archived/incident-shell out of active src imports', () => {
+    const srcRoot = join(process.cwd(), 'src')
+    const violations = collectSourceFiles(srcRoot).filter((filePath) =>
+      IMPORT_VIOLATION.test(readFileSync(filePath, 'utf8'))
+    )
+
+    expect(violations.map((filePath) => relative(process.cwd(), filePath))).toEqual([])
+  })
+
+  it('excludes docs/archived from vitest discovery', () => {
+    const configSource = readFileSync(join(process.cwd(), 'app.vite.config.ts'), 'utf8')
+
+    expect(configSource).toContain("'docs/**'")
+    expect(configSource).toContain("'**/docs/**'")
+    expect(configSource).toContain("'src/**/*.test.{ts,tsx}'")
+  })
+
+  it('excludes docs/archived from eslint lint targets', () => {
+    const eslintSource = readFileSync(join(process.cwd(), 'eslint.config.js'), 'utf8')
+
+    expect(eslintSource).toContain("'docs/archived/**'")
+  })
+})

--- a/src/test/revealPayload.test.ts
+++ b/src/test/revealPayload.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveDetectionScan,
+  stripConcealmentLayers,
+  type ConcealmentLayer,
+  type SubjectTruthState,
+} from '../domain/revealPayload'
+
+const BASE_LAYERS: readonly ConcealmentLayer[] = [
+  {
+    id: 'layer:glamour',
+    blockedTiers: ['category', 'exact_identity', 'hostility'],
+  },
+  {
+    id: 'layer:signature-mask',
+    blockedTiers: ['exact_identity'],
+  },
+]
+
+const CATEGORY_ONLY_LAYERS: readonly ConcealmentLayer[] = [
+  {
+    id: 'layer:signature-mask',
+    blockedTiers: ['exact_identity'],
+  },
+]
+
+function buildSubject(overrides: Partial<SubjectTruthState> = {}): SubjectTruthState {
+  return {
+    present: true,
+    exactIdentity: 'entity:chapel-wraith',
+    category: 'spectral intruder',
+    hostility: 'latent',
+    activeProtections: ['warded perimeter'],
+    concealmentLayers: BASE_LAYERS,
+    activeEffects: ['cold bloom'],
+    dormantEffects: ['dream-residue latch'],
+    ...overrides,
+  }
+}
+
+describe('revealPayload (SPE-781 slice 1)', () => {
+  it('returns presence without exact identity on a category pass while concealment remains', () => {
+    const result = resolveDetectionScan(buildSubject({ concealmentLayers: CATEGORY_ONLY_LAYERS }), {
+      family: 'category_pass',
+    })
+
+    expect(result.fields.map((field) => field.tier)).toEqual(['presence', 'category'])
+    expect(result.fields.find((field) => field.tier === 'presence')?.playerFacingValue).toBe(
+      'contact detected'
+    )
+
+    const category = result.fields.find((field) => field.tier === 'category')
+    expect(category?.internalValue).toBe('spectral intruder')
+    expect(category?.playerFacingValue).toBe('unclassified contact')
+    expect(category?.ambiguous).toBe(true)
+    expect(result.fields.some((field) => field.tier === 'exact_identity')).toBe(false)
+  })
+
+  it('strips concealment layers before exposing deeper identity tiers', () => {
+    const withoutPeel = resolveDetectionScan(buildSubject(), { family: 'identity_probe' })
+    expect(withoutPeel.fields.map((field) => field.tier)).toEqual(['presence', 'concealment_depth'])
+    expect(withoutPeel.remainingConcealmentLayers).toHaveLength(2)
+
+    const withPeel = resolveDetectionScan(buildSubject(), {
+      family: 'identity_probe',
+      layersToStrip: 1,
+    })
+
+    expect(withPeel.strippedLayerIds).toEqual(['layer:glamour'])
+    expect(withPeel.remainingConcealmentLayers.map((layer) => layer.id)).toEqual([
+      'layer:signature-mask',
+    ])
+    expect(withPeel.fields.map((field) => field.tier)).toEqual([
+      'presence',
+      'category',
+      'hostility',
+      'concealment_depth',
+    ])
+
+    const fullyStripped = resolveDetectionScan(buildSubject(), {
+      family: 'identity_probe',
+      layersToStrip: 2,
+    })
+
+    expect(fullyStripped.fields.find((field) => field.tier === 'exact_identity')).toMatchObject({
+      internalValue: 'entity:chapel-wraith',
+      playerFacingValue: 'entity:chapel-wraith',
+      ambiguous: false,
+    })
+  })
+
+  it('shows active effects while dormant effects stay hidden from active-effect scans', () => {
+    const result = resolveDetectionScan(buildSubject(), { family: 'active_effects' })
+
+    const active = result.fields.find((field) => field.tier === 'active_protection')
+    expect(active?.internalValue).toEqual(['warded perimeter', 'cold bloom'])
+    expect(active?.playerFacingValue).toContain('cold bloom')
+    expect(active?.playerFacingValue).not.toContain('dream-residue latch')
+  })
+
+  it('peels layers deterministically via stripConcealmentLayers', () => {
+    expect(stripConcealmentLayers(BASE_LAYERS, 0)).toEqual({
+      remaining: BASE_LAYERS,
+      strippedIds: [],
+    })
+
+    expect(stripConcealmentLayers(BASE_LAYERS, 99)).toEqual({
+      remaining: [],
+      strippedIds: ['layer:glamour', 'layer:signature-mask'],
+    })
+  })
+
+  it('reports remaining concealment depth after a partial peel', () => {
+    const partialPeel = resolveDetectionScan(buildSubject(), {
+      family: 'identity_probe',
+      layersToStrip: 1,
+    })
+
+    expect(partialPeel.remainingConcealmentLayers.map((layer) => layer.id)).toEqual([
+      'layer:signature-mask',
+    ])
+    expect(partialPeel.fields.map((field) => field.tier)).toEqual([
+      'presence',
+      'category',
+      'hostility',
+      'concealment_depth',
+    ])
+    expect(partialPeel.fields.some((field) => field.tier === 'exact_identity')).toBe(false)
+  })
+
+  it('returns only presence when the subject is absent', () => {
+    const result = resolveDetectionScan(buildSubject({ present: false }), {
+      family: 'identity_probe',
+      layersToStrip: 2,
+    })
+
+    expect(result.fields).toEqual([
+      {
+        tier: 'presence',
+        internalValue: false,
+        playerFacingValue: 'no contact',
+        ambiguous: false,
+      },
+    ])
+  })
+
+  it('omits active protection when the tier is blocked or no active signals exist', () => {
+    const blocked = resolveDetectionScan(
+      buildSubject({
+        concealmentLayers: [{ id: 'layer:warded', blockedTiers: ['active_protection'] }],
+      }),
+      { family: 'active_effects' }
+    )
+    expect(blocked.fields.map((field) => field.tier)).toEqual(['presence'])
+
+    const emptySignals = resolveDetectionScan(
+      buildSubject({ activeEffects: [], activeProtections: [] }),
+      { family: 'active_effects' }
+    )
+    expect(emptySignals.fields.map((field) => field.tier)).toEqual(['presence'])
+  })
+
+  it('treats invalid layer strip counts as zero', () => {
+    expect(stripConcealmentLayers(BASE_LAYERS, Number.NaN)).toEqual({
+      remaining: BASE_LAYERS,
+      strippedIds: [],
+    })
+    expect(stripConcealmentLayers(BASE_LAYERS, -3)).toEqual({
+      remaining: BASE_LAYERS,
+      strippedIds: [],
+    })
+  })
+})

--- a/src/test/revealPayload.test.ts
+++ b/src/test/revealPayload.test.ts
@@ -128,7 +128,7 @@ describe('revealPayload (SPE-781 slice 1)', () => {
     expect(partialPeel.fields.some((field) => field.tier === 'exact_identity')).toBe(false)
   })
 
-  it('returns only presence when the subject is absent', () => {
+  it('returns only presence when the subject is absent without peeling concealment', () => {
     const result = resolveDetectionScan(buildSubject({ present: false }), {
       family: 'identity_probe',
       layersToStrip: 2,
@@ -142,6 +142,73 @@ describe('revealPayload (SPE-781 slice 1)', () => {
         ambiguous: false,
       },
     ])
+    expect(result.strippedLayerIds).toEqual([])
+    expect(result.remainingConcealmentLayers).toEqual(BASE_LAYERS)
+  })
+
+  it('suppresses presence when an intact layer blocks the presence tier', () => {
+    const result = resolveDetectionScan(
+      buildSubject({
+        concealmentLayers: [{ id: 'layer:concealed-presence', blockedTiers: ['presence'] }],
+      }),
+      { family: 'presence_sweep' }
+    )
+
+    expect(result.fields).toEqual([])
+  })
+
+  it('never leaks exact identity through category when identity tier is blocked', () => {
+    const result = resolveDetectionScan(
+      buildSubject({
+        exactIdentity: 'entity:unique-id',
+        category: 'entity:unique-id',
+        concealmentLayers: CATEGORY_ONLY_LAYERS,
+      }),
+      { family: 'category_pass' }
+    )
+
+    const category = result.fields.find((field) => field.tier === 'category')
+    expect(category?.playerFacingValue).toBe('unclassified contact')
+    expect(category?.ambiguous).toBe(true)
+  })
+
+  it('suppresses concealment depth when the tier is blocked', () => {
+    const result = resolveDetectionScan(
+      buildSubject({
+        concealmentLayers: [{ id: 'layer:depth-mask', blockedTiers: ['concealment_depth'] }],
+      }),
+      { family: 'identity_probe' }
+    )
+
+    expect(result.fields.map((field) => field.tier)).toEqual([
+      'presence',
+      'category',
+      'hostility',
+      'exact_identity',
+    ])
+    expect(result.fields.some((field) => field.tier === 'concealment_depth')).toBe(false)
+  })
+
+  it('strips all layers when layersToStrip is Infinity', () => {
+    expect(stripConcealmentLayers(BASE_LAYERS, Number.POSITIVE_INFINITY)).toEqual({
+      remaining: [],
+      strippedIds: ['layer:glamour', 'layer:signature-mask'],
+    })
+  })
+
+  it('deduplicates overlapping active protections and effects', () => {
+    const result = resolveDetectionScan(
+      buildSubject({
+        concealmentLayers: [],
+        activeProtections: ['cold bloom'],
+        activeEffects: ['cold bloom'],
+      }),
+      { family: 'active_effects' }
+    )
+
+    const active = result.fields.find((field) => field.tier === 'active_protection')
+    expect(active?.internalValue).toEqual(['cold bloom'])
+    expect(active?.playerFacingValue).toBe('cold bloom')
   })
 
   it('omits active protection when the tier is blocked or no active signals exist', () => {

--- a/src/test/revealPayloadScoutingIntegration.test.ts
+++ b/src/test/revealPayloadScoutingIntegration.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSubjectTruthFromScouting,
+  concealmentLayersFromRating,
+  detectionScanTierOrder,
+  resolveScoutingWithRevealPayload,
+  scoutingOutcomeToDetectionScan,
+} from '../domain/revealPayloadScoutingIntegration'
+import { resolveScouting } from '../domain/scoutingResolution'
+
+const SUBJECT = {
+  exactIdentity: 'entity:chapel-wraith',
+  category: 'spectral intruder',
+  activeEffects: ['cold bloom'],
+  dormantEffects: ['dream-residue latch'],
+  activeProtections: ['warded perimeter'],
+} as const
+
+describe('revealPayloadScoutingIntegration (SPE-781 slice 2)', () => {
+  it('maps concealment rating to deterministic concealment layers', () => {
+    expect(concealmentLayersFromRating(0).map((layer) => layer.id)).toEqual([])
+    expect(concealmentLayersFromRating(1).map((layer) => layer.id)).toEqual(['layer:signature-mask'])
+    expect(concealmentLayersFromRating(2).map((layer) => layer.id)).toEqual([
+      'layer:glamour',
+      'layer:signature-mask',
+    ])
+    expect(concealmentLayersFromRating(3).map((layer) => layer.id)).toEqual([
+      'layer:glamour',
+      'layer:signature-mask',
+    ])
+    expect(concealmentLayersFromRating(Number.NaN).map((layer) => layer.id)).toEqual([])
+  })
+
+  it('uses effective scouting concealment for layer depth, not raw rating alone', () => {
+    const sealed = buildSubjectTruthFromScouting(
+      { teamCapability: 2, anomalyConcealment: 0, containerType: 'sealed' },
+      SUBJECT
+    )
+    const open = buildSubjectTruthFromScouting(
+      { teamCapability: 2, anomalyConcealment: 2, containerType: 'open' },
+      SUBJECT
+    )
+
+    expect(sealed.concealmentLayers.length).toBeGreaterThan(open.concealmentLayers.length)
+  })
+
+  it('builds subject truth from scouting concealment without mutating identity fields', () => {
+    const truth = buildSubjectTruthFromScouting(
+      { teamCapability: 2, anomalyConcealment: 2 },
+      SUBJECT
+    )
+
+    expect(truth.exactIdentity).toBe('entity:chapel-wraith')
+    expect(truth.concealmentLayers).toHaveLength(2)
+    expect(truth.dormantEffects).toEqual(['dream-residue latch'])
+  })
+
+  it('selects deeper scan families for revealed strong outcomes than withheld failures', () => {
+    expect(
+      scoutingOutcomeToDetectionScan({
+        outcome: 'strong',
+        revealed: true,
+        withheld: false,
+      })
+    ).toEqual({ family: 'identity_probe', layersToStrip: 1 })
+
+    expect(
+      scoutingOutcomeToDetectionScan({
+        outcome: 'catastrophic',
+        revealed: false,
+        withheld: true,
+      })
+    ).toEqual({ family: 'presence_sweep' })
+  })
+
+  it('returns presence-only tiers for absent subjects even when scouting reveals', () => {
+    const integrated = resolveScoutingWithRevealPayload({
+      teamCapability: 3,
+      anomalyConcealment: 0,
+      teamTags: ['recon-specialist'],
+      subject: { ...SUBJECT, present: false },
+    })
+
+    expect(integrated.revealed).toBe(true)
+    expect(detectionScanTierOrder(integrated.detectionScan)).toEqual(['presence'])
+    expect(integrated.detectionScan.fields[0]?.playerFacingValue).toBe('no contact')
+    expect(integrated.detectionScan.strippedLayerIds).toEqual([])
+  })
+
+  it('maps partial scouting outcomes to presence-only scans', () => {
+    expect(
+      scoutingOutcomeToDetectionScan({
+        outcome: 'partial',
+        revealed: false,
+        withheld: false,
+      })
+    ).toEqual({ family: 'presence_sweep' })
+  })
+
+  it('preserves legacy scouting fields while attaching tiered detection payloads', () => {
+    const input = {
+      teamCapability: 3,
+      anomalyConcealment: 2,
+      teamTags: ['scout'],
+      gearTags: ['thermal-vision'],
+      subject: SUBJECT,
+    }
+
+    const legacy = resolveScouting(input)
+    const integrated = resolveScoutingWithRevealPayload(input)
+
+    expect(integrated.outcome).toBe(legacy.outcome)
+    expect(integrated.revealed).toBe(legacy.revealed)
+    expect(integrated.withheld).toBe(legacy.withheld)
+    expect(integrated.value).toBe(legacy.value)
+
+    if (integrated.revealed) {
+      expect(detectionScanTierOrder(integrated.detectionScan).length).toBeGreaterThan(1)
+      expect(
+        integrated.detectionScan.fields.some((field) => field.tier === 'category')
+      ).toBe(true)
+    } else {
+      expect(detectionScanTierOrder(integrated.detectionScan)).toEqual(['presence'])
+    }
+  })
+
+  it('blocks exact identity on identity-probe scouting when two concealment layers remain after one peel', () => {
+    const integrated = resolveScoutingWithRevealPayload({
+      teamCapability: 3,
+      anomalyConcealment: 2,
+      teamTags: ['recon-specialist'],
+      gearTags: ['thermal-vision'],
+      subject: SUBJECT,
+    })
+
+    expect(integrated.outcome).toBe('strong')
+    expect(integrated.revealed).toBe(true)
+    expect(scoutingOutcomeToDetectionScan(integrated)).toEqual({
+      family: 'identity_probe',
+      layersToStrip: 1,
+    })
+    expect(detectionScanTierOrder(integrated.detectionScan)).toEqual([
+      'presence',
+      'category',
+      'hostility',
+      'concealment_depth',
+    ])
+    expect(
+      integrated.detectionScan.fields.some((field) => field.tier === 'exact_identity')
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds deterministic tiered reveal payloads (`revealPayload.ts`) with concealment-layer peeling and scan families.
- Hardens tier blocking (presence, category identity leak, concealment depth) and absent-subject layer semantics per review.
- Adds scouting integration (`revealPayloadScoutingIntegration.ts`) composing SPE-59 scouting with effective concealment-aligned layers.
- Adds archived prototype hygiene guard and planning docs for slices 1–2.

## Test plan
- [x] `npm run test:run` (3617 tests)
- [x] `npm run lint`
- [x] Targeted SPE-781 reveal + scouting integration tests

## Slices
- `planning/reveal-payload-slice-1.md` — domain resolver
- `planning/reveal-payload-slice-2.md` — scouting integration

Linear: SPE-781