### PR TITLE
feat(SPE-2284): hidden-state modality matrix — slice 4 recon cache

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -94,7 +94,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |
 | `hidden-modality-matrix-slice-1.md`                       | **Shipped**    | SPE-2281 / PR #2403; domain compose.                          |
 | `hidden-modality-matrix-slice-2.md`                       | **Shipped**    | SPE-2282 / PR #2405; weekly orchestration wiring.              |
-| `hidden-modality-matrix-slice-3.md`                       | **Active**     | SPE-2283; modality report / event-feed copy (next).           |
+| `hidden-modality-matrix-slice-3.md`                       | **Shipped**    | SPE-2283 / PR #2407; modality report copy.                    |
+| `hidden-modality-matrix-slice-4.md`                       | **Active**     | SPE-2284; persistent recon cache.                             |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                         |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                          |
 

--- a/planning/hidden-modality-matrix-slice-4.md
+++ b/planning/hidden-modality-matrix-slice-4.md
@@ -1,0 +1,65 @@
+# SPE-70 — Hidden-state modality matrix slice 4 (persistent recon cache)
+
+One-page implementation plan. Linear: [SPE-2284](https://linear.app/spectranoir/issue/SPE-2284) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Follows shipped [SPE-2283](https://linear.app/spectranoir/issue/SPE-2283) (PR #2407).
+
+| Field | Value |
+| --- | --- |
+| **Linear** | [SPE-2284 — Hidden-state modality matrix slice 4](https://linear.app/spectranoir/issue/SPE-2284) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
+| **Branch** | `jamesdyedbq/spe-2284-hidden-modality-matrix-slice-4-recon-cache` |
+| **Status** | **Shipped** — SPE-2284 (pending PR) |
+
+## Goal
+
+Persist **known-but-unresolved** concealment nodes when hidden-state scouting returns partial tier readouts (fields present, layers still blocking). Carry that cache across assigned weeks so a later pass can peel one cached layer and apply a bounded route-caution score signal — satisfying SPE-70 “known-but-unresolved across scouting passes” without new scan families or UI.
+
+## Prerequisite (on `main`)
+
+| Shipped | Anchor |
+| --- | --- |
+| Modality compose | `hiddenStateModality.ts`, `resolveScoutingWithCaseHiddenState` (SPE-2281) |
+| Weekly orchestration | `evaluateHiddenStateScoutingWithRevealPayload` (SPE-2282) |
+| Modality report copy | `detectionScanReportNotes.ts` (SPE-2283) |
+
+## Gap (pre-slice)
+
+- Each week recomputes scouting scans with no memory of prior partial readouts.
+- Multi-week `in_progress` cases decrement `weeksRemaining` without recording scouting passes.
+- No downstream operational signal from cached unresolved nodes.
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| `HiddenStateScoutingReconCache` on `CaseInstance` | False-entity / structural-illusion lifecycle (slice 5) |
+| `hiddenStateScoutingReconCache.ts` — merge, strip bonus, score hook | New event types |
+| Extra `layersToStrip` in `scoutingOutcomeToDetectionScanForCase` when cache has unresolved nodes | UI components |
+| Merge cache after hidden-state scouting in orchestration + in-progress weekly pass | Full SPE-70 parent closure |
+| `advanceWeek` multi-week integration test | Rewriting disguise or recon modifier systems |
+
+## Cache contract
+
+**Record when:** hidden-state scouting produces `detectionScan.fields.length > 0` and `remainingConcealmentLayers.length > 0`.
+
+**Store:** sorted `knownUnresolvedLayerIds`, increment `scoutingPassCount`, set `lastUpdatedWeek`.
+
+**Apply on later pass:** if `scoutingPassCount >= 1` and unresolved ids non-empty, add `+1` to `layersToStrip` (capped, merged with counter-detection strip).
+
+**Operational hook:** when `scoutingPassCount >= 2`, add bounded `+0.35` mission score adjustment with route-caution reason (deterministic).
+
+## Acceptance
+
+- [x] First partial hidden-state scan records cache on case.
+- [x] Second assigned week applies extra layer strip and route-caution score signal.
+- [x] Disguise-active cases skip hidden-state path; cache unchanged (orchestration regression).
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## Branch
+
+`jamesdyedbq/spe-2284-hidden-modality-matrix-slice-4-recon-cache`
+
+## Out of scope (later)
+
+- False-entity / structural-illusion lifecycle — slice 5
+- Mission triage UI chips
+- `concealment.activated` enrichment from cache

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -11,6 +11,10 @@ import {
   type DisguiseRevealIntegrationResult,
 } from './revealPayloadDisguiseIntegration'
 import {
+  applyHiddenStateScoutingReconCacheToCase,
+  scoutingReconCacheScoreAdjustment,
+} from './hiddenStateScoutingReconCache'
+import {
   evaluateHiddenStateScoutingWithRevealPayload,
   type HiddenStateScoutingRevealIntegrationResult,
 } from './revealPayloadScoutingIntegration'
@@ -147,7 +151,7 @@ export function resolveAssignedCaseForWeek(
       infiltrationAwareness: effectiveCase.infiltrationAwareness,
     },
   })
