### PR TITLE
feat(SPE-2253): wire reveal payloads into weekly case orchestration

### DIFF
--- a/planning/reveal-payload-slice-4.md
+++ b/planning/reveal-payload-slice-4.md
@@ -1,0 +1,36 @@
+# Tiered detection / reveal payloads — slice 4 orchestration (SPE-781)
+
+## Prerequisite
+
+Slices 1–3 on `main` @ `db0ed11` (PR #2342 / #2344): `revealPayload.ts`, scouting + disguise integration.
+
+## Goal
+
+Wire `evaluateBehaviorWeightedDisguiseValidationWithRevealPayload` into **`resolveAssignedCaseForWeek`** so weekly resolution strategies expose tiered `detectionScan` alongside legacy disguise validation — without changing validation scores, detection-confidence application, or mission outcome math.
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| `buildDisguiseRevealSubjectFromCase` — deterministic subject from case fields | Report / event-feed copy for tier labels |
+| `resolveAssignedCaseForWeek` uses composed disguise + reveal helper | `advanceWeek` event drafts consuming `detectionScan` |
+| `WeeklyCaseResolutionStrategy.behaviorValidation` carries optional `detectionScan` | Full hidden-modality matrix (SPE-70 doc) |
+| Integration tests in `src/test/revealPayloadOrchestration.test.ts` | UI components |
+
+## Acceptance
+
+- [x] `resolveAssignedCaseForWeek` returns unchanged legacy validation fields vs pre-slice behavior
+- [x] Hidden infiltration cases attach `detectionScan` with tier depth correlated to validation level
+- [x] `applyBehaviorWeightedDisguiseValidationToCase` and score/outcome paths unchanged
+- [x] `npm run test:run` and `npm run lint` green on touched files
+
+## See also
+
+- `planning/reveal-payload-slice-3.md`
+- Linear child under [SPE-781](https://linear.app/spectranoir/issue/SPE-781)
+- `src/domain/caseResolutionOrchestration.ts`
+- `src/domain/revealPayloadDisguiseIntegration.ts`
+
+## Follow-up (slice 5)
+
+Player-facing report/event copy from `detectionScan.fields[].playerFacingValue` (mirror `infiltrationEncounterReportNotes.ts`).

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -4,11 +4,12 @@ import { buildFactionMissionContext } from './factions'
 import { buildTeamCompositionProfile, getTeamMemberIds, getUniqueTeamMembers } from './teamSimulation'
 import { buildTeamCohesionSummary } from './teamComposition'
 import { buildAgentLoadoutReadinessSummary } from './equipment'
+import { applyBehaviorWeightedDisguiseValidationToCase } from './disguiseValidation'
 import {
-  applyBehaviorWeightedDisguiseValidationToCase,
-  evaluateBehaviorWeightedDisguiseValidation,
-  type BehaviorWeightedDisguiseValidationResult,
-} from './disguiseValidation'
+  buildDisguiseRevealSubjectFromCase,
+  evaluateBehaviorWeightedDisguiseValidationWithRevealPayload,
+  type DisguiseRevealIntegrationResult,
+} from './revealPayloadDisguiseIntegration'
 import {
   evaluateInfiltrationStageMissionPressure,
   type InfiltrationStageMissionPressureResult,
@@ -31,14 +32,14 @@ export interface WeeklyCaseResolutionStrategy {
   assignedAgentLeaderBonuses: Record<string, LeaderBonus>
   activeTeamStressModifiers: Record<string, number>
   outcome: ResolutionOutcome
-  behaviorValidation?: BehaviorWeightedDisguiseValidationResult
+  behaviorValidation?: DisguiseRevealIntegrationResult
   infiltrationStageMission?: InfiltrationStageMissionPressureResult
   stealthLeaveBehindMission?: StealthLeaveBehindMissionPressureResult
   weakestLinkResult?: import('./weakestLinkResolution').WeakestLinkMissionResolutionResult
 }
 
 export function resolveMissionSuccessDegradeHint(input: {
-  behaviorValidation?: BehaviorWeightedDisguiseValidationResult
+  behaviorValidation?: DisguiseRevealIntegrationResult
   infiltrationStageMission?: InfiltrationStageMissionPressureResult
   stealthLeaveBehindMission?: StealthLeaveBehindMissionPressureResult
 }): { shouldDegrade: boolean; reason?: string } {
@@ -130,16 +131,17 @@ export function resolveAssignedCaseForWeek(
     currentCase.assignedTeamIds.length === 1
       ? (state.teams[currentCase.assignedTeamIds[0]]?.leaderId ?? null)
       : null
-  const behaviorValidation = evaluateBehaviorWeightedDisguiseValidation(
-    effectiveCase,
-    assignedAgents,
-    {
+  const behaviorValidation = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+    caseData: effectiveCase,
+    agents: assignedAgents,
+    subject: buildDisguiseRevealSubjectFromCase(effectiveCase),
+    context: {
       supportTags,
       teamTags: supportTags,
       leaderId,
       infiltrationAwareness: effectiveCase.infiltrationAwareness,
-    }
-  )
+    },
+  })
   const resolvedEffectiveCase = applyBehaviorWeightedDisguiseValidationToCase(
     effectiveCase,
     behaviorValidation

--- a/src/domain/revealPayloadDisguiseIntegration.ts
+++ b/src/domain/revealPayloadDisguiseIntegration.ts
@@ -10,7 +10,12 @@ import {
   type BehaviorWeightedDisguiseValidationContext,
   type BehaviorWeightedDisguiseValidationResult,
 } from './disguiseValidation'
+import { isInfiltrationCoverRole, type InfiltrationCoverRole } from './infiltrationCover'
 import type { Agent, CaseInstance } from './models'
+import {
+  DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY,
+  getStealthLeaveBehindById,
+} from './stealthLeaveBehindRegistry'
 import {
   resolveDetectionScan,
   type DetectionScanInput,
@@ -24,6 +29,14 @@ import {
 } from './revealPayloadScoutingIntegration'
 
 export { detectionScanTierOrder }
+
+const DISGUISE_COVER_CATEGORY_LABELS: Record<InfiltrationCoverRole, string> = {
+  uniform_guard: 'uniform guard cover',
+  civilian_staff: 'civilian staff cover',
+  courier: 'courier cover',
+  maintenance: 'maintenance cover',
+  official_inspector: 'official inspector cover',
+}
 
 export interface DisguiseRevealSubject {
   readonly exactIdentity: string
@@ -83,6 +96,67 @@ export function disguiseConcealmentRatingFromCase(
   }
 
   return clampConcealmentRating(rating)
+}
+
+function resolveDisguiseSubjectHostility(caseData: CaseInstance): HostilityLevel {
+  if (caseData.infiltrationStage === 'violent' || caseData.counterDetection === true) {
+    return 'active'
+  }
+
+  return 'latent'
+}
+
+function resolveDisguiseSubjectCategory(caseData: CaseInstance): string {
+  const claimedRole = caseData.infiltrationCoverProfile?.claimedRole
+
+  if (claimedRole !== undefined && isInfiltrationCoverRole(claimedRole)) {
+    return DISGUISE_COVER_CATEGORY_LABELS[claimedRole]
+  }
+
+  if (caseData.tags.includes('infiltration')) {
+    return 'infiltration contact'
+  }
+
+  return 'concealed contact'
+}
+
+function readDisguiseLeaveBehindLabel(caseData: CaseInstance): string | undefined {
+  const leaveBehindId = caseData.stealthLeaveBehindId?.trim()
+  if (!leaveBehindId) {
+    return undefined
+  }
+
+  return getStealthLeaveBehindById(DEFAULT_STEALTH_LEAVE_BEHIND_REGISTRY, leaveBehindId)?.label
+}
+
+function resolveDisguiseActiveProtections(caseData: CaseInstance): readonly string[] {
+  const profile = caseData.infiltrationCoverProfile
+  if (profile === undefined) {
+    return []
+  }
+
+  const documentTier = profile.documentTier
+  if (documentTier === undefined || !Number.isFinite(documentTier)) {
+    return ['document cover']
+  }
+
+  return [`document tier ${Math.max(0, Math.min(2, Math.floor(documentTier)))}`]
+}
+
+/** Deterministic subject snapshot for weekly disguise reveal scans. */
+export function buildDisguiseRevealSubjectFromCase(caseData: CaseInstance): DisguiseRevealSubject {
+  const activeProtections = resolveDisguiseActiveProtections(caseData)
+  const leaveBehindLabel = readDisguiseLeaveBehindLabel(caseData)
+  const activeEffects = leaveBehindLabel !== undefined ? [leaveBehindLabel] : []
+
+  return {
+    exactIdentity: `entity:${caseData.id}`,
+    category: resolveDisguiseSubjectCategory(caseData),
+    hostility: resolveDisguiseSubjectHostility(caseData),
+    activeProtections,
+    activeEffects,
+    dormantEffects: caseData.hiddenState === 'hidden' ? ['undisclosed briefing detail'] : [],
+  }
 }
 
 export function buildSubjectTruthFromDisguise(

--- a/src/test/revealPayloadOrchestration.test.ts
+++ b/src/test/revealPayloadOrchestration.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
+import {
+  buildDisguiseRevealSubjectFromCase,
+  detectionScanTierOrder,
+} from '../domain/revealPayloadDisguiseIntegration'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createBehaviorObserver(id: string, tags: string[], social: number): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation: 50,
+      utility: 40,
+      social,
+    },
+    tags: ['medium', ...tags],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+function createHiddenCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-orchestration-reveal',
+      templateId: 'ops-004',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['infiltration', 'public'],
+    requiredTags: ['medium'],
+    preferredTags: [],
+    assignedTeamIds: ['team-reveal'],
+    weights: { combat: 0, investigation: 0, utility: 0, social: 1 },
+    difficulty: { combat: 0, investigation: 0, utility: 0, social: 40 },
+    infiltrationAwareness: 0.35,
+    infiltrationCoverProfile: { claimedRole: 'official_inspector', documentTier: 1 },
+    ...overrides,
+  }
+}
+
+describe('revealPayloadOrchestration (SPE-781 slice 4)', () => {
+  it('buildDisguiseRevealSubjectFromCase maps cover role and case id', () => {
+    const caseData = createHiddenCase()
+
+    expect(buildDisguiseRevealSubjectFromCase(caseData)).toMatchObject({
+      exactIdentity: 'entity:case-orchestration-reveal',
+      category: 'official inspector cover',
+      hostility: 'latent',
+      activeProtections: ['document tier 1'],
+    })
+  })
+
+  it('resolveAssignedCaseForWeek preserves legacy validation while attaching detectionScan', () => {
+    const observer = createBehaviorObserver('a_orchestration_reveal', ['liaison', 'negotiation'], 58)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createHiddenCase({ assignedTeamIds: [team.id] })
+    const validationContext = {
+      supportTags: team.tags,
+      teamTags: team.tags,
+      leaderId: null,
+      infiltrationAwareness: caseData.infiltrationAwareness,
+    }
+
+    const legacy = evaluateBehaviorWeightedDisguiseValidation(caseData, [observer], validationContext)
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(resolution.behaviorValidation).toMatchObject({
+      active: legacy.active,
+      level: legacy.level,
+      scoreAdjustment: legacy.scoreAdjustment,
+      evidenceSignals: legacy.evidenceSignals,
+      counterDetection: legacy.counterDetection,
+      shouldDegradeSuccessToPartial: legacy.shouldDegradeSuccessToPartial,
+    })
+    expect(resolution.behaviorValidation?.detectionScan).toBeDefined()
+    expect(detectionScanTierOrder(resolution.behaviorValidation!.detectionScan).length).toBeGreaterThan(
+      0
+    )
+  })
+
+  it('returns inactive validation with presence-only scan when case is not hidden', () => {
+    const observer = createBehaviorObserver('a_orchestration_visible', ['liaison'], 58)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createHiddenCase({
+      assignedTeamIds: [team.id],
+      hiddenState: undefined,
+      detectionConfidence: undefined,
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(resolution.behaviorValidation?.active).toBe(false)
+    expect(detectionScanTierOrder(resolution.behaviorValidation!.detectionScan)).toEqual(['presence'])
+    expect(resolution.behaviorValidation?.detectionScan.fields[0]?.playerFacingValue).toBe('no contact')
+  })
+
+  it('exposes deeper detection tiers for strong validation than inactive paths', () => {
+    const observer = createBehaviorObserver('a_orchestration_tiers', ['liaison', 'negotiation'], 60)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const mismatched = resolveAssignedCaseForWeek(
+      createHiddenCase({
+        assignedTeamIds: [team.id],
+        infiltrationCoverProfile: { claimedRole: 'uniform_guard', documentTier: 2 },
+      }),
+      state,
+      () => 0.5
+    )
+    const inactive = resolveAssignedCaseForWeek(
+      createHiddenCase({
+        assignedTeamIds: [team.id],
+        hiddenState: undefined,
+      }),
+      state,
+      () => 0.5
+    )
+
+    expect(detectionScanTierOrder(mismatched.behaviorValidation!.detectionScan)).toContain('category')
+    expect(detectionScanTierOrder(inactive.behaviorValidation!.detectionScan)).toEqual(['presence'])
+  })
+
+  it('falls back to infiltration contact when cover role is invalid', () => {
+    const caseData = createHiddenCase({
+      infiltrationCoverProfile: {
+        claimedRole: 'not-a-role' as 'uniform_guard',
+        documentTier: 1,
+      },
+    })
+
+    expect(buildDisguiseRevealSubjectFromCase(caseData).category).toBe('infiltration contact')
+  })
+
+  it('does not change resolved effective case detection fields vs legacy validation apply', () => {
+    const observer = createBehaviorObserver('a_orchestration_legacy', ['liaison', 'negotiation'], 58)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createHiddenCase({
+      assignedTeamIds: [team.id],
+      infiltrationAwareness: 0.9,
+      counterDetection: true,
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(resolution.effectiveCase.detectionConfidence).toBeGreaterThanOrEqual(
+      caseData.detectionConfidence ?? 0
+    )
+    expect(resolution.effectiveCase.counterDetection).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Wire `evaluateBehaviorWeightedDisguiseValidationWithRevealPayload` into `resolveAssignedCaseForWeek` so weekly resolution exposes `detectionScan` alongside legacy disguise validation fields.
- Add `buildDisguiseRevealSubjectFromCase` for deterministic subject snapshots (cover role, document tier, leave-behind, hostility) without pulling report-copy modules into domain integration.
- Add orchestration integration tests covering legacy parity, non-hidden inactive scans, and tier depth vs validation strength.

## Linear
https://linear.app/spectranoir/issue/SPE-2253/tiered-reveal-payloads-slice-4-weekly-orchestration-wiring

## Test plan
- [x] `npm run test:run -- src/test/revealPayloadOrchestration.test.ts src/test/revealPayloadDisguiseIntegration.test.ts src/test/behaviorDisguiseValidation.test.ts src/test/advanceWeek.behaviorValidation.test.ts src/test/stealthLeaveBehindMission.test.ts src/test/infiltrationStageMission.test.ts`
- [x] `npm run lint` on touched files

## Out of scope
Report/event copy from `detectionScan` (slice 5); full SPE-781 modality matrix.