### PR TITLE
feat(SPE-2110): pattern source series intake registry (slice 1)

### DIFF
--- a/planning/pattern-source-series-registry-slice-1.md
+++ b/planning/pattern-source-series-registry-slice-1.md
@@ -1,0 +1,106 @@
+# SPE-75 — Pattern source series intake registry slice 1
+
+One-page implementation plan. Linear: [SPE-2110](https://linear.app/spectranoir/issue/SPE-2110) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) (public disclosure state registry).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2110 — Pattern source series intake registry (slice 1)](https://linear.app/spectranoir/issue/SPE-2110) |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — Contribution intake and modular release operations |
+| **Branch** | `jamesdyedbq/spe-2110-pattern-source-series-intake-registry-slice-1`                                         |
+| **Status** | Implemented on branch (pending PR)                                                                       |
+
+## Goal
+
+Add a pure deterministic **pattern-source series intake registry** for agent routing — not player-facing canon. Tracks multi-entry source clusters (series hubs) separately from single articles, location/event logs, canons, or organization indexes while preserving only Containment Protocol-safe implementation patterns.
+
+## Prerequisite (on `main` @ `ec611a1d`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Public disclosure    | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109 / PR #2430)    |
+| Self-censoring info  | `src/domain/selfCensoringInformationRegistry.ts` (SPE-2108)            |
+| Intake registry wave | SPE-2104 / SPE-2105 / SPE-2106 sibling patterns                        |
+| Harvest hub closure  | 40+ batches on SPE-2110 in `planning/harvest-reconciliation-index.md` |
+
+## Gap (pre-slice)
+
+- No bounded schema for series-hub intake metadata (source family, editorial status, processing pipeline).
+- No deterministic validation for CP-neutral labels, expression-risk normalization, or publication-order misuse.
+- No queue projection ranked by readiness and CP utility rather than recency.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `PatternSourceSeriesId` + `PatternSourceSeriesRecord` in `src/domain/patternSourceSeriesRegistry.ts`                              | GameState persistence                         |
+| sourceFamily, publicationOrder (ISO date), editorialStatus[], processingStatus, readinessScore, blurbDomainHints, linkedClusterIds | Planning mirror dashboard UI                  |
+| adaptation metadata (normalizationState, expressionRiskFlags, normalizationNote)                                                   | Automated article-level queue generation      |
+| `validatePatternSourceSeriesRecord(record)`                                                                                        | Linear MCP workflow wire-up                   |
+| `projectSeriesProcessingQueue(records, policy)`                                                                                    | Importing harvest mirror rows into TS data    |
+| `classifyBlurbDomains(blurbStub)` — routing hints only                                                                             | SPE-75 / SPE-854 parent Done                  |
+| Focused tests in `src/test/patternSourceSeriesRegistry.test.ts`                                                                    |                                               |
+
+## Record contract (deterministic)
+
+### Core fields
+
+- **sourceFamily** — `series_hub`, `canon_hub`, `single_article`, `organization_format`, `location_log`, `event_log`, `item_log`, `tale`, `anthology`, `meta_hub`.
+- **publicationOrder** — external publication date (`YYYY-MM-DD`); tie-breaker only, not primary queue rank.
+- **editorialStatus** — array; `open_entry` and `completed` may coexist on `series_hub`.
+- **processingStatus** — `unqueued` → `blurb_triaged` → `deep_pass` → `reconciled` / `deferred` / `rejected`.
+- **processingHistory** — optional prior statuses for pipeline warnings.
+- **readinessScore** — 0..1 scalar; primary queue rank input.
+- **adaptation** — normalizationState, expressionRiskFlags, normalizationNote.
+- **crossClusterReinforcementRef** — hook only; no duplicate issue creation.
+
+### Validation rules (examples)
+
+- Franchise / wiki / branded label token in CP-neutral field → error.
+- Imported organization name, character identity, plot, or setting literal → error.
+- `canon_hub` on series archive intake → warning.
+- `deep_pass` without prior `blurb_triaged` in history → warning.
+- `implementationPriorityByPublicationOrder` true → warning.
+- expressionRiskFlags without normalizationNote → warning; `implementation_ready` blocked.
+
+## Acceptance
+
+- [x] Fixture: series_hub with open_entry + completed editorial flags coexisting.
+- [x] Queue projection prefers high readinessScore over recent publicationOrder.
+- [x] Negative: imported organization name in title → validation error.
+- [x] Negative: source-specific character identity in CP-neutral field → validation error.
+- [x] Fixture: expression-risk flags remain provisional until normalizationNote exists.
+- [x] crossClusterReinforcementRef hook on fixture without implying child issue creation.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Schema + types** — unions, record shape, exported fixtures.
+2. **Validation** — positive fixtures + negative lint cases.
+3. **classifyBlurbDomains** — deterministic keyword routing.
+4. **projectSeriesProcessingQueue** — readiness-first ranking.
+5. **Regression** — sibling registry tests unchanged.
+
+## File touch list (expected)
+
+| Area   | Files                                                       |
+| ------ | ----------------------------------------------------------- |
+| Domain | `src/domain/patternSourceSeriesRegistry.ts`                 |
+| Tests  | `src/test/patternSourceSeriesRegistry.test.ts`              |
+| Plan   | `planning/pattern-source-series-registry-slice-1.md`        |
+
+## Branch
+
+`jamesdyedbq/spe-2110-pattern-source-series-intake-registry-slice-1`
+
+## Out of scope (parent closure)
+
+- Full SPE-75 parent Done
+- GameState persistence and harvest mirror dashboard
+- Automated article queue generation and Linear MCP wire-up
+
+## See also
+
+- `planning/harvest-reconciliation-index.md` — adjacent intake tier row for SPE-2110
+- `src/domain/publicDisclosureStateRegistry.ts` — validation + projection conventions (SPE-2109)
+- `docs/harvest-fold-in-linear-comments.md` — hub intake (SPE-2110) batch closure format

--- a/src/domain/patternSourceSeriesRegistry.ts
+++ b/src/domain/patternSourceSeriesRegistry.ts
@@ -313,7 +313,11 @@ function normalizeToken(value: unknown) {
 }
 
 function asStringArray(value: unknown): readonly string[] {
-  return Array.isArray(value) ? value : []
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
 }
 
 function asEditorialStatus(value: unknown): readonly EditorialStatus[] {
@@ -439,7 +443,8 @@ function scanCpNeutralStringField(
   issues: PatternSourceSeriesValidationIssue[],
   id: string,
   field: string,
-  value: string | undefined
+  value: string | undefined,
+  franchiseCode: PatternSourceSeriesValidationCode = 'franchise_token_in_field'
 ) {
   const token = normalizeToken(value ?? '')
   if (!token) {
@@ -448,7 +453,7 @@ function scanCpNeutralStringField(
 
   if (containsFranchiseToken(token)) {
     pushIssue(issues, {
-      code: 'franchise_token_in_field',
+      code: franchiseCode,
       severity: 'error',
       detail: `Pattern source series record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
       relatedIds: id ? [id] : undefined,
@@ -490,6 +495,57 @@ function scanCpNeutralStringField(
       relatedIds: id ? [id] : undefined,
     })
   }
+}
+
+function scanCpNeutralTitleField(
+  issues: PatternSourceSeriesValidationIssue[],
+  id: string,
+  title: string
+) {
+  const token = normalizeToken(title)
+  if (!token) {
+    return
+  }
+
+  if (containsBrandedLabelToken(token)) {
+    pushIssue(issues, {
+      code: 'branded_label_token_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field title contains a branded label token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsImportedOrganizationName(token)) {
+    pushIssue(issues, {
+      code: 'imported_organization_name_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field title contains an imported organization name.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsImportedCharacterIdentity(token)) {
+    pushIssue(issues, {
+      code: 'imported_character_identity_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field title contains a source-specific character identity.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsImportedPlotOrSetting(token)) {
+    pushIssue(issues, {
+      code: 'imported_plot_or_setting_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field title contains imported plot or setting sequence markers.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function resolvePublicationOrderTieBreaker(value: unknown): string {
+  return normalizeToken(value) || '0000-00-00'
 }
 
 function resolveCpUtilityBoost(
@@ -541,6 +597,10 @@ export function isExpressionRiskFlag(value: string): value is ExpressionRiskFlag
 // ---------------------------------------------------------------------------
 
 export function classifyBlurbDomains(blurbStub: PatternSourceBlurbStub): readonly BlurbDomainHint[] {
+  if (!blurbStub || typeof blurbStub !== 'object') {
+    return Object.freeze([])
+  }
+
   const corpus = [
     normalizeToken(blurbStub.title),
     normalizeToken(blurbStub.descriptionStub),
@@ -563,6 +623,46 @@ export function classifyBlurbDomains(blurbStub: PatternSourceBlurbStub): readonl
 export function validatePatternSourceSeriesRecord(
   record: PatternSourceSeriesRecord
 ): PatternSourceSeriesValidationResult {
+  if (!record || typeof record !== 'object') {
+    return freezeValidationResult([
+      {
+        code: 'missing_id',
+        severity: 'error',
+        detail: 'Pattern source series record is missing id.',
+      },
+      {
+        code: 'missing_slug',
+        severity: 'error',
+        detail: 'Pattern source series record is missing slug.',
+      },
+      {
+        code: 'missing_title',
+        severity: 'error',
+        detail: 'Pattern source series record is missing title.',
+      },
+      {
+        code: 'invalid_source_family',
+        severity: 'error',
+        detail: 'Pattern source series record (unknown) has invalid sourceFamily undefined.',
+      },
+      {
+        code: 'invalid_publication_order',
+        severity: 'error',
+        detail: 'Pattern source series record (unknown) publicationOrder must be a valid YYYY-MM-DD date.',
+      },
+      {
+        code: 'invalid_processing_status',
+        severity: 'error',
+        detail: 'Pattern source series record (unknown) has invalid processingStatus undefined.',
+      },
+      {
+        code: 'invalid_readiness_score',
+        severity: 'error',
+        detail: 'Pattern source series record (unknown) readinessScore must be a finite number between 0 and 1.',
+      },
+    ])
+  }
+
   const issues: PatternSourceSeriesValidationIssue[] = []
   const id = normalizeToken(record.id)
   const slug = normalizeToken(record.slug)
@@ -612,7 +712,8 @@ export function validatePatternSourceSeriesRecord(
     })
   }
 
-  scanCpNeutralStringField(issues, id, 'title', title)
+  scanCpNeutralStringField(issues, id, 'slug', slug)
+  scanCpNeutralTitleField(issues, id, title)
   scanCpNeutralStringField(issues, id, 'descriptionStub', record.descriptionStub)
   scanCpNeutralStringField(issues, id, 'dedicatedTag', record.dedicatedTag)
   scanCpNeutralStringField(issues, id, 'crossClusterReinforcementRef', record.crossClusterReinforcementRef)
@@ -834,7 +935,9 @@ export function projectSeriesProcessingQueue(
 
   const ranked = records
     .filter((record) => record && typeof record === 'object')
+    .filter((record) => isProcessingStatus(record.processingStatus))
     .filter((record) => !excluded.has(record.processingStatus))
+    .filter((record) => isValidUnitScore(record.readinessScore))
     .filter((record) => record.readinessScore >= minimumReadiness)
     .map((record) => {
       const cpUtilityScore = resolveCpUtilityBoost(record, policy)
@@ -857,7 +960,9 @@ export function projectSeriesProcessingQueue(
         return readinessCompare
       }
 
-      return left.record.publicationOrder.localeCompare(right.record.publicationOrder)
+      return resolvePublicationOrderTieBreaker(left.record.publicationOrder).localeCompare(
+        resolvePublicationOrderTieBreaker(right.record.publicationOrder)
+      )
     })
     .map((entry, index) =>
       Object.freeze({

--- a/src/domain/patternSourceSeriesRegistry.ts
+++ b/src/domain/patternSourceSeriesRegistry.ts
@@ -1,0 +1,942 @@
+/**
+ * SPE-2110 slice 1: pattern source series intake registry.
+ *
+ * Pure deterministic registry for agent routing over external pattern-source clusters —
+ * series hubs, canon indexes, and related intake shapes — distinct from in-world evidence,
+ * location/event logs, and player-facing canon.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type PatternSourceSeriesId = string
+
+export type SourceFamily =
+  | 'series_hub'
+  | 'canon_hub'
+  | 'single_article'
+  | 'organization_format'
+  | 'location_log'
+  | 'event_log'
+  | 'item_log'
+  | 'tale'
+  | 'anthology'
+  | 'meta_hub'
+
+export const SOURCE_FAMILIES: readonly SourceFamily[] = [
+  'series_hub',
+  'canon_hub',
+  'single_article',
+  'organization_format',
+  'location_log',
+  'event_log',
+  'item_log',
+  'tale',
+  'anthology',
+  'meta_hub',
+] as const
+
+export type EditorialStatus =
+  | 'featured'
+  | 'spotlight'
+  | 'open_entry'
+  | 'completed'
+  | 'active'
+  | 'abandoned'
+  | 'high_signal'
+  | 'low_confidence'
+
+export const EDITORIAL_STATUSES: readonly EditorialStatus[] = [
+  'featured',
+  'spotlight',
+  'open_entry',
+  'completed',
+  'active',
+  'abandoned',
+  'high_signal',
+  'low_confidence',
+] as const
+
+export type ProcessingStatus =
+  | 'unqueued'
+  | 'blurb_triaged'
+  | 'deep_pass'
+  | 'reconciled'
+  | 'deferred'
+  | 'rejected'
+
+export const PROCESSING_STATUSES: readonly ProcessingStatus[] = [
+  'unqueued',
+  'blurb_triaged',
+  'deep_pass',
+  'reconciled',
+  'deferred',
+  'rejected',
+] as const
+
+export type BlurbDomainHint =
+  | 'facility'
+  | 'faction'
+  | 'disclosure'
+  | 'object'
+  | 'media'
+  | 'personnel'
+  | 'ecology'
+  | 'disaster'
+  | 'occult'
+  | 'ethics'
+
+export const BLURB_DOMAIN_HINTS: readonly BlurbDomainHint[] = [
+  'facility',
+  'faction',
+  'disclosure',
+  'object',
+  'media',
+  'personnel',
+  'ecology',
+  'disaster',
+  'occult',
+  'ethics',
+] as const
+
+export type SourceNormalizationState =
+  | 'pattern_library'
+  | 'provisional'
+  | 'implementation_ready'
+
+export const SOURCE_NORMALIZATION_STATES: readonly SourceNormalizationState[] = [
+  'pattern_library',
+  'provisional',
+  'implementation_ready',
+] as const
+
+export type ExpressionRiskFlag =
+  | 'distinctive_prose'
+  | 'source_specific_naming'
+  | 'plot_sequence'
+  | 'character_identity'
+  | 'branded_label'
+  | 'named_organization'
+  | 'problematic_framing'
+  | 'institutional_bias'
+  | 'witness_unreliability'
+  | 'authority_abuse'
+  | 'community_harm'
+  | 'exposure_risk'
+  | 'coercion'
+  | 'misinformation'
+
+export const EXPRESSION_RISK_FLAGS: readonly ExpressionRiskFlag[] = [
+  'distinctive_prose',
+  'source_specific_naming',
+  'plot_sequence',
+  'character_identity',
+  'branded_label',
+  'named_organization',
+  'problematic_framing',
+  'institutional_bias',
+  'witness_unreliability',
+  'authority_abuse',
+  'community_harm',
+  'exposure_risk',
+  'coercion',
+  'misinformation',
+] as const
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface SourceAdaptationMetadata {
+  readonly normalizationState?: SourceNormalizationState
+  readonly expressionRiskFlags?: readonly ExpressionRiskFlag[]
+  readonly normalizationNote?: string
+}
+
+export interface PatternSourceBlurbStub {
+  readonly title?: string
+  readonly descriptionStub?: string
+  readonly dedicatedTag?: string
+}
+
+export interface PatternSourceSeriesRecord {
+  readonly id: PatternSourceSeriesId
+  readonly slug: string
+  readonly title: string
+  readonly descriptionStub?: string
+  readonly sourceFamily: SourceFamily
+  /** External publication date only (YYYY-MM-DD). Queue tie-breaker, not primary rank. */
+  readonly publicationOrder: string
+  readonly editorialStatus?: readonly EditorialStatus[]
+  readonly dedicatedTag?: string
+  readonly processingStatus: ProcessingStatus
+  readonly processingHistory?: readonly ProcessingStatus[]
+  readonly readinessScore: number
+  readonly blurbDomainHints?: readonly BlurbDomainHint[]
+  readonly linkedClusterIds?: readonly string[]
+  readonly crossClusterReinforcementRef?: string
+  readonly adaptation?: SourceAdaptationMetadata
+  /** When true, warns that implementation priority follows publication date instead of readiness. */
+  readonly implementationPriorityByPublicationOrder?: boolean
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type PatternSourceSeriesValidationCode =
+  | 'missing_id'
+  | 'missing_slug'
+  | 'missing_title'
+  | 'invalid_source_family'
+  | 'invalid_publication_order'
+  | 'invalid_editorial_status'
+  | 'invalid_processing_status'
+  | 'invalid_processing_history_status'
+  | 'invalid_readiness_score'
+  | 'invalid_confidence'
+  | 'invalid_blurb_domain_hint'
+  | 'invalid_normalization_state'
+  | 'invalid_expression_risk_flag'
+  | 'empty_linked_cluster_id'
+  | 'canon_hub_on_series_archive_intake'
+  | 'deep_pass_without_blurb_triaged'
+  | 'publication_order_priority_misuse'
+  | 'expression_risk_without_normalization_note'
+  | 'implementation_ready_with_unresolved_expression_risk'
+  | 'open_entry_without_low_confidence_guard'
+  | 'anthology_without_low_confidence_guard'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_title'
+  | 'franchise_token_in_field'
+  | 'branded_label_token_in_cp_field'
+  | 'imported_organization_name_in_cp_field'
+  | 'imported_character_identity_in_cp_field'
+  | 'imported_plot_or_setting_in_cp_field'
+
+export interface PatternSourceSeriesValidationIssue {
+  readonly code: PatternSourceSeriesValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface PatternSourceSeriesValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly PatternSourceSeriesValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Queue projection
+// ---------------------------------------------------------------------------
+
+export interface SeriesProcessingQueuePolicy {
+  readonly minimumReadinessScore?: number
+  readonly cpUtilityBoostBySourceFamily?: Partial<Record<SourceFamily, number>>
+  readonly excludeProcessingStatuses?: readonly ProcessingStatus[]
+}
+
+export interface SeriesProcessingQueueEntry {
+  readonly recordId: PatternSourceSeriesId
+  readonly rank: number
+  readonly readinessScore: number
+  readonly cpUtilityScore: number
+  readonly publicationOrder: string
+  readonly processingStatus: ProcessingStatus
+  readonly sourceFamily: SourceFamily
+}
+
+export interface SeriesProcessingQueueProjection {
+  readonly entries: readonly SeriesProcessingQueueEntry[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const SOURCE_FAMILY_SET = new Set<string>(SOURCE_FAMILIES)
+const EDITORIAL_STATUS_SET = new Set<string>(EDITORIAL_STATUSES)
+const PROCESSING_STATUS_SET = new Set<string>(PROCESSING_STATUSES)
+const BLURB_DOMAIN_HINT_SET = new Set<string>(BLURB_DOMAIN_HINTS)
+const SOURCE_NORMALIZATION_STATE_SET = new Set<string>(SOURCE_NORMALIZATION_STATES)
+const EXPRESSION_RISK_FLAG_SET = new Set<string>(EXPRESSION_RISK_FLAGS)
+
+const OPEN_ENTRY_SOURCE_FAMILIES = new Set<SourceFamily>(['series_hub', 'anthology'])
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest|broken masquerade|masquerade breach|wiki\.|wikidot)\b/i
+
+export const BRANDED_LABEL_PATTERN =
+  /\b(scp-\d{3,4}|object class:\s*(safe|euclid|keter|thaumiel|apollyon)|site-\d{2,4})\b/i
+
+export const IMPORTED_ORGANIZATION_NAME_PATTERN =
+  /\b(global occult coalition|serpent'?s hand|marshall,? carter(?: and dark)?|alexander protocol|are we cool yet)\b/i
+
+export const IMPORTED_CHARACTER_IDENTITY_PATTERN =
+  /\b(?:dr\.|agent|researcher|operative)\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+\b/i
+
+export const IMPORTED_PLOT_OR_SETTING_PATTERN =
+  /\b(?:chapter\s+\d+|act\s+(?:i{1,3}|iv|v)|season\s+\d+\s+finale|episode\s+\d+\s+arc)\b/i
+
+const BLURB_DOMAIN_KEYWORDS: Readonly<Record<BlurbDomainHint, readonly RegExp[]>> = {
+  facility: [/\b(facility|site|vault|containment wing|building|sector)\b/i],
+  faction: [/\b(faction|cell|organization|bureau|agency|trust|syndicate)\b/i],
+  disclosure: [/\b(disclosure|leak|public awareness|secrecy|cover story|masquerade)\b/i],
+  object: [/\b(object|artifact|item|anomaly|device|specimen)\b/i],
+  media: [/\b(media|broadcast|recording|transmission|press|documentary)\b/i],
+  personnel: [/\b(personnel|staff|operator|responder|team|roster)\b/i],
+  ecology: [/\b(ecology|habitat|wildlife|environment|biosphere|predator)\b/i],
+  disaster: [/\b(disaster|catastrophe|collapse|breach|containment failure|casualty)\b/i],
+  occult: [/\b(occult|ritual|sigil|esoteric|paranormal|supernatural)\b/i],
+  ethics: [/\b(ethics|consent|welfare|abuse|coercion|rights|dignity)\b/i],
+}
+
+const DEFAULT_CP_UTILITY_BOOST: Readonly<Partial<Record<SourceFamily, number>>> = {
+  series_hub: 0.08,
+  meta_hub: 0.06,
+}
+
+const HIGH_SIGNAL_EDITORIAL_BOOST = 0.05
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asEditorialStatus(value: unknown): readonly EditorialStatus[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asProcessingHistory(value: unknown): readonly ProcessingStatus[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asBlurbDomainHints(value: unknown): readonly BlurbDomainHint[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asExpressionRiskFlags(value: unknown): readonly ExpressionRiskFlag[] {
+  return Array.isArray(value) ? value : []
+}
+
+function pushIssue(
+  issues: PatternSourceSeriesValidationIssue[],
+  issue: PatternSourceSeriesValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: PatternSourceSeriesValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function freezeValidationResult(
+  issues: PatternSourceSeriesValidationIssue[]
+): PatternSourceSeriesValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedLabelToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_LABEL_PATTERN.test(token)
+}
+
+function containsImportedOrganizationName(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && IMPORTED_ORGANIZATION_NAME_PATTERN.test(token)
+}
+
+function containsImportedCharacterIdentity(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && IMPORTED_CHARACTER_IDENTITY_PATTERN.test(token)
+}
+
+function containsImportedPlotOrSetting(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && IMPORTED_PLOT_OR_SETTING_PATTERN.test(token)
+}
+
+function isValidPublicationOrder(value: string): boolean {
+  if (!ISO_DATE_PATTERN.test(value)) {
+    return false
+  }
+
+  const [year, month, day] = value.split('-').map((part) => Number.parseInt(part, 10))
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return false
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  )
+}
+
+function historyIncludesBlurbTriaged(record: PatternSourceSeriesRecord): boolean {
+  if (record.processingStatus === 'blurb_triaged') {
+    return true
+  }
+
+  for (const status of asProcessingHistory(record.processingHistory)) {
+    if (status === 'blurb_triaged') {
+      return true
+    }
+  }
+
+  return false
+}
+
+function scanCpNeutralStringField(
+  issues: PatternSourceSeriesValidationIssue[],
+  id: string,
+  field: string,
+  value: string | undefined
+) {
+  const token = normalizeToken(value ?? '')
+  if (!token) {
+    return
+  }
+
+  if (containsFranchiseToken(token)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedLabelToken(token)) {
+    pushIssue(issues, {
+      code: 'branded_label_token_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field ${field} contains a branded label token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsImportedOrganizationName(token)) {
+    pushIssue(issues, {
+      code: 'imported_organization_name_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field ${field} contains an imported organization name.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsImportedCharacterIdentity(token)) {
+    pushIssue(issues, {
+      code: 'imported_character_identity_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field ${field} contains a source-specific character identity.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsImportedPlotOrSetting(token)) {
+    pushIssue(issues, {
+      code: 'imported_plot_or_setting_in_cp_field',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} field ${field} contains imported plot or setting sequence markers.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function resolveCpUtilityBoost(
+  record: PatternSourceSeriesRecord,
+  policy: SeriesProcessingQueuePolicy
+): number {
+  const familyBoost = policy.cpUtilityBoostBySourceFamily?.[record.sourceFamily] ?? 0
+  const defaultBoost = DEFAULT_CP_UTILITY_BOOST[record.sourceFamily] ?? 0
+  const editorial = new Set(asEditorialStatus(record.editorialStatus))
+  const editorialBoost = editorial.has('high_signal') ? HIGH_SIGNAL_EDITORIAL_BOOST : 0
+
+  return familyBoost + defaultBoost + editorialBoost
+}
+
+function defineRecord(record: PatternSourceSeriesRecord): PatternSourceSeriesRecord {
+  return Object.freeze({ ...record })
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isSourceFamily(value: string): value is SourceFamily {
+  return SOURCE_FAMILY_SET.has(value)
+}
+
+export function isEditorialStatus(value: string): value is EditorialStatus {
+  return EDITORIAL_STATUS_SET.has(value)
+}
+
+export function isProcessingStatus(value: string): value is ProcessingStatus {
+  return PROCESSING_STATUS_SET.has(value)
+}
+
+export function isBlurbDomainHint(value: string): value is BlurbDomainHint {
+  return BLURB_DOMAIN_HINT_SET.has(value)
+}
+
+export function isSourceNormalizationState(value: string): value is SourceNormalizationState {
+  return SOURCE_NORMALIZATION_STATE_SET.has(value)
+}
+
+export function isExpressionRiskFlag(value: string): value is ExpressionRiskFlag {
+  return EXPRESSION_RISK_FLAG_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function classifyBlurbDomains(blurbStub: PatternSourceBlurbStub): readonly BlurbDomainHint[] {
+  const corpus = [
+    normalizeToken(blurbStub.title),
+    normalizeToken(blurbStub.descriptionStub),
+    normalizeToken(blurbStub.dedicatedTag),
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  if (!corpus) {
+    return Object.freeze([])
+  }
+
+  const hints = BLURB_DOMAIN_HINTS.filter((hint) =>
+    BLURB_DOMAIN_KEYWORDS[hint].some((pattern) => pattern.test(corpus))
+  ).sort((left, right) => left.localeCompare(right))
+
+  return Object.freeze([...hints])
+}
+
+export function validatePatternSourceSeriesRecord(
+  record: PatternSourceSeriesRecord
+): PatternSourceSeriesValidationResult {
+  const issues: PatternSourceSeriesValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const slug = normalizeToken(record.slug)
+  const title = normalizeToken(record.title)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Pattern source series record is missing id.',
+    })
+  }
+
+  if (!slug) {
+    pushIssue(issues, {
+      code: 'missing_slug',
+      severity: 'error',
+      detail: 'Pattern source series record is missing slug.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!title) {
+    pushIssue(issues, {
+      code: 'missing_title',
+      severity: 'error',
+      detail: 'Pattern source series record is missing title.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Pattern source series record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(title)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_title',
+      severity: 'error',
+      detail: `Pattern source series record title ${title || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanCpNeutralStringField(issues, id, 'title', title)
+  scanCpNeutralStringField(issues, id, 'descriptionStub', record.descriptionStub)
+  scanCpNeutralStringField(issues, id, 'dedicatedTag', record.dedicatedTag)
+  scanCpNeutralStringField(issues, id, 'crossClusterReinforcementRef', record.crossClusterReinforcementRef)
+
+  if (!isSourceFamily(record.sourceFamily)) {
+    pushIssue(issues, {
+      code: 'invalid_source_family',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} has invalid sourceFamily ${String(record.sourceFamily)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const publicationOrder = normalizeToken(record.publicationOrder)
+  if (!isValidPublicationOrder(publicationOrder)) {
+    pushIssue(issues, {
+      code: 'invalid_publication_order',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} publicationOrder must be a valid YYYY-MM-DD date.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const status of asEditorialStatus(record.editorialStatus)) {
+    if (!isEditorialStatus(status)) {
+      pushIssue(issues, {
+        code: 'invalid_editorial_status',
+        severity: 'error',
+        detail: `Pattern source series record ${id || '(unknown)'} has invalid editorialStatus ${String(status)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  if (!isProcessingStatus(record.processingStatus)) {
+    pushIssue(issues, {
+      code: 'invalid_processing_status',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} has invalid processingStatus ${String(record.processingStatus)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const status of asProcessingHistory(record.processingHistory)) {
+    if (!isProcessingStatus(status)) {
+      pushIssue(issues, {
+        code: 'invalid_processing_history_status',
+        severity: 'error',
+        detail: `Pattern source series record ${id || '(unknown)'} processingHistory contains invalid status ${String(status)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  if (!isValidUnitScore(record.readinessScore)) {
+    pushIssue(issues, {
+      code: 'invalid_readiness_score',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} readinessScore must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} confidence must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const hint of asBlurbDomainHints(record.blurbDomainHints)) {
+    if (!isBlurbDomainHint(hint)) {
+      pushIssue(issues, {
+        code: 'invalid_blurb_domain_hint',
+        severity: 'error',
+        detail: `Pattern source series record ${id || '(unknown)'} has invalid blurbDomainHint ${String(hint)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const clusterId of asStringArray(record.linkedClusterIds)) {
+    if (!normalizeToken(clusterId)) {
+      pushIssue(issues, {
+        code: 'empty_linked_cluster_id',
+        severity: 'error',
+        detail: `Pattern source series record ${id || '(unknown)'} linkedClusterIds contains empty id.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    } else {
+      scanCpNeutralStringField(issues, id, 'linkedClusterIds', clusterId)
+    }
+  }
+
+  const adaptation = record.adaptation
+  if (adaptation && typeof adaptation === 'object') {
+    if (
+      adaptation.normalizationState !== undefined &&
+      !isSourceNormalizationState(adaptation.normalizationState)
+    ) {
+      pushIssue(issues, {
+        code: 'invalid_normalization_state',
+        severity: 'error',
+        detail: `Pattern source series record ${id || '(unknown)'} has invalid normalizationState ${String(adaptation.normalizationState)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    for (const flag of asExpressionRiskFlags(adaptation.expressionRiskFlags)) {
+      if (!isExpressionRiskFlag(flag)) {
+        pushIssue(issues, {
+          code: 'invalid_expression_risk_flag',
+          severity: 'error',
+          detail: `Pattern source series record ${id || '(unknown)'} has invalid expressionRiskFlag ${String(flag)}.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+    }
+
+    scanCpNeutralStringField(issues, id, 'adaptation.normalizationNote', adaptation.normalizationNote)
+  }
+
+  if (isSourceFamily(record.sourceFamily) && record.sourceFamily === 'canon_hub') {
+    pushIssue(issues, {
+      code: 'canon_hub_on_series_archive_intake',
+      severity: 'warning',
+      detail: `Pattern source series record ${id || '(unknown)'} uses canon_hub on series archive intake.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.processingStatus === 'deep_pass' && !historyIncludesBlurbTriaged(record)) {
+    pushIssue(issues, {
+      code: 'deep_pass_without_blurb_triaged',
+      severity: 'warning',
+      detail: `Pattern source series record ${id || '(unknown)'} is deep_pass without prior blurb_triaged.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.implementationPriorityByPublicationOrder === true) {
+    pushIssue(issues, {
+      code: 'publication_order_priority_misuse',
+      severity: 'warning',
+      detail: `Pattern source series record ${id || '(unknown)'} marks publication date as implementation priority instead of readiness.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const expressionRiskFlags = asExpressionRiskFlags(adaptation?.expressionRiskFlags)
+  const normalizationNote = normalizeToken(adaptation?.normalizationNote ?? '')
+
+  if (expressionRiskFlags.length > 0 && !normalizationNote) {
+    pushIssue(issues, {
+      code: 'expression_risk_without_normalization_note',
+      severity: 'warning',
+      detail: `Pattern source series record ${id || '(unknown)'} declares expressionRiskFlags without normalizationNote.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    adaptation?.normalizationState === 'implementation_ready' &&
+    expressionRiskFlags.length > 0 &&
+    !normalizationNote
+  ) {
+    pushIssue(issues, {
+      code: 'implementation_ready_with_unresolved_expression_risk',
+      severity: 'error',
+      detail: `Pattern source series record ${id || '(unknown)'} cannot be implementation_ready while expression risks lack normalizationNote.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const editorialSet = new Set(asEditorialStatus(record.editorialStatus))
+  if (
+    isSourceFamily(record.sourceFamily) &&
+    OPEN_ENTRY_SOURCE_FAMILIES.has(record.sourceFamily) &&
+    editorialSet.has('open_entry') &&
+    !editorialSet.has('completed') &&
+    !editorialSet.has('low_confidence')
+  ) {
+    pushIssue(issues, {
+      code: 'open_entry_without_low_confidence_guard',
+      severity: 'warning',
+      detail: `Pattern source series record ${id || '(unknown)'} open_entry series lacks low_confidence editorial guard.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    isSourceFamily(record.sourceFamily) &&
+    record.sourceFamily === 'anthology' &&
+    !editorialSet.has('low_confidence')
+  ) {
+    pushIssue(issues, {
+      code: 'anthology_without_low_confidence_guard',
+      severity: 'warning',
+      detail: `Pattern source series record ${id || '(unknown)'} anthology intake lacks low_confidence editorial guard.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Ranks intake records by readinessScore and CP utility — not publication recency.
+ * publicationOrder is a deterministic tie-breaker only.
+ */
+export function projectSeriesProcessingQueue(
+  records: readonly PatternSourceSeriesRecord[],
+  policy: SeriesProcessingQueuePolicy = {}
+): SeriesProcessingQueueProjection {
+  const excluded = new Set(policy.excludeProcessingStatuses ?? [])
+  const minimumReadiness = policy.minimumReadinessScore ?? 0
+
+  const ranked = records
+    .filter((record) => record && typeof record === 'object')
+    .filter((record) => !excluded.has(record.processingStatus))
+    .filter((record) => record.readinessScore >= minimumReadiness)
+    .map((record) => {
+      const cpUtilityScore = resolveCpUtilityBoost(record, policy)
+      const compositeScore = record.readinessScore + cpUtilityScore
+
+      return Object.freeze({
+        record,
+        compositeScore,
+        cpUtilityScore,
+      })
+    })
+    .sort((left, right) => {
+      const scoreCompare = right.compositeScore - left.compositeScore
+      if (scoreCompare !== 0) {
+        return scoreCompare
+      }
+
+      const readinessCompare = right.record.readinessScore - left.record.readinessScore
+      if (readinessCompare !== 0) {
+        return readinessCompare
+      }
+
+      return left.record.publicationOrder.localeCompare(right.record.publicationOrder)
+    })
+    .map((entry, index) =>
+      Object.freeze({
+        recordId: normalizeToken(entry.record.id) || '(unknown)',
+        rank: index + 1,
+        readinessScore: entry.record.readinessScore,
+        cpUtilityScore: entry.cpUtilityScore,
+        publicationOrder: entry.record.publicationOrder,
+        processingStatus: entry.record.processingStatus,
+        sourceFamily: entry.record.sourceFamily,
+      })
+    )
+
+  return Object.freeze({
+    entries: Object.freeze(ranked),
+  })
+}
+
+/** series_hub with open_entry + completed editorial metadata coexisting. */
+export const SERIES_HUB_OPEN_ENTRY_FIXTURE: PatternSourceSeriesRecord = defineRecord({
+  id: 'pattern-series:facility-crisis-hub',
+  slug: 'facility-crisis-hub',
+  title: 'Facility crisis response pattern cluster',
+  descriptionStub: 'Multi-entry hub for triage, escalation, and responder coordination patterns.',
+  sourceFamily: 'series_hub',
+  publicationOrder: '2019-03-14',
+  editorialStatus: ['open_entry', 'completed', 'high_signal'],
+  dedicatedTag: 'facility-crisis',
+  processingStatus: 'reconciled',
+  processingHistory: ['unqueued', 'blurb_triaged', 'deep_pass', 'reconciled'],
+  readinessScore: 0.82,
+  blurbDomainHints: ['facility', 'disaster', 'personnel'],
+  linkedClusterIds: ['cluster:responder-exertion-71', 'cluster:mission-hub-96'],
+  crossClusterReinforcementRef: 'reinforcement:crisis-triage-fold-in-batch-55',
+  adaptation: {
+    normalizationState: 'pattern_library',
+  },
+  confidence: 0.71,
+})
+
+/** Expression-risk record that stays provisional until normalization note exists. */
+export const EXPRESSION_RISK_PROVISIONAL_FIXTURE: PatternSourceSeriesRecord = defineRecord({
+  id: 'pattern-series:occult-investigation-blurb',
+  slug: 'occult-investigation-blurb',
+  title: 'Occult investigation transcript cluster',
+  descriptionStub: 'Blurb-only intake pending CP-safe operational translation.',
+  sourceFamily: 'anthology',
+  publicationOrder: '2024-06-01',
+  editorialStatus: ['low_confidence', 'active'],
+  processingStatus: 'blurb_triaged',
+  readinessScore: 0.34,
+  adaptation: {
+    normalizationState: 'provisional',
+    expressionRiskFlags: ['distinctive_prose', 'problematic_framing', 'witness_unreliability'],
+  },
+  confidence: 0.29,
+})
+
+/** High readiness older series for queue ranking fixture. */
+export const HIGH_READINESS_QUEUE_FIXTURE: PatternSourceSeriesRecord = defineRecord({
+  id: 'pattern-series:urban-concealment-hub',
+  slug: 'urban-concealment-hub',
+  title: 'Urban concealment investigation hub',
+  sourceFamily: 'series_hub',
+  publicationOrder: '2018-01-10',
+  editorialStatus: ['high_signal'],
+  processingStatus: 'deep_pass',
+  processingHistory: ['unqueued', 'blurb_triaged'],
+  readinessScore: 0.91,
+})
+
+/** Lower readiness but newer publication date — should rank below HIGH_READINESS_QUEUE_FIXTURE. */
+export const LOW_READINESS_RECENT_QUEUE_FIXTURE: PatternSourceSeriesRecord = defineRecord({
+  id: 'pattern-series:episodic-incident-metadata',
+  slug: 'episodic-incident-metadata',
+  title: 'Episodic quick incident metadata packet',
+  sourceFamily: 'meta_hub',
+  publicationOrder: '2026-01-15',
+  editorialStatus: ['low_confidence'],
+  processingStatus: 'blurb_triaged',
+  readinessScore: 0.38,
+})

--- a/src/test/patternSourceSeriesRegistry.test.ts
+++ b/src/test/patternSourceSeriesRegistry.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BLURB_DOMAIN_HINTS,
+  EXPRESSION_RISK_PROVISIONAL_FIXTURE,
+  HIGH_READINESS_QUEUE_FIXTURE,
+  LOW_READINESS_RECENT_QUEUE_FIXTURE,
+  SERIES_HUB_OPEN_ENTRY_FIXTURE,
+  SOURCE_FAMILIES,
+  classifyBlurbDomains,
+  projectSeriesProcessingQueue,
+  validatePatternSourceSeriesRecord,
+  type PatternSourceSeriesRecord,
+} from '../domain/patternSourceSeriesRegistry'
+
+function baseRecord(
+  overrides: Partial<PatternSourceSeriesRecord> = {}
+): PatternSourceSeriesRecord {
+  return {
+    id: 'pattern-series:test-base',
+    slug: 'test-base',
+    title: 'Test base record',
+    sourceFamily: 'single_article',
+    publicationOrder: '2020-01-01',
+    processingStatus: 'unqueued',
+    readinessScore: 0.5,
+    ...overrides,
+  }
+}
+
+describe('patternSourceSeriesRegistry (SPE-2110 slice 1)', () => {
+  it('validates series_hub fixture with open_entry and completed editorial flags coexisting', () => {
+    const result = validatePatternSourceSeriesRecord(SERIES_HUB_OPEN_ENTRY_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toHaveLength(0)
+    expect(SERIES_HUB_OPEN_ENTRY_FIXTURE.editorialStatus).toEqual(
+      expect.arrayContaining(['open_entry', 'completed'])
+    )
+    expect(SERIES_HUB_OPEN_ENTRY_FIXTURE.sourceFamily).toBe('series_hub')
+  })
+
+  it('preserves crossClusterReinforcementRef as hook only on series hub fixture', () => {
+    expect(SERIES_HUB_OPEN_ENTRY_FIXTURE.crossClusterReinforcementRef).toMatch(/^reinforcement:/)
+    expect(SERIES_HUB_OPEN_ENTRY_FIXTURE.linkedClusterIds).toHaveLength(2)
+
+    const result = validatePatternSourceSeriesRecord(SERIES_HUB_OPEN_ENTRY_FIXTURE)
+    expect(result.valid).toBe(true)
+  })
+
+  it('ranks high readinessScore above newer publicationOrder in queue projection', () => {
+    const projection = projectSeriesProcessingQueue([
+      LOW_READINESS_RECENT_QUEUE_FIXTURE,
+      HIGH_READINESS_QUEUE_FIXTURE,
+    ])
+
+    expect(projection.entries).toHaveLength(2)
+    expect(projection.entries[0]?.recordId).toBe(HIGH_READINESS_QUEUE_FIXTURE.id)
+    expect(projection.entries[0]?.readinessScore).toBeGreaterThan(
+      projection.entries[1]?.readinessScore ?? 0
+    )
+    expect(projection.entries[1]?.publicationOrder).toBe('2026-01-15')
+  })
+
+  it('errors on imported organization name in title field', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        title: 'Field guide — Global Occult Coalition liaison patterns',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.issues.some((issue) => issue.code === 'imported_organization_name_in_cp_field')
+    ).toBe(true)
+  })
+
+  it('errors on source-specific character identity in CP-neutral descriptionStub', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        descriptionStub: 'Follow Agent Marcus Hale through the breach response sequence.',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'imported_character_identity_in_cp_field',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('warns when expression-risk flags lack normalizationNote and stays provisional', () => {
+    const result = validatePatternSourceSeriesRecord(EXPRESSION_RISK_PROVISIONAL_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(EXPRESSION_RISK_PROVISIONAL_FIXTURE.adaptation?.normalizationState).toBe('provisional')
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'expression_risk_without_normalization_note',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('errors when implementation_ready is set with unresolved expression risks', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        adaptation: {
+          normalizationState: 'implementation_ready',
+          expressionRiskFlags: ['character_identity'],
+        },
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.map((issue) => issue.code).sort()).toEqual(
+      [
+        'expression_risk_without_normalization_note',
+        'implementation_ready_with_unresolved_expression_risk',
+      ].sort()
+    )
+  })
+
+  it('classifies blurb domains as routing hints only', () => {
+    const hints = classifyBlurbDomains({
+      title: 'Facility disaster response and personnel ethics review',
+      descriptionStub: 'Occult ritual exposure during containment breach media cycle.',
+      dedicatedTag: 'faction-disclosure',
+    })
+
+    expect(hints).toEqual(
+      expect.arrayContaining(['facility', 'disaster', 'personnel', 'ethics', 'occult', 'media'])
+    )
+    expect(hints.length).toBeLessThanOrEqual(BLURB_DOMAIN_HINTS.length)
+    expect([...hints].sort()).toEqual([...hints])
+  })
+
+  it('returns empty blurb domain hints for empty stub', () => {
+    expect(classifyBlurbDomains({})).toEqual([])
+  })
+
+  it('warns on canon_hub source family for series archive intake', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        sourceFamily: 'canon_hub',
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'canon_hub_on_series_archive_intake',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('warns when deep_pass lacks prior blurb_triaged in history', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        processingStatus: 'deep_pass',
+        processingHistory: ['unqueued'],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'deep_pass_without_blurb_triaged',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('warns when publication date is marked as implementation priority', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        implementationPriorityByPublicationOrder: true,
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'publication_order_priority_misuse',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('errors on branded or franchise label token in title', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        title: 'Review notes for SCP-173 containment pattern',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.issues.some(
+        (issue) =>
+          issue.code === 'branded_label_token_in_cp_field' ||
+          issue.code === 'franchise_token_in_title' ||
+          issue.code === 'franchise_token_in_field'
+      )
+    ).toBe(true)
+  })
+
+  it('excludes rejected processing statuses from queue projection when configured', () => {
+    const projection = projectSeriesProcessingQueue(
+      [
+        HIGH_READINESS_QUEUE_FIXTURE,
+        baseRecord({
+          id: 'pattern-series:rejected-packet',
+          slug: 'rejected-packet',
+          processingStatus: 'rejected',
+          readinessScore: 0.99,
+        }),
+      ],
+      { excludeProcessingStatuses: ['rejected'] }
+    )
+
+    expect(projection.entries).toHaveLength(1)
+    expect(projection.entries[0]?.recordId).toBe(HIGH_READINESS_QUEUE_FIXTURE.id)
+  })
+
+  it('round-trips sourceFamily union on validation', () => {
+    const record = baseRecord({ sourceFamily: 'meta_hub' })
+    const result = validatePatternSourceSeriesRecord(record)
+
+    expect(result.valid).toBe(true)
+    expect(SOURCE_FAMILIES).toContain(record.sourceFamily)
+  })
+
+  it('validates untrusted payloads without throwing when fields are missing', () => {
+    const result = validatePatternSourceSeriesRecord({} as PatternSourceSeriesRecord)
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.map((issue) => issue.code).sort()).toEqual(
+      [
+        'invalid_publication_order',
+        'invalid_processing_status',
+        'invalid_readiness_score',
+        'invalid_source_family',
+        'missing_id',
+        'missing_slug',
+        'missing_title',
+      ].sort()
+    )
+  })
+
+  it('produces byte-stable validation output on repeated runs', () => {
+    const record = baseRecord({
+      processingStatus: 'deep_pass',
+      processingHistory: ['unqueued'],
+      implementationPriorityByPublicationOrder: true,
+    })
+
+    const first = JSON.stringify(validatePatternSourceSeriesRecord(record))
+    const second = JSON.stringify(validatePatternSourceSeriesRecord(record))
+
+    expect(first).toBe(second)
+  })
+
+  it('produces byte-stable queue projection on repeated runs', () => {
+    const records = [
+      LOW_READINESS_RECENT_QUEUE_FIXTURE,
+      HIGH_READINESS_QUEUE_FIXTURE,
+      SERIES_HUB_OPEN_ENTRY_FIXTURE,
+    ]
+
+    const first = JSON.stringify(projectSeriesProcessingQueue(records))
+    const second = JSON.stringify(projectSeriesProcessingQueue(records))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/test/patternSourceSeriesRegistry.test.ts
+++ b/src/test/patternSourceSeriesRegistry.test.ts
@@ -138,6 +138,25 @@ describe('patternSourceSeriesRegistry (SPE-2110 slice 1)', () => {
 
   it('returns empty blurb domain hints for empty stub', () => {
     expect(classifyBlurbDomains({})).toEqual([])
+    expect(classifyBlurbDomains(null as unknown as PatternSourceBlurbStub)).toEqual([])
+  })
+
+  it('errors on source-literal slug used as routing key', () => {
+    const result = validatePatternSourceSeriesRecord(
+      baseRecord({
+        slug: 'scp-173-containment-pattern',
+        title: 'Neutral intake label',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.issues.some(
+        (issue) =>
+          issue.code === 'branded_label_token_in_cp_field' ||
+          issue.code === 'franchise_token_in_field'
+      )
+    ).toBe(true)
   })
 
   it('warns on canon_hub source family for series archive intake', () => {


### PR DESCRIPTION
## Summary

- Add patternSourceSeriesRegistry.ts — deterministic schema for external pattern-source series intake (source family, editorial/processing pipeline, adaptation metadata, linked clusters).
- Export alidatePatternSourceSeriesRecord, projectSeriesProcessingQueue (readiness-first ranking), and classifyBlurbDomains (routing hints only).
- Add 18 targeted tests and slice doc planning/pattern-source-series-registry-slice-1.md.

## Linear

- **Slice:** [SPE-2110](https://linear.app/spectranoir/issue/SPE-2110) — Pattern source series intake registry (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — Contribution intake and modular release operations (remains open)
- **Adjacent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) information intake wave (remains open)

## What shipped

- PatternSourceSeriesRecord with sourceFamily, publicationOrder, editorialStatus[], processingStatus/history, readinessScore, adaptation metadata, crossClusterReinforcementRef hook
- Validation for franchise/branded/org/character/plot literals; pipeline and expression-risk warnings
- Queue projection preferring readinessScore + CP utility over publication recency
- Fixtures covering open_entry + completed coexistence and expression-risk provisional state

## Test plan

- [x] 
pm run test:run -- src/test/patternSourceSeriesRegistry.test.ts (18/18)
- [x] 
pm run lint

## Docs updated

- planning/pattern-source-series-registry-slice-1.md

Made with [Cursor](https://cursor.com)