### PR TITLE
feat(SPE-16): mission triage deferral comparison columns (slice 2 UX)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -32,7 +32,7 @@ From `README.md` **Current design notes**:
 
 ## Deferred UX (follow-up after SPE-2255)
 
-- **`ux/mission-triage.md`** — comparison columns for infiltration prep cost vs deferral risk; escalation carryover cross-links; full triage layout refresh (list-row chips shipped SPE-2255 / `planning/mission-triage-covert-prep-slice.md`).
+- **`ux/mission-triage.md`** — full triage layout refresh (filters/tabs/split detail panel); list-row chips + deferral compare columns shipped (SPE-2255 / slice 2 `planning/mission-triage-deferral-compare-slice.md`).
 
 ## SCP-9995 harvest — May 2026 reconciliation
 

--- a/planning/mission-triage-deferral-compare-slice.md
+++ b/planning/mission-triage-deferral-compare-slice.md
@@ -1,0 +1,26 @@
+# SPE-16 slice 2 — Mission triage deferral comparison columns (UX)
+
+One-page implementation plan. Parent: [SPE-16 — Mission Intake, Triage, & Routing](https://linear.app/spectranoir/issue/SPE-16/mission-intake-triage-and-routing). Follows [SPE-2255](https://linear.app/spectranoir/issue/SPE-2255) / `planning/mission-triage-covert-prep-slice.md`.
+
+## Goal
+
+On `CasesPage`, surface read-only **comparison columns** for infiltration/covert prep cost vs deferral/escalation risk vs escalation carryover — not chips only.
+
+## Non-goals
+
+- Full triage layout (filters/tabs/split panel/footer)
+- New simulation math or store actions
+- Major-incident rows
+
+## Acceptance
+
+- [x] In-progress eligible cases show 3-column compare table when covert or deferral signals apply
+- [x] Columns use `triageMission` + existing prep views (no duplicate chip text)
+- [x] Carryover cross-link when escalation-high or critical stage
+- [x] Hidden for operational major-incident raid profiles (same gate as covert chips)
+- [x] Covert prep detail matches strain source (infiltration vs forensic vs leave-behind vs concealment)
+- [x] Tests + lint + test:run green
+
+## Branch
+
+`spe-16-mission-triage-deferral-compare-slice-2`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -494,6 +494,75 @@ export const MISSION_TRIAGE_COVERT_PREP_LABELS = {
     'Deferring may let infiltration exposure escalate before you can prep covert follow-up on case detail.',
 } as const
 
+/** Mission triage deferral comparison columns (SPE-16 slice 2). */
+export const MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS = {
+  covertPrepCost: 'Covert prep load',
+  deferralRisk: 'If deferred',
+  escalationCarryover: 'Carryover',
+  covertPrepConcealmentDetail: 'Concealment or posture prep on case detail before advance week.',
+  covertPrepLeaveBehindDetail: 'Leave-behind staged; forensic fallout may compound next resolve.',
+  covertPrepForensicDetail: 'Forensic budget strained; investigation questions cost more before resolve.',
+  carryoverLinkLabel: 'Escalation carryover',
+  carryoverLinkDetail:
+    'Deferred work can worsen under escalation thresholds and incident pressure curves next week.',
+} as const
+
+const DEFERRAL_COMPARE_TONE_VALUES = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+} as const
+
+export function formatMissionTriageCovertPrepCostValue(
+  tone: keyof typeof DEFERRAL_COMPARE_TONE_VALUES
+): string {
+  return DEFERRAL_COMPARE_TONE_VALUES[tone]
+}
+
+export function formatMissionTriageCovertPrepCostDetail(
+  effectiveActionLabel: string,
+  awarenessPercent: number,
+  hasCoverStrain: boolean
+): string {
+  const strain = hasCoverStrain ? ' · cover strain' : ''
+  return `${effectiveActionLabel} · awareness ${awarenessPercent}%${strain}`
+}
+
+export function formatMissionTriageDeferralRiskValue(
+  tone: keyof typeof DEFERRAL_COMPARE_TONE_VALUES,
+  escalationRisk: number
+): string {
+  return `${DEFERRAL_COMPARE_TONE_VALUES[tone]} (${escalationRisk}/20)`
+}
+
+export function formatMissionTriageDeferralRiskDetail(
+  deadlineRemaining: number,
+  stage: number
+): string {
+  const weeksLeft = Math.max(0, Math.trunc(deadlineRemaining))
+
+  if (weeksLeft <= 0) {
+    return `Deadline due this week · stage ${stage}`
+  }
+
+  const deadlineWord = weeksLeft === 1 ? 'week' : 'weeks'
+  return `Deadline ${weeksLeft} ${deadlineWord} left · stage ${stage}`
+}
+
+export function formatMissionTriageDeferralCarryoverLink(
+  tone: keyof typeof DEFERRAL_COMPARE_TONE_VALUES
+): string {
+  return DEFERRAL_COMPARE_TONE_VALUES[tone]
+}
+
+export function formatMissionTriageDeferralCarryoverDetail(
+  stage: number,
+  kind: string
+): string {
+  const kindLabel = kind === 'raid' ? 'raid incident' : 'case'
+  return `Stage ${stage} ${kindLabel} · unresolved work may carry into next week`
+}
+
 export function formatMissionTriageInfiltrationTracksLabel(
   probeProgressPercent: number,
   awarenessPercent: number

--- a/src/domain/missionIntakeRouting.ts
+++ b/src/domain/missionIntakeRouting.ts
@@ -245,6 +245,29 @@ export function triageMission(state: GameState, currentCase: CaseInstance): Miss
   }
 }
 
