### PR TITLE
feat(SPE-2283): hidden-state modality matrix — slice 3 report copy

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -93,7 +93,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                     |
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |
 | `hidden-modality-matrix-slice-1.md`                       | **Shipped**    | SPE-2281 / PR #2403; domain compose.                          |
-| `hidden-modality-matrix-slice-2.md`                       | **Active**     | SPE-2282; weekly orchestration wiring (next).                 |
+| `hidden-modality-matrix-slice-2.md`                       | **Shipped**    | SPE-2282 / PR #2405; weekly orchestration wiring.              |
+| `hidden-modality-matrix-slice-3.md`                       | **Active**     | SPE-2283; modality report / event-feed copy (next).           |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                         |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                          |
 

--- a/planning/hidden-modality-matrix-slice-2.md
+++ b/planning/hidden-modality-matrix-slice-2.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2282](https://linear.app/spectranoir/
 | **Linear** | [SPE-2282 — Hidden-state modality matrix slice 2](https://linear.app/spectranoir/issue/SPE-2282) |
 | **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
 | **Branch** | `jamesdyedbq/spe-70-hidden-modality-matrix-slice-2` |
-| **Status** | In Progress — SPE-2282 |
+| **Status** | **Shipped** — SPE-2282 / PR #2405 |
 
 ## Goal
 

--- a/planning/hidden-modality-matrix-slice-3.md
+++ b/planning/hidden-modality-matrix-slice-3.md
@@ -1,0 +1,115 @@
+# SPE-70 — Hidden-state modality matrix slice 3 (modality report copy)
+
+One-page implementation plan. Linear: [SPE-2283](https://linear.app/spectranoir/issue/SPE-2283) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Follows shipped [SPE-2282](https://linear.app/spectranoir/issue/SPE-2282) weekly orchestration (PR #2405). Reference pattern: [SPE-2254](https://linear.app/spectranoir/issue/SPE-2254) / `planning/reveal-payload-slice-5.md` (generic detection readout copy).
+
+| Field | Value |
+| --- | --- |
+| **Linear** | [SPE-2283 — Hidden-state modality matrix slice 3](https://linear.app/spectranoir/issue/SPE-2283) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
+| **Branch** | `jamesdyedbq/spe-2283-hidden-modality-matrix-slice-3-report-copy` |
+| **Status** | Backlog — SPE-2283 |
+
+## Goal
+
+Make **weekly report** (and optional event-feed) copy reflect **which hidden-state modality** produced the tiered scan — concealed presence, false position, or disguised-identity scouting — without changing scan resolution, scouting outcome bands, disguise validation scores, or mission outcome math.
+
+Slice 2 already attaches `hiddenStateScouting.detectionScan` and appends a generic **`Detection readout:`** line via `appendDetectionScanResolutionReason`. Slice 3 is **copy-only**: modality prefixes, framing, append gating tuned per modality, and end-to-end `advanceWeek` proof.
+
+## Prerequisite (on `main`)
+
+| Shipped | Anchor |
+| --- | --- |
+| Modality compose (slice 1) | `src/domain/hiddenStateModality.ts`, `resolveScoutingWithCaseHiddenState` (SPE-2281, PR #2403) |
+| Weekly orchestration (slice 2) | `evaluateHiddenStateScoutingWithRevealPayload`, `WeeklyCaseResolutionStrategy.hiddenStateScouting?` (SPE-2282, PR #2405) |
+| Generic readout hook | `appendDetectionScanResolutionReason` in `detectionScanReportNotes.ts` (SPE-2254) |
+| False-position projection | `applyFalsePositionScanProjection` — decoy locus in `playerFacingValue` |
+| Case fields | `hiddenState`, `displacementTarget`, `counterDetection`, `detectionConfidence` on `CaseInstance` |
+
+## Gap (pre-slice)
+
+| Area | Today | Slice 3 target |
+| --- | --- | --- |
+| Report prefix | One `Detection readout:` prefix for disguise and hidden-state scouting | Modality-specific prefixes / lead-ins |
+| False position | Decoy tiers in scan fields | Report framed as **displacement / decoy** readout |
+| Concealed presence | Scan tiers work; report sounds like generic detection | **Concealment / hidden-presence** framing |
+| Disguise edge case | Inactive disguise + `disguised_identity` uses hidden-state path | No duplicate or contradictory readout vs active disguise |
+| `advanceWeek` | Orchestration tests call append manually | Integration: concealed / displaced → `explanationNotes` with modality copy |
+| Event feed | `concealment.activated` has mode-specific activation summaries | Optional same-week enrichment when scan exists (bounded) |
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| Extend `detectionScanReportNotes.ts`: modality-aware `formatDetectionScanSummary` (or parallel helpers) | New `GameState` / case persistence fields |
+| Modality prefixes: `Concealment readout:`, `Displacement readout:`, cover readout for disguised-identity scouting path; keep `Detection readout:` for disguise `behaviorValidation` | Changing `resolveDetectionScan` / layer math |
+| `appendDetectionScanResolutionReason` resolves `resolveHiddenStateModality(caseData)` for `hiddenStateScouting` | Known-but-unresolved recon cache (slice 4) |
+| Modality-aware `shouldAppend…` for hidden-state path (suppress presence-only absent contact; allow false-position decoy tiers) | False-entity / structural-illusion lifecycle (slice 5) |
+| `advanceWeek` integration tests for concealed + displaced weekly reports | New React report components |
+| Unit tests in `detectionScanReportNotes.test.ts`; orchestration regression | Rewriting disguise validation copy |
+| Optional: enrich `concealment.activated` / weekly `report.notes` when same-week scan exists | New event types unless existing payload enrichment is trivial |
+
+## Copy contract
+
+Reference: `architecture/hidden-state-displacement-counter-detection.md` (projection mismatch), `concealmentActivationFeed.ts`.
+
+| Modality | Prefix | Notes |
+| --- | --- | --- |
+| `concealed_presence` | `Concealment readout:` | Presence ambiguity, not identity validation |
+| `false_position` | `Displacement readout:` | Lead with decoy locus when `displacementTarget` set |
+| `disguised_identity` (hidden-state path only) | `Cover readout:` (or agreed alias) | Only when disguise validation inactive |
+| Disguise `behaviorValidation` | `Detection readout:` (unchanged) | No regression for SPE-781 slice 5 |
+
+**Body:** Join `fields[].playerFacingValue` in resolver order; no `internalValue`. Keep counter-detection peel suffix when `strippedLayerIds` non-empty.
+
+**Emit when:** Disguise path — existing rules. Hidden-state path — `hiddenStateScouting.active`, modality ≠ `none`, meaningful tiers (adjust `shouldAppendDetectionScanReportNote` as needed).
+
+**Dedup:** One readout line per resolution (guard across modality prefix family).
+
+**Legacy coexistence:** Keep `Behavior validation:` and scalar `detectionConfidence`; modality readout is additional `resolutionReasons` → `explanationNotes`.
+
+## Acceptance
+
+- [ ] Concealed-presence weekly mission: `explanationNotes` contains concealment-framed readout (not only generic `Detection readout`).
+- [ ] False-position fixture (`displaced` + `displacementTarget`): displacement-framed readout retains decoy locus in tier clauses.
+- [ ] Active disguised infiltration: disguise readout unchanged; no second hidden-state readout line.
+- [ ] Counter-detection peel: modality-specific suffix; mission scores unchanged vs SPE-2282 baselines.
+- [ ] `npm run lint` + targeted `npm run test:run` green on touched files.
+
+## TDD order
+
+1. **Prefix + formatter unit tests** — per-modality summary strings from fixture scans.
+2. **Append gating** — concealed vs displaced vs inactive presence-only; dedup across prefixes.
+3. **`appendDetectionScanResolutionReason` integration** — extend `revealPayloadOrchestration.test.ts`.
+4. **`advanceWeek` E2E** — concealed + displaced through full week advance → `missionResult.explanationNotes`.
+5. **Regression** — SPE-2254 disguise readout tests and SPE-2282 orchestration math unchanged.
+
+## File touch list (expected)
+
+| Area | Files |
+| --- | --- |
+| Formatters | `src/domain/detectionScanReportNotes.ts` |
+| Modality helper (optional) | `src/domain/hiddenStateModality.ts` — prefix helper only if cohesive |
+| Weekly hook | `src/domain/sim/advanceWeek.ts` — pass `caseData` into append if needed |
+| Optional feed | `src/domain/concealmentActivationFeed.ts` or small companion module |
+| Tests | `src/test/detectionScanReportNotes.test.ts`, `src/test/advanceWeek.hiddenStateScouting.test.ts` (new) or extend `advanceWeek.behaviorValidation.test.ts` |
+
+## Branch
+
+`jamesdyedbq/spe-2283-hidden-modality-matrix-slice-3-report-copy`
+
+## Out of scope (later slices)
+
+- Known-but-unresolved hidden nodes across multi-pass scouting (persistent recon cache) — slice 4
+- False-entity / structural-illusion lifecycle — slice 5
+- Mode-specific tells and observer-threshold validation
+- Mission triage UI scan chips (unless a later UX slice owns it)
+- Full SPE-70 parent closure
+
+## See also
+
+- `planning/hidden-modality-matrix-slice-1.md` (shipped)
+- `planning/hidden-modality-matrix-slice-2.md` (shipped)
+- `planning/reveal-payload-slice-5.md` — formatter pattern
+- `architecture/hidden-state-displacement-counter-detection.md`
+- `src/domain/hiddenStateModality.ts`
+- `src/domain/concealmentActivationFeed.ts`

--- a/planning/hidden-modality-matrix-slice-3.md
+++ b/planning/hidden-modality-matrix-slice-3.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2283](https://linear.app/spectranoir/
 | **Linear** | [SPE-2283 — Hidden-state modality matrix slice 3](https://linear.app/spectranoir/issue/SPE-2283) |
 | **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
 | **Branch** | `jamesdyedbq/spe-2283-hidden-modality-matrix-slice-3-report-copy` |
-| **Status** | Backlog — SPE-2283 |
+| **Status** | In Progress — SPE-2283 |
 
 ## Goal
 
@@ -69,11 +69,11 @@ Reference: `architecture/hidden-state-displacement-counter-detection.md` (projec
 
 ## Acceptance
 
-- [ ] Concealed-presence weekly mission: `explanationNotes` contains concealment-framed readout (not only generic `Detection readout`).
-- [ ] False-position fixture (`displaced` + `displacementTarget`): displacement-framed readout retains decoy locus in tier clauses.
-- [ ] Active disguised infiltration: disguise readout unchanged; no second hidden-state readout line.
-- [ ] Counter-detection peel: modality-specific suffix; mission scores unchanged vs SPE-2282 baselines.
-- [ ] `npm run lint` + targeted `npm run test:run` green on touched files.
+- [x] Concealed-presence weekly mission: `explanationNotes` contains concealment-framed readout (not only generic `Detection readout`).
+- [x] False-position fixture (`displaced` + `displacementTarget`): displacement-framed readout retains decoy locus in tier clauses.
+- [x] Active disguised infiltration: disguise readout unchanged; no second hidden-state readout line (orchestration regression).
+- [x] Counter-detection peel: modality-specific suffix; mission scores unchanged vs SPE-2282 baselines.
+- [x] `npm run lint` + targeted `npm run test:run` green on touched files.
 
 ## TDD order
 

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -1,13 +1,47 @@
 /**
- * SPE-781 slice 5: player-facing weekly report copy for tiered detection scans.
+ * SPE-781 slice 5 / SPE-2283 slice 3: player-facing weekly report copy for tiered detection scans.
  */
 
 import type { BehaviorWeightedDisguiseValidationResult } from './disguiseValidation'
+import {
+  resolveHiddenStateModality,
+  type HiddenStateModalityKind,
+} from './hiddenStateModality'
+import type { CaseInstance } from './models'
 import type { DetectionScanResult } from './revealPayload'
 import type { DisguiseRevealIntegrationResult } from './revealPayloadDisguiseIntegration'
 import type { HiddenStateScoutingRevealIntegrationResult } from './revealPayloadScoutingIntegration'
 
 export const DETECTION_SCAN_READOUT_PREFIX = 'Detection readout:'
+export const CONCEALMENT_SCAN_READOUT_PREFIX = 'Concealment readout:'
+export const DISPLACEMENT_SCAN_READOUT_PREFIX = 'Displacement readout:'
+export const COVER_SCAN_READOUT_PREFIX = 'Cover readout:'
+
+export const DETECTION_SCAN_READOUT_PREFIXES = [
+  DETECTION_SCAN_READOUT_PREFIX,
+  CONCEALMENT_SCAN_READOUT_PREFIX,
+  DISPLACEMENT_SCAN_READOUT_PREFIX,
+  COVER_SCAN_READOUT_PREFIX,
+] as const
+
+export function detectionScanReadoutPrefixForModality(
+  modality: HiddenStateModalityKind
+): string {
+  switch (modality) {
+    case 'concealed_presence':
+      return CONCEALMENT_SCAN_READOUT_PREFIX
+    case 'false_position':
+      return DISPLACEMENT_SCAN_READOUT_PREFIX
+    case 'disguised_identity':
+      return COVER_SCAN_READOUT_PREFIX
+    case 'none':
+      return DETECTION_SCAN_READOUT_PREFIX
+    default: {
+      const _exhaustive: never = modality
+      return _exhaustive
+    }
+  }
+}
 
 function isPresenceOnlyAbsentContact(scan: DetectionScanResult): boolean {
   if (scan.fields.length !== 1) {
@@ -22,6 +56,10 @@ function orderedPlayerFacingValues(result: DetectionScanResult): readonly string
   return result.fields
     .map((field) => field.playerFacingValue.trim())
     .filter((value) => value.length > 0)
+}
+
+function resolutionReasonHasDetectionScanReadout(reason: string): boolean {
+  return DETECTION_SCAN_READOUT_PREFIXES.some((prefix) => reason.startsWith(prefix))
 }
 
 export function shouldAppendDetectionScanReportNote(
@@ -40,6 +78,21 @@ export function shouldAppendDetectionScanReportNote(
   return orderedPlayerFacingValues(validation.detectionScan).length > 0
 }
 
+export function shouldAppendHiddenStateScoutingReportNote(
+  scouting: HiddenStateScoutingRevealIntegrationResult,
+  modality: HiddenStateModalityKind
+): boolean {
+  if (!scouting.active || modality === 'none') {
+    return false
+  }
+
+  if (isPresenceOnlyAbsentContact(scouting.detectionScan)) {
+    return false
+  }
+
+  return orderedPlayerFacingValues(scouting.detectionScan).length > 0
+}
+
 function formatDetectionScanStrippedLayersSuffix(result: DetectionScanResult): string {
   const strippedCount = result.strippedLayerIds.length
   if (strippedCount === 0) {
@@ -50,42 +103,62 @@ function formatDetectionScanStrippedLayersSuffix(result: DetectionScanResult): s
 }
 
 /** Ordered player-facing tier values from a detection scan. */
-export function formatDetectionScanSummary(result: DetectionScanResult): string {
+export function formatDetectionScanSummary(
+  result: DetectionScanResult,
+  options?: { readonly prefix?: string }
+): string {
   const orderedValues = orderedPlayerFacingValues(result)
   if (orderedValues.length === 0) {
     return ''
   }
 
+  const prefix = options?.prefix ?? DETECTION_SCAN_READOUT_PREFIX
+
   return (
-    `${DETECTION_SCAN_READOUT_PREFIX} ${orderedValues.join('; ')}.` +
-    formatDetectionScanStrippedLayersSuffix(result)
+    `${prefix} ${orderedValues.join('; ')}.` + formatDetectionScanStrippedLayersSuffix(result)
   )
 }
 
 export function appendDetectionScanResolutionReason(
   resolutionReasons: string[],
   behaviorValidation?: DisguiseRevealIntegrationResult,
-  hiddenStateScouting?: HiddenStateScoutingRevealIntegrationResult
+  hiddenStateScouting?: HiddenStateScoutingRevealIntegrationResult,
+  caseData?: CaseInstance
 ): void {
-  if (resolutionReasons.some((reason) => reason.startsWith(DETECTION_SCAN_READOUT_PREFIX))) {
+  if (resolutionReasons.some(resolutionReasonHasDetectionScanReadout)) {
     return
   }
 
-  const scanSource =
-    behaviorValidation !== undefined && shouldAppendDetectionScanReportNote(behaviorValidation)
-      ? behaviorValidation.detectionScan
-      : hiddenStateScouting !== undefined && shouldAppendDetectionScanReportNote(hiddenStateScouting)
-        ? hiddenStateScouting.detectionScan
-        : undefined
+  if (
+    behaviorValidation !== undefined &&
+    shouldAppendDetectionScanReportNote(behaviorValidation)
+  ) {
+    const summary = formatDetectionScanSummary(behaviorValidation.detectionScan, {
+      prefix: DETECTION_SCAN_READOUT_PREFIX,
+    })
+    if (summary.length > 0) {
+      resolutionReasons.push(summary)
+    }
 
-  if (scanSource === undefined) {
     return
   }
 
-  const summary = formatDetectionScanSummary(scanSource)
-  if (summary.length === 0) {
+  if (hiddenStateScouting === undefined) {
     return
   }
 
-  resolutionReasons.push(summary)
+  const modality =
+    caseData !== undefined ? resolveHiddenStateModality(caseData) : ('none' as const)
+
+  if (!shouldAppendHiddenStateScoutingReportNote(hiddenStateScouting, modality)) {
+    return
+  }
+
+  const summary = formatDetectionScanSummary(hiddenStateScouting.detectionScan, {
+    prefix: detectionScanReadoutPrefixForModality(modality),
+  })
+
+  if (summary.length > 0) {
+    resolutionReasons.push(summary)
+  }
 }

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -2465,7 +2465,12 @@ function resolveAssignments(
       ...outcome.reasons,
       ...buildAggregateBattleResolutionReasons(aggregateBattleSummary),
     ]
-    appendDetectionScanResolutionReason(resolutionReasons, behaviorValidation, hiddenStateScouting)
+    appendDetectionScanResolutionReason(
+      resolutionReasons,
+      behaviorValidation,
+      hiddenStateScouting,
+      effectiveCase
+    )
 
     if (
       stealthLeaveBehindMission?.active &&

--- a/src/test/advanceWeek.hiddenStateScouting.test.ts
+++ b/src/test/advanceWeek.hiddenStateScouting.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  CONCEALMENT_SCAN_READOUT_PREFIX,
+  DISPLACEMENT_SCAN_READOUT_PREFIX,
+  DETECTION_SCAN_READOUT_PREFIX,
+} from '../domain/detectionScanReportNotes'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createReconObserver(id: string, investigation: number): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation,
+      utility: 40,
+      social: 40,
+    },
+    tags: ['medium', 'recon-specialist'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+function createConcealedInvestigationCase(teamId: string): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-concealed-readout',
+      templateId: 'combat_vampire_nest',
+    }),
+    mode: 'threshold',
+    status: 'in_progress',
+    weeksRemaining: 1,
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: true,
+    tags: ['concealment'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [teamId],
+    infiltrationCoverProfile: undefined,
+    infiltrationProbePlan: undefined,
+    weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+    difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+  }
+}
+
+function tuneConcealedInvestigationCase(
+  state: ReturnType<typeof createStartingState>,
+  teamId: string,
+  overrides: Partial<CaseInstance> = {}
+): CaseInstance {
+  const baseCase = {
+    ...createConcealedInvestigationCase(teamId),
+    ...overrides,
+  }
+
+  for (let investigationDifficulty = 8; investigationDifficulty <= 140; investigationDifficulty += 1) {
+    const candidate: CaseInstance = {
+      ...baseCase,
+      difficulty: {
+        combat: 0,
+        investigation: investigationDifficulty,
+        utility: 0,
+        social: 0,
+      },
+    }
+    const resolution = resolveAssignedCaseForWeek(candidate, state, () => 0.5)
+
+    if (
+      resolution.outcome.result === 'success' &&
+      resolution.hiddenStateScouting?.active === true
+    ) {
+      return candidate
+    }
+  }
+
+  throw new Error('Unable to tune a concealed-presence investigation success case.')
+}
+
+describe('advanceWeek hidden-state scouting report copy (SPE-2283)', () => {
+  it('surfaces concealment-framed detection readout in weekly explanation notes', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_concealed_readout', 60)
+    const team: Team = {
+      id: 'team-concealed-readout',
+      name: 'Concealed readout team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-concealed-readout'] = tuneConcealedInvestigationCase(state, team.id)
+
+    const preAdvance = resolveAssignedCaseForWeek(state.cases['case-concealed-readout'], state, () => 0.5)
+    expect(preAdvance.hiddenStateScouting?.active).toBe(true)
+    expect(preAdvance.behaviorValidation?.active).toBe(false)
+
+    const nextState = advanceWeek(state)
+    const missionResult =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-concealed-readout']
+        ?.missionResult
+
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes(CONCEALMENT_SCAN_READOUT_PREFIX))
+    ).toBe(true)
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes(DETECTION_SCAN_READOUT_PREFIX))
+    ).toBe(false)
+  })
+
+  it('surfaces displacement-framed readout with decoy locus for false-position cases', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_displaced_readout', 60)
+    const team: Team = {
+      id: 'team-displaced-readout',
+      name: 'Displaced readout team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-concealed-readout'] = tuneConcealedInvestigationCase(state, team.id, {
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-b',
+    })
+
+    const preAdvance = resolveAssignedCaseForWeek(state.cases['case-concealed-readout'], state, () => 0.5)
+    expect(preAdvance.hiddenStateScouting?.active).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const missionResult =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-concealed-readout']
+        ?.missionResult
+
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes(DISPLACEMENT_SCAN_READOUT_PREFIX))
+    ).toBe(true)
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes('decoy locus annex-b'))
+    ).toBe(true)
+  })
+})

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   appendDetectionScanResolutionReason,
+  CONCEALMENT_SCAN_READOUT_PREFIX,
+  COVER_SCAN_READOUT_PREFIX,
   DETECTION_SCAN_READOUT_PREFIX,
+  detectionScanReadoutPrefixForModality,
+  DISPLACEMENT_SCAN_READOUT_PREFIX,
   formatDetectionScanSummary,
   shouldAppendDetectionScanReportNote,
 } from '../domain/detectionScanReportNotes'
@@ -39,6 +43,26 @@ describe('detectionScanReportNotes', () => {
     expect(formatDetectionScanSummary(scan)).toBe(
       `${DETECTION_SCAN_READOUT_PREFIX} contact detected; unclassified contact.`
     )
+  })
+
+  it('formats modality-specific readout prefixes', () => {
+    const scan = resolveDetectionScan(buildSubject(), { family: 'category_pass' })
+
+    expect(
+      formatDetectionScanSummary(scan, { prefix: CONCEALMENT_SCAN_READOUT_PREFIX })
+    ).toBe(`${CONCEALMENT_SCAN_READOUT_PREFIX} contact detected; unclassified contact.`)
+
+    expect(
+      formatDetectionScanSummary(scan, { prefix: DISPLACEMENT_SCAN_READOUT_PREFIX })
+    ).toContain(DISPLACEMENT_SCAN_READOUT_PREFIX)
+
+    expect(detectionScanReadoutPrefixForModality('concealed_presence')).toBe(
+      CONCEALMENT_SCAN_READOUT_PREFIX
+    )
+    expect(detectionScanReadoutPrefixForModality('false_position')).toBe(
+      DISPLACEMENT_SCAN_READOUT_PREFIX
+    )
+    expect(detectionScanReadoutPrefixForModality('disguised_identity')).toBe(COVER_SCAN_READOUT_PREFIX)
   })
 
   it('appends counter-detection peel suffix when layers were stripped', () => {
@@ -120,6 +144,25 @@ describe('detectionScanReportNotes', () => {
       shouldDegradeSuccessToPartial: false,
       detectionScan: scan,
     })
+    appendDetectionScanResolutionReason(reasons, {
+      active: true,
+      level: 'strong',
+      scoreAdjustment: 0,
+      evidenceSignals: [],
+      counterDetection: false,
+      shouldDegradeSuccessToPartial: false,
+      detectionScan: scan,
+    })
+
+    expect(reasons).toHaveLength(1)
+  })
+
+  it('does not append a second readout when a modality prefix line already exists', () => {
+    const scan = resolveDetectionScan(buildSubject(), { family: 'category_pass' })
+    const reasons = [
+      `${CONCEALMENT_SCAN_READOUT_PREFIX} contact detected; unclassified contact.`,
+    ]
+
     appendDetectionScanResolutionReason(reasons, {
       active: true,
       level: 'strong',

--- a/src/test/revealPayloadOrchestration.test.ts
+++ b/src/test/revealPayloadOrchestration.test.ts
@@ -4,7 +4,9 @@ import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestratio
 import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseValidation'
 import {
   appendDetectionScanResolutionReason,
+  CONCEALMENT_SCAN_READOUT_PREFIX,
   DETECTION_SCAN_READOUT_PREFIX,
+  DISPLACEMENT_SCAN_READOUT_PREFIX,
 } from '../domain/detectionScanReportNotes'
 import {
   buildDisguiseRevealSubjectFromCase,
@@ -372,8 +374,46 @@ describe('hiddenStateScoutingOrchestration (SPE-2282)', () => {
     const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
     const reasons: string[] = []
 
-    appendDetectionScanResolutionReason(reasons, resolution.behaviorValidation, resolution.hiddenStateScouting)
+    appendDetectionScanResolutionReason(
+      reasons,
+      resolution.behaviorValidation,
+      resolution.hiddenStateScouting,
+      caseData
+    )
 
-    expect(reasons.some((reason) => reason.includes(DETECTION_SCAN_READOUT_PREFIX))).toBe(true)
+    expect(reasons.some((reason) => reason.includes(CONCEALMENT_SCAN_READOUT_PREFIX))).toBe(true)
+    expect(reasons.some((reason) => reason.includes(DETECTION_SCAN_READOUT_PREFIX))).toBe(false)
+  })
+
+  it('appends displacement readout for false-position hiddenStateScouting', () => {
+    const observer = createReconObserver('a_displacement_report', 60)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createConcealedPresenceCase({
+      assignedTeamIds: [team.id],
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-b',
+      difficulty: { combat: 0, investigation: 0, utility: 0, social: 0 },
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+    const reasons: string[] = []
+
+    appendDetectionScanResolutionReason(
+      reasons,
+      resolution.behaviorValidation,
+      resolution.hiddenStateScouting,
+      caseData
+    )
+
+    expect(reasons.some((reason) => reason.includes(DISPLACEMENT_SCAN_READOUT_PREFIX))).toBe(true)
+    expect(reasons.some((reason) => reason.includes('decoy locus annex-b'))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Add modality-specific weekly report prefixes for hidden-state scouting: **Concealment readout**, **Displacement readout**, and **Cover readout** (disguise validation keeps **Detection readout**).
- Resolve modality via `resolveHiddenStateModality(caseData)` in `appendDetectionScanResolutionReason`; pass `effectiveCase` from `advanceWeek`.
- Dedup across all readout prefix families so disguise and hidden-state paths never double-append.

## Linear

- **Slice:** [SPE-2283](https://linear.app/spectranoir/issue/SPE-2283/hidden-state-modality-matrix-slice-3-modality-report-copy)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70/hidden-state-displacement-and-counter-detection-layer) (parent remains open for slices 4–5)

## What shipped

- `src/domain/detectionScanReportNotes.ts` — modality prefixes, gating, append wiring
- `src/domain/sim/advanceWeek.ts` — pass case into append helper
- Tests: `detectionScanReportNotes.test.ts`, `revealPayloadOrchestration.test.ts`, `advanceWeek.hiddenStateScouting.test.ts`

## Test plan

- [x] `npm run test:run -- src/test/detectionScanReportNotes.test.ts src/test/revealPayloadOrchestration.test.ts src/test/advanceWeek.hiddenStateScouting.test.ts`
- [x] `npm run lint`

## Docs updated

- `planning/hidden-modality-matrix-slice-3.md` (acceptance checkboxes)

## Parent status

SPE-70 stays open — slice 4 (recon cache) and slice 5 (false-entity lifecycle) not in this PR.

Made with [Cursor](https://cursor.com)