-  const resolvedEffectiveCase = applyBehaviorWeightedDisguiseValidationToCase(
+  let resolvedEffectiveCase = applyBehaviorWeightedDisguiseValidationToCase(
     effectiveCase,
     behaviorValidation
   )
@@ -157,18 +161,28 @@ export function resolveAssignedCaseForWeek(
     teamTags: supportTags,
     disguiseValidationActive: behaviorValidation.active,
   })
+  if (hiddenStateScouting !== undefined) {
+    resolvedEffectiveCase = applyHiddenStateScoutingReconCacheToCase(
+      resolvedEffectiveCase,
+      hiddenStateScouting.detectionScan,
+      state.week
+    )
+  }
+  const reconCacheScore = scoutingReconCacheScoreAdjustment(resolvedEffectiveCase)
   const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(resolvedEffectiveCase)
   const stealthLeaveBehindMission = evaluateStealthLeaveBehindMissionPressure(resolvedEffectiveCase)
   const scoreAdjustment =
     factionContext.scoreAdjustment +
     behaviorValidation.scoreAdjustment +
     infiltrationStageMission.scoreAdjustment +
-    stealthLeaveBehindMission.scoreAdjustment
+    stealthLeaveBehindMission.scoreAdjustment +
+    reconCacheScore.delta
   const scoreAdjustmentReason = [
     ...factionContext.reasons,
     behaviorValidation.scoreAdjustmentReason,
     infiltrationStageMission.scoreAdjustmentReason,
     stealthLeaveBehindMission.scoreAdjustmentReason,
+    reconCacheScore.reason,
   ]
     .filter(Boolean)
     .join(' / ')

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -8,6 +8,7 @@ import {
   buildDisguiseRevealSubjectFromCase,
   disguiseConcealmentRatingFromCase,
 } from './revealPayloadDisguiseIntegration'
