### PR TITLE
feat(SPE-2281): hidden-state modality matrix — scouting integration

### DIFF
--- a/planning/hidden-modality-matrix-slice-1.md
+++ b/planning/hidden-modality-matrix-slice-1.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2281](https://linear.app/spectranoir/
 | **Linear** | [SPE-2281 — Hidden-state modality matrix slice 1](https://linear.app/spectranoir/issue/SPE-2281) |
 | **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
 | **Branch** | `jamesdyedbq/spe-70-hidden-modality-matrix-slice-1` |
-| **Status** | Backlog — not started |
+| **Status** | Shipped on branch — pending PR |
 
 ## Goal
 
@@ -58,13 +58,13 @@ Treat these as **first-class modes** (combinable only when explicitly authored o
 
 ## Acceptance
 
-- [ ] Three modalities produce **distinct** `DetectionScanResult` tier payloads in one shared compose function (fixture cases, no manual test-only `hiddenState` assignment beyond spawn helpers).
-- [ ] Concealed presence: strong scouting can reach category/hostility tiers only after layer strip; presence-only sweep stays ambiguous or withheld per policy.
-- [ ] False position: identity/category readouts can mislocate or reference decoy locus while internal truth retains canonical identity.
-- [ ] Disguised identity path: unchanged disguise validation scores; modality compose does not alter SPE-285 math.
-- [ ] Counter-detection strips one modality layer without solving all modalities on the same scan.
-- [ ] `resolveScouting` legacy fields (`outcome`, `revealed`, `withheld`) unchanged vs plain `resolveScouting` for the same inputs.
-- [ ] `npm run lint` + targeted `npm run test:run` green on touched files.
+- [x] Three modalities produce **distinct** `DetectionScanResult` tier payloads in one shared compose function (fixture cases, no manual test-only `hiddenState` assignment beyond spawn helpers).
+- [x] Concealed presence: strong scouting can reach category/hostility tiers only after layer strip; presence-only sweep stays ambiguous or withheld per policy.
+- [x] False position: identity/category readouts can mislocate or reference decoy locus while internal truth retains canonical identity.
+- [x] Disguised identity path: unchanged disguise validation scores; modality compose does not alter SPE-285 math (scouting path delegates disguise subject; SPE-285 weekly path untouched).
+- [x] Counter-detection strips one modality layer without solving all modalities on the same scan.
+- [x] `resolveScouting` legacy fields (`outcome`, `revealed`, `withheld`) unchanged vs plain `resolveScouting` for the same inputs.
+- [x] `npm run lint` + targeted `npm run test:run` green on touched files.
 
 ## TDD order
 

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -14,7 +14,7 @@ import {
   scoutingOutcomeToDetectionScan,
   type ScoutingRevealSubject,
 } from './revealPayloadScoutingIntegration'
-import type { ScoutingInput, ScoutingResult } from './scoutingResolution'
+import { computeEffectiveScoutingConcealment, type ScoutingInput, type ScoutingResult } from './scoutingResolution'
 
 export type HiddenStateModalityKind =
   | 'none'

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -1,0 +1,266 @@
+/**
+ * SPE-70 / SPE-2281 slice 1: case-level hidden-state modalities composed into tiered reveal scans.
+ */
+
+import type { ConcealmentLayer, DetectionScanInput, DetectionScanResult, SubjectTruthState } from './revealPayload'
+import type { CaseInstance, Id } from './models'
+import {
+  buildDisguiseRevealSubjectFromCase,
+  disguiseConcealmentRatingFromCase,
+} from './revealPayloadDisguiseIntegration'
+import {
+  buildSubjectTruthFromScouting,
+  concealmentLayersFromRating,
+  scoutingOutcomeToDetectionScan,
+  type ScoutingRevealSubject,
+} from './revealPayloadScoutingIntegration'
+import type { ScoutingInput, ScoutingResult } from './scoutingResolution'
+
+export type HiddenStateModalityKind =
+  | 'none'
+  | 'concealed_presence'
+  | 'false_position'
+  | 'disguised_identity'
+
+const CONCEALED_PRESENCE_LAYER: ConcealmentLayer = {
+  id: 'layer:concealed-presence',
+  blockedTiers: ['category', 'hostility', 'exact_identity'],
+}
+
+const FALSE_POSITION_LAYER: ConcealmentLayer = {
+  id: 'layer:false-position',
+  blockedTiers: ['exact_identity'],
+}
+
+const DISGUISED_IDENTITY_LAYER: ConcealmentLayer = {
+  id: 'layer:disguised-identity',
+  blockedTiers: ['exact_identity'],
+}
+
+const DISGUISE_SIGNAL_TAGS = ['infiltration', 'disguise', 'covert', 'stealth'] as const
+
+export function caseHasDisguiseSignals(caseData: CaseInstance): boolean {
+  if (caseData.infiltrationCoverProfile !== undefined) {
+    return true
+  }
+
+  const tagSet = new Set([
+    ...caseData.tags,
+    ...caseData.requiredTags,
+    ...caseData.preferredTags,
+  ])
+
+  return DISGUISE_SIGNAL_TAGS.some((tag) => tagSet.has(tag))
+}
+
+export function resolveHiddenStateModality(caseData: CaseInstance): HiddenStateModalityKind {
+  if (caseData.hiddenState === 'displaced') {
+    return 'false_position'
+  }
+
+  if (caseData.hiddenState !== 'hidden') {
+    return 'none'
+  }
+
+  if (caseHasDisguiseSignals(caseData)) {
+    return 'disguised_identity'
+  }
+
+  return 'concealed_presence'
+}
+
+export function hiddenStateModalityLayer(
+  modality: HiddenStateModalityKind
+): ConcealmentLayer | null {
+  switch (modality) {
+    case 'concealed_presence':
+      return CONCEALED_PRESENCE_LAYER
+    case 'false_position':
+      return FALSE_POSITION_LAYER
+    case 'disguised_identity':
+      return DISGUISED_IDENTITY_LAYER
+    case 'none':
+      return null
+    default: {
+      const _exhaustive: never = modality
+      return _exhaustive
+    }
+  }
+}
+
+function mergeConcealmentLayers(
+  ...layerGroups: readonly (readonly ConcealmentLayer[])[]
+): readonly ConcealmentLayer[] {
+  const seen = new Set<string>()
+  const merged: ConcealmentLayer[] = []
+
+  for (const group of layerGroups) {
+    for (const layer of group) {
+      if (seen.has(layer.id)) {
+        continue
+      }
+
+      seen.add(layer.id)
+      merged.push(layer)
+    }
+  }
+
+  return merged
+}
+
+function resolveSubjectPresent(
+  caseData: CaseInstance,
+  subject: ScoutingRevealSubject,
+  modality: HiddenStateModalityKind
+): boolean {
+  if (subject.present !== undefined) {
+    return subject.present
+  }
+
+  if (modality === 'false_position' || modality === 'concealed_presence' || modality === 'disguised_identity') {
+    return true
+  }
+
+  return true
+}
+
+function resolveScoutingSubjectForCase(
+  caseData: CaseInstance,
+  subject: ScoutingRevealSubject,
+  modality: HiddenStateModalityKind
+): ScoutingRevealSubject {
+  if (modality !== 'disguised_identity') {
+    return subject
+  }
+
+  const disguiseSubject = buildDisguiseRevealSubjectFromCase(caseData)
+
+  return {
+    ...subject,
+    category: disguiseSubject.category,
+    hostility: disguiseSubject.hostility ?? subject.hostility,
+    activeProtections: disguiseSubject.activeProtections ?? subject.activeProtections,
+    activeEffects: disguiseSubject.activeEffects ?? subject.activeEffects,
+    dormantEffects: disguiseSubject.dormantEffects ?? subject.dormantEffects,
+  }
+}
+
+function scoutingConcealmentLayersForCase(
+  caseData: CaseInstance,
+  scoutingInput: ScoutingInput,
+  modality: HiddenStateModalityKind
+): readonly ConcealmentLayer[] {
+  const scoutingLayers = buildSubjectTruthFromScouting(scoutingInput, {
+    exactIdentity: 'probe',
+    category: 'probe',
+  }).concealmentLayers
+
+  if (modality === 'disguised_identity') {
+    return mergeConcealmentLayers(
+      concealmentLayersFromRating(disguiseConcealmentRatingFromCase(caseData)),
+      scoutingLayers
+    )
+  }
+
+  return scoutingLayers
+}
+
+/** Truth snapshot for scouting scans with case hidden-state modalities applied. */
+export function buildSubjectTruthFromCaseHiddenState(
+  caseData: CaseInstance,
+  scoutingInput: ScoutingInput,
+  subject: ScoutingRevealSubject
+): SubjectTruthState {
+  const modality = resolveHiddenStateModality(caseData)
+  const modalityLayer = hiddenStateModalityLayer(modality)
+  const resolvedSubject = resolveScoutingSubjectForCase(caseData, subject, modality)
+  const baseTruth = buildSubjectTruthFromScouting(scoutingInput, {
+    ...resolvedSubject,
+    present: resolveSubjectPresent(caseData, resolvedSubject, modality),
+  })
+
+  const scoutingLayers = scoutingConcealmentLayersForCase(caseData, scoutingInput, modality)
+  const concealmentLayers = modalityLayer
+    ? mergeConcealmentLayers([modalityLayer], scoutingLayers)
+    : scoutingLayers
+
+  return {
+    ...baseTruth,
+    present: resolveSubjectPresent(caseData, resolvedSubject, modality),
+    exactIdentity: resolvedSubject.exactIdentity,
+    category: resolvedSubject.category,
+    concealmentLayers,
+  }
+}
+
+export function formatDecoyLocusLabel(displacementTarget: Id | null | undefined): string | null {
+  if (displacementTarget === null || displacementTarget === undefined) {
+    return null
+  }
+
+  const trimmed = String(displacementTarget).trim()
+  if (trimmed.length === 0) {
+    return null
+  }
+
+  return `decoy locus ${trimmed}`
+}
+
+/** Player-facing scan projection for false-position without mutating canonical identity tiers. */
+export function applyFalsePositionScanProjection(
+  scan: DetectionScanResult,
+  caseData: CaseInstance
+): DetectionScanResult {
+  const decoyLabel = formatDecoyLocusLabel(caseData.displacementTarget)
+  if (decoyLabel === null) {
+    return scan
+  }
+
+  const fields = scan.fields.map((field) => {
+    if (field.tier === 'category') {
+      return {
+        ...field,
+        playerFacingValue: decoyLabel,
+        ambiguous: true,
+      }
+    }
+
+    if (field.tier === 'presence') {
+      return {
+        ...field,
+        playerFacingValue: `contact at ${decoyLabel}`,
+        ambiguous: true,
+      }
+    }
+
+    return field
+  })
+
+  return {
+    ...scan,
+    fields,
+  }
+}
+
+export function scoutingOutcomeToDetectionScanForCase(
+  scouting: Pick<ScoutingResult, 'outcome' | 'revealed' | 'withheld'>,
+  caseData: CaseInstance
+): DetectionScanInput {
+  const base = scoutingOutcomeToDetectionScan(scouting)
+  const modality = resolveHiddenStateModality(caseData)
+
+  if (modality === 'none' || !caseData.counterDetection) {
+    return base
+  }
+
+  if (base.family !== 'identity_probe') {
+    return base
+  }
+
+  const layersToStrip = Math.max(base.layersToStrip ?? 0, 1)
+
+  return {
+    ...base,
+    layersToStrip,
+  }
+}

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -14,7 +14,11 @@ import {
   scoutingOutcomeToDetectionScan,
   type ScoutingRevealSubject,
 } from './revealPayloadScoutingIntegration'
-import { computeEffectiveScoutingConcealment, type ScoutingInput, type ScoutingResult } from './scoutingResolution'
+import {
+  computeEffectiveScoutingConcealment,
+  type ScoutingInput,
+  type ScoutingResult,
+} from './scoutingResolution'
 
 export type HiddenStateModalityKind =
   | 'none'
@@ -45,9 +49,9 @@ export function caseHasDisguiseSignals(caseData: CaseInstance): boolean {
   }
 
   const tagSet = new Set([
-    ...caseData.tags,
-    ...caseData.requiredTags,
-    ...caseData.preferredTags,
+    ...(caseData.tags ?? []),
+    ...(caseData.requiredTags ?? []),
+    ...(caseData.preferredTags ?? []),
   ])
 
   return DISGUISE_SIGNAL_TAGS.some((tag) => tagSet.has(tag))
@@ -108,20 +112,8 @@ function mergeConcealmentLayers(
   return merged
 }
 
-function resolveSubjectPresent(
-  caseData: CaseInstance,
-  subject: ScoutingRevealSubject,
-  modality: HiddenStateModalityKind
-): boolean {
-  if (subject.present !== undefined) {
-    return subject.present
-  }
-
-  if (modality === 'false_position' || modality === 'concealed_presence' || modality === 'disguised_identity') {
-    return true
-  }
-
-  return true
+function resolveSubjectPresent(subject: ScoutingRevealSubject): boolean {
+  return subject.present ?? true
 }
 
 function resolveScoutingSubjectForCase(
@@ -150,10 +142,8 @@ function scoutingConcealmentLayersForCase(
   scoutingInput: ScoutingInput,
   modality: HiddenStateModalityKind
 ): readonly ConcealmentLayer[] {
-  const scoutingLayers = buildSubjectTruthFromScouting(scoutingInput, {
-    exactIdentity: 'probe',
-    category: 'probe',
-  }).concealmentLayers
+  const { concealment } = computeEffectiveScoutingConcealment(scoutingInput)
+  const scoutingLayers = concealmentLayersFromRating(concealment)
 
   if (modality === 'disguised_identity') {
     return mergeConcealmentLayers(
@@ -174,9 +164,10 @@ export function buildSubjectTruthFromCaseHiddenState(
   const modality = resolveHiddenStateModality(caseData)
   const modalityLayer = hiddenStateModalityLayer(modality)
   const resolvedSubject = resolveScoutingSubjectForCase(caseData, subject, modality)
+  const present = resolveSubjectPresent(resolvedSubject)
   const baseTruth = buildSubjectTruthFromScouting(scoutingInput, {
     ...resolvedSubject,
-    present: resolveSubjectPresent(caseData, resolvedSubject, modality),
+    present,
   })
 
   const scoutingLayers = scoutingConcealmentLayersForCase(caseData, scoutingInput, modality)
@@ -186,7 +177,7 @@ export function buildSubjectTruthFromCaseHiddenState(
 
   return {
     ...baseTruth,
-    present: resolveSubjectPresent(caseData, resolvedSubject, modality),
+    present,
     exactIdentity: resolvedSubject.exactIdentity,
     category: resolvedSubject.category,
     concealmentLayers,
@@ -253,14 +244,8 @@ export function scoutingOutcomeToDetectionScanForCase(
     return base
   }
 
-  if (base.family !== 'identity_probe') {
-    return base
-  }
-
-  const layersToStrip = Math.max(base.layersToStrip ?? 0, 1)
-
   return {
     ...base,
-    layersToStrip,
+    layersToStrip: Math.max(base.layersToStrip ?? 0, 1),
   }
 }

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -14,6 +14,13 @@ import {
   type SubjectTruthState,
 } from './revealPayload'
 import {
+  applyFalsePositionScanProjection,
+  buildSubjectTruthFromCaseHiddenState,
+  resolveHiddenStateModality,
+  scoutingOutcomeToDetectionScanForCase,
+} from './hiddenStateModality'
+import type { CaseInstance } from './models'
+import {
   computeEffectiveScoutingConcealment,
   resolveScouting,
   type ScoutingInput,
@@ -32,6 +39,10 @@ export interface ScoutingRevealSubject {
 
 export interface ScoutingRevealIntegrationInput extends ScoutingInput {
   readonly subject: ScoutingRevealSubject
+}
+
+export interface CaseScoutingRevealIntegrationInput extends ScoutingRevealIntegrationInput {
+  readonly caseData: CaseInstance
 }
 
 export interface ScoutingRevealIntegrationResult extends ScoutingResult {
@@ -125,6 +136,25 @@ export function resolveScoutingWithRevealPayload(
   const truth = buildSubjectTruthFromScouting(input, input.subject)
   const scanInput = scoutingOutcomeToDetectionScan(scouting)
   const detectionScan = resolveDetectionScan(truth, scanInput)
+
+  return {
+    ...scouting,
+    detectionScan,
+  }
+}
+
+/** SPE-2281: scouting + tiered scan with case hidden-state modalities (SPE-70). */
+export function resolveScoutingWithCaseHiddenState(
+  input: CaseScoutingRevealIntegrationInput
+): ScoutingRevealIntegrationResult {
+  const scouting = resolveScouting(input)
+  const truth = buildSubjectTruthFromCaseHiddenState(input.caseData, input, input.subject)
+  const scanInput = scoutingOutcomeToDetectionScanForCase(scouting, input.caseData)
+  let detectionScan = resolveDetectionScan(truth, scanInput)
+
+  if (resolveHiddenStateModality(input.caseData) === 'false_position') {
+    detectionScan = applyFalsePositionScanProjection(detectionScan, input.caseData)
+  }
 
   return {
     ...scouting,

--- a/src/test/hiddenStateModality.test.ts
+++ b/src/test/hiddenStateModality.test.ts
@@ -141,6 +141,25 @@ describe('hiddenStateModality (SPE-2281)', () => {
     expect(identityField?.playerFacingValue).toBe('entity:chapel-wraith')
   })
 
+  it('strips the outer modality layer on category_pass when counter-detection is active', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      counterDetection: true,
+      tags: ['concealment'],
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_LOW_CONCEALMENT, SUBJECT)
+    const scanInput = scoutingOutcomeToDetectionScanForCase(
+      { outcome: 'success', revealed: true, withheld: false },
+      caseData
+    )
+
+    expect(scanInput).toEqual({ family: 'category_pass', layersToStrip: 1 })
+
+    const scan = resolveDetectionScan(truth, scanInput)
+    expect(scan.strippedLayerIds).toEqual(['layer:concealed-presence'])
+    expect(detectionScanTierOrder(scan)).toContain('category')
+  })
+
   it('strips only the outer modality layer when counter-detection is active', () => {
     const caseData = createModalityCase({
       hiddenState: 'hidden',

--- a/src/test/hiddenStateModality.test.ts
+++ b/src/test/hiddenStateModality.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyFalsePositionScanProjection,
+  buildSubjectTruthFromCaseHiddenState,
+  formatDecoyLocusLabel,
+  hiddenStateModalityLayer,
+  resolveHiddenStateModality,
+  scoutingOutcomeToDetectionScanForCase,
+} from '../domain/hiddenStateModality'
+import { resolveDetectionScan } from '../domain/revealPayload'
+import {
+  detectionScanTierOrder,
+  resolveScoutingWithCaseHiddenState,
+} from '../domain/revealPayloadScoutingIntegration'
+import { resolveScouting } from '../domain/scoutingResolution'
+import type { CaseInstance } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+const SCOUTING_INPUT = {
+  teamCapability: 3,
+  anomalyConcealment: 2,
+  teamTags: ['recon-specialist'],
+  gearTags: ['thermal-vision'],
+} as const
+
+const SCOUTING_LOW_CONCEALMENT = {
+  ...SCOUTING_INPUT,
+  anomalyConcealment: 0,
+} as const
+
+const SUBJECT = {
+  exactIdentity: 'entity:chapel-wraith',
+  category: 'spectral intruder',
+  hostility: 'latent' as const,
+  activeEffects: ['cold bloom'],
+  dormantEffects: ['dream-residue latch'],
+  activeProtections: ['warded perimeter'],
+}
+
+function createModalityCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-modality-matrix',
+      templateId: 'combat_vampire_nest',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['concealment'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: ['team-modality'],
+    infiltrationCoverProfile: undefined,
+    infiltrationProbePlan: undefined,
+    stealthLeaveBehindId: undefined,
+    weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+    difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+    ...overrides,
+  }
+}
+
+describe('hiddenStateModality (SPE-2281)', () => {
+  it('resolves modality kinds from case hidden-state fields', () => {
+    expect(resolveHiddenStateModality(createModalityCase({ hiddenState: undefined }))).toBe('none')
+    expect(resolveHiddenStateModality(createModalityCase({ hiddenState: 'revealed' }))).toBe('none')
+    expect(resolveHiddenStateModality(createModalityCase({ hiddenState: 'hidden' }))).toBe(
+      'concealed_presence'
+    )
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: ['infiltration', 'concealment'],
+          infiltrationCoverProfile: { claimedRole: 'courier', documentTier: 1 },
+        })
+      )
+    ).toBe('disguised_identity')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'displaced',
+          displacementTarget: 'sector-east-wing',
+        })
+      )
+    ).toBe('false_position')
+  })
+
+  it('maps each modality to a distinct concealment layer id', () => {
+    expect(hiddenStateModalityLayer('concealed_presence')?.id).toBe('layer:concealed-presence')
+    expect(hiddenStateModalityLayer('false_position')?.id).toBe('layer:false-position')
+    expect(hiddenStateModalityLayer('disguised_identity')?.id).toBe('layer:disguised-identity')
+    expect(hiddenStateModalityLayer('none')).toBeNull()
+  })
+
+  it('builds concealed-presence truth with modality layer ahead of scouting layers', () => {
+    const caseData = createModalityCase({ hiddenState: 'hidden', tags: ['concealment'] })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_INPUT, SUBJECT)
+
+    expect(truth.present).toBe(true)
+    expect(truth.concealmentLayers[0]?.id).toBe('layer:concealed-presence')
+    expect(truth.concealmentLayers.length).toBeGreaterThan(1)
+  })
+
+  it('blocks category on concealed presence until a modality layer is stripped', () => {
+    const caseData = createModalityCase({ hiddenState: 'hidden', tags: ['concealment'] })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_LOW_CONCEALMENT, SUBJECT)
+
+    const blocked = resolveDetectionScan(truth, { family: 'category_pass' })
+    expect(detectionScanTierOrder(blocked)).toEqual(['presence'])
+    expect(blocked.fields.some((field) => field.tier === 'category')).toBe(false)
+
+    const peeled = resolveDetectionScan(truth, { family: 'identity_probe', layersToStrip: 1 })
+    expect(peeled.strippedLayerIds).toContain('layer:concealed-presence')
+    expect(detectionScanTierOrder(peeled)).toContain('category')
+  })
+
+  it('projects false-position readouts to decoy locus while retaining canonical identity', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'displaced',
+      displacementTarget: 'sector-east-wing',
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_LOW_CONCEALMENT, SUBJECT)
+    const scan = resolveDetectionScan(truth, { family: 'category_pass' })
+    const projected = applyFalsePositionScanProjection(scan, caseData)
+
+    expect(formatDecoyLocusLabel('sector-east-wing')).toBe('decoy locus sector-east-wing')
+    expect(projected.fields.find((field) => field.tier === 'category')?.playerFacingValue).toBe(
+      'decoy locus sector-east-wing'
+    )
+    expect(projected.fields.find((field) => field.tier === 'category')?.internalValue).toBe(
+      'spectral intruder'
+    )
+
+    const identityProbe = applyFalsePositionScanProjection(
+      resolveDetectionScan(truth, { family: 'identity_probe', layersToStrip: 1 }),
+      caseData
+    )
+    const identityField = identityProbe.fields.find((field) => field.tier === 'exact_identity')
+    expect(identityField?.internalValue).toBe('entity:chapel-wraith')
+    expect(identityField?.playerFacingValue).toBe('entity:chapel-wraith')
+  })
+
+  it('strips only the outer modality layer when counter-detection is active', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      counterDetection: true,
+      tags: ['concealment'],
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_INPUT, SUBJECT)
+    const scanInput = scoutingOutcomeToDetectionScanForCase(
+      { outcome: 'strong', revealed: true, withheld: false },
+      caseData
+    )
+
+    expect(scanInput).toEqual({ family: 'identity_probe', layersToStrip: 1 })
+
+    const scan = resolveDetectionScan(truth, scanInput)
+    expect(scan.strippedLayerIds).toEqual(['layer:concealed-presence'])
+    expect(scan.remainingConcealmentLayers.some((layer) => layer.id === 'layer:glamour')).toBe(true)
+    expect(detectionScanTierOrder(scan)).not.toContain('exact_identity')
+  })
+
+  it('produces distinct detection scans across the three modalities in one compose path', () => {
+    const concealed = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({ hiddenState: 'hidden', tags: ['concealment'] }),
+    })
+    const displaced = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'displaced',
+        displacementTarget: 'loading-dock',
+      }),
+    })
+    const disguised = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: ['infiltration', 'concealment'],
+        infiltrationAwareness: 0,
+        infiltrationCoverProfile: { claimedRole: 'courier', documentTier: 2 },
+      }),
+    })
+
+    expect(concealed.outcome).toBe('strong')
+    expect(displaced.outcome).toBe('strong')
+    expect(disguised.outcome).toBe('strong')
+
+    expect(concealed.detectionScan.strippedLayerIds).toEqual(['layer:concealed-presence'])
+    expect(displaced.detectionScan.strippedLayerIds).toEqual(['layer:false-position'])
+    expect(disguised.detectionScan.strippedLayerIds).toEqual(['layer:disguised-identity'])
+
+    expect(
+      displaced.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toContain('decoy locus loading-dock')
+    expect(
+      disguised.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toContain('courier cover')
+    expect(
+      concealed.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toBe('spectral intruder')
+  })
+
+  it('preserves legacy scouting fields while attaching modality-aware detection scans', () => {
+    const input = {
+      ...SCOUTING_INPUT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: ['concealment'],
+      }),
+    }
+
+    const legacy = resolveScouting(input)
+    const integrated = resolveScoutingWithCaseHiddenState(input)
+
+    expect(integrated.outcome).toBe(legacy.outcome)
+    expect(integrated.revealed).toBe(legacy.revealed)
+    expect(integrated.withheld).toBe(legacy.withheld)
+    expect(integrated.value).toBe(legacy.value)
+  })
+})

