### PR TITLE
feat(SPE-2285): hidden-state modality matrix slice 5 — illusion lifecycle

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -96,6 +96,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `hidden-modality-matrix-slice-2.md`                       | **Shipped**    | SPE-2282 / PR #2405; weekly orchestration wiring.              |
 | `hidden-modality-matrix-slice-3.md`                       | **Shipped**    | SPE-2283 / PR #2407; modality report copy.                    |
 | `hidden-modality-matrix-slice-4.md`                       | **Shipped**    | SPE-2284 / PR #2409; persistent recon cache.                 |
+| `hidden-modality-matrix-slice-5.md`                       | **Active**     | SPE-2285; false-entity / structural-illusion lifecycle (next). |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                         |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                          |
 

--- a/planning/hidden-modality-matrix-slice-5.md
+++ b/planning/hidden-modality-matrix-slice-5.md
@@ -1,0 +1,148 @@
+# SPE-70 — Hidden-state modality matrix slice 5 (false-entity / structural-illusion lifecycle)
+
+One-page implementation plan. Linear: [SPE-2285](https://linear.app/spectranoir/issue/SPE-2285) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Follows shipped [SPE-2284](https://linear.app/spectranoir/issue/SPE-2284) (PR #2409).
+
+| Field | Value |
+| --- | --- |
+| **Linear** | [SPE-2285 — Hidden-state modality matrix slice 5](https://linear.app/spectranoir/issue/SPE-2285) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
+| **Branch** | `jamesdyedbq/spe-2285-hidden-modality-matrix-slice-5-illusion-lifecycle` |
+| **Status** | In Progress — SPE-2285 |
+
+## Goal
+
+Add a **bounded illusion lifecycle** for authored false-entity and structural-illusion cases: scans may show fabricated contacts or false terrain anchors, then transition to **disproved** and **collapsed** through deterministic interaction or counter-detection — not instant full reveal.
+
+Slice 5 closes the parent AC line for “false entity / structural illusion sustains a bounded lifecycle and resolves through interaction, traversal, or targeted counter-detection.” It extends the shipped matrix stack (slices 1–4) without rewriting activation, recon cache, or modality report prefixes.
+
+## Prerequisite (on `main` @ `dcee44a6`)
+
+| Shipped | Anchor |
+| --- | --- |
+| Modality compose | `hiddenStateModality.ts`, `resolveScoutingWithCaseHiddenState` (SPE-2281) |
+| Weekly orchestration | `evaluateHiddenStateScoutingWithRevealPayload` (SPE-2282) |
+| Modality report copy | `detectionScanReportNotes.ts` (SPE-2283) |
+| Recon cache | `hiddenStateScoutingReconCache.ts` (SPE-2284) |
+| Case fields | `hiddenState`, `displacementTarget`, `counterDetection`, `route`, `tags` |
+
+## Gap (pre-slice)
+
+- False-position projection mislocates a **real** subject; there is no lifecycle for **fabricated** contacts or **false terrain** that later disproves.
+- Scouting scans always assume a single truth subject; no `active → disproved → collapsed` phase machine.
+- Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) AC: illusion must resolve via interaction, traversal, or counter-detection — not immediate disbelief.
+
+## Scope (this slice)
+
+| In | Out |
+| --- | --- |
+| `HiddenStateIllusionState` on `CaseInstance` (`kind`, `phase`, `anchorLabel?`, `disproofReason?`) | Signature masking, glamour, out-of-phase modalities |
+| `hiddenStateIllusionLifecycle.ts` — resolve activation from tags, phase transitions, scan projection helpers | New scan families or RNG |
+| Extend `resolveHiddenStateModality` / compose path when illusion `active` | Full SPE-70 parent Done |
+| **False entity** (`false-entity` tag + `hidden`): fabricated presence/category in `detectionScan`; truth `present: false` or withheld canonical subject | UI components / mission triage chips |
+| **Structural illusion** (`structural-illusion` tag + `displaced` or `hidden`): false terrain anchor via `displacementTarget`; disproof via traversal/`route` + counter-detection | Rewriting `hiddenStateScoutingReconCache` |
+| Disproof triggers (deterministic): `counterDetection`, strong scouting + recon cache pass ≥ 2, authored `route` traversal on structural cases | Mode-specific tells (speech, metadata spoofing) |
+| Persist phase on case after weekly resolution + in-progress scouting pass | New event types (optional report suffix only) |
+| Orchestration: illusion disproof before modality compose; collapse removes illusion overlay | Template catalog migration (fixtures only) |
+| Tests: unit lifecycle + orchestration + multi-week `advanceWeek` disproof path | Instrumentation-attack / false-detection modality family |
+
+## Illusion lifecycle contract
+
+### Activation (authored)
+
+| Kind | Requires | Initial `phase` |
+| --- | --- | --- |
+| `false_entity` | `hiddenState: 'hidden'` + case tag `false-entity` | `active` |
+| `structural_illusion` | tag `structural-illusion` + (`hidden` or `displaced`) + optional `displacementTarget` as anchor | `active` |
+
+If both tags present, prefer `false_entity` for compose (document in tests).
+
+### Phases
+
+```text
+active → disproved → collapsed
+```
+
+| Phase | Player-facing behavior | Truth |
+| --- | --- | --- |
+| `active` | Fabricated contact or false terrain readout in tiered scan | Canonical subject hidden; illusion layer blocks full identity |
+| `disproved` | Scan suffix / report note: illusion disproven; tiers may partially clear | Illusion layer stripped one step; subject may stay hidden |
+| `collapsed` | Normal modality readouts (concealed / displaced / disguise path) | `hiddenStateIllusionState` cleared or `phase: collapsed` inert |
+
+### Disproof triggers (deterministic, any one)
+
+1. **Counter-detection** — `counterDetection: true` on weekly pass strips illusion layer (one layer id: `layer:false-entity` or `layer:structural-illusion`).
+2. **Interaction / traversal** — case has non-empty `route` and tag `structural-illusion` (or `interaction-disproof`) → `disproved` on assigned week.
+3. **Sustained recon** — `hiddenStateScoutingReconCache.scoutingPassCount >= 2` with unresolved nodes → `disproved` for `false_entity` (bounded follow-up scrutiny).
+
+**Collapse** — after `disproved`, next weekly pass with any disproof trigger again OR mission `success`/`partial` → `collapsed` and clear illusion overlay.
+
+### Scan / copy integration
+
+- **Active false entity:** add concealment layer `layer:false-entity`; player-facing presence/category reference fabricated anchor label (e.g. `fabricated contact at annex-c`).
+- **Active structural illusion:** layer `layer:structural-illusion`; reuse `applyFalsePositionScanProjection` anchor semantics when `displacementTarget` set.
+- **Disproved:** append report resolution reason via existing `resolutionReasons` (domain string); optional `Structural illusion readout:` / `Fabricated contact readout:` prefix family reuse.
+- **Collapsed:** illusion state removed; existing modality prefixes apply unchanged.
+
+## Orchestration contract
+
+```mermaid
+flowchart TD
+  A[resolveAssignedCaseForWeek] --> B{illusion active?}
+  B -->|yes| C[evaluateIllusionDisproof]
+  C --> D[update phase on case]
+  D --> E[hiddenStateScouting compose with illusion layers]
+  B -->|no| E
+  E --> F[recon cache merge]
+  F --> G[report copy append]
+```
+
+- Run disproof **before** `evaluateHiddenStateScoutingWithRevealPayload`.
+- Do not double-compose disguise + illusion fabricated identity as real disguise validation.
+- Mission outcome math unchanged except existing bounded score hooks (reuse recon-cache route caution; optional small disproof malus when `active`).
+
+## Acceptance
+
+- [x] False-entity fixture: active phase shows fabricated scan tiers; truth does not confirm canonical subject identity.
+- [x] Counter-detection or sustained-recon path transitions to `disproved`, then `collapsed` on follow-up week.
+- [x] Structural-illusion fixture: false terrain anchor in scan; `route` + disproof tag transitions phase without instant `revealed`.
+- [x] Collapsed case uses normal concealed/displaced modality readouts (slice 3 prefixes unchanged).
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Lifecycle unit tests** — activation from tags, phase transitions, collapse clears state.
+2. **Scan projection** — active false entity vs structural illusion distinct `DetectionScanResult`.
+3. **Disproof helpers** — counter-detection, route traversal, recon-cache pass threshold.
+4. **Orchestration** — `resolveAssignedCaseForWeek` carries illusion state on effectiveCase.
+5. **`advanceWeek`** — two-week structural-illusion or false-entity disproof integration.
+6. **Regression** — slices 1–4 orchestration and report-copy tests unchanged.
+
+## File touch list (expected)
+
+| Area | Files |
+| --- | --- |
+| Lifecycle | `src/domain/hiddenStateIllusionLifecycle.ts` (new) |
+| Modality compose | `src/domain/hiddenStateModality.ts`, `src/domain/revealPayloadScoutingIntegration.ts` |
+| Orchestration | `src/domain/caseResolutionOrchestration.ts` |
+| Weekly | `src/domain/sim/advanceWeek.ts`, `src/domain/hiddenStateScoutingReconCache.ts` (pass hook only) |
+| Report copy | `src/domain/detectionScanReportNotes.ts` (optional disproved suffix) |
+| Models | `src/domain/models.ts` |
+| Tests | `src/test/hiddenStateIllusionLifecycle.test.ts`, extend `revealPayloadOrchestration.test.ts` |
+
+## Branch
+
+`jamesdyedbq/spe-2285-hidden-modality-matrix-slice-5-illusion-lifecycle`
+
+## Out of scope (post-matrix)
+
+- Mode-specific tells and observer-threshold validation
+- Mission triage UI illusion chips
+- Full SPE-70 parent closure (parent may return to **Backlog** after slice 5 if tells remain)
+- Template-wide migration beyond 2–3 fixture cases in tests
+
+## See also
+
+- `architecture/hidden-state-displacement-counter-detection.md`
+- `planning/hidden-modality-matrix-slice-1.md` … `slice-4.md`
+- `src/domain/investigationExposureClueRegistry.ts` — `clue:deliberate-decoy-signal` (narrative reference only)
+- `src/domain/hiddenStateModality.ts` — `applyFalsePositionScanProjection`

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -11,6 +11,10 @@ import {
   type DisguiseRevealIntegrationResult,
 } from './revealPayloadDisguiseIntegration'
 import {
+  applyHiddenStateIllusionLifecyclePass,
+  buildIllusionLifecycleContext,
+} from './hiddenStateIllusionLifecycle'
+import {
   applyHiddenStateScoutingReconCacheToCase,
   scoutingReconCacheScoreAdjustment,
 } from './hiddenStateScoutingReconCache'
@@ -154,6 +158,10 @@ export function resolveAssignedCaseForWeek(
   let resolvedEffectiveCase = applyBehaviorWeightedDisguiseValidationToCase(
     effectiveCase,
     behaviorValidation
+  )
+  resolvedEffectiveCase = applyHiddenStateIllusionLifecyclePass(
+    resolvedEffectiveCase,
+    buildIllusionLifecycleContext(resolvedEffectiveCase)
   )
   const hiddenStateScouting = evaluateHiddenStateScoutingWithRevealPayload({
     caseData: resolvedEffectiveCase,
@@ -300,6 +308,16 @@ export function resolveAssignedCaseForWeek(
             partyCardReasons: cardBonus?.reasons,
           })
   }
+
+  const missionResult =
+    outcome.result === 'success' || outcome.result === 'partial' || outcome.result === 'fail'
+      ? outcome.result
+      : undefined
+  resolvedEffectiveCase = applyHiddenStateIllusionLifecyclePass(resolvedEffectiveCase, {
+    ...buildIllusionLifecycleContext(resolvedEffectiveCase),
+    missionResult,
+  })
+
   return {
     effectiveCase: resolvedEffectiveCase,
     assignedAgents,

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -4,6 +4,14 @@
 
 import type { BehaviorWeightedDisguiseValidationResult } from './disguiseValidation'
 import {
+  FABRICATED_CONTACT_READOUT_PREFIX,
+  STRUCTURAL_ILLUSION_READOUT_PREFIX,
+  formatIllusionDisproofSuffix,
+  illusionReadoutPrefixForState,
+} from './hiddenStateIllusionLifecycle'
+
+export { FABRICATED_CONTACT_READOUT_PREFIX, STRUCTURAL_ILLUSION_READOUT_PREFIX }
+import {
   resolveHiddenStateModality,
   type HiddenStateModalityKind,
 } from './hiddenStateModality'
@@ -22,6 +30,8 @@ export const DETECTION_SCAN_READOUT_PREFIXES = [
   CONCEALMENT_SCAN_READOUT_PREFIX,
   DISPLACEMENT_SCAN_READOUT_PREFIX,
   COVER_SCAN_READOUT_PREFIX,
+  FABRICATED_CONTACT_READOUT_PREFIX,
+  STRUCTURAL_ILLUSION_READOUT_PREFIX,
 ] as const
 
 export function detectionScanReadoutPrefixForModality(
@@ -80,10 +90,16 @@ export function shouldAppendDetectionScanReportNote(
 
 export function shouldAppendHiddenStateScoutingReportNote(
   scouting: HiddenStateScoutingRevealIntegrationResult,
-  modality: HiddenStateModalityKind
+  modality: HiddenStateModalityKind,
+  caseData?: CaseInstance
 ): boolean {
   if (!scouting.active || modality === 'none') {
     return false
+  }
+
+  const illusionPhase = caseData?.hiddenStateIllusionState?.phase
+  if (illusionPhase === 'active' || illusionPhase === 'disproved') {
+    return orderedPlayerFacingValues(scouting.detectionScan).length > 0
   }
 
   if (isPresenceOnlyAbsentContact(scouting.detectionScan)) {
@@ -147,18 +163,27 @@ export function appendDetectionScanResolutionReason(
     return
   }
 
+  const illusionPrefix =
+    hiddenStateScouting.illusionReadoutPrefix ??
+    (caseData !== undefined
+      ? illusionReadoutPrefixForState(caseData.hiddenStateIllusionState)
+      : null)
   const modality =
     caseData !== undefined ? resolveHiddenStateModality(caseData) : ('none' as const)
 
-  if (!shouldAppendHiddenStateScoutingReportNote(hiddenStateScouting, modality)) {
+  if (!shouldAppendHiddenStateScoutingReportNote(hiddenStateScouting, modality, caseData)) {
     return
   }
 
-  const summary = formatDetectionScanSummary(hiddenStateScouting.detectionScan, {
-    prefix: detectionScanReadoutPrefixForModality(modality),
+  const prefix = illusionPrefix ?? detectionScanReadoutPrefixForModality(modality)
+  let summary = formatDetectionScanSummary(hiddenStateScouting.detectionScan, {
+    prefix,
   })
 
   if (summary.length > 0) {
+    summary +=
+      hiddenStateScouting.illusionDisproofSuffix ??
+      formatIllusionDisproofSuffix(caseData?.hiddenStateIllusionState)
     resolutionReasons.push(summary)
   }
 }

--- a/src/domain/hiddenStateIllusionLifecycle.ts
+++ b/src/domain/hiddenStateIllusionLifecycle.ts
@@ -302,8 +302,11 @@ export function applyHiddenStateIllusionLifecyclePass(
     }
   }
 
-  if (state.phase === 'disproved' && (trigger || missionCollapse)) {
-    return clearIllusionState(caseData)
+  if (state.phase === 'disproved') {
+    const isPostMission = context.missionResult !== undefined
+    if (isPostMission ? missionCollapse : trigger) {
+      return clearIllusionState(caseData)
+    }
   }
 
   return {

--- a/src/domain/hiddenStateIllusionLifecycle.ts
+++ b/src/domain/hiddenStateIllusionLifecycle.ts
@@ -1,0 +1,321 @@
+/**
+ * SPE-2285 slice 5: bounded false-entity / structural-illusion lifecycle (active → disproved → collapsed).
+ */
+
+import type { ConcealmentLayer, DetectionScanResult } from './revealPayload'
+import type { CaseInstance } from './models'
+import {
+  applyFalsePositionScanProjection,
+  formatDecoyLocusLabel,
+} from './hiddenStateModality'
+
+export type HiddenStateIllusionKind = 'false_entity' | 'structural_illusion'
+export type HiddenStateIllusionPhase = 'active' | 'disproved' | 'collapsed'
+
+export interface HiddenStateIllusionState {
+  readonly kind: HiddenStateIllusionKind
+  readonly phase: HiddenStateIllusionPhase
+  readonly anchorLabel?: string
+  readonly disproofReason?: string
+}
+
+export const FALSE_ENTITY_LAYER: ConcealmentLayer = {
+  id: 'layer:false-entity',
+  blockedTiers: ['category', 'exact_identity'],
+}
+
+export const STRUCTURAL_ILLUSION_LAYER: ConcealmentLayer = {
+  id: 'layer:structural-illusion',
+  blockedTiers: ['exact_identity'],
+}
+
+export const FABRICATED_CONTACT_READOUT_PREFIX = 'Fabricated contact readout:'
+export const STRUCTURAL_ILLUSION_READOUT_PREFIX = 'Structural illusion readout:'
+
+const FALSE_ENTITY_TAG = 'false-entity'
+const STRUCTURAL_ILLUSION_TAG = 'structural-illusion'
+const INTERACTION_DISPROOF_TAG = 'interaction-disproof'
+
+function caseTagSet(caseData: CaseInstance): Set<string> {
+  return new Set([
+    ...(caseData.tags ?? []),
+    ...(caseData.requiredTags ?? []),
+    ...(caseData.preferredTags ?? []),
+  ])
+}
+
+/** Authored illusion kind; false-entity wins when both tags are present. */
+export function resolveIllusionKindFromCase(caseData: CaseInstance): HiddenStateIllusionKind | null {
+  const tags = caseTagSet(caseData)
+
+  if (caseData.hiddenState === 'hidden' && tags.has(FALSE_ENTITY_TAG)) {
+    return 'false_entity'
+  }
+
+  if (
+    tags.has(STRUCTURAL_ILLUSION_TAG) &&
+    (caseData.hiddenState === 'hidden' || caseData.hiddenState === 'displaced')
+  ) {
+    return 'structural_illusion'
+  }
+
+  return null
+}
+
+export function resolveIllusionAnchorLabel(
+  caseData: CaseInstance,
+  kind: HiddenStateIllusionKind
+): string {
+  if (kind === 'structural_illusion') {
+    return formatDecoyLocusLabel(caseData.displacementTarget) ?? 'false terrain anchor'
+  }
+
+  return `fabricated contact at ${caseData.id}`
+}
+
+export function illusionConcealmentLayer(
+  kind: HiddenStateIllusionKind
+): ConcealmentLayer {
+  return kind === 'false_entity' ? FALSE_ENTITY_LAYER : STRUCTURAL_ILLUSION_LAYER
+}
+
+export function isIllusionLifecycleInert(caseData: CaseInstance): boolean {
+  const kind = resolveIllusionKindFromCase(caseData)
+  if (kind === null) {
+    return true
+  }
+
+  const phase = caseData.hiddenStateIllusionState?.phase
+  return phase === 'collapsed'
+}
+
+export function illusionReadoutPrefixForState(
+  state: HiddenStateIllusionState | undefined
+): string | null {
+  if (state === undefined || state.phase === 'collapsed') {
+    return null
+  }
+
+  return state.kind === 'false_entity'
+    ? FABRICATED_CONTACT_READOUT_PREFIX
+    : STRUCTURAL_ILLUSION_READOUT_PREFIX
+}
+
+export function extraLayersToStripFromIllusion(caseData: CaseInstance): number {
+  const state = caseData.hiddenStateIllusionState
+  if (state === undefined) {
+    return 0
+  }
+
+  if (state.phase === 'disproved') {
+    return 1
+  }
+
+  if (state.phase === 'active' && caseData.counterDetection) {
+    return 1
+  }
+
+  return 0
+}
+
+export function shouldWithholdCanonicalSubjectForIllusion(caseData: CaseInstance): boolean {
+  const state = caseData.hiddenStateIllusionState
+  return state?.phase === 'active' && state.kind === 'false_entity'
+}
+
+export function applyFalseEntityScanProjection(
+  scan: DetectionScanResult,
+  anchorLabel: string
+): DetectionScanResult {
+  const label = anchorLabel.trim().length > 0 ? anchorLabel : 'fabricated contact'
+
+  const fields =
+    scan.fields.length > 0
+      ? scan.fields.map((field) => {
+          if (field.tier === 'presence') {
+            return {
+              ...field,
+              playerFacingValue: label,
+              ambiguous: true,
+            }
+          }
+
+          if (field.tier === 'category') {
+            return {
+              ...field,
+              playerFacingValue: `fabricated ${label}`,
+              ambiguous: true,
+            }
+          }
+
+          return field
+        })
+      : [
+          {
+            tier: 'presence' as const,
+            internalValue: false,
+            playerFacingValue: label,
+            ambiguous: true,
+          },
+        ]
+
+  return {
+    ...scan,
+    fields,
+  }
+}
+
+export function applyIllusionScanProjection(
+  scan: DetectionScanResult,
+  caseData: CaseInstance
+): DetectionScanResult {
+  const state = caseData.hiddenStateIllusionState
+  if (state === undefined || state.phase === 'collapsed') {
+    return scan
+  }
+
+  if (state.kind === 'false_entity') {
+    return applyFalseEntityScanProjection(scan, state.anchorLabel ?? resolveIllusionAnchorLabel(caseData, state.kind))
+  }
+
+  if (caseData.displacementTarget !== null && caseData.displacementTarget !== undefined) {
+    return applyFalsePositionScanProjection(scan, caseData)
+  }
+
+  const anchor = state.anchorLabel ?? resolveIllusionAnchorLabel(caseData, state.kind)
+  return applyFalseEntityScanProjection(scan, anchor)
+}
+
+export interface IllusionLifecycleContext {
+  readonly counterDetection: boolean
+  readonly route?: string | null
+  readonly tags: readonly string[]
+  readonly reconPassCount: number
+  readonly missionResult?: 'success' | 'partial' | 'fail'
+}
+
+export function buildIllusionLifecycleContext(caseData: CaseInstance): IllusionLifecycleContext {
+  return {
+    counterDetection: caseData.counterDetection === true,
+    route: caseData.route,
+    tags: caseData.tags ?? [],
+    reconPassCount: caseData.hiddenStateScoutingReconCache?.scoutingPassCount ?? 0,
+  }
+}
+
+function hasTraversalDisproof(
+  context: IllusionLifecycleContext,
+  kind: HiddenStateIllusionKind
+): boolean {
+  const route = (context.route ?? '').trim()
+  if (route.length === 0) {
+    return false
+  }
+
+  if (context.tags.includes(INTERACTION_DISPROOF_TAG)) {
+    return true
+  }
+
+  return kind === 'structural_illusion' && context.tags.includes(STRUCTURAL_ILLUSION_TAG)
+}
+
+function hasSustainedReconDisproof(
+  context: IllusionLifecycleContext,
+  kind: HiddenStateIllusionKind
+): boolean {
+  return kind === 'false_entity' && context.reconPassCount >= 2
+}
+
+function anyDisproofTrigger(
+  context: IllusionLifecycleContext,
+  kind: HiddenStateIllusionKind
+): boolean {
+  return (
+    context.counterDetection ||
+    hasTraversalDisproof(context, kind) ||
+    hasSustainedReconDisproof(context, kind)
+  )
+}
+
+function resolveDisproofReason(
+  context: IllusionLifecycleContext,
+  kind: HiddenStateIllusionKind
+): string {
+  if (context.counterDetection) {
+    return 'Targeted counter-detection invalidated the illusion overlay.'
+  }
+
+  if (hasTraversalDisproof(context, kind)) {
+    return 'Route traversal exposed the false terrain anchor.'
+  }
+
+  if (hasSustainedReconDisproof(context, kind)) {
+    return 'Sustained recon scrutiny disproved the fabricated contact.'
+  }
+
+  return 'Illusion overlay disproved.'
+}
+
+function clearIllusionState(caseData: CaseInstance): CaseInstance {
+  if (caseData.hiddenStateIllusionState === undefined) {
+    return caseData
+  }
+
+  const { hiddenStateIllusionState: _illusionState, ...rest } = caseData
+  void _illusionState
+  return rest
+}
+
+/** Initialize or advance illusion phase before/after weekly resolution. */
+export function applyHiddenStateIllusionLifecyclePass(
+  caseData: CaseInstance,
+  context: IllusionLifecycleContext
+): CaseInstance {
+  const kind = resolveIllusionKindFromCase(caseData)
+  if (kind === null) {
+    return clearIllusionState(caseData)
+  }
+
+  let state = caseData.hiddenStateIllusionState
+  const anchorLabel = resolveIllusionAnchorLabel(caseData, kind)
+
+  if (state === undefined || state.kind !== kind || state.phase === 'collapsed') {
+    state = { kind, phase: 'active', anchorLabel }
+  } else {
+    state = { ...state, anchorLabel }
+  }
+
+  const trigger = anyDisproofTrigger(context, kind)
+  const missionCollapse =
+    state.phase === 'disproved' &&
+    (context.missionResult === 'success' || context.missionResult === 'partial')
+
+  if (state.phase === 'active' && trigger) {
+    return {
+      ...caseData,
+      hiddenStateIllusionState: {
+        kind,
+        phase: 'disproved',
+        anchorLabel,
+        disproofReason: resolveDisproofReason(context, kind),
+      },
+    }
+  }
+
+  if (state.phase === 'disproved' && (trigger || missionCollapse)) {
+    return clearIllusionState(caseData)
+  }
+
+  return {
+    ...caseData,
+    hiddenStateIllusionState: state,
+  }
+}
+
+export function formatIllusionDisproofSuffix(state: HiddenStateIllusionState | undefined): string {
+  if (state?.phase !== 'disproved' || state.disproofReason === undefined) {
+    return ''
+  }
+
+  return ` ${state.disproofReason}`
+}

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -190,11 +190,11 @@ export function buildSubjectTruthFromCaseHiddenState(
       ? illusionConcealmentLayer(illusionKind)
       : null
   const layerGroups: ConcealmentLayer[][] = []
-  if (modalityLayer) {
-    layerGroups.push([modalityLayer])
-  }
   if (illusionLayer) {
     layerGroups.push([illusionLayer])
+  }
+  if (modalityLayer) {
+    layerGroups.push([modalityLayer])
   }
   layerGroups.push(scoutingLayers)
   const concealmentLayers =

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -8,6 +8,12 @@ import {
   buildDisguiseRevealSubjectFromCase,
   disguiseConcealmentRatingFromCase,
 } from './revealPayloadDisguiseIntegration'
+import {
+  extraLayersToStripFromIllusion,
+  illusionConcealmentLayer,
+  resolveIllusionKindFromCase,
+  shouldWithholdCanonicalSubjectForIllusion,
+} from './hiddenStateIllusionLifecycle'
 import { extraLayersToStripFromReconCache } from './hiddenStateScoutingReconCache'
 import {
   buildSubjectTruthFromScouting,
@@ -165,16 +171,34 @@ export function buildSubjectTruthFromCaseHiddenState(
   const modality = resolveHiddenStateModality(caseData)
   const modalityLayer = hiddenStateModalityLayer(modality)
   const resolvedSubject = resolveScoutingSubjectForCase(caseData, subject, modality)
-  const present = resolveSubjectPresent(resolvedSubject)
+  let present = resolveSubjectPresent(resolvedSubject)
+  if (shouldWithholdCanonicalSubjectForIllusion(caseData)) {
+    present = false
+  }
+
   const baseTruth = buildSubjectTruthFromScouting(scoutingInput, {
     ...resolvedSubject,
     present,
   })
 
   const scoutingLayers = scoutingConcealmentLayersForCase(caseData, scoutingInput, modality)
-  const concealmentLayers = modalityLayer
-    ? mergeConcealmentLayers([modalityLayer], scoutingLayers)
-    : scoutingLayers
+  const illusionKind = resolveIllusionKindFromCase(caseData)
+  const illusionLayer =
+    illusionKind !== null &&
+    caseData.hiddenStateIllusionState !== undefined &&
+    caseData.hiddenStateIllusionState.phase !== 'collapsed'
+      ? illusionConcealmentLayer(illusionKind)
+      : null
+  const layerGroups: ConcealmentLayer[][] = []
+  if (modalityLayer) {
+    layerGroups.push([modalityLayer])
+  }
+  if (illusionLayer) {
+    layerGroups.push([illusionLayer])
+  }
+  layerGroups.push(scoutingLayers)
+  const concealmentLayers =
+    layerGroups.length > 0 ? mergeConcealmentLayers(...layerGroups) : scoutingLayers
 
   return {
     ...baseTruth,
@@ -243,6 +267,7 @@ export function scoutingOutcomeToDetectionScanForCase(
   let layersToStrip = base.layersToStrip ?? 0
 
   layersToStrip = Math.max(layersToStrip, extraLayersToStripFromReconCache(caseData))
+  layersToStrip = Math.max(layersToStrip, extraLayersToStripFromIllusion(caseData))
 
   if (modality !== 'none' && caseData.counterDetection) {
     layersToStrip = Math.max(layersToStrip, 1)

--- a/src/domain/hiddenStateScoutingReconCache.ts
+++ b/src/domain/hiddenStateScoutingReconCache.ts
@@ -6,6 +6,10 @@ import type { DetectionScanResult } from './revealPayload'
 import type { CaseInstance } from './models'
 import type { GameState } from './models'
 import {
+  applyHiddenStateIllusionLifecyclePass,
+  buildIllusionLifecycleContext,
+} from './hiddenStateIllusionLifecycle'
+import {
   evaluateHiddenStateScoutingWithRevealPayload,
 } from './revealPayloadScoutingIntegration'
 import { evaluateBehaviorWeightedDisguiseValidation } from './disguiseValidation'
@@ -122,10 +126,14 @@ export function applyWeeklyHiddenStateScoutingReconPass(
   const supportTags = [
     ...new Set(assignedTeamIds.flatMap((teamId) => state.teams[teamId]?.tags ?? [])),
   ]
-  const disguiseValidation = evaluateBehaviorWeightedDisguiseValidation({
+  const illusionAdjustedCase = applyHiddenStateIllusionLifecyclePass(
     caseData,
+    buildIllusionLifecycleContext(caseData)
+  )
+  const disguiseValidation = evaluateBehaviorWeightedDisguiseValidation({
+    caseData: illusionAdjustedCase,
     agents,
-    subject: buildDisguiseRevealSubjectFromCase(caseData),
+    subject: buildDisguiseRevealSubjectFromCase(illusionAdjustedCase),
     context: {
       supportTags,
       teamTags: supportTags,
@@ -133,18 +141,18 @@ export function applyWeeklyHiddenStateScoutingReconPass(
     },
   })
   const hiddenStateScouting = evaluateHiddenStateScoutingWithRevealPayload({
-    caseData,
+    caseData: illusionAdjustedCase,
     agents,
     teamTags: supportTags,
     disguiseValidationActive: disguiseValidation.active,
   })
 
   if (hiddenStateScouting === undefined) {
-    return caseData
+    return illusionAdjustedCase
   }
 
   return mergeHiddenStateScoutingReconCache(
-    caseData,
+    illusionAdjustedCase,
     hiddenStateScouting.detectionScan,
     state.week
   )

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1342,6 +1342,8 @@ export interface CaseInstance {
   route?: string | null
   /** SPE-2284: known-but-unresolved hidden-state scouting nodes across weekly passes. */
   hiddenStateScoutingReconCache?: import('./hiddenStateScoutingReconCache').HiddenStateScoutingReconCache
+  /** SPE-2285: false-entity / structural-illusion lifecycle overlay. */
+  hiddenStateIllusionState?: import('./hiddenStateIllusionLifecycle').HiddenStateIllusionState
   /** SPE-521 slice 1: covert objective progress while under cover (0–1). */
   infiltrationProbeProgress?: number
   /** SPE-521 slice 1: accumulated site awareness while infiltrating (0–1). */

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -14,6 +14,13 @@ import {
   type SubjectTruthState,
 } from './revealPayload'
 import {
+  applyIllusionScanProjection,
+  formatIllusionDisproofSuffix,
+  illusionReadoutPrefixForState,
+  isIllusionLifecycleInert,
+  resolveIllusionKindFromCase,
+} from './hiddenStateIllusionLifecycle'
+import {
   applyFalsePositionScanProjection,
   buildSubjectTruthFromCaseHiddenState,
   resolveHiddenStateModality,
@@ -51,6 +58,9 @@ export interface ScoutingRevealIntegrationResult extends ScoutingResult {
 
 export interface HiddenStateScoutingRevealIntegrationResult extends ScoutingRevealIntegrationResult {
   readonly active: true
+  /** SPE-2285: prefix captured at compose time (survives post-resolution illusion collapse). */
+  readonly illusionReadoutPrefix?: string | null
+  readonly illusionDisproofSuffix?: string
 }
 
 export interface CaseScoutingRevealBuildResult {
@@ -212,16 +222,20 @@ export function evaluateHiddenStateScoutingWithRevealPayload(input: {
     input.teamTags ?? []
   )
 
+  const integrated = resolveScoutingWithCaseHiddenState({
+    teamCapability: built.teamCapability,
+    anomalyConcealment: built.anomalyConcealment,
+    teamTags: [...built.teamTags],
+    anomalyTags: [...built.anomalyTags],
+    subject: built.subject,
+    caseData: input.caseData,
+  })
+
   return {
     active: true,
-    ...resolveScoutingWithCaseHiddenState({
-      teamCapability: built.teamCapability,
-      anomalyConcealment: built.anomalyConcealment,
-      teamTags: [...built.teamTags],
-      anomalyTags: [...built.anomalyTags],
-      subject: built.subject,
-      caseData: input.caseData,
-    }),
+    ...integrated,
+    illusionReadoutPrefix: illusionReadoutPrefixForState(input.caseData.hiddenStateIllusionState),
+    illusionDisproofSuffix: formatIllusionDisproofSuffix(input.caseData.hiddenStateIllusionState),
   }
 }
 
@@ -297,6 +311,13 @@ export function resolveScoutingWithCaseHiddenState(
 
   if (resolveHiddenStateModality(input.caseData) === 'false_position') {
     detectionScan = applyFalsePositionScanProjection(detectionScan, input.caseData)
+  }
+
+  if (
+    resolveIllusionKindFromCase(input.caseData) !== null &&
+    !isIllusionLifecycleInert(input.caseData)
+  ) {
+    detectionScan = applyIllusionScanProjection(detectionScan, input.caseData)
   }
 
   return {

--- a/src/test/hiddenStateIllusionLifecycle.test.ts
+++ b/src/test/hiddenStateIllusionLifecycle.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
+import {
+  FABRICATED_CONTACT_READOUT_PREFIX,
+  STRUCTURAL_ILLUSION_READOUT_PREFIX,
+} from '../domain/detectionScanReportNotes'
+import {
+  applyHiddenStateIllusionLifecyclePass,
+  applyIllusionScanProjection,
+  buildIllusionLifecycleContext,
+  resolveIllusionKindFromCase,
+  resolveIllusionAnchorLabel,
+} from '../domain/hiddenStateIllusionLifecycle'
+import { resolveHiddenStateModality } from '../domain/hiddenStateModality'
+import {
+  detectionScanTierOrder,
+  resolveScoutingWithCaseHiddenState,
+} from '../domain/revealPayloadScoutingIntegration'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import type { Agent, CaseInstance, Team } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+const SCOUTING_INPUT = {
+  teamCapability: 3,
+  anomalyConcealment: 2,
+  teamTags: ['recon-specialist'],
+  anomalyTags: ['concealment'],
+} as const
+
+const SUBJECT = {
+  exactIdentity: 'entity:illusion-case',
+  category: 'hidden contact',
+  hostility: 'latent' as const,
+  activeEffects: [],
+  dormantEffects: [],
+  activeProtections: [],
+}
+
+function createIllusionCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-illusion-matrix',
+      templateId: 'combat_vampire_nest',
+    }),
+    mode: 'threshold',
+    status: 'in_progress',
+    weeksRemaining: 2,
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['concealment'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: ['team-illusion'],
+    infiltrationCoverProfile: undefined,
+    infiltrationProbePlan: undefined,
+    stealthLeaveBehindId: undefined,
+    weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+    difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+    ...overrides,
+  }
+}
+
+function createReconObserver(id: string, investigation = 60): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: { combat: 10, investigation, utility: 40, social: 40 },
+    tags: ['medium', 'recon-specialist'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+describe('hiddenStateIllusionLifecycle (SPE-2285)', () => {
+  it('activates false_entity from hidden + false-entity tag (prefers over structural)', () => {
+    const caseData = createIllusionCase({
+      tags: ['concealment', 'false-entity', 'structural-illusion'],
+    })
+
+    expect(resolveIllusionKindFromCase(caseData)).toBe('false_entity')
+    expect(resolveHiddenStateModality(caseData)).toBe('concealed_presence')
+  })
+
+  it('activates structural_illusion for displaced cases with structural-illusion tag', () => {
+    const caseData = createIllusionCase({
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-c',
+      tags: ['structural-illusion'],
+    })
+
+    expect(resolveIllusionKindFromCase(caseData)).toBe('structural_illusion')
+    expect(resolveIllusionAnchorLabel(caseData, 'structural_illusion')).toContain('annex-c')
+  })
+
+  it('transitions active → disproved → collapsed via counter-detection and mission success', () => {
+    const base = createIllusionCase({ tags: ['concealment', 'false-entity'] })
+    const active = applyHiddenStateIllusionLifecyclePass(
+      base,
+      buildIllusionLifecycleContext(base)
+    )
+
+    expect(active.hiddenStateIllusionState?.phase).toBe('active')
+
+    const withCounterDetection = { ...active, counterDetection: true }
+    const disproved = applyHiddenStateIllusionLifecyclePass(withCounterDetection, {
+      ...buildIllusionLifecycleContext(withCounterDetection),
+      counterDetection: true,
+    })
+
+    expect(disproved.hiddenStateIllusionState?.phase).toBe('disproved')
+    expect(disproved.hiddenStateIllusionState?.disproofReason).toContain('counter-detection')
+
+    const collapsed = applyHiddenStateIllusionLifecyclePass(disproved, {
+      ...buildIllusionLifecycleContext(disproved),
+      missionResult: 'success',
+    })
+
+    expect(collapsed.hiddenStateIllusionState).toBeUndefined()
+  })
+
+  it('disproves false_entity via sustained recon without revealing canonical subject', () => {
+    const caseData = createIllusionCase({
+      tags: ['concealment', 'false-entity'],
+      hiddenStateScoutingReconCache: {
+        knownUnresolvedLayerIds: ['layer:false-entity'],
+        scoutingPassCount: 1,
+        lastUpdatedWeek: 1,
+      },
+    })
+
+    const initialized = applyHiddenStateIllusionLifecyclePass(
+      caseData,
+      buildIllusionLifecycleContext(caseData)
+    )
+    expect(initialized.hiddenStateIllusionState?.phase).toBe('active')
+
+    const disproved = applyHiddenStateIllusionLifecyclePass(initialized, {
+      ...buildIllusionLifecycleContext(initialized),
+      reconPassCount: 2,
+    })
+
+    expect(disproved.hiddenStateIllusionState?.phase).toBe('disproved')
+
+    const integrated = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_INPUT,
+      subject: SUBJECT,
+      caseData: disproved,
+    })
+
+    expect(integrated.detectionScan.fields.some((field) => field.tier === 'exact_identity')).toBe(
+      false
+    )
+    expect(disproved.hiddenState).toBe('hidden')
+  })
+
+  it('projects fabricated contact tiers while illusion is active', () => {
+    const caseData = createIllusionCase({
+      tags: ['concealment', 'false-entity'],
+      hiddenStateIllusionState: {
+        kind: 'false_entity',
+        phase: 'active',
+        anchorLabel: 'fabricated contact at annex-c',
+      },
+    })
+
+    const integrated = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_INPUT,
+      subject: { ...SUBJECT, present: true },
+      caseData,
+    })
+
+    expect(detectionScanTierOrder(integrated.detectionScan).length).toBeGreaterThan(0)
+    expect(
+      integrated.detectionScan.fields.some((field) =>
+        field.playerFacingValue.includes('fabricated')
+      )
+    ).toBe(true)
+
+    const projected = applyIllusionScanProjection(integrated.detectionScan, caseData)
+    expect(projected.fields[0]?.playerFacingValue).toContain('fabricated')
+  })
+
+  it('disproves structural illusion via route traversal without forcing revealed hiddenState', () => {
+    const caseData = createIllusionCase({
+      hiddenState: 'displaced',
+      displacementTarget: 'sector-east',
+      tags: ['structural-illusion'],
+    })
+
+    const active = applyHiddenStateIllusionLifecyclePass(
+      caseData,
+      buildIllusionLifecycleContext(caseData)
+    )
+    expect(active.hiddenStateIllusionState?.phase).toBe('active')
+
+    const withRoute = { ...active, route: 'perimeter-loop' }
+    const disproved = applyHiddenStateIllusionLifecyclePass(withRoute, {
+      ...buildIllusionLifecycleContext(withRoute),
+      route: 'perimeter-loop',
+    })
+
+    expect(disproved.hiddenStateIllusionState?.phase).toBe('disproved')
+    expect(disproved.hiddenState).toBe('displaced')
+  })
+})
+
+describe('hiddenStateIllusionLifecycle integration', () => {
+  function tuneFalseEntityCase(
+    state: ReturnType<typeof createStartingState>,
+    teamId: string
+  ): CaseInstance {
+    const baseCase = createIllusionCase({
+      id: 'case-false-entity-readout',
+      tags: ['concealment', 'false-entity'],
+      assignedTeamIds: [teamId],
+      counterDetection: false,
+      weeksRemaining: 1,
+    })
+
+    for (let investigationDifficulty = 8; investigationDifficulty <= 140; investigationDifficulty += 1) {
+      const candidate: CaseInstance = {
+        ...baseCase,
+        difficulty: {
+          combat: 0,
+          investigation: investigationDifficulty,
+          utility: 0,
+          social: 0,
+        },
+      }
+      const resolution = resolveAssignedCaseForWeek(candidate, state, () => 0.5)
+
+      if (
+        resolution.outcome.result === 'success' &&
+        resolution.hiddenStateScouting?.active === true
+      ) {
+        return candidate
+      }
+    }
+
+    throw new Error('Unable to tune false-entity investigation success case.')
+  }
+
+  it('surfaces fabricated-contact readout in weekly explanation notes', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_false_entity_readout')
+    const team: Team = {
+      id: 'team-false-entity-readout',
+      name: 'False entity readout team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    state.cases['case-false-entity-readout'] = tuneFalseEntityCase(state, team.id)
+
+    const preAdvance = resolveAssignedCaseForWeek(
+      state.cases['case-false-entity-readout'],
+      state,
+      () => 0.5
+    )
+    expect(preAdvance.hiddenStateScouting?.active).toBe(true)
+    expect(preAdvance.effectiveCase.hiddenStateIllusionState?.phase).toBe('active')
+
+    const nextState = advanceWeek(state)
+    const storedCase = nextState.cases['case-false-entity-readout']
+    expect(storedCase?.hiddenState).toBe('hidden')
+    const missionResult =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-false-entity-readout']
+        ?.missionResult
+
+    expect(
+      missionResult?.explanationNotes.some((note) =>
+        note.includes(FABRICATED_CONTACT_READOUT_PREFIX)
+      )
+    ).toBe(true)
+  })
+
+  it('surfaces structural-illusion readout with decoy locus for displaced structural cases', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_structural_readout')
+    const team: Team = {
+      id: 'team-structural-readout',
+      name: 'Structural illusion readout team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+    }
+
+    const baseCase = createIllusionCase({
+      id: 'case-structural-readout',
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-b',
+      route: 'service-corridor',
+      tags: ['structural-illusion'],
+      assignedTeamIds: [team.id],
+      weeksRemaining: 1,
+    })
+
+    let tunedCase: CaseInstance | undefined
+    for (let investigationDifficulty = 8; investigationDifficulty <= 140; investigationDifficulty += 1) {
+      const candidate: CaseInstance = {
+        ...baseCase,
+        difficulty: {
+          combat: 0,
+          investigation: investigationDifficulty,
+          utility: 0,
+          social: 0,
+        },
+      }
+      const resolution = resolveAssignedCaseForWeek(candidate, state, () => 0.5)
+      if (
+        resolution.outcome.result === 'success' &&
+        resolution.hiddenStateScouting?.active === true
+      ) {
+        tunedCase = candidate
+        break
+      }
+    }
+
+    if (tunedCase === undefined) {
+      throw new Error('Unable to tune structural-illusion investigation success case.')
+    }
+
+    state.cases['case-structural-readout'] = tunedCase
+
+    const preAdvance = resolveAssignedCaseForWeek(
+      state.cases['case-structural-readout'],
+      state,
+      () => 0.5
+    )
+    expect(preAdvance.hiddenStateScouting?.active).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const missionResult =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-structural-readout']
+        ?.missionResult
+
+    expect(
+      missionResult?.explanationNotes.some((note) =>
+        note.includes(STRUCTURAL_ILLUSION_READOUT_PREFIX)
+      )
+    ).toBe(true)
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes('decoy locus annex-b'))
+    ).toBe(true)
+    expect(state.cases['case-structural-readout']?.hiddenState).toBe('displaced')
+  })
+})

--- a/src/test/hiddenStateIllusionLifecycle.test.ts
+++ b/src/test/hiddenStateIllusionLifecycle.test.ts
@@ -114,8 +114,15 @@ describe('hiddenStateIllusionLifecycle (SPE-2285)', () => {
     expect(disproved.hiddenStateIllusionState?.phase).toBe('disproved')
     expect(disproved.hiddenStateIllusionState?.disproofReason).toContain('counter-detection')
 
+    const stillDisprovedAfterTriggerOnly = applyHiddenStateIllusionLifecyclePass(
+      withCounterDetection,
+      buildIllusionLifecycleContext(withCounterDetection)
+    )
+    expect(stillDisprovedAfterTriggerOnly.hiddenStateIllusionState?.phase).toBe('disproved')
+
     const collapsed = applyHiddenStateIllusionLifecyclePass(disproved, {
       ...buildIllusionLifecycleContext(disproved),
+      counterDetection: true,
       missionResult: 'success',
     })
 


### PR DESCRIPTION
## Summary

- Adds bounded \ctive → disproved → collapsed\ lifecycle for **false-entity** and **structural-illusion** authored cases (SPE-70 matrix slice 5).
- New \hiddenStateIllusionLifecycle.ts\: tag activation, phase transitions, scan projection, and disproof via counter-detection, route traversal, or sustained recon cache.
- Wires lifecycle before hidden-state scouting compose in \esolveAssignedCaseForWeek\ and weekly recon pass; preserves illusion readout prefixes on scouting results for weekly report copy after post-resolution collapse.

## Linear

- **Slice:** [SPE-2285](https://linear.app/spectranoir/issue/SPE-2285)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70) (parent remains open for mode-specific tells)

## Docs

- \planning/hidden-modality-matrix-slice-5.md\
- \planning/backlog.md\ (slice 5 active)

## Test plan

- [x] \
pm run lint\
- [x] \
pm run test:run -- src/test/hiddenStateIllusionLifecycle.test.ts src/test/hiddenStateModality.test.ts src/test/hiddenStateScoutingReconCache.test.ts src/test/detectionScanReportNotes.test.ts src/test/advanceWeek.hiddenStateScouting.test.ts src/test/revealPayloadOrchestration.test.ts\

## Parent status

Do **not** close SPE-70 on this PR; mode-specific tells and full parent AC remain backlog.

Made with [Cursor](https://cursor.com)