### PR TITLE
feat(SPE-2260): site operational exploration turn clock

### DIFF
--- a/planning/site-operational-exploration-turn-slice.md
+++ b/planning/site-operational-exploration-turn-slice.md
@@ -1,0 +1,32 @@
+# SPE-1610 slice 1 — Site operational exploration turn clock
+
+One-page implementation plan. Linear: child under [SPE-1610 — Free investigation versus crisis action mode](https://linear.app/spectranoir/issue/SPE-1610). Harvest traceability: batch `osr-site-exploration-metadata-165` (C1–C2).
+
+## Goal
+
+Add a pure domain layer so field search, breach, listen, and related actions consume discrete operational turns and raise site alert pressure on cases with an active site map.
+
+## Non-goals
+
+- Player UI for choosing exploration actions
+- Procedural encounter tables, trap adaptation, door taxonomy (later harvest slices)
+- Weekly `advanceWeek` integration (follow-up)
+
+## Shipped (this slice)
+
+| Area | Files |
+| --- | --- |
+| Action catalog + costs | `src/domain/siteOperationalExploration.ts` |
+| Tests | `src/test/siteOperationalExploration.test.ts` |
+
+## Acceptance
+
+- [x] Turn and alert clocks are deterministic per `caseId`
+- [x] Each exploration action advances turn clock by authored cost
+- [x] Noisy actions raise alert clock; wandering check fires at threshold
+- [x] Inactive when case lacks `mapLayer` + spatial site flags
+- [x] Targeted Vitest green
+
+## Branch
+
+`spe-1610-site-exploration-turn-slice-1`

--- a/src/domain/siteOperationalExploration.ts
+++ b/src/domain/siteOperationalExploration.ts
@@ -75,7 +75,7 @@ export function isSiteExplorationActionId(value: string): value is SiteExplorati
  */
 export function isCaseInSiteExplorationPhase(currentCase: CaseInstance): boolean {
   return (
-    currentCase.status !== 'resolved' &&
+    currentCase.status === 'in_progress' &&
     currentCase.mapLayer != null &&
     (currentCase.spatialFlags?.length ?? 0) > 0
   )

--- a/src/domain/siteOperationalExploration.ts
+++ b/src/domain/siteOperationalExploration.ts
@@ -128,7 +128,7 @@ export interface ApplySiteExplorationActionResult {
 export function applySiteExplorationAction(
   state: GameState,
   caseId: string,
-  actionId: SiteExplorationActionId
+  actionId: string
 ): ApplySiteExplorationActionResult {
   const currentCase = state.cases[caseId]
   if (!currentCase) {

--- a/src/domain/siteOperationalExploration.ts
+++ b/src/domain/siteOperationalExploration.ts
@@ -105,12 +105,33 @@ export function readSiteExplorationAlertValue(state: GameState, caseId: string):
   return readProgressClock(state, getSiteExplorationAlertClockId(caseId))?.value ?? 0
 }
 
-export function shouldTriggerSiteWanderingCheck(turnValue: number, alertValue: number): boolean {
+/** True when nextTurnValue crosses a new wander-interval bucket (e.g. 2→4 still hits the 3-turn boundary). */
+export function crossedSiteTurnWanderInterval(
+  previousTurnValue: number,
+  nextTurnValue: number
+): boolean {
+  if (nextTurnValue <= 0 || nextTurnValue <= previousTurnValue) {
+    return false
+  }
+
+  const interval = SITE_EXPLORATION_TURN_WANDER_INTERVAL
+  return Math.floor(nextTurnValue / interval) > Math.floor(previousTurnValue / interval)
+}
+
+export function shouldTriggerSiteWanderingCheck(
+  previousTurnValue: number,
+  nextTurnValue: number,
+  alertValue: number
+): boolean {
   if (alertValue >= SITE_EXPLORATION_ALERT_WANDER_THRESHOLD) {
     return true
   }
 
-  return turnValue > 0 && turnValue % SITE_EXPLORATION_TURN_WANDER_INTERVAL === 0 && alertValue > 0
+  if (alertValue <= 0) {
+    return false
+  }
+
+  return crossedSiteTurnWanderInterval(previousTurnValue, nextTurnValue)
 }
 
 export interface ApplySiteExplorationActionResult {
@@ -147,6 +168,7 @@ export function applySiteExplorationAction(
   const alertDelta = SITE_EXPLORATION_ACTION_ALERT_DELTA[actionId]
   const turnClockId = getSiteExplorationTurnClockId(caseId)
   const alertClockId = getSiteExplorationAlertClockId(caseId)
+  const previousTurnValue = readSiteExplorationTurnValue(state, caseId)
 
   let nextState = advanceDefinedProgressClock(state, turnClockId, turnCost, turnClockDefaults(currentCase))
   nextState = advanceDefinedProgressClock(
@@ -167,6 +189,10 @@ export function applySiteExplorationAction(
     alertDelta,
     turnValue,
     alertValue,
-    wanderingCheckTriggered: shouldTriggerSiteWanderingCheck(turnValue, alertValue),
+    wanderingCheckTriggered: shouldTriggerSiteWanderingCheck(
+      previousTurnValue,
+      turnValue,
+      alertValue
+    ),
   }
 }

--- a/src/domain/siteOperationalExploration.ts
+++ b/src/domain/siteOperationalExploration.ts
@@ -149,17 +149,12 @@ export function applySiteExplorationAction(
   const alertClockId = getSiteExplorationAlertClockId(caseId)
 
   let nextState = advanceDefinedProgressClock(state, turnClockId, turnCost, turnClockDefaults(currentCase))
-  if (alertDelta > 0) {
-    nextState = advanceDefinedProgressClock(
-      nextState,
-      alertClockId,
-      alertDelta,
-      alertClockDefaults(currentCase)
-    )
-  } else {
-    // Ensure alert clock exists for wandering reads even on silent actions.
-    nextState = advanceDefinedProgressClock(nextState, alertClockId, 0, alertClockDefaults(currentCase))
-  }
+  nextState = advanceDefinedProgressClock(
+    nextState,
+    alertClockId,
+    alertDelta,
+    alertClockDefaults(currentCase)
+  )
 
   const turnValue = readSiteExplorationTurnValue(nextState, caseId)
   const alertValue = readSiteExplorationAlertValue(nextState, caseId)

--- a/src/domain/siteOperationalExploration.ts
+++ b/src/domain/siteOperationalExploration.ts
@@ -1,0 +1,177 @@
+// SPE-1610 / SPE-2260: Discrete site exploration turns and action costs for active map sites.
+import {
+  advanceDefinedProgressClock,
+  readProgressClock,
+  type ProgressClockDefaults,
+} from './progressClocks'
+import type { CaseInstance, GameState } from './models'
+
+export const SITE_EXPLORATION_ACTION_IDS = [
+  'search',
+  'scan',
+  'breach',
+  'listen',
+  'hide',
+  'rest',
+  'repair',
+  'disarm',
+  'interrogate',
+  'move',
+  'retreat',
+] as const
+
+export type SiteExplorationActionId = (typeof SITE_EXPLORATION_ACTION_IDS)[number]
+
+/** Turn segments consumed per exploration action. */
+export const SITE_EXPLORATION_ACTION_COST_TURNS: Record<SiteExplorationActionId, number> = {
+  search: 1,
+  scan: 1,
+  listen: 1,
+  hide: 1,
+  move: 1,
+  rest: 2,
+  repair: 2,
+  disarm: 2,
+  interrogate: 2,
+  breach: 3,
+  retreat: 1,
+}
+
+/** Alert pressure added when the action is noisy or exposes the team. */
+export const SITE_EXPLORATION_ACTION_ALERT_DELTA: Record<SiteExplorationActionId, number> = {
+  search: 0,
+  scan: 0,
+  listen: 0,
+  hide: 0,
+  move: 0,
+  rest: 0,
+  repair: 1,
+  disarm: 1,
+  interrogate: 1,
+  breach: 3,
+  retreat: 1,
+}
+
+export const SITE_EXPLORATION_ALERT_WANDER_THRESHOLD = 4
+export const SITE_EXPLORATION_TURN_WANDER_INTERVAL = 3
+
+const EXPLORATION_TURN_CLOCK_MAX = 99
+const EXPLORATION_ALERT_CLOCK_MAX = 12
+
+export function getSiteExplorationTurnClockId(caseId: string): string {
+  return `site.exploration.${caseId}.turn`
+}
+
+export function getSiteExplorationAlertClockId(caseId: string): string {
+  return `site.exploration.${caseId}.alert`
+}
+
+export function isSiteExplorationActionId(value: string): value is SiteExplorationActionId {
+  return (SITE_EXPLORATION_ACTION_IDS as readonly string[]).includes(value)
+}
+
+/**
+ * Active when the case has a resolved site map and spatial site flags (field operations).
+ */
+export function isCaseInSiteExplorationPhase(currentCase: CaseInstance): boolean {
+  return (
+    currentCase.status !== 'resolved' &&
+    currentCase.mapLayer != null &&
+    (currentCase.spatialFlags?.length ?? 0) > 0
+  )
+}
+
+function turnClockDefaults(currentCase: CaseInstance): ProgressClockDefaults {
+  return {
+    label: `Site turns: ${currentCase.title}`,
+    max: EXPLORATION_TURN_CLOCK_MAX,
+    hidden: true,
+  }
+}
+
+function alertClockDefaults(currentCase: CaseInstance): ProgressClockDefaults {
+  return {
+    label: `Site alert: ${currentCase.title}`,
+    max: EXPLORATION_ALERT_CLOCK_MAX,
+    hidden: true,
+  }
+}
+
+export function readSiteExplorationTurnValue(state: GameState, caseId: string): number {
+  return readProgressClock(state, getSiteExplorationTurnClockId(caseId))?.value ?? 0
+}
+
+export function readSiteExplorationAlertValue(state: GameState, caseId: string): number {
+  return readProgressClock(state, getSiteExplorationAlertClockId(caseId))?.value ?? 0
+}
+
+export function shouldTriggerSiteWanderingCheck(turnValue: number, alertValue: number): boolean {
+  if (alertValue >= SITE_EXPLORATION_ALERT_WANDER_THRESHOLD) {
+    return true
+  }
+
+  return turnValue > 0 && turnValue % SITE_EXPLORATION_TURN_WANDER_INTERVAL === 0 && alertValue > 0
+}
+
+export interface ApplySiteExplorationActionResult {
+  state: GameState
+  applied: boolean
+  reason?: 'invalid_case' | 'not_site_exploration' | 'unknown_action'
+  actionId?: SiteExplorationActionId
+  turnCost?: number
+  alertDelta?: number
+  turnValue?: number
+  alertValue?: number
+  wanderingCheckTriggered?: boolean
+}
+
+export function applySiteExplorationAction(
+  state: GameState,
+  caseId: string,
+  actionId: SiteExplorationActionId
+): ApplySiteExplorationActionResult {
+  const currentCase = state.cases[caseId]
+  if (!currentCase) {
+    return { state, applied: false, reason: 'invalid_case' }
+  }
+
+  if (!isCaseInSiteExplorationPhase(currentCase)) {
+    return { state, applied: false, reason: 'not_site_exploration' }
+  }
+
+  if (!isSiteExplorationActionId(actionId)) {
+    return { state, applied: false, reason: 'unknown_action' }
+  }
+
+  const turnCost = SITE_EXPLORATION_ACTION_COST_TURNS[actionId]
+  const alertDelta = SITE_EXPLORATION_ACTION_ALERT_DELTA[actionId]
+  const turnClockId = getSiteExplorationTurnClockId(caseId)
+  const alertClockId = getSiteExplorationAlertClockId(caseId)
+
+  let nextState = advanceDefinedProgressClock(state, turnClockId, turnCost, turnClockDefaults(currentCase))
+  if (alertDelta > 0) {
+    nextState = advanceDefinedProgressClock(
+      nextState,
+      alertClockId,
+      alertDelta,
+      alertClockDefaults(currentCase)
+    )
+  } else {
+    // Ensure alert clock exists for wandering reads even on silent actions.
+    nextState = advanceDefinedProgressClock(nextState, alertClockId, 0, alertClockDefaults(currentCase))
+  }
+
+  const turnValue = readSiteExplorationTurnValue(nextState, caseId)
+  const alertValue = readSiteExplorationAlertValue(nextState, caseId)
+
+  return {
+    state: nextState,
+    applied: true,
+    actionId,
+    turnCost,
+    alertDelta,
+    turnValue,
+    alertValue,
+    wanderingCheckTriggered: shouldTriggerSiteWanderingCheck(turnValue, alertValue),
+  }
+}

--- a/src/domain/siteOperationalExploration.ts
+++ b/src/domain/siteOperationalExploration.ts
@@ -146,6 +146,11 @@ export interface ApplySiteExplorationActionResult {
   wanderingCheckTriggered?: boolean
 }
 
+/**
+ * Applies one exploration action. `actionId` is a string (not the union type) so UI,
+ * saves, and future callers can pass runtime input without casting; invalid ids return
+ * `unknown_action` instead of throwing.
+ */
 export function applySiteExplorationAction(
   state: GameState,
   caseId: string,
@@ -164,8 +169,9 @@ export function applySiteExplorationAction(
     return { state, applied: false, reason: 'unknown_action' }
   }
 
-  const turnCost = SITE_EXPLORATION_ACTION_COST_TURNS[actionId]
-  const alertDelta = SITE_EXPLORATION_ACTION_ALERT_DELTA[actionId]
+  const validatedActionId = actionId
+  const turnCost = SITE_EXPLORATION_ACTION_COST_TURNS[validatedActionId]
+  const alertDelta = SITE_EXPLORATION_ACTION_ALERT_DELTA[validatedActionId]
   const turnClockId = getSiteExplorationTurnClockId(caseId)
   const alertClockId = getSiteExplorationAlertClockId(caseId)
   const previousTurnValue = readSiteExplorationTurnValue(state, caseId)
@@ -184,7 +190,7 @@ export function applySiteExplorationAction(
   return {
     state: nextState,
     applied: true,
-    actionId,
+    actionId: validatedActionId,
     turnCost,
     alertDelta,
     turnValue,

--- a/src/test/siteOperationalExploration.test.ts
+++ b/src/test/siteOperationalExploration.test.ts
@@ -80,11 +80,27 @@ describe('siteOperationalExploration', () => {
     expect(result.reason).toBe('not_site_exploration')
   })
 
-  it('triggers wandering check at alert threshold or turn cadence with alert', () => {
-    expect(shouldTriggerSiteWanderingCheck(2, SITE_EXPLORATION_ALERT_WANDER_THRESHOLD)).toBe(true)
-    expect(shouldTriggerSiteWanderingCheck(3, 1)).toBe(true)
-    expect(shouldTriggerSiteWanderingCheck(3, 0)).toBe(false)
-    expect(shouldTriggerSiteWanderingCheck(2, 1)).toBe(false)
+  it('triggers wandering check at alert threshold or when turn interval bucket is crossed', () => {
+    expect(shouldTriggerSiteWanderingCheck(0, 2, SITE_EXPLORATION_ALERT_WANDER_THRESHOLD)).toBe(true)
+    expect(shouldTriggerSiteWanderingCheck(2, 3, 1)).toBe(true)
+    expect(shouldTriggerSiteWanderingCheck(2, 4, 1)).toBe(true)
+    expect(shouldTriggerSiteWanderingCheck(3, 4, 0)).toBe(false)
+    expect(shouldTriggerSiteWanderingCheck(2, 2, 1)).toBe(false)
+    expect(shouldTriggerSiteWanderingCheck(3, 4, 1)).toBe(false)
+  })
+
+  it('triggers cadence wandering when a multi-turn action skips an interval boundary', () => {
+    const state = createStartingState()
+    const currentCase = buildExplorationCase('skip')
+    let game = { ...state, cases: { skip: currentCase } }
+
+    const first = applySiteExplorationAction(game, 'skip', 'listen')
+    const second = applySiteExplorationAction(first.state, 'skip', 'listen')
+    expect(readSiteExplorationTurnValue(second.state, 'skip')).toBe(2)
+
+    const rest = applySiteExplorationAction(second.state, 'skip', 'repair')
+    expect(readSiteExplorationTurnValue(rest.state, 'skip')).toBe(4)
+    expect(rest.wanderingCheckTriggered).toBe(true)
   })
 
   it('flags wandering check after cumulative breach noise', () => {

--- a/src/test/siteOperationalExploration.test.ts
+++ b/src/test/siteOperationalExploration.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import type { CaseInstance } from '../domain/models'
+import {
+  applySiteExplorationAction,
+  getSiteExplorationAlertClockId,
+  getSiteExplorationTurnClockId,
+  isCaseInSiteExplorationPhase,
+  readSiteExplorationAlertValue,
+  readSiteExplorationTurnValue,
+  shouldTriggerSiteWanderingCheck,
+  SITE_EXPLORATION_ACTION_COST_TURNS,
+  SITE_EXPLORATION_ALERT_WANDER_THRESHOLD,
+} from '../domain/siteOperationalExploration'
+import { readProgressClock } from '../domain/progressClocks'
+
+function buildExplorationCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
+  const state = createStartingState()
+  const base = state.cases['case-001']!
+  return {
+    ...base,
+    id,
+    title: `Exploration ${id}`,
+    status: 'in_progress',
+    spatialFlags: ['ingress:service_door'],
+    mapLayer: {
+      authoringMode: 'map-metadata-first',
+      legend: [],
+      zones: [],
+      routes: [],
+      occupierKnownRouteIds: [],
+      scaleAnchors: [],
+    },
+    ...overrides,
+  }
+}
+
+describe('siteOperationalExploration', () => {
+  it('uses deterministic per-case clock ids', () => {
+    expect(getSiteExplorationTurnClockId('case-a')).toBe('site.exploration.case-a.turn')
+    expect(getSiteExplorationAlertClockId('case-a')).toBe('site.exploration.case-a.alert')
+  })
+
+  it('requires mapLayer and spatial flags for exploration phase', () => {
+    const active = buildExplorationCase('active')
+    expect(isCaseInSiteExplorationPhase(active)).toBe(true)
+
+    const noMap = buildExplorationCase('no-map', { mapLayer: undefined })
+    expect(isCaseInSiteExplorationPhase(noMap)).toBe(false)
+
+    const noFlags = buildExplorationCase('no-flags', { spatialFlags: [] })
+    expect(isCaseInSiteExplorationPhase(noFlags)).toBe(false)
+  })
+
+  it('advances turn clock by action cost and raises alert on noisy actions', () => {
+    const state = createStartingState()
+    const currentCase = buildExplorationCase('site-1')
+    const game = { ...state, cases: { 'site-1': currentCase } }
+
+    const listen = applySiteExplorationAction(game, 'site-1', 'listen')
+    expect(listen.applied).toBe(true)
+    expect(listen.turnCost).toBe(SITE_EXPLORATION_ACTION_COST_TURNS.listen)
+    expect(readSiteExplorationTurnValue(listen.state, 'site-1')).toBe(1)
+    expect(readSiteExplorationAlertValue(listen.state, 'site-1')).toBe(0)
+
+    const breach = applySiteExplorationAction(listen.state, 'site-1', 'breach')
+    expect(breach.applied).toBe(true)
+    expect(readSiteExplorationTurnValue(breach.state, 'site-1')).toBe(4)
+    expect(readSiteExplorationAlertValue(breach.state, 'site-1')).toBe(3)
+    expect(readProgressClock(breach.state, getSiteExplorationTurnClockId('site-1'))?.hidden).toBe(true)
+  })
+
+  it('rejects actions when case is not in site exploration phase', () => {
+    const state = createStartingState()
+    const flat = { ...state.cases['case-001']!, id: 'flat', spatialFlags: [], mapLayer: undefined }
+    const game = { ...state, cases: { flat } }
+
+    const result = applySiteExplorationAction(game, 'flat', 'search')
+    expect(result.applied).toBe(false)
+    expect(result.reason).toBe('not_site_exploration')
+  })
+
+  it('triggers wandering check at alert threshold or turn cadence with alert', () => {
+    expect(shouldTriggerSiteWanderingCheck(2, SITE_EXPLORATION_ALERT_WANDER_THRESHOLD)).toBe(true)
+    expect(shouldTriggerSiteWanderingCheck(3, 1)).toBe(true)
+    expect(shouldTriggerSiteWanderingCheck(3, 0)).toBe(false)
+    expect(shouldTriggerSiteWanderingCheck(2, 1)).toBe(false)
+  })
+
+  it('flags wandering check after cumulative breach noise', () => {
+    const state = createStartingState()
+    const currentCase = buildExplorationCase('noisy')
+    let game = { ...state, cases: { noisy: currentCase } }
+
+    let last = applySiteExplorationAction(game, 'noisy', 'breach')
+    game = last.state
+    last = applySiteExplorationAction(game, 'noisy', 'breach')
+    expect(last.wanderingCheckTriggered).toBe(true)
+  })
+})

--- a/src/test/siteOperationalExploration.test.ts
+++ b/src/test/siteOperationalExploration.test.ts
@@ -70,6 +70,16 @@ describe('siteOperationalExploration', () => {
     expect(readProgressClock(breach.state, getSiteExplorationTurnClockId('site-1'))?.hidden).toBe(true)
   })
 
+  it('rejects unknown action ids at runtime without casting', () => {
+    const state = createStartingState()
+    const currentCase = buildExplorationCase('site-1')
+    const game = { ...state, cases: { 'site-1': currentCase } }
+
+    const result = applySiteExplorationAction(game, 'site-1', 'not-a-valid-action')
+    expect(result.applied).toBe(false)
+    expect(result.reason).toBe('unknown_action')
+  })
+
   it('rejects actions when case is not in site exploration phase', () => {
     const state = createStartingState()
     const flat = { ...state.cases['case-001']!, id: 'flat', spatialFlags: [], mapLayer: undefined }

--- a/src/test/siteOperationalExploration.test.ts
+++ b/src/test/siteOperationalExploration.test.ts
@@ -3,6 +3,7 @@ import { createStartingState } from '../data/startingState'
 import type { CaseInstance } from '../domain/models'
 import {
   applySiteExplorationAction,
+  crossedSiteTurnWanderInterval,
   getSiteExplorationAlertClockId,
   getSiteExplorationTurnClockId,
   isCaseInSiteExplorationPhase,
@@ -99,18 +100,38 @@ describe('siteOperationalExploration', () => {
     expect(shouldTriggerSiteWanderingCheck(3, 4, 1)).toBe(false)
   })
 
-  it('triggers cadence wandering when a multi-turn action skips an interval boundary', () => {
+  it('crossedSiteTurnWanderInterval detects skipped boundaries (2→4, not 3→4)', () => {
+    expect(crossedSiteTurnWanderInterval(2, 4)).toBe(true)
+    expect(crossedSiteTurnWanderInterval(3, 4)).toBe(false)
+    expect(crossedSiteTurnWanderInterval(0, 3)).toBe(true)
+  })
+
+  it('triggers cadence wandering when repair skips turn 3 (2→4)', () => {
     const state = createStartingState()
-    const currentCase = buildExplorationCase('skip')
-    let game = { ...state, cases: { skip: currentCase } }
+    const currentCase = buildExplorationCase('skip-repair')
+    let game = { ...state, cases: { 'skip-repair': currentCase } }
 
-    const first = applySiteExplorationAction(game, 'skip', 'listen')
-    const second = applySiteExplorationAction(first.state, 'skip', 'listen')
-    expect(readSiteExplorationTurnValue(second.state, 'skip')).toBe(2)
+    const first = applySiteExplorationAction(game, 'skip-repair', 'listen')
+    const second = applySiteExplorationAction(first.state, 'skip-repair', 'listen')
+    expect(readSiteExplorationTurnValue(second.state, 'skip-repair')).toBe(2)
 
-    const rest = applySiteExplorationAction(second.state, 'skip', 'repair')
-    expect(readSiteExplorationTurnValue(rest.state, 'skip')).toBe(4)
-    expect(rest.wanderingCheckTriggered).toBe(true)
+    const repair = applySiteExplorationAction(second.state, 'skip-repair', 'repair')
+    expect(readSiteExplorationTurnValue(repair.state, 'skip-repair')).toBe(4)
+    expect(repair.wanderingCheckTriggered).toBe(true)
+  })
+
+  it('triggers cadence wandering when breach skips turn 3 (1→4 in one action)', () => {
+    const state = createStartingState()
+    const currentCase = buildExplorationCase('skip-breach')
+    const game = { ...state, cases: { 'skip-breach': currentCase } }
+
+    const setup = applySiteExplorationAction(game, 'skip-breach', 'listen')
+    expect(readSiteExplorationTurnValue(setup.state, 'skip-breach')).toBe(1)
+
+    const breach = applySiteExplorationAction(setup.state, 'skip-breach', 'breach')
+    expect(readSiteExplorationTurnValue(breach.state, 'skip-breach')).toBe(4)
+    expect(readSiteExplorationAlertValue(breach.state, 'skip-breach')).toBe(3)
+    expect(breach.wanderingCheckTriggered).toBe(true)
   })
 
   it('flags wandering check after cumulative breach noise', () => {

--- a/src/test/siteOperationalExploration.test.ts
+++ b/src/test/siteOperationalExploration.test.ts
@@ -109,7 +109,7 @@ describe('siteOperationalExploration', () => {
   it('triggers cadence wandering when repair skips turn 3 (2→4)', () => {
     const state = createStartingState()
     const currentCase = buildExplorationCase('skip-repair')
-    let game = { ...state, cases: { 'skip-repair': currentCase } }
+    const game = { ...state, cases: { 'skip-repair': currentCase } }
 
     const first = applySiteExplorationAction(game, 'skip-repair', 'listen')
     const second = applySiteExplorationAction(first.state, 'skip-repair', 'listen')


### PR DESCRIPTION
- [x] Inspect the referenced review comment context and current implementation
- [x] Run existing lint, build, and test commands to capture baseline status
- [x] Apply only the requested change for the referenced comment
- [x] Run targeted tests for the touched area
- [x] Run final validation and report completion