### PR TITLE
feat(SPE-2290): hidden-state modality slice 9 — glamour overlay

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -15,7 +15,7 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Hidden / disguised activation — post-matrix queue (SPE-70)** — Slice 7 shipped ([SPE-2288](https://linear.app/spectranoir/issue/SPE-2288) / PR #2421). **Next implementation:** [SPE-2289](https://linear.app/spectranoir/issue/SPE-2289) slice 8 (false-detection output) → [SPE-2290](https://linear.app/spectranoir/issue/SPE-2290) slice 9 (glamour). Queue: `planning/hidden-modality-matrix-post-matrix-queue.md`; slice 8 plan: `planning/hidden-modality-matrix-slice-8.md`.
+1. **Hidden / disguised activation — post-matrix queue (SPE-70)** — Slices 7–8 shipped ([SPE-2288](https://linear.app/spectranoir/issue/SPE-2288) / PR #2421, [SPE-2289](https://linear.app/spectranoir/issue/SPE-2289) / PR #2422). **Next implementation:** [SPE-2290](https://linear.app/spectranoir/issue/SPE-2290) slice 9 (glamour / presentation overlay). Queue: `planning/hidden-modality-matrix-post-matrix-queue.md`; slice 9 plan: `planning/hidden-modality-matrix-slice-9.md`.
 2. **Infiltration optional content depth** — Batch-4 probe/cover/leave-behind and report copy slice complete (`src/domain/infiltrationEncounterReportNotes.ts`). Further authored content only; not new probe mechanics.
 3. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
 
@@ -101,7 +101,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `hidden-modality-matrix-slice-6.md`                       | **Shipped**    | SPE-2286 / PR #2415; mode-specific tells / observer-threshold.                                                                                      |
 | `hidden-modality-matrix-post-matrix-queue.md`             | **Active**     | Post-matrix slices 7–9 routing; Linear SPE-2288–SPE-2290.                                                                                           |
 | `hidden-modality-matrix-slice-7.md`                       | **Shipped**    | SPE-2288 / PR #2421; signature masking modality.                                                                                                    |
-| `hidden-modality-matrix-slice-8.md`                       | **Queued**     | SPE-2289; false-detection output — next implementation slice.                                                                                       |
+| `hidden-modality-matrix-slice-8.md`                       | **Shipped**    | SPE-2289 / PR #2422; false-detection output modality.                                                                                                |
+| `hidden-modality-matrix-slice-9.md`                       | **Queued**     | SPE-2290; glamour / presentation overlay — next implementation slice.                                                                               |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/hidden-modality-matrix-post-matrix-queue.md
+++ b/planning/hidden-modality-matrix-post-matrix-queue.md
@@ -23,12 +23,12 @@ Implement **one slice at a time** — each touches `hiddenStateModality.ts` and 
 | Order | Slice | Linear   | Modality family           | Plan |
 | ----- | ----- | -------- | ------------------------- | ---- |
 | 1     | 7     | SPE-2288 | Signature masking         | `planning/hidden-modality-matrix-slice-7.md` (shipped PR #2421) |
-| 2     | 8     | SPE-2289 | False-detection output    | `planning/hidden-modality-matrix-slice-8.md` |
-| 3     | 9     | SPE-2290 | Glamour / presentation overlay | Linear body only (planning doc when slice 8 ships) |
+| 2     | 8     | SPE-2289 | False-detection output    | `planning/hidden-modality-matrix-slice-8.md` (shipped PR #2422) |
+| 3     | 9     | SPE-2290 | Glamour / presentation overlay | `planning/hidden-modality-matrix-slice-9.md` |
 
 ### Repo anchors (pre-implementation)
 
-- `HiddenStateModalityKind` today: `none`, `concealed_presence`, `false_position`, `disguised_identity`, `signature_masking` — see `src/domain/hiddenStateModality.ts`.
+- `HiddenStateModalityKind` today: `none`, `concealed_presence`, `false_position`, `disguised_identity`, `signature_masking`, `false_detection_output` — see `src/domain/hiddenStateModality.ts`.
 - Authored signature mask uses `layer:authored-signature-mask` (distinct from rating `layer:signature-mask`).
 - `layer:glamour` and rating `layer:signature-mask` remain in `concealmentLayersFromRating`; post-matrix slices add **case-authored modality paths** without removing rating layers.
 
@@ -42,7 +42,7 @@ Implement **one slice at a time** — each touches `hiddenStateModality.ts` and 
 ## Agent handoff template (next implementation slice)
 
 ```text
-PR #2421 merged. On main @ c474af93. Next: https://linear.app/spectranoir/issue/SPE-2289 — see planning/hidden-modality-matrix-slice-8.md — branch jamesdyedbq/spe-2289-hidden-state-modality-matrix-slice-8-false-detection-output.
+PR #2422 merged. On main @ 2d10cb9d. Next: https://linear.app/spectranoir/issue/SPE-2290 — see planning/hidden-modality-matrix-slice-9.md — branch jamesdyedbq/spe-2290-hidden-state-modality-matrix-slice-9-glamour-presentation.
 ```
 
 ## See also

--- a/planning/hidden-modality-matrix-slice-8.md
+++ b/planning/hidden-modality-matrix-slice-8.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2289](https://linear.app/spectranoir/
 | **Linear** | [SPE-2289 — Hidden-state modality matrix slice 8](https://linear.app/spectranoir/issue/SPE-2289) |
 | **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70)                                                |
 | **Branch** | `jamesdyedbq/spe-2289-hidden-state-modality-matrix-slice-8-false-detection-output`                   |
-| **Status** | **Implemented** — pending PR                                                                                         |
+| **Status** | Shipped — SPE-2289 / PR #2422                                                                                      |
 
 ## Goal
 

--- a/planning/hidden-modality-matrix-slice-9.md
+++ b/planning/hidden-modality-matrix-slice-9.md
@@ -1,0 +1,105 @@
+# SPE-70 — Hidden-state modality matrix slice 9 (glamour / presentation overlay)
+
+One-page implementation plan. Linear: [SPE-2290](https://linear.app/spectranoir/issue/SPE-2290) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Follows shipped [SPE-2289](https://linear.app/spectranoir/issue/SPE-2289) (PR #2422).
+
+| Field      | Value                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2290 — Hidden-state modality matrix slice 9](https://linear.app/spectranoir/issue/SPE-2290) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70)                                                |
+| **Branch** | `jamesdyedbq/spe-2290-hidden-state-modality-matrix-slice-9-glamour-presentation`                   |
+| **Status** | **In Progress** — implementation on branch                                                   |
+
+## Goal
+
+Add **glamour / presentation overlay** as a sixth case-authored `HiddenStateModalityKind` so perception-layer fiction can block or skew category/hostility/identity tiers through the modality compose path — reusing glamour semantics beyond generic `concealmentLayersFromRating`, without collapsing to instant full reveal.
+
+## Prerequisite (on `main` @ `2d10cb9d`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Modality compose     | `hiddenStateModality.ts`, `resolveScoutingWithCaseHiddenState`         |
+| Post-matrix slice 7  | `signature_masking`, `layer:authored-signature-mask`, category skew    |
+| Post-matrix slice 8  | `false_detection_output`, `layer:authored-false-detection`, fabricated readouts |
+| Weekly orchestration | `evaluateHiddenStateScoutingWithRevealPayload`                         |
+| Modality report copy | `detectionScanReportNotes.ts`                                          |
+| Rating glamour layer | `concealmentLayersFromRating` → `layer:glamour` in `revealPayloadScoutingIntegration.ts` |
+
+## Gap (pre-slice)
+
+- `layer:glamour` applies from **anomaly concealment rating ≥ 2** only; no authored case modality.
+- `HiddenStateModalityKind` has no `glamour_overlay` family.
+- Modality report copy has no glamour/presentation-overlay prefix.
+- Counter-reveal strips modality layers per family; glamour is not a selectable outer layer in the modality path.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Extend `HiddenStateModalityKind` with `glamour_overlay`                                                                            | Out-of-phase / anti-scan compartment families |
+| Authored activation via case tags (`modality-glamour` and/or `presentation-overlay`)                                               | Mission triage UI                             |
+| Modality layer **`layer:authored-glamour`** (distinct from rating `layer:glamour` — same dedupe lesson as slice 7)                 | Full SPE-70 parent Done                       |
+| `applyGlamourOverlayScanProjection` — deterministic presentation skew (category/hostility); canonical truth fields unchanged       | Per-channel observer matrix                   |
+| Report prefix **`Glamour readout:`** (or align with slice 3 naming in implementation)                                              | Template-wide migration beyond 2–3 fixtures   |
+| Wire through orchestration stack; optional tell tag hook if bounded                                                                 | RNG / probabilistic outputs                   |
+| Unit + `advanceWeek` integration tests                                                                                             | Removing rating-derived `layer:glamour`       |
+
+## Modality contract (deterministic)
+
+### Activation (authored)
+
+- Tag `modality-glamour` or `presentation-overlay` while `hiddenState` is non-`revealed`.
+- Resolver priority (stable): `displaced` > `disguised_identity` > `false_detection_output` > `signature_masking` > **`glamour_overlay`** > `concealed_presence`.
+
+### Scan behavior
+
+- Presence may register; **category, hostility, and exact identity** tiers blocked by `layer:authored-glamour` (mirror rating glamour blocked tiers).
+- Category/hostility readouts show **authored presentation skew** (fixture constant e.g. `benign facility presentation`) while internal truth retains canonical identity.
+- Skew values are **projection-only** — do not mutate `CaseInstance` truth fields.
+- `counterDetection: true` strips `layer:authored-glamour` without solving other modality families.
+- Rating-derived `layer:glamour` still applies when modality tag absent (regression).
+
+### Player-facing output
+
+- Prefix: `Glamour readout:` (distinct from signature-mask and false-detection prefixes).
+- One deterministic sentence when modality active; dedupe via existing `resolutionReasons` guard.
+
+## Acceptance
+
+- [ ] Authored fixture: scan shows presentation skew; category/hostility/exact_identity blocked; internal truth unchanged; `hiddenState` stays non-`revealed`.
+- [ ] Distinct `DetectionScanResult` from signature-mask and false-detection fixtures in shared compose path.
+- [ ] Counter-detection strips glamour overlay layer only; slices 1–8 regression unchanged.
+- [ ] Rating-derived `layer:glamour` from high concealment rating still works when modality tag absent.
+- [ ] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Modality resolver** — tag activation, priority vs slice 7–8 families.
+2. **Truth + layer compose** — presentation projection + counter-reveal strip.
+3. **Report copy** — prefix + append dedupe.
+4. **`advanceWeek`** — one integration fixture for glamour overlay.
+5. **Regression** — signature-mask, false-detection, tells, recon cache, rating-layer tests unchanged.
+
+## File touch list (expected)
+
+| Area           | Files                                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| Modality       | `src/domain/hiddenStateModality.ts`                                                           |
+| Compose        | `src/domain/revealPayloadScoutingIntegration.ts`                                              |
+| Report copy    | `src/domain/detectionScanReportNotes.ts`                                                      |
+| Tells (optional) | `src/domain/hiddenStateModalityTells.ts`                                                    |
+| Tests          | `src/test/hiddenStateModality.test.ts`, extend `advanceWeek.hiddenStateScouting.test.ts`      |
+
+## Branch
+
+`jamesdyedbq/spe-2290-hidden-state-modality-matrix-slice-9-glamour-presentation`
+
+## Out of scope (parent closure)
+
+- Full SPE-70 parent Done (evaluate after slice 9 ships or owner defers remainder)
+- Out-of-phase / liminal presence, anti-scan compartments, mission triage chips
+
+## See also
+
+- `architecture/hidden-state-displacement-counter-detection.md` — Glamour / presentation overlay vocabulary
+- `planning/hidden-modality-matrix-slice-8.md`
+- `src/domain/revealPayloadScoutingIntegration.ts` — `GLAMOUR_LAYER`, `concealmentLayersFromRating`

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -35,6 +35,7 @@ export const DISPLACEMENT_SCAN_READOUT_PREFIX = 'Displacement readout:'
 export const COVER_SCAN_READOUT_PREFIX = 'Cover readout:'
 export const SIGNATURE_MASK_SCAN_READOUT_PREFIX = 'Signature mask readout:'
 export const FALSE_DETECTION_SCAN_READOUT_PREFIX = 'False-detection readout:'
+export const GLAMOUR_SCAN_READOUT_PREFIX = 'Glamour readout:'
 
 export const DETECTION_SCAN_READOUT_PREFIXES = [
   DETECTION_SCAN_READOUT_PREFIX,
@@ -43,6 +44,7 @@ export const DETECTION_SCAN_READOUT_PREFIXES = [
   COVER_SCAN_READOUT_PREFIX,
   SIGNATURE_MASK_SCAN_READOUT_PREFIX,
   FALSE_DETECTION_SCAN_READOUT_PREFIX,
+  GLAMOUR_SCAN_READOUT_PREFIX,
   FABRICATED_CONTACT_READOUT_PREFIX,
   STRUCTURAL_ILLUSION_READOUT_PREFIX,
 ] as const
@@ -61,6 +63,8 @@ export function detectionScanReadoutPrefixForModality(
       return SIGNATURE_MASK_SCAN_READOUT_PREFIX
     case 'false_detection_output':
       return FALSE_DETECTION_SCAN_READOUT_PREFIX
+    case 'glamour_overlay':
+      return GLAMOUR_SCAN_READOUT_PREFIX
     case 'none':
       return DETECTION_SCAN_READOUT_PREFIX
     default: {

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -34,13 +34,20 @@ export type HiddenStateModalityKind =
   | 'disguised_identity'
   | 'signature_masking'
   | 'false_detection_output'
+  | 'glamour_overlay'
 
 export const MODALITY_SIGNATURE_MASK_TAG = 'modality-signature-mask'
 export const MODALITY_FALSE_DETECTION_TAG = 'modality-false-detection'
+export const MODALITY_GLAMOUR_TAG = 'modality-glamour'
+export const PRESENTATION_OVERLAY_TAG = 'presentation-overlay'
 export const INSTRUMENTATION_ATTACK_TAG = 'instrumentation-attack'
 
 /** Player-facing category skew when signature-masking modality is active. */
 export const SIGNATURE_MASK_CATEGORY_SKEW = 'benign utility signature'
+
+/** Player-facing presentation skew when glamour-overlay modality is active. */
+export const GLAMOUR_OVERLAY_CATEGORY_SKEW = 'benign facility presentation'
+export const GLAMOUR_OVERLAY_HOSTILITY_SKEW = 'dormant presentation'
 
 /** Player-facing fabricated readouts when false-detection modality is active. */
 export const FALSE_DETECTION_FABRICATED_PRESENCE = 'fabricated maintenance contact'
@@ -71,6 +78,11 @@ const FALSE_DETECTION_LAYER: ConcealmentLayer = {
   blockedTiers: ['exact_identity'],
 }
 
+const GLAMOUR_OVERLAY_LAYER: ConcealmentLayer = {
+  id: 'layer:authored-glamour',
+  blockedTiers: ['category', 'hostility', 'exact_identity'],
+}
+
 const DISGUISE_SIGNAL_TAGS = ['infiltration', 'disguise', 'covert', 'stealth'] as const
 
 function caseModalityTagSet(caseData: CaseInstance): Set<string> {
@@ -89,6 +101,12 @@ export function caseHasFalseDetectionModality(caseData: CaseInstance): boolean {
 
 export function caseHasSignatureMaskModality(caseData: CaseInstance): boolean {
   return caseModalityTagSet(caseData).has(MODALITY_SIGNATURE_MASK_TAG)
+}
+
+export function caseHasGlamourOverlayModality(caseData: CaseInstance): boolean {
+  const tags = caseModalityTagSet(caseData)
+
+  return tags.has(MODALITY_GLAMOUR_TAG) || tags.has(PRESENTATION_OVERLAY_TAG)
 }
 
 export function caseHasDisguiseSignals(caseData: CaseInstance): boolean {
@@ -122,6 +140,10 @@ export function resolveHiddenStateModality(caseData: CaseInstance): HiddenStateM
     return 'signature_masking'
   }
 
+  if (caseHasGlamourOverlayModality(caseData)) {
+    return 'glamour_overlay'
+  }
+
   return 'concealed_presence'
 }
 
@@ -139,6 +161,8 @@ export function hiddenStateModalityLayer(
       return SIGNATURE_MASKING_LAYER
     case 'false_detection_output':
       return FALSE_DETECTION_LAYER
+    case 'glamour_overlay':
+      return GLAMOUR_OVERLAY_LAYER
     case 'none':
       return null
     default: {
@@ -314,6 +338,34 @@ export function applySignatureMaskScanProjection(scan: DetectionScanResult): Det
       return {
         ...field,
         playerFacingValue: SIGNATURE_MASK_CATEGORY_SKEW,
+        ambiguous: true,
+      }
+    }
+
+    return field
+  })
+
+  return {
+    ...scan,
+    fields,
+  }
+}
+
+/** Player-facing scan projection for glamour overlay without mutating canonical truth tiers. */
+export function applyGlamourOverlayScanProjection(scan: DetectionScanResult): DetectionScanResult {
+  const fields = scan.fields.map((field) => {
+    if (field.tier === 'category') {
+      return {
+        ...field,
+        playerFacingValue: GLAMOUR_OVERLAY_CATEGORY_SKEW,
+        ambiguous: true,
+      }
+    }
+
+    if (field.tier === 'hostility') {
+      return {
+        ...field,
+        playerFacingValue: GLAMOUR_OVERLAY_HOSTILITY_SKEW,
         ambiguous: true,
       }
     }

--- a/src/domain/hiddenStateModalityTells.ts
+++ b/src/domain/hiddenStateModalityTells.ts
@@ -148,6 +148,8 @@ export function tellReadoutPrefixForModality(modality: HiddenStateModalityKind):
       return COVER_TELL_READOUT_PREFIX
     case 'signature_masking':
       return SIGNATURE_MASK_TELL_READOUT_PREFIX
+    case 'false_detection_output':
+    case 'glamour_overlay':
     case 'none':
       return null
     default: {

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -23,6 +23,7 @@ import {
 import {
   applyFalsePositionScanProjection,
   applyFalseDetectionScanProjection,
+  applyGlamourOverlayScanProjection,
   applySignatureMaskScanProjection,
   buildSubjectTruthFromCaseHiddenState,
   resolveHiddenStateModality,
@@ -323,6 +324,10 @@ export function resolveScoutingWithCaseHiddenState(
 
   if (modality === 'false_detection_output') {
     detectionScan = applyFalseDetectionScanProjection(detectionScan)
+  }
+
+  if (modality === 'glamour_overlay') {
+    detectionScan = applyGlamourOverlayScanProjection(detectionScan)
   }
 
   if (

--- a/src/test/advanceWeek.hiddenStateScouting.test.ts
+++ b/src/test/advanceWeek.hiddenStateScouting.test.ts
@@ -8,10 +8,13 @@ import {
   DETECTION_SCAN_READOUT_PREFIX,
   SIGNATURE_MASK_SCAN_READOUT_PREFIX,
   FALSE_DETECTION_SCAN_READOUT_PREFIX,
+  GLAMOUR_SCAN_READOUT_PREFIX,
 } from '../domain/detectionScanReportNotes'
 import {
   MODALITY_FALSE_DETECTION_TAG,
+  MODALITY_GLAMOUR_TAG,
   MODALITY_SIGNATURE_MASK_TAG,
+  GLAMOUR_OVERLAY_CATEGORY_SKEW,
 } from '../domain/hiddenStateModality'
 import { TELL_ROUTE_TIMING_TAG, TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
 import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
@@ -330,6 +333,50 @@ describe('advanceWeek hidden-state scouting report copy (SPE-2283)', () => {
     expect(
       snapshot?.missionResult?.explanationNotes.some((note) =>
         note.includes('fabricated maintenance contact')
+      )
+    ).toBe(true)
+    expect(snapshot?.hiddenState).not.toBe('revealed')
+  })
+
+  it('surfaces glamour readout without revealing hidden state', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_glamour_readout', 60)
+    const team: Team = {
+      id: 'team-glamour-readout',
+      name: 'Glamour readout team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-concealed-readout'] = tuneConcealedInvestigationCase(state, team.id, {
+      tags: [MODALITY_GLAMOUR_TAG],
+    })
+
+    const preAdvance = resolveAssignedCaseForWeek(state.cases['case-concealed-readout'], state, () => 0.5)
+    expect(preAdvance.hiddenStateScouting?.active).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const snapshot =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-concealed-readout']
+
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) =>
+        note.includes(GLAMOUR_SCAN_READOUT_PREFIX)
+      )
+    ).toBe(true)
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) =>
+        note.includes(GLAMOUR_OVERLAY_CATEGORY_SKEW)
       )
     ).toBe(true)
     expect(snapshot?.hiddenState).not.toBe('revealed')

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -8,6 +8,7 @@ import {
   DETECTION_SCAN_READOUT_PREFIX,
   detectionScanReadoutPrefixForModality,
   DISPLACEMENT_SCAN_READOUT_PREFIX,
+  GLAMOUR_SCAN_READOUT_PREFIX,
   formatDetectionScanSummary,
   shouldAppendDetectionScanReportNote,
   shouldAppendModalityTellReportNote,
@@ -68,6 +69,7 @@ describe('detectionScanReportNotes', () => {
       DISPLACEMENT_SCAN_READOUT_PREFIX
     )
     expect(detectionScanReadoutPrefixForModality('disguised_identity')).toBe(COVER_SCAN_READOUT_PREFIX)
+    expect(detectionScanReadoutPrefixForModality('glamour_overlay')).toBe(GLAMOUR_SCAN_READOUT_PREFIX)
   })
 
   it('appends counter-detection peel suffix when layers were stripped', () => {

--- a/src/test/hiddenStateModality.test.ts
+++ b/src/test/hiddenStateModality.test.ts
@@ -2,15 +2,20 @@ import { describe, expect, it } from 'vitest'
 import {
   applyFalsePositionScanProjection,
   applyFalseDetectionScanProjection,
+  applyGlamourOverlayScanProjection,
   applySignatureMaskScanProjection,
   buildSubjectTruthFromCaseHiddenState,
   formatDecoyLocusLabel,
   FALSE_DETECTION_FABRICATED_CATEGORY,
   FALSE_DETECTION_FABRICATED_PRESENCE,
+  GLAMOUR_OVERLAY_CATEGORY_SKEW,
+  GLAMOUR_OVERLAY_HOSTILITY_SKEW,
   hiddenStateModalityLayer,
   INSTRUMENTATION_ATTACK_TAG,
   MODALITY_FALSE_DETECTION_TAG,
+  MODALITY_GLAMOUR_TAG,
   MODALITY_SIGNATURE_MASK_TAG,
+  PRESENTATION_OVERLAY_TAG,
   resolveHiddenStateModality,
   scoutingOutcomeToDetectionScanForCase,
   SIGNATURE_MASK_CATEGORY_SKEW,
@@ -124,6 +129,42 @@ describe('hiddenStateModality (SPE-2281)', () => {
         })
       )
     ).toBe('false_detection_output')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [MODALITY_GLAMOUR_TAG],
+        })
+      )
+    ).toBe('glamour_overlay')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [PRESENTATION_OVERLAY_TAG],
+        })
+      )
+    ).toBe('glamour_overlay')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [MODALITY_SIGNATURE_MASK_TAG, MODALITY_GLAMOUR_TAG],
+        })
+      )
+    ).toBe('signature_masking')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [MODALITY_FALSE_DETECTION_TAG, MODALITY_GLAMOUR_TAG],
+        })
+      )
+    ).toBe('false_detection_output')
+  })
+
+  it('maps glamour overlay to authored glamour layer', () => {
+    expect(hiddenStateModalityLayer('glamour_overlay')?.id).toBe('layer:authored-glamour')
   })
 
   it('maps false-detection output to authored false-detection layer', () => {
@@ -433,6 +474,134 @@ describe('hiddenStateModality (SPE-2281)', () => {
       signatureMasked.detectionScan.fields.find((field) => field.tier === 'category')
         ?.playerFacingValue
     ).toBe(SIGNATURE_MASK_CATEGORY_SKEW)
+  })
+
+  it('projects glamour-overlay presentation skew while blocking deeper tiers until stripped', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_GLAMOUR_TAG],
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_LOW_CONCEALMENT, SUBJECT)
+    const blocked = resolveDetectionScan(truth, { family: 'category_pass' })
+
+    expect(detectionScanTierOrder(blocked)).toEqual(['presence'])
+    expect(blocked.fields.some((field) => field.tier === 'category')).toBe(false)
+
+    const blockedProbe = resolveDetectionScan(truth, { family: 'identity_probe' })
+    expect(detectionScanTierOrder(blockedProbe)).toEqual(['presence', 'concealment_depth'])
+    expect(blockedProbe.fields.some((field) => field.tier === 'category')).toBe(false)
+    expect(blockedProbe.fields.some((field) => field.tier === 'hostility')).toBe(false)
+    expect(blockedProbe.fields.some((field) => field.tier === 'exact_identity')).toBe(false)
+
+    const scan = applyGlamourOverlayScanProjection(
+      resolveDetectionScan(truth, { family: 'identity_probe', layersToStrip: 1 })
+    )
+
+    expect(scan.fields.find((field) => field.tier === 'category')?.playerFacingValue).toBe(
+      GLAMOUR_OVERLAY_CATEGORY_SKEW
+    )
+    expect(scan.fields.find((field) => field.tier === 'category')?.internalValue).toBe(
+      'spectral intruder'
+    )
+    expect(scan.fields.find((field) => field.tier === 'hostility')?.playerFacingValue).toBe(
+      GLAMOUR_OVERLAY_HOSTILITY_SKEW
+    )
+    expect(scan.fields.find((field) => field.tier === 'hostility')?.internalValue).toBe('latent')
+    expect(scan.strippedLayerIds).toEqual(['layer:authored-glamour'])
+  })
+
+  it('strips glamour-overlay layer on counter-detection without solving rating layers', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      counterDetection: true,
+      tags: [MODALITY_GLAMOUR_TAG],
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_INPUT, SUBJECT)
+    const scanInput = scoutingOutcomeToDetectionScanForCase(
+      { outcome: 'strong', revealed: true, withheld: false },
+      caseData
+    )
+
+    expect(scanInput).toEqual({ family: 'identity_probe', layersToStrip: 1 })
+
+    const scan = resolveDetectionScan(truth, scanInput)
+    expect(scan.strippedLayerIds).toEqual(['layer:authored-glamour'])
+    expect(scan.remainingConcealmentLayers.some((layer) => layer.id === 'layer:glamour')).toBe(true)
+    expect(detectionScanTierOrder(scan)).not.toContain('exact_identity')
+  })
+
+  it('preserves rating-derived glamour when authored glamour layer is stripped', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      counterDetection: true,
+      tags: [MODALITY_GLAMOUR_TAG],
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_INPUT, SUBJECT)
+
+    expect(truth.concealmentLayers.map((layer) => layer.id)).toEqual([
+      'layer:authored-glamour',
+      'layer:glamour',
+      'layer:signature-mask',
+    ])
+
+    const scan = resolveDetectionScan(truth, { family: 'identity_probe', layersToStrip: 1 })
+    expect(scan.strippedLayerIds).toEqual(['layer:authored-glamour'])
+    expect(scan.remainingConcealmentLayers.map((layer) => layer.id)).toEqual([
+      'layer:glamour',
+      'layer:signature-mask',
+    ])
+    expect(detectionScanTierOrder(scan)).not.toContain('exact_identity')
+  })
+
+  it('includes glamour overlay in distinct modality compose path', () => {
+    const glamourOverlay = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_GLAMOUR_TAG],
+      }),
+    })
+    const signatureMasked = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_SIGNATURE_MASK_TAG],
+      }),
+    })
+    const falseDetection = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_FALSE_DETECTION_TAG],
+      }),
+    })
+
+    expect(glamourOverlay.detectionScan.strippedLayerIds).toEqual(['layer:authored-glamour'])
+    expect(
+      glamourOverlay.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toBe(GLAMOUR_OVERLAY_CATEGORY_SKEW)
+    expect(
+      glamourOverlay.detectionScan.fields.find((field) => field.tier === 'hostility')?.playerFacingValue
+    ).toBe(GLAMOUR_OVERLAY_HOSTILITY_SKEW)
+    expect(
+      signatureMasked.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toBe(SIGNATURE_MASK_CATEGORY_SKEW)
+    expect(
+      falseDetection.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toBe(FALSE_DETECTION_FABRICATED_CATEGORY)
+  })
+
+  it('preserves rating-derived glamour layer when modality tag absent', () => {
+    const caseData = createModalityCase({ hiddenState: 'hidden', tags: ['concealment'] })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_INPUT, SUBJECT)
+
+    expect(truth.concealmentLayers.some((layer) => layer.id === 'layer:glamour')).toBe(true)
+    expect(truth.concealmentLayers.some((layer) => layer.id === 'layer:authored-glamour')).toBe(
+      false
+    )
   })
 
   it('preserves legacy scouting fields while attaching modality-aware detection scans', () => {


### PR DESCRIPTION
## Summary

- Add glamour_overlay as a sixth case-authored HiddenStateModalityKind, activated by modality-glamour or presentation-overlay tags while hiddenState is non-revealed.
- Introduce layer:authored-glamour (distinct from rating layer:glamour) blocking category/hostility/exact_identity; pplyGlamourOverlayScanProjection skews presentation readouts without mutating canonical truth.
- Wire Glamour readout: report prefix through orchestration; counter-detection strips only the authored layer.

**Linear:** [SPE-2290](https://linear.app/spectranoir/issue/SPE-2290) (child of [SPE-70](https://linear.app/spectranoir/issue/SPE-70))

## What shipped

- Modality resolver, layer compose, scan projection, report copy
- Unit tests in hiddenStateModality.test.ts and detectionScanReportNotes.test.ts
- dvanceWeek integration fixture for glamour readout
- Planning docs: slice 9 plan, backlog/queue reconciliation

## Validation

- 
pm run test:run -- src/test/hiddenStateModality.test.ts src/test/advanceWeek.hiddenStateScouting.test.ts src/test/detectionScanReportNotes.test.ts src/test/revealPayloadScoutingIntegration.test.ts — 53 passed
- 
pm run lint — green

## Docs updated

- planning/hidden-modality-matrix-slice-9.md
- planning/backlog.md
- planning/hidden-modality-matrix-post-matrix-queue.md
- planning/hidden-modality-matrix-slice-8.md (shipped status)

## Parent status

SPE-70 remains **open** — slice 9 completes the post-matrix queue (slices 7–9); out-of-phase / anti-scan families remain out of scope.

Made with [Cursor](https://cursor.com)