### PR TITLE
feat(SPE-2258): mission triage status-bar tail (slice 4 UX)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -32,7 +32,7 @@ From `README.md` **Current design notes**:
 
 ## Deferred UX (follow-up after SPE-2255)
 
-- **`ux/mission-triage.md`** — status-bar triage tail + route/defer/ignore actions (layout tabs/split/footer shipped SPE-2257 / `planning/mission-triage-layout-slice.md`; row chips + deferral compare SPE-2255–2256).
+- **`ux/mission-triage.md`** — route/defer/ignore actions (status-bar triage tail shipped SPE-2258 / `planning/mission-triage-status-bar-slice.md`; layout SPE-2257; row chips SPE-2255–2256).
 
 ## SCP-9995 harvest — May 2026 reconciliation
 

--- a/planning/mission-triage-status-bar-slice.md
+++ b/planning/mission-triage-status-bar-slice.md
@@ -1,0 +1,35 @@
+# SPE-16 slice 4 — Mission triage operations status-bar tail (UX)
+
+One-page implementation plan. Linear: [SPE-2258](https://linear.app/spectranoir/issue/SPE-2258/mission-triage-operations-status-bar-tail-slice-4-ux). Parent: [SPE-16 — Mission Intake, Triage, & Routing](https://linear.app/spectranoir/issue/SPE-16/mission-intake-triage-and-routing). Follows [SPE-2257](https://linear.app/spectranoir/issue/SPE-2257) / `planning/mission-triage-layout-slice.md`.
+
+## Goal
+
+When the player is on `/cases`, extend the global shell status strip with read-only triage queue chips (routable count, unassigned urgent) from the same projection as `MissionTriageContextFooter` — per `ux/navigation-map.md` optional extensions and `ux/mission-triage.md` deferred block.
+
+## Non-goals
+
+- Route / defer / ignore disposition actions (slice 5)
+- New simulation math or second telemetry store
+- Showing extensions on non-cases routes
+
+## Acceptance
+
+- [x] On `/cases` (and `/cases/:id` if shell is shared), shell tail shows routable + urgent chips
+- [x] Chips link to cases list; aria labels include detail text
+- [x] Other routes unchanged
+- [x] Unit tests for signal builder + `ShellStatusBar` route guard
+- [x] Lint + targeted Vitest green
+
+## Branch
+
+`spe-16-mission-triage-status-bar-slice-4`
+
+## Audit notes (May 2026)
+
+- Shell extension uses `buildMissionTriageBoardViews` (shared with `CasesPage` footer/tab counts) so metrics match the triage board filters.
+- Chip `href` preserves canonical filter query via `writeCaseListFilters`.
+- `buildMissionTriageShellExtensionSignals(game, views, casesHref)` takes pre-built board views; no parallel metrics helper.
+
+## Follow-up (slice 5)
+
+Route / defer / ignore actions on triage detail panel — separate Linear issue and `planning/mission-triage-disposition-slice.md` (TBD).

--- a/src/components/layout/ShellStatusBar.test.tsx
+++ b/src/components/layout/ShellStatusBar.test.tsx
@@ -1,8 +1,8 @@
 // cspell:words topbar
 import '../../test/setup'
-import { act, render, screen, within } from '@testing-library/react'
+import { act, cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router'
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { createStartingState } from '../../data/startingState'
@@ -10,19 +10,37 @@ import { normalizeGameState } from '../../domain/teamSimulation'
 import { useGameStore } from '../../app/store/gameStore'
 import { ShellStatusBar } from './ShellStatusBar'
 
+function ShellStatusBarLayout() {
+  return (
+    <>
+      <ShellStatusBar />
+      <Outlet />
+    </>
+  )
+}
+
 function renderShellStatusBar(route = '/') {
   return render(
     <MemoryRouter initialEntries={[route]}>
       <Routes>
-        <Route path="/" element={<ShellStatusBar />} />
-        <Route path="/report" element={<div data-testid="report-index-route">Report index</div>} />
-        <Route path="/report/:week" element={<div data-testid="report-route">Report route</div>} />
-        <Route path="/agency" element={<div data-testid="agency-route">Agency route</div>} />
-        <Route path="/help" element={<div data-testid="help-route">Help route</div>} />
-        <Route path="/recruitment" element={<div data-testid="recruitment-route">Recruitment</div>} />
-        <Route path="/teams" element={<div data-testid="teams-route">Teams</div>} />
-        <Route path="/intel" element={<div data-testid="intel-route">Intel</div>} />
-        <Route path="/cases" element={<div data-testid="cases-route">Cases</div>} />
+        <Route element={<ShellStatusBarLayout />}>
+          <Route path="/" element={<div data-testid="home-route">Home</div>} />
+          <Route path="/report" element={<div data-testid="report-index-route">Report index</div>} />
+          <Route path="/report/:week" element={<div data-testid="report-route">Report route</div>} />
+          <Route path="/agency" element={<div data-testid="agency-route">Agency route</div>} />
+          <Route path="/help" element={<div data-testid="help-route">Help route</div>} />
+          <Route
+            path="/recruitment"
+            element={<div data-testid="recruitment-route">Recruitment</div>}
+          />
+          <Route path="/teams" element={<div data-testid="teams-route">Teams</div>} />
+          <Route path="/intel" element={<div data-testid="intel-route">Intel</div>} />
+          <Route path="/cases" element={<div data-testid="cases-route">Cases</div>} />
+          <Route
+            path="/cases/:caseId"
+            element={<div data-testid="case-detail-route">Case detail</div>}
+          />
+        </Route>
       </Routes>
     </MemoryRouter>
   )
@@ -252,6 +270,78 @@ describe('ShellStatusBar', () => {
 
     expect(topBar).toHaveClass('topbar-shell')
     expect(strip).toHaveClass('whitespace-nowrap')
+  })
+
+  it('aligns triage queue depth with cases URL status filters', () => {
+    const game = createBaseGame()
+    game.cases = {
+      'case-open': {
+        ...game.cases['case-001']!,
+        id: 'case-open',
+        templateId: 'case-open',
+        title: 'Open only',
+        status: 'open',
+        assignedTeamIds: [],
+        contract: undefined,
+      },
+      'case-active': {
+        ...game.cases['case-001']!,
+        id: 'case-active',
+        templateId: 'case-active',
+        title: 'In progress',
+        status: 'in_progress',
+        assignedTeamIds: [],
+        contract: undefined,
+      },
+    }
+    useGameStore.setState({ game: normalizeGameState(game) })
+
+    renderShellStatusBar('/cases')
+    const allQueue = screen.getByTestId('shell-status-triage-queue')
+    expect(allQueue).toHaveTextContent('Queue2')
+    cleanup()
+
+    renderShellStatusBar('/cases?status=open')
+    const openQueue = screen.getByTestId('shell-status-triage-queue')
+    expect(openQueue).toHaveTextContent('Queue1')
+    expect(openQueue.textContent).not.toEqual(allQueue.textContent)
+
+    const routableLink = screen.getByTestId('shell-status-triage-routable')
+    expect(routableLink).toHaveAttribute('href', '/cases?status=open')
+  })
+
+  it('shows triage tail chips on cases routes only', () => {
+    const game = createBaseGame()
+    game.cases['case-urgent'] = {
+      ...game.cases['case-001']!,
+      id: 'case-urgent',
+      templateId: 'case-urgent',
+      title: 'Urgent triage case',
+      status: 'open',
+      stage: 4,
+      deadlineRemaining: 1,
+      assignedTeamIds: [],
+      contract: undefined,
+    }
+    useGameStore.setState({ game: normalizeGameState(game) })
+
+    renderShellStatusBar('/agency')
+    const agencySignals = screen.getByTestId('shell-status-signals-row')
+    expect(within(agencySignals).queryByTestId('shell-status-triage-routable')).not.toBeInTheDocument()
+    cleanup()
+
+    renderShellStatusBar('/cases')
+    const casesSignals = screen.getByTestId('shell-status-signals-row')
+    expect(within(casesSignals).getByTestId('shell-status-triage-queue')).toBeInTheDocument()
+    expect(within(casesSignals).getByTestId('shell-status-triage-routable')).toBeInTheDocument()
+    expect(within(casesSignals).getByTestId('shell-status-triage-urgent')).toHaveAttribute(
+      'data-status-tone',
+      'warning'
+    )
+    cleanup()
+
+    renderShellStatusBar('/cases/case-urgent')
+    expect(screen.getByTestId('shell-status-triage-routable')).toBeInTheDocument()
   })
 
   it('disables advance action when simulation is halted', () => {

--- a/src/components/layout/ShellStatusBar.tsx
+++ b/src/components/layout/ShellStatusBar.tsx
@@ -1,8 +1,15 @@
 import { useMemo, useState } from 'react'
-import { Link } from 'react-router'
+import { Link, useLocation, useSearchParams } from 'react-router'
 
 import { APP_ROUTES } from '../../app/routes'
 import { useGameStore } from '../../app/store/gameStore'
+import {
+  buildMissionTriageBoardViews,
+  normalizeCaseListFilters,
+  readCaseListFilters,
+  writeCaseListFilters,
+} from '../../features/cases/caseView'
+import { buildMissionTriageShellExtensionSignals } from '../../features/cases/missionTriageShellExtensionView'
 import {
   IconAdvance,
   IconReports,
@@ -12,10 +19,37 @@ import {
 } from '../icons'
 import { buildShellStatusBarView, type ShellStatusSignalView } from './shellStatusBarView'
 
+function isCasesRoute(pathname: string) {
+  return pathname === APP_ROUTES.cases || pathname.startsWith(`${APP_ROUTES.cases}/`)
+}
+
 export function ShellStatusBar() {
   const { game, advanceWeek } = useGameStore()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
   const [muted, setMuted] = useState(false)
   const view = useMemo(() => buildShellStatusBarView(game), [game])
+  const extensionSignals = useMemo(() => {
+    if (!isCasesRoute(location.pathname)) {
+      return []
+    }
+
+    const triageViewOptions = { includeCovertPrepSignals: true as const }
+    const filters = normalizeCaseListFilters(
+      game,
+      readCaseListFilters(searchParams),
+      triageViewOptions
+    )
+    const boardViews = buildMissionTriageBoardViews(game, filters, triageViewOptions)
+    const queryString = writeCaseListFilters(filters).toString()
+    const casesHref = queryString ? `${APP_ROUTES.cases}?${queryString}` : APP_ROUTES.cases
+
+    return buildMissionTriageShellExtensionSignals(game, boardViews, casesHref)
+  }, [game, location.pathname, searchParams])
+  const signals = useMemo(
+    () => [...view.signals, ...extensionSignals],
+    [view.signals, extensionSignals]
+  )
 
   return (
     <header className="topbar-shell" role="banner" aria-label="Shell status bar">
@@ -38,7 +72,7 @@ export function ShellStatusBar() {
           </ul>
 
           <div className="topbar-signal-group" data-testid="shell-status-signals-row">
-            {view.signals.map((signal) => (
+            {signals.map((signal) => (
               <SignalChip key={signal.id} signal={signal} />
             ))}
           </div>

--- a/src/components/layout/shellStatusBarView.ts
+++ b/src/components/layout/shellStatusBarView.ts
@@ -13,7 +13,15 @@ const SEASONS = ['Spring', 'Summer', 'Autumn', 'Winter'] as const
 export type ShellStatusTone = 'neutral' | 'info' | 'warning' | 'danger'
 
 export interface ShellStatusSignalView {
-  id: 'budget' | 'staffing' | 'readiness' | 'intel' | 'alert'
+  id:
+    | 'budget'
+    | 'staffing'
+    | 'readiness'
+    | 'intel'
+    | 'alert'
+    | 'triage-queue'
+    | 'triage-routable'
+    | 'triage-urgent'
   label: string
   value: string
   tone: ShellStatusTone

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -51,6 +51,7 @@ import {
   CASE_SORTS,
   CASE_STAGE_FILTERS,
   CASE_STATUS_FILTERS,
+  buildMissionTriageBoardViews,
   getFilteredCaseViews,
   matchesCaseTriageTab,
   normalizeCaseListFilters,
@@ -105,11 +106,7 @@ export default function CasesPage() {
     }
   }, [normalizedSearchString, searchParamsString, setSearchParams])
 
-  const viewsForTabCounts = getFilteredCaseViews(
-    game,
-    { ...filters, tab: 'all' },
-    triageViewOptions
-  )
+  const viewsForTabCounts = buildMissionTriageBoardViews(game, filters, triageViewOptions)
   const tabCounts = buildTriageTabCounts(viewsForTabCounts, game)
   const cases =
     filters.tab === 'all'

--- a/src/features/cases/caseView.ts
+++ b/src/features/cases/caseView.ts
@@ -295,6 +295,15 @@ export function getFilteredCaseViews(
     .sort((left, right) => compareCaseViews(left, right, filters.sort))
 }
 
+/** Board-wide triage views for tab counts, context footer, and shell extensions (tab forced to `all`). */
+export function buildMissionTriageBoardViews(
+  game: GameState,
+  filters: CaseListFilters,
+  options?: CaseListItemViewOptions
+) {
+  return getFilteredCaseViews(game, { ...filters, tab: 'all' }, options)
+}
+
 export function readCaseListFilters(searchParams: URLSearchParams): CaseListFilters {
   return {
     q: readStringParam(searchParams, 'q'),

--- a/src/features/cases/missionTriageShellExtensionView.ts
+++ b/src/features/cases/missionTriageShellExtensionView.ts
@@ -1,0 +1,47 @@
+import { APP_ROUTES } from '../../app/routes'
+import type { ShellStatusSignalView } from '../../components/layout/shellStatusBarView'
+import type { GameState } from '../../domain/models'
+import type { CaseListItemView } from './caseView'
+import { buildMissionTriageContextFooterView } from './missionTriageLayoutView'
+
+export function buildMissionTriageShellExtensionSignals(
+  game: GameState,
+  views: readonly CaseListItemView[],
+  casesHref: string = APP_ROUTES.cases
+): ShellStatusSignalView[] {
+  const activeViews = views.filter((view) => view.currentCase.status !== 'resolved')
+  const footer = buildMissionTriageContextFooterView(activeViews, game)
+  const queueDepth = activeViews.length
+
+  const signals: ShellStatusSignalView[] = [
+    {
+      id: 'triage-queue',
+      label: 'Queue',
+      value: String(queueDepth),
+      tone: 'neutral',
+      href: casesHref,
+      detail: `${queueDepth} open or in-progress case(s) matching the triage board filters.`,
+    },
+    {
+      id: 'triage-routable',
+      label: 'Routable',
+      value: String(footer.routableCount),
+      tone: footer.routableCount > 0 ? 'info' : 'neutral',
+      href: casesHref,
+      detail: `${footer.routableCount} open case(s) without role or tag blockers.`,
+    },
+  ]
+
+  if (footer.urgentIfDeferred > 0) {
+    signals.push({
+      id: 'triage-urgent',
+      label: 'Urgent',
+      value: String(footer.urgentIfDeferred),
+      tone: 'warning',
+      href: casesHref,
+      detail: `${footer.urgentIfDeferred} unassigned case(s) that worsen if deferred this week.`,
+    })
+  }
+
+  return signals
+}

--- a/src/test/missionTriageShellExtensionView.test.ts
+++ b/src/test/missionTriageShellExtensionView.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { APP_ROUTES } from '../app/routes'
+import {
+  buildMissionTriageBoardViews,
+  getCaseListItemView,
+} from '../features/cases/caseView'
+import { buildMissionTriageShellExtensionSignals } from '../features/cases/missionTriageShellExtensionView'
+import { buildMissionTriageContextFooterView } from '../features/cases/missionTriageLayoutView'
+import type { CaseInstance } from '../domain/models'
+
+function makeCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    id,
+    templateId: id,
+    title: overrides.title ?? id,
+    description: 'details',
+    kind: overrides.kind ?? 'case',
+    status: overrides.status ?? 'open',
+    mode: overrides.mode ?? 'threshold',
+    difficulty: { combat: 10, investigation: 10, utility: 10, social: 10 },
+    weights: { combat: 0.25, investigation: 0.25, utility: 0.25, social: 0.25 },
+    tags: overrides.tags ?? [],
+    stage: overrides.stage ?? 1,
+    durationWeeks: 2,
+    deadlineWeeks: 3,
+    deadlineRemaining: overrides.deadlineRemaining ?? 3,
+    intelConfidence: 1,
+    intelUncertainty: 0,
+    intelLastUpdatedWeek: 0,
+    assignedTeamIds: overrides.assignedTeamIds ?? [],
+    requiredRoles: [],
+    requiredTags: [],
+    preferredTags: [],
+    onFail: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] },
+    onUnresolved: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] },
+    ...overrides,
+  }
+}
+
+describe('missionTriageShellExtensionView', () => {
+  it('excludes resolved cases from supplied board views', () => {
+    const game = createStartingState()
+    game.cases = {
+      open: makeCase('open', { status: 'open' }),
+      resolved: makeCase('resolved', { status: 'resolved', stage: 5 }),
+    }
+
+    const views = Object.values(game.cases).map((entry) => getCaseListItemView(entry, game))
+    const signals = buildMissionTriageShellExtensionSignals(
+      game,
+      views,
+      `${APP_ROUTES.cases}?status=open&tab=all`
+    )
+
+    expect(signals.find((signal) => signal.id === 'triage-queue')).toMatchObject({ value: '1' })
+  })
+
+  it('builds queue and routable signals aligned with context footer', () => {
+    const game = createStartingState()
+    game.cases = {
+      urgent: makeCase('urgent', { stage: 4, deadlineRemaining: 1 }),
+      assigned: makeCase('assigned', {
+        status: 'in_progress',
+        assignedTeamIds: [Object.keys(game.teams)[0]!],
+      }),
+    }
+
+    const views = Object.values(game.cases).map((entry) => getCaseListItemView(entry, game))
+    const footer = buildMissionTriageContextFooterView(views, game)
+    const signals = buildMissionTriageShellExtensionSignals(
+      game,
+      views,
+      `${APP_ROUTES.cases}?status=open&tab=all`
+    )
+
+    expect(signals.find((signal) => signal.id === 'triage-queue')).toMatchObject({
+      label: 'Queue',
+      value: '2',
+      href: `${APP_ROUTES.cases}?status=open&tab=all`,
+    })
+    expect(signals.find((signal) => signal.id === 'triage-routable')).toMatchObject({
+      label: 'Routable',
+      value: String(footer.routableCount),
+      href: `${APP_ROUTES.cases}?status=open&tab=all`,
+    })
+    expect(signals.find((signal) => signal.id === 'triage-urgent')).toMatchObject({
+      label: 'Urgent',
+      value: String(footer.urgentIfDeferred),
+      tone: 'warning',
+    })
+  })
+
+  it('omits urgent chip when no unassigned urgent cases', () => {
+    const game = createStartingState()
+    const teamId = Object.keys(game.teams)[0]!
+    game.cases = {
+      assigned: makeCase('assigned', {
+        status: 'in_progress',
+        assignedTeamIds: [teamId],
+        stage: 1,
+        deadlineRemaining: 3,
+      }),
+    }
+
+    const views = Object.values(game.cases).map((entry) => getCaseListItemView(entry, game))
+    const signals = buildMissionTriageShellExtensionSignals(
+      game,
+      views,
+      `${APP_ROUTES.cases}?status=open&tab=all`
+    )
+
+    expect(signals.map((signal) => signal.id)).toEqual(['triage-queue', 'triage-routable'])
+  })
+
+  it('respects the same status filters as the triage board footer', () => {
+    const game = createStartingState()
+    game.cases = {
+      open: makeCase('open', { status: 'open' }),
+      active: makeCase('active', { status: 'in_progress' }),
+    }
+
+    const allViews = Object.values(game.cases).map((entry) => getCaseListItemView(entry, game))
+    const openOnlyViews = buildMissionTriageBoardViews(
+      game,
+      {
+        q: '',
+        status: 'open',
+        mode: 'all',
+        stage: 'all',
+        sort: 'priority',
+        risk: false,
+        tab: 'all',
+        selectedCaseId: '',
+      },
+      { includeCovertPrepSignals: true }
+    )
+
+    expect(buildMissionTriageShellExtensionSignals(game, allViews).find((s) => s.id === 'triage-queue'))
+      .toMatchObject({ value: '2' })
+    expect(buildMissionTriageShellExtensionSignals(game, openOnlyViews).find((s) => s.id === 'triage-queue'))
+      .toMatchObject({ value: '1' })
+  })
+
+  it('returns no signals for an empty board view list', () => {
+    const game = createStartingState()
+    game.cases = {}
+
+    expect(buildMissionTriageShellExtensionSignals(game, [])).toEqual([
+      expect.objectContaining({ id: 'triage-queue', value: '0' }),
+      expect.objectContaining({ id: 'triage-routable', value: '0' }),
+    ])
+  })
+})

--- a/src/test/missionTriageShellExtensionView.test.ts
+++ b/src/test/missionTriageShellExtensionView.test.ts
@@ -142,7 +142,7 @@ describe('missionTriageShellExtensionView', () => {
       .toMatchObject({ value: '1' })
   })
 
-  it('returns no signals for an empty board view list', () => {
+  it('returns zero-valued queue and routable chips for an empty board view list', () => {
     const game = createStartingState()
     game.cases = {}
 

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -36,9 +36,10 @@ This spec is for:
 
 **Slice 3 shipped (SPE-2257):** `CasesPage` case queue uses triage category tabs (URL `tab`), split list/detail panel (URL `case`), and context footer via `missionTriageLayoutView` + `MissionTriageTabs` / `MissionTriageListRow` / `MissionTriageContextFooter`. Plan: `planning/mission-triage-layout-slice.md`.
 
+**Slice 4 shipped (SPE-2258):** On `/cases` routes, `ShellStatusBar` appends read-only triage tail chips (queue depth, routable count, unassigned urgent when &gt; 0) via `buildMissionTriageShellExtensionSignals`, using the same filtered board views as `MissionTriageContextFooter`. Plan: `planning/mission-triage-status-bar-slice.md`.
+
 **Still deferred (follow-up slices):**
 
-- status-bar routable/urgent tail chips per `ux/navigation-map.md`
 - route/defer/ignore actions distinct from team assignment
 
 ---

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -36,7 +36,7 @@ This spec is for:
 
 **Slice 3 shipped (SPE-2257):** `CasesPage` case queue uses triage category tabs (URL `tab`), split list/detail panel (URL `case`), and context footer via `missionTriageLayoutView` + `MissionTriageTabs` / `MissionTriageListRow` / `MissionTriageContextFooter`. Plan: `planning/mission-triage-layout-slice.md`.
 
-**Slice 4 shipped (SPE-2258):** On `/cases` routes, `ShellStatusBar` appends read-only triage tail chips (queue depth, routable count, unassigned urgent when &gt; 0) via `buildMissionTriageShellExtensionSignals`, using the same filtered board views as `MissionTriageContextFooter`. Plan: `planning/mission-triage-status-bar-slice.md`.
+**Slice 4 shipped (SPE-2258):** On `/cases` routes, `ShellStatusBar` appends read-only triage tail chips (queue depth, routable count, unassigned urgent when > 0) via `buildMissionTriageShellExtensionSignals`, using the same filtered board views as `MissionTriageContextFooter`. Plan: `planning/mission-triage-status-bar-slice.md`.
 
 **Still deferred (follow-up slices):**
 


### PR DESCRIPTION
## Summary
- Extend `ShellStatusBar` on `/cases` routes with read-only triage tail chips: queue depth, routable count, and unassigned urgent (when > 0).
- Reuse `buildMissionTriageBoardViews` and `buildMissionTriageContextFooterView` so shell metrics match the triage board footer and URL filters.
- Preserve canonical filter query in chip links via `writeCaseListFilters`.

## Linear
https://linear.app/spectranoir/issue/SPE-2258/mission-triage-operations-status-bar-tail-slice-4-ux

## Plan
`planning/mission-triage-status-bar-slice.md`

## Test plan
- [x] `npm run test:run` — missionTriageShellExtensionView, ShellStatusBar, cases features, App.workflow
- [x] `npm run lint` on touched files
- [x] CI green
