### PR TITLE
feat(SPE-2252): tiered reveal payloads — slice 3 disguise integration

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -19,7 +19,7 @@ From `README.md` **Current design notes**:
 2. **Infiltration and access follow-through** — Batch-4 probe/cover/leave-behind complete; **report copy slice** shipped (`src/domain/infiltrationEncounterReportNotes.ts` — weekly encounter + leave-behind tradeoff notes). Further optional content depth only (not new probe mechanics).
 3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
 4. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
-5. **Tiered detection / reveal payloads (SPE-781)** — Slice 1 domain resolver (`planning/reveal-payload-slice-1.md`); encounter/scan integration and full modality matrix remain follow-up.
+5. **Tiered detection / reveal payloads (SPE-781)** — Slices 1–2 shipped (`revealPayload.ts`, scouting integration, PR #2342). **Slice 3** disguise-validation integration in progress ([SPE-2252](https://linear.app/spectranoir/issue/SPE-2252), `planning/reveal-payload-slice-3.md`). Orchestration wiring, UI copy, and full modality matrix remain follow-up.
 
 ## Shipped (May 2026 — remove from active queue when scanning)
 

--- a/planning/reveal-payload-slice-3.md
+++ b/planning/reveal-payload-slice-3.md
@@ -1,0 +1,34 @@
+# Tiered detection / reveal payloads — slice 3 integration (SPE-2252)
+
+## Prerequisite
+
+Merge [PR #2342](https://github.com/JamesJedi420/containment-protocol/pull/2342) (SPE-781 slices 1–2 on `main`).
+
+## Goal
+
+Wire the reveal-payload resolver into **behavior-weighted disguise validation** (`evaluateBehaviorWeightedDisguiseValidation`) without changing validation scores, `detectionConfidence` math, or `applyBehaviorWeightedDisguiseValidationToCase`.
+
+Callers can consume tiered `DetectionScanResult` alongside legacy validation fields.
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| `buildSubjectTruthFromDisguise` — map case + subject to `SubjectTruthState` | Orchestration wiring in `resolveAssignedCaseForWeek` |
+| `disguiseValidationToDetectionScan` — derive `DetectionScanInput` from validation level | UI / report copy for tier labels |
+| `evaluateBehaviorWeightedDisguiseValidationWithRevealPayload` | Changing `evaluateBehaviorWeightedDisguiseValidation` signature or behavior |
+| Integration tests in `src/test/revealPayloadDisguiseIntegration.test.ts` | Full hidden-modality matrix (SPE-70 doc) |
+
+## Acceptance
+
+- [x] Strong validation yields deeper scan families than inactive / low-level paths
+- [x] Infiltration awareness and weak document tier add deterministic concealment layers
+- [x] Composed helper returns unchanged validation fields vs plain `evaluateBehaviorWeightedDisguiseValidation`
+- [x] `npm run test:run` and `npm run lint` green (integration tests + targeted suite)
+
+## See also
+
+- `planning/reveal-payload-slice-2.md`
+- Linear [SPE-2252](https://linear.app/spectranoir/issue/SPE-2252) (child of [SPE-781](https://linear.app/spectranoir/issue/SPE-781))
+- `src/domain/disguiseValidation.ts`
+- `src/domain/revealPayloadScoutingIntegration.ts`

--- a/src/domain/revealPayloadDisguiseIntegration.ts
+++ b/src/domain/revealPayloadDisguiseIntegration.ts
@@ -1,0 +1,150 @@
+/**
+ * SPE-781 slice 3 (SPE-2252): compose behavior-weighted disguise validation with tiered reveal payloads.
+ *
+ * Does not alter validation scores, detection confidence aggregation, or case application helpers.
+ */
+
+import {
+  evaluateBehaviorWeightedDisguiseValidation,
+  resolveDisguiseValidationContextFromCase,
+  type BehaviorWeightedDisguiseValidationContext,
+  type BehaviorWeightedDisguiseValidationResult,
+} from './disguiseValidation'
+import type { Agent, CaseInstance } from './models'
+import {
+  resolveDetectionScan,
+  type DetectionScanInput,
+  type DetectionScanResult,
+  type HostilityLevel,
+  type SubjectTruthState,
+} from './revealPayload'
+import {
+  concealmentLayersFromRating,
+  detectionScanTierOrder,
+} from './revealPayloadScoutingIntegration'
+
+export { detectionScanTierOrder }
+
+export interface DisguiseRevealSubject {
+  readonly exactIdentity: string
+  readonly category: string
+  readonly hostility?: HostilityLevel
+  readonly activeProtections?: readonly string[]
+  readonly activeEffects?: readonly string[]
+  readonly dormantEffects?: readonly string[]
+}
+
+export interface DisguiseRevealIntegrationInput {
+  readonly caseData: CaseInstance
+  readonly agents: readonly Agent[]
+  readonly subject: DisguiseRevealSubject
+  readonly context?: BehaviorWeightedDisguiseValidationContext
+}
+
+export interface DisguiseRevealIntegrationResult extends BehaviorWeightedDisguiseValidationResult {
+  readonly detectionScan: DetectionScanResult
+}
+
+function clampConcealmentRating(rating: number) {
+  if (!Number.isFinite(rating)) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(3, Math.floor(rating)))
+}
+
+function normalizeAwarenessPressure(value: number | undefined) {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(1, value))
+}
+
+function normalizeDocumentTier(value: number | undefined) {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 2
+  }
+
+  return Math.max(0, Math.min(2, Math.floor(value)))
+}
+
+export function disguiseConcealmentRatingFromCase(
+  caseData: CaseInstance,
+  context: BehaviorWeightedDisguiseValidationContext = {}
+): number {
+  const resolved = resolveDisguiseValidationContextFromCase(caseData, context)
+  const awareness = normalizeAwarenessPressure(resolved.infiltrationAwareness)
+  const documentTier = normalizeDocumentTier(resolved.documentTier)
+  let rating = Math.floor(awareness * 2)
+
+  if (documentTier <= 0) {
+    rating += 1
+  }
+
+  return clampConcealmentRating(rating)
+}
+
+export function buildSubjectTruthFromDisguise(
+  caseData: CaseInstance,
+  subject: DisguiseRevealSubject,
+  context: BehaviorWeightedDisguiseValidationContext = {}
+): SubjectTruthState {
+  const present = caseData.hiddenState === 'hidden'
+
+  return {
+    present,
+    exactIdentity: subject.exactIdentity,
+    category: subject.category,
+    hostility: subject.hostility ?? 'latent',
+    activeProtections: subject.activeProtections ?? [],
+    concealmentLayers: concealmentLayersFromRating(
+      disguiseConcealmentRatingFromCase(caseData, context)
+    ),
+    activeEffects: subject.activeEffects ?? [],
+    dormantEffects: subject.dormantEffects ?? [],
+  }
+}
+
+export function disguiseValidationToDetectionScan(
+  validation: Pick<BehaviorWeightedDisguiseValidationResult, 'active' | 'level' | 'counterDetection'>
+): DetectionScanInput {
+  if (!validation.active) {
+    return { family: 'presence_sweep' }
+  }
+
+  switch (validation.level) {
+    case 'none':
+      return { family: 'presence_sweep' }
+    case 'meaningful':
+      return { family: 'category_pass' }
+    case 'strong':
+      return {
+        family: 'identity_probe',
+        layersToStrip: validation.counterDetection ? 1 : 0,
+      }
+    default: {
+      const _exhaustive: never = validation.level
+      return _exhaustive
+    }
+  }
+}
+
+export function evaluateBehaviorWeightedDisguiseValidationWithRevealPayload(
+  input: DisguiseRevealIntegrationInput
+): DisguiseRevealIntegrationResult {
+  const context = input.context ?? {}
+  const validation = evaluateBehaviorWeightedDisguiseValidation(
+    input.caseData,
+    [...input.agents],
+    context
+  )
+  const truth = buildSubjectTruthFromDisguise(input.caseData, input.subject, context)
+  const scanInput = disguiseValidationToDetectionScan(validation)
+  const detectionScan = resolveDetectionScan(truth, scanInput)
+
+  return {
+    ...validation,
+    detectionScan,
+  }
+}

