### PR TITLE
feat(SPE-2106): unexplained location registry — low-threat site intake (slice 1)

### DIFF
--- a/src/domain/unexplainedLocationRegistry.ts
+++ b/src/domain/unexplainedLocationRegistry.ts
@@ -264,6 +264,20 @@ function normalizeToken(value: unknown) {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function asStringArray(value: unknown): readonly string[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asPopulationSelectors(value: unknown): readonly PopulationSelector[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asStatusHistory(
+  value: unknown
+): readonly UnexplainedLocationStatusHistoryEntry[] {
+  return Array.isArray(value) ? value : []
+}
+
 function pushIssue(
   issues: UnexplainedLocationValidationIssue[],
   issue: UnexplainedLocationValidationIssue
@@ -322,15 +336,15 @@ function hasSecurityTag(
   record: UnexplainedLocationRecord,
   tag: SecurityControlTag
 ): boolean {
-  return (record.securityControlTags ?? []).includes(tag)
+  return asStringArray(record.securityControlTags).includes(tag)
 }
 
 function resolveConfidence(
   record: UnexplainedLocationRecord,
   policy: UnexplainedLocationMapProjectionPolicy
 ): number | null {
-  const redactedFields = new Set(record.redactedFields ?? [])
-  const unknownFields = record.unknownFields ?? []
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
 
   if (redactedFields.has('confidence')) {
     return null
@@ -352,7 +366,7 @@ function resolveLocationTag(
   record: UnexplainedLocationRecord,
   policy: UnexplainedLocationMapProjectionPolicy
 ): string | null {
-  const redactedFields = new Set(record.redactedFields ?? [])
+  const redactedFields = new Set(asStringArray(record.redactedFields))
   const locationRedacted =
     redactedFields.has('locationTag') ||
     (policy.suppressRedactedLocation === true && redactedFields.has('location'))
@@ -428,7 +442,7 @@ export function validateUnexplainedLocationRecord(
     })
   }
 
-  for (const tag of record.effectDomainTags ?? []) {
+  for (const tag of asStringArray(record.effectDomainTags)) {
     if (!isEffectDomainTag(tag)) {
       pushIssue(issues, {
         code: 'invalid_effect_domain_tag',
@@ -439,7 +453,17 @@ export function validateUnexplainedLocationRecord(
     }
   }
 
-  for (const selector of record.populationSelectors ?? []) {
+  for (const selector of asPopulationSelectors(record.populationSelectors)) {
+    if (!selector || typeof selector !== 'object') {
+      pushIssue(issues, {
+        code: 'invalid_population_selector_kind',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} has invalid population selector entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
     if (!isPopulationSelectorKind(selector.kind)) {
       pushIssue(issues, {
         code: 'invalid_population_selector_kind',
@@ -459,7 +483,7 @@ export function validateUnexplainedLocationRecord(
     }
   }
 
-  for (const tag of record.securityControlTags ?? []) {
+  for (const tag of asStringArray(record.securityControlTags)) {
     if (!isSecurityControlTag(tag)) {
       pushIssue(issues, {
         code: 'invalid_security_control_tag',
@@ -536,7 +560,17 @@ export function validateUnexplainedLocationRecord(
     })
   }
 
-  for (const entry of record.statusHistory ?? []) {
+  for (const entry of asStatusHistory(record.statusHistory)) {
+    if (!entry || typeof entry !== 'object') {
+      pushIssue(issues, {
+        code: 'invalid_status_history_state',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} statusHistory contains invalid entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
     if (!isUnexplainedLocationLifecycleState(entry.fromState) || !isUnexplainedLocationLifecycleState(entry.toState)) {
       pushIssue(issues, {
         code: 'invalid_status_history_state',
@@ -580,7 +614,7 @@ export function validateUnexplainedLocationRecord(
 
   if (
     record.lifecycleState === 'disputed' &&
-    (record.contradictionRefs ?? []).every((ref) => !normalizeToken(ref))
+    asStringArray(record.contradictionRefs).every((ref) => !normalizeToken(ref))
   ) {
     pushIssue(issues, {
       code: 'disputed_without_contradiction_refs',
@@ -626,7 +660,9 @@ export function projectUnexplainedLocationForMap(
   const locationId = normalizeToken(record.id) || '(unknown)'
   const locationTag = resolveLocationTag(record, policy)
   const confidence = resolveConfidence(record, policy)
-  const unknownFields = Object.freeze([...(record.unknownFields ?? [])].sort((a, b) => a.localeCompare(b)))
+  const unknownFields = Object.freeze(
+    [...asStringArray(record.unknownFields)].sort((a, b) => a.localeCompare(b))
+  )
   const mapSuppressed = hasSecurityTag(record, 'map_manipulation')
 
   const publicLayer = Object.freeze({

--- a/src/domain/unexplainedLocationRegistry.ts
+++ b/src/domain/unexplainedLocationRegistry.ts
@@ -1,0 +1,733 @@
+/**
+ * SPE-2106 slice 1: unexplained location registry for low-threat site intake.
+ *
+ * Pure deterministic registry for persistent anomalous places warranting securing
+ * and cover-up below full containment-project priority — distinct from minor objects,
+ * brief events, and full facility/case lifecycle.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type UnexplainedLocationId = string
+
+export type EffectDomainTag =
+  | 'biological'
+  | 'spatial'
+  | 'temporal'
+  | 'media'
+  | 'cognitive'
+  | 'animal'
+  | 'environmental'
+  | 'infrastructural'
+  | 'jurisdictional'
+  | 'record_affecting'
+
+export const EFFECT_DOMAIN_TAGS: readonly EffectDomainTag[] = [
+  'biological',
+  'spatial',
+  'temporal',
+  'media',
+  'cognitive',
+  'animal',
+  'environmental',
+  'infrastructural',
+  'jurisdictional',
+  'record_affecting',
+] as const
+
+export type EffectGeometry =
+  | 'point'
+  | 'room'
+  | 'building'
+  | 'route'
+  | 'radius'
+  | 'volume'
+  | 'civic_boundary'
+  | 'orbital_zone'
+
+export const EFFECT_GEOMETRIES: readonly EffectGeometry[] = [
+  'point',
+  'room',
+  'building',
+  'route',
+  'radius',
+  'volume',
+  'civic_boundary',
+  'orbital_zone',
+] as const
+
+export type PopulationSelectorKind =
+  | 'location'
+  | 'role'
+  | 'name'
+  | 'species'
+  | 'staff'
+  | 'viewer'
+  | 'memory_state'
+
+export const POPULATION_SELECTOR_KINDS: readonly PopulationSelectorKind[] = [
+  'location',
+  'role',
+  'name',
+  'species',
+  'staff',
+  'viewer',
+  'memory_state',
+] as const
+
+export type SecurityControlTag =
+  | 'physical_exclusion'
+  | 'legal_ownership'
+  | 'public_cover'
+  | 'sensor_monitoring'
+  | 'staff_presence'
+  | 'map_manipulation'
+  | 'minimal_response'
+
+export const SECURITY_CONTROL_TAGS: readonly SecurityControlTag[] = [
+  'physical_exclusion',
+  'legal_ownership',
+  'public_cover',
+  'sensor_monitoring',
+  'staff_presence',
+  'map_manipulation',
+  'minimal_response',
+] as const
+
+export type UnexplainedLocationLifecycleState =
+  | 'active'
+  | 'monitor_only'
+  | 'utility_use'
+  | 'public_managed'
+  | 'neutralized'
+  | 'archived'
+  | 'destroyed'
+  | 'disputed'
+  | 'pending_reactivation'
+
+export const UNEXPLAINED_LOCATION_LIFECYCLE_STATES: readonly UnexplainedLocationLifecycleState[] =
+  [
+    'active',
+    'monitor_only',
+    'utility_use',
+    'public_managed',
+    'neutralized',
+    'archived',
+    'destroyed',
+    'disputed',
+    'pending_reactivation',
+  ] as const
+
+export type UnexplainedLocationMapLayer = 'public' | 'agency' | 'sensor' | 'inferred_route'
+
+export const UNEXPLAINED_LOCATION_MAP_LAYERS: readonly UnexplainedLocationMapLayer[] = [
+  'public',
+  'agency',
+  'sensor',
+  'inferred_route',
+] as const
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface PopulationSelector {
+  readonly kind: PopulationSelectorKind
+  readonly value: string
+}
+
+export interface UnexplainedLocationStatusHistoryEntry {
+  readonly fromState: UnexplainedLocationLifecycleState
+  readonly toState: UnexplainedLocationLifecycleState
+  readonly week: number
+  readonly note?: string
+}
+
+export interface UnexplainedLocationUpdateLedgerEntry {
+  readonly week: number
+  readonly field: string
+  readonly note?: string
+}
+
+export interface UnexplainedLocationRecord {
+  readonly id: UnexplainedLocationId
+  readonly label: string
+  readonly descriptionStub?: string
+  readonly effectGeometry: EffectGeometry
+  readonly effectDomainTags: readonly EffectDomainTag[]
+  readonly populationSelectors: readonly PopulationSelector[]
+  readonly discoveryWeek?: number
+  readonly containmentWeek?: number
+  readonly securityControlTags?: readonly SecurityControlTag[]
+  readonly coverStoryCode?: string
+  readonly monitoringCadenceWeeks?: number
+  readonly lifecycleState: UnexplainedLocationLifecycleState
+  readonly latentSeverityScore: number
+  readonly accessProbability?: number
+  readonly lowPriority?: boolean
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+  readonly disputedFields?: readonly string[]
+  readonly contradictionRefs?: readonly string[]
+  readonly neutralizationAuthorizationRef?: string
+  readonly mapLayerPolicy?: string
+  readonly locationTag?: string
+  readonly statusHistory?: readonly UnexplainedLocationStatusHistoryEntry[]
+  readonly updateLedger?: readonly UnexplainedLocationUpdateLedgerEntry[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type UnexplainedLocationValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'invalid_effect_geometry'
+  | 'invalid_effect_domain_tag'
+  | 'invalid_population_selector_kind'
+  | 'empty_population_selector_value'
+  | 'invalid_security_control_tag'
+  | 'invalid_lifecycle_state'
+  | 'invalid_latent_severity_score'
+  | 'invalid_access_probability'
+  | 'invalid_confidence'
+  | 'invalid_discovery_week'
+  | 'invalid_containment_week'
+  | 'invalid_monitoring_cadence'
+  | 'invalid_status_history_state'
+  | 'invalid_status_history_week'
+  | 'neutralized_without_authorization'
+  | 'low_priority_without_latent_severity'
+  | 'disputed_without_contradiction_refs'
+  | 'map_suppression_without_layer_policy'
+  | 'severity_underestimate'
+
+export interface UnexplainedLocationValidationIssue {
+  readonly code: UnexplainedLocationValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface UnexplainedLocationValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly UnexplainedLocationValidationIssue[]
+}
+
+export interface UnexplainedLocationValidationPolicy {
+  readonly requireNeutralizationAuthorization?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Map projection
+// ---------------------------------------------------------------------------
+
+export interface UnexplainedLocationMapProjectionPolicy {
+  readonly minimumConfidence?: number
+  readonly redactUnknown?: boolean
+  readonly suppressRedactedLocation?: boolean
+}
+
+export interface UnexplainedLocationMapLayerProjection {
+  readonly layer: UnexplainedLocationMapLayer
+  readonly locationTag: string | null
+  readonly effectGeometry: EffectGeometry
+  readonly confidence: number | null
+  readonly suppressed: boolean
+  readonly unknownFields: readonly string[]
+}
+
+export interface UnexplainedLocationMapProjection {
+  readonly locationId: UnexplainedLocationId
+  readonly layers: readonly UnexplainedLocationMapLayerProjection[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const EFFECT_DOMAIN_TAG_SET = new Set<string>(EFFECT_DOMAIN_TAGS)
+const EFFECT_GEOMETRY_SET = new Set<string>(EFFECT_GEOMETRIES)
+const POPULATION_SELECTOR_KIND_SET = new Set<string>(POPULATION_SELECTOR_KINDS)
+const SECURITY_CONTROL_TAG_SET = new Set<string>(SECURITY_CONTROL_TAGS)
+const LIFECYCLE_STATE_SET = new Set<string>(UNEXPLAINED_LOCATION_LIFECYCLE_STATES)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function pushIssue(
+  issues: UnexplainedLocationValidationIssue[],
+  issue: UnexplainedLocationValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: UnexplainedLocationValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function isValidUnitInterval(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function isValidSeverityScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 100
+}
+
+function freezeValidationResult(
+  issues: UnexplainedLocationValidationIssue[]
+): UnexplainedLocationValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function hasSecurityTag(
+  record: UnexplainedLocationRecord,
+  tag: SecurityControlTag
+): boolean {
+  return (record.securityControlTags ?? []).includes(tag)
+}
+
+function resolveConfidence(
+  record: UnexplainedLocationRecord,
+  policy: UnexplainedLocationMapProjectionPolicy
+): number | null {
+  const redactedFields = new Set(record.redactedFields ?? [])
+  const unknownFields = record.unknownFields ?? []
+
+  if (redactedFields.has('confidence')) {
+    return null
+  }
+
+  const confidence = record.confidence ?? null
+  if (confidence !== null && policy.minimumConfidence !== undefined && confidence < policy.minimumConfidence) {
+    return null
+  }
+
+  if (policy.redactUnknown === true && unknownFields.includes('confidence')) {
+    return null
+  }
+
+  return confidence
+}
+
+function resolveLocationTag(
+  record: UnexplainedLocationRecord,
+  policy: UnexplainedLocationMapProjectionPolicy
+): string | null {
+  const redactedFields = new Set(record.redactedFields ?? [])
+  const locationRedacted =
+    redactedFields.has('locationTag') ||
+    (policy.suppressRedactedLocation === true && redactedFields.has('location'))
+
+  if (locationRedacted) {
+    return null
+  }
+
+  return normalizeToken(record.locationTag ?? '') || null
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isEffectDomainTag(value: string): value is EffectDomainTag {
+  return EFFECT_DOMAIN_TAG_SET.has(value)
+}
+
+export function isEffectGeometry(value: string): value is EffectGeometry {
+  return EFFECT_GEOMETRY_SET.has(value)
+}
+
+export function isPopulationSelectorKind(value: string): value is PopulationSelectorKind {
+  return POPULATION_SELECTOR_KIND_SET.has(value)
+}
+
+export function isSecurityControlTag(value: string): value is SecurityControlTag {
+  return SECURITY_CONTROL_TAG_SET.has(value)
+}
+
+export function isUnexplainedLocationLifecycleState(
+  value: string
+): value is UnexplainedLocationLifecycleState {
+  return LIFECYCLE_STATE_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateUnexplainedLocationRecord(
+  record: UnexplainedLocationRecord,
+  policy: UnexplainedLocationValidationPolicy = {}
+): UnexplainedLocationValidationResult {
+  const issues: UnexplainedLocationValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Unexplained location record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Unexplained location record is missing label.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isEffectGeometry(record.effectGeometry)) {
+    pushIssue(issues, {
+      code: 'invalid_effect_geometry',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} has invalid effectGeometry ${String(record.effectGeometry)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const tag of record.effectDomainTags ?? []) {
+    if (!isEffectDomainTag(tag)) {
+      pushIssue(issues, {
+        code: 'invalid_effect_domain_tag',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} has invalid effectDomainTag ${String(tag)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const selector of record.populationSelectors ?? []) {
+    if (!isPopulationSelectorKind(selector.kind)) {
+      pushIssue(issues, {
+        code: 'invalid_population_selector_kind',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} has invalid population selector kind ${String(selector.kind)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!normalizeToken(selector.value)) {
+      pushIssue(issues, {
+        code: 'empty_population_selector_value',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} declares an empty population selector value.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const tag of record.securityControlTags ?? []) {
+    if (!isSecurityControlTag(tag)) {
+      pushIssue(issues, {
+        code: 'invalid_security_control_tag',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} has invalid securityControlTag ${String(tag)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  if (!isUnexplainedLocationLifecycleState(record.lifecycleState)) {
+    pushIssue(issues, {
+      code: 'invalid_lifecycle_state',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} has invalid lifecycleState ${String(record.lifecycleState)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidSeverityScore(record.latentSeverityScore)) {
+    pushIssue(issues, {
+      code: 'invalid_latent_severity_score',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} latentSeverityScore must be a finite number between 0 and 100.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.accessProbability !== undefined && !isValidUnitInterval(record.accessProbability)) {
+    pushIssue(issues, {
+      code: 'invalid_access_probability',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} accessProbability must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitInterval(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} confidence must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.discoveryWeek !== undefined && !isFiniteWeek(record.discoveryWeek)) {
+    pushIssue(issues, {
+      code: 'invalid_discovery_week',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} has invalid discoveryWeek.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.containmentWeek !== undefined && !isFiniteWeek(record.containmentWeek)) {
+    pushIssue(issues, {
+      code: 'invalid_containment_week',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} has invalid containmentWeek.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.monitoringCadenceWeeks !== undefined &&
+    (!isFiniteWeek(record.monitoringCadenceWeeks) || record.monitoringCadenceWeeks === 0)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_monitoring_cadence',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} has invalid monitoringCadenceWeeks.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const entry of record.statusHistory ?? []) {
+    if (!isUnexplainedLocationLifecycleState(entry.fromState) || !isUnexplainedLocationLifecycleState(entry.toState)) {
+      pushIssue(issues, {
+        code: 'invalid_status_history_state',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} statusHistory contains invalid lifecycle state.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!isFiniteWeek(entry.week)) {
+      pushIssue(issues, {
+        code: 'invalid_status_history_week',
+        severity: 'error',
+        detail: `Unexplained location ${id || '(unknown)'} statusHistory contains invalid week.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  if (
+    record.lifecycleState === 'neutralized' &&
+    policy.requireNeutralizationAuthorization === true &&
+    !normalizeToken(record.neutralizationAuthorizationRef ?? '')
+  ) {
+    pushIssue(issues, {
+      code: 'neutralized_without_authorization',
+      severity: 'error',
+      detail: `Unexplained location ${id || '(unknown)'} is neutralized without neutralizationAuthorizationRef.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.lowPriority === true && record.latentSeverityScore === undefined) {
+    pushIssue(issues, {
+      code: 'low_priority_without_latent_severity',
+      severity: 'warning',
+      detail: `Unexplained location ${id || '(unknown)'} is low_priority without latentSeverityScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.lifecycleState === 'disputed' &&
+    (record.contradictionRefs ?? []).every((ref) => !normalizeToken(ref))
+  ) {
+    pushIssue(issues, {
+      code: 'disputed_without_contradiction_refs',
+      severity: 'warning',
+      detail: `Unexplained location ${id || '(unknown)'} is disputed without contradiction refs.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (hasSecurityTag(record, 'map_manipulation') && !normalizeToken(record.mapLayerPolicy ?? '')) {
+    pushIssue(issues, {
+      code: 'map_suppression_without_layer_policy',
+      severity: 'warning',
+      detail: `Unexplained location ${id || '(unknown)'} declares map_manipulation without mapLayerPolicy.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.lowPriority === true &&
+    record.latentSeverityScore === 0 &&
+    record.lifecycleState === 'public_managed'
+  ) {
+    pushIssue(issues, {
+      code: 'severity_underestimate',
+      severity: 'warning',
+      detail: `Unexplained location ${id || '(unknown)'} low_priority with latentSeverityScore 0 under public_managed posture risks severity underestimate.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Projects record-derived location visibility across map layers.
+ * Does not assert objective truth — only what the record declares.
+ */
+export function projectUnexplainedLocationForMap(
+  record: UnexplainedLocationRecord,
+  policy: UnexplainedLocationMapProjectionPolicy = {}
+): UnexplainedLocationMapProjection {
+  const locationId = normalizeToken(record.id) || '(unknown)'
+  const locationTag = resolveLocationTag(record, policy)
+  const confidence = resolveConfidence(record, policy)
+  const unknownFields = Object.freeze([...(record.unknownFields ?? [])].sort((a, b) => a.localeCompare(b)))
+  const mapSuppressed = hasSecurityTag(record, 'map_manipulation')
+
+  const publicLayer = Object.freeze({
+    layer: 'public' as const,
+    locationTag: mapSuppressed || !hasSecurityTag(record, 'public_cover') ? null : locationTag,
+    effectGeometry: record.effectGeometry,
+    confidence: mapSuppressed ? null : confidence,
+    suppressed: mapSuppressed,
+    unknownFields,
+  })
+
+  const agencyLayer = Object.freeze({
+    layer: 'agency' as const,
+    locationTag,
+    effectGeometry: record.effectGeometry,
+    confidence,
+    suppressed: false,
+    unknownFields,
+  })
+
+  const sensorLayer = Object.freeze({
+    layer: 'sensor' as const,
+    locationTag: hasSecurityTag(record, 'sensor_monitoring') ? locationTag : null,
+    effectGeometry: record.effectGeometry,
+    confidence: hasSecurityTag(record, 'sensor_monitoring') ? confidence : null,
+    suppressed: mapSuppressed && !hasSecurityTag(record, 'sensor_monitoring'),
+    unknownFields,
+  })
+
+  const inferredRouteLayer = Object.freeze({
+    layer: 'inferred_route' as const,
+    locationTag:
+      record.effectGeometry === 'route' && (record.accessProbability ?? 0) > 0 ? locationTag : null,
+    effectGeometry: record.effectGeometry,
+    confidence:
+      record.effectGeometry === 'route' && (record.accessProbability ?? 0) > 0 ? confidence : null,
+    suppressed: mapSuppressed && record.effectGeometry !== 'route',
+    unknownFields,
+  })
+
+  return Object.freeze({
+    locationId,
+    layers: Object.freeze([publicLayer, agencyLayer, sensorLayer, inferredRouteLayer]),
+  })
+}
+
+function defineLocation(record: UnexplainedLocationRecord): UnexplainedLocationRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Remote site under monitor-only posture with map suppression and low remote access probability. */
+export const REMOTE_MONITOR_SITE_FIXTURE: UnexplainedLocationRecord = defineLocation({
+  id: 'location:remote-ridge-station',
+  label: 'Remote ridge relay station',
+  descriptionStub: 'Persistent low-amplitude spatial drift near decommissioned relay hardware.',
+  effectGeometry: 'radius',
+  effectDomainTags: ['spatial', 'infrastructural'],
+  populationSelectors: [
+    { kind: 'location', value: 'north-ridge-relay' },
+    { kind: 'staff', value: 'remote-inspection-crew' },
+  ],
+  discoveryWeek: 8,
+  containmentWeek: 10,
+  securityControlTags: [
+    'physical_exclusion',
+    'sensor_monitoring',
+    'map_manipulation',
+    'minimal_response',
+  ],
+  coverStoryCode: 'utility-relay-maintenance',
+  monitoringCadenceWeeks: 4,
+  lifecycleState: 'monitor_only',
+  latentSeverityScore: 22,
+  accessProbability: 0.08,
+  lowPriority: true,
+  confidence: 0.54,
+  mapLayerPolicy: 'policy:public-map-suppress-north-ridge',
+  locationTag: 'site:north-ridge-relay',
+})
+
+/** Lifecycle chain preserving append-only statusHistory across active → utility_use → archived. */
+export const LIFECYCLE_CHAIN_LOCATION_FIXTURE: UnexplainedLocationRecord = defineLocation({
+  id: 'location:canal-pump-house',
+  label: 'Canal pump house annex',
+  descriptionStub: 'Low-threat annex repurposed for municipal utility after perimeter securing.',
+  effectGeometry: 'building',
+  effectDomainTags: ['environmental', 'spatial'],
+  populationSelectors: [{ kind: 'location', value: 'east-canal-pump-annex' }],
+  discoveryWeek: 4,
+  containmentWeek: 6,
+  securityControlTags: ['physical_exclusion', 'public_cover', 'staff_presence'],
+  coverStoryCode: 'municipal-pump-retrofit',
+  monitoringCadenceWeeks: 12,
+  lifecycleState: 'archived',
+  latentSeverityScore: 18,
+  accessProbability: 0.35,
+  lowPriority: true,
+  confidence: 0.71,
+  locationTag: 'site:east-canal-pump',
+  statusHistory: [
+    { fromState: 'active', toState: 'utility_use', week: 14, note: 'Repurposed under utility cover.' },
+    { fromState: 'utility_use', toState: 'archived', week: 52, note: 'Monitoring cadence retired.' },
+  ],
+})

--- a/src/test/unexplainedLocationRegistry.test.ts
+++ b/src/test/unexplainedLocationRegistry.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EFFECT_DOMAIN_TAGS,
+  EFFECT_GEOMETRIES,
+  LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+  POPULATION_SELECTOR_KINDS,
+  REMOTE_MONITOR_SITE_FIXTURE,
+  projectUnexplainedLocationForMap,
+  validateUnexplainedLocationRecord,
+  type UnexplainedLocationRecord,
+} from '../domain/unexplainedLocationRegistry'
+
+function baseRecord(
+  overrides: Partial<UnexplainedLocationRecord> = {}
+): UnexplainedLocationRecord {
+  return {
+    id: 'location:test-base',
+    label: 'Test base location',
+    effectGeometry: 'room',
+    effectDomainTags: ['spatial'],
+    populationSelectors: [{ kind: 'location', value: 'test-room' }],
+    lifecycleState: 'active',
+    latentSeverityScore: 15,
+    ...overrides,
+  }
+}
+
+describe('unexplainedLocationRegistry (SPE-2106 slice 1)', () => {
+  it('validates remote site fixture with monitor_only, map suppression, and low accessProbability', () => {
+    const result = validateUnexplainedLocationRecord(REMOTE_MONITOR_SITE_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toHaveLength(0)
+    expect(REMOTE_MONITOR_SITE_FIXTURE.lifecycleState).toBe('monitor_only')
+    expect(REMOTE_MONITOR_SITE_FIXTURE.securityControlTags).toContain('map_manipulation')
+    expect(REMOTE_MONITOR_SITE_FIXTURE.accessProbability).toBe(0.08)
+    expect(REMOTE_MONITOR_SITE_FIXTURE.mapLayerPolicy).toBeTruthy()
+  })
+
+  it('preserves lifecycle statusHistory for active → utility_use → archived chain', () => {
+    const result = validateUnexplainedLocationRecord(LIFECYCLE_CHAIN_LOCATION_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(LIFECYCLE_CHAIN_LOCATION_FIXTURE.lifecycleState).toBe('archived')
+    expect(LIFECYCLE_CHAIN_LOCATION_FIXTURE.statusHistory).toEqual([
+      { fromState: 'active', toState: 'utility_use', week: 14, note: 'Repurposed under utility cover.' },
+      { fromState: 'utility_use', toState: 'archived', week: 52, note: 'Monitoring cadence retired.' },
+    ])
+  })
+
+  it('round-trips effectGeometry and populationSelectors on validation', () => {
+    const record = baseRecord({
+      effectGeometry: 'route',
+      effectDomainTags: [...EFFECT_DOMAIN_TAGS],
+      populationSelectors: POPULATION_SELECTOR_KINDS.map((kind) => ({
+        kind,
+        value: `${kind}-value`,
+      })),
+    })
+
+    const result = validateUnexplainedLocationRecord(record)
+
+    expect(result.valid).toBe(true)
+    expect(record.effectGeometry).toBe('route')
+    expect(record.effectDomainTags).toEqual([...EFFECT_DOMAIN_TAGS])
+    expect(record.populationSelectors).toHaveLength(POPULATION_SELECTOR_KINDS.length)
+  })
+
+  it('warns on severity_underestimate for low_priority with latentSeverityScore 0 under public_managed', () => {
+    const result = validateUnexplainedLocationRecord(
+      baseRecord({
+        lowPriority: true,
+        latentSeverityScore: 0,
+        lifecycleState: 'public_managed',
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'severity_underestimate',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('warns when disputed lifecycle lacks contradiction refs', () => {
+    const result = validateUnexplainedLocationRecord(
+      baseRecord({
+        lifecycleState: 'disputed',
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'disputed_without_contradiction_refs',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('accepts disputed lifecycle when contradiction refs are present', () => {
+    const result = validateUnexplainedLocationRecord(
+      baseRecord({
+        lifecycleState: 'disputed',
+        contradictionRefs: ['contradiction:sensor-vs-witness'],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues.some((issue) => issue.code === 'disputed_without_contradiction_refs')).toBe(
+      false
+    )
+  })
+
+  it('errors on neutralized without authorization when policy requires it', () => {
+    const result = validateUnexplainedLocationRecord(
+      baseRecord({
+        lifecycleState: 'neutralized',
+      }),
+      { requireNeutralizationAuthorization: true }
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'neutralized_without_authorization',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('accepts neutralized when authorization ref is present under strict policy', () => {
+    const result = validateUnexplainedLocationRecord(
+      baseRecord({
+        lifecycleState: 'neutralized',
+        neutralizationAuthorizationRef: 'auth:field-neutralization-12',
+      }),
+      { requireNeutralizationAuthorization: true }
+    )
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('warns when map_manipulation tag is declared without mapLayerPolicy', () => {
+    const result = validateUnexplainedLocationRecord(
+      baseRecord({
+        securityControlTags: ['map_manipulation'],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'map_suppression_without_layer_policy',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('exposes canonical effect geometry values including orbital_zone and volume', () => {
+    expect(EFFECT_GEOMETRIES).toContain('orbital_zone')
+    expect(EFFECT_GEOMETRIES).toContain('volume')
+  })
+
+  it('projects public, agency, sensor, and inferred route layers with record-derived confidence', () => {
+    const projection = projectUnexplainedLocationForMap(REMOTE_MONITOR_SITE_FIXTURE)
+
+    expect(projection.locationId).toBe('location:remote-ridge-station')
+    expect(projection.layers).toHaveLength(4)
+
+    const byLayer = Object.fromEntries(projection.layers.map((layer) => [layer.layer, layer]))
+
+    expect(byLayer.public.suppressed).toBe(true)
+    expect(byLayer.public.locationTag).toBeNull()
+    expect(byLayer.agency.locationTag).toBe('site:north-ridge-relay')
+    expect(byLayer.agency.confidence).toBe(0.54)
+    expect(byLayer.sensor.locationTag).toBe('site:north-ridge-relay')
+    expect(byLayer.inferred_route.locationTag).toBeNull()
+  })
+
+  it('projects inferred route layer when geometry is route and accessProbability is positive', () => {
+    const projection = projectUnexplainedLocationForMap(
+      baseRecord({
+        effectGeometry: 'route',
+        accessProbability: 0.2,
+        locationTag: 'route:maintenance-corridor',
+        confidence: 0.44,
+        securityControlTags: ['sensor_monitoring'],
+      })
+    )
+
+    const inferred = projection.layers.find((layer) => layer.layer === 'inferred_route')
+    expect(inferred?.locationTag).toBe('route:maintenance-corridor')
+    expect(inferred?.confidence).toBe(0.44)
+  })
+
+  it('respects map projection policy minimum confidence and redaction', () => {
+    const redactedRecord = baseRecord({
+      locationTag: 'site:restricted',
+      confidence: 0.4,
+      redactedFields: ['locationTag'],
+      unknownFields: ['confidence'],
+      securityControlTags: ['public_cover'],
+    })
+
+    const projection = projectUnexplainedLocationForMap(redactedRecord, {
+      minimumConfidence: 0.5,
+      redactUnknown: true,
+      suppressRedactedLocation: true,
+    })
+
+    const agency = projection.layers.find((layer) => layer.layer === 'agency')
+    expect(agency?.locationTag).toBeNull()
+    expect(agency?.confidence).toBeNull()
+  })
+
+  it('validates untrusted payloads without throwing when fields are missing or nullish', () => {
+    const result = validateUnexplainedLocationRecord({} as UnexplainedLocationRecord)
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.map((issue) => issue.code).sort()).toEqual(
+      [
+        'invalid_effect_geometry',
+        'invalid_latent_severity_score',
+        'invalid_lifecycle_state',
+        'missing_id',
+        'missing_label',
+      ].sort()
+    )
+  })
+
+  it('produces byte-stable validation output on repeated runs', () => {
+    const record = baseRecord({
+      lowPriority: true,
+      latentSeverityScore: 0,
+      lifecycleState: 'public_managed',
+      securityControlTags: ['map_manipulation'],
+    })
+
+    const first = JSON.stringify(validateUnexplainedLocationRecord(record))
+    const second = JSON.stringify(validateUnexplainedLocationRecord(record))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/test/unexplainedLocationRegistry.test.ts
+++ b/src/test/unexplainedLocationRegistry.test.ts
@@ -231,6 +231,41 @@ describe('unexplainedLocationRegistry (SPE-2106 slice 1)', () => {
     )
   })
 
+  it('validates malformed array fields without throwing on untrusted payloads', () => {
+    const result = validateUnexplainedLocationRecord({
+      id: 'location:malformed',
+      label: 'Malformed payload',
+      effectGeometry: 'point',
+      effectDomainTags: 'spatial' as unknown as UnexplainedLocationRecord['effectDomainTags'],
+      populationSelectors: null as unknown as UnexplainedLocationRecord['populationSelectors'],
+      securityControlTags: 'map_manipulation' as unknown as UnexplainedLocationRecord['securityControlTags'],
+      lifecycleState: 'active',
+      latentSeverityScore: 10,
+      statusHistory: 'invalid' as unknown as UnexplainedLocationRecord['statusHistory'],
+      contradictionRefs: 42 as unknown as UnexplainedLocationRecord['contradictionRefs'],
+    })
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('projects map layers without throwing when array metadata is malformed', () => {
+    const projection = projectUnexplainedLocationForMap({
+      id: 'location:malformed-map',
+      label: 'Malformed map payload',
+      effectGeometry: 'point',
+      effectDomainTags: [],
+      populationSelectors: [],
+      lifecycleState: 'active',
+      latentSeverityScore: 10,
+      redactedFields: 'confidence' as unknown as UnexplainedLocationRecord['redactedFields'],
+      unknownFields: null as unknown as UnexplainedLocationRecord['unknownFields'],
+      securityControlTags: null as unknown as UnexplainedLocationRecord['securityControlTags'],
+    })
+
+    expect(projection.locationId).toBe('location:malformed-map')
+    expect(projection.layers).toHaveLength(4)
+  })
+
   it('produces byte-stable validation output on repeated runs', () => {
     const record = baseRecord({
       lowPriority: true,


### PR DESCRIPTION
## Summary

- Add pure deterministic `unexplainedLocationRegistry` domain module for persistent low-threat anomalous places (SPE-2106 slice 1).
- Schema covers effectGeometry, securityControlTags, lifecycle states, latentSeverityScore, accessProbability, statusHistory, and map-layer projection.
- `validateUnexplainedLocationRecord` and `projectUnexplainedLocationForMap` with 15 focused acceptance tests.

## Linear

- **Slice:** [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) — Unexplained location registry — low-threat site intake, security protocol schema, and lifecycle states (slice 1)
- **Parent:** [SPE-88](https://linear.app/spectranoir/issue/SPE-88) — remains open (slice 1 only)

## What shipped

- `src/domain/unexplainedLocationRegistry.ts` — record schema, validation, map projection, fixtures
- `src/test/unexplainedLocationRegistry.test.ts` — acceptance coverage per issue boundary

## Validation

- [x] `npm run test:run -- src/test/unexplainedLocationRegistry.test.ts` (15/15)
- [x] `npm run lint` on touched files

## Docs updated

- None (slice doc `planning/unexplained-location-registry-slice-1.md` not yet in repo)

## Out of scope / deferred

- GameState persistence and location registry UI
- Cover-story matcher wire-up (SPE-899 / SPE-1347)
- Threshold-route graph (SPE-292), case escalation (SPE-1310), uncertain-world-state map collapse (SPE-1317)

Made with [Cursor](https://cursor.com)