### PR TITLE
feat(SPE-2259): mission triage list scan polish (slice 6 UX)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -32,7 +32,7 @@ From `README.md` **Current design notes**:
 
 ## Deferred UX (follow-up after SPE-2255)
 
-- **`ux/mission-triage.md`** — mission-triage slices 1–5 shipped (row chips, deferral compare, split layout, status-bar tail, route/defer/ignore disposition actions); future triage UX expansion remains follow-up.
+- **`ux/mission-triage.md`** — mission-triage slices 1–6 shipped (covert row signals, deferral compare, split layout, status-bar tail, disposition actions, list scan chips); further triage expansion remains follow-up.
 
 ## SCP-9995 harvest — May 2026 reconciliation
 

--- a/planning/mission-triage-list-scan-slice.md
+++ b/planning/mission-triage-list-scan-slice.md
@@ -1,0 +1,34 @@
+# SPE-2259 slice 6 — Mission triage list scan polish (UX)
+
+One-page implementation plan. Linear: [SPE-2259](https://linear.app/spectranoir/issue/SPE-2259/mission-triage-list-scan-polish-slice-6-ux). Parent: [SPE-16 — Mission Intake, Triage, & Routing](https://linear.app/spectranoir/issue/SPE-16) (Done). Follows slice 5 disposition ([planning/mission-triage-disposition-slice.md](mission-triage-disposition-slice.md)).
+
+## Goal
+
+On the compact `/cases` triage list, show read-only **disposition** and **marker chips** so players can scan weekly intent and covert load without opening each case detail panel.
+
+## Non-goals
+
+- List-row disposition actions (detail panel only)
+- Full deferral compare table on every row
+- New `missionRouting` fields or simulation math
+
+## Shipped
+
+| Area | Files |
+| --- | --- |
+| Chip builder | `buildMissionTriageListRowChips`, `buildMissionTriageCompactRowView` in `missionTriageLayoutView.ts` |
+| List UI | `MissionTriageListRow.tsx` chip row + row `aria-label` |
+| Detail reuse | `CasesPage` detail markers via same chip builder |
+| Tests | `missionTriageLayoutView.test.ts`, `CasesPage.test.tsx` |
+
+## Acceptance
+
+- [x] Active route/defer/ignore visible as first chip on list row for current week
+- [x] Urgency + covert-prep markers render as chips (max 5 per row)
+- [x] Ignored cases still sort deprioritized (unchanged `triageIgnored`)
+- [x] Lint + targeted Vitest green
+- [x] Full `npm run test:run` green (3726 tests, post-audit)
+
+## Branch
+
+`spe-16-mission-triage-list-scan-slice-6`

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -199,7 +199,7 @@ it('renders covert prep markers on triage list rows', async () => {
   expect(within(listChips).getByText('Leave-behind staged')).toBeInTheDocument()
 
   const covertCard = getCardByName('Covert Infiltration Case')
-  const markerRegion = within(covertCard).getByLabelText('Case triage markers')
+  const markerRegion = within(covertCard).getByLabelText('Case triage signals')
   expect(within(markerRegion).getByText(/Probe 35%/)).toBeInTheDocument()
   expect(within(markerRegion).getByText(/awareness 50%/)).toBeInTheDocument()
   expect(within(markerRegion).getByText('Cover strain')).toBeInTheDocument()

--- a/src/features/cases/CasesPage.test.tsx
+++ b/src/features/cases/CasesPage.test.tsx
@@ -193,17 +193,22 @@ it('renders covert prep markers on triage list rows', async () => {
   renderCasesPage(['/cases'])
   await selectTriageCase(user, 'Covert Infiltration Case')
 
+  const listChips = screen.getByTestId('case-triage-chips-covert')
+  expect(within(listChips).getByText(/Probe 35%/)).toBeInTheDocument()
+  expect(within(listChips).getByText(/awareness 50%/)).toBeInTheDocument()
+  expect(within(listChips).getByText('Leave-behind staged')).toBeInTheDocument()
+
   const covertCard = getCardByName('Covert Infiltration Case')
   const markerRegion = within(covertCard).getByLabelText('Case triage markers')
   expect(within(markerRegion).getByText(/Probe 35%/)).toBeInTheDocument()
   expect(within(markerRegion).getByText(/awareness 50%/)).toBeInTheDocument()
   expect(within(markerRegion).getByText('Cover strain')).toBeInTheDocument()
-  expect(within(covertCard).queryByText('Leave-behind staged')).not.toBeInTheDocument()
+  expect(within(markerRegion).getByText('Leave-behind staged')).toBeInTheDocument()
   expect(
     within(covertCard).getAllByText(/Deferring may let infiltration exposure escalate/i)
   ).toHaveLength(1)
 
-  expect(markerRegion.querySelectorAll('span').length).toBe(4)
+  expect(markerRegion.querySelectorAll('span').length).toBe(5)
 
   const compareTable = within(covertCard).getByRole('table', {
     name: 'Deferral and covert prep comparison',
@@ -237,8 +242,11 @@ it('renders concealment prep chip on triage list rows', async () => {
   useGameStore.setState({ game })
 
   renderCasesPage(['/cases'])
-  await selectTriageCase(user, 'Covert Preview Case')
 
+  const listChips = screen.getByTestId('case-triage-chips-conceal')
+  expect(within(listChips).getByText('Covert next week')).toBeInTheDocument()
+
+  await selectTriageCase(user, 'Covert Preview Case')
   expect(within(getCardByName('Covert Preview Case')).getByText('Covert next week')).toBeInTheDocument()
 })
 
@@ -473,8 +481,17 @@ it('sets defer disposition from triage detail panel', async () => {
   expect(
     useGameStore.getState().game.missionRouting?.missions['case-triage-defer']?.routingState
   ).toBe('deferred')
+
+  const listChips = screen.getByTestId('case-triage-chips-case-triage-defer')
+  expect(within(listChips).getByText(MISSION_TRIAGE_DISPOSITION_LABELS.activeDefer)).toBeInTheDocument()
+
+  const detail = getCardByName('Defer Me Case')
+  expect(within(detail).getByLabelText('Triage disposition')).toBeInTheDocument()
   expect(
-    screen.getByText(MISSION_TRIAGE_DISPOSITION_LABELS.activeDefer)
+    within(detail).getByRole('button', { name: MISSION_TRIAGE_DISPOSITION_LABELS.defer, exact: true })
+  ).toHaveAttribute('aria-pressed', 'true')
+  expect(
+    within(detail).getByRole('button', { name: MISSION_TRIAGE_DISPOSITION_LABELS.clear })
   ).toBeInTheDocument()
 })
 

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -767,7 +767,7 @@ function renderCaseTriageDetail({
                 </div>
 
                 {detailRowChips.length > 0 ? (
-                  <div className="flex flex-wrap gap-2" aria-label="Case triage markers">
+                  <div className="flex flex-wrap gap-2" aria-label="Case triage signals">
                     {detailRowChips.map((chip) => (
                       <span
                         key={chip.id}

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -71,6 +71,7 @@ import { triageMission } from '../../domain/missionIntakeRouting'
 import {
   buildMissionTriageCompactRowView,
   buildMissionTriageContextFooterView,
+  buildMissionTriageListRowChips,
   buildTriageTabCounts,
 } from './missionTriageLayoutView'
 
@@ -561,13 +562,11 @@ export default function CasesPage() {
                 const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${
                   rowQueryString ? `?${rowQueryString}` : ''
                 }`
-                const listRowMarkers = getListRowMarkers(view)
-                const markerPreview = listRowMarkers.map((marker) => marker.label).slice(0, 2).join(' · ')
                 const compactRow = buildMissionTriageCompactRowView(
                   view,
                   triageMission(game, view.currentCase),
                   effectiveSelectedCaseId,
-                  markerPreview
+                  game
                 )
 
                 return (
@@ -689,7 +688,7 @@ function renderCaseTriageDetail({
   const dispositionView = buildMissionTriageDispositionView(view, game)
   const detailHref = `${APP_ROUTES.caseDetail(view.currentCase.id)}${querySuffix}`
   const intelHref = APP_ROUTES.intelDetail(view.currentCase.templateId)
-  const listRowMarkers = getListRowMarkers(view)
+  const detailRowChips = buildMissionTriageListRowChips(view, dispositionView)
   const incidentStrategy =
     majorIncidentStrategyState[view.currentCase.id] ??
     view.currentCase.majorIncident?.strategy ??
@@ -767,15 +766,15 @@ function renderCaseTriageDetail({
                   </span>
                 </div>
 
-                {listRowMarkers.length > 0 ? (
+                {detailRowChips.length > 0 ? (
                   <div className="flex flex-wrap gap-2" aria-label="Case triage markers">
-                    {listRowMarkers.map((marker) => (
+                    {detailRowChips.map((chip) => (
                       <span
-                        key={marker.key}
-                        title={marker.title}
-                        className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${marker.className}`}
+                        key={chip.id}
+                        title={chip.title}
+                        className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${chip.className}`}
                       >
-                        {marker.label}
+                        {chip.label}
                       </span>
                     ))}
                   </div>
@@ -1066,82 +1065,6 @@ function renderCaseTriageDetail({
   )
 }
 
-const MAX_LIST_ROW_MARKERS = 4
-
-function getListRowMarkers(view: CaseListItemView) {
-  const markers: Array<{ key: string; label: string; className: string; title?: string }> = []
-
-  for (const marker of getUrgencyMarkers(view)) {
-    if (markers.length >= MAX_LIST_ROW_MARKERS) {
-      break
-    }
-
-    markers.push({ key: `urgency:${marker.label}`, ...marker })
-  }
-
-  for (const marker of view.covertPrepSignals.markers) {
-    if (markers.length >= MAX_LIST_ROW_MARKERS) {
-      break
-    }
-
-    markers.push({
-      key: marker.id,
-      label: marker.label,
-      className: marker.className,
-      title: marker.title,
-    })
-  }
-
-  return markers
-}
-
-function getUrgencyMarkers(view: CaseListItemView) {
-  const markers: Array<{ label: string; className: string }> = []
-
-  if (view.isUnassigned) {
-    markers.push({
-      label: 'Unassigned',
-      className: 'border-slate-500/40 bg-slate-500/10 text-slate-200',
-    })
-  }
-
-  if (view.isCriticalStage) {
-    markers.push({
-      label: 'High stage',
-      className: 'border-red-500/40 bg-red-500/10 text-red-200',
-    })
-  }
-
-  if (view.hasDeadlineRisk) {
-    markers.push({
-      label: 'Deadline risk',
-      className: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
-    })
-  }
-
-  if (view.isBlockedByRequiredRoles) {
-    markers.push({
-      label: 'Required-role blocked',
-      className: 'border-violet-500/40 bg-violet-500/10 text-violet-200',
-    })
-  }
-
-  if (view.isBlockedByRequiredTags) {
-    markers.push({
-      label: 'Required-tag blocked',
-      className: 'border-orange-500/40 bg-orange-500/10 text-orange-200',
-    })
-  }
-
-  if (view.isRaidAtCapacity) {
-    markers.push({
-      label: 'Raid at capacity',
-      className: 'border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-200',
-    })
-  }
-
-  return markers
-}
 
 function getBestEligibleSuccess(view: CaseListItemView) {
   const eligible = view.availableTeams.filter(

--- a/src/features/cases/MissionTriageListRow.tsx
+++ b/src/features/cases/MissionTriageListRow.tsx
@@ -8,6 +8,10 @@ const PRIORITY_STYLES: Record<MissionTriageCompactRowView['priority'], string> =
   low: 'border-slate-500/40 bg-slate-500/10 text-slate-200',
 }
 
+function buildRowAriaLabel(row: MissionTriageCompactRowView) {
+  return [row.title, row.typeLabel, ...row.chips.map((chip) => chip.label)].join('. ')
+}
+
 export function MissionTriageListRow({
   row,
   detailHref,
@@ -17,6 +21,8 @@ export function MissionTriageListRow({
   detailHref: string
   onSelect: () => void
 }) {
+  const rowAriaLabel = buildRowAriaLabel(row)
+
   return (
     <li
       className={`rounded border px-3 py-2 transition ${
@@ -24,6 +30,7 @@ export function MissionTriageListRow({
           ? 'border-sky-400/50 bg-sky-500/10'
           : 'border-white/10 bg-white/5 hover:border-white/20'
       }`}
+      aria-label={rowAriaLabel}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
@@ -34,10 +41,7 @@ export function MissionTriageListRow({
           >
             {row.title}
           </Link>
-          <p className="text-xs opacity-60">
-            {row.typeLabel}
-            {row.markerPreview ? ` · ${row.markerPreview}` : ''}
-          </p>
+          <p className="text-xs opacity-60">{row.typeLabel}</p>
         </div>
         <span
           className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide ${PRIORITY_STYLES[row.priority]}`}
@@ -45,6 +49,23 @@ export function MissionTriageListRow({
           {row.priority}
         </span>
       </div>
+      {row.chips.length > 0 ? (
+        <div
+          className="mt-2 flex flex-wrap gap-1"
+          aria-label={`${row.title} triage signals`}
+          data-testid={`case-triage-chips-${row.caseId}`}
+        >
+          {row.chips.map((chip) => (
+            <span
+              key={chip.id}
+              className={`rounded-full border px-2 py-0.5 text-[10px] ${chip.className}`}
+              title={chip.title}
+            >
+              {chip.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
       <div className="mt-2 flex items-center justify-between gap-2">
         <p className="text-[11px] opacity-50">Triage score {row.priorityScore}</p>
         <button

--- a/src/features/cases/MissionTriageListRow.tsx
+++ b/src/features/cases/MissionTriageListRow.tsx
@@ -8,8 +8,12 @@ const PRIORITY_STYLES: Record<MissionTriageCompactRowView['priority'], string> =
   low: 'border-slate-500/40 bg-slate-500/10 text-slate-200',
 }
 
-function buildRowAriaLabel(row: MissionTriageCompactRowView) {
-  return [row.title, row.typeLabel, ...row.chips.map((chip) => chip.label)].join('. ')
+function buildTriageSignalsDescription(row: MissionTriageCompactRowView) {
+  if (row.chips.length === 0) {
+    return ''
+  }
+
+  return `Triage signals: ${row.chips.map((chip) => chip.label).join(', ')}`
 }
 
 export function MissionTriageListRow({
@@ -21,7 +25,11 @@ export function MissionTriageListRow({
   detailHref: string
   onSelect: () => void
 }) {
-  const rowAriaLabel = buildRowAriaLabel(row)
+  const titleId = `mission-triage-row-${row.caseId}-title`
+  const typeId = `mission-triage-row-${row.caseId}-type`
+  const signalsId = `mission-triage-row-${row.caseId}-signals`
+  const labelledBy =
+    row.chips.length > 0 ? `${titleId} ${typeId} ${signalsId}` : `${titleId} ${typeId}`
 
   return (
     <li
@@ -30,18 +38,21 @@ export function MissionTriageListRow({
           ? 'border-sky-400/50 bg-sky-500/10'
           : 'border-white/10 bg-white/5 hover:border-white/20'
       }`}
-      aria-label={rowAriaLabel}
+      aria-labelledby={labelledBy}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <Link
+            id={titleId}
             to={detailHref}
             className="truncate font-medium hover:underline focus-ring"
             data-testid={`case-title-link-${row.caseId}`}
           >
             {row.title}
           </Link>
-          <p className="text-xs opacity-60">{row.typeLabel}</p>
+          <p id={typeId} className="text-xs opacity-60">
+            {row.typeLabel}
+          </p>
         </div>
         <span
           className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide ${PRIORITY_STYLES[row.priority]}`}
@@ -50,21 +61,26 @@ export function MissionTriageListRow({
         </span>
       </div>
       {row.chips.length > 0 ? (
-        <div
-          className="mt-2 flex flex-wrap gap-1"
-          aria-label={`${row.title} triage signals`}
-          data-testid={`case-triage-chips-${row.caseId}`}
-        >
-          {row.chips.map((chip) => (
-            <span
-              key={chip.id}
-              className={`rounded-full border px-2 py-0.5 text-[10px] ${chip.className}`}
-              title={chip.title}
-            >
-              {chip.label}
-            </span>
-          ))}
-        </div>
+        <>
+          <p id={signalsId} className="sr-only">
+            {buildTriageSignalsDescription(row)}
+          </p>
+          <div
+            className="mt-2 flex flex-wrap gap-1"
+            aria-hidden="true"
+            data-testid={`case-triage-chips-${row.caseId}`}
+          >
+            {row.chips.map((chip) => (
+              <span
+                key={chip.id}
+                className={`rounded-full border px-2 py-0.5 text-[10px] ${chip.className}`}
+                title={chip.title}
+              >
+                {chip.label}
+              </span>
+            ))}
+          </div>
+        </>
       ) : null}
       <div className="mt-2 flex items-center justify-between gap-2">
         <p className="text-[11px] opacity-50">Triage score {row.priorityScore}</p>

--- a/src/features/cases/missionTriageLayoutView.ts
+++ b/src/features/cases/missionTriageLayoutView.ts
@@ -76,9 +76,7 @@ function pushListRowChip(chips: MissionTriageListRowChip[], chip: MissionTriageL
   chips.push(chip)
 }
 
-function buildUrgencyListRowChips(view: CaseListItemView): MissionTriageListRowChip[] {
-  const chips: MissionTriageListRowChip[] = []
-
+function appendUrgencyListRowChips(chips: MissionTriageListRowChip[], view: CaseListItemView) {
   if (view.isUnassigned) {
     pushListRowChip(chips, {
       id: 'urgency:unassigned',
@@ -126,8 +124,6 @@ function buildUrgencyListRowChips(view: CaseListItemView): MissionTriageListRowC
       className: 'border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-200',
     })
   }
-
-  return chips
 }
 
 export function buildMissionTriageListRowChips(
@@ -150,9 +146,7 @@ export function buildMissionTriageListRowChips(
     })
   }
 
-  for (const chip of buildUrgencyListRowChips(view)) {
-    pushListRowChip(chips, chip)
-  }
+  appendUrgencyListRowChips(chips, view)
 
   for (const marker of view.covertPrepSignals.markers) {
     pushListRowChip(chips, {

--- a/src/features/cases/missionTriageLayoutView.ts
+++ b/src/features/cases/missionTriageLayoutView.ts
@@ -7,12 +7,17 @@ import {
 import type { GameState, MissionCategory, MissionPriorityBand } from '../../domain/models'
 import { isTeamBlockedByTraining } from '../../domain/sim/training'
 import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
+import { MISSION_TRIAGE_DISPOSITION_LABELS } from '../../data/copy'
 import {
   CASE_TRIAGE_TABS,
   matchesCaseTriageTab,
   type CaseListItemView,
   type CaseTriageTab,
 } from './caseView'
+import {
+  buildMissionTriageDispositionView,
+  type MissionTriageDispositionView,
+} from './missionTriageDispositionView'
 
 export const CASE_TRIAGE_TAB_LABELS: Record<CaseTriageTab, string> = {
   all: 'All',
@@ -35,14 +40,130 @@ export function missionTriageItemTypeLabel(category: MissionCategory): string {
   return MISSION_CATEGORY_LABELS[category]
 }
 
+export interface MissionTriageListRowChip {
+  readonly id: string
+  readonly label: string
+  readonly className: string
+  readonly title?: string
+}
+
+const MAX_LIST_ROW_CHIPS = 5
+
+const DISPOSITION_CHIP_CLASS: Record<
+  NonNullable<MissionTriageDispositionView['active']>,
+  string
+> = {
+  route: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+  defer: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+  ignore: 'border-slate-500/40 bg-slate-500/10 text-slate-300',
+}
+
 export interface MissionTriageCompactRowView {
   readonly caseId: string
   readonly title: string
   readonly typeLabel: string
   readonly priority: MissionPriorityBand
   readonly priorityScore: number
-  readonly markerPreview: string
+  readonly chips: readonly MissionTriageListRowChip[]
   readonly isSelected: boolean
+}
+
+function pushListRowChip(chips: MissionTriageListRowChip[], chip: MissionTriageListRowChip) {
+  if (chips.length >= MAX_LIST_ROW_CHIPS) {
+    return
+  }
+
+  chips.push(chip)
+}
+
+function buildUrgencyListRowChips(view: CaseListItemView): MissionTriageListRowChip[] {
+  const chips: MissionTriageListRowChip[] = []
+
+  if (view.isUnassigned) {
+    pushListRowChip(chips, {
+      id: 'urgency:unassigned',
+      label: 'Unassigned',
+      className: 'border-slate-500/40 bg-slate-500/10 text-slate-200',
+    })
+  }
+
+  if (view.isCriticalStage) {
+    pushListRowChip(chips, {
+      id: 'urgency:high-stage',
+      label: 'High stage',
+      className: 'border-red-500/40 bg-red-500/10 text-red-200',
+    })
+  }
+
+  if (view.hasDeadlineRisk) {
+    pushListRowChip(chips, {
+      id: 'urgency:deadline',
+      label: 'Deadline risk',
+      className: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+    })
+  }
+
+  if (view.isBlockedByRequiredRoles) {
+    pushListRowChip(chips, {
+      id: 'urgency:role-blocked',
+      label: 'Required-role blocked',
+      className: 'border-violet-500/40 bg-violet-500/10 text-violet-200',
+    })
+  }
+
+  if (view.isBlockedByRequiredTags) {
+    pushListRowChip(chips, {
+      id: 'urgency:tag-blocked',
+      label: 'Required-tag blocked',
+      className: 'border-orange-500/40 bg-orange-500/10 text-orange-200',
+    })
+  }
+
+  if (view.isRaidAtCapacity) {
+    pushListRowChip(chips, {
+      id: 'urgency:raid-capacity',
+      label: 'Raid at capacity',
+      className: 'border-fuchsia-500/40 bg-fuchsia-500/10 text-fuchsia-200',
+    })
+  }
+
+  return chips
+}
+
+export function buildMissionTriageListRowChips(
+  view: CaseListItemView,
+  disposition: MissionTriageDispositionView
+): readonly MissionTriageListRowChip[] {
+  const chips: MissionTriageListRowChip[] = []
+
+  if (disposition.active && disposition.activeLabel) {
+    pushListRowChip(chips, {
+      id: `disposition:${disposition.active}`,
+      label: disposition.activeLabel,
+      className: DISPOSITION_CHIP_CLASS[disposition.active],
+      title:
+        disposition.active === 'route'
+          ? MISSION_TRIAGE_DISPOSITION_LABELS.routeDetail
+          : disposition.active === 'defer'
+            ? MISSION_TRIAGE_DISPOSITION_LABELS.deferDetail
+            : MISSION_TRIAGE_DISPOSITION_LABELS.ignoreDetail,
+    })
+  }
+
+  for (const chip of buildUrgencyListRowChips(view)) {
+    pushListRowChip(chips, chip)
+  }
+
+  for (const marker of view.covertPrepSignals.markers) {
+    pushListRowChip(chips, {
+      id: marker.id,
+      label: marker.label,
+      className: marker.className,
+      title: marker.title,
+    })
+  }
+
+  return chips
 }
 
 export function buildMissionTriageResultsByCaseId(
@@ -58,8 +179,10 @@ export function buildMissionTriageCompactRowView(
   view: CaseListItemView,
   triage: MissionTriageResult,
   selectedCaseId: string,
-  markerPreview: string
+  game: GameState
 ): MissionTriageCompactRowView {
+  const disposition = buildMissionTriageDispositionView(view, game)
+
   return {
     caseId: view.currentCase.id,
     title: view.currentCase.title,
@@ -68,7 +191,7 @@ export function buildMissionTriageCompactRowView(
       : missionTriageItemTypeLabel(deriveMissionCategory(view.currentCase)),
     priority: triage.priority,
     priorityScore: triage.score,
-    markerPreview,
+    chips: buildMissionTriageListRowChips(view, disposition),
     isSelected: selectedCaseId === view.currentCase.id,
   }
 }

--- a/src/test/missionTriageLayoutView.test.ts
+++ b/src/test/missionTriageLayoutView.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { getCaseListItemView, matchesCaseTriageTab } from '../features/cases/caseView'
+import { MISSION_TRIAGE_DISPOSITION_LABELS } from '../data/copy'
 import {
   buildMissionTriageCompactRowView,
   buildMissionTriageContextFooterView,
+  buildMissionTriageListRowChips,
 } from '../features/cases/missionTriageLayoutView'
+import { buildMissionTriageDispositionView } from '../features/cases/missionTriageDispositionView'
 import {
   applyMissionTriageDisposition,
   normalizeMissionRoutingState,
+  recomputeMissionRouting,
   triageMission,
 } from '../domain/missionIntakeRouting'
 import type { CaseInstance } from '../domain/models'
@@ -80,11 +84,184 @@ describe('missionTriageLayoutView', () => {
 
     const view = getCaseListItemView(game.cases.urgent!, game)
     const triage = triageMission(game, view.currentCase)
-    const row = buildMissionTriageCompactRowView(view, triage, '', '')
+    const row = buildMissionTriageCompactRowView(view, triage, '', game)
 
     expect(row.priority).toBe(triage.priority)
     expect(row.priorityScore).toBe(triage.score)
     expect(row.priorityScore).toBeGreaterThan(0)
+  })
+
+  it('puts disposition chip first on compact row chips', () => {
+    const starter = createStartingState()
+    const openCase = makeCase('open-defer', { status: 'open', title: 'Defer scan' })
+    const game = applyMissionTriageDisposition(
+      {
+        ...starter,
+        cases: { 'open-defer': openCase },
+        missionRouting: normalizeMissionRoutingState({ ...starter, cases: { 'open-defer': openCase } }),
+      },
+      'open-defer',
+      'defer'
+    )
+
+    const view = getCaseListItemView(game.cases['open-defer']!, game, {
+      includeCovertPrepSignals: true,
+    })
+    const disposition = buildMissionTriageDispositionView(view, game)
+    const chips = buildMissionTriageListRowChips(view, disposition)
+
+    expect(chips[0]?.id).toBe('disposition:defer')
+    expect(chips[0]?.label).toBe(MISSION_TRIAGE_DISPOSITION_LABELS.activeDefer)
+
+    const row = buildMissionTriageCompactRowView(
+      view,
+      triageMission(game, view.currentCase),
+      '',
+      game
+    )
+    expect(row.chips[0]?.label).toBe(MISSION_TRIAGE_DISPOSITION_LABELS.activeDefer)
+  })
+
+  it('omits disposition chip on list row when case is assigned', () => {
+    const game = createStartingState()
+    const teamId = Object.keys(game.teams)[0]!
+    const assignedCase = makeCase('assigned-defer', {
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+    })
+    const withDisposition = applyMissionTriageDisposition(
+      {
+        ...game,
+        cases: { 'assigned-defer': assignedCase },
+        missionRouting: normalizeMissionRoutingState({ ...game, cases: { 'assigned-defer': assignedCase } }),
+      },
+      'assigned-defer',
+      'defer'
+    )
+
+    const view = getCaseListItemView(withDisposition.cases['assigned-defer']!, withDisposition)
+    const chips = buildMissionTriageListRowChips(
+      view,
+      buildMissionTriageDispositionView(view, withDisposition)
+    )
+
+    expect(chips.some((chip) => chip.id.startsWith('disposition:'))).toBe(false)
+  })
+
+  it('caps list row chips at five signals', () => {
+    const game = createStartingState()
+    game.cases = {
+      busy: makeCase('busy', {
+        status: 'open',
+        stage: 4,
+        deadlineRemaining: 1,
+        requiredRoles: ['investigator'],
+        requiredTags: ['stealth'],
+        tags: ['infiltration', 'concealment'],
+        infiltrationProbePlan: {
+          plannedAction: 'probe_access',
+          coverRole: 'maintenance',
+          coverTier: 2,
+        },
+        stealthLeaveBehindId: 'leave-behind:risk-discovery',
+      }),
+    }
+
+    const withDisposition = applyMissionTriageDisposition(
+      {
+        ...game,
+        missionRouting: normalizeMissionRoutingState(game),
+      },
+      'busy',
+      'route'
+    )
+    const dispositionView = buildMissionTriageDispositionView(
+      getCaseListItemView(withDisposition.cases.busy!, withDisposition, {
+        includeCovertPrepSignals: true,
+      }),
+      withDisposition
+    )
+    const chips = buildMissionTriageListRowChips(
+      getCaseListItemView(withDisposition.cases.busy!, withDisposition, {
+        includeCovertPrepSignals: true,
+      }),
+      dispositionView
+    )
+
+    expect(chips.length).toBe(5)
+    expect(chips[0]?.id).toBe('disposition:route')
+  })
+
+  it('drops stale disposition chips after the planning week advances', () => {
+    const starter = createStartingState()
+    const openCase = makeCase('stale-disposition', { status: 'open' })
+    const weekOne = applyMissionTriageDisposition(
+      {
+        ...starter,
+        cases: { 'stale-disposition': openCase },
+        missionRouting: normalizeMissionRoutingState({ ...starter, cases: { 'stale-disposition': openCase } }),
+      },
+      'stale-disposition',
+      'defer'
+    )
+
+    const nextWeek = weekOne.week + 1
+    const weekTwo = {
+      ...weekOne,
+      week: nextWeek,
+      missionRouting: recomputeMissionRouting({ ...weekOne, week: nextWeek }, nextWeek),
+    }
+    const view = getCaseListItemView(weekTwo.cases['stale-disposition']!, weekTwo)
+    const chips = buildMissionTriageListRowChips(
+      view,
+      buildMissionTriageDispositionView(view, weekTwo)
+    )
+
+    expect(chips.some((chip) => chip.id.startsWith('disposition:'))).toBe(false)
+  })
+
+  it('returns empty chips when no urgency, covert, or disposition signals apply', () => {
+    const game = createStartingState()
+    game.cases = {
+      assigned: makeCase('assigned', {
+        status: 'in_progress',
+        assignedTeamIds: [Object.keys(game.teams)[0]!],
+      }),
+    }
+
+    const view = getCaseListItemView(game.cases.assigned!, game)
+    const chips = buildMissionTriageListRowChips(
+      view,
+      buildMissionTriageDispositionView(view, game)
+    )
+
+    expect(chips).toEqual([])
+  })
+
+  it('includes urgency and covert-prep chips after disposition on compact row', () => {
+    const game = createStartingState()
+    game.cases = {
+      urgent: makeCase('urgent', {
+        status: 'open',
+        stage: 4,
+        deadlineRemaining: 1,
+        tags: ['infiltration', 'concealment'],
+        infiltrationProbePlan: {
+          plannedAction: 'probe_access',
+          coverRole: 'maintenance',
+          coverTier: 2,
+        },
+      }),
+    }
+
+    const view = getCaseListItemView(game.cases.urgent!, game, { includeCovertPrepSignals: true })
+    const chips = buildMissionTriageListRowChips(
+      view,
+      buildMissionTriageDispositionView(view, game)
+    )
+
+    expect(chips.some((chip) => chip.id.startsWith('urgency:'))).toBe(true)
+    expect(chips.length).toBeGreaterThan(1)
   })
 
   it('builds context footer with zero active cases', () => {

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -40,9 +40,11 @@ This spec is for:
 
 **Slice 4 shipped (SPE-2258):** On `/cases` routes, `ShellStatusBar` appends read-only triage tail chips (queue depth, routable count, unassigned urgent when > 0) via `buildMissionTriageShellExtensionSignals`, using the same filtered board views as `MissionTriageContextFooter`. Plan: `planning/mission-triage-status-bar-slice.md`.
 
+**Slice 6 shipped (SPE-2259):** Compact triage list rows show disposition + urgency + covert-prep chips via `buildMissionTriageListRowChips` and `MissionTriageListRow`. Plan: `planning/mission-triage-list-scan-slice.md`.
+
 **Still deferred (follow-up slices):**
 
-- route/defer/ignore action follow-up polish and additional triage UX expansion beyond shipped slices 1–5
+- Additional triage UX expansion beyond shipped slices 1–6 (compare-top-2 on list, bulk actions, spec §13 visual grouping)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add read-only triage chips on compact `/cases` list rows: weekly disposition (route/defer/ignore) first, then urgency and covert-prep markers (max 5).
- Centralize chip building in `buildMissionTriageListRowChips` and reuse it in the triage detail panel markers.
- Remove duplicated marker helpers from `CasesPage`.

## Linear
https://linear.app/spectranoir/issue/SPE-2259/mission-triage-list-scan-polish-slice-6-ux

Parent: SPE-16 (Mission Intake, Triage, & Routing)

## Test plan
- [x] `npm run test:run -- src/test/missionTriageLayoutView.test.ts src/features/cases/CasesPage.test.tsx`
- [x] `npm run lint`
- [x] `npm run test:run` (3726 tests)
- [x] Manual: on `/cases`, set defer/route/ignore on an open case and confirm chip appears on list row without opening detail
- [x] Manual: confirm covert-prep chips still visible on list for in-progress infiltration cases