--- a/src/test/revealPayloadScoutingIntegration.test.ts
+++ b/src/test/revealPayloadScoutingIntegration.test.ts
@@ -3,10 +3,13 @@ import {
   buildSubjectTruthFromScouting,
   concealmentLayersFromRating,
   detectionScanTierOrder,
+  resolveScoutingWithCaseHiddenState,
   resolveScoutingWithRevealPayload,
   scoutingOutcomeToDetectionScan,
 } from '../domain/revealPayloadScoutingIntegration'
+import type { CaseInstance } from '../domain/models'
 import { resolveScouting } from '../domain/scoutingResolution'
+import { createStarterCase } from '../domain/templates/startingCases'
 
 const SUBJECT = {
   exactIdentity: 'entity:chapel-wraith',
@@ -122,6 +125,43 @@ describe('revealPayloadScoutingIntegration (SPE-781 slice 2)', () => {
     } else {
       expect(detectionScanTierOrder(integrated.detectionScan)).toEqual(['presence'])
     }
+  })
+
+  it('anchors false-position scouting scans to decoy locus without changing scouting outcome', () => {
+    const caseData: CaseInstance = {
+      ...createStarterCase({ id: 'case-scout-displaced', templateId: 'combat_vampire_nest' }),
+      mode: 'threshold',
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-b',
+      detectionConfidence: 0.55,
+      counterDetection: false,
+      tags: ['concealment'],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: [],
+      infiltrationCoverProfile: undefined,
+      infiltrationProbePlan: undefined,
+      weights: { combat: 0, investigation: 0, utility: 0, social: 0 },
+      difficulty: { combat: 0, investigation: 0, utility: 0, social: 0 },
+    }
+
+    const input = {
+      teamCapability: 3,
+      anomalyConcealment: 0,
+      teamTags: ['recon-specialist'],
+      gearTags: ['thermal-vision'],
+      subject: SUBJECT,
+      caseData,
+    }
+
+    const legacy = resolveScouting(input)
+    const integrated = resolveScoutingWithCaseHiddenState(input)
+
+    expect(integrated.outcome).toBe(legacy.outcome)
+    expect(integrated.revealed).toBe(legacy.revealed)
+    expect(
+      integrated.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toContain('decoy locus annex-b')
   })
 
   it('blocks exact identity on identity-probe scouting when two concealment layers remain after one peel', () => {


### PR DESCRIPTION
## Summary

- Add hiddenStateModality.ts mapping case hiddenState / displacementTarget / disguise signals into tiered reveal scans (concealed presence, false position, disguised identity).
- Expose esolveScoutingWithCaseHiddenState for case-aware scouting composition without changing SPE-59 outcome bands or SPE-285 disguise validation scores.
- False-position scans project decoy-locus player copy while preserving canonical identity in scan internalValue fields; counter-reveal strips one modality layer per strong identity probe.

## Linear

- **Slice:** [SPE-2281](https://linear.app/spectranoir/issue/SPE-2281) — Hidden-state modality matrix slice 1 (scouting integration)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70) — Hidden-State, Displacement, & Counter-Detection Layer (remains open)

## Plan

planning/hidden-modality-matrix-slice-1.md

## What shipped

| Area | Files |
| --- | --- |
| Modality helpers | src/domain/hiddenStateModality.ts |
| Scouting compose | src/domain/revealPayloadScoutingIntegration.ts |
| Tests | src/test/hiddenStateModality.test.ts, src/test/revealPayloadScoutingIntegration.test.ts |
| Docs | planning/hidden-modality-matrix-slice-1.md (acceptance checked) |

## Test plan

- [x] 
pm run test:run -- src/test/hiddenStateModality.test.ts src/test/revealPayloadScoutingIntegration.test.ts src/test/revealPayloadDisguiseIntegration.test.ts
- [x] 
pm run lint

Made with [Cursor](https://cursor.com)