+export type MissionTriageEscalationBand = 'low' | 'medium' | 'high'
+
+/** Mirrors `escalation-*` reason codes emitted by {@link triageMission}. */
+export function missionTriageEscalationBandFromReasonCodes(
+  reasonCodes: readonly string[]
+): MissionTriageEscalationBand {
+  if (reasonCodes.includes('escalation-high')) {
+    return 'high'
+  }
+
+  if (reasonCodes.includes('escalation-medium')) {
+    return 'medium'
+  }
+
+  return 'low'
+}
+
+export function missionTriageShowsEscalationDeferralRisk(reasonCodes: readonly string[]) {
+  return (
+    reasonCodes.includes('escalation-high') || reasonCodes.includes('escalation-medium')
+  )
+}
+
 /** Matches `escalation-high` reason code banding in {@link triageMission}. */
 export function hasHighMissionEscalationRisk(currentCase: CaseInstance): boolean {
   const escalationRisk = clampInteger(

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -180,16 +180,24 @@ it('renders covert prep markers on triage list rows', () => {
   renderCasesPage(['/cases'])
 
   const covertCard = getCardByName('Covert Infiltration Case')
-  expect(within(covertCard).getByText(/Probe 35%/)).toBeInTheDocument()
-  expect(within(covertCard).getByText(/awareness 50%/)).toBeInTheDocument()
-  expect(within(covertCard).getByText('Cover strain')).toBeInTheDocument()
+  const markerRegion = within(covertCard).getByLabelText('Case triage markers')
+  expect(within(markerRegion).getByText(/Probe 35%/)).toBeInTheDocument()
+  expect(within(markerRegion).getByText(/awareness 50%/)).toBeInTheDocument()
+  expect(within(markerRegion).getByText('Cover strain')).toBeInTheDocument()
   expect(within(covertCard).queryByText('Leave-behind staged')).not.toBeInTheDocument()
   expect(
     within(covertCard).getAllByText(/Deferring may let infiltration exposure escalate/i)
   ).toHaveLength(1)
 
-  const markerRegion = within(covertCard).getByLabelText('Case triage markers')
   expect(markerRegion.querySelectorAll('span').length).toBe(4)
+
+  const compareTable = within(covertCard).getByRole('table', {
+    name: 'Deferral and covert prep comparison',
+  })
+  expect(within(compareTable).getByText('Covert prep load')).toBeInTheDocument()
+  expect(within(compareTable).getByText('If deferred')).toBeInTheDocument()
+  expect(within(compareTable).getByText('Carryover')).toBeInTheDocument()
+  expect(within(covertCard).getByText(/Escalation carryover:/)).toBeInTheDocument()
 
   const plainCard = getCardByName('Plain Open Case')
   expect(within(plainCard).queryByText('Leave-behind staged')).not.toBeInTheDocument()

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -56,6 +56,7 @@ import {
   type CaseListItemView,
   writeCaseListFilters,
 } from './caseView'
+import { MissionTriageDeferralCompareTable } from './MissionTriageDeferralCompareTable'
 
 export default function CasesPage() {
   const { game, launchContract, launchMajorIncident, assign, unassign } = useGameStore()
@@ -569,6 +570,8 @@ export default function CasesPage() {
                 {view.covertPrepSignals.deferralNote && !recommendation ? (
                   <p className="text-xs text-amber-200/90">{view.covertPrepSignals.deferralNote}</p>
                 ) : null}
+
+                <MissionTriageDeferralCompareTable view={view.deferralCompare} />
 
                 {recommendation ? (
                   <div className="rounded border border-sky-400/25 bg-sky-500/8 px-3 py-2">

--- a/src/features/cases/MissionTriageDeferralCompareTable.tsx
+++ b/src/features/cases/MissionTriageDeferralCompareTable.tsx
@@ -1,0 +1,54 @@
+import type {
+  MissionTriageDeferralCompareTone,
+  MissionTriageDeferralCompareView,
+} from './missionTriageDeferralCompareView'
+
+const TONE_VALUE_CLASS: Record<MissionTriageDeferralCompareTone, string> = {
+  low: 'text-emerald-200/90',
+  medium: 'text-amber-200/90',
+  high: 'text-rose-200/90',
+}
+
+export function MissionTriageDeferralCompareTable({
+  view,
+}: {
+  view: MissionTriageDeferralCompareView
+}) {
+  if (!view.visible || view.columns.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className="rounded border border-white/10 bg-white/5 px-3 py-2 text-xs"
+      role="table"
+      aria-label="Deferral and covert prep comparison"
+    >
+      <div role="rowgroup">
+        <div role="row" className="grid grid-cols-3 gap-3 border-b border-white/10 pb-2">
+          {view.columns.map((column) => (
+            <div key={column.id} role="columnheader" className="font-medium uppercase tracking-wide opacity-60">
+              {column.label}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div role="rowgroup" className="pt-2">
+        <div role="row" className="grid grid-cols-3 gap-3">
+          {view.columns.map((column) => (
+            <div key={column.id} role="cell" className="space-y-0.5">
+              <p className={`font-medium ${TONE_VALUE_CLASS[column.tone]}`}>{column.value}</p>
+              {column.detail ? <p className="opacity-70">{column.detail}</p> : null}
+            </div>
+          ))}
+        </div>
+      </div>
+      {view.carryoverLink ? (
+        <p className="mt-2 border-t border-white/10 pt-2 text-amber-200/90">
+          <span className="font-medium">{view.carryoverLink.label}: </span>
+          {view.carryoverLink.detail}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/features/cases/MissionTriageDeferralCompareTable.tsx
+++ b/src/features/cases/MissionTriageDeferralCompareTable.tsx
@@ -18,6 +18,10 @@ export function MissionTriageDeferralCompareTable({
     return null
   }
 
+  const columnGridStyle = {
+    gridTemplateColumns: `repeat(${view.columns.length}, minmax(0, 1fr))`,
+  }
+
   return (
     <div
       className="rounded border border-white/10 bg-white/5 px-3 py-2 text-xs"
@@ -25,7 +29,11 @@ export function MissionTriageDeferralCompareTable({
       aria-label="Deferral and covert prep comparison"
     >
       <div role="rowgroup">
-        <div role="row" className="grid grid-cols-3 gap-3 border-b border-white/10 pb-2">
+        <div
+          role="row"
+          className="grid gap-3 border-b border-white/10 pb-2"
+          style={columnGridStyle}
+        >
           {view.columns.map((column) => (
             <div key={column.id} role="columnheader" className="font-medium uppercase tracking-wide opacity-60">
               {column.label}
@@ -34,7 +42,7 @@ export function MissionTriageDeferralCompareTable({
         </div>
       </div>
       <div role="rowgroup" className="pt-2">
-        <div role="row" className="grid grid-cols-3 gap-3">
+        <div role="row" className="grid gap-3" style={columnGridStyle}>
           {view.columns.map((column) => (
             <div key={column.id} role="cell" className="space-y-0.5">
               <p className={`font-medium ${TONE_VALUE_CLASS[column.tone]}`}>{column.value}</p>

--- a/src/features/cases/caseView.ts
+++ b/src/features/cases/caseView.ts
@@ -17,6 +17,10 @@ import {
 import { isTeamBlockedByTraining } from '../../domain/sim/training'
 import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
 import {
+  buildMissionTriageDeferralCompareView,
+  type MissionTriageDeferralCompareView,
+} from './missionTriageDeferralCompareView'
+import {
   buildMissionTriageCovertPrepSignals,
   type MissionTriageCovertPrepSignals,
 } from './missionTriageCovertPrepView'
@@ -61,6 +65,7 @@ export interface CaseListItemView {
   isBlockedByRequiredTags: boolean
   isRaidAtCapacity: boolean
   covertPrepSignals: MissionTriageCovertPrepSignals
+  deferralCompare: MissionTriageDeferralCompareView
 }
 
 export const DEFAULT_CASE_LIST_FILTERS: CaseListFilters = {
@@ -171,6 +176,11 @@ export function getCaseListItemView(
     ? majorIncidentBestSuccess
     : assignedOdds?.success ?? availableTeams.reduce((best, option) => Math.max(best, option.odds.success), 0)
 
+  const covertPrepSignals =
+    options?.includeCovertPrepSignals === true
+      ? buildMissionTriageCovertPrepSignals(currentCase, game)
+      : { visible: false, markers: [] }
+
   return {
     currentCase,
     assignedTeams,
@@ -194,10 +204,11 @@ export function getCaseListItemView(
     isBlockedByRequiredRoles,
     isBlockedByRequiredTags,
     isRaidAtCapacity,
-    covertPrepSignals:
+    covertPrepSignals,
+    deferralCompare:
       options?.includeCovertPrepSignals === true
-        ? buildMissionTriageCovertPrepSignals(currentCase, game)
-        : { visible: false, markers: [] },
+        ? buildMissionTriageDeferralCompareView(currentCase, game, { covertPrepSignals })
+        : { visible: false, columns: [] },
   }
 }
 

--- a/src/features/cases/investigationCasePrepView.ts
+++ b/src/features/cases/investigationCasePrepView.ts
@@ -50,6 +50,19 @@ export function canShowInvestigationCasePrepOnCase(caseData: CaseInstance) {
   return caseData.status === 'in_progress'
 }
 
+/** Shared with mission triage covert chips and deferral-compare (SPE-2255 / SPE-16 slice 2). */
+export function hasInvestigationForensicStrain(investigation: InvestigationCasePrepView | null) {
+  if (investigation === null || !investigation.visible) {
+    return false
+  }
+
+  const forensic = investigation.forensic.budget
+  return (
+    investigation.custodyMarkers.length > 0 ||
+    (forensic.granted > 0 && forensic.remaining === 0)
+  )
+}
+
 export function canAskInvestigationQuestionOnCase(caseData: CaseInstance | undefined) {
   return caseData !== undefined && canShowInvestigationCasePrepOnCase(caseData)
 }

--- a/src/features/cases/missionTriageCovertPrepView.ts
+++ b/src/features/cases/missionTriageCovertPrepView.ts
@@ -15,6 +15,7 @@ import {
 import {
   buildInvestigationCasePrepView,
   canShowInvestigationCasePrepOnCase,
+  hasInvestigationForensicStrain,
 } from './investigationCasePrepView'
 import { buildStealthLeaveBehindSelectionView } from './stealthLeaveBehindSelectionView'
 
@@ -124,29 +125,23 @@ export function buildMissionTriageCovertPrepSignals(
     })
   }
 
-  if (investigation?.visible) {
+  if (investigation?.visible && hasInvestigationForensicStrain(investigation)) {
     const forensicBudget = investigation.forensic.budget
-    const forensicStrain =
-      investigation.custodyMarkers.length > 0 ||
-      (forensicBudget.granted > 0 && forensicBudget.remaining === 0)
-
-    if (forensicStrain) {
-      pushMarker(markers, {
-        id: 'forensic-strain',
-        label: MISSION_TRIAGE_COVERT_PREP_LABELS.forensicStrain,
-        className: MARKER_STYLES.forensic,
-        title:
-          investigation.custodyMarkers.length > 0
-            ? formatMissionTriageForensicCustodyTitle(
-                investigation.custodyMarkers.length,
-                forensicBudget.remaining
-              )
-            : formatMissionTriageForensicBudgetExhaustedTitle(
-                forensicBudget.spent,
-                forensicBudget.granted
-              ),
-      })
-    }
+    pushMarker(markers, {
+      id: 'forensic-strain',
+      label: MISSION_TRIAGE_COVERT_PREP_LABELS.forensicStrain,
+      className: MARKER_STYLES.forensic,
+      title:
+        investigation.custodyMarkers.length > 0
+          ? formatMissionTriageForensicCustodyTitle(
+              investigation.custodyMarkers.length,
+              forensicBudget.remaining
+            )
+          : formatMissionTriageForensicBudgetExhaustedTitle(
+              forensicBudget.spent,
+              forensicBudget.granted
+            ),
+    })
   }
 
   let deferralNote: string | undefined

--- a/src/features/cases/missionTriageDeferralCompareView.ts
+++ b/src/features/cases/missionTriageDeferralCompareView.ts
@@ -1,0 +1,273 @@
+import { AWARENESS_COMPLICATION_THRESHOLD } from '../../domain/infiltrationProbe'
+import {
+  hasHighMissionEscalationRisk,
+  triageMission,
+  type MissionTriageResult,
+} from '../../domain/missionIntakeRouting'
+import { isOperationalMajorIncidentCase } from '../../domain/majorIncidentOperations'
+import type { CaseInstance, GameState } from '../../domain/models'
+import {
+  formatMissionTriageDeferralCarryoverDetail,
+  formatMissionTriageDeferralCarryoverLink,
+  formatMissionTriageDeferralRiskDetail,
+  formatMissionTriageDeferralRiskValue,
+  formatMissionTriageCovertPrepCostDetail,
+  formatMissionTriageCovertPrepCostValue,
+  MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS,
+} from '../../data/copy'
+import {
+  buildMissionTriageCovertPrepSignals,
+  type MissionTriageCovertPrepSignals,
+} from './missionTriageCovertPrepView'
+import {
+  buildInfiltrationCasePrepView,
+  canShowInfiltrationCasePrepOnCase,
+  type InfiltrationCasePrepView,
+} from './infiltrationCasePrepView'
+import {
+  buildInvestigationCasePrepView,
+  canShowInvestigationCasePrepOnCase,
+  type InvestigationCasePrepView,
+} from './investigationCasePrepView'
+import {
+  buildStealthLeaveBehindSelectionView,
+  type StealthLeaveBehindSelectionView,
+} from './stealthLeaveBehindSelectionView'
+
+export type MissionTriageDeferralCompareTone = 'low' | 'medium' | 'high'
+
+export interface MissionTriageDeferralCompareColumn {
+  readonly id: 'covertPrepCost' | 'deferralRisk' | 'escalationCarryover'
+  readonly label: string
+  readonly value: string
+  readonly detail?: string
+  readonly tone: MissionTriageDeferralCompareTone
+}
+
+export interface MissionTriageDeferralCompareCarryoverLink {
+  readonly label: string
+  readonly detail: string
+}
+
+export interface MissionTriageDeferralCompareView {
+  readonly visible: boolean
+  readonly columns: readonly MissionTriageDeferralCompareColumn[]
+  readonly carryoverLink?: MissionTriageDeferralCompareCarryoverLink
+}
+
+interface DeferralComparePrepContext {
+  readonly infiltration: InfiltrationCasePrepView | null
+  readonly leaveBehind: StealthLeaveBehindSelectionView
+  readonly investigation: InvestigationCasePrepView | null
+}
+
+const AWARENESS_COMPLICATION_PERCENT = Math.round(AWARENESS_COMPLICATION_THRESHOLD * 100)
+
+function escalationBand(escalationRisk: number): MissionTriageDeferralCompareTone {
+  if (escalationRisk >= 14) {
+    return 'high'
+  }
+
+  if (escalationRisk >= 7) {
+    return 'medium'
+  }
+
+  return 'low'
+}
+
+function buildDeferralComparePrepContext(
+  caseData: CaseInstance,
+  game: GameState
+): DeferralComparePrepContext {
+  return {
+    infiltration: canShowInfiltrationCasePrepOnCase(caseData)
+      ? buildInfiltrationCasePrepView(caseData)
+      : null,
+    leaveBehind: buildStealthLeaveBehindSelectionView(caseData, game),
+    investigation: canShowInvestigationCasePrepOnCase(caseData)
+      ? buildInvestigationCasePrepView(caseData, game)
+      : null,
+  }
+}
+
+function hasForensicStrain(investigation: InvestigationCasePrepView | null) {
+  if (investigation === null || !investigation.visible) {
+    return false
+  }
+
+  const forensic = investigation.forensic.budget
+  return (
+    investigation.custodyMarkers.length > 0 ||
+    (forensic.granted > 0 && forensic.remaining === 0)
+  )
+}
+
+function resolveCovertPrepCostTone(context: DeferralComparePrepContext): MissionTriageDeferralCompareTone {
+  const { infiltration, leaveBehind, investigation } = context
+
+  if (infiltration?.visible) {
+    if (
+      infiltration.hasCoverStrain ||
+      infiltration.awarenessPercent >= AWARENESS_COMPLICATION_PERCENT
+    ) {
+      return 'high'
+    }
+
+    if (infiltration.probeProgressPercent > 0) {
+      return 'medium'
+    }
+  }
+
+  if (hasForensicStrain(investigation)) {
+    return 'medium'
+  }
+
+  if (leaveBehind.visible && leaveBehind.selectedLeaveBehindId !== undefined) {
+    return 'medium'
+  }
+
+  return 'low'
+}
+
+function infiltrationDrivesCovertPrepCost(context: DeferralComparePrepContext) {
+  const infiltration = context.infiltration
+  if (infiltration === null || !infiltration.visible) {
+    return false
+  }
+
+  return (
+    infiltration.hasCoverStrain ||
+    infiltration.awarenessPercent >= AWARENESS_COMPLICATION_PERCENT ||
+    infiltration.probeProgressPercent > 0
+  )
+}
+
+function buildCovertPrepCostColumn(
+  context: DeferralComparePrepContext
+): MissionTriageDeferralCompareColumn {
+  const tone = resolveCovertPrepCostTone(context)
+  const { infiltration, leaveBehind, investigation } = context
+
+  let detail: string
+  if (infiltration !== null && infiltration.visible && infiltrationDrivesCovertPrepCost(context)) {
+    detail = formatMissionTriageCovertPrepCostDetail(
+      infiltration.effectiveActionLabel,
+      infiltration.awarenessPercent,
+      infiltration.hasCoverStrain
+    )
+  } else if (hasForensicStrain(investigation)) {
+    detail = MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepForensicDetail
+  } else if (leaveBehind.visible && leaveBehind.selectedLeaveBehindId !== undefined) {
+    detail = MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepLeaveBehindDetail
+  } else {
+    detail = MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepConcealmentDetail
+  }
+
+  return {
+    id: 'covertPrepCost',
+    label: MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepCost,
+    value: formatMissionTriageCovertPrepCostValue(tone),
+    detail,
+    tone,
+  }
+}
+
+function buildDeferralRiskColumn(
+  caseData: CaseInstance,
+  triage: MissionTriageResult
+): MissionTriageDeferralCompareColumn {
+  const escalationRisk = triage.dimensions.escalationRisk
+  const tone = escalationBand(escalationRisk)
+
+  return {
+    id: 'deferralRisk',
+    label: MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.deferralRisk,
+    value: formatMissionTriageDeferralRiskValue(tone, escalationRisk),
+    detail: formatMissionTriageDeferralRiskDetail(
+      caseData.deadlineRemaining,
+      caseData.stage
+    ),
+    tone,
+  }
+}
+
+function buildEscalationCarryoverColumn(caseData: CaseInstance): MissionTriageDeferralCompareColumn {
+  const highEscalation = hasHighMissionEscalationRisk(caseData)
+  const criticalStage = caseData.stage >= 4
+  const raidPressure = caseData.kind === 'raid'
+  const tone: MissionTriageDeferralCompareTone =
+    highEscalation || criticalStage ? 'high' : raidPressure || caseData.stage >= 2 ? 'medium' : 'low'
+
+  return {
+    id: 'escalationCarryover',
+    label: MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.escalationCarryover,
+    value: formatMissionTriageDeferralCarryoverLink(tone),
+    detail: formatMissionTriageDeferralCarryoverDetail(caseData.stage, caseData.kind),
+    tone,
+  }
+}
+
+function shouldShowDeferralCompare(
+  caseData: CaseInstance,
+  triage: MissionTriageResult,
+  covertVisible: boolean
+): boolean {
+  if (caseData.status !== 'in_progress' || isOperationalMajorIncidentCase(caseData)) {
+    return false
+  }
+
+  if (covertVisible) {
+    return true
+  }
+
+  if (triage.dimensions.escalationRisk >= 7) {
+    return true
+  }
+
+  return caseData.deadlineRemaining <= 2
+}
+
+function shouldShowCarryoverLink(caseData: CaseInstance, triage: MissionTriageResult) {
+  return (
+    hasHighMissionEscalationRisk(caseData) || triage.reasonCodes.includes('escalation-high')
+  )
+}
+
+export interface BuildMissionTriageDeferralCompareViewOptions {
+  readonly covertPrepSignals?: MissionTriageCovertPrepSignals
+}
+
+export function buildMissionTriageDeferralCompareView(
+  caseData: CaseInstance,
+  game: GameState,
+  options?: BuildMissionTriageDeferralCompareViewOptions
+): MissionTriageDeferralCompareView {
+  const resolvedCase = game.cases[caseData.id] ?? caseData
+  const covertPrepSignals =
+    options?.covertPrepSignals ?? buildMissionTriageCovertPrepSignals(resolvedCase, game)
+  const triage = triageMission(game, resolvedCase)
+
+  if (!shouldShowDeferralCompare(resolvedCase, triage, covertPrepSignals.visible)) {
+    return { visible: false, columns: [] }
+  }
+
+  const prepContext = buildDeferralComparePrepContext(resolvedCase, game)
+  const columns = [
+    buildCovertPrepCostColumn(prepContext),
+    buildDeferralRiskColumn(resolvedCase, triage),
+    buildEscalationCarryoverColumn(resolvedCase),
+  ]
+
+  const carryoverLink = shouldShowCarryoverLink(resolvedCase, triage)
+    ? {
+        label: MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.carryoverLinkLabel,
+        detail: MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.carryoverLinkDetail,
+      }
+    : undefined
+
+  return {
+    visible: true,
+    columns,
+    carryoverLink,
+  }
+}

--- a/src/features/cases/missionTriageDeferralCompareView.ts
+++ b/src/features/cases/missionTriageDeferralCompareView.ts
@@ -1,6 +1,8 @@
 import { AWARENESS_COMPLICATION_THRESHOLD } from '../../domain/infiltrationProbe'
 import {
   hasHighMissionEscalationRisk,
+  missionTriageEscalationBandFromReasonCodes,
+  missionTriageShowsEscalationDeferralRisk,
   triageMission,
   type MissionTriageResult,
 } from '../../domain/missionIntakeRouting'
@@ -27,6 +29,7 @@ import {
 import {
   buildInvestigationCasePrepView,
   canShowInvestigationCasePrepOnCase,
+  hasInvestigationForensicStrain,
   type InvestigationCasePrepView,
 } from './investigationCasePrepView'
 import {
@@ -63,18 +66,6 @@ interface DeferralComparePrepContext {
 
 const AWARENESS_COMPLICATION_PERCENT = Math.round(AWARENESS_COMPLICATION_THRESHOLD * 100)
 
-function escalationBand(escalationRisk: number): MissionTriageDeferralCompareTone {
-  if (escalationRisk >= 14) {
-    return 'high'
-  }
-
-  if (escalationRisk >= 7) {
-    return 'medium'
-  }
-
-  return 'low'
-}
-
 function buildDeferralComparePrepContext(
   caseData: CaseInstance,
   game: GameState
@@ -88,18 +79,6 @@ function buildDeferralComparePrepContext(
       ? buildInvestigationCasePrepView(caseData, game)
       : null,
   }
-}
-
-function hasForensicStrain(investigation: InvestigationCasePrepView | null) {
-  if (investigation === null || !investigation.visible) {
-    return false
-  }
-
-  const forensic = investigation.forensic.budget
-  return (
-    investigation.custodyMarkers.length > 0 ||
-    (forensic.granted > 0 && forensic.remaining === 0)
-  )
 }
 
 function resolveCovertPrepCostTone(context: DeferralComparePrepContext): MissionTriageDeferralCompareTone {
@@ -118,7 +97,7 @@ function resolveCovertPrepCostTone(context: DeferralComparePrepContext): Mission
     }
   }
 
-  if (hasForensicStrain(investigation)) {
+  if (hasInvestigationForensicStrain(investigation)) {
     return 'medium'
   }
 
@@ -155,7 +134,7 @@ function buildCovertPrepCostColumn(
       infiltration.awarenessPercent,
       infiltration.hasCoverStrain
     )
-  } else if (hasForensicStrain(investigation)) {
+  } else if (hasInvestigationForensicStrain(investigation)) {
     detail = MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepForensicDetail
   } else if (leaveBehind.visible && leaveBehind.selectedLeaveBehindId !== undefined) {
     detail = MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepLeaveBehindDetail
@@ -177,7 +156,7 @@ function buildDeferralRiskColumn(
   triage: MissionTriageResult
 ): MissionTriageDeferralCompareColumn {
   const escalationRisk = triage.dimensions.escalationRisk
-  const tone = escalationBand(escalationRisk)
+  const tone = missionTriageEscalationBandFromReasonCodes(triage.reasonCodes)
 
   return {
     id: 'deferralRisk',
@@ -196,7 +175,11 @@ function buildEscalationCarryoverColumn(caseData: CaseInstance): MissionTriageDe
   const criticalStage = caseData.stage >= 4
   const raidPressure = caseData.kind === 'raid'
   const tone: MissionTriageDeferralCompareTone =
-    highEscalation || criticalStage ? 'high' : raidPressure || caseData.stage >= 2 ? 'medium' : 'low'
+    highEscalation || criticalStage
+      ? 'high'
+      : raidPressure || caseData.stage >= 2
+        ? 'medium'
+        : 'low'
 
   return {
     id: 'escalationCarryover',
@@ -220,7 +203,7 @@ function shouldShowDeferralCompare(
     return true
   }
 
-  if (triage.dimensions.escalationRisk >= 7) {
+  if (missionTriageShowsEscalationDeferralRisk(triage.reasonCodes)) {
     return true
   }
 

--- a/src/test/mission.intake.triage.routing.test.ts
+++ b/src/test/mission.intake.triage.routing.test.ts
@@ -7,6 +7,8 @@ import {
   routeMission,
   routeMissionToTeam,
   shortlistMissionCandidateTeams,
+  missionTriageEscalationBandFromReasonCodes,
+  missionTriageShowsEscalationDeferralRisk,
   triageMission,
 } from '../domain/missionIntakeRouting'
 import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
@@ -188,5 +190,14 @@ describe('mission intake, triage, and routing', () => {
 
     const roundTripped = loadGameSave(serializeGameSave(assignedState))
     expect(roundTripped.missionRouting?.missions[missionId]?.routingState).toBe('assigned')
+  })
+
+  it('maps escalation reason codes to triage UI bands', () => {
+    expect(missionTriageEscalationBandFromReasonCodes(['escalation-high'])).toBe('high')
+    expect(missionTriageEscalationBandFromReasonCodes(['escalation-medium'])).toBe('medium')
+    expect(missionTriageEscalationBandFromReasonCodes(['escalation-low'])).toBe('low')
+    expect(missionTriageShowsEscalationDeferralRisk(['escalation-high'])).toBe(true)
+    expect(missionTriageShowsEscalationDeferralRisk(['escalation-medium'])).toBe(true)
+    expect(missionTriageShowsEscalationDeferralRisk(['escalation-low'])).toBe(false)
   })
 })

--- a/src/test/missionTriageDeferralCompareView.test.ts
+++ b/src/test/missionTriageDeferralCompareView.test.ts
@@ -146,7 +146,7 @@ describe('missionTriageDeferralCompareView', () => {
     expect(view.visible).toBe(false)
   })
 
-  it('shows medium covert prep when only conceal flag is set', () => {
+  it('shows low covert prep when only conceal flag is set', () => {
     let state = createStartingState()
     const caseData = createConcealmentEligibleCase({ tags: [] })
     state.cases[caseData.id] = caseData

--- a/src/test/missionTriageDeferralCompareView.test.ts
+++ b/src/test/missionTriageDeferralCompareView.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from 'vitest'
+import { copyInfiltrationProbePlan } from '../domain/infiltrationProbe'
+import {
+  applyStealthLeaveBehindInvestigationCustodyLoss,
+} from '../domain/investigationCustodyLoss'
+import { grantInvestigationQuestionBudget } from '../domain/investigationEconomy'
+import { setPersistentFlag } from '../domain/flagSystem'
+import { buildConcealCaseFlagId } from '../domain/concealmentCasePrep'
+import type { CaseInstance } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { caseTemplateMap } from '../domain/templates/caseTemplates'
+import { createStartingState } from '../data/startingState'
+import {
+  MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS,
+  formatMissionTriageDeferralRiskValue,
+} from '../data/copy'
+import { getCaseListItemView } from '../features/cases/caseView'
+import { buildMissionTriageDeferralCompareView } from '../features/cases/missionTriageDeferralCompareView'
+
+function createConcealmentEligibleCase(overrides: Partial<CaseInstance> = {}) {
+  return {
+    ...createStarterCase({ id: 'case-deferral-conceal', templateId: 'ops-003' }),
+    status: 'in_progress' as const,
+    tags: ['infiltration'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+function createInfiltrationCase(overrides: Partial<CaseInstance> = {}) {
+  return {
+    ...createStarterCase({ id: 'case-deferral-infiltration', templateId: 'ops-004' }),
+    status: 'in_progress' as const,
+    hiddenState: 'hidden' as const,
+    infiltrationProbeProgress: 0.42,
+    infiltrationAwareness: 0.61,
+    infiltrationStage: 'probing' as const,
+    tags: ['infiltration', 'media', 'public'],
+    infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+    infiltrationCoverProfile: caseTemplateMap['ops-004'].infiltrationCoverProfile,
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+describe('missionTriageDeferralCompareView', () => {
+  it('is hidden for open and resolved cases', () => {
+    const inProgress = createConcealmentEligibleCase()
+    const game = createStartingState()
+
+    expect(buildMissionTriageDeferralCompareView({ ...inProgress, status: 'open' }, game).visible).toBe(
+      false
+    )
+    expect(
+      buildMissionTriageDeferralCompareView({ ...inProgress, status: 'resolved' }, game).visible
+    ).toBe(false)
+  })
+
+  it('shows three columns when covert prep signals are visible', () => {
+    const game = createStartingState()
+    const caseData = createConcealmentEligibleCase()
+    const view = buildMissionTriageDeferralCompareView(caseData, game)
+
+    expect(view.visible).toBe(true)
+    expect(view.columns.map((column) => column.id)).toEqual([
+      'covertPrepCost',
+      'deferralRisk',
+      'escalationCarryover',
+    ])
+    expect(view.columns[0]?.label).toBe(MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepCost)
+  })
+
+  it('rates covert prep cost high when awareness exceeds complication band', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase()
+    game.cases[caseData.id] = caseData
+
+    const view = buildMissionTriageDeferralCompareView(caseData, game)
+    const covertColumn = view.columns.find((column) => column.id === 'covertPrepCost')
+
+    expect(covertColumn?.tone).toBe('high')
+    expect(covertColumn?.value).toBe('High')
+    expect(covertColumn?.detail).toContain('awareness 61%')
+  })
+
+  it('surfaces high deferral risk for critical-stage infiltration cases', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase({ stage: 4 })
+    game.cases[caseData.id] = caseData
+
+    const view = buildMissionTriageDeferralCompareView(caseData, game)
+    const deferralColumn = view.columns.find((column) => column.id === 'deferralRisk')
+
+    expect(deferralColumn?.tone).toBe('high')
+    expect(deferralColumn?.value).toBe(formatMissionTriageDeferralRiskValue('high', 20))
+    expect(deferralColumn?.detail).toContain('Deadline')
+  })
+
+  it('includes carryover cross-link when escalation is high', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase({ stage: 4 })
+    game.cases[caseData.id] = caseData
+
+    const view = buildMissionTriageDeferralCompareView(caseData, game)
+
+    expect(view.carryoverLink?.label).toBe(MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.carryoverLinkLabel)
+    expect(view.carryoverLink?.detail).toContain('escalation thresholds')
+  })
+
+  it('shows compare view for deadline-risk cases without covert chips', () => {
+    const game = createStartingState()
+    const caseData = {
+      ...createStarterCase({ id: 'case-deadline', templateId: 'ops-001' }),
+      status: 'in_progress' as const,
+      deadlineRemaining: 1,
+      stage: 1,
+      tags: [],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    }
+    game.cases[caseData.id] = caseData
+
+    const view = buildMissionTriageDeferralCompareView(caseData, game)
+
+    expect(view.visible).toBe(true)
+    expect(view.columns.find((column) => column.id === 'deferralRisk')?.detail).toContain(
+      '1 week left'
+    )
+  })
+
+  it('is hidden when case is not in progress in canonical game state', () => {
+    const game = createStartingState()
+    const caseData = createConcealmentEligibleCase()
+    game.cases[caseData.id] = { ...caseData, status: 'resolved' }
+
+    const view = buildMissionTriageDeferralCompareView(
+      { ...caseData, status: 'in_progress' },
+      game
+    )
+
+    expect(view.visible).toBe(false)
+  })
+
+  it('shows medium covert prep when only conceal flag is set', () => {
+    let state = createStartingState()
+    const caseData = createConcealmentEligibleCase({ tags: [] })
+    state.cases[caseData.id] = caseData
+    state = setPersistentFlag(state, buildConcealCaseFlagId(caseData.id), true)
+
+    const view = buildMissionTriageDeferralCompareView(state.cases[caseData.id]!, state)
+    const covertColumn = view.columns.find((column) => column.id === 'covertPrepCost')
+
+    expect(view.visible).toBe(true)
+    expect(covertColumn?.tone).toBe('low')
+    expect(covertColumn?.detail).toBe(MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepConcealmentDetail)
+  })
+
+  it('uses forensic detail when strain applies without infiltration prep', () => {
+    let state = createStartingState()
+    const caseData = {
+      ...createStarterCase({ id: 'case-forensic-only', templateId: 'ops-003' }),
+      status: 'in_progress' as const,
+      hiddenState: 'hidden' as const,
+      detectionConfidence: 0.25,
+      counterDetection: false,
+      tags: ['infiltration', 'archive'],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    }
+    state.cases[caseData.id] = caseData
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: caseData.id,
+      domain: 'forensic',
+      amount: 1,
+    })
+    const custodyResult = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: caseData.id,
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      leaveBehindKind: 'abandon_evidence',
+      leaveBehindLabel: 'Abandon compromised evidence',
+      custodyLossRefs: ['custody:field-packet'],
+      week: 1,
+    })
+    state = custodyResult.state
+
+    const view = buildMissionTriageDeferralCompareView(state.cases[caseData.id]!, state)
+    const covertColumn = view.columns.find((column) => column.id === 'covertPrepCost')
+
+    expect(view.visible).toBe(true)
+    expect(covertColumn?.tone).toBe('medium')
+    expect(covertColumn?.detail).toBe(MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepForensicDetail)
+  })
+
+  it('is hidden for operational major-incident raid profiles', () => {
+    const game = createStartingState()
+    const caseData = createInfiltrationCase({
+      stage: 3,
+      kind: 'raid',
+      raid: { minTeams: 2, maxTeams: 2 },
+    })
+    game.cases[caseData.id] = caseData
+
+    expect(buildMissionTriageDeferralCompareView(caseData, game).visible).toBe(false)
+  })
+
+  it('formats zero-week deadline as due this week', () => {
+    const game = createStartingState()
+    const caseData = {
+      ...createStarterCase({ id: 'case-deadline-zero', templateId: 'ops-001' }),
+      status: 'in_progress' as const,
+      deadlineRemaining: 0,
+      stage: 2,
+      tags: [],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    }
+    game.cases[caseData.id] = caseData
+
+    const view = buildMissionTriageDeferralCompareView(caseData, game)
+
+    expect(view.visible).toBe(true)
+    expect(view.columns.find((column) => column.id === 'deferralRisk')?.detail).toBe(
+      'Deadline due this week · stage 2'
+    )
+  })
+
+  it('wires deferral compare through case list view when covert signals enabled', () => {
+    const game = createStartingState()
+    const caseData = createConcealmentEligibleCase()
+    game.cases[caseData.id] = caseData
+
+    const listView = getCaseListItemView(caseData, game, { includeCovertPrepSignals: true })
+
+    expect(listView.deferralCompare.visible).toBe(true)
+    expect(listView.deferralCompare.columns).toHaveLength(3)
+  })
+
+  it('prefers forensic detail over leave-behind when both strains apply', () => {
+    let state = createStartingState()
+    const caseData = {
+      ...createStarterCase({ id: 'case-forensic-leave', templateId: 'ops-003' }),
+      status: 'in_progress' as const,
+      hiddenState: 'hidden' as const,
+      detectionConfidence: 0.25,
+      counterDetection: false,
+      tags: ['archive'],
+      stealthLeaveBehindId: 'leave-behind:risk-discovery',
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    }
+    state.cases[caseData.id] = caseData
+    state = grantInvestigationQuestionBudget(state, {
+      caseId: caseData.id,
+      domain: 'forensic',
+      amount: 1,
+    })
+    const custodyResult = applyStealthLeaveBehindInvestigationCustodyLoss({
+      state,
+      caseId: caseData.id,
+      leaveBehindId: 'leave-behind:abandon-evidence',
+      leaveBehindKind: 'abandon_evidence',
+      leaveBehindLabel: 'Abandon compromised evidence',
+      custodyLossRefs: ['custody:field-packet'],
+      week: 1,
+    })
+    state = custodyResult.state
+
+    const view = buildMissionTriageDeferralCompareView(state.cases[caseData.id]!, state)
+    const covertColumn = view.columns.find((column) => column.id === 'covertPrepCost')
+
+    expect(covertColumn?.tone).toBe('medium')
+    expect(covertColumn?.detail).toBe(MISSION_TRIAGE_DEFERRAL_COMPARE_LABELS.covertPrepForensicDetail)
+  })
+
+  it('formats negative deadline as due this week', () => {
+    const game = createStartingState()
+    const caseData = {
+      ...createStarterCase({ id: 'case-deadline-negative', templateId: 'ops-001' }),
+      status: 'in_progress' as const,
+      deadlineRemaining: -1,
+      stage: 2,
+      tags: [],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+    }
+    game.cases[caseData.id] = caseData
+
+    const view = buildMissionTriageDeferralCompareView(caseData, game)
+
+    expect(view.visible).toBe(true)
+    expect(view.columns.find((column) => column.id === 'deferralRisk')?.detail).toBe(
+      'Deadline due this week · stage 2'
+    )
+  })
+
+  it('omits deferral compare from case list view when covert signals disabled', () => {
+    const game = createStartingState()
+    const caseData = createConcealmentEligibleCase()
+    game.cases[caseData.id] = caseData
+
+    const listView = getCaseListItemView(caseData, game)
+
+    expect(listView.deferralCompare.visible).toBe(false)
+    expect(listView.deferralCompare.columns).toHaveLength(0)
+  })
+})

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -32,10 +32,10 @@ This spec is for:
 
 **Slice 1 shipped (SPE-2255):** `CasesPage` list rows show read-only covert-prep chips (concealment preview/request, infiltration probe/awareness, staged leave-behind, forensic strain) via `buildMissionTriageCovertPrepSignals`; optional deferral note when escalation risk is high during active infiltration. Plan: `planning/mission-triage-covert-prep-slice.md`.
 
+**Slice 2 shipped:** `CasesPage` list rows show a three-column deferral comparison table (`Covert prep load` / `If deferred` / `Carryover`) via `buildMissionTriageDeferralCompareView` and `MissionTriageDeferralCompareTable`; escalation carryover cross-link when deferral risk is high. Plan: `planning/mission-triage-deferral-compare-slice.md`.
+
 **Still deferred (follow-up slices):**
 
-- comparison columns for infiltration prep cost vs deferral risk (dedicated columns, not chips only)
-- cross-links from triage deferral to escalation carryover (see comparison table and escalation carryover risk rows below)
 - full triage layout refresh (filters/tabs/split detail panel per §3)
 
 ---


### PR DESCRIPTION
## Summary
- Add a three-column deferral comparison table on `CasesPage` list rows: **Covert prep load**, **If deferred**, and **Carryover**, with an escalation carryover cross-link when deferral risk is high.
- Introduce `buildMissionTriageDeferralCompareView` and `MissionTriageDeferralCompareTable`, wired through `CaseListItemView.deferralCompare` (reuses shared `covertPrepSignals` to avoid duplicate builders per row).
- Read-only UX only: bands derive from `triageMission` and existing infiltration/investigation/leave-behind prep views; hidden for operational major-incident profiles (same gate as SPE-2255 chips).

## Plan
- `planning/mission-triage-deferral-compare-slice.md`
- Parent: [SPE-16 — Mission Intake, Triage, & Routing](https://linear.app/spectranoir/issue/SPE-16/mission-intake-triage-and-routing)
- Follows SPE-2255 / PR #2350

## Test plan
- [x] `npm run test:run -- src/test/missionTriageDeferralCompareView.test.ts src/features/cases/CasesPage.test.tsx`
- [x] `npm run lint`
- [x] `npm run test:run` (3676 tests)
