### PR TITLE
feat(SPE-2257): mission triage layout refresh (slice 3 UX)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -32,7 +32,7 @@ From `README.md` **Current design notes**:
 
 ## Deferred UX (follow-up after SPE-2255)
 
-- **`ux/mission-triage.md`** — full triage layout refresh (filters/tabs/split detail panel); list-row chips + deferral compare columns shipped (SPE-2255 / slice 2 `planning/mission-triage-deferral-compare-slice.md`).
+- **`ux/mission-triage.md`** — status-bar triage tail + route/defer/ignore actions (layout tabs/split/footer shipped SPE-2257 / `planning/mission-triage-layout-slice.md`; row chips + deferral compare SPE-2255–2256).
 
 ## SCP-9995 harvest — May 2026 reconciliation
 

--- a/planning/mission-triage-layout-slice.md
+++ b/planning/mission-triage-layout-slice.md
@@ -1,0 +1,34 @@
+# SPE-16 slice 3 — Mission triage layout refresh (UX)
+
+One-page implementation plan. Parent: [SPE-16 — Mission Intake, Triage, & Routing](https://linear.app/spectranoir/issue/SPE-16/mission-intake-triage-and-routing). Follows [SPE-2256](https://linear.app/spectranoir/issue/SPE-2256) / `planning/mission-triage-deferral-compare-slice.md`.
+
+## Goal
+
+Restructure `CasesPage` case queue toward `ux/mission-triage.md` §3: category tabs, split list/detail panel, and context footer — without new simulation math.
+
+## Non-goals
+
+- Replacing contract board block
+- Route/defer/ignore store actions (still assignment-focused)
+- Full status-bar shell extension (navigation-map tail deferred)
+
+## Acceptance
+
+- [x] Triage tabs (All / Incidents / Contracts / Leads / Escalating / Assigned) filter list via URL `tab`
+- [x] Split layout: compact selectable list + detail panel for selected case
+- [x] Context footer: support load, teams available, urgent-if-deferred, escalation carryover risk
+- [x] Slice 1–2 row signals preserved in detail panel
+- [x] Tests + lint + `npm run test:run` green
+
+## Branch
+
+`spe-16-mission-triage-layout-slice-3`
+
+## Audit repairs (May 2026)
+
+- `matchesCaseTriageTab` moved to `caseView.ts` (removed `caseView` ↔ `missionTriageLayoutView` circular import).
+- `normalizeCaseListFilters` strips stale `case` URL ids not visible under current filters.
+- `MissionTriageListRow` — title link and inspect control are siblings (no nested interactive elements).
+- `filterHelpers.test.ts` updated for `tab` / `case` params; invalid `tab` falls back to `all`.
+- Triage context footer renders even when the filtered list is empty.
+- Tab change preserves `case` when the selection remains visible under the new tab; re-clicking the active tab is a no-op.

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -248,15 +248,33 @@ function createCasesCoverageGame() {
   return game
 }
 
+function getTriageList() {
+  return screen.getByLabelText('Triage list')
+}
+
+function openCaseTriageDetailSync(caseTitle: RegExp | string) {
+  const list = getTriageList()
+  const titleLink = within(list).getByRole('link', { name: caseTitle })
+  const row = titleLink.closest('li')
+
+  expect(row).not.toBeNull()
+  fireEvent.click(
+    within(row!).getByRole('button', { name: new RegExp(`Select .* for triage detail`, 'i') })
+  )
+}
+
 function getRaidCaseListItem() {
   return getCaseListItem(RAID_CASE_TITLE)
 }
 
 function getCaseListItem(caseTitle: RegExp | string) {
-  const caseItem = screen.getByText(caseTitle).closest('li')
+  openCaseTriageDetailSync(caseTitle)
+  const titleLink = within(getTriageList()).getByRole('link', { name: caseTitle })
+  const escapedTitle = (titleLink.textContent ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
-  expect(caseItem).not.toBeNull()
-  return caseItem!
+  return screen.getByRole('region', {
+    name: new RegExp(`Case triage detail: ${escapedTitle}`, 'i'),
+  })
 }
 
 function getTeamCard(teamName: RegExp | string) {
@@ -500,7 +518,7 @@ describe('game app routes', () => {
     await user.click(screen.getByRole('link', { name: /^cases$/i }))
 
     expect(screen.getByRole('heading', { name: CASES_PAGE_HEADING })).toBeInTheDocument()
-    expect(screen.getByText(VAMPIRE_NEST_CASE_TITLE)).toBeInTheDocument()
+    expect(within(getTriageList()).getByText(VAMPIRE_NEST_CASE_TITLE)).toBeInTheDocument()
   })
 
   it('assigns a team from cases and reflects it on teams', async () => {
@@ -663,33 +681,31 @@ describe('game app routes', () => {
     renderApp('/cases')
 
     const stageTwoCase = getCaseListItem(/vampire nest in the stockyards/i)
-    const stageThreeCase = getCaseListItem(/whispering archive/i)
-    const stageFourCase = getCaseListItem(/eclipse ritual/i)
-    const oddsFallbackCase = getCaseListItem(/overflow checkpoint/i)
-
-    expect(within(stageTwoCase!).getByText(/^stage 2$/i)).toHaveClass(
+    expect(within(stageTwoCase).getByText(/^stage 2$/i).closest('span')).toHaveClass(
       'bg-yellow-900/50',
       'text-yellow-300'
     )
-    expect(within(stageThreeCase!).getByText(/^stage 3$/i)).toHaveClass(
+
+    const stageThreeCase = getCaseListItem(/whispering archive/i)
+    expect(within(stageThreeCase).getByText(/^stage 3$/i).closest('span')).toHaveClass(
       'bg-orange-900/50',
       'text-orange-300'
     )
-    expect(within(stageFourCase!).getByText(/^stage 4$/i)).toHaveClass(
+    expect(within(stageThreeCase).getByText(/remaining: 1 week/i)).toBeInTheDocument()
+    expect(within(stageThreeCase).getByText(/assigned: night watch/i)).toBeInTheDocument()
+
+    const stageFourCase = getCaseListItem(/eclipse ritual/i)
+    expect(within(stageFourCase).getByText(/^stage 4$/i).closest('span')).toHaveClass(
       'bg-red-900/50',
       'text-red-300'
     )
+    expect(within(stageFourCase).queryByRole('button', { name: /assign/i })).not.toBeInTheDocument()
 
-    expect(within(stageThreeCase!).getByText(/remaining: 1 week/i)).toBeInTheDocument()
-    expect(within(stageThreeCase!).getByText(/assigned: night watch/i)).toBeInTheDocument()
-    expect(
-      within(stageFourCase!).queryByRole('button', { name: /assign/i })
-    ).not.toBeInTheDocument()
-
-    expect(within(oddsFallbackCase!).getByText(/success: 0%/i)).toBeInTheDocument()
-    expect(within(oddsFallbackCase!).queryByRole('button', { name: /assign/i })).toBeNull()
-    expect(within(oddsFallbackCase!).queryByText(/required tags:/i)).not.toBeInTheDocument()
-    expect(within(oddsFallbackCase!).queryByText(/preferred tags:/i)).not.toBeInTheDocument()
+    const oddsFallbackCase = getCaseListItem(/overflow checkpoint/i)
+    expect(within(oddsFallbackCase).getByText(/success: 0%/i)).toBeInTheDocument()
+    expect(within(oddsFallbackCase).queryByRole('button', { name: /assign/i })).toBeNull()
+    expect(within(oddsFallbackCase).queryByText(/required tags:/i)).not.toBeInTheDocument()
+    expect(within(oddsFallbackCase).queryByText(/preferred tags:/i)).not.toBeInTheDocument()
   })
 
   it('renders zero-fatigue dashboard stats when the roster is empty', () => {
@@ -1118,9 +1134,10 @@ describe('game app routes', () => {
     renderApp('/cases')
 
     expect(screen.getByRole('heading', { name: CASES_PAGE_HEADING })).toBeInTheDocument()
-    expect(screen.getByText(/vampire nest in the stockyards/i)).toBeInTheDocument()
-    expect(screen.getByText(/the whispering archive/i)).toBeInTheDocument()
-    expect(screen.getByText(/eclipse ritual at the riverfront/i)).toBeInTheDocument()
+    const triageList = getTriageList()
+    expect(within(triageList).getByRole('link', { name: /vampire nest in the stockyards/i })).toBeInTheDocument()
+    expect(within(triageList).getByRole('link', { name: /the whispering archive/i })).toBeInTheDocument()
+    expect(within(triageList).getByRole('link', { name: /eclipse ritual at the riverfront/i })).toBeInTheDocument()
   })
 
   it('shows both starter teams and all eight agents on the teams route', () => {
@@ -1198,7 +1215,7 @@ describe('game app routes', () => {
     await user.click(screen.getByRole('link', { name: /back to cases/i }))
 
     expect(screen.getByRole('heading', { name: CASES_PAGE_HEADING })).toBeInTheDocument()
-    expect(screen.getByText(VAMPIRE_NEST_CASE_TITLE)).toBeInTheDocument()
+    expect(within(getTriageList()).getByText(VAMPIRE_NEST_CASE_TITLE)).toBeInTheDocument()
   })
 
   it('keeps primary shell navigation working from a detail route', async () => {

--- a/src/app/filterHelpers.test.ts
+++ b/src/app/filterHelpers.test.ts
@@ -125,10 +125,16 @@ describe('filter helper read/write contracts', () => {
       stage: '4',
       sort: 'deadline',
       risk: true,
+      tab: 'all',
+      selectedCaseId: '',
     })
 
     const riskDisabled = readCaseListFilters(new URLSearchParams('risk=0'))
     expect(riskDisabled.risk).toBe(false)
+
+    const invalidTab = readCaseListFilters(new URLSearchParams('tab=bogus&case=stale-id'))
+    expect(invalidTab.tab).toBe('all')
+    expect(invalidTab.selectedCaseId).toBe('stale-id')
 
     const output = writeCaseListFilters(
       {
@@ -136,10 +142,10 @@ describe('filter helper read/write contracts', () => {
         mode: 'deterministic',
         risk: true,
       },
-      new URLSearchParams('tab=ops')
+      new URLSearchParams('panel=ops')
     )
 
-    expect(output.get('tab')).toBe('ops')
+    expect(output.get('panel')).toBe('ops')
     expect(output.get('mode')).toBe('deterministic')
     expect(output.get('risk')).toBe('1')
     expect(output.has('status')).toBe(false)
@@ -155,6 +161,8 @@ describe('filter helper read/write contracts', () => {
       stage: '4' as const,
       sort: 'deadline' as const,
       risk: true,
+      tab: 'escalating' as const,
+      selectedCaseId: 'case-001',
     }
 
     const serialized = writeCaseListFilters(original)
@@ -168,6 +176,8 @@ describe('filter helper read/write contracts', () => {
       stage: '4',
       sort: 'deadline',
       risk: true,
+      tab: 'escalating',
+      selectedCaseId: 'case-001',
     })
   })
 

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -237,34 +237,45 @@ it('renders concealment prep chip on triage list rows', async () => {
   expect(within(getCardByName('Covert Preview Case')).getByText('Covert next week')).toBeInTheDocument()
 })
 
-it('renders recommended action guidance for assignable cases', () => {
+it('renders recommended action guidance for assignable cases', async () => {
+  const user = userEvent.setup()
   renderCasesPage(['/cases'])
 
-  expect(screen.getAllByText(/recommended action/i).length).toBeGreaterThan(0)
-  expect(screen.getAllByText(/best current success:/i).length).toBeGreaterThan(0)
   expect(
     screen.getByText(
       /core loop: triage cases here, open each dossier to prep, then advance week from front desk and review the new report\./i
     )
   ).toBeInTheDocument()
-  expect(screen.getAllByRole('link', { name: /open prep dossier/i }).length).toBeGreaterThan(0)
+
+  await selectTriageCase(user, 'The Whispering Archive')
+
+  const detail = getCardByName('The Whispering Archive')
+  expect(within(detail).getByText(/recommended action/i)).toBeInTheDocument()
+  expect(within(detail).getByText(/best current success:/i)).toBeInTheDocument()
+  expect(within(detail).getByRole('link', { name: /open prep dossier/i })).toBeInTheDocument()
 })
 
-it('renders open intel dossier quick action and next-step copy for each case card', () => {
+it('renders open intel dossier quick action and next-step copy for each case card', async () => {
+  const user = userEvent.setup()
   renderCasesPage(['/cases'])
 
-  expect(screen.getAllByRole('link', { name: /open intel dossier/i }).length).toBeGreaterThan(0)
+  await selectTriageCase(user, 'The Whispering Archive')
+
+  const detail = getCardByName('The Whispering Archive')
+  expect(within(detail).getByRole('link', { name: /open intel dossier/i })).toBeInTheDocument()
   expect(
-    screen.getAllByText(/next step: assign response units, then advance week from front desk\./i).length
-  ).toBeGreaterThan(0)
+    within(detail).getByText(/next step: assign response units, then advance week from front desk\./i)
+  ).toBeInTheDocument()
 })
 
 it('supports top-option comparison and shows confidence/commit cues on assignment actions', async () => {
   const user = userEvent.setup()
 
   renderCasesPage(['/cases'])
+  await selectTriageCase(user, 'The Whispering Archive')
 
-  const compareButton = screen.getAllByRole('button', { name: /compare top 2/i })[0]
+  const detail = getCardByName('The Whispering Archive')
+  const compareButton = within(detail).getByRole('button', { name: /compare top 2/i })
   expect(compareButton).toHaveAttribute('aria-expanded', 'false')
   const controlsId = compareButton.getAttribute('aria-controls')
   expect(controlsId).toBeTruthy()
@@ -272,10 +283,10 @@ it('supports top-option comparison and shows confidence/commit cues on assignmen
 
   expect(compareButton).toHaveAttribute('aria-expanded', 'true')
   expect(document.getElementById(controlsId!)).not.toBeNull()
-  expect(screen.getByText(/success delta:/i)).toBeInTheDocument()
-  expect(screen.getByText(/fail delta:/i)).toBeInTheDocument()
-  expect(screen.getAllByText(/confidence:/i).length).toBeGreaterThan(0)
-  expect(screen.getAllByText(/commit clarity:/i).length).toBeGreaterThan(0)
+  expect(within(detail).getByText(/success delta:/i)).toBeInTheDocument()
+  expect(within(detail).getByText(/fail delta:/i)).toBeInTheDocument()
+  expect(within(detail).getAllByText(/confidence:/i).length).toBeGreaterThan(0)
+  expect(within(detail).getAllByText(/commit clarity:/i).length).toBeGreaterThan(0)
 })
 
 it('renders a major incident planner and warns when one selected team is much weaker', async () => {

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -81,9 +81,12 @@ it('sanitizes invalid query params and preserves canonical case links', async ()
 
   const caseLink = screen
     .getAllByRole('link', { name: /vampire nest in the stockyards/i })
-    .find((link) => link.getAttribute('href') === '/cases/case-001?q=stockyards&sort=title')
+    .find((link) => link.getAttribute('href')?.includes('/cases/case-001?'))
   expect(caseLink).toBeDefined()
-  expect(caseLink).toHaveAttribute('href', '/cases/case-001?q=stockyards&sort=title')
+  expect(caseLink).toHaveAttribute(
+    'href',
+    '/cases/case-001?q=stockyards&sort=title&case=case-001'
+  )
 })
 
 it('sorts cases by title from query state', () => {

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -79,7 +79,10 @@ it('sanitizes invalid query params and preserves canonical case links', async ()
   expect(screen.getByLabelText('Stage')).toHaveValue('all')
   expect(screen.getByLabelText('Sort')).toHaveValue('title')
 
-  const caseLink = screen.getByRole('link', { name: /vampire nest in the stockyards/i })
+  const caseLink = screen
+    .getAllByRole('link', { name: /vampire nest in the stockyards/i })
+    .find((link) => link.getAttribute('href') === '/cases/case-001?q=stockyards&sort=title')
+  expect(caseLink).toBeDefined()
   expect(caseLink).toHaveAttribute('href', '/cases/case-001?q=stockyards&sort=title')
 })
 
@@ -94,12 +97,14 @@ it('sorts cases by title from query state', () => {
 
   renderCasesPage(['/cases?sort=title'])
 
-  const alphaLink = screen.getByTestId('case-title-link-alpha')
-  const zuluLink = screen.getByTestId('case-title-link-zulu')
+  const triageList = screen.getByLabelText('Triage list')
+  const alphaLink = within(triageList).getByTestId('case-title-link-alpha')
+  const zuluLink = within(triageList).getByTestId('case-title-link-zulu')
   expect(alphaLink.compareDocumentPosition(zuluLink) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 })
 
-it('renders urgency markers for triage cases', () => {
+it('renders urgency markers for triage cases', async () => {
+  const user = userEvent.setup()
   const game = createStartingState()
   game.cases = {
     high: makeCase('high', 'High Risk Case', {
@@ -133,23 +138,28 @@ it('renders urgency markers for triage cases', () => {
   useGameStore.setState({ game })
 
   renderCasesPage(['/cases'])
+  await selectTriageCase(user, 'High Risk Case')
 
   const highRiskCard = getCardByName('High Risk Case')
   expect(within(highRiskCard).getByText('Unassigned')).toBeInTheDocument()
   expect(within(highRiskCard).getByText('High stage')).toBeInTheDocument()
   expect(within(highRiskCard).getByText('Deadline risk')).toBeInTheDocument()
 
+  await selectTriageCase(user, 'Blocked Case')
   const blockedCard = getCardByName('Blocked Case')
   expect(within(blockedCard).getByText('Required-role blocked')).toBeInTheDocument()
 
+  await selectTriageCase(user, 'Raid Capacity Case')
   const raidCard = getCardByName('Raid Capacity Case')
   expect(within(raidCard).getByText('Raid at capacity')).toBeInTheDocument()
 
+  await selectTriageCase(user, 'Unassigned Case')
   const idleCard = getCardByName('Unassigned Case')
   expect(within(idleCard).getByText('Unassigned')).toBeInTheDocument()
 })
 
-it('renders covert prep markers on triage list rows', () => {
+it('renders covert prep markers on triage list rows', async () => {
+  const user = userEvent.setup()
   const game = createStartingState()
   const assignedTeamId = Object.keys(game.teams)[0]!
   game.cases = {
@@ -176,6 +186,7 @@ it('renders covert prep markers on triage list rows', () => {
   useGameStore.setState({ game })
 
   renderCasesPage(['/cases'])
+  await selectTriageCase(user, 'Covert Infiltration Case')
 
   const covertCard = getCardByName('Covert Infiltration Case')
   const markerRegion = within(covertCard).getByLabelText('Case triage markers')
@@ -197,12 +208,14 @@ it('renders covert prep markers on triage list rows', () => {
   expect(within(compareTable).getByText('Carryover')).toBeInTheDocument()
   expect(within(covertCard).getByText(/Escalation carryover:/)).toBeInTheDocument()
 
+  await selectTriageCase(user, 'Plain Open Case')
   const plainCard = getCardByName('Plain Open Case')
   expect(within(plainCard).queryByText('Leave-behind staged')).not.toBeInTheDocument()
   expect(within(plainCard).queryByText(/Probe \d+%/)).not.toBeInTheDocument()
 })
 
-it('renders concealment prep chip on triage list rows', () => {
+it('renders concealment prep chip on triage list rows', async () => {
+  const user = userEvent.setup()
   const game = createStartingState()
   game.cases = {
     conceal: {
@@ -219,6 +232,7 @@ it('renders concealment prep chip on triage list rows', () => {
   useGameStore.setState({ game })
 
   renderCasesPage(['/cases'])
+  await selectTriageCase(user, 'Covert Preview Case')
 
   expect(within(getCardByName('Covert Preview Case')).getByText('Covert next week')).toBeInTheDocument()
 })
@@ -270,6 +284,7 @@ it('renders a major incident planner and warns when one selected team is much we
 
   useGameStore.setState({ game })
   renderCasesPage(['/cases'])
+  await selectTriageCase(user, 'Regional Fracture Event')
 
   const incidentCard = getCardByName('Regional Fracture Event')
   expect(within(incidentCard).getByText(/major incident planner/i)).toBeInTheDocument()
@@ -324,9 +339,9 @@ it('toggles the at-risk filter and syncs it to query state', async () => {
   })
 
   expect(screen.getByRole('button', { name: /^at-risk$/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /high risk case/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /blocked case/i })).toBeInTheDocument()
-  expect(screen.queryByRole('link', { name: /low risk case/i })).not.toBeInTheDocument()
+  expect(screen.getAllByRole('link', { name: /high risk case/i }).length).toBeGreaterThan(0)
+  expect(screen.getAllByRole('link', { name: /blocked case/i }).length).toBeGreaterThan(0)
+  expect(screen.queryAllByRole('link', { name: /low risk case/i })).toHaveLength(0)
   expect(screen.queryByRole('link', { name: /resolved critical case/i })).not.toBeInTheDocument()
 
   await user.click(screen.getByRole('button', { name: /^at-risk$/i }))
@@ -336,8 +351,96 @@ it('toggles the at-risk filter and syncs it to query state', async () => {
   })
 
   expect(screen.getByRole('button', { name: /at-risk only/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /low risk case/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /resolved critical case/i })).toBeInTheDocument()
+  expect(screen.getAllByRole('link', { name: /low risk case/i }).length).toBeGreaterThan(0)
+  expect(screen.getAllByRole('link', { name: /resolved critical case/i }).length).toBeGreaterThan(0)
+})
+
+it('re-clicking the active triage tab does not clear the case query', async () => {
+  const user = userEvent.setup()
+
+  renderCasesPage(['/cases?case=case-001&tab=all'])
+
+  await waitFor(() => {
+    expect(screen.getByTestId('location-search')).toHaveTextContent('case=case-001')
+  })
+
+  await user.click(screen.getByRole('tab', { name: /^all\b/i }))
+
+  expect(screen.getByTestId('location-search')).toHaveTextContent('case=case-001')
+})
+
+it('preserves case query when the selected case remains visible after a tab change', async () => {
+  const user = userEvent.setup()
+  const game = createStartingState()
+  const teamId = Object.keys(game.teams)[0]!
+  const caseId = 'case-001'
+  game.cases = {
+    ...game.cases,
+    [caseId]: {
+      ...game.cases[caseId]!,
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    },
+  }
+
+  useGameStore.setState({ game })
+  renderCasesPage([`/cases?case=${caseId}&tab=all`])
+
+  await waitFor(() => {
+    expect(screen.getByTestId('location-search')).toHaveTextContent(`case=${caseId}`)
+  })
+
+  await user.click(screen.getByRole('tab', { name: /assigned/i }))
+
+  await waitFor(() => {
+    const search = screen.getByTestId('location-search').textContent ?? ''
+    expect(search).toContain('tab=assigned')
+    expect(search).toContain(`case=${caseId}`)
+  })
+})
+
+it('filters triage list by tab and syncs tab to query state', async () => {
+  const user = userEvent.setup()
+  const game = createStartingState()
+  const teamId = Object.keys(game.teams)[0]!
+  game.cases = {
+    assigned: makeCase('assigned', 'Assigned Case', {
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    }),
+    open: makeCase('open', 'Open Case', { status: 'open' }),
+  }
+
+  useGameStore.setState({ game })
+  renderCasesPage(['/cases'])
+
+  await user.click(screen.getByRole('tab', { name: /assigned/i }))
+
+  await waitFor(() => {
+    expect(screen.getByTestId('location-search')).toHaveTextContent('tab=assigned')
+  })
+
+  expect(screen.getAllByRole('link', { name: /assigned case/i }).length).toBeGreaterThan(0)
+  expect(screen.queryAllByRole('link', { name: /^open case$/i })).toHaveLength(0)
+  expect(screen.getByLabelText(/mission triage context/i)).toBeInTheDocument()
+})
+
+it('shows triage context footer when filters match no cases', () => {
+  renderCasesPage(['/cases?q=definitely-no-match'])
+
+  expect(screen.getByRole('region', { name: /case triage queue/i })).toBeInTheDocument()
+  expect(screen.getByRole('region', { name: /no matching cases/i })).toBeInTheDocument()
+  expect(screen.getByLabelText(/mission triage context/i)).toBeInTheDocument()
+  expect(screen.getByText(/teams available:/i)).toBeInTheDocument()
+})
+
+it('sanitizes stale case query when the case is outside the filtered triage list', async () => {
+  renderCasesPage(['/cases?case=case-does-not-exist&status=open'])
+
+  await waitFor(() => {
+    const search = screen.getByTestId('location-search').textContent ?? ''
+    expect(search).not.toContain('case=case-does-not-exist')
+  })
 })
 
 it('renders the case assignment guidance panel', () => {
@@ -454,8 +557,16 @@ it('shows a clear-filters recovery action in empty results state', async () => {
 })
 
 function getCardByName(name: string) {
-  const link = screen.getByRole('link', { name: new RegExp(name, 'i') })
-  return link.closest('li') as HTMLElement
+  return screen.getByRole('region', {
+    name: new RegExp(`Case triage detail:.*${name}`, 'i'),
+  })
+}
+
+async function selectTriageCase(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await user.click(screen.getByRole('button', { name: new RegExp(`Select ${name} for triage detail`, 'i') }))
+  await screen.findByRole('region', {
+    name: new RegExp(`Case triage detail:.*${name}`, 'i'),
+  })
 }
 
 function makeCase(id: string, title: string, overrides: Partial<CaseInstance> = {}): CaseInstance {

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
 import { Link, useSearchParams } from 'react-router'
 import { APP_ROUTES } from '../../app/routes'
 import { useGameStore } from '../../app/store/gameStore'
@@ -21,6 +21,7 @@ import {
 } from '../../domain/majorIncidentOperations'
 import { getAgencyProgressionUnlockLabel } from '../../domain/agencyProgression'
 import type {
+  GameState,
   MajorIncidentProvisionType,
   MajorIncidentStrategy,
 } from '../../domain/models'
@@ -51,12 +52,21 @@ import {
   CASE_STAGE_FILTERS,
   CASE_STATUS_FILTERS,
   getFilteredCaseViews,
+  normalizeCaseListFilters,
   readCaseListFilters,
   type CaseListFilters,
   type CaseListItemView,
   writeCaseListFilters,
 } from './caseView'
+import { MissionTriageContextFooter } from './MissionTriageContextFooter'
 import { MissionTriageDeferralCompareTable } from './MissionTriageDeferralCompareTable'
+import { MissionTriageListRow } from './MissionTriageListRow'
+import { MissionTriageTabs } from './MissionTriageTabs'
+import {
+  buildMissionTriageCompactRowView,
+  buildMissionTriageContextFooterView,
+  buildTriageTabCounts,
+} from './missionTriageLayoutView'
 
 export default function CasesPage() {
   const { game, launchContract, launchMajorIncident, assign, unassign } = useGameStore()
@@ -71,7 +81,12 @@ export default function CasesPage() {
   >({})
   const [selectedContractId, setSelectedContractId] = useState<string | null>(null)
   const searchParamsString = searchParams.toString()
-  const filters = readCaseListFilters(searchParams)
+  const triageViewOptions = { includeCovertPrepSignals: true as const }
+  const filters = normalizeCaseListFilters(
+    game,
+    readCaseListFilters(searchParams),
+    triageViewOptions
+  )
   const normalizedSearchString = writeCaseListFilters(filters).toString()
   const querySuffix = normalizedSearchString ? `?${normalizedSearchString}` : ''
   const contractOffers = getContractOffers(game)
@@ -79,8 +94,6 @@ export default function CasesPage() {
     contractOffers.find((offer) => offer.id === selectedContractId) ?? contractOffers[0]
   const selectedContractSuggestions = selectedContract
     ? getContractTeamSuggestions(game, selectedContract).slice(0, 3)
-
-  // Presentation: Add visual cues for incident/case variety in list
     : []
   const recommendedContractTeam = selectedContractSuggestions[0]
 
@@ -90,11 +103,45 @@ export default function CasesPage() {
     }
   }, [normalizedSearchString, searchParamsString, setSearchParams])
 
-  const cases = getFilteredCaseViews(game, filters, { includeCovertPrepSignals: true })
+  const viewsForTabCounts = getFilteredCaseViews(
+    game,
+    { ...filters, tab: 'all' },
+    triageViewOptions
+  )
+  const tabCounts = buildTriageTabCounts(viewsForTabCounts, game)
+  const cases = getFilteredCaseViews(game, filters, triageViewOptions)
   const totalCases = Object.keys(game.cases).length
+  const effectiveSelectedCaseId =
+    filters.selectedCaseId || (cases[0]?.currentCase.id ?? '')
+  const selectedView =
+    cases.find((view) => view.currentCase.id === effectiveSelectedCaseId) ?? null
+  const triageFooter = buildMissionTriageContextFooterView(cases, game)
 
   function updateFilters(nextFilters: CaseListFilters) {
     setSearchParams(writeCaseListFilters(nextFilters), { replace: true })
+  }
+
+  function selectTriageCase(caseId: string) {
+    updateFilters({ ...filters, selectedCaseId: caseId })
+  }
+
+  function selectTriageTab(tab: CaseListFilters['tab']) {
+    if (tab === filters.tab) {
+      return
+    }
+
+    const nextTabCases = getFilteredCaseViews(
+      game,
+      { ...filters, tab },
+      triageViewOptions
+    )
+    const selectedCaseId = nextTabCases.some(
+      (view) => view.currentCase.id === filters.selectedCaseId
+    )
+      ? filters.selectedCaseId
+      : ''
+
+    updateFilters({ ...filters, tab, selectedCaseId })
   }
 
   return (
@@ -454,6 +501,12 @@ export default function CasesPage() {
         <div className="rounded border border-white/10 bg-white/5 px-3 py-2 text-sm opacity-80">
           Core loop: triage cases here, open each dossier to prep, then advance week from Front Desk and review the new report.
         </div>
+
+        <MissionTriageTabs
+          activeTab={filters.tab}
+          tabCounts={tabCounts}
+          onSelectTab={selectTriageTab}
+        />
       </article>
 
       <article className="panel space-y-3" role="region" aria-label="Case assignment guidance">
@@ -483,51 +536,173 @@ export default function CasesPage() {
         <p className="text-xs text-amber-200/90">⚠ {CASES_GUIDANCE.stageWarning}</p>
       </article>
 
-      {cases.length > 0 ? (
-        <ul id="cases-results" className="space-y-3" aria-label="Case results">
-          {cases.map((view) => {
-            const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${querySuffix}`
-            const intelHref = APP_ROUTES.intelDetail(view.currentCase.templateId)
-            const listRowMarkers = getListRowMarkers(view)
-            const incidentStrategy =
-              majorIncidentStrategyState[view.currentCase.id] ??
-              view.currentCase.majorIncident?.strategy ??
-              'balanced'
-            const incidentProvisions =
-              majorIncidentProvisionState[view.currentCase.id] ??
-              view.currentCase.majorIncident?.provisions ??
-              []
-            const selectedIncidentTeamIds =
-              majorIncidentTeamState[view.currentCase.id] ??
-              (view.currentCase.majorIncident ? view.currentCase.assignedTeamIds : [])
-            const majorIncidentPlan = view.isMajorIncident
-              ? evaluateMajorIncidentPlan(game, view.currentCase, selectedIncidentTeamIds, {
-                  strategy: incidentStrategy,
-                  provisions: incidentProvisions,
-                })
-              : null
-            const recommendedIncidentPlan = view.isMajorIncident
-              ? getBestMajorIncidentPlanSuggestion(game, view.currentCase, {
-                  strategy: incidentStrategy,
-                  provisions: incidentProvisions,
-                })
-              : null
-            const majorIncidentProvisionDefs = view.isMajorIncident
-              ? getMajorIncidentProvisionDefinitions(game)
-              : []
-            const selectableIncidentTeams = view.isMajorIncident
-              ? getMajorIncidentSelectableTeams(game, view.currentCase)
-              : []
-            const recommendation = view.isMajorIncident
-              ? getMajorIncidentRecommendation(majorIncidentPlan, recommendedIncidentPlan)
-              : getCaseRecommendation(view)
-            const bestEligibleSuccess = getBestEligibleSuccess(view)
-            const topTwoOptions = getTopTwoEligibleOptions(view)
-            const compareOpen = compareCaseState[view.currentCase.id] ?? false
-            const comparePanelId = `case-compare-${view.currentCase.id}`
+      <div id="cases-results" className="space-y-3" role="region" aria-label="Case triage queue">
+        {cases.length > 0 ? (
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.35fr)]">
+            <ul className="space-y-2" aria-label="Triage list">
+              {cases.map((view) => {
+                const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${querySuffix}`
+                const listRowMarkers = getListRowMarkers(view)
+                const markerPreview = listRowMarkers.map((marker) => marker.label).slice(0, 2).join(' · ')
+                const compactRow = buildMissionTriageCompactRowView(
+                  view,
+                  game,
+                  effectiveSelectedCaseId,
+                  markerPreview
+                )
 
-            return (
-              <li key={view.currentCase.id} className="panel panel-support space-y-3">
+                return (
+                  <MissionTriageListRow
+                    key={view.currentCase.id}
+                    row={compactRow}
+                    detailHref={detailHref}
+                    onSelect={() => selectTriageCase(view.currentCase.id)}
+                  />
+                )
+              })}
+            </ul>
+
+            {selectedView ? (
+              <div
+                role="region"
+                aria-label={`Case triage detail: ${selectedView.currentCase.title}`}
+                className="min-w-0"
+              >
+                {renderCaseTriageDetail({
+                  view: selectedView,
+                  game,
+                  querySuffix,
+                  compareCaseState,
+                  setCompareCaseState,
+                  majorIncidentTeamState,
+                  setMajorIncidentTeamState,
+                  majorIncidentStrategyState,
+                  setMajorIncidentStrategyState,
+                  majorIncidentProvisionState,
+                  setMajorIncidentProvisionState,
+                  assign,
+                  unassign,
+                  launchMajorIncident,
+                })}
+              </div>
+            ) : (
+              <p className="panel panel-support p-4 text-sm opacity-70">
+                Select a case from the triage list to inspect routing detail.
+              </p>
+            )}
+          </div>
+        ) : (
+          <div
+            className="panel panel-support space-y-2 p-4"
+            role="region"
+            aria-label="No matching cases"
+          >
+            <p className="text-sm font-medium">
+              {filters.status === 'open'
+                ? CASES_GUIDANCE.noOpenCases
+                : filters.status === 'in_progress'
+                  ? CASES_GUIDANCE.noActiveCases
+                  : CASES_GUIDANCE.noResolvedCases}
+            </p>
+            <p className="text-sm opacity-70">{CASES_GUIDANCE.allCasesFiltered}</p>
+            {normalizedSearchString.length > 0 ? (
+              <div>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-ghost"
+                  onClick={() => setSearchParams(new URLSearchParams(), { replace: true })}
+                >
+                  Clear filters
+                </button>
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        <MissionTriageContextFooter footer={triageFooter} />
+      </div>
+    </section>
+  )
+}
+
+function renderCaseTriageDetail({
+  view,
+  game,
+  querySuffix,
+  compareCaseState,
+  setCompareCaseState,
+  majorIncidentTeamState,
+  setMajorIncidentTeamState,
+  majorIncidentStrategyState,
+  setMajorIncidentStrategyState,
+  majorIncidentProvisionState,
+  setMajorIncidentProvisionState,
+  assign,
+  unassign,
+  launchMajorIncident,
+}: {
+  view: CaseListItemView
+  game: GameState
+  querySuffix: string
+  compareCaseState: Record<string, boolean>
+  setCompareCaseState: Dispatch<SetStateAction<Record<string, boolean>>>
+  majorIncidentTeamState: Record<string, string[]>
+  setMajorIncidentTeamState: Dispatch<SetStateAction<Record<string, string[]>>>
+  majorIncidentStrategyState: Record<string, MajorIncidentStrategy>
+  setMajorIncidentStrategyState: Dispatch<SetStateAction<Record<string, MajorIncidentStrategy>>>
+  majorIncidentProvisionState: Record<string, MajorIncidentProvisionType[]>
+  setMajorIncidentProvisionState: Dispatch<SetStateAction<Record<string, MajorIncidentProvisionType[]>>>
+  assign: (caseId: string, teamId: string) => void
+  unassign: (caseId: string, teamId: string) => void
+  launchMajorIncident: (
+    caseId: string,
+    teamIds: string[],
+    strategy: MajorIncidentStrategy,
+    provisions: MajorIncidentProvisionType[]
+  ) => void
+}) {
+  const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${querySuffix}`
+  const intelHref = APP_ROUTES.intelDetail(view.currentCase.templateId)
+  const listRowMarkers = getListRowMarkers(view)
+  const incidentStrategy =
+    majorIncidentStrategyState[view.currentCase.id] ??
+    view.currentCase.majorIncident?.strategy ??
+    'balanced'
+  const incidentProvisions =
+    majorIncidentProvisionState[view.currentCase.id] ??
+    view.currentCase.majorIncident?.provisions ??
+    []
+  const selectedIncidentTeamIds =
+    majorIncidentTeamState[view.currentCase.id] ??
+    (view.currentCase.majorIncident ? view.currentCase.assignedTeamIds : [])
+  const majorIncidentPlan = view.isMajorIncident
+    ? evaluateMajorIncidentPlan(game, view.currentCase, selectedIncidentTeamIds, {
+        strategy: incidentStrategy,
+        provisions: incidentProvisions,
+      })
+    : null
+  const recommendedIncidentPlan = view.isMajorIncident
+    ? getBestMajorIncidentPlanSuggestion(game, view.currentCase, {
+        strategy: incidentStrategy,
+        provisions: incidentProvisions,
+      })
+    : null
+  const majorIncidentProvisionDefs = view.isMajorIncident
+    ? getMajorIncidentProvisionDefinitions(game)
+    : []
+  const selectableIncidentTeams = view.isMajorIncident
+    ? getMajorIncidentSelectableTeams(game, view.currentCase)
+    : []
+  const recommendation = view.isMajorIncident
+    ? getMajorIncidentRecommendation(majorIncidentPlan, recommendedIncidentPlan)
+    : getCaseRecommendation(view)
+  const bestEligibleSuccess = getBestEligibleSuccess(view)
+  const topTwoOptions = getTopTwoEligibleOptions(view)
+  const compareOpen = compareCaseState[view.currentCase.id] ?? false
+  const comparePanelId = `case-compare-${view.currentCase.id}`
+
+  return (
+    <article className="panel panel-support space-y-3">
                 <div className="flex items-start justify-between gap-4">
                   <div>
                     <p className="font-medium">
@@ -853,39 +1028,7 @@ export default function CasesPage() {
                     </div>
                   )
                 ) : null}
-              </li>
-            )
-          })}
-        </ul>
-      ) : (
-        <div
-          id="cases-results"
-          className="panel panel-support space-y-2 p-4"
-          role="region"
-          aria-label="No matching cases"
-        >
-          <p className="text-sm font-medium">
-            {filters.status === 'open'
-              ? CASES_GUIDANCE.noOpenCases
-              : filters.status === 'in_progress'
-                ? CASES_GUIDANCE.noActiveCases
-                : CASES_GUIDANCE.noResolvedCases}
-          </p>
-          <p className="text-sm opacity-70">{CASES_GUIDANCE.allCasesFiltered}</p>
-          {normalizedSearchString.length > 0 ? (
-            <div>
-              <button
-                type="button"
-                className="btn btn-sm btn-ghost focus-ring"
-                onClick={() => setSearchParams(new URLSearchParams(), { replace: true })}
-              >
-                Clear filters
-              </button>
-            </div>
-          ) : null}
-        </div>
-      )}
-    </section>
+    </article>
   )
 }
 

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -109,7 +109,12 @@ export default function CasesPage() {
     triageViewOptions
   )
   const tabCounts = buildTriageTabCounts(viewsForTabCounts, game)
-  const cases = getFilteredCaseViews(game, filters, triageViewOptions)
+  const cases =
+    filters.tab === 'all'
+      ? viewsForTabCounts
+      : viewsForTabCounts.filter(
+          (view) => buildTriageTabCounts([view], game)[filters.tab] > 0
+        )
   const totalCases = Object.keys(game.cases).length
   const effectiveSelectedCaseId =
     filters.selectedCaseId

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -112,7 +112,7 @@ export default function CasesPage() {
   const cases = getFilteredCaseViews(game, filters, triageViewOptions)
   const totalCases = Object.keys(game.cases).length
   const effectiveSelectedCaseId =
-    filters.selectedCaseId || (cases[0]?.currentCase.id ?? '')
+    filters.selectedCaseId
   const selectedView =
     cases.find((view) => view.currentCase.id === effectiveSelectedCaseId) ?? null
   const triageFooter = buildMissionTriageContextFooterView(cases, game)

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -62,6 +62,7 @@ import { MissionTriageContextFooter } from './MissionTriageContextFooter'
 import { MissionTriageDeferralCompareTable } from './MissionTriageDeferralCompareTable'
 import { MissionTriageListRow } from './MissionTriageListRow'
 import { MissionTriageTabs } from './MissionTriageTabs'
+import { triageMission } from '../../domain/missionIntakeRouting'
 import {
   buildMissionTriageCompactRowView,
   buildMissionTriageContextFooterView,
@@ -551,7 +552,7 @@ export default function CasesPage() {
                 const markerPreview = listRowMarkers.map((marker) => marker.label).slice(0, 2).join(' · ')
                 const compactRow = buildMissionTriageCompactRowView(
                   view,
-                  game,
+                  triageMission(game, view.currentCase),
                   effectiveSelectedCaseId,
                   markerPreview
                 )

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -52,6 +52,7 @@ import {
   CASE_STAGE_FILTERS,
   CASE_STATUS_FILTERS,
   getFilteredCaseViews,
+  matchesCaseTriageTab,
   normalizeCaseListFilters,
   readCaseListFilters,
   type CaseListFilters,
@@ -113,15 +114,13 @@ export default function CasesPage() {
   const cases =
     filters.tab === 'all'
       ? viewsForTabCounts
-      : viewsForTabCounts.filter(
-          (view) => buildTriageTabCounts([view], game)[filters.tab] > 0
-        )
+      : viewsForTabCounts.filter((view) => matchesCaseTriageTab(view, filters.tab, game))
   const totalCases = Object.keys(game.cases).length
   const effectiveSelectedCaseId =
     filters.selectedCaseId
   const selectedView =
     cases.find((view) => view.currentCase.id === effectiveSelectedCaseId) ?? null
-  const triageFooter = buildMissionTriageContextFooterView(cases, game)
+  const triageFooter = buildMissionTriageContextFooterView(viewsForTabCounts, game)
 
   function updateFilters(nextFilters: CaseListFilters) {
     setSearchParams(writeCaseListFilters(nextFilters), { replace: true })
@@ -547,7 +546,13 @@ export default function CasesPage() {
           <div className="grid gap-4 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.35fr)]">
             <ul className="space-y-2" aria-label="Triage list">
               {cases.map((view) => {
-                const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${querySuffix}`
+                const rowQueryString = writeCaseListFilters({
+                  ...filters,
+                  selectedCaseId: view.currentCase.id,
+                }).toString()
+                const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${
+                  rowQueryString ? `?${rowQueryString}` : ''
+                }`
                 const listRowMarkers = getListRowMarkers(view)
                 const markerPreview = listRowMarkers.map((marker) => marker.label).slice(0, 2).join(' · ')
                 const compactRow = buildMissionTriageCompactRowView(

--- a/src/features/cases/MissionTriageContextFooter.tsx
+++ b/src/features/cases/MissionTriageContextFooter.tsx
@@ -1,0 +1,37 @@
+import {
+  MISSION_TRIAGE_FOOTER_LOAD_LABELS,
+  type MissionTriageContextFooterView,
+} from './missionTriageLayoutView'
+
+export function MissionTriageContextFooter({ footer }: { footer: MissionTriageContextFooterView }) {
+  return (
+    <footer
+      className="rounded border border-white/10 bg-white/5 px-4 py-3 text-sm"
+      aria-label="Mission triage context"
+    >
+      <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-4">
+        <p>
+          <span className="opacity-60">Projected support load:</span>{' '}
+          <span className="font-medium">
+            {MISSION_TRIAGE_FOOTER_LOAD_LABELS[footer.projectedSupportLoad]}
+          </span>
+        </p>
+        <p>
+          <span className="opacity-60">Teams available:</span>{' '}
+          <span className="font-medium">{footer.teamsAvailable}</span>
+        </p>
+        <p>
+          <span className="opacity-60">Urgent if deferred:</span>{' '}
+          <span className="font-medium">{footer.urgentIfDeferred}</span>
+        </p>
+        <p>
+          <span className="opacity-60">Escalation carryover risk:</span>{' '}
+          <span className="font-medium">{footer.escalationCarryoverRisk}</span>
+        </p>
+      </div>
+      <p className="mt-2 text-xs opacity-65">
+        Routable this week: {footer.routableCount} — open cases without role/tag blockers.
+      </p>
+    </footer>
+  )
+}

--- a/src/features/cases/MissionTriageListRow.tsx
+++ b/src/features/cases/MissionTriageListRow.tsx
@@ -1,0 +1,62 @@
+import { Link } from 'react-router'
+import type { MissionTriageCompactRowView } from './missionTriageLayoutView'
+
+const PRIORITY_STYLES: Record<MissionTriageCompactRowView['priority'], string> = {
+  critical: 'border-red-500/40 bg-red-500/10 text-red-200',
+  high: 'border-orange-500/40 bg-orange-500/10 text-orange-200',
+  normal: 'border-sky-500/40 bg-sky-500/10 text-sky-200',
+  low: 'border-slate-500/40 bg-slate-500/10 text-slate-200',
+}
+
+export function MissionTriageListRow({
+  row,
+  detailHref,
+  onSelect,
+}: {
+  row: MissionTriageCompactRowView
+  detailHref: string
+  onSelect: () => void
+}) {
+  return (
+    <li
+      className={`rounded border px-3 py-2 transition ${
+        row.isSelected
+          ? 'border-sky-400/50 bg-sky-500/10'
+          : 'border-white/10 bg-white/5 hover:border-white/20'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <Link
+            to={detailHref}
+            className="truncate font-medium hover:underline focus-ring"
+            data-testid={`case-title-link-${row.caseId}`}
+          >
+            {row.title}
+          </Link>
+          <p className="text-xs opacity-60">
+            {row.typeLabel}
+            {row.markerPreview ? ` · ${row.markerPreview}` : ''}
+          </p>
+        </div>
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide ${PRIORITY_STYLES[row.priority]}`}
+        >
+          {row.priority}
+        </span>
+      </div>
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <p className="text-[11px] opacity-50">Triage score {row.priorityScore}</p>
+        <button
+          type="button"
+          onClick={onSelect}
+          aria-pressed={row.isSelected}
+          aria-label={`Select ${row.title} for triage detail`}
+          className="btn btn-xs btn-ghost"
+        >
+          {row.isSelected ? 'Selected' : 'Inspect'}
+        </button>
+      </div>
+    </li>
+  )
+}

--- a/src/features/cases/MissionTriageTabs.tsx
+++ b/src/features/cases/MissionTriageTabs.tsx
@@ -1,0 +1,43 @@
+import { CASE_TRIAGE_TABS, type CaseTriageTab } from './caseView'
+import { CASE_TRIAGE_TAB_LABELS } from './missionTriageLayoutView'
+
+export function MissionTriageTabs({
+  activeTab,
+  tabCounts,
+  onSelectTab,
+}: {
+  activeTab: CaseTriageTab
+  tabCounts: Record<CaseTriageTab, number>
+  onSelectTab: (tab: CaseTriageTab) => void
+}) {
+  return (
+    <div
+      className="flex flex-wrap gap-2"
+      role="tablist"
+      aria-label="Mission triage categories"
+    >
+      {CASE_TRIAGE_TABS.map((tab) => {
+        const selected = activeTab === tab
+        const count = tabCounts[tab]
+
+        return (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            className={selected ? 'btn btn-sm btn-primary' : 'btn btn-sm btn-ghost'}
+            onClick={() => {
+              if (tab !== activeTab) {
+                onSelectTab(tab)
+              }
+            }}
+          >
+            {CASE_TRIAGE_TAB_LABELS[tab]}
+            <span className="ml-1 opacity-70">({count})</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/cases/caseView.test.ts
+++ b/src/features/cases/caseView.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import type { CaseInstance } from '../../domain/models'
+import {
+  getCaseListItemView,
+  getFilteredCaseViews,
+  matchesCaseTriageTab,
+  normalizeCaseListFilters,
+  readCaseListFilters,
+  writeCaseListFilters,
+} from './caseView'
+
+function makeCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    id,
+    templateId: id,
+    title: overrides.title ?? id,
+    description: 'details',
+    kind: overrides.kind ?? 'case',
+    status: overrides.status ?? 'open',
+    mode: overrides.mode ?? 'threshold',
+    difficulty: { combat: 10, investigation: 10, utility: 10, social: 10 },
+    weights: { combat: 0.25, investigation: 0.25, utility: 0.25, social: 0.25 },
+    tags: overrides.tags ?? [],
+    stage: overrides.stage ?? 1,
+    durationWeeks: 2,
+    deadlineWeeks: 3,
+    deadlineRemaining: overrides.deadlineRemaining ?? 3,
+    intelConfidence: 1,
+    intelUncertainty: 0,
+    intelLastUpdatedWeek: 0,
+    assignedTeamIds: overrides.assignedTeamIds ?? [],
+    requiredRoles: [],
+    requiredTags: [],
+    preferredTags: [],
+    onFail: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] },
+    onUnresolved: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] },
+    ...overrides,
+  }
+}
+
+describe('caseView triage filters', () => {
+  it('normalizeCaseListFilters drops selection hidden by active triage tab', () => {
+    const game = createStartingState()
+    game.cases = {
+      open: makeCase('open', { title: 'Open Case' }),
+      assigned: makeCase('assigned', {
+        title: 'Assigned Case',
+        status: 'in_progress',
+        assignedTeamIds: [Object.keys(game.teams)[0]!],
+      }),
+    }
+
+    const normalized = normalizeCaseListFilters(game, {
+      q: '',
+      status: 'all',
+      mode: 'all',
+      stage: 'all',
+      sort: 'priority',
+      risk: false,
+      tab: 'assigned',
+      selectedCaseId: 'open',
+    })
+
+    expect(normalized.selectedCaseId).toBe('')
+  })
+
+  it('writeCaseListFilters round-trips tab and case params', () => {
+    const serialized = writeCaseListFilters({
+      q: '',
+      status: 'all',
+      mode: 'all',
+      stage: 'all',
+      sort: 'priority',
+      risk: false,
+      tab: 'leads',
+      selectedCaseId: 'case-lead-1',
+    })
+
+    expect(readCaseListFilters(serialized)).toMatchObject({
+      tab: 'leads',
+      selectedCaseId: 'case-lead-1',
+    })
+  })
+
+  it('getFilteredCaseViews applies triage tab before status filters', () => {
+    const game = createStartingState()
+    const teamId = Object.keys(game.teams)[0]!
+    game.cases = {
+      open: makeCase('open', { title: 'Open Case' }),
+      assigned: makeCase('assigned', {
+        title: 'Assigned Case',
+        status: 'in_progress',
+        assignedTeamIds: [teamId],
+      }),
+    }
+
+    const views = getFilteredCaseViews(game, {
+      q: '',
+      status: 'all',
+      mode: 'all',
+      stage: 'all',
+      sort: 'title',
+      risk: false,
+      tab: 'assigned',
+      selectedCaseId: '',
+    })
+
+    expect(views.map((view) => view.currentCase.id)).toEqual(['assigned'])
+    expect(matchesCaseTriageTab(getCaseListItemView(game.cases.open!, game), 'assigned', game)).toBe(
+      false
+    )
+  })
+})

--- a/src/features/cases/caseView.ts
+++ b/src/features/cases/caseView.ts
@@ -21,6 +21,11 @@ import {
   type MissionTriageDeferralCompareView,
 } from './missionTriageDeferralCompareView'
 import {
+  deriveMissionCategory,
+  missionTriageShowsEscalationDeferralRisk,
+  triageMission,
+} from '../../domain/missionIntakeRouting'
+import {
   buildMissionTriageCovertPrepSignals,
   type MissionTriageCovertPrepSignals,
 } from './missionTriageCovertPrepView'
@@ -29,11 +34,20 @@ export const CASE_STATUS_FILTERS = ['all', 'open', 'in_progress', 'resolved'] as
 export const CASE_MODE_FILTERS = ['all', 'threshold', 'probability', 'deterministic'] as const
 export const CASE_STAGE_FILTERS = ['all', '1', '2', '3', '4', '5'] as const
 export const CASE_SORTS = ['priority', 'deadline', 'success', 'title'] as const
+export const CASE_TRIAGE_TABS = [
+  'all',
+  'incidents',
+  'contracts',
+  'leads',
+  'escalating',
+  'assigned',
+] as const
 
 export type CaseStatusFilter = (typeof CASE_STATUS_FILTERS)[number]
 export type CaseModeFilter = (typeof CASE_MODE_FILTERS)[number]
 export type CaseStageFilter = (typeof CASE_STAGE_FILTERS)[number]
 export type CaseSort = (typeof CASE_SORTS)[number]
+export type CaseTriageTab = (typeof CASE_TRIAGE_TABS)[number]
 
 export interface CaseListFilters {
   q: string
@@ -42,6 +56,8 @@ export interface CaseListFilters {
   stage: CaseStageFilter
   sort: CaseSort
   risk: boolean
+  tab: CaseTriageTab
+  selectedCaseId: string
 }
 
 export interface CaseTeamOddsView {
@@ -75,6 +91,8 @@ export const DEFAULT_CASE_LIST_FILTERS: CaseListFilters = {
   stage: 'all',
   sort: 'priority',
   risk: false,
+  tab: 'all',
+  selectedCaseId: '',
 }
 
 export interface CaseListItemViewOptions {
@@ -212,6 +230,60 @@ export function getCaseListItemView(
   }
 }
 
+export function matchesCaseTriageTab(
+  view: CaseListItemView,
+  tab: CaseTriageTab,
+  game: GameState
+): boolean {
+  const currentCase = view.currentCase
+
+  switch (tab) {
+    case 'all':
+      return true
+    case 'contracts':
+      return Boolean(currentCase.contract)
+    case 'assigned':
+      return view.assignedTeams.length > 0
+    case 'leads':
+      return deriveMissionCategory(currentCase) === 'investigation_lead'
+    case 'incidents':
+      return (
+        !currentCase.contract && deriveMissionCategory(currentCase) !== 'investigation_lead'
+      )
+    case 'escalating': {
+      const triage = triageMission(game, currentCase)
+      return (
+        currentCase.stage > 1 ||
+        view.isCriticalStage ||
+        view.hasDeadlineRisk ||
+        missionTriageShowsEscalationDeferralRisk(triage.reasonCodes)
+      )
+    }
+    default: {
+      const _exhaustive: never = tab
+      return _exhaustive
+    }
+  }
+}
+
+export function normalizeCaseListFilters(
+  game: GameState,
+  filters: CaseListFilters,
+  options?: CaseListItemViewOptions
+): CaseListFilters {
+  if (!filters.selectedCaseId) {
+    return filters
+  }
+
+  const visibleCaseIds = new Set(
+    getFilteredCaseViews(game, filters, options).map((view) => view.currentCase.id)
+  )
+
+  return visibleCaseIds.has(filters.selectedCaseId)
+    ? filters
+    : { ...filters, selectedCaseId: '' }
+}
+
 export function getFilteredCaseViews(
   game: GameState,
   filters: CaseListFilters,
@@ -219,7 +291,7 @@ export function getFilteredCaseViews(
 ) {
   return Object.values(game.cases)
     .map((currentCase) => getCaseListItemView(currentCase, game, options))
-    .filter((view) => matchesCaseFilters(view, filters))
+    .filter((view) => matchesCaseFilters(view, filters, game))
     .sort((left, right) => compareCaseViews(left, right, filters.sort))
 }
 
@@ -241,6 +313,8 @@ export function readCaseListFilters(searchParams: URLSearchParams): CaseListFilt
     ),
     sort: readEnumParam(searchParams, 'sort', CASE_SORTS, DEFAULT_CASE_LIST_FILTERS.sort),
     risk: searchParams.get('risk') === '1',
+    tab: readEnumParam(searchParams, 'tab', CASE_TRIAGE_TABS, DEFAULT_CASE_LIST_FILTERS.tab),
+    selectedCaseId: readStringParam(searchParams, 'case'),
   }
 }
 
@@ -258,6 +332,9 @@ export function writeCaseListFilters(filters: CaseListFilters, baseSearchParams?
   } else {
     nextSearchParams.delete('risk')
   }
+
+  writeEnumParam(nextSearchParams, 'tab', filters.tab, DEFAULT_CASE_LIST_FILTERS.tab)
+  writeStringParam(nextSearchParams, 'case', filters.selectedCaseId)
 
   return nextSearchParams
 }
@@ -278,7 +355,11 @@ function isTeamAvailableForCase(team: Team, currentCase: CaseInstance, game: Gam
   return true
 }
 
-function matchesCaseFilters(view: CaseListItemView, filters: CaseListFilters) {
+function matchesCaseFilters(view: CaseListItemView, filters: CaseListFilters, game: GameState) {
+  if (!matchesCaseTriageTab(view, filters.tab, game)) {
+    return false
+  }
+
   if (filters.status !== 'all' && view.currentCase.status !== filters.status) {
     return false
   }
@@ -316,16 +397,20 @@ function matchesCaseFilters(view: CaseListItemView, filters: CaseListFilters) {
   return searchableText.includes(normalizedQuery)
 }
 
+function compareCaseTitle(left: CaseListItemView, right: CaseListItemView) {
+  return String(left.currentCase.title).localeCompare(String(right.currentCase.title))
+}
+
 function compareCaseViews(left: CaseListItemView, right: CaseListItemView, sort: CaseSort) {
   if (sort === 'title') {
-    return left.currentCase.title.localeCompare(right.currentCase.title)
+    return compareCaseTitle(left, right)
   }
 
   if (sort === 'deadline') {
     return (
       left.currentCase.deadlineRemaining - right.currentCase.deadlineRemaining ||
       right.currentCase.stage - left.currentCase.stage ||
-      left.currentCase.title.localeCompare(right.currentCase.title)
+      compareCaseTitle(left, right)
     )
   }
 
@@ -333,14 +418,14 @@ function compareCaseViews(left: CaseListItemView, right: CaseListItemView, sort:
     return (
       right.bestSuccess - left.bestSuccess ||
       right.priorityScore - left.priorityScore ||
-      left.currentCase.title.localeCompare(right.currentCase.title)
+      compareCaseTitle(left, right)
     )
   }
 
   return (
     right.priorityScore - left.priorityScore ||
     left.currentCase.deadlineRemaining - right.currentCase.deadlineRemaining ||
-    left.currentCase.title.localeCompare(right.currentCase.title)
+    compareCaseTitle(left, right)
   )
 }
 

--- a/src/features/cases/missionTriageLayoutView.ts
+++ b/src/features/cases/missionTriageLayoutView.ts
@@ -1,0 +1,192 @@
+import {
+  deriveMissionCategory,
+  missionTriageShowsEscalationDeferralRisk,
+  triageMission,
+  type MissionTriageResult,
+} from '../../domain/missionIntakeRouting'
+import type { GameState, MissionCategory, MissionPriorityBand } from '../../domain/models'
+import { isTeamBlockedByTraining } from '../../domain/sim/training'
+import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
+import {
+  CASE_TRIAGE_TABS,
+  matchesCaseTriageTab,
+  type CaseListItemView,
+  type CaseTriageTab,
+} from './caseView'
+
+export const CASE_TRIAGE_TAB_LABELS: Record<CaseTriageTab, string> = {
+  all: 'All',
+  incidents: 'Incidents',
+  contracts: 'Contracts',
+  leads: 'Leads',
+  escalating: 'Escalating',
+  assigned: 'Assigned',
+}
+
+const MISSION_CATEGORY_LABELS: Record<MissionCategory, string> = {
+  containment_breach: 'Incident',
+  investigation_lead: 'Lead',
+  civilian_infrastructure_incident: 'Incident',
+  faction_hostile_activity: 'Incident',
+  strategic_opportunity: 'Opportunity',
+}
+
+export function missionTriageItemTypeLabel(category: MissionCategory): string {
+  return MISSION_CATEGORY_LABELS[category]
+}
+
+export interface MissionTriageCompactRowView {
+  readonly caseId: string
+  readonly title: string
+  readonly typeLabel: string
+  readonly priority: MissionPriorityBand
+  readonly priorityScore: number
+  readonly markerPreview: string
+  readonly isSelected: boolean
+}
+
+export function buildMissionTriageCompactRowView(
+  view: CaseListItemView,
+  game: GameState,
+  selectedCaseId: string,
+  markerPreview: string
+): MissionTriageCompactRowView {
+  const triage = triageMission(game, view.currentCase)
+
+  return {
+    caseId: view.currentCase.id,
+    title: view.currentCase.title,
+    typeLabel: view.currentCase.contract
+      ? 'Contract'
+      : missionTriageItemTypeLabel(deriveMissionCategory(view.currentCase)),
+    priority: triage.priority,
+    priorityScore: triage.score,
+    markerPreview,
+    isSelected: selectedCaseId === view.currentCase.id,
+  }
+}
+
+export type MissionTriageFooterLoadBand = 'low' | 'medium' | 'high'
+
+export interface MissionTriageContextFooterView {
+  readonly projectedSupportLoad: MissionTriageFooterLoadBand
+  readonly teamsAvailable: number
+  readonly urgentIfDeferred: number
+  readonly escalationCarryoverRisk: number
+  readonly routableCount: number
+}
+
+function supportLoadBand(highCapacityCount: number, total: number): MissionTriageFooterLoadBand {
+  if (total === 0) {
+    return 'low'
+  }
+
+  const ratio = highCapacityCount / total
+
+  if (ratio >= 0.5) {
+    return 'high'
+  }
+
+  if (ratio >= 0.25) {
+    return 'medium'
+  }
+
+  return 'low'
+}
+
+function countTeamsAvailable(game: GameState) {
+  return Object.values(game.teams).filter((team) => {
+    if (getTeamAssignedCaseId(team)) {
+      return false
+    }
+
+    return !isTeamBlockedByTraining(team, game.agents)
+  }).length
+}
+
+function isUrgentIfDeferred(view: CaseListItemView, triage: MissionTriageResult) {
+  if (view.currentCase.status === 'resolved') {
+    return false
+  }
+
+  return (
+    view.isUnassigned &&
+    (view.hasDeadlineRisk ||
+      view.isCriticalStage ||
+      missionTriageShowsEscalationDeferralRisk(triage.reasonCodes))
+  )
+}
+
+function hasEscalationCarryoverRisk(view: CaseListItemView, triage: MissionTriageResult) {
+  if (view.currentCase.status === 'resolved') {
+    return false
+  }
+
+  return (
+    view.isCriticalStage ||
+    triage.reasonCodes.includes('escalation-high') ||
+    (view.isUnassigned && view.currentCase.stage >= 3)
+  )
+}
+
+export function buildMissionTriageContextFooterView(
+  views: readonly CaseListItemView[],
+  game: GameState
+): MissionTriageContextFooterView {
+  const activeViews = views.filter((view) => view.currentCase.status !== 'resolved')
+  const triageByCaseId = new Map(
+    activeViews.map((view) => [view.currentCase.id, triageMission(game, view.currentCase)] as const)
+  )
+
+  let highCapacityCount = 0
+  let urgentIfDeferred = 0
+  let escalationCarryoverRisk = 0
+  let routableCount = 0
+
+  for (const view of activeViews) {
+    const triage = triageByCaseId.get(view.currentCase.id)!
+
+    if (triage.reasonCodes.includes('capacity-high') || triage.reasonCodes.includes('capacity-medium')) {
+      highCapacityCount += 1
+    }
+
+    if (isUrgentIfDeferred(view, triage)) {
+      urgentIfDeferred += 1
+    }
+
+    if (hasEscalationCarryoverRisk(view, triage)) {
+      escalationCarryoverRisk += 1
+    }
+
+    if (view.currentCase.status === 'open' && !view.isBlockedByRequiredRoles && !view.isBlockedByRequiredTags) {
+      routableCount += 1
+    }
+  }
+
+  return {
+    projectedSupportLoad: supportLoadBand(highCapacityCount, activeViews.length),
+    teamsAvailable: countTeamsAvailable(game),
+    urgentIfDeferred,
+    escalationCarryoverRisk,
+    routableCount,
+  }
+}
+
+export function buildTriageTabCounts(
+  views: readonly CaseListItemView[],
+  game: GameState
+): Record<CaseTriageTab, number> {
+  return CASE_TRIAGE_TABS.reduce(
+    (counts, tab) => {
+      counts[tab] = views.filter((view) => matchesCaseTriageTab(view, tab, game)).length
+      return counts
+    },
+    {} as Record<CaseTriageTab, number>
+  )
+}
+
+export const MISSION_TRIAGE_FOOTER_LOAD_LABELS: Record<MissionTriageFooterLoadBand, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+}

--- a/src/features/cases/missionTriageLayoutView.ts
+++ b/src/features/cases/missionTriageLayoutView.ts
@@ -45,14 +45,21 @@ export interface MissionTriageCompactRowView {
   readonly isSelected: boolean
 }
 
+export function buildMissionTriageResultsByCaseId(
+  views: readonly CaseListItemView[],
+  game: GameState
+): ReadonlyMap<string, MissionTriageResult> {
+  return new Map(
+    views.map((view) => [view.currentCase.id, triageMission(game, view.currentCase)]),
+  )
+}
+
 export function buildMissionTriageCompactRowView(
   view: CaseListItemView,
-  game: GameState,
+  triage: MissionTriageResult,
   selectedCaseId: string,
   markerPreview: string
 ): MissionTriageCompactRowView {
-  const triage = triageMission(game, view.currentCase)
-
   return {
     caseId: view.currentCase.id,
     title: view.currentCase.title,

--- a/src/features/cases/missionTriageLayoutView.ts
+++ b/src/features/cases/missionTriageLayoutView.ts
@@ -83,18 +83,15 @@ export interface MissionTriageContextFooterView {
   readonly routableCount: number
 }
 
-function supportLoadBand(highCapacityCount: number, total: number): MissionTriageFooterLoadBand {
-  if (total === 0) {
-    return 'low'
-  }
-
-  const ratio = highCapacityCount / total
-
-  if (ratio >= 0.5) {
+/** Capacity reason codes are global (same for every open case in a week), not per-row. */
+function projectedSupportLoadFromCapacityCodes(
+  reasonCodes: readonly string[]
+): MissionTriageFooterLoadBand {
+  if (reasonCodes.includes('capacity-high')) {
     return 'high'
   }
 
-  if (ratio >= 0.25) {
+  if (reasonCodes.includes('capacity-medium')) {
     return 'medium'
   }
 
@@ -145,17 +142,12 @@ export function buildMissionTriageContextFooterView(
     activeViews.map((view) => [view.currentCase.id, triageMission(game, view.currentCase)] as const)
   )
 
-  let highCapacityCount = 0
   let urgentIfDeferred = 0
   let escalationCarryoverRisk = 0
   let routableCount = 0
 
   for (const view of activeViews) {
     const triage = triageByCaseId.get(view.currentCase.id)!
-
-    if (triage.reasonCodes.includes('capacity-high') || triage.reasonCodes.includes('capacity-medium')) {
-      highCapacityCount += 1
-    }
 
     if (isUrgentIfDeferred(view, triage)) {
       urgentIfDeferred += 1
@@ -170,8 +162,12 @@ export function buildMissionTriageContextFooterView(
     }
   }
 
+  const sampleTriage = activeViews[0] ? triageByCaseId.get(activeViews[0].currentCase.id) : undefined
+
   return {
-    projectedSupportLoad: supportLoadBand(highCapacityCount, activeViews.length),
+    projectedSupportLoad: sampleTriage
+      ? projectedSupportLoadFromCapacityCodes(sampleTriage.reasonCodes)
+      : 'low',
     teamsAvailable: countTeamsAvailable(game),
     urgentIfDeferred,
     escalationCarryoverRisk,

--- a/src/test/missionTriageLayoutView.test.ts
+++ b/src/test/missionTriageLayoutView.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { getCaseListItemView, matchesCaseTriageTab } from '../features/cases/caseView'
+import { buildMissionTriageContextFooterView } from '../features/cases/missionTriageLayoutView'
+import type { CaseInstance } from '../domain/models'
+
+function makeCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    id,
+    templateId: id,
+    title: overrides.title ?? id,
+    description: 'details',
+    kind: overrides.kind ?? 'case',
+    status: overrides.status ?? 'open',
+    mode: overrides.mode ?? 'threshold',
+    difficulty: { combat: 10, investigation: 10, utility: 10, social: 10 },
+    weights: { combat: 0.25, investigation: 0.25, utility: 0.25, social: 0.25 },
+    tags: overrides.tags ?? [],
+    stage: overrides.stage ?? 1,
+    durationWeeks: 2,
+    deadlineWeeks: 3,
+    deadlineRemaining: overrides.deadlineRemaining ?? 3,
+    intelConfidence: 1,
+    intelUncertainty: 0,
+    intelLastUpdatedWeek: 0,
+    assignedTeamIds: overrides.assignedTeamIds ?? [],
+    requiredRoles: [],
+    requiredTags: [],
+    preferredTags: [],
+    onFail: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] },
+    onUnresolved: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] },
+    ...overrides,
+  }
+}
+
+describe('missionTriageLayoutView', () => {
+  it('matches triage tabs by contract, assignment, lead tags, and escalation', () => {
+    const game = createStartingState()
+    game.cases = {
+      contract: makeCase('contract', { contract: { templateId: 'c-1' }, tags: ['contract'] }),
+      lead: makeCase('lead', { tags: ['investigation', 'analysis'] }),
+      assigned: makeCase('assigned', { assignedTeamIds: [Object.keys(game.teams)[0]!] }),
+      escalating: makeCase('escalating', { stage: 4, deadlineRemaining: 1 }),
+      plain: makeCase('plain', { tags: ['facility'] }),
+    }
+
+    const views = Object.values(game.cases).map((entry) => getCaseListItemView(entry, game))
+
+    expect(matchesCaseTriageTab(views.find((v) => v.currentCase.id === 'contract')!, 'contracts', game)).toBe(
+      true
+    )
+    expect(matchesCaseTriageTab(views.find((v) => v.currentCase.id === 'lead')!, 'leads', game)).toBe(true)
+    expect(matchesCaseTriageTab(views.find((v) => v.currentCase.id === 'assigned')!, 'assigned', game)).toBe(
+      true
+    )
+    expect(matchesCaseTriageTab(views.find((v) => v.currentCase.id === 'escalating')!, 'escalating', game)).toBe(
+      true
+    )
+    expect(matchesCaseTriageTab(views.find((v) => v.currentCase.id === 'plain')!, 'incidents', game)).toBe(
+      true
+    )
+    expect(matchesCaseTriageTab(views.find((v) => v.currentCase.id === 'contract')!, 'incidents', game)).toBe(
+      false
+    )
+  })
+
+  it('builds context footer with zero active cases', () => {
+    const game = createStartingState()
+    game.cases = {
+      resolved: makeCase('resolved', { status: 'resolved', stage: 5 }),
+    }
+
+    const views = Object.values(game.cases).map((entry) => getCaseListItemView(entry, game))
+    const footer = buildMissionTriageContextFooterView(views, game)
+
+    expect(footer.projectedSupportLoad).toBe('low')
+    expect(footer.urgentIfDeferred).toBe(0)
+    expect(footer.escalationCarryoverRisk).toBe(0)
+    expect(footer.routableCount).toBe(0)
+  })
+
+  it('builds context footer counts from active triage views', () => {
+    const game = createStartingState()
+    game.cases = {
+      urgent: makeCase('urgent', { stage: 4, deadlineRemaining: 1 }),
+      assigned: makeCase('assigned', {
+        status: 'in_progress',
+        assignedTeamIds: [Object.keys(game.teams)[0]!],
+      }),
+      resolved: makeCase('resolved', { status: 'resolved', stage: 5 }),
+    }
+
+    const views = Object.values(game.cases).map((entry) =>
+      getCaseListItemView(entry, game, { includeCovertPrepSignals: true })
+    )
+    const footer = buildMissionTriageContextFooterView(views, game)
+
+    expect(footer.teamsAvailable).toBeGreaterThan(0)
+    expect(footer.urgentIfDeferred).toBeGreaterThanOrEqual(1)
+    expect(footer.routableCount).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/src/test/missionTriageLayoutView.test.ts
+++ b/src/test/missionTriageLayoutView.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { getCaseListItemView, matchesCaseTriageTab } from '../features/cases/caseView'
-import { buildMissionTriageContextFooterView } from '../features/cases/missionTriageLayoutView'
+import {
+  buildMissionTriageCompactRowView,
+  buildMissionTriageContextFooterView,
+} from '../features/cases/missionTriageLayoutView'
+import { triageMission } from '../domain/missionIntakeRouting'
 import type { CaseInstance } from '../domain/models'
 
 function makeCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
@@ -62,6 +66,21 @@ describe('missionTriageLayoutView', () => {
     expect(matchesCaseTriageTab(views.find((v) => v.currentCase.id === 'contract')!, 'incidents', game)).toBe(
       false
     )
+  })
+
+  it('builds compact row priority from triage result', () => {
+    const game = createStartingState()
+    game.cases = {
+      urgent: makeCase('urgent', { stage: 4, deadlineRemaining: 1 }),
+    }
+
+    const view = getCaseListItemView(game.cases.urgent!, game)
+    const triage = triageMission(game, view.currentCase)
+    const row = buildMissionTriageCompactRowView(view, triage, '', '')
+
+    expect(row.priority).toBe(triage.priority)
+    expect(row.priorityScore).toBe(triage.score)
+    expect(row.priorityScore).toBeGreaterThan(0)
   })
 
   it('builds context footer with zero active cases', () => {

--- a/src/test/missionTriageLayoutView.test.ts
+++ b/src/test/missionTriageLayoutView.test.ts
@@ -98,6 +98,25 @@ describe('missionTriageLayoutView', () => {
     expect(footer.routableCount).toBe(0)
   })
 
+  it('maps global capacity-medium to medium support load, not high', () => {
+    const game = createStartingState()
+    const teamId = Object.keys(game.teams)[0]!
+    game.cases = {
+      openA: makeCase('openA', { status: 'open' }),
+      openB: makeCase('openB', { status: 'open' }),
+      active: makeCase('active', { status: 'in_progress', assignedTeamIds: [teamId] }),
+    }
+
+    const views = Object.values(game.cases).map((entry) => getCaseListItemView(entry, game))
+    const sampleTriage = triageMission(game, game.cases.openA!)
+    expect(sampleTriage.reasonCodes).toContain('capacity-medium')
+    expect(sampleTriage.reasonCodes).not.toContain('capacity-high')
+
+    const footer = buildMissionTriageContextFooterView(views, game)
+
+    expect(footer.projectedSupportLoad).toBe('medium')
+  })
+
   it('builds context footer counts from active triage views', () => {
     const game = createStartingState()
     game.cases = {

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -34,9 +34,12 @@ This spec is for:
 
 **Slice 2 shipped:** `CasesPage` list rows show a three-column deferral comparison table (`Covert prep load` / `If deferred` / `Carryover`) via `buildMissionTriageDeferralCompareView` and `MissionTriageDeferralCompareTable`; escalation carryover cross-link when deferral risk is high. Plan: `planning/mission-triage-deferral-compare-slice.md`.
 
+**Slice 3 shipped (SPE-2257):** `CasesPage` case queue uses triage category tabs (URL `tab`), split list/detail panel (URL `case`), and context footer via `missionTriageLayoutView` + `MissionTriageTabs` / `MissionTriageListRow` / `MissionTriageContextFooter`. Plan: `planning/mission-triage-layout-slice.md`.
+
 **Still deferred (follow-up slices):**
 
-- full triage layout refresh (filters/tabs/split detail panel per §3)
+- status-bar routable/urgent tail chips per `ux/navigation-map.md`
+- route/defer/ignore actions distinct from team assignment
 
 ---
 


### PR DESCRIPTION
## Summary

- Restructures the `CasesPage` case queue toward `ux/mission-triage.md` slice 3: category tabs (URL `tab`), split triage list/detail panel (URL `case`), and context footer aggregates.
- Adds `missionTriageLayoutView`, `normalizeCaseListFilters`, and focused tests; preserves slice 1–2 covert/deferral signals in the detail panel.
- Merges with main’s core-loop hint, prep dossier links, and `case-title-link-*` test ids.

## Linear

https://linear.app/spectranoir/issue/SPE-2257/mission-triage-layout-refresh-slice-3-ux

Parent: SPE-16

## Test plan

- [x] `npm run test:run -- src/features/cases src/test/missionTriageLayoutView.test.ts src/app/filterHelpers.test.ts`
- [x] `npm run lint`
- [x] CI green
- [x] Manual: tabs filter list; Inspect selects detail; footer shows with empty filter; stale `case` param stripped

## Deferred (out of scope)

- Status-bar routable/urgent tail chips
- Route/defer/ignore store actions distinct from assignment
