### PR TITLE
feat(SPE-2111): visual-trigger hazard registry — pursuit state and hazardous media (slice 1)

### DIFF
--- a/planning/visual-trigger-hazard-registry-slice-1.md
+++ b/planning/visual-trigger-hazard-registry-slice-1.md
@@ -1,0 +1,110 @@
+# SPE-947 — Visual-trigger hazard registry slice 1
+
+One-page implementation plan. Linear: [SPE-2111](https://linear.app/spectranoir/issue/SPE-2111) (child under [SPE-947](https://linear.app/spectranoir/issue/SPE-947)). Follows shipped [SPE-2110](https://linear.app/spectranoir/issue/SPE-2110) (pattern source series intake registry).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2111 — Visual-trigger hazard registry — pursuit state, hazardous media, and exposure targets (slice 1)](https://linear.app/spectranoir/issue/SPE-2111) |
+| **Parent** | [SPE-947](https://linear.app/spectranoir/issue/SPE-947) — Visual-trigger and pursuit-adjacent hazard intake |
+| **Branch** | `jamesdyedbq/spe-2111-visual-trigger-hazard-registry-pursuit-state-hazardous-media`                         |
+| **Status** | Implemented on branch (pending PR)                                                                       |
+
+## Goal
+
+Add a pure deterministic **visual-trigger hazard registry** for anomalies whose hazardous feature propagates through sight, recordings, and derivative media — plus exposure-created pursuit targets — without importing external wiki object numbers, incident names, or franchise labels.
+
+## Prerequisite (on `main` @ `933634c2`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Pattern source series | `src/domain/patternSourceSeriesRegistry.ts` (SPE-2110 / PR #2431)   |
+| Public disclosure    | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109)               |
+| Self-censoring info  | `src/domain/selfCensoringInformationRegistry.ts` (SPE-2108)            |
+| Intake registry wave | SPE-2104 / SPE-2105 / SPE-2106 sibling patterns                        |
+| Harvest hub closure  | batches on SPE-2111 in `planning/harvest-reconciliation-index.md`    |
+
+## Gap (pre-slice)
+
+- No bounded schema for visual-trigger media hazards, pursuit state, or exposure targets.
+- No deterministic validation for franchise tokens, active pursuit without targets, or filter-latency countermeasure gaps.
+- No exposure-chain risk projection or observer-awareness escalation helper.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `VisualTriggerHazardId` + `VisualTriggerHazardRecord` in `src/domain/visualTriggerHazardRegistry.ts`                              | GameState persistence                         |
+| triggerMedium, awarenessRequirement, derivativeHazardProfile, pursuitState, targetInstanceIds, occlusionState, latentActivation   | Pursuit vector simulator integration          |
+| `observerAwarenessEscalation` — deterministic pursuit/manifestation/communication/dream/evidence bands                           | Countermeasure ledger link                    |
+| `presentationMismatchProfile` — uncanny human-mimic metadata fields                                                                | Propagation graph wire-up (#965 family)       |
+| `HazardousMediaInstance` sub-record — custody, deletion, storage, access history, sweep, disposal deadline, repost chain           | Field UI                                    |
+| `validateVisualTriggerHazardRecord(record)`                                                                                        | SPE-947 parent Done                           |
+| `projectExposureChainRisk(record, policy)` — broadcast-scale escalation forecast                                                   |                                               |
+| Focused tests in `src/test/visualTriggerHazardRegistry.test.ts`                                                                    |                                               |
+
+## Record contract (deterministic)
+
+### Core fields
+
+- **triggerMedium** — `direct_sight`, `photo`, `video_frame`, `thumbnail`, `sensor_feed`, `background_fragment`.
+- **awarenessRequirement** — `conscious`, `subconscious_retinal`, `machine_preprocess`.
+- **derivativeHazardProfile** — `full`, `partial`, `artistic_exempt`, `unknown`, `distorted`, `latent`.
+- **pursuitState** — `dormant`, `distressed`, `active_pursuit`, `resolved`.
+- **targetInstanceIds** — exposure-created pursuit target queue entries.
+- **occlusionState** — `exposed`, `covered`, `filtered`.
+- **latentActivation** — dormant public-media hazard flag (years-later activation path).
+- **presentationMismatchProfile** — optional limb drift, feature occlusion, nonstandard movement, camera-specific reveal scalars.
+- **hazardousMediaInstances** — custody, deletion status, storage scope, access history, sweep status, disposal deadline week, copy/repost chain refs.
+
+### Validation rules (examples)
+
+- Franchise / wiki / branded object-number token in id or CP-neutral field → error.
+- `active_pursuit` without non-empty `targetInstanceIds` → error.
+- `filterLatencyWeeks` < `exposurePathWeeks` without documented filter failure mode → warning.
+- Invalid union values, empty media instance ids, out-of-range unit scores → error.
+
+## Acceptance
+
+- [x] Fixture: background_fragment trigger with years-later latent activation.
+- [x] Fixture: subconscious_retinal exposure with failed filter latency.
+- [x] Fixture: artistic_exempt derivative does not inherit full trigger profile.
+- [x] Fixture: observer awareness increase transitions pursuit band without random roll.
+- [x] Fixture: disposal deadline week forces sweep/occlusion/redaction state before week N.
+- [x] occlusionState `covered` allows pursuit resolution transition.
+- [x] Negative: imported object number in record id → validation error.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Schema + types** — unions, record shape, exported fixtures.
+2. **Validation** — positive fixtures + negative lint cases.
+3. **resolveEffectiveDerivativeHazard** — artistic_exempt / partial profiles.
+4. **observerAwarenessEscalation** — deterministic pursuit band transitions.
+5. **resolveDisposalDeadlineCompliance** + **resolvePursuitStateAfterOcclusion**.
+6. **projectExposureChainRisk** — broadcast-scale forecast.
+7. **Regression** — sibling registry tests unchanged.
+
+## File touch list (expected)
+
+| Area   | Files                                                       |
+| ------ | ----------------------------------------------------------- |
+| Domain | `src/domain/visualTriggerHazardRegistry.ts`                 |
+| Tests  | `src/test/visualTriggerHazardRegistry.test.ts`              |
+| Plan   | `planning/visual-trigger-hazard-registry-slice-1.md`        |
+
+## Branch
+
+`jamesdyedbq/spe-2111-visual-trigger-hazard-registry-pursuit-state-hazardous-media`
+
+## Out of scope (parent closure)
+
+- Full SPE-947 parent Done
+- GameState persistence and weekly orchestration wiring
+- Propagation graph, pursuit simulator, countermeasure ledger
+
+## See also
+
+- `planning/harvest-reconciliation-index.md` — adjacent intake tier row for SPE-2111
+- `src/domain/publicDisclosureStateRegistry.ts` — validation + projection conventions (SPE-2109)
+- Harvest batches: `visual-trigger-hostile-65`, `collaborative-visual-folklore-20`, `domestic-media-intrusion-43`

--- a/src/domain/visualTriggerHazardRegistry.ts
+++ b/src/domain/visualTriggerHazardRegistry.ts
@@ -1,0 +1,1340 @@
+/**
+ * SPE-2111 slice 1: visual-trigger hazard registry.
+ *
+ * Pure deterministic registry for anomalies whose hazardous feature propagates through
+ * sight, recordings, and derivative media — plus exposure-created pursuit targets —
+ * distinct from jump-scare chase logic and GameState persistence.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type VisualTriggerHazardId = string
+
+export type TriggerMedium =
+  | 'direct_sight'
+  | 'photo'
+  | 'video_frame'
+  | 'thumbnail'
+  | 'sensor_feed'
+  | 'background_fragment'
+
+export const TRIGGER_MEDIA: readonly TriggerMedium[] = [
+  'direct_sight',
+  'photo',
+  'video_frame',
+  'thumbnail',
+  'sensor_feed',
+  'background_fragment',
+] as const
+
+export type AwarenessRequirement =
+  | 'conscious'
+  | 'subconscious_retinal'
+  | 'machine_preprocess'
+
+export const AWARENESS_REQUIREMENTS: readonly AwarenessRequirement[] = [
+  'conscious',
+  'subconscious_retinal',
+  'machine_preprocess',
+] as const
+
+export type DerivativeHazardProfile =
+  | 'full'
+  | 'partial'
+  | 'artistic_exempt'
+  | 'unknown'
+  | 'distorted'
+  | 'latent'
+
+export const DERIVATIVE_HAZARD_PROFILES: readonly DerivativeHazardProfile[] = [
+  'full',
+  'partial',
+  'artistic_exempt',
+  'unknown',
+  'distorted',
+  'latent',
+] as const
+
+export type PursuitState = 'dormant' | 'distressed' | 'active_pursuit' | 'resolved'
+
+export const PURSUIT_STATES: readonly PursuitState[] = [
+  'dormant',
+  'distressed',
+  'active_pursuit',
+  'resolved',
+] as const
+
+export type OcclusionState = 'exposed' | 'covered' | 'filtered'
+
+export const OCCLUSION_STATES: readonly OcclusionState[] = [
+  'exposed',
+  'covered',
+  'filtered',
+] as const
+
+export type ObserverAwarenessBand = 'unaware' | 'peripheral' | 'conscious' | 'heightened' | 'full'
+
+export const OBSERVER_AWARENESS_BANDS: readonly ObserverAwarenessBand[] = [
+  'unaware',
+  'peripheral',
+  'conscious',
+  'heightened',
+  'full',
+] as const
+
+export type EvidenceCorruptionBand = 'none' | 'minor' | 'moderate' | 'severe'
+
+export const EVIDENCE_CORRUPTION_BANDS: readonly EvidenceCorruptionBand[] = [
+  'none',
+  'minor',
+  'moderate',
+  'severe',
+] as const
+
+export type MediaCustody = 'internal_archive' | 'public_host' | 'partner_custody' | 'unknown'
+
+export const MEDIA_CUSTODIES: readonly MediaCustody[] = [
+  'internal_archive',
+  'public_host',
+  'partner_custody',
+  'unknown',
+] as const
+
+export type MediaDeletionStatus =
+  | 'intact'
+  | 'pending'
+  | 'partial'
+  | 'claimed_complete'
+  | 'verified'
+
+export const MEDIA_DELETION_STATUSES: readonly MediaDeletionStatus[] = [
+  'intact',
+  'pending',
+  'partial',
+  'claimed_complete',
+  'verified',
+] as const
+
+export type MediaStorageScope = 'local' | 'network' | 'broadcast' | 'offline'
+
+export const MEDIA_STORAGE_SCOPES: readonly MediaStorageScope[] = [
+  'local',
+  'network',
+  'broadcast',
+  'offline',
+] as const
+
+export type MediaSweepStatus = 'none' | 'scheduled' | 'in_progress' | 'complete' | 'failed'
+
+export const MEDIA_SWEEP_STATUSES: readonly MediaSweepStatus[] = [
+  'none',
+  'scheduled',
+  'in_progress',
+  'complete',
+  'failed',
+] as const
+
+export type DisposalComplianceAction = 'sweep' | 'occlusion' | 'redaction'
+
+export type ExposureEscalationBand = 'local' | 'regional' | 'broadcast'
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface PresentationMismatchProfile {
+  readonly limbProportionDrift?: number
+  readonly featureOcclusion?: number
+  readonly nonstandardMovement?: number
+  readonly cameraSpecificReveal?: number
+}
+
+export interface MediaAccessHistoryEntry {
+  readonly week: number
+  readonly actorRef: string
+  readonly action: string
+}
+
+export interface HazardousMediaInstance {
+  readonly mediaInstanceId: string
+  readonly custody: MediaCustody
+  readonly deletionStatus: MediaDeletionStatus
+  readonly storageScope: MediaStorageScope
+  readonly accessHistory?: readonly MediaAccessHistoryEntry[]
+  readonly sweepStatus: MediaSweepStatus
+  readonly disposalDeadlineWeek: number
+  readonly copyRepostChainRefs?: readonly string[]
+  readonly derivativeHazardProfile?: DerivativeHazardProfile
+}
+
+export interface VisualTriggerHazardRecord {
+  readonly id: VisualTriggerHazardId
+  readonly label: string
+  readonly summary?: string
+  readonly triggerMedium: TriggerMedium
+  readonly awarenessRequirement: AwarenessRequirement
+  readonly derivativeHazardProfile: DerivativeHazardProfile
+  readonly pursuitState: PursuitState
+  readonly targetInstanceIds?: readonly string[]
+  readonly occlusionState: OcclusionState
+  readonly latentActivation?: boolean
+  readonly presentationMismatchProfile?: PresentationMismatchProfile
+  readonly hazardousMediaInstances?: readonly HazardousMediaInstance[]
+  readonly observerAwarenessBand?: ObserverAwarenessBand
+  readonly filterLatencyWeeks?: number
+  readonly exposurePathWeeks?: number
+  readonly filterFailureMode?: string
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type VisualTriggerHazardValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'invalid_trigger_medium'
+  | 'invalid_awareness_requirement'
+  | 'invalid_derivative_hazard_profile'
+  | 'invalid_pursuit_state'
+  | 'invalid_occlusion_state'
+  | 'invalid_observer_awareness_band'
+  | 'invalid_confidence'
+  | 'invalid_filter_latency_weeks'
+  | 'invalid_exposure_path_weeks'
+  | 'invalid_presentation_mismatch_score'
+  | 'empty_target_instance_id'
+  | 'active_pursuit_without_target'
+  | 'invalid_media_instance_id'
+  | 'invalid_media_custody'
+  | 'invalid_media_deletion_status'
+  | 'invalid_media_storage_scope'
+  | 'invalid_media_sweep_status'
+  | 'invalid_media_disposal_deadline_week'
+  | 'invalid_media_access_history_week'
+  | 'empty_media_access_actor_ref'
+  | 'empty_media_access_action'
+  | 'invalid_media_derivative_profile'
+  | 'filter_latency_below_exposure_without_failure_mode'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_field'
+
+export interface VisualTriggerHazardValidationIssue {
+  readonly code: VisualTriggerHazardValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface VisualTriggerHazardValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly VisualTriggerHazardValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Observer awareness escalation
+// ---------------------------------------------------------------------------
+
+export interface ObserverAwarenessEscalationResult {
+  readonly pursuitPressure: number
+  readonly manifestationRisk: number
+  readonly communicationFailure: boolean
+  readonly dreamIntrusion: boolean
+  readonly evidenceCorruptionBand: EvidenceCorruptionBand
+  readonly pursuitState: PursuitState
+}
+
+// ---------------------------------------------------------------------------
+// Derivative hazard resolution
+// ---------------------------------------------------------------------------
+
+export interface EffectiveDerivativeHazard {
+  readonly inheritsFullTrigger: boolean
+  readonly hazardWeight: number
+}
+
+// ---------------------------------------------------------------------------
+// Disposal compliance
+// ---------------------------------------------------------------------------
+
+export interface DisposalDeadlineComplianceResult {
+  readonly compliant: boolean
+  readonly requiredActions: readonly DisposalComplianceAction[]
+  readonly overdueMediaInstanceIds: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Exposure chain projection
+// ---------------------------------------------------------------------------
+
+export interface ExposureChainRiskPolicy {
+  readonly broadcastThreshold?: number
+  readonly repostAmplification?: number
+  readonly minimumConfidence?: number
+}
+
+export interface ExposureChainRiskProjection {
+  readonly recordId: VisualTriggerHazardId
+  readonly broadcastRiskScore: number
+  readonly repostChainDepth: number
+  readonly latentActivationForecast: boolean
+  readonly requiredCountermeasures: readonly string[]
+  readonly escalationBand: ExposureEscalationBand
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const TRIGGER_MEDIUM_SET = new Set<string>(TRIGGER_MEDIA)
+const AWARENESS_REQUIREMENT_SET = new Set<string>(AWARENESS_REQUIREMENTS)
+const DERIVATIVE_HAZARD_PROFILE_SET = new Set<string>(DERIVATIVE_HAZARD_PROFILES)
+const PURSUIT_STATE_SET = new Set<string>(PURSUIT_STATES)
+const OCCLUSION_STATE_SET = new Set<string>(OCCLUSION_STATES)
+const OBSERVER_AWARENESS_BAND_SET = new Set<string>(OBSERVER_AWARENESS_BANDS)
+const MEDIA_CUSTODY_SET = new Set<string>(MEDIA_CUSTODIES)
+const MEDIA_DELETION_STATUS_SET = new Set<string>(MEDIA_DELETION_STATUSES)
+const MEDIA_STORAGE_SCOPE_SET = new Set<string>(MEDIA_STORAGE_SCOPES)
+const MEDIA_SWEEP_STATUS_SET = new Set<string>(MEDIA_SWEEP_STATUSES)
+
+const OBSERVER_AWARENESS_BAND_ORDER: Readonly<Record<ObserverAwarenessBand, number>> = {
+  unaware: 0,
+  peripheral: 1,
+  conscious: 2,
+  heightened: 3,
+  full: 4,
+}
+
+const DERIVATIVE_HAZARD_WEIGHTS: Readonly<Record<DerivativeHazardProfile, number>> = {
+  full: 1,
+  partial: 0.5,
+  artistic_exempt: 0,
+  unknown: 0.3,
+  distorted: 0.7,
+  latent: 0.2,
+}
+
+const TRIGGER_MEDIUM_EXPOSURE_WEIGHT: Readonly<Partial<Record<TriggerMedium, number>>> = {
+  direct_sight: 0.15,
+  photo: 0.35,
+  video_frame: 0.45,
+  thumbnail: 0.25,
+  sensor_feed: 0.55,
+  background_fragment: 0.4,
+}
+
+const STORAGE_SCOPE_EXPOSURE_WEIGHT: Readonly<Record<MediaStorageScope, number>> = {
+  local: 0.1,
+  offline: 0.05,
+  network: 0.45,
+  broadcast: 0.85,
+}
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest|broken masquerade|masquerade breach|wiki\.|wikidot)\b/i
+
+export const BRANDED_OBJECT_NUMBER_PATTERN = /\b(scp-\d{3,4}|object class:\s*(safe|euclid|keter|thaumiel|apollyon))\b/i
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function asHazardousMediaInstances(value: unknown): readonly HazardousMediaInstance[] {
+  return Array.isArray(value) ? value : []
+}
+
+function asMediaAccessHistory(value: unknown): readonly MediaAccessHistoryEntry[] {
+  return Array.isArray(value) ? value : []
+}
+
+function pushIssue(
+  issues: VisualTriggerHazardValidationIssue[],
+  issue: VisualTriggerHazardValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: VisualTriggerHazardValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function freezeValidationResult(
+  issues: VisualTriggerHazardValidationIssue[]
+): VisualTriggerHazardValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function clampUnit(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+function roundBand(value: number): number {
+  return Math.round(value * 1000) / 1000
+}
+
+function defineRecord(record: VisualTriggerHazardRecord): VisualTriggerHazardRecord {
+  return Object.freeze({ ...record })
+}
+
+function scanCpNeutralStringField(
+  issues: VisualTriggerHazardValidationIssue[],
+  id: string,
+  field: string,
+  value: string | undefined,
+  franchiseCode: VisualTriggerHazardValidationCode = 'franchise_token_in_field'
+) {
+  const token = normalizeToken(value ?? '')
+  if (!token) {
+    return
+  }
+
+  if (containsFranchiseToken(token)) {
+    pushIssue(issues, {
+      code: franchiseCode,
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(token)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_field',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} field ${field} contains an imported object number token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function validatePresentationMismatchProfile(
+  issues: VisualTriggerHazardValidationIssue[],
+  id: string,
+  profile: PresentationMismatchProfile | undefined
+) {
+  if (!profile || typeof profile !== 'object') {
+    return
+  }
+
+  const fields: Array<{ field: string; value: number | undefined }> = [
+    { field: 'presentationMismatchProfile.limbProportionDrift', value: profile.limbProportionDrift },
+    { field: 'presentationMismatchProfile.featureOcclusion', value: profile.featureOcclusion },
+    { field: 'presentationMismatchProfile.nonstandardMovement', value: profile.nonstandardMovement },
+    { field: 'presentationMismatchProfile.cameraSpecificReveal', value: profile.cameraSpecificReveal },
+  ]
+
+  for (const { field, value } of fields) {
+    if (value !== undefined && !isValidUnitScore(value)) {
+      pushIssue(issues, {
+        code: 'invalid_presentation_mismatch_score',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} ${field} must be a finite number between 0 and 1.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+}
+
+function resolveAwarenessBandOrder(band: ObserverAwarenessBand | undefined): number {
+  if (band === undefined || !OBSERVER_AWARENESS_BAND_SET.has(band)) {
+    return OBSERVER_AWARENESS_BAND_ORDER.unaware
+  }
+
+  return OBSERVER_AWARENESS_BAND_ORDER[band]
+}
+
+function resolvePursuitStateFromPressure(
+  currentState: PursuitState,
+  pursuitPressure: number
+): PursuitState {
+  if (currentState === 'resolved') {
+    return 'resolved'
+  }
+
+  if (pursuitPressure >= 0.75) {
+    return 'active_pursuit'
+  }
+
+  if (pursuitPressure >= 0.4) {
+    return 'distressed'
+  }
+
+  if (currentState === 'active_pursuit' || currentState === 'distressed') {
+    return pursuitPressure >= 0.2 ? 'distressed' : 'dormant'
+  }
+
+  return 'dormant'
+}
+
+function resolveEvidenceCorruptionBand(
+  awarenessRequirement: AwarenessRequirement,
+  band: ObserverAwarenessBand
+): EvidenceCorruptionBand {
+  const order = resolveAwarenessBandOrder(band)
+
+  if (awarenessRequirement !== 'machine_preprocess') {
+    if (order >= 4) {
+      return 'moderate'
+    }
+
+    if (order >= 3) {
+      return 'minor'
+    }
+
+    return 'none'
+  }
+
+  if (order >= 3) {
+    return 'severe'
+  }
+
+  if (order >= 2) {
+    return 'moderate'
+  }
+
+  if (order >= 1) {
+    return 'minor'
+  }
+
+  return 'none'
+}
+
+function resolveMaxRepostDepth(instances: readonly HazardousMediaInstance[]): number {
+  let depth = 0
+
+  for (const instance of instances) {
+    const chainLength = asStringArray(instance.copyRepostChainRefs).filter(Boolean).length
+    depth = Math.max(depth, chainLength)
+  }
+
+  return depth
+}
+
+function resolveBroadcastRiskScore(record: VisualTriggerHazardRecord): number {
+  const triggerWeight = TRIGGER_MEDIUM_EXPOSURE_WEIGHT[record.triggerMedium] ?? 0.2
+  const derivative = resolveEffectiveDerivativeHazard(
+    record.derivativeHazardProfile,
+    record.latentActivation === true
+  )
+  const instances = asHazardousMediaInstances(record.hazardousMediaInstances)
+
+  let storageBoost = 0
+  for (const instance of instances) {
+    if (instance && typeof instance === 'object' && isMediaStorageScope(instance.storageScope)) {
+      storageBoost = Math.max(storageBoost, STORAGE_SCOPE_EXPOSURE_WEIGHT[instance.storageScope])
+    }
+  }
+
+  const repostDepth = resolveMaxRepostDepth(instances)
+  const repostBoost = Math.min(0.35, repostDepth * 0.08)
+  const latentBoost = record.latentActivation === true ? 0.15 : 0
+
+  return roundBand(
+    clampUnit(triggerWeight * derivative.hazardWeight + storageBoost * 0.5 + repostBoost + latentBoost)
+  )
+}
+
+function resolveEscalationBand(score: number): ExposureEscalationBand {
+  if (score >= 0.72) {
+    return 'broadcast'
+  }
+
+  if (score >= 0.42) {
+    return 'regional'
+  }
+
+  return 'local'
+}
+
+function resolveRequiredCountermeasures(
+  record: VisualTriggerHazardRecord,
+  score: number
+): readonly string[] {
+  const measures = new Set<string>()
+
+  if (record.occlusionState !== 'covered') {
+    measures.add('occlusion_barrier')
+  }
+
+  if (record.occlusionState !== 'filtered') {
+    measures.add('visual_filter')
+  }
+
+  for (const instance of asHazardousMediaInstances(record.hazardousMediaInstances)) {
+    if (!instance || typeof instance !== 'object') {
+      continue
+    }
+
+    if (instance.sweepStatus !== 'complete' && instance.sweepStatus !== 'in_progress') {
+      measures.add('media_sweep')
+    }
+
+    if (instance.deletionStatus === 'intact' || instance.deletionStatus === 'partial') {
+      measures.add('custody_redaction')
+    }
+
+    if (asStringArray(instance.copyRepostChainRefs).length > 0) {
+      measures.add('repost_chain_trace')
+    }
+  }
+
+  if (score >= 0.72) {
+    measures.add('broadcast_takedown')
+  }
+
+  if (record.awarenessRequirement === 'subconscious_retinal') {
+    measures.add('retinal_exposure_review')
+  }
+
+  return Object.freeze([...measures].sort((left, right) => left.localeCompare(right)))
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isTriggerMedium(value: string): value is TriggerMedium {
+  return TRIGGER_MEDIUM_SET.has(value)
+}
+
+export function isAwarenessRequirement(value: string): value is AwarenessRequirement {
+  return AWARENESS_REQUIREMENT_SET.has(value)
+}
+
+export function isDerivativeHazardProfile(value: string): value is DerivativeHazardProfile {
+  return DERIVATIVE_HAZARD_PROFILE_SET.has(value)
+}
+
+export function isPursuitState(value: string): value is PursuitState {
+  return PURSUIT_STATE_SET.has(value)
+}
+
+export function isOcclusionState(value: string): value is OcclusionState {
+  return OCCLUSION_STATE_SET.has(value)
+}
+
+export function isObserverAwarenessBand(value: string): value is ObserverAwarenessBand {
+  return OBSERVER_AWARENESS_BAND_SET.has(value)
+}
+
+export function isMediaCustody(value: string): value is MediaCustody {
+  return MEDIA_CUSTODY_SET.has(value)
+}
+
+export function isMediaDeletionStatus(value: string): value is MediaDeletionStatus {
+  return MEDIA_DELETION_STATUS_SET.has(value)
+}
+
+export function isMediaStorageScope(value: string): value is MediaStorageScope {
+  return MEDIA_STORAGE_SCOPE_SET.has(value)
+}
+
+export function isMediaSweepStatus(value: string): value is MediaSweepStatus {
+  return MEDIA_SWEEP_STATUS_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves whether a derivative profile inherits the full trigger hazard weight.
+ * artistic_exempt and inactive latent profiles do not inherit full trigger behavior.
+ */
+export function resolveEffectiveDerivativeHazard(
+  profile: DerivativeHazardProfile,
+  latentActivation = false
+): EffectiveDerivativeHazard {
+  if (profile === 'artistic_exempt') {
+    return Object.freeze({
+      inheritsFullTrigger: false,
+      hazardWeight: 0,
+    })
+  }
+
+  if (profile === 'latent' && !latentActivation) {
+    return Object.freeze({
+      inheritsFullTrigger: false,
+      hazardWeight: DERIVATIVE_HAZARD_WEIGHTS.latent,
+    })
+  }
+
+  const hazardWeight = profile === 'latent' && latentActivation ? 0.85 : DERIVATIVE_HAZARD_WEIGHTS[profile]
+
+  return Object.freeze({
+    inheritsFullTrigger: profile === 'full' || (profile === 'latent' && latentActivation),
+    hazardWeight,
+  })
+}
+
+/**
+ * Deterministic escalation when observer or audience awareness increases.
+ * Paired with awarenessRequirement — no random rolls.
+ */
+export function observerAwarenessEscalation(
+  record: VisualTriggerHazardRecord,
+  priorBand: ObserverAwarenessBand,
+  nextBand: ObserverAwarenessBand
+): ObserverAwarenessEscalationResult {
+  const priorOrder = resolveAwarenessBandOrder(priorBand)
+  const nextOrder = resolveAwarenessBandOrder(nextBand)
+  const delta = Math.max(0, nextOrder - priorOrder)
+
+  const requirementMultiplier =
+    record.awarenessRequirement === 'subconscious_retinal'
+      ? 1.15
+      : record.awarenessRequirement === 'machine_preprocess'
+        ? 0.95
+        : 1
+
+  const derivative = resolveEffectiveDerivativeHazard(
+    record.derivativeHazardProfile,
+    record.latentActivation === true
+  )
+
+  const basePressure = nextOrder * 0.18 * requirementMultiplier * Math.max(derivative.hazardWeight, 0.1)
+  const pursuitPressure = roundBand(clampUnit(basePressure + delta * 0.12))
+  const manifestationRisk = roundBand(
+    clampUnit(pursuitPressure * 0.85 + (record.latentActivation === true ? 0.1 : 0))
+  )
+
+  const communicationFailure =
+    nextOrder >= 3 &&
+    (record.awarenessRequirement === 'conscious' || record.awarenessRequirement === 'machine_preprocess')
+
+  const dreamIntrusion =
+    record.awarenessRequirement === 'subconscious_retinal' && nextOrder >= 2 && delta > 0
+
+  const evidenceCorruptionBand = resolveEvidenceCorruptionBand(
+    record.awarenessRequirement,
+    nextBand
+  )
+
+  const pursuitState = resolvePursuitStateFromPressure(record.pursuitState, pursuitPressure)
+
+  return Object.freeze({
+    pursuitPressure,
+    manifestationRisk,
+    communicationFailure,
+    dreamIntrusion,
+    evidenceCorruptionBand,
+    pursuitState,
+  })
+}
+
+/**
+ * When occlusion covers the hazard, active pursuit may resolve deterministically.
+ */
+export function resolvePursuitStateAfterOcclusion(record: VisualTriggerHazardRecord): PursuitState {
+  if (record.occlusionState !== 'covered') {
+    return record.pursuitState
+  }
+
+  if (record.pursuitState === 'active_pursuit' || record.pursuitState === 'distressed') {
+    return 'resolved'
+  }
+
+  return record.pursuitState
+}
+
+/**
+ * Before disposalDeadlineWeek, media instances require sweep/occlusion/redaction posture.
+ */
+export function resolveDisposalDeadlineCompliance(
+  record: VisualTriggerHazardRecord,
+  currentWeek: number
+): DisposalDeadlineComplianceResult {
+  const requiredActions = new Set<DisposalComplianceAction>()
+  const overdueMediaInstanceIds: string[] = []
+
+  for (const instance of asHazardousMediaInstances(record.hazardousMediaInstances)) {
+    if (!instance || typeof instance !== 'object') {
+      continue
+    }
+
+    const mediaInstanceId = normalizeToken(instance.mediaInstanceId)
+    if (!mediaInstanceId) {
+      continue
+    }
+
+    if (currentWeek >= instance.disposalDeadlineWeek) {
+      continue
+    }
+
+    overdueMediaInstanceIds.push(mediaInstanceId)
+
+    if (instance.sweepStatus !== 'complete' && instance.sweepStatus !== 'in_progress') {
+      requiredActions.add('sweep')
+    }
+
+    if (record.occlusionState !== 'covered' && record.occlusionState !== 'filtered') {
+      requiredActions.add('occlusion')
+    }
+
+    if (
+      instance.deletionStatus === 'intact' ||
+      instance.deletionStatus === 'pending' ||
+      instance.deletionStatus === 'partial'
+    ) {
+      requiredActions.add('redaction')
+    }
+  }
+
+  return Object.freeze({
+    compliant: overdueMediaInstanceIds.length === 0 || requiredActions.size === 0,
+    requiredActions: Object.freeze(
+      [...requiredActions].sort((left, right) => left.localeCompare(right))
+    ),
+    overdueMediaInstanceIds: Object.freeze([...overdueMediaInstanceIds].sort()),
+  })
+}
+
+export function validateVisualTriggerHazardRecord(
+  record: VisualTriggerHazardRecord
+): VisualTriggerHazardValidationResult {
+  if (!record || typeof record !== 'object') {
+    return freezeValidationResult([
+      {
+        code: 'missing_id',
+        severity: 'error',
+        detail: 'Visual trigger hazard record is missing id.',
+      },
+      {
+        code: 'missing_label',
+        severity: 'error',
+        detail: 'Visual trigger hazard record is missing label.',
+      },
+      {
+        code: 'invalid_trigger_medium',
+        severity: 'error',
+        detail: 'Visual trigger hazard record (unknown) has invalid triggerMedium undefined.',
+      },
+      {
+        code: 'invalid_awareness_requirement',
+        severity: 'error',
+        detail: 'Visual trigger hazard record (unknown) has invalid awarenessRequirement undefined.',
+      },
+      {
+        code: 'invalid_derivative_hazard_profile',
+        severity: 'error',
+        detail: 'Visual trigger hazard record (unknown) has invalid derivativeHazardProfile undefined.',
+      },
+      {
+        code: 'invalid_pursuit_state',
+        severity: 'error',
+        detail: 'Visual trigger hazard record (unknown) has invalid pursuitState undefined.',
+      },
+      {
+        code: 'invalid_occlusion_state',
+        severity: 'error',
+        detail: 'Visual trigger hazard record (unknown) has invalid occlusionState undefined.',
+      },
+    ])
+  }
+
+  const issues: VisualTriggerHazardValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Visual trigger hazard record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Visual trigger hazard record is missing label.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Visual trigger hazard record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Visual trigger hazard record id ${id || '(unknown)'} contains an imported object number token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Visual trigger hazard record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanCpNeutralStringField(issues, id, 'summary', record.summary)
+  scanCpNeutralStringField(issues, id, 'filterFailureMode', record.filterFailureMode)
+
+  if (!isTriggerMedium(record.triggerMedium)) {
+    pushIssue(issues, {
+      code: 'invalid_trigger_medium',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} has invalid triggerMedium ${String(record.triggerMedium)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isAwarenessRequirement(record.awarenessRequirement)) {
+    pushIssue(issues, {
+      code: 'invalid_awareness_requirement',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} has invalid awarenessRequirement ${String(record.awarenessRequirement)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isDerivativeHazardProfile(record.derivativeHazardProfile)) {
+    pushIssue(issues, {
+      code: 'invalid_derivative_hazard_profile',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} has invalid derivativeHazardProfile ${String(record.derivativeHazardProfile)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isPursuitState(record.pursuitState)) {
+    pushIssue(issues, {
+      code: 'invalid_pursuit_state',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} has invalid pursuitState ${String(record.pursuitState)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isOcclusionState(record.occlusionState)) {
+    pushIssue(issues, {
+      code: 'invalid_occlusion_state',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} has invalid occlusionState ${String(record.occlusionState)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.observerAwarenessBand !== undefined &&
+    !isObserverAwarenessBand(record.observerAwarenessBand)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_observer_awareness_band',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} has invalid observerAwarenessBand ${String(record.observerAwarenessBand)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} confidence must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.filterLatencyWeeks !== undefined && !isFiniteWeek(record.filterLatencyWeeks)) {
+    pushIssue(issues, {
+      code: 'invalid_filter_latency_weeks',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} filterLatencyWeeks must be a non-negative integer.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.exposurePathWeeks !== undefined && !isFiniteWeek(record.exposurePathWeeks)) {
+    pushIssue(issues, {
+      code: 'invalid_exposure_path_weeks',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} exposurePathWeeks must be a non-negative integer.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  validatePresentationMismatchProfile(issues, id, record.presentationMismatchProfile)
+
+  const targetInstanceIds = asStringArray(record.targetInstanceIds)
+  for (const targetId of targetInstanceIds) {
+    if (!normalizeToken(targetId)) {
+      pushIssue(issues, {
+        code: 'empty_target_instance_id',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} targetInstanceIds contains empty id.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    } else {
+      scanCpNeutralStringField(issues, id, 'targetInstanceIds', targetId)
+    }
+  }
+
+  if (
+    record.pursuitState === 'active_pursuit' &&
+    targetInstanceIds.filter((entry) => normalizeToken(entry)).length === 0
+  ) {
+    pushIssue(issues, {
+      code: 'active_pursuit_without_target',
+      severity: 'error',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} is active_pursuit without targetInstanceIds.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const instance of asHazardousMediaInstances(record.hazardousMediaInstances)) {
+    if (!instance || typeof instance !== 'object') {
+      pushIssue(issues, {
+        code: 'invalid_media_instance_id',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} hazardousMediaInstances contains invalid entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
+    const mediaInstanceId = normalizeToken(instance.mediaInstanceId)
+    if (!mediaInstanceId) {
+      pushIssue(issues, {
+        code: 'invalid_media_instance_id',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} hazardousMediaInstances requires mediaInstanceId.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    } else {
+      scanCpNeutralStringField(issues, id, 'hazardousMediaInstances.mediaInstanceId', mediaInstanceId)
+    }
+
+    if (!isMediaCustody(instance.custody)) {
+      pushIssue(issues, {
+        code: 'invalid_media_custody',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} media instance ${mediaInstanceId || '(unknown)'} has invalid custody ${String(instance.custody)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!isMediaDeletionStatus(instance.deletionStatus)) {
+      pushIssue(issues, {
+        code: 'invalid_media_deletion_status',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} media instance ${mediaInstanceId || '(unknown)'} has invalid deletionStatus ${String(instance.deletionStatus)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!isMediaStorageScope(instance.storageScope)) {
+      pushIssue(issues, {
+        code: 'invalid_media_storage_scope',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} media instance ${mediaInstanceId || '(unknown)'} has invalid storageScope ${String(instance.storageScope)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!isMediaSweepStatus(instance.sweepStatus)) {
+      pushIssue(issues, {
+        code: 'invalid_media_sweep_status',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} media instance ${mediaInstanceId || '(unknown)'} has invalid sweepStatus ${String(instance.sweepStatus)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!isFiniteWeek(instance.disposalDeadlineWeek)) {
+      pushIssue(issues, {
+        code: 'invalid_media_disposal_deadline_week',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} media instance ${mediaInstanceId || '(unknown)'} disposalDeadlineWeek must be a non-negative integer.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (
+      instance.derivativeHazardProfile !== undefined &&
+      !isDerivativeHazardProfile(instance.derivativeHazardProfile)
+    ) {
+      pushIssue(issues, {
+        code: 'invalid_media_derivative_profile',
+        severity: 'error',
+        detail: `Visual trigger hazard record ${id || '(unknown)'} media instance ${mediaInstanceId || '(unknown)'} has invalid derivativeHazardProfile ${String(instance.derivativeHazardProfile)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    for (const entry of asMediaAccessHistory(instance.accessHistory)) {
+      if (!entry || typeof entry !== 'object') {
+        continue
+      }
+
+      if (!isFiniteWeek(entry.week)) {
+        pushIssue(issues, {
+          code: 'invalid_media_access_history_week',
+          severity: 'error',
+          detail: `Visual trigger hazard record ${id || '(unknown)'} media accessHistory contains invalid week.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+
+      if (!normalizeToken(entry.actorRef)) {
+        pushIssue(issues, {
+          code: 'empty_media_access_actor_ref',
+          severity: 'error',
+          detail: `Visual trigger hazard record ${id || '(unknown)'} media accessHistory requires actorRef.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+
+      if (!normalizeToken(entry.action)) {
+        pushIssue(issues, {
+          code: 'empty_media_access_action',
+          severity: 'error',
+          detail: `Visual trigger hazard record ${id || '(unknown)'} media accessHistory requires action.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+    }
+
+    for (const chainRef of asStringArray(instance.copyRepostChainRefs)) {
+      scanCpNeutralStringField(issues, id, 'copyRepostChainRefs', chainRef)
+    }
+  }
+
+  if (
+    typeof record.filterLatencyWeeks === 'number' &&
+    typeof record.exposurePathWeeks === 'number' &&
+    record.filterLatencyWeeks < record.exposurePathWeeks &&
+    !normalizeToken(record.filterFailureMode ?? '')
+  ) {
+    pushIssue(issues, {
+      code: 'filter_latency_below_exposure_without_failure_mode',
+      severity: 'warning',
+      detail: `Visual trigger hazard record ${id || '(unknown)'} filterLatencyWeeks is shorter than exposurePathWeeks without documented filterFailureMode.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Broadcast-scale escalation forecast from media custody, repost chains, and derivative hazard.
+ */
+export function projectExposureChainRisk(
+  record: VisualTriggerHazardRecord,
+  policy: ExposureChainRiskPolicy = {}
+): ExposureChainRiskProjection {
+  const recordId = normalizeToken(record.id) || '(unknown)'
+  const broadcastRiskScore = resolveBroadcastRiskScore(record)
+  const repostChainDepth = resolveMaxRepostDepth(asHazardousMediaInstances(record.hazardousMediaInstances))
+  const latentActivationForecast =
+    record.derivativeHazardProfile === 'latent' || record.latentActivation === true
+
+  const threshold = policy.broadcastThreshold ?? 0.72
+  const escalationBand =
+    broadcastRiskScore >= threshold ? 'broadcast' : resolveEscalationBand(broadcastRiskScore)
+
+  const confidence = record.confidence ?? 1
+  const requiredCountermeasures =
+    policy.minimumConfidence !== undefined && confidence < policy.minimumConfidence
+      ? Object.freeze([] as readonly string[])
+      : resolveRequiredCountermeasures(record, broadcastRiskScore)
+
+  return Object.freeze({
+    recordId,
+    broadcastRiskScore,
+    repostChainDepth,
+    latentActivationForecast,
+    requiredCountermeasures,
+    escalationBand,
+  })
+}
+
+/** background_fragment trigger with years-later latent activation. */
+export const BACKGROUND_FRAGMENT_LATENT_FIXTURE: VisualTriggerHazardRecord = defineRecord({
+  id: 'visual-trigger:public-broadcast-background-fragment',
+  label: 'Peripheral broadcast background fragment hazard',
+  summary: 'Hazard dormant in archived footage until latent activation years after initial exposure.',
+  triggerMedium: 'background_fragment',
+  awarenessRequirement: 'subconscious_retinal',
+  derivativeHazardProfile: 'latent',
+  pursuitState: 'dormant',
+  occlusionState: 'exposed',
+  latentActivation: true,
+  observerAwarenessBand: 'peripheral',
+  hazardousMediaInstances: [
+    {
+      mediaInstanceId: 'media:archive-segment-14',
+      custody: 'public_host',
+      deletionStatus: 'intact',
+      storageScope: 'broadcast',
+      sweepStatus: 'none',
+      disposalDeadlineWeek: 312,
+      copyRepostChainRefs: ['repost:clip-mirror-3', 'repost:regional-feed-9'],
+      accessHistory: [{ week: 48, actorRef: 'actor:archive-reviewer', action: 'flagged_for_review' }],
+    },
+  ],
+  confidence: 0.62,
+})
+
+/** subconscious_retinal exposure with filter latency shorter than exposure path. */
+export const SUBCONSCIOUS_RETINAL_FILTER_FAILURE_FIXTURE: VisualTriggerHazardRecord = defineRecord({
+  id: 'visual-trigger:retinal-filter-latency-gap',
+  label: 'Retinal exposure with countermeasure latency gap',
+  summary: 'Subconscious retinal trigger outruns deployed visual filter latency.',
+  triggerMedium: 'video_frame',
+  awarenessRequirement: 'subconscious_retinal',
+  derivativeHazardProfile: 'full',
+  pursuitState: 'distressed',
+  targetInstanceIds: ['target:viewer-queue-7'],
+  occlusionState: 'filtered',
+  filterLatencyWeeks: 2,
+  exposurePathWeeks: 5,
+  observerAwarenessBand: 'conscious',
+  presentationMismatchProfile: {
+    limbProportionDrift: 0.41,
+    featureOcclusion: 0.28,
+    nonstandardMovement: 0.55,
+    cameraSpecificReveal: 0.67,
+  },
+  confidence: 0.71,
+})
+
+/** artistic_exempt derivative on repost chain — does not inherit full trigger profile. */
+export const ARTISTIC_EXEMPT_DERIVATIVE_FIXTURE: VisualTriggerHazardRecord = defineRecord({
+  id: 'visual-trigger:stylized-repost-derivative',
+  label: 'Stylized repost derivative with artistic exemption',
+  summary: 'Fan edit derivative marked artistic_exempt; full trigger weight suppressed.',
+  triggerMedium: 'thumbnail',
+  awarenessRequirement: 'conscious',
+  derivativeHazardProfile: 'full',
+  pursuitState: 'dormant',
+  occlusionState: 'exposed',
+  hazardousMediaInstances: [
+    {
+      mediaInstanceId: 'media:stylized-edit-2',
+      custody: 'public_host',
+      deletionStatus: 'intact',
+      storageScope: 'network',
+      sweepStatus: 'scheduled',
+      disposalDeadlineWeek: 84,
+      derivativeHazardProfile: 'artistic_exempt',
+      copyRepostChainRefs: ['repost:fan-edit-chain-1'],
+    },
+  ],
+  confidence: 0.44,
+})
+
+/** Disposal deadline forces sweep/occlusion/redaction before deadline week. */
+export const DISPOSAL_DEADLINE_SWEEP_FIXTURE: VisualTriggerHazardRecord = defineRecord({
+  id: 'visual-trigger:pending-disposal-sweep',
+  label: 'Pending disposal sweep with exposed custody',
+  summary: 'Media instance approaching disposal deadline without completed sweep or redaction.',
+  triggerMedium: 'photo',
+  awarenessRequirement: 'conscious',
+  derivativeHazardProfile: 'partial',
+  pursuitState: 'dormant',
+  occlusionState: 'exposed',
+  hazardousMediaInstances: [
+    {
+      mediaInstanceId: 'media:custody-roll-11',
+      custody: 'internal_archive',
+      deletionStatus: 'pending',
+      storageScope: 'local',
+      sweepStatus: 'scheduled',
+      disposalDeadlineWeek: 40,
+      accessHistory: [{ week: 28, actorRef: 'actor:custody-clerk', action: 'queued_for_sweep' }],
+    },
+  ],
+  confidence: 0.53,
+})
+
+/** Covered occlusion allows pursuit resolution from active pursuit. */
+export const COVERED_PURSUIT_RESOLUTION_FIXTURE: VisualTriggerHazardRecord = defineRecord({
+  id: 'visual-trigger:covered-pursuit-resolution',
+  label: 'Covered hazard with active pursuit target',
+  summary: 'Occlusion barrier applied; pursuit may resolve without neutralization.',
+  triggerMedium: 'direct_sight',
+  awarenessRequirement: 'conscious',
+  derivativeHazardProfile: 'full',
+  pursuitState: 'active_pursuit',
+  targetInstanceIds: ['target:field-team-4'],
+  occlusionState: 'covered',
+  confidence: 0.66,
+})

--- a/src/domain/visualTriggerHazardRegistry.ts
+++ b/src/domain/visualTriggerHazardRegistry.ts
@@ -225,6 +225,7 @@ export type VisualTriggerHazardValidationCode =
   | 'franchise_token_in_label'
   | 'franchise_token_in_field'
   | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
   | 'branded_object_number_in_field'
 
 export interface VisualTriggerHazardValidationIssue {
@@ -268,7 +269,8 @@ export interface EffectiveDerivativeHazard {
 export interface DisposalDeadlineComplianceResult {
   readonly compliant: boolean
   readonly requiredActions: readonly DisposalComplianceAction[]
-  readonly overdueMediaInstanceIds: readonly string[]
+  /** Media instances still inside the pre-deadline compliance window. */
+  readonly pendingComplianceMediaInstanceIds: readonly string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -566,6 +568,10 @@ function resolveMaxRepostDepth(instances: readonly HazardousMediaInstance[]): nu
   let depth = 0
 
   for (const instance of instances) {
+    if (!instance || typeof instance !== 'object') {
+      continue
+    }
+
     const chainLength = asStringArray(instance.copyRepostChainRefs).filter(Boolean).length
     depth = Math.max(depth, chainLength)
   }
@@ -573,7 +579,10 @@ function resolveMaxRepostDepth(instances: readonly HazardousMediaInstance[]): nu
   return depth
 }
 
-function resolveBroadcastRiskScore(record: VisualTriggerHazardRecord): number {
+function resolveBroadcastRiskScore(
+  record: VisualTriggerHazardRecord,
+  repostAmplification = 1
+): number {
   const triggerWeight = TRIGGER_MEDIUM_EXPOSURE_WEIGHT[record.triggerMedium] ?? 0.2
   const derivative = resolveEffectiveDerivativeHazard(
     record.derivativeHazardProfile,
@@ -589,7 +598,7 @@ function resolveBroadcastRiskScore(record: VisualTriggerHazardRecord): number {
   }
 
   const repostDepth = resolveMaxRepostDepth(instances)
-  const repostBoost = Math.min(0.35, repostDepth * 0.08)
+  const repostBoost = Math.min(0.35, repostDepth * 0.08 * repostAmplification)
   const latentBoost = record.latentActivation === true ? 0.15 : 0
 
   return roundBand(
@@ -597,12 +606,13 @@ function resolveBroadcastRiskScore(record: VisualTriggerHazardRecord): number {
   )
 }
 
-function resolveEscalationBand(score: number): ExposureEscalationBand {
-  if (score >= 0.72) {
+function resolveEscalationBand(score: number, broadcastThreshold = 0.72): ExposureEscalationBand {
+  if (score >= broadcastThreshold) {
     return 'broadcast'
   }
 
-  if (score >= 0.42) {
+  const regionalThreshold = broadcastThreshold * (0.42 / 0.72)
+  if (score >= regionalThreshold) {
     return 'regional'
   }
 
@@ -611,7 +621,8 @@ function resolveEscalationBand(score: number): ExposureEscalationBand {
 
 function resolveRequiredCountermeasures(
   record: VisualTriggerHazardRecord,
-  score: number
+  score: number,
+  broadcastThreshold = 0.72
 ): readonly string[] {
   const measures = new Set<string>()
 
@@ -641,7 +652,7 @@ function resolveRequiredCountermeasures(
     }
   }
 
-  if (score >= 0.72) {
+  if (score >= broadcastThreshold) {
     measures.add('broadcast_takedown')
   }
 
@@ -755,8 +766,19 @@ export function observerAwarenessEscalation(
     record.latentActivation === true
   )
 
-  const basePressure = nextOrder * 0.18 * requirementMultiplier * Math.max(derivative.hazardWeight, 0.1)
-  const pursuitPressure = roundBand(clampUnit(basePressure + delta * 0.12))
+  if (derivative.hazardWeight === 0) {
+    return Object.freeze({
+      pursuitPressure: 0,
+      manifestationRisk: 0,
+      communicationFailure: false,
+      dreamIntrusion: false,
+      evidenceCorruptionBand: 'none' as EvidenceCorruptionBand,
+      pursuitState: record.pursuitState === 'resolved' ? 'resolved' : 'dormant',
+    })
+  }
+
+  const basePressure = nextOrder * 0.18 * requirementMultiplier * derivative.hazardWeight
+  const pursuitPressure = roundBand(clampUnit(basePressure + delta * 0.12 * derivative.hazardWeight))
   const manifestationRisk = roundBand(
     clampUnit(pursuitPressure * 0.85 + (record.latentActivation === true ? 0.1 : 0))
   )
@@ -808,7 +830,7 @@ export function resolveDisposalDeadlineCompliance(
   currentWeek: number
 ): DisposalDeadlineComplianceResult {
   const requiredActions = new Set<DisposalComplianceAction>()
-  const overdueMediaInstanceIds: string[] = []
+  const pendingComplianceMediaInstanceIds: string[] = []
 
   for (const instance of asHazardousMediaInstances(record.hazardousMediaInstances)) {
     if (!instance || typeof instance !== 'object') {
@@ -820,11 +842,12 @@ export function resolveDisposalDeadlineCompliance(
       continue
     }
 
+    // Compliance window: required actions must be complete before disposalDeadlineWeek.
     if (currentWeek >= instance.disposalDeadlineWeek) {
       continue
     }
 
-    overdueMediaInstanceIds.push(mediaInstanceId)
+    pendingComplianceMediaInstanceIds.push(mediaInstanceId)
 
     if (instance.sweepStatus !== 'complete' && instance.sweepStatus !== 'in_progress') {
       requiredActions.add('sweep')
@@ -844,11 +867,13 @@ export function resolveDisposalDeadlineCompliance(
   }
 
   return Object.freeze({
-    compliant: overdueMediaInstanceIds.length === 0 || requiredActions.size === 0,
+    compliant: pendingComplianceMediaInstanceIds.length === 0 || requiredActions.size === 0,
     requiredActions: Object.freeze(
       [...requiredActions].sort((left, right) => left.localeCompare(right))
     ),
-    overdueMediaInstanceIds: Object.freeze([...overdueMediaInstanceIds].sort()),
+    pendingComplianceMediaInstanceIds: Object.freeze(
+      [...pendingComplianceMediaInstanceIds].sort()
+    ),
   })
 }
 
@@ -939,6 +964,15 @@ export function validateVisualTriggerHazardRecord(
       code: 'franchise_token_in_label',
       severity: 'error',
       detail: `Visual trigger hazard record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Visual trigger hazard record label ${label || '(unknown)'} contains an imported object number token.`,
       relatedIds: id ? [id] : undefined,
     })
   }
@@ -1200,21 +1234,32 @@ export function projectExposureChainRisk(
   record: VisualTriggerHazardRecord,
   policy: ExposureChainRiskPolicy = {}
 ): ExposureChainRiskProjection {
+  if (!record || typeof record !== 'object') {
+    return Object.freeze({
+      recordId: '(unknown)',
+      broadcastRiskScore: 0,
+      repostChainDepth: 0,
+      latentActivationForecast: false,
+      requiredCountermeasures: Object.freeze([] as readonly string[]),
+      escalationBand: 'local' as ExposureEscalationBand,
+    })
+  }
+
   const recordId = normalizeToken(record.id) || '(unknown)'
-  const broadcastRiskScore = resolveBroadcastRiskScore(record)
+  const repostAmplification = policy.repostAmplification ?? 1
+  const broadcastRiskScore = resolveBroadcastRiskScore(record, repostAmplification)
   const repostChainDepth = resolveMaxRepostDepth(asHazardousMediaInstances(record.hazardousMediaInstances))
   const latentActivationForecast =
     record.derivativeHazardProfile === 'latent' || record.latentActivation === true
 
   const threshold = policy.broadcastThreshold ?? 0.72
-  const escalationBand =
-    broadcastRiskScore >= threshold ? 'broadcast' : resolveEscalationBand(broadcastRiskScore)
+  const escalationBand = resolveEscalationBand(broadcastRiskScore, threshold)
 
   const confidence = record.confidence ?? 1
   const requiredCountermeasures =
     policy.minimumConfidence !== undefined && confidence < policy.minimumConfidence
       ? Object.freeze([] as readonly string[])
-      : resolveRequiredCountermeasures(record, broadcastRiskScore)
+      : resolveRequiredCountermeasures(record, broadcastRiskScore, threshold)
 
   return Object.freeze({
     recordId,

--- a/src/test/visualTriggerHazardRegistry.test.ts
+++ b/src/test/visualTriggerHazardRegistry.test.ts
@@ -113,10 +113,10 @@ describe('visualTriggerHazardRegistry (SPE-2111 slice 1)', () => {
     expect(compliance.requiredActions).toEqual(
       expect.arrayContaining(['sweep', 'occlusion', 'redaction'])
     )
-    expect(compliance.overdueMediaInstanceIds).toContain('media:custody-roll-11')
+    expect(compliance.pendingComplianceMediaInstanceIds).toContain('media:custody-roll-11')
 
     const afterDeadline = resolveDisposalDeadlineCompliance(DISPOSAL_DEADLINE_SWEEP_FIXTURE, 42)
-    expect(afterDeadline.overdueMediaInstanceIds).toHaveLength(0)
+    expect(afterDeadline.pendingComplianceMediaInstanceIds).toHaveLength(0)
     expect(afterDeadline.compliant).toBe(true)
   })
 
@@ -133,6 +133,17 @@ describe('visualTriggerHazardRegistry (SPE-2111 slice 1)', () => {
       targetInstanceIds: ['target:viewer-1'],
     })
     expect(resolvePursuitStateAfterOcclusion(exposedRecord)).toBe('active_pursuit')
+  })
+
+  it('errors on imported object number in record label', () => {
+    const result = validateVisualTriggerHazardRecord(
+      baseRecord({
+        label: 'Archive hazard linked to SCP-096 exposure clip',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'branded_object_number_in_label')).toBe(true)
   })
 
   it('errors on imported object number in record id', () => {
@@ -166,6 +177,46 @@ describe('visualTriggerHazardRegistry (SPE-2111 slice 1)', () => {
         severity: 'error',
       }),
     ])
+  })
+
+  it('honors custom broadcastThreshold in exposure projection escalation band', () => {
+    const defaultProjection = projectExposureChainRisk(BACKGROUND_FRAGMENT_LATENT_FIXTURE)
+    const strictProjection = projectExposureChainRisk(BACKGROUND_FRAGMENT_LATENT_FIXTURE, {
+      broadcastThreshold: 1.05,
+    })
+
+    expect(defaultProjection.escalationBand).toBe('broadcast')
+    expect(strictProjection.escalationBand).not.toBe('broadcast')
+  })
+
+  it('applies repostAmplification policy to exposure risk score', () => {
+    const baseline = projectExposureChainRisk(BACKGROUND_FRAGMENT_LATENT_FIXTURE)
+    const amplified = projectExposureChainRisk(BACKGROUND_FRAGMENT_LATENT_FIXTURE, {
+      repostAmplification: 2,
+    })
+
+    expect(amplified.broadcastRiskScore).toBeGreaterThanOrEqual(baseline.broadcastRiskScore)
+  })
+
+  it('returns zero pursuit pressure for artistic_exempt derivative profile', () => {
+    const record = baseRecord({
+      derivativeHazardProfile: 'artistic_exempt',
+      awarenessRequirement: 'conscious',
+    })
+
+    const result = observerAwarenessEscalation(record, 'unaware', 'full')
+
+    expect(result.pursuitPressure).toBe(0)
+    expect(result.manifestationRisk).toBe(0)
+    expect(result.pursuitState).toBe('dormant')
+  })
+
+  it('returns safe projection for untrusted null record input', () => {
+    const projection = projectExposureChainRisk(null as unknown as VisualTriggerHazardRecord)
+
+    expect(projection.recordId).toBe('(unknown)')
+    expect(projection.broadcastRiskScore).toBe(0)
+    expect(projection.escalationBand).toBe('local')
   })
 
   it('projects broadcast-scale exposure chain risk from repost chains and storage scope', () => {

--- a/src/test/visualTriggerHazardRegistry.test.ts
+++ b/src/test/visualTriggerHazardRegistry.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ARTISTIC_EXEMPT_DERIVATIVE_FIXTURE,
+  BACKGROUND_FRAGMENT_LATENT_FIXTURE,
+  COVERED_PURSUIT_RESOLUTION_FIXTURE,
+  DISPOSAL_DEADLINE_SWEEP_FIXTURE,
+  SUBCONSCIOUS_RETINAL_FILTER_FAILURE_FIXTURE,
+  observerAwarenessEscalation,
+  projectExposureChainRisk,
+  resolveDisposalDeadlineCompliance,
+  resolveEffectiveDerivativeHazard,
+  resolvePursuitStateAfterOcclusion,
+  validateVisualTriggerHazardRecord,
+  type VisualTriggerHazardRecord,
+} from '../domain/visualTriggerHazardRegistry'
+
+function baseRecord(
+  overrides: Partial<VisualTriggerHazardRecord> = {}
+): VisualTriggerHazardRecord {
+  return {
+    id: 'visual-trigger:test-base',
+    label: 'Test base record',
+    triggerMedium: 'photo',
+    awarenessRequirement: 'conscious',
+    derivativeHazardProfile: 'full',
+    pursuitState: 'dormant',
+    occlusionState: 'exposed',
+    ...overrides,
+  }
+}
+
+describe('visualTriggerHazardRegistry (SPE-2111 slice 1)', () => {
+  it('validates background_fragment fixture with years-later latent activation', () => {
+    const result = validateVisualTriggerHazardRecord(BACKGROUND_FRAGMENT_LATENT_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(BACKGROUND_FRAGMENT_LATENT_FIXTURE.triggerMedium).toBe('background_fragment')
+    expect(BACKGROUND_FRAGMENT_LATENT_FIXTURE.latentActivation).toBe(true)
+    expect(BACKGROUND_FRAGMENT_LATENT_FIXTURE.derivativeHazardProfile).toBe('latent')
+
+    const derivative = resolveEffectiveDerivativeHazard('latent', true)
+    expect(derivative.inheritsFullTrigger).toBe(true)
+    expect(derivative.hazardWeight).toBeGreaterThan(0.8)
+  })
+
+  it('warns on subconscious_retinal exposure with filter latency shorter than exposure path', () => {
+    const result = validateVisualTriggerHazardRecord(SUBCONSCIOUS_RETINAL_FILTER_FAILURE_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(SUBCONSCIOUS_RETINAL_FILTER_FAILURE_FIXTURE.awarenessRequirement).toBe(
+      'subconscious_retinal'
+    )
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'filter_latency_below_exposure_without_failure_mode',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('does not inherit full trigger profile for artistic_exempt derivative media', () => {
+    const mediaInstance = ARTISTIC_EXEMPT_DERIVATIVE_FIXTURE.hazardousMediaInstances?.[0]
+    expect(mediaInstance?.derivativeHazardProfile).toBe('artistic_exempt')
+
+    const derivative = resolveEffectiveDerivativeHazard('artistic_exempt')
+    expect(derivative.inheritsFullTrigger).toBe(false)
+    expect(derivative.hazardWeight).toBe(0)
+
+    const parentDerivative = resolveEffectiveDerivativeHazard(
+      ARTISTIC_EXEMPT_DERIVATIVE_FIXTURE.derivativeHazardProfile
+    )
+    expect(parentDerivative.inheritsFullTrigger).toBe(true)
+
+    const result = validateVisualTriggerHazardRecord(ARTISTIC_EXEMPT_DERIVATIVE_FIXTURE)
+    expect(result.valid).toBe(true)
+  })
+
+  it('transitions pursuit band deterministically when observer awareness increases', () => {
+    const record = baseRecord({
+      derivativeHazardProfile: 'full',
+      pursuitState: 'dormant',
+      awarenessRequirement: 'conscious',
+    })
+
+    const baseline = observerAwarenessEscalation(record, 'unaware', 'unaware')
+    const escalated = observerAwarenessEscalation(record, 'unaware', 'heightened')
+
+    expect(baseline.pursuitState).toBe('dormant')
+    expect(escalated.pursuitPressure).toBeGreaterThan(baseline.pursuitPressure)
+    expect(escalated.pursuitState).toBe('active_pursuit')
+    expect(escalated.manifestationRisk).toBeGreaterThan(baseline.manifestationRisk)
+
+    const repeat = observerAwarenessEscalation(record, 'unaware', 'heightened')
+    expect(repeat).toEqual(escalated)
+  })
+
+  it('raises dream-intrusion flag for subconscious_retinal awareness escalation', () => {
+    const record = baseRecord({
+      awarenessRequirement: 'subconscious_retinal',
+      derivativeHazardProfile: 'partial',
+    })
+
+    const result = observerAwarenessEscalation(record, 'unaware', 'conscious')
+
+    expect(result.dreamIntrusion).toBe(true)
+    expect(result.pursuitPressure).toBeGreaterThan(0)
+  })
+
+  it('forces sweep/occlusion/redaction compliance before disposal deadline week', () => {
+    const compliance = resolveDisposalDeadlineCompliance(DISPOSAL_DEADLINE_SWEEP_FIXTURE, 32)
+
+    expect(compliance.compliant).toBe(false)
+    expect(compliance.requiredActions).toEqual(
+      expect.arrayContaining(['sweep', 'occlusion', 'redaction'])
+    )
+    expect(compliance.overdueMediaInstanceIds).toContain('media:custody-roll-11')
+
+    const afterDeadline = resolveDisposalDeadlineCompliance(DISPOSAL_DEADLINE_SWEEP_FIXTURE, 42)
+    expect(afterDeadline.overdueMediaInstanceIds).toHaveLength(0)
+    expect(afterDeadline.compliant).toBe(true)
+  })
+
+  it('allows pursuit resolution when occlusionState is covered', () => {
+    expect(COVERED_PURSUIT_RESOLUTION_FIXTURE.pursuitState).toBe('active_pursuit')
+    expect(COVERED_PURSUIT_RESOLUTION_FIXTURE.occlusionState).toBe('covered')
+
+    const nextState = resolvePursuitStateAfterOcclusion(COVERED_PURSUIT_RESOLUTION_FIXTURE)
+    expect(nextState).toBe('resolved')
+
+    const exposedRecord = baseRecord({
+      pursuitState: 'active_pursuit',
+      occlusionState: 'exposed',
+      targetInstanceIds: ['target:viewer-1'],
+    })
+    expect(resolvePursuitStateAfterOcclusion(exposedRecord)).toBe('active_pursuit')
+  })
+
+  it('errors on imported object number in record id', () => {
+    const result = validateVisualTriggerHazardRecord(
+      baseRecord({
+        id: 'visual-trigger:scp-096-recording-hazard',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(
+      result.issues.some(
+        (issue) =>
+          issue.code === 'branded_object_number_in_id' || issue.code === 'franchise_token_in_id'
+      )
+    ).toBe(true)
+  })
+
+  it('errors on active_pursuit without targetInstanceIds', () => {
+    const result = validateVisualTriggerHazardRecord(
+      baseRecord({
+        pursuitState: 'active_pursuit',
+        targetInstanceIds: [],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'active_pursuit_without_target',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('projects broadcast-scale exposure chain risk from repost chains and storage scope', () => {
+    const projection = projectExposureChainRisk(BACKGROUND_FRAGMENT_LATENT_FIXTURE)
+
+    expect(projection.recordId).toBe(BACKGROUND_FRAGMENT_LATENT_FIXTURE.id)
+    expect(projection.repostChainDepth).toBe(2)
+    expect(projection.latentActivationForecast).toBe(true)
+    expect(projection.broadcastRiskScore).toBeGreaterThan(0.4)
+    expect(projection.requiredCountermeasures).toEqual(
+      expect.arrayContaining(['broadcast_takedown', 'media_sweep', 'repost_chain_trace'])
+    )
+    expect(['local', 'regional', 'broadcast']).toContain(projection.escalationBand)
+  })
+
+  it('preserves presentationMismatchProfile on subconscious retinal fixture', () => {
+    const profile = SUBCONSCIOUS_RETINAL_FILTER_FAILURE_FIXTURE.presentationMismatchProfile
+
+    expect(profile?.cameraSpecificReveal).toBe(0.67)
+    expect(profile?.nonstandardMovement).toBe(0.55)
+
+    const result = validateVisualTriggerHazardRecord(SUBCONSCIOUS_RETINAL_FILTER_FAILURE_FIXTURE)
+    expect(result.valid).toBe(true)
+  })
+
+  it('validates untrusted payloads without throwing when fields are missing', () => {
+    const result = validateVisualTriggerHazardRecord({} as VisualTriggerHazardRecord)
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.map((issue) => issue.code).sort()).toEqual(
+      [
+        'invalid_awareness_requirement',
+        'invalid_derivative_hazard_profile',
+        'invalid_occlusion_state',
+        'invalid_pursuit_state',
+        'invalid_trigger_medium',
+        'missing_id',
+        'missing_label',
+      ].sort()
+    )
+  })
+
+  it('produces byte-stable validation output on repeated runs', () => {
+    const record = baseRecord({
+      pursuitState: 'active_pursuit',
+      targetInstanceIds: ['target:viewer-1'],
+      filterLatencyWeeks: 1,
+      exposurePathWeeks: 4,
+    })
+
+    const first = JSON.stringify(validateVisualTriggerHazardRecord(record))
+    const second = JSON.stringify(validateVisualTriggerHazardRecord(record))
+
+    expect(first).toBe(second)
+  })
+
+  it('produces byte-stable exposure projection on repeated runs', () => {
+    const first = JSON.stringify(projectExposureChainRisk(BACKGROUND_FRAGMENT_LATENT_FIXTURE))
+    const second = JSON.stringify(projectExposureChainRisk(BACKGROUND_FRAGMENT_LATENT_FIXTURE))
+
+    expect(first).toBe(second)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds pure deterministic **visual-trigger hazard registry** ([SPE-2111](https://linear.app/spectranoir/issue/SPE-2111)) for anomalies whose hazardous feature propagates through sight, recordings, and derivative media — plus exposure-created pursuit targets.
- Implements `VisualTriggerHazardRecord` schema, `validateVisualTriggerHazardRecord`, `observerAwarenessEscalation`, `resolveEffectiveDerivativeHazard`, `resolveDisposalDeadlineCompliance`, `resolvePursuitStateAfterOcclusion`, and `projectExposureChainRisk` in `src/domain/visualTriggerHazardRegistry.ts`.
- Adds focused tests (14) and slice doc `planning/visual-trigger-hazard-registry-slice-1.md`.

**Parent:** [SPE-947](https://linear.app/spectranoir/issue/SPE-947) — remains **open** (slice 1 only; full parent scope not shipped).

**Deferred (not in this PR):** propagation graph wire-up (#965 family), pursuit vector simulator integration, countermeasure ledger link, GameState persistence and field UI.

## Linear

- Slice: [SPE-2111](https://linear.app/spectranoir/issue/SPE-2111)
- Parent: [SPE-947](https://linear.app/spectranoir/issue/SPE-947) (stays open)

## Docs updated

- `planning/visual-trigger-hazard-registry-slice-1.md` (new)

## Validation

- [x] `npm run test:run -- src/test/visualTriggerHazardRegistry.test.ts` (14 passed)
- [x] `npm run lint` (new files)

## Test plan

- [ ] CI green
- [ ] Acceptance fixtures: background_fragment latent activation, subconscious_retinal filter latency warning, artistic_exempt derivative, observer awareness pursuit transition, disposal deadline compliance, covered occlusion resolution, branded object-number validation error