### PR TITLE
feat(SPE-781): tiered detection readouts in weekly report copy (slice 5)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -19,7 +19,7 @@ From `README.md` **Current design notes**:
 2. **Infiltration and access follow-through** — Batch-4 probe/cover/leave-behind complete; **report copy slice** shipped (`src/domain/infiltrationEncounterReportNotes.ts` — weekly encounter + leave-behind tradeoff notes). Further optional content depth only (not new probe mechanics).
 3. **Route and week navigation** — Report prev/next shipped (`planning/report-week-navigation-slice.md`, PR #2329); operations drill-down shipped (`planning/operations-route-drill-down-slice.md`, SPE-2248).
 4. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
-5. **Tiered detection / reveal payloads (SPE-781)** — Slices 1–4 shipped (`revealPayload.ts`, scouting + disguise integration, weekly orchestration in `resolveAssignedCaseForWeek`, PR #2342 / #2344 / #2346). Report/event copy from `detectionScan` and full modality matrix remain follow-up.
+5. **Tiered detection / reveal payloads (SPE-781)** — Slices 1–4 shipped (`revealPayload.ts`, scouting + disguise integration, weekly orchestration in `resolveAssignedCaseForWeek`, PR #2342 / #2344 / #2346). Slice 5 report copy (`detectionScanReportNotes.ts`, `advanceWeek` resolution reasons) in review. Full hidden-modality matrix remains follow-up.
 
 ## Shipped (May 2026 — remove from active queue when scanning)
 

--- a/planning/reveal-payload-slice-4.md
+++ b/planning/reveal-payload-slice-4.md
@@ -33,4 +33,4 @@ Wire `evaluateBehaviorWeightedDisguiseValidationWithRevealPayload` into **`resol
 
 ## Follow-up (slice 5)
 
-Player-facing report/event copy from `detectionScan.fields[].playerFacingValue` (mirror `infiltrationEncounterReportNotes.ts`).
+Shipped in `planning/reveal-payload-slice-5.md` — `detectionScanReportNotes.ts` + `advanceWeek` resolution reasons.

--- a/planning/reveal-payload-slice-5.md
+++ b/planning/reveal-payload-slice-5.md
@@ -1,0 +1,56 @@
+# Tiered detection / reveal payloads — slice 5 report copy (SPE-781)
+
+## Prerequisite
+
+Slice 4 on `main` @ `0486111` (PR #2346): `resolveAssignedCaseForWeek` exposes `behaviorValidation.detectionScan` alongside legacy disguise validation.
+
+## Goal
+
+Surface **tiered detection readouts** in player-facing weekly report copy using `detectionScan.fields[].playerFacingValue`, mirroring the pure-formatter pattern in `infiltrationEncounterReportNotes.ts` — without changing scan resolution, validation scores, detection-confidence math, or mission outcome logic.
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| `src/domain/detectionScanReportNotes.ts` — ordered `playerFacingValue` summary formatters | Full hidden-modality matrix (`architecture/hidden-state-displacement-counter-detection.md`) |
+| `detectionScanTierOrder` + `playerFacingValue` only in player copy (no `internalValue`) | Changing `resolveDetectionScan` or `disguiseValidationToDetectionScan` |
+| `advanceWeek` `resolveAssignments`: append scan line to `resolutionReasons` when validation is active | Replacing legacy `Behavior validation:` reason strings |
+| Unit tests `src/test/detectionScanReportNotes.test.ts` | New React report components (use existing `explanationNotes` in `MissionResultSummary`) |
+| Extend `src/test/advanceWeek.behaviorValidation.test.ts` for tier copy in weekly report snapshots | Scouting path (`resolveScoutingWithRevealPayload`) unless trivially shared formatters only |
+| Optional: enrich `concealment.activated` summary when scan is already available deterministically | New event types or payload schema churn |
+
+## Copy contract
+
+- **Formatter module** (domain-only): `formatDetectionScanSummary(result)` joins scan field order and `playerFacingValue` clauses (e.g. `Detection readout: contact detected; unclassified contact; 2 concealed layers.`).
+- **Emit when:** `behaviorValidation.active` and `detectionScan.fields.length > 0`; suppress redundant presence-only noise when validation is inactive unless tests/product require otherwise.
+- **Legacy coexistence:** keep existing `Behavior validation: +N (...)` and scalar `detectionConfidence` on mission results; add scan readout as an **additional** explanation note via `resolutionReasons` → `buildMissionResult` → `explanationNotes`.
+- **Optional suffix:** if `strippedLayerIds.length > 0`, append deterministic counter-detection peel hint (only when covered by tests).
+
+## Acceptance
+
+- [x] Strong hidden/disguise weekly resolution shows tiered readout in report `missionResult.explanationNotes` (not only legacy behavior-validation text)
+- [x] Inactive / low-depth paths do not spam empty or duplicate “no contact” lines by default
+- [x] Pre-slice behavior: validation scores, degrade hints, and mission outcome math unchanged (`revealPayloadOrchestration.test.ts` still green)
+- [x] `npm run test:run` and `npm run lint` green on touched files
+- [x] CP-native copy only (no franchise names or copyrighted setting labels)
+
+## Implementation notes
+
+1. Import `detectionScanTierOrder` and `DetectionScanResult` from `revealPayloadDisguiseIntegration.ts` (or re-export surface used by tests).
+2. Wire in `src/domain/sim/advanceWeek.ts` after `weeklyResolution` destructuring, before `buildSuccessCaseOutcomeDraft` / escalated drafts — same block for success, partial, and fail paths that already push `resolutionReasons`.
+3. Post-merge: update `planning/backlog.md` item #5 (slice 5 shipped; modality matrix remains follow-up).
+
+## See also
+
+- `planning/reveal-payload-slice-4.md`
+- [SPE-781](https://linear.app/spectranoir/issue/SPE-781) (parent)
+- `src/domain/infiltrationEncounterReportNotes.ts` — formatter pattern
+- `src/domain/revealPayloadDisguiseIntegration.ts`
+- `src/domain/sim/advanceWeek.ts` — `resolveAssignments`
+- `src/features/report/reportDetailHelpers.tsx` — `MissionResultSummary` / `explanationNotes`
+
+## Out of scope (later)
+
+- Full SPE-70 hidden-modality matrix
+- False-detection / instrumentation attack modalities
+- Dedicated event-feed tier metadata unless report notes prove insufficient

--- a/planning/reveal-payload-slice-5.md
+++ b/planning/reveal-payload-slice-5.md
@@ -43,7 +43,7 @@ Surface **tiered detection readouts** in player-facing weekly report copy using 
 ## See also
 
 - `planning/reveal-payload-slice-4.md`
-- [SPE-781](https://linear.app/spectranoir/issue/SPE-781) (parent)
+- Linear [SPE-2254](https://linear.app/spectranoir/issue/SPE-2254) (child of [SPE-781](https://linear.app/spectranoir/issue/SPE-781))
 - `src/domain/infiltrationEncounterReportNotes.ts` — formatter pattern
 - `src/domain/revealPayloadDisguiseIntegration.ts`
 - `src/domain/sim/advanceWeek.ts` — `resolveAssignments`

--- a/planning/reveal-payload-slice-5.md
+++ b/planning/reveal-payload-slice-5.md
@@ -36,8 +36,8 @@ Surface **tiered detection readouts** in player-facing weekly report copy using 
 
 ## Implementation notes
 
-1. Import `detectionScanTierOrder` and `DetectionScanResult` from `revealPayloadDisguiseIntegration.ts` (or re-export surface used by tests).
-2. Wire in `src/domain/sim/advanceWeek.ts` after `weeklyResolution` destructuring, before `buildSuccessCaseOutcomeDraft` / escalated drafts — same block for success, partial, and fail paths that already push `resolutionReasons`.
+1. `detectionScanReportNotes.ts` formats `DetectionScanResult.fields` in resolver order via `playerFacingValue` only.
+2. Wire in `src/domain/sim/advanceWeek.ts` immediately after `resolutionReasons` is seeded (shared success / partial / fail / degrade paths).
 3. Post-merge: update `planning/backlog.md` item #5 (slice 5 shipped; modality matrix remains follow-up).
 
 ## See also

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -9,7 +9,9 @@ import type { DisguiseRevealIntegrationResult } from './revealPayloadDisguiseInt
 export const DETECTION_SCAN_READOUT_PREFIX = 'Detection readout:'
 
 function orderedPlayerFacingValues(result: DetectionScanResult): readonly string[] {
-  return result.fields.map((field) => field.playerFacingValue)
+  return result.fields
+    .map((field) => field.playerFacingValue.trim())
+    .filter((value) => value.length > 0)
 }
 
 export function shouldAppendDetectionScanReportNote(
@@ -60,6 +62,10 @@ export function appendDetectionScanResolutionReason(
   behaviorValidation?: DisguiseRevealIntegrationResult
 ): void {
   if (behaviorValidation === undefined || !shouldAppendDetectionScanReportNote(behaviorValidation)) {
+    return
+  }
+
+  if (resolutionReasons.some((reason) => reason.startsWith(DETECTION_SCAN_READOUT_PREFIX))) {
     return
   }
 

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -8,6 +8,15 @@ import type { DisguiseRevealIntegrationResult } from './revealPayloadDisguiseInt
 
 export const DETECTION_SCAN_READOUT_PREFIX = 'Detection readout:'
 
+function isPresenceOnlyAbsentContact(scan: DetectionScanResult): boolean {
+  if (scan.fields.length !== 1) {
+    return false
+  }
+
+  const field = scan.fields[0]
+  return field.tier === 'presence' && field.internalValue === false
+}
+
 function orderedPlayerFacingValues(result: DetectionScanResult): readonly string[] {
   return result.fields
     .map((field) => field.playerFacingValue.trim())
@@ -23,18 +32,11 @@ export function shouldAppendDetectionScanReportNote(
     return false
   }
 
-  const { fields } = validation.detectionScan
-  if (fields.length === 0) {
+  if (isPresenceOnlyAbsentContact(validation.detectionScan)) {
     return false
   }
 
-  // Suppress if the only information is that no contact was found.
-  if (fields.length === 1 && fields[0].tier === 'presence' && fields[0].internalValue === false) {
-    return false
-  }
-
-
-  return true
+  return orderedPlayerFacingValues(validation.detectionScan).length > 0
 }
 
 function formatDetectionScanStrippedLayersSuffix(result: DetectionScanResult): string {

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -23,14 +23,16 @@ export function shouldAppendDetectionScanReportNote(
     return false
   }
 
-  const values = orderedPlayerFacingValues(validation.detectionScan)
-  if (values.length === 0) {
+  const { fields } = validation.detectionScan
+  if (fields.length === 0) {
     return false
   }
 
-  if (values.length === 1 && values[0] === 'no contact') {
+  // Suppress if the only information is that no contact was found.
+  if (fields.length === 1 && fields[0].tier === 'presence' && fields[0].internalValue === false) {
     return false
   }
+
 
   return true
 }

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -1,0 +1,72 @@
+/**
+ * SPE-781 slice 5: player-facing weekly report copy for tiered detection scans.
+ */
+
+import type { BehaviorWeightedDisguiseValidationResult } from './disguiseValidation'
+import type { DetectionScanResult } from './revealPayload'
+import type { DisguiseRevealIntegrationResult } from './revealPayloadDisguiseIntegration'
+
+export const DETECTION_SCAN_READOUT_PREFIX = 'Detection readout:'
+
+function orderedPlayerFacingValues(result: DetectionScanResult): readonly string[] {
+  return result.fields.map((field) => field.playerFacingValue)
+}
+
+export function shouldAppendDetectionScanReportNote(
+  validation: Pick<BehaviorWeightedDisguiseValidationResult, 'active'> & {
+    readonly detectionScan: DetectionScanResult
+  }
+): boolean {
+  if (!validation.active) {
+    return false
+  }
+
+  const values = orderedPlayerFacingValues(validation.detectionScan)
+  if (values.length === 0) {
+    return false
+  }
+
+  if (values.length === 1 && values[0] === 'no contact') {
+    return false
+  }
+
+  return true
+}
+
+function formatDetectionScanStrippedLayersSuffix(result: DetectionScanResult): string {
+  const strippedCount = result.strippedLayerIds.length
+  if (strippedCount === 0) {
+    return ''
+  }
+
+  return ` Counter-detection stripped ${strippedCount} concealment layer${strippedCount === 1 ? '' : 's'}.`
+}
+
+/** Ordered player-facing tier values from a detection scan. */
+export function formatDetectionScanSummary(result: DetectionScanResult): string {
+  const orderedValues = orderedPlayerFacingValues(result)
+  if (orderedValues.length === 0) {
+    return ''
+  }
+
+  return (
+    `${DETECTION_SCAN_READOUT_PREFIX} ${orderedValues.join('; ')}.` +
+    formatDetectionScanStrippedLayersSuffix(result)
+  )
+}
+
+export function appendDetectionScanResolutionReason(
+  resolutionReasons: string[],
+  behaviorValidation?: DisguiseRevealIntegrationResult
+): void {
+  if (behaviorValidation === undefined || !shouldAppendDetectionScanReportNote(behaviorValidation)) {
+    return
+  }
+
+  const summary = formatDetectionScanSummary(behaviorValidation.detectionScan)
+  if (summary.length === 0) {
+    return
+  }
+
+  resolutionReasons.push(summary)
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -178,6 +178,7 @@ import {
   buildExecutionInstabilityRouteShift,
 } from '../executionInstability'
 import { buildMissionRewardBreakdown } from '../missionResults'
+import { appendDetectionScanResolutionReason } from '../detectionScanReportNotes'
 import { formatConcealmentActivationSummary } from '../concealmentActivationFeed'
 import {
   mergeConcealmentActivationResult,
@@ -2453,6 +2454,7 @@ function resolveAssignments(
       ...outcome.reasons,
       ...buildAggregateBattleResolutionReasons(aggregateBattleSummary),
     ]
+    appendDetectionScanResolutionReason(resolutionReasons, behaviorValidation)
 
     if (
       stealthLeaveBehindMission?.active &&

--- a/src/test/advanceWeek.behaviorValidation.test.ts
+++ b/src/test/advanceWeek.behaviorValidation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
+import { DETECTION_SCAN_READOUT_PREFIX } from '../domain/detectionScanReportNotes'
 import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import { detectionScanTierOrder } from '../domain/revealPayloadDisguiseIntegration'
 import type { Agent, CaseInstance, Team } from '../domain/models'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { createStarterCase } from '../domain/templates/startingCases'
@@ -111,6 +113,10 @@ describe('advanceWeek behavior-weighted disguise validation', () => {
     expect(
       preAdvanceResolution.outcome.reasons.some((reason) => reason.includes('cover role mismatch'))
     ).toBe(true)
+    expect(preAdvanceResolution.behaviorValidation?.active).toBe(true)
+    expect(detectionScanTierOrder(preAdvanceResolution.behaviorValidation!.detectionScan).length).toBeGreaterThan(
+      1
+    )
 
     const nextState = advanceWeek(state)
     const lastReport = nextState.reports[nextState.reports.length - 1]
@@ -127,6 +133,12 @@ describe('advanceWeek behavior-weighted disguise validation', () => {
       missionResult?.explanationNotes.some((note) =>
         note.includes('Behavior mismatch triggered visible authority scrutiny')
       )
+    ).toBe(true)
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes(DETECTION_SCAN_READOUT_PREFIX))
+    ).toBe(true)
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes('contact detected'))
     ).toBe(true)
     expect(nextState.cases['case-001'].status).toBe('open')
   })

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -107,6 +107,32 @@ describe('detectionScanReportNotes', () => {
     )
   })
 
+  it('does not append duplicate detection readout lines', () => {
+    const scan = resolveDetectionScan(buildSubject(), { family: 'category_pass' })
+    const reasons: string[] = []
+
+    appendDetectionScanResolutionReason(reasons, {
+      active: true,
+      level: 'strong',
+      scoreAdjustment: 0,
+      evidenceSignals: [],
+      counterDetection: false,
+      shouldDegradeSuccessToPartial: false,
+      detectionScan: scan,
+    })
+    appendDetectionScanResolutionReason(reasons, {
+      active: true,
+      level: 'strong',
+      scoreAdjustment: 0,
+      evidenceSignals: [],
+      counterDetection: false,
+      shouldDegradeSuccessToPartial: false,
+      detectionScan: scan,
+    })
+
+    expect(reasons).toHaveLength(1)
+  })
+
   it('appendDetectionScanResolutionReason pushes a formatted line', () => {
     const agent: Agent = {
       id: 'a_scan_copy',

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendDetectionScanResolutionReason,
+  DETECTION_SCAN_READOUT_PREFIX,
+  formatDetectionScanSummary,
+  shouldAppendDetectionScanReportNote,
+} from '../domain/detectionScanReportNotes'
+import { resolveDetectionScan, type SubjectTruthState } from '../domain/revealPayload'
+import {
+  buildDisguiseRevealSubjectFromCase,
+  evaluateBehaviorWeightedDisguiseValidationWithRevealPayload,
+} from '../domain/revealPayloadDisguiseIntegration'
+import { createStarterCase } from '../domain/templates/startingCases'
+import type { Agent } from '../domain/models'
+
+function buildSubject(overrides: Partial<SubjectTruthState> = {}): SubjectTruthState {
+  return {
+    present: true,
+    exactIdentity: 'entity:case-scan-copy',
+    category: 'concealed contact',
+    hostility: 'latent',
+    activeProtections: [],
+    concealmentLayers: [
+      {
+        id: 'layer:mask',
+        blockedTiers: ['exact_identity'],
+      },
+    ],
+    activeEffects: [],
+    dormantEffects: [],
+    ...overrides,
+  }
+}
+
+describe('detectionScanReportNotes', () => {
+  it('formats ordered tier values into a detection readout line', () => {
+    const scan = resolveDetectionScan(buildSubject(), { family: 'category_pass' })
+
+    expect(formatDetectionScanSummary(scan)).toBe(
+      `${DETECTION_SCAN_READOUT_PREFIX} contact detected; unclassified contact.`
+    )
+  })
+
+  it('appends counter-detection peel suffix when layers were stripped', () => {
+    const scan = resolveDetectionScan(buildSubject(), {
+      family: 'identity_probe',
+      layersToStrip: 1,
+    })
+
+    expect(formatDetectionScanSummary(scan)).toContain('Counter-detection stripped 1 concealment layer.')
+    expect(formatDetectionScanSummary(scan)).toContain('entity:case-scan-copy')
+  })
+
+  it('returns false when validation is inactive', () => {
+    const scan = resolveDetectionScan(buildSubject({ present: false }), { family: 'presence_sweep' })
+
+    expect(
+      shouldAppendDetectionScanReportNote({
+        active: false,
+        detectionScan: scan,
+      })
+    ).toBe(false)
+  })
+
+  it('allows active scans with informational presence readouts', () => {
+    const scan = resolveDetectionScan(buildSubject(), { family: 'presence_sweep' })
+
+    expect(
+      shouldAppendDetectionScanReportNote({
+        active: true,
+        detectionScan: scan,
+      })
+    ).toBe(true)
+  })
+
+  it('returns false for active validation with only a no-contact readout', () => {
+    const scan = resolveDetectionScan(buildSubject({ present: false }), { family: 'presence_sweep' })
+
+    expect(
+      shouldAppendDetectionScanReportNote({
+        active: true,
+        detectionScan: scan,
+      })
+    ).toBe(false)
+  })
+
+  it('does not append when validation is inactive', () => {
+    const scan = resolveDetectionScan(buildSubject({ present: false }), { family: 'presence_sweep' })
+    const reasons: string[] = []
+
+    appendDetectionScanResolutionReason(reasons, {
+      active: false,
+      level: 'none',
+      scoreAdjustment: 0,
+      evidenceSignals: [],
+      counterDetection: false,
+      shouldDegradeSuccessToPartial: false,
+      detectionScan: scan,
+    })
+
+    expect(reasons).toHaveLength(0)
+  })
+
+  it('does not append a readout prefix-only line when tier values are empty', () => {
+    expect(formatDetectionScanSummary({ fields: [], remainingConcealmentLayers: [], strippedLayerIds: [] })).toBe(
+      ''
+    )
+  })
+
+  it('appendDetectionScanResolutionReason pushes a formatted line', () => {
+    const agent: Agent = {
+      id: 'a_scan_copy',
+      name: 'a_scan_copy',
+      role: 'medium',
+      baseStats: { combat: 10, investigation: 50, utility: 40, social: 70 },
+      tags: ['medium', 'liaison', 'negotiation'],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    }
+    const caseData = {
+      ...createStarterCase({ id: 'case-scan-copy', templateId: 'ops-004' }),
+      hiddenState: 'hidden' as const,
+      detectionConfidence: 0.2,
+      counterDetection: false,
+      tags: ['public'],
+      requiredTags: ['medium'],
+      preferredTags: [],
+      assignedTeamIds: ['team-scan'],
+      weights: { combat: 0, investigation: 0, utility: 0, social: 1 },
+      difficulty: { combat: 0, investigation: 0, utility: 0, social: 40 },
+    }
+    const validation = evaluateBehaviorWeightedDisguiseValidationWithRevealPayload({
+      caseData,
+      agents: [agent],
+      subject: buildDisguiseRevealSubjectFromCase(caseData),
+      context: { teamTags: [], supportTags: [] },
+    })
+
+    const reasons: string[] = []
+    appendDetectionScanResolutionReason(reasons, validation)
+
+    expect(reasons).toHaveLength(1)
+    expect(reasons[0]).toContain(DETECTION_SCAN_READOUT_PREFIX)
+    expect(reasons[0]).toContain('contact detected')
+  })
+})

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -73,7 +73,7 @@ describe('detectionScanReportNotes', () => {
     ).toBe(true)
   })
 
-  it('returns false for active validation with only a no-contact readout', () => {
+  it('returns false for active validation with presence-only absent contact', () => {
     const scan = resolveDetectionScan(buildSubject({ present: false }), { family: 'presence_sweep' })
 
     expect(

--- a/src/test/revealPayloadOrchestration.test.ts
+++ b/src/test/revealPayloadOrchestration.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
 import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
-import { appendDetectionScanResolutionReason } from '../domain/detectionScanReportNotes'
+import {
+  appendDetectionScanResolutionReason,
+  DETECTION_SCAN_READOUT_PREFIX,
+} from '../domain/detectionScanReportNotes'
 import {
   buildDisguiseRevealSubjectFromCase,
   detectionScanTierOrder,
@@ -159,7 +162,7 @@ describe('revealPayloadOrchestration (SPE-781 slice 4)', () => {
 
     const activeReasons: string[] = []
     appendDetectionScanResolutionReason(activeReasons, mismatched.behaviorValidation)
-    expect(activeReasons.some((reason) => reason.includes('Detection readout:'))).toBe(true)
+    expect(activeReasons.some((reason) => reason.includes(DETECTION_SCAN_READOUT_PREFIX))).toBe(true)
   })
 
   it('falls back to infiltration contact when cover role is invalid', () => {

--- a/src/test/revealPayloadOrchestration.test.ts
+++ b/src/test/revealPayloadOrchestration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
 import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
+import { appendDetectionScanResolutionReason } from '../domain/detectionScanReportNotes'
 import {
   buildDisguiseRevealSubjectFromCase,
   detectionScanTierOrder,
@@ -151,6 +152,14 @@ describe('revealPayloadOrchestration (SPE-781 slice 4)', () => {
 
     expect(detectionScanTierOrder(mismatched.behaviorValidation!.detectionScan)).toContain('category')
     expect(detectionScanTierOrder(inactive.behaviorValidation!.detectionScan)).toEqual(['presence'])
+
+    const inactiveReasons: string[] = []
+    appendDetectionScanResolutionReason(inactiveReasons, inactive.behaviorValidation)
+    expect(inactiveReasons).toHaveLength(0)
+
+    const activeReasons: string[] = []
+    appendDetectionScanResolutionReason(activeReasons, mismatched.behaviorValidation)
+    expect(activeReasons.some((reason) => reason.includes('Detection readout:'))).toBe(true)
   })
 
   it('falls back to infiltration contact when cover role is invalid', () => {


### PR DESCRIPTION
## Summary
- Add `detectionScanReportNotes.ts` formatters that turn `behaviorValidation.detectionScan` into player-facing weekly report copy.
- Wire `appendDetectionScanResolutionReason` into `advanceWeek` `resolveAssignments` so mission `explanationNotes` include tiered scan readouts alongside legacy behavior-validation text.
- Add slice plan doc and tests; slice 4 follow-up marked shipped.

## Linear
- **Slice issue:** [SPE-2254](https://linear.app/spectranoir/issue/SPE-2254)
- **Parent:** [SPE-781](https://linear.app/spectranoir/issue/SPE-781)

## Test plan
- [x] Targeted tests (detectionScanReportNotes, advanceWeek.behaviorValidation, revealPayloadOrchestration)
- [x] `npm run lint`
- [x] `npm run test:run` (full suite)