+import { extraLayersToStripFromReconCache } from './hiddenStateScoutingReconCache'
 import {
   buildSubjectTruthFromScouting,
   concealmentLayersFromRating,
@@ -239,13 +240,20 @@ export function scoutingOutcomeToDetectionScanForCase(
 ): DetectionScanInput {
   const base = scoutingOutcomeToDetectionScan(scouting)
   const modality = resolveHiddenStateModality(caseData)
+  let layersToStrip = base.layersToStrip ?? 0
 
-  if (modality === 'none' || !caseData.counterDetection) {
+  layersToStrip = Math.max(layersToStrip, extraLayersToStripFromReconCache(caseData))
+
+  if (modality !== 'none' && caseData.counterDetection) {
+    layersToStrip = Math.max(layersToStrip, 1)
+  }
+
+  if (layersToStrip === (base.layersToStrip ?? 0)) {
     return base
   }
 
   return {
     ...base,
-    layersToStrip: Math.max(base.layersToStrip ?? 0, 1),
+    layersToStrip,
   }
 }

--- a/src/domain/hiddenStateScoutingReconCache.ts
+++ b/src/domain/hiddenStateScoutingReconCache.ts
@@ -1,0 +1,151 @@
+/**
+ * SPE-2284 slice 4: persistent known-but-unresolved hidden-state scouting recon cache.
+ */
+
+import type { DetectionScanResult } from './revealPayload'
+import type { CaseInstance } from './models'
+import type { GameState } from './models'
+import {
+  evaluateHiddenStateScoutingWithRevealPayload,
+} from './revealPayloadScoutingIntegration'
+import { evaluateBehaviorWeightedDisguiseValidation } from './disguiseValidation'
+import { buildDisguiseRevealSubjectFromCase } from './revealPayloadDisguiseIntegration'
+
+export interface HiddenStateScoutingReconCache {
+  /** Concealment layer ids still blocking tiers after a partial scan. */
+  readonly knownUnresolvedLayerIds: readonly string[]
+  /** Count of weekly passes that recorded cache state. */
+  readonly scoutingPassCount: number
+  readonly lastUpdatedWeek: number
+}
+
+export function isKnownButUnresolvedHiddenStateScan(scan: DetectionScanResult): boolean {
+  return scan.fields.length > 0 && scan.remainingConcealmentLayers.length > 0
+}
+
+export function mergeHiddenStateScoutingReconCache(
+  caseData: CaseInstance,
+  scan: DetectionScanResult,
+  week: number
+): CaseInstance {
+  if (!isKnownButUnresolvedHiddenStateScan(scan)) {
+    return caseData
+  }
+
+  const knownUnresolvedLayerIds = scan.remainingConcealmentLayers
+    .map((layer) => layer.id)
+    .sort((left, right) => left.localeCompare(right))
+  const previous = caseData.hiddenStateScoutingReconCache
+
+  return {
+    ...caseData,
+    hiddenStateScoutingReconCache: {
+      knownUnresolvedLayerIds,
+      scoutingPassCount: (previous?.scoutingPassCount ?? 0) + 1,
+      lastUpdatedWeek: week,
+    },
+  }
+}
+
+/** Extra layer peel on follow-up passes when prior partial readouts left unresolved nodes. */
+export function extraLayersToStripFromReconCache(caseData: CaseInstance): number {
+  const cache = caseData.hiddenStateScoutingReconCache
+  if (cache === undefined || cache.knownUnresolvedLayerIds.length === 0) {
+    return 0
+  }
+
+  if (cache.scoutingPassCount < 1) {
+    return 0
+  }
+
+  return 1
+}
+
+export interface HiddenStateScoutingReconCacheScoreAdjustment {
+  readonly delta: number
+  readonly reason?: string
+}
+
+export function scoutingReconCacheScoreAdjustment(
+  caseData: CaseInstance
+): HiddenStateScoutingReconCacheScoreAdjustment {
+  const cache = caseData.hiddenStateScoutingReconCache
+  if (cache === undefined || cache.knownUnresolvedLayerIds.length === 0) {
+    return { delta: 0 }
+  }
+
+  if (cache.scoutingPassCount < 2) {
+    return { delta: 0 }
+  }
+
+  const nodeCount = cache.knownUnresolvedLayerIds.length
+
+  return {
+    delta: 0.35,
+    reason: `Prior recon: ${nodeCount} unresolved concealment node${nodeCount === 1 ? '' : 's'} — route caution.`,
+  }
+}
+
+export function applyHiddenStateScoutingReconCacheToCase(
+  caseData: CaseInstance,
+  scan: DetectionScanResult | undefined,
+  week: number
+): CaseInstance {
+  if (scan === undefined) {
+    return caseData
+  }
+
+  return mergeHiddenStateScoutingReconCache(caseData, scan, week)
+}
+
+/** In-progress weekly pass: record scouting + cache without full mission resolution. */
+export function applyWeeklyHiddenStateScoutingReconPass(
+  state: GameState,
+  caseData: CaseInstance,
+  assignedTeamIds: readonly string[]
+): CaseInstance {
+  const agents = assignedTeamIds.flatMap((teamId) => {
+    const team = state.teams[teamId]
+    if (team === undefined) {
+      return []
+    }
+
+    return team.agentIds
+      .map((agentId) => state.agents[agentId])
+      .filter((agent): agent is NonNullable<typeof agent> => agent !== undefined)
+  })
+
+  if (agents.length === 0) {
+    return caseData
+  }
+
+  const supportTags = [
+    ...new Set(assignedTeamIds.flatMap((teamId) => state.teams[teamId]?.tags ?? [])),
+  ]
+  const disguiseValidation = evaluateBehaviorWeightedDisguiseValidation({
+    caseData,
+    agents,
+    subject: buildDisguiseRevealSubjectFromCase(caseData),
+    context: {
+      supportTags,
+      teamTags: supportTags,
+      infiltrationAwareness: caseData.infiltrationAwareness,
+    },
+  })
+  const hiddenStateScouting = evaluateHiddenStateScoutingWithRevealPayload({
+    caseData,
+    agents,
+    teamTags: supportTags,
+    disguiseValidationActive: disguiseValidation.active,
+  })
+
+  if (hiddenStateScouting === undefined) {
+    return caseData
+  }
+
+  return mergeHiddenStateScoutingReconCache(
+    caseData,
+    hiddenStateScouting.detectionScan,
+    state.week
+  )
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1340,6 +1340,8 @@ export interface CaseInstance {
   counterDetection?: boolean
   displacementTarget?: Id | null
   route?: string | null
+  /** SPE-2284: known-but-unresolved hidden-state scouting nodes across weekly passes. */
+  hiddenStateScoutingReconCache?: import('./hiddenStateScoutingReconCache').HiddenStateScoutingReconCache
   /** SPE-521 slice 1: covert objective progress while under cover (0–1). */
   infiltrationProbeProgress?: number
   /** SPE-521 slice 1: accumulated site awareness while infiltrating (0–1). */

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -179,6 +179,7 @@ import {
 } from '../executionInstability'
 import { buildMissionRewardBreakdown } from '../missionResults'
 import { appendDetectionScanResolutionReason } from '../detectionScanReportNotes'
+import { applyWeeklyHiddenStateScoutingReconPass } from '../hiddenStateScoutingReconCache'
 import { formatConcealmentActivationSummary } from '../concealmentActivationFeed'
 import {
   mergeConcealmentActivationResult,
@@ -2282,6 +2283,11 @@ function resolveAssignments(
 
     currentCase = applyWeeklyConcealmentActivation(context, caseId, currentCase)
     currentCase = applyWeeklyInfiltrationProbe(context, caseId, currentCase)
+    currentCase = applyWeeklyHiddenStateScoutingReconPass(
+      context.sourceState,
+      currentCase,
+      existingAssignedTeamIds
+    )
 
     // SPE-38: Support consumption and shortage
     if (supportAvailable >= supportConsumptionPerCase) {

--- a/src/test/hiddenStateScoutingReconCache.test.ts
+++ b/src/test/hiddenStateScoutingReconCache.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import {
+  applyWeeklyHiddenStateScoutingReconPass,
+  extraLayersToStripFromReconCache,
+  isKnownButUnresolvedHiddenStateScan,
+  mergeHiddenStateScoutingReconCache,
+  scoutingReconCacheScoreAdjustment,
+} from '../domain/hiddenStateScoutingReconCache'
+import { scoutingOutcomeToDetectionScanForCase } from '../domain/hiddenStateModality'
+import { resolveDetectionScan, type ConcealmentLayer } from '../domain/revealPayload'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+const MASK_LAYER: ConcealmentLayer = {
+  id: 'layer:mask',
+  blockedTiers: ['exact_identity'],
+}
+
+function buildSubject() {
+  return {
+    present: true,
+    exactIdentity: 'entity:cache-test',
+    category: 'concealed presence',
+    hostility: 'latent' as const,
+    activeProtections: [],
+    concealmentLayers: [MASK_LAYER],
+    activeEffects: [],
+    dormantEffects: [],
+  }
+}
+
+function createReconObserver(id: string): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: { combat: 10, investigation: 60, utility: 40, social: 40 },
+    tags: ['medium', 'recon-specialist'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+function createConcealedCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({ id: 'case-recon-cache', templateId: 'combat_vampire_nest' }),
+    mode: 'threshold',
+    status: 'in_progress',
+    weeksRemaining: 2,
+    durationWeeks: 2,
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: true,
+    tags: ['concealment'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: ['team-recon-cache'],
+    weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+    difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+    ...overrides,
+  }
+}
+
+describe('hiddenStateScoutingReconCache (SPE-2284)', () => {
+  it('detects known-but-unresolved partial scans', () => {
+    const partial = resolveDetectionScan(buildSubject(), { family: 'category_pass' })
+
+    expect(isKnownButUnresolvedHiddenStateScan(partial)).toBe(true)
+
+    const peeled = resolveDetectionScan(buildSubject(), {
+      family: 'identity_probe',
+      layersToStrip: 2,
+    })
+
+    expect(isKnownButUnresolvedHiddenStateScan(peeled)).toBe(
+      peeled.remainingConcealmentLayers.length > 0
+    )
+  })
+
+  it('merges unresolved layer ids and increments scouting pass count', () => {
+    const scan = resolveDetectionScan(buildSubject(), { family: 'category_pass' })
+    const caseData = createConcealedCase()
+
+    const merged = mergeHiddenStateScoutingReconCache(caseData, scan, 3)
+
+    expect(merged.hiddenStateScoutingReconCache?.knownUnresolvedLayerIds).toEqual(['layer:mask'])
+    expect(merged.hiddenStateScoutingReconCache?.scoutingPassCount).toBe(1)
+    expect(merged.hiddenStateScoutingReconCache?.lastUpdatedWeek).toBe(3)
+
+    const secondPass = mergeHiddenStateScoutingReconCache(merged, scan, 4)
+
+    expect(secondPass.hiddenStateScoutingReconCache?.scoutingPassCount).toBe(2)
+  })
+
+  it('adds extra layersToStrip from cache on follow-up scouting passes', () => {
+    const cachedCase = createConcealedCase({
+      hiddenStateScoutingReconCache: {
+        knownUnresolvedLayerIds: ['layer:concealed-presence'],
+        scoutingPassCount: 1,
+        lastUpdatedWeek: 2,
+      },
+    })
+
+    expect(extraLayersToStripFromReconCache(cachedCase)).toBe(1)
+
+    const scanInput = scoutingOutcomeToDetectionScanForCase(
+      { outcome: 'strong', revealed: true, withheld: false },
+      cachedCase
+    )
+
+    expect(scanInput.layersToStrip).toBeGreaterThanOrEqual(1)
+  })
+
+  it('applies route-caution score adjustment after two scouting passes', () => {
+    const cachedCase = createConcealedCase({
+      hiddenStateScoutingReconCache: {
+        knownUnresolvedLayerIds: ['layer:concealed-presence'],
+        scoutingPassCount: 2,
+        lastUpdatedWeek: 4,
+      },
+    })
+
+    expect(scoutingReconCacheScoreAdjustment(cachedCase)).toMatchObject({
+      delta: 0.35,
+      reason: expect.stringContaining('Prior recon'),
+    })
+  })
+
+  it('records cache on in-progress weekly scouting pass', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_cache_weekly')
+    const team: Team = {
+      id: 'team-recon-cache',
+      name: 'Recon cache team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+
+    const updated = applyWeeklyHiddenStateScoutingReconPass(
+      state,
+      createConcealedCase(),
+      [team.id]
+    )
+
+    expect(updated.hiddenStateScoutingReconCache?.scoutingPassCount).toBe(1)
+    expect(updated.hiddenStateScoutingReconCache?.knownUnresolvedLayerIds.length).toBeGreaterThan(
+      0
+    )
+  })
+
+  it('orchestration carries recon-cache score reason when cache has two passes', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_cache_orchestration')
+    const team: Team = {
+      id: 'team-recon-cache',
+      name: 'Recon cache team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createConcealedCase({
+      weeksRemaining: 1,
+      hiddenStateScoutingReconCache: {
+        knownUnresolvedLayerIds: ['layer:concealed-presence'],
+        scoutingPassCount: 2,
+        lastUpdatedWeek: state.week,
+      },
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+
+    expect(
+      resolution.outcome.reasons.some((reason) => reason.includes('Prior recon'))
+    ).toBe(true)
+  })
+
+  it('advanceWeek persists cache across assigned weeks before final resolution', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_cache_advance')
+    const team: Team = {
+      id: 'team-recon-cache',
+      name: 'Recon cache team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    state.cases['case-recon-cache'] = createConcealedCase()
+
+    const afterWeekOne = advanceWeek(state)
+
+    expect(
+      afterWeekOne.cases['case-recon-cache'].hiddenStateScoutingReconCache?.scoutingPassCount
+    ).toBe(1)
+
+    const afterWeekTwo = advanceWeek(afterWeekOne)
+
+    expect(
+      afterWeekTwo.cases['case-recon-cache'].hiddenStateScoutingReconCache?.scoutingPassCount
+    ).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `HiddenStateScoutingReconCache` on cases to persist known-but-unresolved concealment layer ids after partial hidden-state scouting scans.
- Apply `+1` extra `layersToStrip` on follow-up passes and a bounded route-caution mission score adjustment when `scoutingPassCount >= 2`.
- Record cache during multi-week `in_progress` assigned weeks via `applyWeeklyHiddenStateScoutingReconPass`.

## Linear

- **Slice:** [SPE-2284](https://linear.app/spectranoir/issue/SPE-2284/hidden-state-modality-matrix-slice-4-persistent-recon-cache)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70/hidden-state-displacement-and-counter-detection-layer) (parent remains open for slice 5)

## What shipped

- `src/domain/hiddenStateScoutingReconCache.ts` — merge, strip bonus, score hook, weekly pass
- `src/domain/hiddenStateModality.ts` — recon-cache layer peel in scan input
- `src/domain/caseResolutionOrchestration.ts` — persist cache + score reason
- `src/domain/sim/advanceWeek.ts` — in-progress weekly recon pass
- `src/test/hiddenStateScoutingReconCache.test.ts`

## Test plan

- [x] `npm run test:run -- src/test/hiddenStateScoutingReconCache.test.ts src/test/hiddenStateModality.test.ts src/test/revealPayloadOrchestration.test.ts`
- [x] `npm run lint`

## Docs updated

- `planning/hidden-modality-matrix-slice-4.md`
- `planning/backlog.md` slice index

## Parent status

SPE-70 stays open — slice 5 (false-entity / structural-illusion lifecycle) not in this PR.

Made with [Cursor](https://cursor.com)