### PR TITLE
docs(SPE-2278): reconcile shipped case-prep planning docs

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,7 @@ From `README.md` **Current design notes**:
 1. **Hidden / disguised activation — remaining umbrella scope** — [SPE-70](https://linear.app/spectranoir/issue/SPE-70/hidden-state-displacement-and-counter-detection-layer) parent: optional post-matrix modality families (signature masking, false-detection output, glamour). **Next matrix slice:** [SPE-2286](https://linear.app/spectranoir/issue/SPE-2286) mode-specific tells — `planning/hidden-modality-matrix-slice-6.md`. **Shipped:** concealment activation, batch-4, infiltration stack, SPE-781 reveal, matrix slices 1–5 (PR #2403–#2411).
 2. **Infiltration optional content depth** — Batch-4 probe/cover/leave-behind and report copy slice complete (`src/domain/infiltrationEncounterReportNotes.ts`). Further authored content only; not new probe mechanics.
 3. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
-4. **Docs hygiene** — [SPE-2280](https://linear.app/spectranoir/issue/SPE-2280) shipped (PR #2412); [SPE-2278](https://linear.app/spectranoir/issue/SPE-2278) case-prep planning doc reconciliation (in progress).
+4. **Docs hygiene** — [SPE-2280](https://linear.app/spectranoir/issue/SPE-2280) shipped (PR #2412); [SPE-2278](https://linear.app/spectranoir/issue/SPE-2278) case-prep planning docs reconciled (SPE-2251 / SPE-626 / SPE-70 prep / SPE-2247).
 
 ## Blocked / waiting
 

--- a/planning/concealment-case-prep-slice.md
+++ b/planning/concealment-case-prep-slice.md
@@ -8,6 +8,9 @@
 | **Merged PR**     | [#2326](https://github.com/JamesJedi420/containment-protocol/pull/2326) — `feat(SPE-70): concealment case prep panel on case detail`                                              |
 | **Shipped scope** | `ConcealmentCasePrepPanel` + `buildConcealmentCasePrepView`; player `conceal.case.{caseId}` toggle; activation preview via `resolveConcealmentActivation`                         |
 | **Validation**    | `concealmentCasePrepView.test.ts`, `CaseDetailPage.test.tsx`; integrated in `WeeklyCasePrepPanel` stack                                                                           |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
+
+> **Agent note:** Do not treat pre-ship gap tables or follow-up lists as open work unless explicitly marked unshipped.
 
 ---
 

--- a/planning/concealment-case-prep-slice.md
+++ b/planning/concealment-case-prep-slice.md
@@ -2,13 +2,13 @@
 
 ## Shipped status
 
-| Field             | Value                                                                                                                                                                             |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Parent**        | [SPE-70 — Hidden-State, Displacement, & Counter-Detection Layer](https://linear.app/spectranoir/issue/SPE-70) (domain: [SPE-2107](https://linear.app/spectranoir/issue/SPE-2107)) |
-| **Merged PR**     | [#2326](https://github.com/JamesJedi420/containment-protocol/pull/2326) — `feat(SPE-70): concealment case prep panel on case detail`                                              |
-| **Shipped scope** | `ConcealmentCasePrepPanel` + `buildConcealmentCasePrepView`; player `conceal.case.{caseId}` toggle; activation preview via `resolveConcealmentActivation`                         |
-| **Validation**    | `concealmentCasePrepView.test.ts`, `CaseDetailPage.test.tsx`; integrated in `WeeklyCasePrepPanel` stack                                                                           |
-| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
+| Field                             | Value                                                                                                                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Parent**                        | [SPE-70 — Hidden-State, Displacement, & Counter-Detection Layer](https://linear.app/spectranoir/issue/SPE-70) (domain: [SPE-2107](https://linear.app/spectranoir/issue/SPE-2107)) |
+| **Merged PR**                     | [#2326](https://github.com/JamesJedi420/containment-protocol/pull/2326) — `feat(SPE-70): concealment case prep panel on case detail`                                              |
+| **Shipped scope**                 | `ConcealmentCasePrepPanel` + `buildConcealmentCasePrepView`; player `conceal.case.{caseId}` toggle; activation preview via `resolveConcealmentActivation`                         |
+| **Validation**                    | `concealmentCasePrepView.test.ts`, `CaseDetailPage.test.tsx`; integrated in `WeeklyCasePrepPanel` stack                                                                           |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only.                                                                         |
 
 > **Agent note:** Do not treat pre-ship gap tables or follow-up lists as open work unless explicitly marked unshipped.
 

--- a/planning/investigation-question-case-prep-slice.md
+++ b/planning/investigation-question-case-prep-slice.md
@@ -8,6 +8,9 @@
 | **Merged PR**     | [#2324](https://github.com/JamesJedi420/containment-protocol/pull/2324) — `feat(SPE-626): investigation question case prep UI`                                              |
 | **Shipped scope** | `InvestigationCasePrepPanel` + `buildInvestigationCasePrepView`; store `askInvestigationQuestion`; forensic/tactical budget spend and custody-marker display on case detail |
 | **Validation**    | `investigationCasePrepView.test.ts`, `CaseDetailPage.test.tsx`; complements [SPE-2247](https://linear.app/spectranoir/issue/SPE-2247) / PR #2323 leave-behind selection     |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
+
+> **Agent note:** Do not treat pre-ship gap tables as open work unless explicitly marked unshipped.
 
 ---
 

--- a/planning/investigation-question-case-prep-slice.md
+++ b/planning/investigation-question-case-prep-slice.md
@@ -2,13 +2,13 @@
 
 ## Shipped status
 
-| Field             | Value                                                                                                                                                                       |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Parent**        | [SPE-626 — Question-budget investigation and tactical reads](https://linear.app/spectranoir/issue/SPE-626/question-budget-investigation-and-tactical-reads)                 |
-| **Merged PR**     | [#2324](https://github.com/JamesJedi420/containment-protocol/pull/2324) — `feat(SPE-626): investigation question case prep UI`                                              |
-| **Shipped scope** | `InvestigationCasePrepPanel` + `buildInvestigationCasePrepView`; store `askInvestigationQuestion`; forensic/tactical budget spend and custody-marker display on case detail |
-| **Validation**    | `investigationCasePrepView.test.ts`, `CaseDetailPage.test.tsx`; complements [SPE-2247](https://linear.app/spectranoir/issue/SPE-2247) / PR #2323 leave-behind selection     |
-| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
+| Field                             | Value                                                                                                                                                                       |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Parent**                        | [SPE-626 — Question-budget investigation and tactical reads](https://linear.app/spectranoir/issue/SPE-626/question-budget-investigation-and-tactical-reads)                 |
+| **Merged PR**                     | [#2324](https://github.com/JamesJedi420/containment-protocol/pull/2324) — `feat(SPE-626): investigation question case prep UI`                                              |
+| **Shipped scope**                 | `InvestigationCasePrepPanel` + `buildInvestigationCasePrepView`; store `askInvestigationQuestion`; forensic/tactical budget spend and custody-marker display on case detail |
+| **Validation**                    | `investigationCasePrepView.test.ts`, `CaseDetailPage.test.tsx`; complements [SPE-2247](https://linear.app/spectranoir/issue/SPE-2247) / PR #2323 leave-behind selection     |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only.                                                                   |
 
 > **Agent note:** Do not treat pre-ship gap tables as open work unless explicitly marked unshipped.
 

--- a/planning/mvp-weekly-loop-proof-slice-1.md
+++ b/planning/mvp-weekly-loop-proof-slice-1.md
@@ -2,13 +2,13 @@
 
 ## Shipped status
 
-| Field             | Value                                                                                                                                                                                  |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Linear**        | [SPE-2251](https://linear.app/spectranoir/issue/SPE-2251) — MVP weekly loop proof (slice 1)                                                                                            |
-| **Merged PR**     | [#2339](https://github.com/JamesJedi420/containment-protocol/pull/2339)                                                                                                                |
-| **Shipped scope** | Deterministic multi-week integration harness: prep mutations → `advanceWeek` → report notes + event-feed drill-down + week navigation ([SPE-2251](https://linear.app/spectranoir/issue/SPE-2251), milestone 6) |
-| **Validation**    | `weeklyMvpLoopProof.integration.test.ts`, `src/test/helpers/weeklyMvpLoopProof.ts`; slice 2 persistence reload in `weeklyMvpLoopProof.slice2.integration.test.ts`                      |
-| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
+| Field                             | Value                                                                                                                                                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**                        | [SPE-2251](https://linear.app/spectranoir/issue/SPE-2251) — MVP weekly loop proof (slice 1)                                                                                                                    |
+| **Merged PR**                     | [#2339](https://github.com/JamesJedi420/containment-protocol/pull/2339)                                                                                                                                        |
+| **Shipped scope**                 | Deterministic multi-week integration harness: prep mutations → `advanceWeek` → report notes + event-feed drill-down + week navigation ([SPE-2251](https://linear.app/spectranoir/issue/SPE-2251), milestone 6) |
+| **Validation**                    | `weeklyMvpLoopProof.integration.test.ts`, `src/test/helpers/weeklyMvpLoopProof.ts`; slice 2 persistence reload in `weeklyMvpLoopProof.slice2.integration.test.ts`                                              |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only.                                                                                                      |
 
 > **Agent note:** Do not treat candidate comparison tables as open queue items.
 

--- a/planning/mvp-weekly-loop-proof-slice-1.md
+++ b/planning/mvp-weekly-loop-proof-slice-1.md
@@ -8,6 +8,9 @@
 | **Merged PR**     | [#2339](https://github.com/JamesJedi420/containment-protocol/pull/2339)                                                                                                                |
 | **Shipped scope** | Deterministic multi-week integration harness: prep mutations → `advanceWeek` → report notes + event-feed drill-down + week navigation ([SPE-2251](https://linear.app/spectranoir/issue/SPE-2251), milestone 6) |
 | **Validation**    | `weeklyMvpLoopProof.integration.test.ts`, `src/test/helpers/weeklyMvpLoopProof.ts`; slice 2 persistence reload in `weeklyMvpLoopProof.slice2.integration.test.ts`                      |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
+
+> **Agent note:** Do not treat candidate comparison tables as open queue items.
 
 ---
 

--- a/planning/stealth-leave-behind-tradeoff-selection-slice-5.md
+++ b/planning/stealth-leave-behind-tradeoff-selection-slice-5.md
@@ -9,14 +9,17 @@
 | **Merged PR**     | [#2323](https://github.com/JamesJedi420/containment-protocol/pull/2323) — `feat(SPE-2247): stealth leave-behind tradeoff selection (slice 5)` |
 | **Shipped scope** | Player selection of `stealthLeaveBehindId` on eligible cases; `stealthLeaveBehindSelection.ts` + `StealthLeaveBehindSelectionPanel`           |
 | **Validation**    | `stealthLeaveBehindSelection.test.ts`, `stealthLeaveBehindSelectionView.test.ts`                                                              |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
 
 **Prerequisite (shipped):** SPE-2163 registry, SPE-2244 mission fallout, SPE-2246 template catalog + `advanceWeek` proof, investigation custody-loss markers + forensic `custodyLossBurden` (PR #2321).
+
+> **Agent note:** Do not treat domain contract sections below as unimplemented.
 
 ---
 
 ## Original implementation plan (historical)
 
-## Goal
+### Goal
 
 Let players **choose** an authored stealth leave-behind on eligible infiltration cases before weekly resolution, instead of only using the template default. Selection must drive existing `evaluateStealthLeaveBehindMissionPressure()` and custody-loss apply paths unchanged in semantics.
 

--- a/planning/stealth-leave-behind-tradeoff-selection-slice-5.md
+++ b/planning/stealth-leave-behind-tradeoff-selection-slice-5.md
@@ -2,14 +2,14 @@
 
 ## Shipped status
 
-| Field             | Value                                                                                                                                         |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Linear**        | [SPE-2247](https://linear.app/spectranoir/issue/SPE-2247/stealth-leave-behind-tradeoff-selection-slice-5)                                     |
-| **Parent**        | [SPE-70](https://linear.app/spectranoir/issue/SPE-70)                                                                                         |
-| **Merged PR**     | [#2323](https://github.com/JamesJedi420/containment-protocol/pull/2323) — `feat(SPE-2247): stealth leave-behind tradeoff selection (slice 5)` |
-| **Shipped scope** | Player selection of `stealthLeaveBehindId` on eligible cases; `stealthLeaveBehindSelection.ts` + `StealthLeaveBehindSelectionPanel`           |
-| **Validation**    | `stealthLeaveBehindSelection.test.ts`, `stealthLeaveBehindSelectionView.test.ts`                                                              |
-| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only. |
+| Field                             | Value                                                                                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**                        | [SPE-2247](https://linear.app/spectranoir/issue/SPE-2247/stealth-leave-behind-tradeoff-selection-slice-5)                                     |
+| **Parent**                        | [SPE-70](https://linear.app/spectranoir/issue/SPE-70)                                                                                         |
+| **Merged PR**                     | [#2323](https://github.com/JamesJedi420/containment-protocol/pull/2323) — `feat(SPE-2247): stealth leave-behind tradeoff selection (slice 5)` |
+| **Shipped scope**                 | Player selection of `stealthLeaveBehindId` on eligible cases; `stealthLeaveBehindSelection.ts` + `StealthLeaveBehindSelectionPanel`           |
+| **Validation**                    | `stealthLeaveBehindSelection.test.ts`, `stealthLeaveBehindSelectionView.test.ts`                                                              |
+| **Doc reconciliation (SPE-2278)** | May 2026 @ main `64225023` — shipped block is authoritative; historical sections below are archival only.                                     |
 
 **Prerequisite (shipped):** SPE-2163 registry, SPE-2244 mission fallout, SPE-2246 template catalog + `advanceWeek` proof, investigation custody-loss markers + forensic `custodyLossBurden` (PR #2321).
 


### PR DESCRIPTION
## Summary

- Add SPE-2278 doc-reconciliation rows and agent notes to four shipped case-prep / MVP loop planning docs so historical sections read as archival, not open work.
- Update `planning/backlog.md` docs-hygiene queue item.

## Linear

- **Slice:** [SPE-2278](https://linear.app/spectranoir/issue/SPE-2278)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70)

## Test plan

- [x] `rg "Suggested Linear|recommended next issue|no UI today"` on affected planning paths — no matches
- [x] Shipped-status blocks present on all four plans
