### PR TITLE
feat(SPE-2286): hidden-state modality tells (slice 6)

### DIFF
--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -14,6 +14,8 @@ import {
   applyHiddenStateIllusionLifecyclePass,
   buildIllusionLifecycleContext,
 } from './hiddenStateIllusionLifecycle'
+import { evaluateHiddenStateModalityTell } from './hiddenStateModalityTells'
+import type { HiddenStateModalityTellResult } from './hiddenStateModalityTells'
 import {
   applyHiddenStateScoutingReconCacheToCase,
   scoutingReconCacheScoreAdjustment,
@@ -45,6 +47,7 @@ export interface WeeklyCaseResolutionStrategy {
   activeTeamStressModifiers: Record<string, number>
   outcome: ResolutionOutcome
   behaviorValidation?: DisguiseRevealIntegrationResult
+  hiddenStateModalityTell?: HiddenStateModalityTellResult
   hiddenStateScouting?: HiddenStateScoutingRevealIntegrationResult
   infiltrationStageMission?: InfiltrationStageMissionPressureResult
   stealthLeaveBehindMission?: StealthLeaveBehindMissionPressureResult
@@ -163,6 +166,11 @@ export function resolveAssignedCaseForWeek(
     resolvedEffectiveCase,
     buildIllusionLifecycleContext(resolvedEffectiveCase)
   )
+  const hiddenStateModalityTell = evaluateHiddenStateModalityTell({
+    caseData: resolvedEffectiveCase,
+    agents: assignedAgents,
+    disguiseValidationActive: behaviorValidation.active,
+  })
   const hiddenStateScouting = evaluateHiddenStateScoutingWithRevealPayload({
     caseData: resolvedEffectiveCase,
     agents: assignedAgents,
@@ -182,12 +190,14 @@ export function resolveAssignedCaseForWeek(
   const scoreAdjustment =
     factionContext.scoreAdjustment +
     behaviorValidation.scoreAdjustment +
+    hiddenStateModalityTell.scoreAdjustment +
     infiltrationStageMission.scoreAdjustment +
     stealthLeaveBehindMission.scoreAdjustment +
     reconCacheScore.delta
   const scoreAdjustmentReason = [
     ...factionContext.reasons,
     behaviorValidation.scoreAdjustmentReason,
+    hiddenStateModalityTell.scoreAdjustmentReason,
     infiltrationStageMission.scoreAdjustmentReason,
     stealthLeaveBehindMission.scoreAdjustmentReason,
     reconCacheScore.reason,
@@ -325,6 +335,7 @@ export function resolveAssignedCaseForWeek(
     activeTeamStressModifiers,
     outcome,
     behaviorValidation,
+    hiddenStateModalityTell,
     hiddenStateScouting,
     infiltrationStageMission,
     stealthLeaveBehindMission,

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -18,7 +18,16 @@ import {
 import type { CaseInstance } from './models'
 import type { DetectionScanResult } from './revealPayload'
 import type { DisguiseRevealIntegrationResult } from './revealPayloadDisguiseIntegration'
+import type { HiddenStateModalityTellResult } from './hiddenStateModalityTells'
+import { MODALITY_TELL_READOUT_PREFIXES } from './hiddenStateModalityTells'
 import type { HiddenStateScoutingRevealIntegrationResult } from './revealPayloadScoutingIntegration'
+
+export {
+  CONCEALMENT_TELL_READOUT_PREFIX,
+  COVER_TELL_READOUT_PREFIX,
+  DISPLACEMENT_TELL_READOUT_PREFIX,
+  MODALITY_TELL_READOUT_PREFIXES,
+} from './hiddenStateModalityTells'
 
 export const DETECTION_SCAN_READOUT_PREFIX = 'Detection readout:'
 export const CONCEALMENT_SCAN_READOUT_PREFIX = 'Concealment readout:'
@@ -70,6 +79,31 @@ function orderedPlayerFacingValues(result: DetectionScanResult): readonly string
 
 function resolutionReasonHasDetectionScanReadout(reason: string): boolean {
   return DETECTION_SCAN_READOUT_PREFIXES.some((prefix) => reason.startsWith(prefix))
+}
+
+function resolutionReasonHasModalityTellReadout(reason: string): boolean {
+  return MODALITY_TELL_READOUT_PREFIXES.some((prefix) => reason.startsWith(prefix))
+}
+
+export function shouldAppendModalityTellReportNote(
+  tell: HiddenStateModalityTellResult | undefined
+): boolean {
+  return tell?.active === true && (tell.readoutLine?.length ?? 0) > 0
+}
+
+export function appendModalityTellResolutionReason(
+  resolutionReasons: string[],
+  tell: HiddenStateModalityTellResult | undefined
+): void {
+  if (!shouldAppendModalityTellReportNote(tell)) {
+    return
+  }
+
+  if (resolutionReasons.some(resolutionReasonHasModalityTellReadout)) {
+    return
+  }
+
+  resolutionReasons.push(tell!.readoutLine!)
 }
 
 export function shouldAppendDetectionScanReportNote(
@@ -139,7 +173,8 @@ export function appendDetectionScanResolutionReason(
   resolutionReasons: string[],
   behaviorValidation?: DisguiseRevealIntegrationResult,
   hiddenStateScouting?: HiddenStateScoutingRevealIntegrationResult,
-  caseData?: CaseInstance
+  caseData?: CaseInstance,
+  modalityTell?: HiddenStateModalityTellResult
 ): void {
   if (resolutionReasons.some(resolutionReasonHasDetectionScanReadout)) {
     return
@@ -186,4 +221,6 @@ export function appendDetectionScanResolutionReason(
       formatIllusionDisproofSuffix(caseData?.hiddenStateIllusionState)
     resolutionReasons.push(summary)
   }
+
+  appendModalityTellResolutionReason(resolutionReasons, modalityTell)
 }

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -176,50 +176,40 @@ export function appendDetectionScanResolutionReason(
   caseData?: CaseInstance,
   modalityTell?: HiddenStateModalityTellResult
 ): void {
-  if (resolutionReasons.some(resolutionReasonHasDetectionScanReadout)) {
-    return
-  }
+  if (!resolutionReasons.some(resolutionReasonHasDetectionScanReadout)) {
+    if (
+      behaviorValidation !== undefined &&
+      shouldAppendDetectionScanReportNote(behaviorValidation)
+    ) {
+      const summary = formatDetectionScanSummary(behaviorValidation.detectionScan, {
+        prefix: DETECTION_SCAN_READOUT_PREFIX,
+      })
+      if (summary.length > 0) {
+        resolutionReasons.push(summary)
+      }
+    } else if (hiddenStateScouting !== undefined) {
+      const illusionPrefix =
+        hiddenStateScouting.illusionReadoutPrefix ??
+        (caseData !== undefined
+          ? illusionReadoutPrefixForState(caseData.hiddenStateIllusionState)
+          : null)
+      const modality =
+        caseData !== undefined ? resolveHiddenStateModality(caseData) : ('none' as const)
 
-  if (
-    behaviorValidation !== undefined &&
-    shouldAppendDetectionScanReportNote(behaviorValidation)
-  ) {
-    const summary = formatDetectionScanSummary(behaviorValidation.detectionScan, {
-      prefix: DETECTION_SCAN_READOUT_PREFIX,
-    })
-    if (summary.length > 0) {
-      resolutionReasons.push(summary)
+      if (shouldAppendHiddenStateScoutingReportNote(hiddenStateScouting, modality, caseData)) {
+        const prefix = illusionPrefix ?? detectionScanReadoutPrefixForModality(modality)
+        let summary = formatDetectionScanSummary(hiddenStateScouting.detectionScan, {
+          prefix,
+        })
+
+        if (summary.length > 0) {
+          summary +=
+            hiddenStateScouting.illusionDisproofSuffix ??
+            formatIllusionDisproofSuffix(caseData?.hiddenStateIllusionState)
+          resolutionReasons.push(summary)
+        }
+      }
     }
-
-    return
-  }
-
-  if (hiddenStateScouting === undefined) {
-    return
-  }
-
-  const illusionPrefix =
-    hiddenStateScouting.illusionReadoutPrefix ??
-    (caseData !== undefined
-      ? illusionReadoutPrefixForState(caseData.hiddenStateIllusionState)
-      : null)
-  const modality =
-    caseData !== undefined ? resolveHiddenStateModality(caseData) : ('none' as const)
-
-  if (!shouldAppendHiddenStateScoutingReportNote(hiddenStateScouting, modality, caseData)) {
-    return
-  }
-
-  const prefix = illusionPrefix ?? detectionScanReadoutPrefixForModality(modality)
-  let summary = formatDetectionScanSummary(hiddenStateScouting.detectionScan, {
-    prefix,
-  })
-
-  if (summary.length > 0) {
-    summary +=
-      hiddenStateScouting.illusionDisproofSuffix ??
-      formatIllusionDisproofSuffix(caseData?.hiddenStateIllusionState)
-    resolutionReasons.push(summary)
   }
 
   appendModalityTellResolutionReason(resolutionReasons, modalityTell)

--- a/src/domain/hiddenStateModalityTells.ts
+++ b/src/domain/hiddenStateModalityTells.ts
@@ -1,0 +1,215 @@
+/**
+ * SPE-2286 slice 6: deterministic mode-specific tells for hidden-state modalities.
+ */
+
+import type { Agent, CaseInstance } from './models'
+import {
+  anomalyConcealmentFromCase,
+  teamScoutingCapabilityFromAgents,
+} from './revealPayloadScoutingIntegration'
+import { resolveHiddenStateModality, type HiddenStateModalityKind } from './hiddenStateModality'
+
+export type HiddenStateTellKind =
+  | 'thermal_residual'
+  | 'route_timing'
+  | 'speech_cadence'
+  | 'metadata_spoof'
+
+export const TELL_THERMAL_RESIDUAL_TAG = 'tell-thermal-residual'
+export const TELL_ROUTE_TIMING_TAG = 'tell-route-timing'
+export const TELL_SPEECH_CADENCE_TAG = 'tell-speech-cadence'
+export const TELL_METADATA_SPOOF_TAG = 'tell-metadata-spoof'
+export const OBSERVER_THRESHOLD_STRICT_TAG = 'observer-threshold-strict'
+
+export const CONCEALMENT_TELL_READOUT_PREFIX = 'Concealment tell readout:'
+export const DISPLACEMENT_TELL_READOUT_PREFIX = 'Displacement tell readout:'
+export const COVER_TELL_READOUT_PREFIX = 'Cover tell readout:'
+
+export const MODALITY_TELL_READOUT_PREFIXES = [
+  CONCEALMENT_TELL_READOUT_PREFIX,
+  DISPLACEMENT_TELL_READOUT_PREFIX,
+  COVER_TELL_READOUT_PREFIX,
+] as const
+
+const MEANINGFUL_DETECTION_CONFIDENCE_FLOOR = 0.6
+const TELL_SCORE_ADJUSTMENT = 2
+
+export interface HiddenStateModalityTellResult {
+  readonly active: boolean
+  readonly kind?: HiddenStateTellKind
+  readonly modality: HiddenStateModalityKind
+  readonly readoutPrefix?: string
+  readonly readoutLine?: string
+  readonly scoreAdjustment: number
+  readonly scoreAdjustmentReason?: string
+}
+
+const INACTIVE_TELL: HiddenStateModalityTellResult = {
+  active: false,
+  modality: 'none',
+  scoreAdjustment: 0,
+}
+
+interface TellCandidate {
+  readonly priority: number
+  readonly kind: HiddenStateTellKind
+  readonly modality: HiddenStateModalityKind
+  readonly tag: string
+}
+
+const TELL_CANDIDATES: readonly TellCandidate[] = [
+  {
+    priority: 0,
+    kind: 'speech_cadence',
+    modality: 'disguised_identity',
+    tag: TELL_SPEECH_CADENCE_TAG,
+  },
+  {
+    priority: 1,
+    kind: 'metadata_spoof',
+    modality: 'disguised_identity',
+    tag: TELL_METADATA_SPOOF_TAG,
+  },
+  {
+    priority: 2,
+    kind: 'route_timing',
+    modality: 'false_position',
+    tag: TELL_ROUTE_TIMING_TAG,
+  },
+  {
+    priority: 3,
+    kind: 'thermal_residual',
+    modality: 'concealed_presence',
+    tag: TELL_THERMAL_RESIDUAL_TAG,
+  },
+]
+
+function caseTagSet(caseData: CaseInstance): Set<string> {
+  return new Set([
+    ...(caseData.tags ?? []),
+    ...(caseData.requiredTags ?? []),
+    ...(caseData.preferredTags ?? []),
+  ])
+}
+
+function requiresObserverThresholdGate(caseData: CaseInstance, tags: Set<string>): boolean {
+  if (tags.has(OBSERVER_THRESHOLD_STRICT_TAG)) {
+    return true
+  }
+
+  const detectionConfidence =
+    typeof caseData.detectionConfidence === 'number' ? caseData.detectionConfidence : 0
+
+  return detectionConfidence > MEANINGFUL_DETECTION_CONFIDENCE_FLOOR
+}
+
+function observerBandTooWeakForConcealment(
+  caseData: CaseInstance,
+  agents: readonly Agent[]
+): boolean {
+  const teamCapability = teamScoutingCapabilityFromAgents(agents)
+  const anomalyConcealment = anomalyConcealmentFromCase(caseData)
+
+  return teamCapability < anomalyConcealment
+}
+
+function resolvePrimaryTellCandidate(
+  caseData: CaseInstance,
+  modality: HiddenStateModalityKind
+): TellCandidate | null {
+  const tags = caseTagSet(caseData)
+
+  for (const candidate of TELL_CANDIDATES) {
+    if (candidate.modality === modality && tags.has(candidate.tag)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+export function tellReadoutPrefixForModality(modality: HiddenStateModalityKind): string | null {
+  switch (modality) {
+    case 'concealed_presence':
+      return CONCEALMENT_TELL_READOUT_PREFIX
+    case 'false_position':
+      return DISPLACEMENT_TELL_READOUT_PREFIX
+    case 'disguised_identity':
+      return COVER_TELL_READOUT_PREFIX
+    case 'none':
+      return null
+    default: {
+      const _exhaustive: never = modality
+      return _exhaustive
+    }
+  }
+}
+
+export function formatModalityTellReadout(
+  kind: HiddenStateTellKind,
+  caseData: CaseInstance
+): string {
+  switch (kind) {
+    case 'thermal_residual':
+      return 'Residual signature and timing do not match baseline occupancy.'
+    case 'route_timing': {
+      const decoy = caseData.displacementTarget?.trim()
+      if (decoy !== undefined && decoy.length > 0) {
+        return `Decoy locus ${decoy} timing is inconsistent with the filed movement log.`
+      }
+
+      return 'Decoy locus timing is inconsistent with the filed movement log.'
+    }
+    case 'speech_cadence':
+      return 'Speech cadence does not match the claimed cover profile.'
+    case 'metadata_spoof':
+      return 'Contact metadata shows spoofed chain-of-custody markers.'
+    default: {
+      const _exhaustive: never = kind
+      return _exhaustive
+    }
+  }
+}
+
+export function evaluateHiddenStateModalityTell(input: {
+  readonly caseData: CaseInstance
+  readonly agents: readonly Agent[]
+  readonly disguiseValidationActive: boolean
+}): HiddenStateModalityTellResult {
+  if (input.disguiseValidationActive || input.agents.length === 0) {
+    return INACTIVE_TELL
+  }
+
+  const modality = resolveHiddenStateModality(input.caseData)
+  if (modality === 'none') {
+    return INACTIVE_TELL
+  }
+
+  const candidate = resolvePrimaryTellCandidate(input.caseData, modality)
+  if (candidate === null) {
+    return { ...INACTIVE_TELL, modality }
+  }
+
+  const tags = caseTagSet(input.caseData)
+  if (
+    requiresObserverThresholdGate(input.caseData, tags) &&
+    !observerBandTooWeakForConcealment(input.caseData, input.agents)
+  ) {
+    return { ...INACTIVE_TELL, modality }
+  }
+
+  const prefix = tellReadoutPrefixForModality(modality)
+  const sentence = formatModalityTellReadout(candidate.kind, input.caseData)
+  const readoutLine =
+    prefix !== null && sentence.length > 0 ? `${prefix} ${sentence}` : undefined
+
+  return {
+    active: true,
+    kind: candidate.kind,
+    modality,
+    readoutPrefix: prefix ?? undefined,
+    readoutLine,
+    scoreAdjustment: TELL_SCORE_ADJUSTMENT,
+    scoreAdjustmentReason: readoutLine,
+  }
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -1575,6 +1575,9 @@ interface WeeklyCaseResolutionStrategy {
   outcome: ResolutionOutcomeWithDetails
   aggregateBattleSummary?: AggregateBattleCampaignSummary
   behaviorValidation?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['behaviorValidation']
+  hiddenStateModalityTell?: ReturnType<
+    typeof resolveCanonicalAssignedCaseForWeek
+  >['hiddenStateModalityTell']
   hiddenStateScouting?: ReturnType<typeof resolveCanonicalAssignedCaseForWeek>['hiddenStateScouting']
   infiltrationStageMission?: ReturnType<
     typeof resolveCanonicalAssignedCaseForWeek
@@ -1718,6 +1721,7 @@ function resolveAssignedCaseForWeek(
     outcome,
     aggregateBattleSummary,
     behaviorValidation: canonicalResolution.behaviorValidation,
+    hiddenStateModalityTell: canonicalResolution.hiddenStateModalityTell,
     hiddenStateScouting: canonicalResolution.hiddenStateScouting,
     infiltrationStageMission: canonicalResolution.infiltrationStageMission,
     stealthLeaveBehindMission: canonicalResolution.stealthLeaveBehindMission,
@@ -2410,6 +2414,7 @@ function resolveAssignments(
       outcome,
       aggregateBattleSummary,
       behaviorValidation,
+      hiddenStateModalityTell,
       hiddenStateScouting,
       infiltrationStageMission,
       stealthLeaveBehindMission,
@@ -2475,7 +2480,8 @@ function resolveAssignments(
       resolutionReasons,
       behaviorValidation,
       hiddenStateScouting,
-      effectiveCase
+      effectiveCase,
+      hiddenStateModalityTell
     )
 
     if (

--- a/src/test/advanceWeek.hiddenStateScouting.test.ts
+++ b/src/test/advanceWeek.hiddenStateScouting.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import {
   CONCEALMENT_SCAN_READOUT_PREFIX,
+  CONCEALMENT_TELL_READOUT_PREFIX,
   DISPLACEMENT_SCAN_READOUT_PREFIX,
+  DISPLACEMENT_TELL_READOUT_PREFIX,
   DETECTION_SCAN_READOUT_PREFIX,
 } from '../domain/detectionScanReportNotes'
+import { TELL_ROUTE_TIMING_TAG, TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
 import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
 import type { Agent, CaseInstance, Team } from '../domain/models'
 import { advanceWeek } from '../domain/sim/advanceWeek'
@@ -162,6 +165,84 @@ describe('advanceWeek hidden-state scouting report copy (SPE-2283)', () => {
     ).toBe(true)
     expect(
       missionResult?.explanationNotes.some((note) => note.includes('decoy locus annex-b'))
+    ).toBe(true)
+  })
+
+  it('surfaces concealment tell readout without revealing hidden state', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_concealed_tell', 60)
+    const team: Team = {
+      id: 'team-concealed-tell',
+      name: 'Concealed tell team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-concealed-readout'] = tuneConcealedInvestigationCase(state, team.id, {
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+    })
+
+    const preAdvance = resolveAssignedCaseForWeek(state.cases['case-concealed-readout'], state, () => 0.5)
+    expect(preAdvance.hiddenStateModalityTell?.active).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const snapshot =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-concealed-readout']
+
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) =>
+        note.includes(CONCEALMENT_TELL_READOUT_PREFIX)
+      )
+    ).toBe(true)
+    expect(snapshot?.hiddenState).not.toBe('revealed')
+  })
+
+  it('surfaces displacement tell readout for route-timing tags', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_displaced_tell', 60)
+    const team: Team = {
+      id: 'team-displaced-tell',
+      name: 'Displaced tell team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-concealed-readout'] = tuneConcealedInvestigationCase(state, team.id, {
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-b',
+      tags: [TELL_ROUTE_TIMING_TAG],
+    })
+
+    const nextState = advanceWeek(state)
+    const missionResult =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-concealed-readout']
+        ?.missionResult
+
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes(DISPLACEMENT_TELL_READOUT_PREFIX))
+    ).toBe(true)
+    expect(
+      missionResult?.explanationNotes.some((note) => note.includes('movement log'))
     ).toBe(true)
   })
 })

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import {
   appendDetectionScanResolutionReason,
+  appendModalityTellResolutionReason,
   CONCEALMENT_SCAN_READOUT_PREFIX,
+  CONCEALMENT_TELL_READOUT_PREFIX,
   COVER_SCAN_READOUT_PREFIX,
   DETECTION_SCAN_READOUT_PREFIX,
   detectionScanReadoutPrefixForModality,
   DISPLACEMENT_SCAN_READOUT_PREFIX,
   formatDetectionScanSummary,
   shouldAppendDetectionScanReportNote,
+  shouldAppendModalityTellReportNote,
 } from '../domain/detectionScanReportNotes'
+import { evaluateHiddenStateModalityTell } from '../domain/hiddenStateModalityTells'
+import { TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
 import { resolveDetectionScan, type SubjectTruthState } from '../domain/revealPayload'
 import {
   buildDisguiseRevealSubjectFromCase,
@@ -212,5 +217,46 @@ describe('detectionScanReportNotes', () => {
     expect(reasons).toHaveLength(1)
     expect(reasons[0]).toContain(DETECTION_SCAN_READOUT_PREFIX)
     expect(reasons[0]).toContain('contact detected')
+  })
+
+  it('appends modality tell readout after scouting copy without duplicate prefixes', () => {
+    const caseData = {
+      ...createStarterCase({ id: 'case-tell-copy', templateId: 'combat_vampire_nest' }),
+      hiddenState: 'hidden' as const,
+      detectionConfidence: 0.2,
+      counterDetection: false,
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: ['team-tell'],
+      infiltrationCoverProfile: undefined,
+      infiltrationProbePlan: undefined,
+      weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+      difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+    }
+    const agent: Agent = {
+      id: 'a_tell_copy',
+      name: 'a_tell_copy',
+      role: 'medium',
+      baseStats: { combat: 10, investigation: 60, utility: 40, social: 40 },
+      tags: ['medium'],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    }
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents: [agent],
+      disguiseValidationActive: false,
+    })
+
+    expect(shouldAppendModalityTellReportNote(tell)).toBe(true)
+
+    const reasons: string[] = []
+    appendModalityTellResolutionReason(reasons, tell)
+    appendModalityTellResolutionReason(reasons, tell)
+
+    expect(reasons).toHaveLength(1)
+    expect(reasons[0]).toContain(CONCEALMENT_TELL_READOUT_PREFIX)
   })
 })

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -259,4 +259,67 @@ describe('detectionScanReportNotes', () => {
     expect(reasons).toHaveLength(1)
     expect(reasons[0]).toContain(CONCEALMENT_TELL_READOUT_PREFIX)
   })
+
+  it('appends modality tell when hidden-state scouting scan has no player-facing fields', () => {
+    const caseData = {
+      ...createStarterCase({ id: 'case-tell-no-scan', templateId: 'combat_vampire_nest' }),
+      hiddenState: 'hidden' as const,
+      detectionConfidence: 0.2,
+      counterDetection: false,
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+      requiredTags: [],
+      preferredTags: [],
+      assignedTeamIds: ['team-tell'],
+      infiltrationCoverProfile: undefined,
+      infiltrationProbePlan: undefined,
+      weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+      difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+    }
+    const agent: Agent = {
+      id: 'a_tell_no_scan',
+      name: 'a_tell_no_scan',
+      role: 'medium',
+      baseStats: { combat: 10, investigation: 60, utility: 40, social: 40 },
+      tags: ['medium'],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    }
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents: [agent],
+      disguiseValidationActive: false,
+    })
+    const presenceOnlyScan = resolveDetectionScan(
+      {
+        present: false,
+        exactIdentity: 'entity:case-tell-no-scan',
+        category: 'concealed presence',
+        hostility: 'latent',
+        activeProtections: [],
+        concealmentLayers: [],
+        activeEffects: [],
+        dormantEffects: [],
+      },
+      { family: 'presence_sweep' }
+    )
+    const reasons: string[] = []
+
+    appendDetectionScanResolutionReason(
+      reasons,
+      undefined,
+      {
+        active: true,
+        outcome: 'fail',
+        revealed: false,
+        withheld: true,
+        detectionScan: presenceOnlyScan,
+      },
+      caseData,
+      tell
+    )
+
+    expect(reasons.some((reason) => reason.includes(CONCEALMENT_TELL_READOUT_PREFIX))).toBe(true)
+    expect(reasons.some((reason) => reason.includes(CONCEALMENT_SCAN_READOUT_PREFIX))).toBe(false)
+  })
 })

--- a/src/test/hiddenStateModalityTells.test.ts
+++ b/src/test/hiddenStateModalityTells.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONCEALMENT_TELL_READOUT_PREFIX,
+  COVER_TELL_READOUT_PREFIX,
+  DISPLACEMENT_TELL_READOUT_PREFIX,
+  evaluateHiddenStateModalityTell,
+  formatModalityTellReadout,
+  OBSERVER_THRESHOLD_STRICT_TAG,
+  TELL_METADATA_SPOOF_TAG,
+  TELL_ROUTE_TIMING_TAG,
+  TELL_SPEECH_CADENCE_TAG,
+  TELL_THERMAL_RESIDUAL_TAG,
+} from '../domain/hiddenStateModalityTells'
+import type { Agent, CaseInstance } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createObserver(id: string, investigation: number): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: {
+      combat: 10,
+      investigation,
+      utility: 40,
+      social: 40,
+    },
+    tags: ['medium'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+function createHiddenCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-modality-tell',
+      templateId: 'combat_vampire_nest',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['concealment'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: ['team-tell'],
+    infiltrationCoverProfile: undefined,
+    infiltrationProbePlan: undefined,
+    weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+    difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+    ...overrides,
+  }
+}
+
+describe('hiddenStateModalityTells (SPE-2286)', () => {
+  it('fires concealment thermal-residual tell with prefix and score adjustment', () => {
+    const caseData = createHiddenCase({ tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG] })
+    const agents = [createObserver('a_thermal', 60)]
+
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents,
+      disguiseValidationActive: false,
+    })
+
+    expect(tell.active).toBe(true)
+    expect(tell.kind).toBe('thermal_residual')
+    expect(tell.readoutLine).toContain(CONCEALMENT_TELL_READOUT_PREFIX)
+    expect(tell.readoutLine).toContain('Residual signature')
+    expect(tell.scoreAdjustment).toBeGreaterThan(0)
+  })
+
+  it('fires displacement route-timing tell referencing decoy locus', () => {
+    const caseData = createHiddenCase({
+      hiddenState: 'displaced',
+      displacementTarget: 'annex-b',
+      tags: [TELL_ROUTE_TIMING_TAG],
+      difficulty: { combat: 0, investigation: 0, utility: 0, social: 0 },
+    })
+    const agents = [createObserver('a_route', 60)]
+
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents,
+      disguiseValidationActive: false,
+    })
+
+    expect(tell.active).toBe(true)
+    expect(tell.kind).toBe('route_timing')
+    expect(tell.readoutLine).toContain(DISPLACEMENT_TELL_READOUT_PREFIX)
+    expect(tell.readoutLine).toContain('annex-b')
+    expect(formatModalityTellReadout('route_timing', caseData)).toContain('movement log')
+  })
+
+  it('prefers speech cadence over metadata spoof on disguised-identity cases', () => {
+    const caseData = createHiddenCase({
+      tags: ['disguise', TELL_SPEECH_CADENCE_TAG, TELL_METADATA_SPOOF_TAG],
+      infiltrationCoverProfile: undefined,
+    })
+    const agents = [createObserver('a_cover', 60)]
+
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents,
+      disguiseValidationActive: false,
+    })
+
+    expect(tell.active).toBe(true)
+    expect(tell.modality).toBe('disguised_identity')
+    expect(tell.kind).toBe('speech_cadence')
+    expect(tell.readoutLine).toContain(COVER_TELL_READOUT_PREFIX)
+  })
+
+  it('skips tell evaluation when disguise validation is active', () => {
+    const caseData = createHiddenCase({ tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG] })
+
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents: [createObserver('a_skip', 60)],
+      disguiseValidationActive: true,
+    })
+
+    expect(tell.active).toBe(false)
+  })
+
+  it('suppresses tell under observer-threshold-strict when capability meets concealment', () => {
+    const caseData = createHiddenCase({
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG, OBSERVER_THRESHOLD_STRICT_TAG],
+      difficulty: { combat: 0, investigation: 15, utility: 0, social: 0 },
+    })
+    const strongObserver = createObserver('a_strong', 60)
+
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents: [strongObserver],
+      disguiseValidationActive: false,
+    })
+
+    expect(tell.active).toBe(false)
+  })
+
+  it('fires tell under observer-threshold-strict when observer band is too weak', () => {
+    const caseData = createHiddenCase({
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG, OBSERVER_THRESHOLD_STRICT_TAG],
+      difficulty: { combat: 0, investigation: 45, utility: 0, social: 0 },
+    })
+    const weakObserver = createObserver('a_weak', 20)
+
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents: [weakObserver],
+      disguiseValidationActive: false,
+    })
+
+    expect(tell.active).toBe(true)
+    expect(tell.readoutLine).toContain(CONCEALMENT_TELL_READOUT_PREFIX)
+  })
+
+  it('does not fire without a matching tell tag', () => {
+    const caseData = createHiddenCase({ tags: ['concealment'] })
+
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents: [createObserver('a_none', 60)],
+      disguiseValidationActive: false,
+    })
+
+    expect(tell.active).toBe(false)
+  })
+})