--- a/src/test/revealPayloadDisguiseIntegration.test.ts
+++ b/src/test/revealPayloadDisguiseIntegration.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
+import {
+  buildSubjectTruthFromDisguise,
+  detectionScanTierOrder,
+  disguiseConcealmentRatingFromCase,
+  disguiseValidationToDetectionScan,
+  evaluateBehaviorWeightedDisguiseValidationWithRevealPayload,
+} from '../domain/revealPayloadDisguiseIntegration'
+import type { Agent, CaseInstance } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+const SUBJECT = {
+  exactIdentity: 'entity:covert-briefing',
+  category: 'embedded operative',
+  activeEffects: ['forged credentials'],
+  dormantEffects: ['backup legend'],
+  activeProtections: ['document cover'],
+} as const
+
+function createBehaviorObserver(id: string, tags: string[], social: number): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation: 50,
+      utility: 40,
+      social,
+    },
+    tags: ['medium', ...tags],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+function createHiddenCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-disguise-reveal',
+      templateId: 'ops-004',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['infiltration', 'public'],
+    requiredTags: ['medium'],
+    preferredTags: [],
+    assignedTeamIds: [],
+    weights: { combat: 0, investigation: 0, utility: 0, social: 1 },
+    difficulty: { combat: 0, investigation: 0, utility: 0, social: 40 },
+    ...overrides,
+  }
+}
+
+describe('revealPayloadDisguiseIntegration (SPE-781 slice 3)', () => {
+  it('maps infiltration awareness and document tier to concealment rating', () => {
+    const lowAwareness = createHiddenCase({
+      infiltrationAwareness: 0.1,
+      infiltrationCoverProfile: { claimedRole: 'courier', documentTier: 2 },
+    })
+    const highAwarenessWeakDocs = createHiddenCase({
+      infiltrationAwareness: 1,
+      infiltrationCoverProfile: { claimedRole: 'maintenance', documentTier: 0 },
+    })
+
+    expect(disguiseConcealmentRatingFromCase(lowAwareness)).toBe(0)
+    expect(disguiseConcealmentRatingFromCase(highAwarenessWeakDocs)).toBe(3)
+  })
+
+  it('builds subject truth with disguise concealment layers', () => {
+    const caseData = createHiddenCase({
+      infiltrationAwareness: 0.9,
+      infiltrationCoverProfile: { claimedRole: 'maintenance', documentTier: 0 },
+    })
+    const truth = buildSubjectTruthFromDisguise(caseData, SUBJECT)
+
+    expect(truth.present).toBe(true)
+    expect(truth.exactIdentity).toBe('entity:covert-briefing')
+    expect(truth.concealmentLayers).toHaveLength(2)
+  })
+
+  it('selects deeper scan families for strong validation than inactive paths', () => {
+    expect(
+      disguiseValidationToDetectionScan({
+        active: false,
+        level: 'none',
+        counterDetection: false,
+      })
+    ).toEqual({ family: 'presence_sweep' })
+
+    expect(
+      disguiseValidationToDetectionScan({
+        active: true,
+        level: 'meaningful',
+        counterDetection: false,
+      })
+    ).toEqual({ family: 'category_pass' })
+
+    expect(
+      disguiseValidationToDetectionScan({
+        active: true,
+        level: 'strong',
+        counterDetection: true,
+      })
+    ).toEqual({ family: 'identity_probe', layersToStrip: 1 })
+  })
+
+  it('preserves legacy validation fields while attaching tiered detection payloads', () => {
+    const observer = createBehaviorObserver('a_disguise_reveal', ['liaison', 'negotiation'], 58)
+    const caseData = createHiddenCase({
+      infiltrationAwareness: 0.35,
+      infiltrationCoverProfile: { claimedRole: 'official_inspector', documentTier: 1 },
+    })
+
+    const legacy = evaluateBehaviorWeightedDisguiseValidation(caseData, [observer])
+    const integrated = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+      caseData,
+      agents: [observer],
+      subject: SUBJECT,
+    })
+
+    expect(integrated.active).toBe(legacy.active)
+    expect(integrated.level).toBe(legacy.level)
+    expect(integrated.scoreAdjustment).toBe(legacy.scoreAdjustment)
+    expect(integrated.detectionConfidence).toBe(legacy.detectionConfidence)
+    expect(integrated.counterDetection).toBe(legacy.counterDetection)
+
+    if (integrated.level === 'strong') {
+      expect(detectionScanTierOrder(integrated.detectionScan).length).toBeGreaterThan(2)
+    } else if (integrated.active) {
+      expect(
+        integrated.detectionScan.fields.some((field) => field.tier === 'category')
+      ).toBe(true)
+    } else {
+      expect(detectionScanTierOrder(integrated.detectionScan)).toEqual(['presence'])
+    }
+  })
+
+  it('blocks exact identity on strong counter-detection when two concealment layers remain', () => {
+    const observer = createBehaviorObserver('a_disguise_reveal_strong', ['liaison', 'negotiation'], 60)
+    const caseData = createHiddenCase({
+      infiltrationAwareness: 0.95,
+      infiltrationCoverProfile: { claimedRole: 'maintenance', documentTier: 0 },
+      counterDetection: true,
+    })
+
+    const integrated = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+      caseData,
+      agents: [observer],
+      subject: SUBJECT,
+    })
+
+    expect(integrated.level).toBe('strong')
+    expect(disguiseValidationToDetectionScan(integrated)).toEqual({
+      family: 'identity_probe',
+      layersToStrip: 1,
+    })
+    expect(
+      integrated.detectionScan.fields.some((field) => field.tier === 'exact_identity')
+    ).toBe(false)
+    expect(detectionScanTierOrder(integrated.detectionScan)).toContain('category')
+  })
+
+  it('maps active none-level validation to presence-only scans for hidden subjects', () => {
+    expect(
+      disguiseValidationToDetectionScan({
+        active: true,
+        level: 'none',
+        counterDetection: false,
+      })
+    ).toEqual({ family: 'presence_sweep' })
+
+    const integrated = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+      caseData: createHiddenCase(),
+      agents: [],
+      subject: SUBJECT,
+    })
+
+    expect(integrated.active).toBe(false)
+    expect(disguiseValidationToDetectionScan(integrated)).toEqual({ family: 'presence_sweep' })
+  })
+
+  it('maps meaningful validation to category scans without exposing exact identity under concealment', () => {
+    const observer = createBehaviorObserver('a_partial_proc', ['investigator'], 46)
+    const caseData = createHiddenCase({
+      tags: ['infiltration', 'witness'],
+      weights: { combat: 0, investigation: 1, utility: 0, social: 0 },
+      difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+      infiltrationAwareness: 0.9,
+      infiltrationCoverProfile: { claimedRole: 'maintenance', documentTier: 0 },
+    })
+
+    const integrated = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+      caseData,
+      agents: [observer],
+      subject: SUBJECT,
+    })
+
+    expect(integrated.level).toBe('meaningful')
+    expect(disguiseValidationToDetectionScan(integrated)).toEqual({ family: 'category_pass' })
+    expect(
+      integrated.detectionScan.fields.some((field) => field.tier === 'exact_identity')
+    ).toBe(false)
+    expect(integrated.detectionScan.fields[0]?.playerFacingValue).toBe('contact detected')
+  })
+
+  it('uses context overrides for concealment rating independent of stored case fields', () => {
+    const caseData = createHiddenCase({
+      infiltrationAwareness: 0,
+      infiltrationCoverProfile: { claimedRole: 'courier', documentTier: 2 },
+    })
+
+    expect(disguiseConcealmentRatingFromCase(caseData)).toBe(0)
+    expect(disguiseConcealmentRatingFromCase(caseData, { infiltrationAwareness: 1 })).toBe(2)
+    expect(
+      disguiseConcealmentRatingFromCase(caseData, {
+        infiltrationAwareness: 1,
+        documentTier: 0,
+      })
+    ).toBe(3)
+  })
+
+  it('treats non-finite awareness as zero concealment contribution', () => {
+    const caseData = createHiddenCase({
+      infiltrationAwareness: Number.NaN,
+      infiltrationCoverProfile: { claimedRole: 'courier', documentTier: 0 },
+    })
+
+    expect(disguiseConcealmentRatingFromCase(caseData)).toBe(1)
+  })
+
+  it('does not run disguise scans as contact when case is displaced', () => {
+    const observer = createBehaviorObserver('a_displaced', ['liaison', 'negotiation'], 60)
+    const displacedCase = createHiddenCase({ hiddenState: 'displaced' })
+
+    const integrated = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+      caseData: displacedCase,
+      agents: [observer],
+      subject: SUBJECT,
+    })
+
+    expect(integrated.active).toBe(false)
+    expect(detectionScanTierOrder(integrated.detectionScan)).toEqual(['presence'])
+    expect(integrated.detectionScan.fields[0]?.playerFacingValue).toBe('no contact')
+  })
+
+  it('returns presence-only tiers for visible cases even when validation is inactive', () => {
+    const observer = createBehaviorObserver('a_visible', ['liaison'], 55)
+    const visibleCase = createHiddenCase({ hiddenState: undefined })
+
+    const integrated = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+      caseData: visibleCase,
+      agents: [observer],
+      subject: SUBJECT,
+    })
+
+    expect(integrated.active).toBe(false)
+    expect(detectionScanTierOrder(integrated.detectionScan)).toEqual(['presence'])
+    expect(integrated.detectionScan.fields[0]?.playerFacingValue).toBe('no contact')
+  })
+})


### PR DESCRIPTION
## Summary

- Wire SPE-781 tiered \DetectionScanResult\ into behavior-weighted disguise validation via \evaluateBehaviorWeightedDisguiseValidationWithRevealPayload\, without changing validation scores, detection confidence, or case application helpers.
- Map validation level to scan families (presence / category / identity probe) and derive concealment layers from infiltration awareness + document tier.
- Harden non-finite awareness inputs; add integration tests for meaningful/strong depth, displaced cases, and context overrides.

## Linear

https://linear.app/spectranoir/issue/SPE-2252/tiered-reveal-payloads-slice-3-disguise-validation-integration

## Test plan

- [x] \
pm run test:run -- src/test/revealPayloadDisguiseIntegration.test.ts\
- [x] \
pm run test:run -- src/test/revealPayload*.test.ts\
- [x] \
pm run lint\
- [ ] CI green

Made with [Cursor](https://cursor.com)