### PR TITLE
feat(SPE-2282): hidden-state modality matrix — weekly orchestration wiring

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -92,6 +92,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `mvp-weekly-loop-proof-slice-1.md`                        | **Shipped**    | SPE-2251 slice 1; see Shipped MVP loop proof.                 |
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                     |
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |
+| `hidden-modality-matrix-slice-1.md`                       | **Shipped**    | SPE-2281 / PR #2403; domain compose.                          |
+| `hidden-modality-matrix-slice-2.md`                       | **Active**     | SPE-2282; weekly orchestration wiring (next).                 |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                         |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                          |
 

--- a/planning/hidden-modality-matrix-slice-1.md
+++ b/planning/hidden-modality-matrix-slice-1.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2281](https://linear.app/spectranoir/
 | **Linear** | [SPE-2281 — Hidden-state modality matrix slice 1](https://linear.app/spectranoir/issue/SPE-2281) |
 | **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
 | **Branch** | `jamesdyedbq/spe-70-hidden-modality-matrix-slice-1` |
-| **Status** | Shipped on branch — pending PR |
+| **Status** | **Shipped** — PR #2403 |
 
 ## Goal
 

--- a/planning/hidden-modality-matrix-slice-2.md
+++ b/planning/hidden-modality-matrix-slice-2.md
@@ -1,0 +1,108 @@
+# SPE-70 — Hidden-state modality matrix slice 2 (weekly orchestration wiring)
+
+One-page implementation plan. Linear: [SPE-2282](https://linear.app/spectranoir/issue/SPE-2282) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Follows shipped [SPE-2281](https://linear.app/spectranoir/issue/SPE-2281) domain compose (PR #2403). Reference pattern: [SPE-781](https://linear.app/spectranoir/issue/SPE-781) slice 4 orchestration ([SPE-2253](https://linear.app/spectranoir/issue/SPE-2253), `planning/reveal-payload-slice-4.md`).
+
+| Field | Value |
+| --- | --- |
+| **Linear** | [SPE-2282 — Hidden-state modality matrix slice 2](https://linear.app/spectranoir/issue/SPE-2282) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
+| **Branch** | `jamesdyedbq/spe-70-hidden-modality-matrix-slice-2` |
+| **Status** | In Progress — SPE-2282 |
+
+## Goal
+
+Wire slice-1 **`resolveScoutingWithCaseHiddenState`** into **`resolveAssignedCaseForWeek`** so concealed-presence and false-position cases attach tiered `detectionScan` during weekly resolution — mirroring the disguise orchestration path without changing scouting outcome bands, disguise validation scores, or mission outcome math.
+
+Slice 2 is **orchestration-only**: input builders + weekly strategy carrier + report reason hook + tests. No UI, no new persistence shapes, no modality-specific report copy (slice 3).
+
+## Prerequisite (on `main`)
+
+| Shipped | Anchor |
+| --- | --- |
+| Modality compose (slice 1) | `src/domain/hiddenStateModality.ts`, `resolveScoutingWithCaseHiddenState` in `revealPayloadScoutingIntegration.ts` (SPE-2281, PR #2403) |
+| Disguise orchestration (reference) | `evaluateBehaviorWeightedDisguiseValidationWithRevealPayload` in `caseResolutionOrchestration.ts` (SPE-2253) |
+| Report reason hook | `appendDetectionScanResolutionReason` in `detectionScanReportNotes.ts` (SPE-2254) |
+| Case fields | `hiddenState`, `displacementTarget`, `counterDetection`, `detectionConfidence` on `CaseInstance` |
+
+## Gap (pre-slice)
+
+- Slice 1 compose is **test-only**; no production caller invokes `resolveScoutingWithCaseHiddenState`.
+- **`evaluateBehaviorWeightedDisguiseValidation`** activates only when `hiddenState === 'hidden'` **and** infiltration scrutiny tags fire — pure concealment cases get **no** `detectionScan`.
+- **`hiddenState: 'displaced'`** fails disguise activation (`hiddenState !== 'hidden'`) — false-position cases get **no** `detectionScan`.
+- Disguised infiltration cases already receive scans via the disguise path; slice 2 must **not** double-compose when disguise validation is active.
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| `buildScoutingRevealInputFromCase(case, agents, context)` — deterministic `ScoutingInput` + `ScoutingRevealSubject` from case/team (mirror `buildDisguiseRevealSubjectFromCase`) | New `GameState` / case persistence fields |
+| `evaluateHiddenStateScoutingWithRevealPayload(...)` — gates on active modality; calls `resolveScoutingWithCaseHiddenState` | Modality-specific report copy (slice 3) |
+| `resolveAssignedCaseForWeek` attaches result when modality ≠ `none` and disguise validation inactive | False-entity / structural-illusion lifecycle |
+| `WeeklyCaseResolutionStrategy.hiddenStateScouting?` (or equivalent scan carrier on strategy) | Known-but-unresolved recon cache (slice 4) |
+| `advanceWeek` reuses `appendDetectionScanResolutionReason` for hidden-state scouting scans | UI components |
+| Integration tests in `revealPayloadOrchestration.test.ts`; optional `weeklyMvpLoopProof` extension for concealed case | Rewriting disguise path for active infiltration cases |
+| Regression: existing disguise orchestration tests unchanged | Full SPE-70 parent closure |
+
+## Orchestration contract
+
+**When to run hidden-state scouting compose:**
+
+1. `resolveHiddenStateModality(caseData)` returns `concealed_presence` or `false_position`, **or**
+2. Modality is `disguised_identity` **and** `evaluateBehaviorWeightedDisguiseValidation` returns `active: false` (edge case — modality signal without scrutiny activation).
+
+**When to skip (disguise path owns the scan):**
+
+- Modality is `disguised_identity` **and** disguise validation is `active: true` — use existing `behaviorValidation.detectionScan` only.
+- Modality is `none` (`hiddenState` unset or `revealed`).
+
+**Outcome invariants:**
+
+- Legacy scouting fields on compose result (`outcome`, `revealed`, `withheld`) must match plain `resolveScouting` for the same derived input.
+- Mission score, degrade hints, and `applyBehaviorWeightedDisguiseValidationToCase` paths unchanged.
+- Counter-detection layer strip behavior unchanged vs slice 1.
+
+## Acceptance
+
+- [ ] Concealed-presence fixture (hidden, concealment tags, no infiltration scrutiny): weekly strategy carries distinct `detectionScan`; legacy validation remains inactive.
+- [ ] False-position fixture (`displaced` + `displacementTarget`): strategy carries decoy-anchored player-facing scan tiers; internal truth unchanged.
+- [ ] Active disguised-infiltration fixture: existing `behaviorValidation.detectionScan` unchanged; hidden-state scouting compose **not** attached.
+- [ ] Counter-detection case: one modality layer stripped in scan; mission outcome math unchanged vs pre-slice.
+- [ ] `advanceWeek` appends detection readout resolution reason for eligible concealed case (reuse SPE-2254 formatter).
+- [ ] `npm run lint` + targeted `npm run test:run` green on touched files.
+
+## TDD order
+
+1. **Input builder** — unit tests for `buildScoutingRevealInputFromCase`: team capability, anomaly concealment from case weights/tags, subject identity fields.
+2. **Gating helper** — `evaluateHiddenStateScoutingWithRevealPayload`: skip when modality `none`; skip when disguise active; run for concealed + displaced.
+3. **Orchestration** — `resolveAssignedCaseForWeek` integration tests (extend `revealPayloadOrchestration.test.ts`).
+4. **Report hook** — `advanceWeek` or resolution-reason test for concealed case readout.
+5. **Regression** — disguise orchestration tests + slice-1 modality tests unchanged.
+
+## File touch list (expected)
+
+| Area | Files |
+| --- | --- |
+| Scouting input builder | `src/domain/revealPayloadScoutingIntegration.ts` (extend) |
+| Weekly orchestration | `src/domain/caseResolutionOrchestration.ts` |
+| Report reasons | `src/domain/sim/advanceWeek.ts` (if carrier wiring needed) |
+| Tests | `src/test/revealPayloadOrchestration.test.ts`, optionally `src/test/weeklyMvpLoopProof.integration.test.ts` |
+
+## Branch
+
+`jamesdyedbq/spe-70-hidden-modality-matrix-slice-2`
+
+## Out of scope (later slices)
+
+- Modality-aware report/event-feed copy (`detectionScanReportNotes` extensions) — slice 3
+- Known-but-unresolved hidden nodes across multi-pass scouting (persistent recon cache) — slice 4
+- False-entity / structural-illusion lifecycle — slice 5
+- Mode-specific tells and observer-threshold validation
+- Full SPE-70 parent closure
+
+## See also
+
+- `planning/hidden-modality-matrix-slice-1.md` (shipped)
+- `planning/reveal-payload-slice-4.md` — orchestration pattern
+- `architecture/hidden-state-displacement-counter-detection.md`
+- `src/domain/hiddenStateModality.ts`
+- `src/domain/disguiseValidation.ts` — activation gate (`hiddenState`, scrutiny tags)

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -11,6 +11,10 @@ import {
   type DisguiseRevealIntegrationResult,
 } from './revealPayloadDisguiseIntegration'
 import {
+  evaluateHiddenStateScoutingWithRevealPayload,
+  type HiddenStateScoutingRevealIntegrationResult,
+} from './revealPayloadScoutingIntegration'
+import {
   evaluateInfiltrationStageMissionPressure,
   type InfiltrationStageMissionPressureResult,
 } from './infiltrationProbe'
@@ -33,6 +37,7 @@ export interface WeeklyCaseResolutionStrategy {
   activeTeamStressModifiers: Record<string, number>
   outcome: ResolutionOutcome
   behaviorValidation?: DisguiseRevealIntegrationResult
+  hiddenStateScouting?: HiddenStateScoutingRevealIntegrationResult
   infiltrationStageMission?: InfiltrationStageMissionPressureResult
   stealthLeaveBehindMission?: StealthLeaveBehindMissionPressureResult
   weakestLinkResult?: import('./weakestLinkResolution').WeakestLinkMissionResolutionResult
@@ -146,6 +151,12 @@ export function resolveAssignedCaseForWeek(
     effectiveCase,
     behaviorValidation
   )
+  const hiddenStateScouting = evaluateHiddenStateScoutingWithRevealPayload({
+    caseData: resolvedEffectiveCase,
+    agents: assignedAgents,
+    teamTags: supportTags,
+    disguiseValidationActive: behaviorValidation.active,
+  })
   const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(resolvedEffectiveCase)
   const stealthLeaveBehindMission = evaluateStealthLeaveBehindMissionPressure(resolvedEffectiveCase)
   const scoreAdjustment =
@@ -282,6 +293,7 @@ export function resolveAssignedCaseForWeek(
     activeTeamStressModifiers,
     outcome,
     behaviorValidation,
+    hiddenStateScouting,
     infiltrationStageMission,
     stealthLeaveBehindMission,
     weakestLinkResult,

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -5,6 +5,7 @@
 import type { BehaviorWeightedDisguiseValidationResult } from './disguiseValidation'
 import type { DetectionScanResult } from './revealPayload'
 import type { DisguiseRevealIntegrationResult } from './revealPayloadDisguiseIntegration'
+import type { HiddenStateScoutingRevealIntegrationResult } from './revealPayloadScoutingIntegration'
 
 export const DETECTION_SCAN_READOUT_PREFIX = 'Detection readout:'
 
@@ -63,17 +64,25 @@ export function formatDetectionScanSummary(result: DetectionScanResult): string 
 
 export function appendDetectionScanResolutionReason(
   resolutionReasons: string[],
-  behaviorValidation?: DisguiseRevealIntegrationResult
+  behaviorValidation?: DisguiseRevealIntegrationResult,
+  hiddenStateScouting?: HiddenStateScoutingRevealIntegrationResult
 ): void {
-  if (behaviorValidation === undefined || !shouldAppendDetectionScanReportNote(behaviorValidation)) {
-    return
-  }
-
   if (resolutionReasons.some((reason) => reason.startsWith(DETECTION_SCAN_READOUT_PREFIX))) {
     return
   }
 
-  const summary = formatDetectionScanSummary(behaviorValidation.detectionScan)
+  const scanSource =
+    behaviorValidation !== undefined && shouldAppendDetectionScanReportNote(behaviorValidation)
+      ? behaviorValidation.detectionScan
+      : hiddenStateScouting !== undefined && shouldAppendDetectionScanReportNote(hiddenStateScouting)
+        ? hiddenStateScouting.detectionScan
+        : undefined
+
+  if (scanSource === undefined) {
+    return
+  }
+
+  const summary = formatDetectionScanSummary(scanSource)
   if (summary.length === 0) {
     return
   }

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -128,7 +128,7 @@ function resolveScoutingSubjectCategory(caseData: CaseInstance): string {
     return 'displaced contact'
   }
 
-  if (caseData.tags.includes('concealment')) {
+  if (caseData.tags?.includes('concealment')) {
     return 'concealed presence'
   }
 
@@ -153,7 +153,7 @@ export function buildScoutingRevealSubjectFromCase(caseData: CaseInstance): Scou
     category: resolveScoutingSubjectCategory(caseData),
     hostility: resolveScoutingSubjectHostility(caseData),
     activeProtections: [],
-    activeEffects: caseData.tags.includes('concealment') ? ['concealment field'] : [],
+    activeEffects: caseData.tags?.includes('concealment') ? ['concealment field'] : [],
     dormantEffects: caseData.hiddenState === 'hidden' ? ['undisclosed briefing detail'] : [],
   }
 }
@@ -170,7 +170,7 @@ export function buildScoutingRevealInputFromCase(
     teamCapability: teamScoutingCapabilityFromAgents(agents),
     anomalyConcealment: anomalyConcealmentFromCase(caseData),
     teamTags: [...new Set([...teamTags, ...agentTags])],
-    anomalyTags: [...caseData.tags],
+    anomalyTags: [...(caseData.tags ?? [])],
     subject: buildScoutingRevealSubjectFromCase(caseData),
   }
 }

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -19,7 +19,7 @@ import {
   resolveHiddenStateModality,
   scoutingOutcomeToDetectionScanForCase,
 } from './hiddenStateModality'
-import type { CaseInstance } from './models'
+import type { Agent, CaseInstance } from './models'
 import {
   computeEffectiveScoutingConcealment,
   resolveScouting,
@@ -47,6 +47,18 @@ export interface CaseScoutingRevealIntegrationInput extends ScoutingRevealIntegr
 
 export interface ScoutingRevealIntegrationResult extends ScoutingResult {
   readonly detectionScan: DetectionScanResult
+}
+
+export interface HiddenStateScoutingRevealIntegrationResult extends ScoutingRevealIntegrationResult {
+  readonly active: true
+}
+
+export interface CaseScoutingRevealBuildResult {
+  readonly teamCapability: number
+  readonly anomalyConcealment: number
+  readonly teamTags: readonly string[]
+  readonly anomalyTags: readonly string[]
+  readonly subject: ScoutingRevealSubject
 }
 
 const GLAMOUR_LAYER: ConcealmentLayer = {
@@ -80,6 +92,137 @@ export function concealmentLayersFromRating(anomalyConcealment: number): readonl
   }
 
   return layers
+}
+
+function clampScoutingRating(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(3, Math.floor(value)))
+}
+
+function averageAgentInvestigation(agents: readonly Agent[]): number {
+  if (agents.length === 0) {
+    return 0
+  }
+
+  return agents.reduce((sum, agent) => sum + agent.baseStats.investigation, 0) / agents.length
+}
+
+/** Deterministic team scouting capability (0–3) from assigned agents. */
+export function teamScoutingCapabilityFromAgents(agents: readonly Agent[]): number {
+  return clampScoutingRating(averageAgentInvestigation(agents) / 20)
+}
+
+/** Deterministic anomaly concealment rating (0–3) from case investigation pressure. */
+export function anomalyConcealmentFromCase(caseData: CaseInstance): number {
+  const investigation =
+    caseData.difficulty?.investigation ?? Math.round((caseData.weights?.investigation ?? 0) * 100)
+
+  return clampScoutingRating(investigation / 15)
+}
+
+function resolveScoutingSubjectCategory(caseData: CaseInstance): string {
+  if (caseData.hiddenState === 'displaced') {
+    return 'displaced contact'
+  }
+
+  if (caseData.tags.includes('concealment')) {
+    return 'concealed presence'
+  }
+
+  return 'hidden contact'
+}
+
+function resolveScoutingSubjectHostility(caseData: CaseInstance): HostilityLevel {
+  if (caseData.counterDetection === true || caseData.infiltrationStage === 'violent') {
+    return 'active'
+  }
+
+  return 'latent'
+}
+
+/** Deterministic subject snapshot for weekly hidden-state scouting scans. */
+export function buildScoutingRevealSubjectFromCase(caseData: CaseInstance): ScoutingRevealSubject {
+  const present = caseData.hiddenState === 'hidden' || caseData.hiddenState === 'displaced'
+
+  return {
+    present,
+    exactIdentity: `entity:${caseData.id}`,
+    category: resolveScoutingSubjectCategory(caseData),
+    hostility: resolveScoutingSubjectHostility(caseData),
+    activeProtections: [],
+    activeEffects: caseData.tags.includes('concealment') ? ['concealment field'] : [],
+    dormantEffects: caseData.hiddenState === 'hidden' ? ['undisclosed briefing detail'] : [],
+  }
+}
+
+/** Deterministic scouting input + subject for weekly hidden-state modality compose. */
+export function buildScoutingRevealInputFromCase(
+  caseData: CaseInstance,
+  agents: readonly Agent[],
+  teamTags: readonly string[] = []
+): CaseScoutingRevealBuildResult {
+  const agentTags = agents.flatMap((agent) => agent.tags ?? [])
+
+  return {
+    teamCapability: teamScoutingCapabilityFromAgents(agents),
+    anomalyConcealment: anomalyConcealmentFromCase(caseData),
+    teamTags: [...new Set([...teamTags, ...agentTags])],
+    anomalyTags: [...caseData.tags],
+    subject: buildScoutingRevealSubjectFromCase(caseData),
+  }
+}
+
+export function shouldRunHiddenStateScoutingCompose(
+  caseData: CaseInstance,
+  disguiseValidationActive: boolean
+): boolean {
+  const modality = resolveHiddenStateModality(caseData)
+
+  if (modality === 'none') {
+    return false
+  }
+
+  if (modality === 'disguised_identity' && disguiseValidationActive) {
+    return false
+  }
+
+  return true
+}
+
+/** SPE-2282: weekly hidden-state scouting + tiered scan when disguise path is inactive. */
+export function evaluateHiddenStateScoutingWithRevealPayload(input: {
+  readonly caseData: CaseInstance
+  readonly agents: readonly Agent[]
+  readonly teamTags?: readonly string[]
+  readonly disguiseValidationActive: boolean
+}): HiddenStateScoutingRevealIntegrationResult | undefined {
+  if (
+    input.agents.length === 0 ||
+    !shouldRunHiddenStateScoutingCompose(input.caseData, input.disguiseValidationActive)
+  ) {
+    return undefined
+  }
+
+  const built = buildScoutingRevealInputFromCase(
+    input.caseData,
+    input.agents,
+    input.teamTags ?? []
+  )
+
+  return {
+    active: true,
+    ...resolveScoutingWithCaseHiddenState({
+      teamCapability: built.teamCapability,
+      anomalyConcealment: built.anomalyConcealment,
+      teamTags: [...built.teamTags],
+      anomalyTags: [...built.anomalyTags],
+      subject: built.subject,
+      caseData: input.caseData,
+    }),
+  }
 }
 
 export function buildSubjectTruthFromScouting(

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -1574,6 +1574,7 @@ interface WeeklyCaseResolutionStrategy {
   outcome: ResolutionOutcomeWithDetails
   aggregateBattleSummary?: AggregateBattleCampaignSummary
   behaviorValidation?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['behaviorValidation']
+  hiddenStateScouting?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['hiddenStateScouting']
   infiltrationStageMission?: ReturnType<
     typeof resolveCanonicalAssignedCaseForWeek
   >['infiltrationStageMission']
@@ -1716,6 +1717,7 @@ function resolveAssignedCaseForWeek(
     outcome,
     aggregateBattleSummary,
     behaviorValidation: canonicalResolution.behaviorValidation,
+    hiddenStateScouting: canonicalResolution.hiddenStateScouting,
     infiltrationStageMission: canonicalResolution.infiltrationStageMission,
     stealthLeaveBehindMission: canonicalResolution.stealthLeaveBehindMission,
     weakestLinkResult: canonicalResolution.weakestLinkResult,
@@ -2402,6 +2404,7 @@ function resolveAssignments(
       outcome,
       aggregateBattleSummary,
       behaviorValidation,
+      hiddenStateScouting,
       infiltrationStageMission,
       stealthLeaveBehindMission,
       weakestLinkResult,
@@ -2462,7 +2465,7 @@ function resolveAssignments(
       ...outcome.reasons,
       ...buildAggregateBattleResolutionReasons(aggregateBattleSummary),
     ]
-    appendDetectionScanResolutionReason(resolutionReasons, behaviorValidation)
+    appendDetectionScanResolutionReason(resolutionReasons, behaviorValidation, hiddenStateScouting)
 
     if (
       stealthLeaveBehindMission?.active &&

--- a/src/test/revealPayloadOrchestration.test.ts
+++ b/src/test/revealPayloadOrchestration.test.ts
@@ -10,6 +10,9 @@ import {
   buildDisguiseRevealSubjectFromCase,
   detectionScanTierOrder,
 } from '../domain/revealPayloadDisguiseIntegration'
+import {
+  buildScoutingRevealInputFromCase,
+} from '../domain/revealPayloadScoutingIntegration'
 import type { Agent, CaseInstance, Team } from '../domain/models'
 import { createStarterCase } from '../domain/templates/startingCases'
 
@@ -25,6 +28,24 @@ function createBehaviorObserver(id: string, tags: string[], social: number): Age
       social,
     },
     tags: ['medium', ...tags],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+function createReconObserver(id: string, investigation: number): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation,
+      utility: 40,
+      social: 40,
+    },
+    tags: ['medium', 'recon-specialist'],
     relationships: {},
     fatigue: 0,
     status: 'active',
@@ -49,6 +70,28 @@ function createHiddenCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
     difficulty: { combat: 0, investigation: 0, utility: 0, social: 40 },
     infiltrationAwareness: 0.35,
     infiltrationCoverProfile: { claimedRole: 'official_inspector', documentTier: 1 },
+    ...overrides,
+  }
+}
+
+function createConcealedPresenceCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-orchestration-concealed',
+      templateId: 'combat_vampire_nest',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['concealment'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: ['team-reveal'],
+    infiltrationCoverProfile: undefined,
+    infiltrationProbePlan: undefined,
+    weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+    difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
     ...overrides,
   }
 }
@@ -199,5 +242,138 @@ describe('revealPayloadOrchestration (SPE-781 slice 4)', () => {
       caseData.detectionConfidence ?? 0
     )
     expect(resolution.effectiveCase.counterDetection).toBe(true)
+  })
+})
+
+describe('hiddenStateScoutingOrchestration (SPE-2282)', () => {
+  it('buildScoutingRevealInputFromCase maps investigation pressure and team capability', () => {
+    const observer = createReconObserver('a_scouting_input', 60)
+    const caseData = createConcealedPresenceCase()
+
+    expect(buildScoutingRevealInputFromCase(caseData, [observer])).toMatchObject({
+      teamCapability: 3,
+      anomalyConcealment: 2,
+      subject: {
+        exactIdentity: 'entity:case-orchestration-concealed',
+        category: 'concealed presence',
+        present: true,
+      },
+    })
+  })
+
+  it('attach hiddenStateScouting for concealed-presence cases without active disguise validation', () => {
+    const observer = createReconObserver('a_concealed_orchestration', 60)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createConcealedPresenceCase({ assignedTeamIds: [team.id] })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(resolution.behaviorValidation?.active).toBe(false)
+    expect(resolution.hiddenStateScouting?.active).toBe(true)
+    expect(detectionScanTierOrder(resolution.hiddenStateScouting!.detectionScan).length).toBeGreaterThan(
+      0
+    )
+  })
+
+  it('anchors false-position hiddenStateScouting readouts to decoy locus', () => {
+    const observer = createReconObserver('a_displaced_orchestration', 60)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createConcealedPresenceCase({
+      assignedTeamIds: [team.id],
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-b',
+      difficulty: { combat: 0, investigation: 0, utility: 0, social: 0 },
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(resolution.hiddenStateScouting?.active).toBe(true)
+    const playerFacingValues = resolution.hiddenStateScouting!.detectionScan.fields.map(
+      (field) => field.playerFacingValue
+    )
+    expect(playerFacingValues.some((value) => value.includes('decoy locus annex-b'))).toBe(true)
+  })
+
+  it('does not attach hiddenStateScouting when disguised infiltration validation is active', () => {
+    const observer = createBehaviorObserver('a_disguise_orchestration', ['liaison', 'negotiation'], 58)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createHiddenCase({ assignedTeamIds: [team.id] })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(resolution.behaviorValidation?.active).toBe(true)
+    expect(resolution.hiddenStateScouting).toBeUndefined()
+    expect(resolution.behaviorValidation?.detectionScan).toBeDefined()
+  })
+
+  it('strips one modality layer when counter-detection is enabled on concealed cases', () => {
+    const observer = createReconObserver('a_counter_orchestration', 60)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createConcealedPresenceCase({
+      assignedTeamIds: [team.id],
+      counterDetection: true,
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(resolution.hiddenStateScouting?.detectionScan.strippedLayerIds).toContain(
+      'layer:concealed-presence'
+    )
+  })
+
+  it('appends detection readout resolution reasons from hiddenStateScouting when disguise is inactive', () => {
+    const observer = createReconObserver('a_report_orchestration', 60)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createConcealedPresenceCase({
+      assignedTeamIds: [team.id],
+      counterDetection: true,
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+    const reasons: string[] = []
+
+    appendDetectionScanResolutionReason(reasons, resolution.behaviorValidation, resolution.hiddenStateScouting)
+
+    expect(reasons.some((reason) => reason.includes(DETECTION_SCAN_READOUT_PREFIX))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Wire SPE-2281 esolveScoutingWithCaseHiddenState into esolveAssignedCaseForWeek so concealed-presence and false-position cases attach tiered detectionScan when disguise validation is inactive.
- Add scouting input builders (uildScoutingRevealInputFromCase, evaluateHiddenStateScoutingWithRevealPayload) and WeeklyCaseResolutionStrategy.hiddenStateScouting.
- Extend ppendDetectionScanResolutionReason / dvanceWeek to surface hidden-state scan readouts when disguise path does not produce one.
- Add orchestration integration tests; add slice-2 plan doc and backlog index entries.

## Linear

- **Slice:** [SPE-2282](https://linear.app/spectranoir/issue/SPE-2282) — Hidden-state modality matrix slice 2 (weekly orchestration wiring)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70) — remains open (umbrella AC not fully satisfied)

## What shipped

Domain orchestration only — no UI, no new persistence shapes, no modality-specific report copy (slice 3).

## Validation

- 
pm run lint
- 
pm run test:run -- src/test/revealPayloadOrchestration.test.ts src/test/hiddenStateModality.test.ts src/test/detectionScanReportNotes.test.ts

## Docs updated

- planning/hidden-modality-matrix-slice-2.md (new)
- planning/hidden-modality-matrix-slice-1.md (shipped status)
- planning/backlog.md (slice index)

Made with [Cursor](https://cursor.com)