--- a/src/test/revealPayloadOrchestration.test.ts
+++ b/src/test/revealPayloadOrchestration.test.ts
@@ -5,9 +5,11 @@ import { evaluateBehaviorWeightedDisguiseValidation } from '../domain/disguiseVa
 import {
   appendDetectionScanResolutionReason,
   CONCEALMENT_SCAN_READOUT_PREFIX,
+  CONCEALMENT_TELL_READOUT_PREFIX,
   DETECTION_SCAN_READOUT_PREFIX,
   DISPLACEMENT_SCAN_READOUT_PREFIX,
 } from '../domain/detectionScanReportNotes'
+import { TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
 import {
   buildDisguiseRevealSubjectFromCase,
   detectionScanTierOrder,
@@ -415,5 +417,38 @@ describe('hiddenStateScoutingOrchestration (SPE-2282)', () => {
 
     expect(reasons.some((reason) => reason.includes(DISPLACEMENT_SCAN_READOUT_PREFIX))).toBe(true)
     expect(reasons.some((reason) => reason.includes('decoy locus annex-b'))).toBe(true)
+  })
+
+  it('attaches hiddenStateModalityTell and appends tell readout when tell tags are authored', () => {
+    const observer = createReconObserver('a_tell_orchestration', 60)
+    const team: Team = {
+      id: 'team-reveal',
+      name: 'Reveal team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    const state = createStartingState()
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    const caseData = createConcealedPresenceCase({
+      assignedTeamIds: [team.id],
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+    })
+
+    const resolution = resolveAssignedCaseForWeek(caseData, state, () => 0.5)
+    const reasons: string[] = []
+
+    expect(resolution.hiddenStateModalityTell?.active).toBe(true)
+
+    appendDetectionScanResolutionReason(
+      reasons,
+      resolution.behaviorValidation,
+      resolution.hiddenStateScouting,
+      resolution.effectiveCase,
+      resolution.hiddenStateModalityTell
+    )
+
+    expect(reasons.some((reason) => reason.includes(CONCEALMENT_TELL_READOUT_PREFIX))).toBe(true)
+    expect(resolution.effectiveCase.hiddenState).not.toBe('revealed')
   })
 })


### PR DESCRIPTION
## Summary

- Add hiddenStateModalityTells.ts with deterministic tag activation (	ell-thermal-residual, 	ell-route-timing, 	ell-speech-cadence, 	ell-metadata-spoof) and observer-threshold-strict gating via scouting capability vs concealment bands.
- Wire tell evaluation after illusion lifecycle and before hidden-state scouting compose; skip when disguise validation is active.
- Append modality-specific tell readouts to weekly esolutionReasons after scan/illusion copy, with bounded score adjustment.

## Linear

- **Slice:** [SPE-2286](https://linear.app/spectranoir/issue/SPE-2286) — Hidden-state modality matrix slice 6 (mode-specific tells)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70) — remains open (optional post-matrix families still out of scope)

## Test plan

- [x] 
pm run lint
- [x] 
pm run test:run -- src/test/hiddenStateModalityTells.test.ts src/test/detectionScanReportNotes.test.ts src/test/revealPayloadOrchestration.test.ts src/test/advanceWeek.hiddenStateScouting.test.ts
- [x] Regression: src/test/hiddenStateModality.test.ts src/test/hiddenStateIllusionLifecycle.test.ts src/test/hiddenStateScoutingReconCache.test.ts

## Docs

- Plan: planning/hidden-modality-matrix-slice-6.md (no code doc changes in this PR)

Made with [Cursor](https://cursor.com)