### PR TITLE
feat(SPE-2255): mission triage covert prep row signals

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -30,9 +30,9 @@ From `README.md` **Current design notes**:
 | **Tuning and QA references** | Infiltration/concealment tuning reference, QA matrix, edge-case §12.6–12.9, integration Scenario F. **SPE-25 calibration pass (May 2026):** MVP harness confirms current probe/action deltas — no constant changes; anchor `src/test/weeklyMvpLoopProof.calibration.test.ts`. |
 | **MVP loop proof (#6)** | Slice 1 (`SPE-2251`) + slice 2 persistence/4-week fixture (`weeklyMvpLoopProof.slice2.integration.test.ts`). |
 
-## Deferred UX (pick up when triage UI is next)
+## Deferred UX (follow-up after SPE-2255)
 
-- **`ux/mission-triage.md`** — covert prep row signals, leave-behind staging hints, deferral vs batch-4 flag UX (spec status block lists scope).
+- **`ux/mission-triage.md`** — comparison columns for infiltration prep cost vs deferral risk; escalation carryover cross-links; full triage layout refresh (list-row chips shipped SPE-2255 / `planning/mission-triage-covert-prep-slice.md`).
 
 ## SCP-9995 harvest — May 2026 reconciliation
 

--- a/planning/mission-triage-covert-prep-slice.md
+++ b/planning/mission-triage-covert-prep-slice.md
@@ -1,0 +1,139 @@
+# SPE-2255 slice — Mission triage covert-prep row signals (UI)
+
+One-page implementation plan. Linear: [SPE-2255 — Mission triage covert prep row signals (slice 1 UX)](https://linear.app/spectranoir/issue/SPE-2255/mission-triage-covert-prep-row-signals-slice-1-ux). Parent: [SPE-16 — Mission Intake, Triage, & Routing](https://linear.app/spectranoir/issue/SPE-16/mission-intake-triage-and-routing). Spec: `ux/mission-triage.md` (deferred block, May 2026).
+
+## Why this is next
+
+| Shipped | Gap |
+| --- | --- |
+| Covert prep panels on case detail (`WeeklyCasePrepPanel`, SPE-70 / SPE-521 / SPE-626 / SPE-2247) | Player must open each case to see covert posture before prioritizing the week |
+| `triageMission` + `CasesPage` urgency markers (deadline, stage, roles) | No list-row signals for concealment preview, infiltration strain, leave-behind staging, or forensic custody pressure |
+| Operations report + navigation map for batch-4 covert notes | Triage list still omits deferral vs covert-prep tradeoffs at scan time |
+
+**Backlog alignment:** `planning/backlog.md` Deferred UX — mission triage covert-prep surfacing. Closes the May 2026 covert-ops prep arc at the **decision surface** (`CasesPage`), not case detail.
+
+## Goal
+
+On the **mission triage list** (`CasesPage`), show compact read-only chips per case so the player can scan:
+
+1. **Concealment** — eligible posture, preview activation, or active `conceal.case.*` request.
+2. **Infiltration** — probe / awareness summary when a probe plan applies.
+3. **Leave-behind** — staged selection or tradeoff pending before `advanceWeek`.
+4. **Forensic strain** — low remaining budget or custody markers from prior leave-behind fallout.
+5. **Deferral hint** (optional slice-1b) — one line tying `triageMission` escalation dimension to infiltration strain when both apply.
+
+Reuse existing view builders and `triageMission`; no new persistence shapes or store actions.
+
+## Non-goals
+
+- Full `ux/mission-triage.md` layout (filters/tabs/split detail panel/footer)
+- New domain simulation for covert mechanics
+- Player actions from the list (toggle conceal flag, probe override, ask questions) — case detail only
+- Contracts/leads hub unification beyond existing `CasesPage` scope
+- SPE-70 full hidden-modality matrix or SPE-781 extensions
+
+## Domain / view reuse (read-only)
+
+```ts
+// Already shipped — compose in a thin list helper
+buildWeeklyCasePrepView(caseData, game)
+buildConcealmentCasePrepView(caseData, game)
+buildInfiltrationCasePrepView(caseData)
+buildStealthLeaveBehindSelectionView(caseData, game)
+buildInvestigationCasePrepView(caseData, game)
+
+// Deferral / priority context
+triageMission(state, caseData) // priority band, dimensions, reasonCodes
+```
+
+### New view module
+
+```ts
+// src/features/cases/missionTriageCovertPrepView.ts
+
+export interface MissionTriageCovertPrepMarker {
+  readonly id: string
+  readonly label: string
+  readonly className: string
+  readonly title?: string
+}
+
+export interface MissionTriageCovertPrepSignals {
+  readonly visible: boolean
+  readonly markers: readonly MissionTriageCovertPrepMarker[]
+  readonly deferralNote?: string
+}
+
+export function buildMissionTriageCovertPrepSignals(
+  caseData: CaseInstance,
+  game: GameState
+): MissionTriageCovertPrepSignals
+```
+
+**Eligibility:** `caseData.status === 'in_progress'` for actionable covert chips. Resolved / open cases: `visible: false`. Already `hiddenState` set: concealment toggle chips hidden; optional read-only “Concealed” chip only if product wants one-liner (prefer hide for slice 1).
+
+### Label mapping (humanized, short)
+
+| Source | Example chip |
+| --- | --- |
+| `concealment.previewApplied` + `previewReasonLabel` | “Covert next week” |
+| `concealment.playerConcealFlagActive` | “Covert requested” |
+| `infiltration.probeProgressPercent` / `awarenessPercent` | “Probe 42% · awareness 61%” |
+| `infiltration.coverStrainNotes[0]` (if any) | “Cover strain” (tooltip = note) |
+| `stealthLeaveBehind` selection pending | “Leave-behind staged” |
+| custody markers or (`forensic.granted > 0` and `remaining === 0`) | “Forensic strain” |
+| `triage.dimensions.escalationRisk` high + infiltration visible | deferralNote one-liner |
+
+## UI (minimal)
+
+| Surface | Content |
+| --- | --- |
+| `CasesPage` list row | Extend marker strip beside existing `getUrgencyMarkers` output |
+| Chip styling | Reuse urgency marker pattern (`rounded-full border px-2 py-0.5 text-[11px]`) with distinct tones per category |
+| Compare panel (if open) | Optional `deferralNote` under recommendation block |
+
+Wire via `getCaseListItemView` → add `covertPrepSignals` field, or compute in page from `buildMissionTriageCovertPrepSignals` (prefer view on `CaseListItemView` for tests).
+
+## Tests (TDD order)
+
+1. `missionTriageCovertPrepView.test.ts` — hidden for open/resolved; concealment chip when preview applied; infiltration chip when probe plan present; leave-behind chip when selection staged; forensic chip when custody burden
+2. `CasesPage.test.tsx` — list row renders covert chips on tuned fixtures (extend or mirror `renders urgency markers for triage cases`)
+3. Regression — `weeklyCasePrepView.test.ts`, `concealmentCasePrepView.test.ts`, `infiltrationCasePrepView.test.ts` unchanged
+
+## Acceptance criteria
+
+- [x] In-progress concealment-eligible case shows at least one covert chip on `/cases` without opening case detail
+- [x] Infiltration-tagged in-progress case shows probe/awareness summary chip
+- [x] Staged leave-behind or zero forensic remaining surfaces on list row
+- [x] Resolved and non-eligible cases show no covert chips
+- [x] `npm run lint` + `npm run test:run` green
+- [x] `ux/mission-triage.md` spec status updated; slice linked from `planning/backlog.md` Deferred UX
+
+## File touch list (expected)
+
+| Area | Files |
+| --- | --- |
+| View | `src/features/cases/missionTriageCovertPrepView.ts` |
+| List view | `src/features/cases/caseView.ts` |
+| UI | `src/features/cases/CasesPage.tsx` |
+| Tests | `src/test/missionTriageCovertPrepView.test.ts`, `src/features/cases/CasesPage.test.tsx` |
+| Docs | `ux/mission-triage.md`, `planning/backlog.md` |
+
+## Risks
+
+- **Marker clutter:** cap at 4 chips; prefer highest-signal (concealment preview > infiltration awareness > leave-behind > forensic)
+- **Preview drift:** concealment preview must use same `globalFlags` source as `buildConcealmentCasePrepView` (already matches `advanceWeek`)
+- **False positives:** gate infiltration chips on `isInfiltrationProbeEligible` / `infiltrationCasePrepView.visible`
+
+## Branch
+
+`spe-16-mission-triage-covert-prep-slice-1`
+
+## See also
+
+- `ux/mission-triage.md` — deferred covert-prep block
+- `src/features/cases/weeklyCasePrepView.ts`
+- `planning/concealment-case-prep-slice.md`
+- `planning/infiltration-case-prep-slice.md`
+- `planning/investigation-question-case-prep-slice.md`
+- `src/domain/missionIntakeRouting.ts` — `triageMission`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -482,6 +482,49 @@ export const CASE_UI_LABELS: Record<string, string> = {
 }
 
 /**
+ * Mission triage list covert-prep chip labels (SPE-2255).
+ */
+export const MISSION_TRIAGE_COVERT_PREP_LABELS = {
+  concealmentRequested: 'Covert requested',
+  concealmentPreview: 'Covert next week',
+  coverStrain: 'Cover strain',
+  leaveBehindStaged: 'Leave-behind staged',
+  forensicStrain: 'Forensic strain',
+  deferralNote:
+    'Deferring may let infiltration exposure escalate before you can prep covert follow-up on case detail.',
+} as const
+
+export function formatMissionTriageInfiltrationTracksLabel(
+  probeProgressPercent: number,
+  awarenessPercent: number
+): string {
+  return `Probe ${probeProgressPercent}% · awareness ${awarenessPercent}%`
+}
+
+export function formatMissionTriageInfiltrationTracksTitle(
+  stageLabel: string,
+  plannedActionLabel: string
+): string {
+  return `${stageLabel} · planned ${plannedActionLabel}`
+}
+
+export function formatMissionTriageForensicCustodyTitle(
+  markerCount: number,
+  remainingQuestions: number
+): string {
+  const markerWord = markerCount === 1 ? 'marker' : 'markers'
+  const questionWord = remainingQuestions === 1 ? 'question' : 'questions'
+  return `${markerCount} custody ${markerWord}; ${remainingQuestions} forensic ${questionWord} left`
+}
+
+export function formatMissionTriageForensicBudgetExhaustedTitle(
+  spent: number,
+  granted: number
+): string {
+  return `Forensic budget exhausted (${spent}/${granted})`
+}
+
+/**
  * Agency-themed labels used across operational views.
  */
 export const AGENCY_LABELS: Record<string, string> = {

--- a/src/domain/missionIntakeRouting.ts
+++ b/src/domain/missionIntakeRouting.ts
@@ -245,6 +245,17 @@ export function triageMission(state: GameState, currentCase: CaseInstance): Miss
   }
 }
 
+/** Matches `escalation-high` reason code banding in {@link triageMission}. */
+export function hasHighMissionEscalationRisk(currentCase: CaseInstance): boolean {
+  const escalationRisk = clampInteger(
+    currentCase.stage * 6 + (currentCase.kind === 'raid' ? 8 : 0),
+    0,
+    20
+  )
+
+  return escalationRisk >= 14
+}
+
 export interface MissionTeamRoutingCandidate {
   teamId: Id
   valid: boolean

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -5,7 +5,10 @@ import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-rou
 import userEvent from '@testing-library/user-event'
 import { useGameStore } from '../../app/store/gameStore'
 import { createStartingState } from '../../data/startingState'
+import { copyInfiltrationProbePlan } from '../../domain/infiltrationProbe'
 import type { CaseInstance } from '../../domain/models'
+import { caseTemplateMap } from '../../domain/templates/caseTemplates'
+import { createStarterCase } from '../../domain/templates/startingCases'
 import CasesPage from './CasesPage'
 
 function LocationProbe() {
@@ -146,6 +149,67 @@ it('renders urgency markers for triage cases', () => {
 
   const idleCard = getCardByName('Unassigned Case')
   expect(within(idleCard).getByText('Unassigned')).toBeInTheDocument()
+})
+
+it('renders covert prep markers on triage list rows', () => {
+  const game = createStartingState()
+  game.cases = {
+    covert: {
+      ...createStarterCase({ id: 'covert', templateId: 'ops-004' }),
+      status: 'in_progress',
+      title: 'Covert Infiltration Case',
+      stage: 4,
+      hiddenState: 'hidden',
+      infiltrationProbeProgress: 0.35,
+      infiltrationAwareness: 0.5,
+      infiltrationStage: 'probing',
+      tags: ['infiltration'],
+      infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+      infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
+      stealthLeaveBehindId: 'leave-behind:risk-discovery',
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    },
+    plain: makeCase('plain', 'Plain Open Case', { status: 'open' }),
+  }
+
+  useGameStore.setState({ game })
+
+  renderCasesPage(['/cases'])
+
+  const covertCard = getCardByName('Covert Infiltration Case')
+  expect(within(covertCard).getByText(/Probe 35%/)).toBeInTheDocument()
+  expect(within(covertCard).getByText(/awareness 50%/)).toBeInTheDocument()
+  expect(within(covertCard).getByText('Leave-behind staged')).toBeInTheDocument()
+  expect(
+    within(covertCard).getAllByText(/Deferring may let infiltration exposure escalate/i)
+  ).toHaveLength(1)
+
+  const plainCard = getCardByName('Plain Open Case')
+  expect(within(plainCard).queryByText('Leave-behind staged')).not.toBeInTheDocument()
+  expect(within(plainCard).queryByText(/Probe \d+%/)).not.toBeInTheDocument()
+})
+
+it('renders concealment prep chip on triage list rows', () => {
+  const game = createStartingState()
+  game.cases = {
+    conceal: {
+      ...createStarterCase({ id: 'conceal', templateId: 'ops-003' }),
+      status: 'in_progress',
+      title: 'Covert Preview Case',
+      tags: ['infiltration'],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    },
+  }
+
+  useGameStore.setState({ game })
+
+  renderCasesPage(['/cases'])
+
+  expect(within(getCardByName('Covert Preview Case')).getByText('Covert next week')).toBeInTheDocument()
 })
 
 it('renders recommended action guidance for assignable cases', () => {

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -153,6 +153,7 @@ it('renders urgency markers for triage cases', () => {
 
 it('renders covert prep markers on triage list rows', () => {
   const game = createStartingState()
+  const assignedTeamId = Object.keys(game.teams)[0]!
   game.cases = {
     covert: {
       ...createStarterCase({ id: 'covert', templateId: 'ops-004' }),
@@ -163,13 +164,13 @@ it('renders covert prep markers on triage list rows', () => {
       infiltrationProbeProgress: 0.35,
       infiltrationAwareness: 0.5,
       infiltrationStage: 'probing',
-      tags: ['infiltration'],
+      tags: ['infiltration', 'media', 'public'],
       infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
       infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
       stealthLeaveBehindId: 'leave-behind:risk-discovery',
       requiredTags: [],
       preferredTags: [],
-      assignedTeamIds: [],
+      assignedTeamIds: [assignedTeamId],
     },
     plain: makeCase('plain', 'Plain Open Case', { status: 'open' }),
   }
@@ -181,10 +182,14 @@ it('renders covert prep markers on triage list rows', () => {
   const covertCard = getCardByName('Covert Infiltration Case')
   expect(within(covertCard).getByText(/Probe 35%/)).toBeInTheDocument()
   expect(within(covertCard).getByText(/awareness 50%/)).toBeInTheDocument()
-  expect(within(covertCard).getByText('Leave-behind staged')).toBeInTheDocument()
+  expect(within(covertCard).getByText('Cover strain')).toBeInTheDocument()
+  expect(within(covertCard).queryByText('Leave-behind staged')).not.toBeInTheDocument()
   expect(
     within(covertCard).getAllByText(/Deferring may let infiltration exposure escalate/i)
   ).toHaveLength(1)
+
+  const markerRegion = within(covertCard).getByLabelText('Case triage markers')
+  expect(markerRegion.querySelectorAll('span').length).toBe(4)
 
   const plainCard = getCardByName('Plain Open Case')
   expect(within(plainCard).queryByText('Leave-behind staged')).not.toBeInTheDocument()

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -89,7 +89,7 @@ export default function CasesPage() {
     }
   }, [normalizedSearchString, searchParamsString, setSearchParams])
 
-  const cases = getFilteredCaseViews(game, filters)
+  const cases = getFilteredCaseViews(game, filters, { includeCovertPrepSignals: true })
   const totalCases = Object.keys(game.cases).length
 
   function updateFilters(nextFilters: CaseListFilters) {
@@ -873,14 +873,24 @@ export default function CasesPage() {
   )
 }
 
+const MAX_LIST_ROW_MARKERS = 4
+
 function getListRowMarkers(view: CaseListItemView) {
   const markers: Array<{ key: string; label: string; className: string; title?: string }> = []
 
   for (const marker of getUrgencyMarkers(view)) {
+    if (markers.length >= MAX_LIST_ROW_MARKERS) {
+      break
+    }
+
     markers.push({ key: `urgency:${marker.label}`, ...marker })
   }
 
   for (const marker of view.covertPrepSignals.markers) {
+    if (markers.length >= MAX_LIST_ROW_MARKERS) {
+      break
+    }
+
     markers.push({
       key: marker.id,
       label: marker.label,

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -484,7 +484,7 @@ export default function CasesPage() {
           {cases.map((view) => {
             const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${querySuffix}`
             const intelHref = APP_ROUTES.intelDetail(view.currentCase.templateId)
-            const urgencyMarkers = getUrgencyMarkers(view)
+            const listRowMarkers = getListRowMarkers(view)
             const incidentStrategy =
               majorIncidentStrategyState[view.currentCase.id] ??
               view.currentCase.majorIncident?.strategy ??
@@ -552,17 +552,22 @@ export default function CasesPage() {
                   </span>
                 </div>
 
-                {urgencyMarkers.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {urgencyMarkers.map((marker) => (
+                {listRowMarkers.length > 0 ? (
+                  <div className="flex flex-wrap gap-2" aria-label="Case triage markers">
+                    {listRowMarkers.map((marker) => (
                       <span
-                        key={marker.label}
+                        key={marker.key}
+                        title={marker.title}
                         className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${marker.className}`}
                       >
                         {marker.label}
                       </span>
                     ))}
                   </div>
+                ) : null}
+
+                {view.covertPrepSignals.deferralNote && !recommendation ? (
+                  <p className="text-xs text-amber-200/90">{view.covertPrepSignals.deferralNote}</p>
                 ) : null}
 
                 {recommendation ? (
@@ -572,6 +577,9 @@ export default function CasesPage() {
                     </p>
                     <p className="mt-1 text-sm font-medium">{recommendation.title}</p>
                     <p className="text-xs opacity-70">{recommendation.detail}</p>
+                    {view.covertPrepSignals.deferralNote ? (
+                      <p className="mt-2 text-xs text-amber-200/90">{view.covertPrepSignals.deferralNote}</p>
+                    ) : null}
                   </div>
                 ) : null}
 
@@ -863,6 +871,25 @@ export default function CasesPage() {
       )}
     </section>
   )
+}
+
+function getListRowMarkers(view: CaseListItemView) {
+  const markers: Array<{ key: string; label: string; className: string; title?: string }> = []
+
+  for (const marker of getUrgencyMarkers(view)) {
+    markers.push({ key: `urgency:${marker.label}`, ...marker })
+  }
+
+  for (const marker of view.covertPrepSignals.markers) {
+    markers.push({
+      key: marker.id,
+      label: marker.label,
+      className: marker.className,
+      title: marker.title,
+    })
+  }
+
+  return markers
 }
 
 function getUrgencyMarkers(view: CaseListItemView) {

--- a/src/features/cases/caseView.ts
+++ b/src/features/cases/caseView.ts
@@ -16,6 +16,10 @@ import {
 } from '../../domain/sim/resolve'
 import { isTeamBlockedByTraining } from '../../domain/sim/training'
 import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
+import {
+  buildMissionTriageCovertPrepSignals,
+  type MissionTriageCovertPrepSignals,
+} from './missionTriageCovertPrepView'
 
 export const CASE_STATUS_FILTERS = ['all', 'open', 'in_progress', 'resolved'] as const
 export const CASE_MODE_FILTERS = ['all', 'threshold', 'probability', 'deterministic'] as const
@@ -56,6 +60,7 @@ export interface CaseListItemView {
   isBlockedByRequiredRoles: boolean
   isBlockedByRequiredTags: boolean
   isRaidAtCapacity: boolean
+  covertPrepSignals: MissionTriageCovertPrepSignals
 }
 
 export const DEFAULT_CASE_LIST_FILTERS: CaseListFilters = {
@@ -181,6 +186,7 @@ export function getCaseListItemView(currentCase: CaseInstance, game: GameState):
     isBlockedByRequiredRoles,
     isBlockedByRequiredTags,
     isRaidAtCapacity,
+    covertPrepSignals: buildMissionTriageCovertPrepSignals(currentCase, game),
   }
 }
 

--- a/src/features/cases/caseView.ts
+++ b/src/features/cases/caseView.ts
@@ -72,7 +72,15 @@ export const DEFAULT_CASE_LIST_FILTERS: CaseListFilters = {
   risk: false,
 }
 
-export function getCaseListItemView(currentCase: CaseInstance, game: GameState): CaseListItemView {
+export interface CaseListItemViewOptions {
+  readonly includeCovertPrepSignals?: boolean
+}
+
+export function getCaseListItemView(
+  currentCase: CaseInstance,
+  game: GameState,
+  options?: CaseListItemViewOptions
+): CaseListItemView {
   const previewState = buildResolutionPreviewState(game)
   const isMajorIncident = isOperationalMajorIncidentCase(currentCase)
   const assignedTeams = currentCase.assignedTeamIds
@@ -186,13 +194,20 @@ export function getCaseListItemView(currentCase: CaseInstance, game: GameState):
     isBlockedByRequiredRoles,
     isBlockedByRequiredTags,
     isRaidAtCapacity,
-    covertPrepSignals: buildMissionTriageCovertPrepSignals(currentCase, game),
+    covertPrepSignals:
+      options?.includeCovertPrepSignals === true
+        ? buildMissionTriageCovertPrepSignals(currentCase, game)
+        : { visible: false, markers: [] },
   }
 }
 
-export function getFilteredCaseViews(game: GameState, filters: CaseListFilters) {
+export function getFilteredCaseViews(
+  game: GameState,
+  filters: CaseListFilters,
+  options?: CaseListItemViewOptions
+) {
   return Object.values(game.cases)
-    .map((currentCase) => getCaseListItemView(currentCase, game))
+    .map((currentCase) => getCaseListItemView(currentCase, game, options))
     .filter((view) => matchesCaseFilters(view, filters))
     .sort((left, right) => compareCaseViews(left, right, filters.sort))
 }

--- a/src/features/cases/infiltrationCasePrepView.ts
+++ b/src/features/cases/infiltrationCasePrepView.ts
@@ -56,6 +56,7 @@ export interface InfiltrationCasePrepView {
   readonly documentTier?: number
   readonly doctrineBandPercent?: number
   readonly coverStrainNotes: readonly string[]
+  readonly hasCoverStrain: boolean
   readonly plannedAction: InfiltrationProbeAction
   readonly plannedActionLabel: string
   readonly overrideAction?: InfiltrationProbeAction
@@ -74,6 +75,15 @@ function formatPercent(value: number) {
   return Math.round(value * 100)
 }
 
+function resolveCoverRoleMismatch(caseData: CaseInstance) {
+  const profile = caseData.infiltrationCoverProfile
+  if (profile === undefined) {
+    return { hasRoleMismatch: false, hasExtraRouteViolation: false }
+  }
+
+  return evaluateCoverRoleMismatchPressure(caseData, profile.claimedRole)
+}
+
 function buildCoverStrainNotes(caseData: CaseInstance): string[] {
   const profile = caseData.infiltrationCoverProfile
   if (profile === undefined) {
@@ -81,7 +91,7 @@ function buildCoverStrainNotes(caseData: CaseInstance): string[] {
   }
 
   const notes: string[] = []
-  const mismatch = evaluateCoverRoleMismatchPressure(caseData, profile.claimedRole)
+  const mismatch = resolveCoverRoleMismatch(caseData)
 
   if (mismatch.hasRoleMismatch) {
     notes.push(`Claimed ${COVER_ROLE_LABELS[profile.claimedRole]} clashes with site tags.`)
@@ -120,6 +130,7 @@ export function buildInfiltrationCasePrepView(caseData: CaseInstance): Infiltrat
       stageLabel: INFILTRATION_STAGE_LABELS.probing,
       awarenessComplicationBandPercent: formatPercent(AWARENESS_COMPLICATION_THRESHOLD),
       coverStrainNotes: [],
+      hasCoverStrain: false,
       plannedAction: 'probe_access',
       plannedActionLabel: INFILTRATION_PROBE_ACTION_LABELS.probe_access,
       effectiveAction: 'probe_access',
@@ -146,6 +157,10 @@ export function buildInfiltrationCasePrepView(caseData: CaseInstance): Infiltrat
     documentTier: profile?.documentTier,
     doctrineBandPercent: profile?.doctrineBand !== undefined ? formatPercent(profile.doctrineBand) : undefined,
     coverStrainNotes: buildCoverStrainNotes(caseData),
+    hasCoverStrain: (() => {
+      const mismatch = resolveCoverRoleMismatch(caseData)
+      return mismatch.hasRoleMismatch || mismatch.hasExtraRouteViolation
+    })(),
     plannedAction,
     plannedActionLabel: INFILTRATION_PROBE_ACTION_LABELS[plannedAction],
     overrideAction,

--- a/src/features/cases/missionTriageCovertPrepView.ts
+++ b/src/features/cases/missionTriageCovertPrepView.ts
@@ -1,4 +1,4 @@
-import { triageMission } from '../../domain/missionIntakeRouting'
+import { hasHighMissionEscalationRisk } from '../../domain/missionIntakeRouting'
 import type { CaseInstance, GameState } from '../../domain/models'
 import {
   formatMissionTriageForensicBudgetExhaustedTitle,
@@ -19,7 +19,6 @@ import {
 import { buildStealthLeaveBehindSelectionView } from './stealthLeaveBehindSelectionView'
 
 const MAX_COVER_MARKERS = 4
-const HIGH_ESCALATION_RISK_THRESHOLD = 14
 
 const MARKER_STYLES = {
   concealment: 'border-violet-500/40 bg-violet-500/10 text-violet-100',
@@ -151,11 +150,8 @@ export function buildMissionTriageCovertPrepSignals(
   }
 
   let deferralNote: string | undefined
-  if (infiltration?.visible) {
-    const triage = triageMission(game, resolvedCase)
-    if (triage.dimensions.escalationRisk >= HIGH_ESCALATION_RISK_THRESHOLD) {
-      deferralNote = MISSION_TRIAGE_COVERT_PREP_LABELS.deferralNote
-    }
+  if (infiltration?.visible && hasHighMissionEscalationRisk(resolvedCase)) {
+    deferralNote = MISSION_TRIAGE_COVERT_PREP_LABELS.deferralNote
   }
 
   return {

--- a/src/features/cases/missionTriageCovertPrepView.ts
+++ b/src/features/cases/missionTriageCovertPrepView.ts
@@ -1,0 +1,157 @@
+import { triageMission } from '../../domain/missionIntakeRouting'
+import type { CaseInstance, GameState } from '../../domain/models'
+import { buildConcealmentCasePrepView } from './concealmentCasePrepView'
+import {
+  buildInfiltrationCasePrepView,
+  canShowInfiltrationCasePrepOnCase,
+} from './infiltrationCasePrepView'
+import {
+  buildInvestigationCasePrepView,
+  canShowInvestigationCasePrepOnCase,
+} from './investigationCasePrepView'
+import { buildStealthLeaveBehindSelectionView } from './stealthLeaveBehindSelectionView'
+
+const MAX_COVER_MARKERS = 4
+const HIGH_ESCALATION_RISK_THRESHOLD = 14
+
+const MARKER_STYLES = {
+  concealment: 'border-violet-500/40 bg-violet-500/10 text-violet-100',
+  infiltration: 'border-sky-500/40 bg-sky-500/10 text-sky-100',
+  leaveBehind: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100',
+  forensic: 'border-amber-600/40 bg-amber-600/10 text-amber-100',
+  coverStrain: 'border-orange-500/40 bg-orange-500/10 text-orange-100',
+} as const
+
+export interface MissionTriageCovertPrepMarker {
+  readonly id: string
+  readonly label: string
+  readonly className: string
+  readonly title?: string
+}
+
+export interface MissionTriageCovertPrepSignals {
+  readonly visible: boolean
+  readonly markers: readonly MissionTriageCovertPrepMarker[]
+  readonly deferralNote?: string
+}
+
+function hasCoverStrain(infiltration: ReturnType<typeof buildInfiltrationCasePrepView>) {
+  const note = infiltration.coverStrainNotes[0]
+  if (note === undefined) {
+    return false
+  }
+
+  return !note.toLowerCase().includes('stable')
+}
+
+function pushMarker(
+  markers: MissionTriageCovertPrepMarker[],
+  marker: MissionTriageCovertPrepMarker
+) {
+  if (markers.length >= MAX_COVER_MARKERS) {
+    return
+  }
+
+  markers.push(marker)
+}
+
+export function buildMissionTriageCovertPrepSignals(
+  caseData: CaseInstance,
+  game: GameState
+): MissionTriageCovertPrepSignals {
+  const resolvedCase = game.cases[caseData.id] ?? caseData
+
+  if (resolvedCase.status !== 'in_progress') {
+    return { visible: false, markers: [] }
+  }
+  const markers: MissionTriageCovertPrepMarker[] = []
+  const concealment =
+    resolvedCase.hiddenState === undefined
+      ? buildConcealmentCasePrepView(resolvedCase, game)
+      : null
+  const infiltration = canShowInfiltrationCasePrepOnCase(resolvedCase)
+    ? buildInfiltrationCasePrepView(resolvedCase)
+    : null
+  const leaveBehind = buildStealthLeaveBehindSelectionView(resolvedCase, game)
+  const investigation = canShowInvestigationCasePrepOnCase(resolvedCase)
+    ? buildInvestigationCasePrepView(resolvedCase, game)
+    : null
+
+  if (concealment?.visible) {
+    if (concealment.playerConcealFlagActive) {
+      pushMarker(markers, {
+        id: 'concealment-requested',
+        label: 'Covert requested',
+        className: MARKER_STYLES.concealment,
+        title: concealment.previewReasonLabel,
+      })
+    } else if (concealment.previewApplied) {
+      pushMarker(markers, {
+        id: 'concealment-preview',
+        label: 'Covert next week',
+        className: MARKER_STYLES.concealment,
+        title: concealment.previewReasonLabel,
+      })
+    }
+  }
+
+  if (infiltration?.visible) {
+    pushMarker(markers, {
+      id: 'infiltration-tracks',
+      label: `Probe ${infiltration.probeProgressPercent}% · awareness ${infiltration.awarenessPercent}%`,
+      className: MARKER_STYLES.infiltration,
+      title: `${infiltration.stageLabel} · planned ${infiltration.plannedActionLabel}`,
+    })
+
+    if (hasCoverStrain(infiltration)) {
+      pushMarker(markers, {
+        id: 'infiltration-cover-strain',
+        label: 'Cover strain',
+        className: MARKER_STYLES.coverStrain,
+        title: infiltration.coverStrainNotes[0],
+      })
+    }
+  }
+
+  if (leaveBehind.visible && leaveBehind.selectedLeaveBehindId !== undefined) {
+    pushMarker(markers, {
+      id: 'leave-behind-staged',
+      label: 'Leave-behind staged',
+      className: MARKER_STYLES.leaveBehind,
+    })
+  }
+
+  if (investigation?.visible) {
+    const forensicBudget = investigation.forensic.budget
+    const forensicStrain =
+      investigation.custodyMarkers.length > 0 ||
+      (forensicBudget.granted > 0 && forensicBudget.remaining === 0)
+
+    if (forensicStrain) {
+      pushMarker(markers, {
+        id: 'forensic-strain',
+        label: 'Forensic strain',
+        className: MARKER_STYLES.forensic,
+        title:
+          investigation.custodyMarkers.length > 0
+            ? `${investigation.custodyMarkers.length} custody marker(s); ${forensicBudget.remaining} forensic question(s) left`
+            : `Forensic budget exhausted (${forensicBudget.spent}/${forensicBudget.granted})`,
+      })
+    }
+  }
+
+  let deferralNote: string | undefined
+  if (infiltration?.visible) {
+    const triage = triageMission(game, resolvedCase)
+    if (triage.dimensions.escalationRisk >= HIGH_ESCALATION_RISK_THRESHOLD) {
+      deferralNote =
+        'Deferring may let infiltration exposure escalate before you can prep covert follow-up on case detail.'
+    }
+  }
+
+  return {
+    visible: markers.length > 0 || deferralNote !== undefined,
+    markers,
+    deferralNote,
+  }
+}

--- a/src/features/cases/missionTriageCovertPrepView.ts
+++ b/src/features/cases/missionTriageCovertPrepView.ts
@@ -1,5 +1,12 @@
 import { triageMission } from '../../domain/missionIntakeRouting'
 import type { CaseInstance, GameState } from '../../domain/models'
+import {
+  formatMissionTriageForensicBudgetExhaustedTitle,
+  formatMissionTriageForensicCustodyTitle,
+  formatMissionTriageInfiltrationTracksLabel,
+  formatMissionTriageInfiltrationTracksTitle,
+  MISSION_TRIAGE_COVERT_PREP_LABELS,
+} from '../../data/copy'
 import { buildConcealmentCasePrepView } from './concealmentCasePrepView'
 import {
   buildInfiltrationCasePrepView,
@@ -33,15 +40,6 @@ export interface MissionTriageCovertPrepSignals {
   readonly visible: boolean
   readonly markers: readonly MissionTriageCovertPrepMarker[]
   readonly deferralNote?: string
-}
-
-function hasCoverStrain(infiltration: ReturnType<typeof buildInfiltrationCasePrepView>) {
-  const note = infiltration.coverStrainNotes[0]
-  if (note === undefined) {
-    return false
-  }
-
-  return !note.toLowerCase().includes('stable')
 }
 
 function pushMarker(
@@ -81,14 +79,14 @@ export function buildMissionTriageCovertPrepSignals(
     if (concealment.playerConcealFlagActive) {
       pushMarker(markers, {
         id: 'concealment-requested',
-        label: 'Covert requested',
+        label: MISSION_TRIAGE_COVERT_PREP_LABELS.concealmentRequested,
         className: MARKER_STYLES.concealment,
         title: concealment.previewReasonLabel,
       })
     } else if (concealment.previewApplied) {
       pushMarker(markers, {
         id: 'concealment-preview',
-        label: 'Covert next week',
+        label: MISSION_TRIAGE_COVERT_PREP_LABELS.concealmentPreview,
         className: MARKER_STYLES.concealment,
         title: concealment.previewReasonLabel,
       })
@@ -98,15 +96,21 @@ export function buildMissionTriageCovertPrepSignals(
   if (infiltration?.visible) {
     pushMarker(markers, {
       id: 'infiltration-tracks',
-      label: `Probe ${infiltration.probeProgressPercent}% · awareness ${infiltration.awarenessPercent}%`,
+      label: formatMissionTriageInfiltrationTracksLabel(
+        infiltration.probeProgressPercent,
+        infiltration.awarenessPercent
+      ),
       className: MARKER_STYLES.infiltration,
-      title: `${infiltration.stageLabel} · planned ${infiltration.plannedActionLabel}`,
+      title: formatMissionTriageInfiltrationTracksTitle(
+        infiltration.stageLabel,
+        infiltration.plannedActionLabel
+      ),
     })
 
-    if (hasCoverStrain(infiltration)) {
+    if (infiltration.hasCoverStrain) {
       pushMarker(markers, {
         id: 'infiltration-cover-strain',
-        label: 'Cover strain',
+        label: MISSION_TRIAGE_COVERT_PREP_LABELS.coverStrain,
         className: MARKER_STYLES.coverStrain,
         title: infiltration.coverStrainNotes[0],
       })
@@ -116,7 +120,7 @@ export function buildMissionTriageCovertPrepSignals(
   if (leaveBehind.visible && leaveBehind.selectedLeaveBehindId !== undefined) {
     pushMarker(markers, {
       id: 'leave-behind-staged',
-      label: 'Leave-behind staged',
+      label: MISSION_TRIAGE_COVERT_PREP_LABELS.leaveBehindStaged,
       className: MARKER_STYLES.leaveBehind,
     })
   }
@@ -130,12 +134,18 @@ export function buildMissionTriageCovertPrepSignals(
     if (forensicStrain) {
       pushMarker(markers, {
         id: 'forensic-strain',
-        label: 'Forensic strain',
+        label: MISSION_TRIAGE_COVERT_PREP_LABELS.forensicStrain,
         className: MARKER_STYLES.forensic,
         title:
           investigation.custodyMarkers.length > 0
-            ? `${investigation.custodyMarkers.length} custody marker(s); ${forensicBudget.remaining} forensic question(s) left`
-            : `Forensic budget exhausted (${forensicBudget.spent}/${forensicBudget.granted})`,
+            ? formatMissionTriageForensicCustodyTitle(
+                investigation.custodyMarkers.length,
+                forensicBudget.remaining
+              )
+            : formatMissionTriageForensicBudgetExhaustedTitle(
+                forensicBudget.spent,
+                forensicBudget.granted
+              ),
       })
     }
   }
@@ -144,8 +154,7 @@ export function buildMissionTriageCovertPrepSignals(
   if (infiltration?.visible) {
     const triage = triageMission(game, resolvedCase)
     if (triage.dimensions.escalationRisk >= HIGH_ESCALATION_RISK_THRESHOLD) {
-      deferralNote =
-        'Deferring may let infiltration exposure escalate before you can prep covert follow-up on case detail.'
+      deferralNote = MISSION_TRIAGE_COVERT_PREP_LABELS.deferralNote
     }
   }
 

--- a/src/test/infiltrationCasePrepView.test.ts
+++ b/src/test/infiltrationCasePrepView.test.ts
@@ -15,7 +15,7 @@ function createEligibleCase() {
     infiltrationProbeProgress: 0.35,
     infiltrationAwareness: 0.42,
     infiltrationStage: 'probing' as const,
-    tags: ['infiltration'],
+    tags: ['infiltration', 'media', 'public'],
     infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
     infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
     infiltrationWeeklyProbeActionOverride: 'probe_route' as const,
@@ -46,5 +46,6 @@ describe('infiltrationCasePrepView', () => {
     expect(view.effectiveAction).toBe('probe_route')
     expect(view.plannedAction).toBe('probe_access')
     expect(view.coverStrainNotes.length).toBeGreaterThan(0)
+    expect(view.hasCoverStrain).toBe(true)
   })
 })

--- a/src/test/missionTriageCovertPrepView.test.ts
+++ b/src/test/missionTriageCovertPrepView.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from 'vitest'
+import { copyInfiltrationProbePlan } from '../domain/infiltrationProbe'
+import {
+  applyStealthLeaveBehindInvestigationCustodyLoss,
+  buildInvestigationCustodyLossFlagId,
+} from '../domain/investigationCustodyLoss'
+import {
+  applySuccessfulInvestigation,
+  askInvestigationQuestion,
+  grantInvestigationQuestionBudget,
+} from '../domain/investigationEconomy'
+import { setPersistentFlag } from '../domain/flagSystem'
+import { buildConcealCaseFlagId } from '../domain/concealmentCasePrep'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { caseTemplateMap } from '../domain/templates/caseTemplates'
+import { createStartingState } from '../data/startingState'
+import { buildInvestigationCasePrepView } from '../features/cases/investigationCasePrepView'
+import { buildMissionTriageCovertPrepSignals } from '../features/cases/missionTriageCovertPrepView'
+
+function createConcealmentEligibleCase() {
+  return {
+    ...createStarterCase({ id: 'case-triage-conceal', templateId: 'ops-003' }),
+    status: 'in_progress' as const,
+    tags: ['infiltration'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+  }
+}
+
+function createInfiltrationCase() {
+  return {
+    ...createStarterCase({ id: 'case-triage-infiltration', templateId: 'ops-004' }),
+    status: 'in_progress' as const,
+    hiddenState: 'hidden' as const,
+    infiltrationProbeProgress: 0.42,
+    infiltrationAwareness: 0.61,
+    infiltrationStage: 'probing' as const,
+    tags: ['infiltration'],
+    infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+    infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+  }
+}
+
+describe('missionTriageCovertPrepView', () => {
+  it('is hidden for open and resolved cases', () => {
+    const inProgress = createConcealmentEligibleCase()
+    const open = { ...inProgress, status: 'open' as const }
+    const resolved = { ...inProgress, status: 'resolved' as const }
+    const game = createStartingState()
+
+    expect(buildMissionTriageCovertPrepSignals(open, game).visible).toBe(false)
+    expect(buildMissionTriageCovertPrepSignals(resolved, game).markers).toHaveLength(0)
+  })
+
+  it('uses canonical game status when case argument is stale', () => {
+    const game = createStartingState()
+    const caseData = createConcealmentEligibleCase()
+    game.cases[caseData.id] = { ...caseData, status: 'resolved' }
+
+    const signals = buildMissionTriageCovertPrepSignals(
+      { ...caseData, status: 'in_progress' },
+      game
+    )
+
+    expect(signals.visible).toBe(false)
+    expect(signals.markers).toHaveLength(0)
+  })
+
+  it('shows concealment preview chip for tag-eligible in-progress cases', () => {
+    const game = createStartingState()
+    const caseData = createConcealmentEligibleCase()
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(signals.markers.some((marker) => marker.label === 'Covert next week')).toBe(true)
+  })
+
+  it('shows covert requested chip when conceal flag is active', () => {
+    let state = createStartingState()
+    const caseData = createConcealmentEligibleCase({ tags: [] })
+    state.cases[caseData.id] = caseData
+    state = setPersistentFlag(state, buildConcealCaseFlagId(caseData.id), true)
+
+    const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, state)
+
+    expect(signals.markers.some((marker) => marker.label === 'Covert requested')).toBe(true)
+  })
+
+  it('shows infiltration probe and awareness chip when probe plan applies', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase()
+    game.cases[caseData.id] = caseData
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(signals.markers.some((marker) => marker.label.includes('Probe 42%'))).toBe(true)
+    expect(signals.markers.some((marker) => marker.label.includes('awareness 61%'))).toBe(true)
+  })
+
+  it('omits infiltration chips when case is not infiltration-eligible', () => {
+    const game = createStartingState()
+    const caseData = {
+      ...createConcealmentEligibleCase(),
+      hiddenState: undefined,
+    }
+    game.cases[caseData.id] = caseData
+
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(signals.markers.some((marker) => marker.id.startsWith('infiltration'))).toBe(false)
+  })
+
+  it('shows leave-behind staged chip when selection is set', () => {
+    const game = createStartingState()
+    const caseData = {
+      ...createInfiltrationCase(),
+      stealthLeaveBehindId: 'leave-behind:risk-discovery',
+    }
+    game.cases[caseData.id] = caseData
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(signals.markers.some((marker) => marker.label === 'Leave-behind staged')).toBe(true)
+  })
+
+  it('shows forensic strain when custody markers burden the case', () => {
+    let state = createStartingState()
+    const caseData = createInfiltrationCase()
+    state.cases[caseData.id] = caseData
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: caseData.id,
+      domain: 'forensic',
+      amount: 2,
+    })
+    const custodyResult = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: caseData.id,
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      leaveBehindKind: 'abandon_evidence',
+      leaveBehindLabel: 'Abandon compromised evidence',
+      custodyLossRefs: ['custody:field-packet'],
+      week: 1,
+    })
+    state = custodyResult.state
+
+    const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, state)
+
+    expect(signals.markers.some((marker) => marker.label === 'Forensic strain')).toBe(true)
+    expect(
+      state.runtimeState?.globalFlags?.[
+        buildInvestigationCustodyLossFlagId(caseData.id, 'custody:field-packet')
+      ]
+    ).toBeTruthy()
+  })
+
+  it('prefers covert requested chip over preview when both apply', () => {
+    let state = createStartingState()
+    const caseData = createConcealmentEligibleCase()
+    state.cases[caseData.id] = caseData
+    state = setPersistentFlag(state, buildConcealCaseFlagId(caseData.id), true)
+
+    const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, state)
+
+    expect(signals.markers.some((marker) => marker.label === 'Covert requested')).toBe(true)
+    expect(signals.markers.some((marker) => marker.label === 'Covert next week')).toBe(false)
+  })
+
+  it('shows forensic strain when granted budget is exhausted without custody markers', () => {
+    let state = createStartingState()
+    const caseData = {
+      ...createStarterCase({ id: 'case-triage-forensic', templateId: 'ops-003' }),
+      status: 'in_progress' as const,
+      hiddenState: 'hidden' as const,
+      detectionConfidence: 0.25,
+      counterDetection: false,
+      tags: ['infiltration', 'archive'],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    }
+    state.cases[caseData.id] = caseData
+    state = applySuccessfulInvestigation(state, {
+      caseId: caseData.id,
+      forensicBudget: 1,
+      tacticalBudget: 0,
+    })
+    const asked = askInvestigationQuestion(state, {
+      caseId: caseData.id,
+      domain: 'forensic',
+      questionId: 'forensic.present-signature',
+    })
+
+    expect(asked.applied).toBe(true)
+    expect(asked.remainingBudget).toBe(0)
+
+    const prep = buildInvestigationCasePrepView(state.cases[caseData.id]!, asked.state)
+    expect(prep.forensic.budget.granted).toBeGreaterThan(0)
+    expect(prep.forensic.budget.remaining).toBe(0)
+
+    const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, asked.state)
+
+    expect(signals.markers.map((marker) => marker.id)).toContain('forensic-strain')
+  })
+
+  it('does not show forensic strain without granted budget or custody markers', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase()
+    game.cases[caseData.id] = caseData
+
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(signals.markers.some((marker) => marker.label === 'Forensic strain')).toBe(false)
+  })
+
+  it('reads leave-behind selection from canonical game case state', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase()
+    game.cases[caseData.id] = {
+      ...caseData,
+      stealthLeaveBehindId: 'leave-behind:risk-discovery',
+    }
+
+    const signals = buildMissionTriageCovertPrepSignals(
+      { ...caseData, stealthLeaveBehindId: undefined },
+      game
+    )
+
+    expect(signals.markers.some((marker) => marker.label === 'Leave-behind staged')).toBe(true)
+  })
+
+  it('surfaces deferral note when infiltration strain coincides with high escalation risk', () => {
+    const game = createStartingState()
+    const caseData = {
+      ...createInfiltrationCase(),
+      stage: 4,
+      kind: 'raid' as const,
+      raid: { minTeams: 2, maxTeams: 2 },
+    }
+    game.cases[caseData.id] = caseData
+
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(signals.deferralNote).toContain('Deferring may let infiltration exposure escalate')
+  })
+
+  it('omits concealment chips when case is already concealed', () => {
+    const game = createStartingState()
+    const caseData = { ...createConcealmentEligibleCase(), hiddenState: 'hidden' as const }
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(signals.markers.some((marker) => marker.id.startsWith('concealment'))).toBe(false)
+  })
+
+  it('caps marker count at four', () => {
+    let state = createStartingState()
+    const caseData = {
+      ...createInfiltrationCase(),
+      stage: 4,
+      kind: 'raid' as const,
+      raid: { minTeams: 2, maxTeams: 2 },
+      stealthLeaveBehindId: 'leave-behind:risk-discovery',
+    }
+    state.cases[caseData.id] = caseData
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: caseData.id,
+      domain: 'forensic',
+      amount: 1,
+    })
+    const custodyResult = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: caseData.id,
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      leaveBehindKind: 'abandon_evidence',
+      leaveBehindLabel: 'Abandon compromised evidence',
+      custodyLossRefs: ['custody:field-packet', 'custody:chain-seal'],
+      week: 1,
+    })
+    state = custodyResult.state
+
+    const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, state)
+
+    expect(signals.markers.length).toBeLessThanOrEqual(4)
+  })
+})

--- a/src/test/missionTriageCovertPrepView.test.ts
+++ b/src/test/missionTriageCovertPrepView.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../domain/investigationEconomy'
 import { setPersistentFlag } from '../domain/flagSystem'
 import { buildConcealCaseFlagId } from '../domain/concealmentCasePrep'
+import type { CaseInstance } from '../domain/models'
 import { createStarterCase } from '../domain/templates/startingCases'
 import { caseTemplateMap } from '../domain/templates/caseTemplates'
 import { createStartingState } from '../data/startingState'
@@ -18,7 +19,7 @@ import { buildInvestigationCasePrepView } from '../features/cases/investigationC
 import { MISSION_TRIAGE_COVERT_PREP_LABELS } from '../data/copy'
 import { buildMissionTriageCovertPrepSignals } from '../features/cases/missionTriageCovertPrepView'
 
-function createConcealmentEligibleCase() {
+function createConcealmentEligibleCase(overrides: Partial<CaseInstance> = {}) {
   return {
     ...createStarterCase({ id: 'case-triage-conceal', templateId: 'ops-003' }),
     status: 'in_progress' as const,
@@ -26,6 +27,7 @@ function createConcealmentEligibleCase() {
     requiredTags: [],
     preferredTags: [],
     assignedTeamIds: [],
+    ...overrides,
   }
 }
 

--- a/src/test/missionTriageCovertPrepView.test.ts
+++ b/src/test/missionTriageCovertPrepView.test.ts
@@ -15,6 +15,7 @@ import { createStarterCase } from '../domain/templates/startingCases'
 import { caseTemplateMap } from '../domain/templates/caseTemplates'
 import { createStartingState } from '../data/startingState'
 import { buildInvestigationCasePrepView } from '../features/cases/investigationCasePrepView'
+import { MISSION_TRIAGE_COVERT_PREP_LABELS } from '../data/copy'
 import { buildMissionTriageCovertPrepSignals } from '../features/cases/missionTriageCovertPrepView'
 
 function createConcealmentEligibleCase() {
@@ -36,7 +37,7 @@ function createInfiltrationCase() {
     infiltrationProbeProgress: 0.42,
     infiltrationAwareness: 0.61,
     infiltrationStage: 'probing' as const,
-    tags: ['infiltration'],
+    tags: ['infiltration', 'media', 'public'],
     infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
     infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
     requiredTags: [],
@@ -75,7 +76,11 @@ describe('missionTriageCovertPrepView', () => {
     const caseData = createConcealmentEligibleCase()
     const signals = buildMissionTriageCovertPrepSignals(caseData, game)
 
-    expect(signals.markers.some((marker) => marker.label === 'Covert next week')).toBe(true)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.concealmentPreview
+      )
+    ).toBe(true)
   })
 
   it('shows covert requested chip when conceal flag is active', () => {
@@ -86,7 +91,24 @@ describe('missionTriageCovertPrepView', () => {
 
     const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, state)
 
-    expect(signals.markers.some((marker) => marker.label === 'Covert requested')).toBe(true)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.concealmentRequested
+      )
+    ).toBe(true)
+  })
+
+  it('shows cover strain chip when infiltration cover posture is strained', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase()
+    game.cases[caseData.id] = caseData
+    const signals = buildMissionTriageCovertPrepSignals(caseData, game)
+
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.coverStrain
+      )
+    ).toBe(true)
   })
 
   it('shows infiltration probe and awareness chip when probe plan applies', () => {
@@ -121,7 +143,11 @@ describe('missionTriageCovertPrepView', () => {
     game.cases[caseData.id] = caseData
     const signals = buildMissionTriageCovertPrepSignals(caseData, game)
 
-    expect(signals.markers.some((marker) => marker.label === 'Leave-behind staged')).toBe(true)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.leaveBehindStaged
+      )
+    ).toBe(true)
   })
 
   it('shows forensic strain when custody markers burden the case', () => {
@@ -146,7 +172,11 @@ describe('missionTriageCovertPrepView', () => {
 
     const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, state)
 
-    expect(signals.markers.some((marker) => marker.label === 'Forensic strain')).toBe(true)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.forensicStrain
+      )
+    ).toBe(true)
     expect(
       state.runtimeState?.globalFlags?.[
         buildInvestigationCustodyLossFlagId(caseData.id, 'custody:field-packet')
@@ -162,8 +192,16 @@ describe('missionTriageCovertPrepView', () => {
 
     const signals = buildMissionTriageCovertPrepSignals(state.cases[caseData.id]!, state)
 
-    expect(signals.markers.some((marker) => marker.label === 'Covert requested')).toBe(true)
-    expect(signals.markers.some((marker) => marker.label === 'Covert next week')).toBe(false)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.concealmentRequested
+      )
+    ).toBe(true)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.concealmentPreview
+      )
+    ).toBe(false)
   })
 
   it('shows forensic strain when granted budget is exhausted without custody markers', () => {
@@ -210,7 +248,11 @@ describe('missionTriageCovertPrepView', () => {
 
     const signals = buildMissionTriageCovertPrepSignals(caseData, game)
 
-    expect(signals.markers.some((marker) => marker.label === 'Forensic strain')).toBe(false)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.forensicStrain
+      )
+    ).toBe(false)
   })
 
   it('reads leave-behind selection from canonical game case state', () => {
@@ -226,7 +268,11 @@ describe('missionTriageCovertPrepView', () => {
       game
     )
 
-    expect(signals.markers.some((marker) => marker.label === 'Leave-behind staged')).toBe(true)
+    expect(
+      signals.markers.some(
+        (marker) => marker.label === MISSION_TRIAGE_COVERT_PREP_LABELS.leaveBehindStaged
+      )
+    ).toBe(true)
   })
 
   it('surfaces deferral note when infiltration strain coincides with high escalation risk', () => {
@@ -241,7 +287,7 @@ describe('missionTriageCovertPrepView', () => {
 
     const signals = buildMissionTriageCovertPrepSignals(caseData, game)
 
-    expect(signals.deferralNote).toContain('Deferring may let infiltration exposure escalate')
+    expect(signals.deferralNote).toBe(MISSION_TRIAGE_COVERT_PREP_LABELS.deferralNote)
   })
 
   it('omits concealment chips when case is already concealed', () => {

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -28,15 +28,15 @@ This spec is for:
 
 ## Spec status (May 2026)
 
-**Partial refresh shipped elsewhere:** batch-4 covert operations surfacing (concealment activation, infiltration report note types, leave-behind tradeoff copy, report week prev/next) is specified in `ux/operations-report.md` §5.3.1 and `ux/navigation-map.md` §3.5.1–3.5.2. Weekly prep UI behavior lives in domain helpers and case prep views — not re-specified here yet.
+**Partial refresh shipped elsewhere:** batch-4 covert operations surfacing (concealment activation, infiltration report note types, leave-behind tradeoff copy, report week prev/next) is specified in `ux/operations-report.md` §5.3.1 and `ux/navigation-map.md` §3.5.1–3.5.2. Weekly prep UI behavior lives in domain helpers and case prep views on case detail.
 
-**Deferred until triage UI is next:**
+**Slice 1 shipped (SPE-2255):** `CasesPage` list rows show read-only covert-prep chips (concealment preview/request, infiltration probe/awareness, staged leave-behind, forensic strain) via `buildMissionTriageCovertPrepSignals`; optional deferral note when escalation risk is high during active infiltration. Plan: `planning/mission-triage-covert-prep-slice.md`.
 
-- triage row signals for hidden/concealment-eligible cases and staged leave-behind
-- comparison columns for infiltration prep cost vs deferral risk
+**Still deferred (follow-up slices):**
+
+- comparison columns for infiltration prep cost vs deferral risk (dedicated columns, not chips only)
 - cross-links from triage deferral to escalation carryover (see comparison table and escalation carryover risk rows below)
-
-Do not treat this document as stale for core prioritization UX; treat covert-prep surfacing as **out of scope** until the deferred block is picked up (`planning/backlog.md` item #4).
+- full triage layout refresh (filters/tabs/split detail panel per §3)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add read-only covert-ops prep chips on the CasesPage mission triage list (max 4 markers per row).
- Compose existing concealment, infiltration, leave-behind, and forensic prep signals via `buildMissionTriageCovertPrepSignals`; no new domain math.
- Show optional deferral note when infiltration escalation risk is high; update slice doc, backlog, and `ux/mission-triage.md`.

## Linear

- Slice: [SPE-2255](https://linear.app/spectranoir/issue/SPE-2255) (child of SPE-16)

## Test plan

- [x] `npm run lint`
- [x] `npm run test:run`
- [x] Targeted: `missionTriageCovertPrepView.test.ts`, `CasesPage.test.tsx` covert marker tests