### PR TITLE
feat(SPE-2114): entity welfare reclassification registry (slice 1)

### DIFF
--- a/planning/entity-welfare-reclassification-registry-slice-1.md
+++ b/planning/entity-welfare-reclassification-registry-slice-1.md
@@ -1,4 +1,4 @@
-# SPE-1046 — Entity welfare reclassification registry slice 1
+# SPE-2114 — Entity welfare reclassification registry slice 1
 
 One-page implementation plan. Linear: [SPE-2114](https://linear.app/spectranoir/issue/SPE-2114) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows shipped [SPE-2111](https://linear.app/spectranoir/issue/SPE-2111) (visual-trigger hazard registry).
 

--- a/planning/entity-welfare-reclassification-registry-slice-1.md
+++ b/planning/entity-welfare-reclassification-registry-slice-1.md
@@ -1,0 +1,105 @@
+# SPE-1046 — Entity welfare reclassification registry slice 1
+
+One-page implementation plan. Linear: [SPE-2114](https://linear.app/spectranoir/issue/SPE-2114) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows shipped [SPE-2111](https://linear.app/spectranoir/issue/SPE-2111) (visual-trigger hazard registry).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2114 — Entity welfare reclassification registry — threat label drift and disposition review (slice 1)](https://linear.app/spectranoir/issue/SPE-2114) |
+| **Parent** | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) — Affiliation status and entity custody posture |
+| **Branch** | `jamesdyedbq/spe-2114-entity-welfare-reclassification-registry-threat-label-drift`                           |
+| **Status** | In Progress                                                                                                |
+
+## Goal
+
+Add a pure deterministic **entity welfare reclassification registry** so cases can move from hostile-threat containment to rights-aware custody when evidence, behavior, or ethics review warrants — without importing external object numbers or franchise labels.
+
+## Prerequisite (on `main` @ `fe59d62e`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Visual-trigger hazard | `src/domain/visualTriggerHazardRegistry.ts` (SPE-2111 / PR #2432)   |
+| Pattern source series | `src/domain/patternSourceSeriesRegistry.ts` (SPE-2110)               |
+| Public disclosure    | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109)               |
+| Intake registry wave | SPE-2104 / SPE-2105 / SPE-2106 / SPE-2108 sibling patterns             |
+| Harvest batch        | `starter-picks-routing-65` (C34) in `planning/harvest-reconciliation-index.md` |
+
+## Gap (pre-slice)
+
+- No bounded schema for threat-label drift, disposition review gates, or containment revision hooks.
+- No deterministic validation for terminal reclassification states without review artifacts or evidence bundles.
+- No staff morale, liability, or public-risk pressure projection helper.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `EntityWelfareReclassificationId` + `EntityWelfareReclassificationRecord` in `src/domain/entityWelfareReclassificationRegistry.ts` | GameState persistence                         |
+| priorThreatLabel, proposedDisposition, welfareDebtRef, reviewGate, reviewArtifactRef, reclassificationState, evidenceBundleRefs, containmentRevisionRefs | SPE-1046 affiliation wire-up                  |
+| transitionHistory — append-only pending → approved / denied / reverted trail                                                       | SPE-1310 case lifecycle integration           |
+| `validateEntityWelfareReclassificationRecord(record)` — terminal states require review artifact + evidence; franchise token → error | SPE-1203 animal welfare cross-check           |
+| `projectReclassificationPressure(record, policy)` — staff morale, liability, and public-risk forecast                              | SPE-1888 welfare-debt accounting engine       |
+| Focused tests in `src/test/entityWelfareReclassificationRegistry.test.ts`                                                        | Full SPE-1046 parent Done                     |
+
+## Record contract (deterministic)
+
+### Core fields
+
+- **priorThreatLabel** — institutional threat classification at review open (free-text ref, not franchise object number).
+- **proposedDisposition** — `hostile`, `cooperative`, `medical`, `sapient_remains`, `unknown`.
+- **welfareDebtRef** — external hook to SPE-1888 welfare-debt ledger (field only in slice 1).
+- **reviewGate** — `ethics`, `veterinary`, `psych`, `executive`.
+- **reviewArtifactRef** — signed review packet ref required for terminal states.
+- **reclassificationState** — `pending`, `approved`, `denied`, `reverted`.
+- **evidenceBundleRefs** — non-empty required before approval; sympathy alone never sufficient.
+- **containmentRevisionRefs** — containment posture changes tied to approved reclassification.
+- **transitionHistory** — append-only `{ fromState, toState, week, reviewGate?, reviewArtifactRef?, note? }[]`.
+- **confidence / unknown / redacted** — projection legibility without dumping hidden dossier truth.
+
+### Validation rules (examples)
+
+- `approved` or `denied` without `reviewArtifactRef` → error.
+- `approved` without non-empty `evidenceBundleRefs` → error.
+- `approved` without non-empty `containmentRevisionRefs` when disposition softens from hostile posture → warning.
+- Terminal state without matching `reviewGate` on record or history entry → warning.
+- Franchise / wiki / branded object-number token in id or CP-neutral field → error.
+
+## Acceptance
+
+- [x] Fixture: pending → approved with ethics review ref and containment revision.
+- [x] Fixture: hostile → cooperative with welfare debt accumulation hook.
+- [x] Negative: approved without reviewGate artifact → validation error.
+- [x] Negative: denied without review artifact → validation error.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Schema + types** — unions, record shape, exported fixtures.
+2. **Validation** — positive fixtures + negative lint cases.
+3. **Projection** — reclassification pressure forecast.
+4. **Regression** — sibling registry tests unchanged.
+
+## File touch list (expected)
+
+| Area   | Files                                                       |
+| ------ | ----------------------------------------------------------- |
+| Domain | `src/domain/entityWelfareReclassificationRegistry.ts`       |
+| Tests  | `src/test/entityWelfareReclassificationRegistry.test.ts`    |
+| Plan   | `planning/entity-welfare-reclassification-registry-slice-1.md` |
+
+## Branch
+
+`jamesdyedbq/spe-2114-entity-welfare-reclassification-registry-threat-label-drift`
+
+## Out of scope (parent closure)
+
+- Full SPE-1046 parent Done
+- GameState persistence and weekly orchestration wiring
+- SPE-1888 welfare-debt engine, SPE-1203 veterinary cross-check, SPE-1310 case lifecycle
+
+## See also
+
+- `planning/harvest-reconciliation-index.md` — harvest batch `starter-picks-routing-65`
+- `planning/proximity-chemical-predator-metadata-26-harvest.md` — C13–C14 owner map
+- `src/domain/publicDisclosureStateRegistry.ts` — validation + projection conventions (SPE-2109)
+- `src/domain/visualTriggerHazardRegistry.ts` — sibling intake registry pattern (SPE-2111)

--- a/src/domain/entityWelfareReclassificationRegistry.ts
+++ b/src/domain/entityWelfareReclassificationRegistry.ts
@@ -1,0 +1,793 @@
+/**
+ * SPE-2114 slice 1: entity welfare reclassification registry.
+ *
+ * Pure deterministic registry for moving entities from hostile-threat containment
+ * to rights-aware custody when evidence, behavior, or ethics review warrants —
+ * distinct from affiliation status wire-up (SPE-1046) and welfare-debt accounting (SPE-1888).
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type EntityWelfareReclassificationId = string
+
+export type ProposedDisposition =
+  | 'hostile'
+  | 'cooperative'
+  | 'medical'
+  | 'sapient_remains'
+  | 'unknown'
+
+export const PROPOSED_DISPOSITIONS: readonly ProposedDisposition[] = [
+  'hostile',
+  'cooperative',
+  'medical',
+  'sapient_remains',
+  'unknown',
+] as const
+
+export type ReviewGate = 'ethics' | 'veterinary' | 'psych' | 'executive'
+
+export const REVIEW_GATES: readonly ReviewGate[] = [
+  'ethics',
+  'veterinary',
+  'psych',
+  'executive',
+] as const
+
+export type ReclassificationState = 'pending' | 'approved' | 'denied' | 'reverted'
+
+export const RECLASSIFICATION_STATES: readonly ReclassificationState[] = [
+  'pending',
+  'approved',
+  'denied',
+  'reverted',
+] as const
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface ReclassificationTransitionHistoryEntry {
+  readonly fromState: ReclassificationState
+  readonly toState: ReclassificationState
+  readonly week: number
+  readonly reviewGate?: ReviewGate
+  readonly reviewArtifactRef?: string
+  readonly note?: string
+}
+
+export interface EntityWelfareReclassificationRecord {
+  readonly id: EntityWelfareReclassificationId
+  readonly label: string
+  readonly summary?: string
+  readonly priorThreatLabel: string
+  readonly proposedDisposition: ProposedDisposition
+  readonly welfareDebtRef?: string
+  readonly reviewGate?: ReviewGate
+  readonly reviewArtifactRef?: string
+  readonly reclassificationState: ReclassificationState
+  readonly evidenceBundleRefs?: readonly string[]
+  readonly containmentRevisionRefs?: readonly string[]
+  readonly transitionHistory?: readonly ReclassificationTransitionHistoryEntry[]
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type EntityWelfareReclassificationValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_prior_threat_label'
+  | 'invalid_proposed_disposition'
+  | 'invalid_review_gate'
+  | 'invalid_reclassification_state'
+  | 'invalid_confidence'
+  | 'empty_evidence_bundle_ref'
+  | 'invalid_transition_history_entry'
+  | 'invalid_transition_history_week'
+  | 'invalid_transition_history_state'
+  | 'terminal_state_without_review_artifact'
+  | 'approved_without_evidence_bundles'
+  | 'approved_without_containment_revision'
+  | 'terminal_state_without_review_gate'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_field'
+
+export interface EntityWelfareReclassificationValidationIssue {
+  readonly code: EntityWelfareReclassificationValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface EntityWelfareReclassificationValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly EntityWelfareReclassificationValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Pressure projection
+// ---------------------------------------------------------------------------
+
+export interface ReclassificationPressureProjectionPolicy {
+  readonly minimumConfidence?: number
+  readonly redactUnknown?: boolean
+  readonly liabilityAmplification?: number
+}
+
+export interface ReclassificationPressureProjection {
+  readonly recordId: EntityWelfareReclassificationId
+  readonly label: string
+  readonly reclassificationState: ReclassificationState
+  readonly staffMoraleForecast: number | null
+  readonly liabilityForecast: number | null
+  readonly publicRiskForecast: number | null
+  readonly welfareDebtLinked: boolean
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const PROPOSED_DISPOSITION_SET = new Set<string>(PROPOSED_DISPOSITIONS)
+const REVIEW_GATE_SET = new Set<string>(REVIEW_GATES)
+const RECLASSIFICATION_STATE_SET = new Set<string>(RECLASSIFICATION_STATES)
+
+const HOSTILE_PRIOR_LABEL_PATTERN = /\b(hostile|keter|euclid|threat|predator|apex)\b/i
+const SOFT_DISPOSITIONS = new Set<ProposedDisposition>(['cooperative', 'medical', 'unknown'])
+const TERMINAL_STATES = new Set<ReclassificationState>(['approved', 'denied', 'reverted'])
+
+const REVIEW_GATE_LIABILITY_WEIGHT: Readonly<Record<ReviewGate, number>> = {
+  ethics: 0.72,
+  veterinary: 0.48,
+  psych: 0.56,
+  executive: 0.84,
+}
+
+const DISPOSITION_PUBLIC_RISK_WEIGHT: Readonly<Record<ProposedDisposition, number>> = {
+  hostile: 0.82,
+  cooperative: 0.34,
+  medical: 0.28,
+  sapient_remains: 0.41,
+  unknown: 0.55,
+}
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest|broken masquerade|masquerade breach)\b/i
+
+export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return Object.freeze(
+    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function asTransitionHistory(value: unknown): readonly ReclassificationTransitionHistoryEntry[] {
+  return Array.isArray(value) ? value : []
+}
+
+function pushIssue(
+  issues: EntityWelfareReclassificationValidationIssue[],
+  issue: EntityWelfareReclassificationValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: EntityWelfareReclassificationValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function freezeValidationResult(
+  issues: EntityWelfareReclassificationValidationIssue[]
+): EntityWelfareReclassificationValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function hasNonEmptyEvidenceBundles(record: EntityWelfareReclassificationRecord): boolean {
+  return asStringArray(record.evidenceBundleRefs).some((ref) => normalizeToken(ref).length > 0)
+}
+
+function hasReviewArtifact(record: EntityWelfareReclassificationRecord): boolean {
+  if (normalizeToken(record.reviewArtifactRef ?? '').length > 0) {
+    return true
+  }
+
+  return asTransitionHistory(record.transitionHistory).some(
+    (entry) => entry && typeof entry === 'object' && normalizeToken(entry.reviewArtifactRef ?? '').length > 0
+  )
+}
+
+function hasReviewGate(record: EntityWelfareReclassificationRecord): boolean {
+  if (record.reviewGate && isReviewGate(record.reviewGate)) {
+    return true
+  }
+
+  return asTransitionHistory(record.transitionHistory).some(
+    (entry) => entry && typeof entry === 'object' && entry.reviewGate !== undefined && isReviewGate(entry.reviewGate)
+  )
+}
+
+function hasContainmentRevision(record: EntityWelfareReclassificationRecord): boolean {
+  return asStringArray(record.containmentRevisionRefs).some((ref) => normalizeToken(ref).length > 0)
+}
+
+function isHostilePriorLabel(label: string): boolean {
+  return HOSTILE_PRIOR_LABEL_PATTERN.test(normalizeToken(label))
+}
+
+function dispositionSoftensFromHostilePosture(record: EntityWelfareReclassificationRecord): boolean {
+  return (
+    isHostilePriorLabel(record.priorThreatLabel) &&
+    SOFT_DISPOSITIONS.has(record.proposedDisposition)
+  )
+}
+
+function clampUnit(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+function roundUnit(value: number): number {
+  return Math.round(clampUnit(value) * 1000) / 1000
+}
+
+function scanForbiddenTokens(
+  issues: EntityWelfareReclassificationValidationIssue[],
+  id: string,
+  label: string,
+  record: EntityWelfareReclassificationRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Entity welfare reclassification record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Entity welfare reclassification record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Entity welfare reclassification record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Entity welfare reclassification record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const stringFields: Array<{ field: string; value: string | undefined }> = [
+    { field: 'summary', value: record.summary },
+    { field: 'priorThreatLabel', value: record.priorThreatLabel },
+    { field: 'welfareDebtRef', value: record.welfareDebtRef },
+    { field: 'reviewArtifactRef', value: record.reviewArtifactRef },
+  ]
+
+  for (const { field, value } of stringFields) {
+    const token = normalizeToken(value ?? '')
+    if (!token) {
+      continue
+    }
+
+    if (containsFranchiseToken(token)) {
+      pushIssue(issues, {
+        code: 'franchise_token_in_field',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (containsBrandedObjectNumber(token)) {
+      pushIssue(issues, {
+        code: 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} field ${field} contains a branded object number.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const ref of asStringArray(record.evidenceBundleRefs)) {
+    const token = normalizeToken(ref)
+    if (token && (containsFranchiseToken(token) || containsBrandedObjectNumber(token))) {
+      pushIssue(issues, {
+        code: containsFranchiseToken(token) ? 'franchise_token_in_field' : 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} evidenceBundleRefs contains a forbidden token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const ref of asStringArray(record.containmentRevisionRefs)) {
+    const token = normalizeToken(ref)
+    if (token && (containsFranchiseToken(token) || containsBrandedObjectNumber(token))) {
+      pushIssue(issues, {
+        code: containsFranchiseToken(token) ? 'franchise_token_in_field' : 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} containmentRevisionRefs contains a forbidden token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const entry of asTransitionHistory(record.transitionHistory)) {
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+
+    for (const token of [entry.note, entry.reviewArtifactRef]) {
+      const normalized = normalizeToken(token ?? '')
+      if (!normalized) {
+        continue
+      }
+
+      if (containsFranchiseToken(normalized)) {
+        pushIssue(issues, {
+          code: 'franchise_token_in_field',
+          severity: 'error',
+          detail: `Entity welfare reclassification record ${id || '(unknown)'} transitionHistory contains a franchise or source-literal token.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+
+      if (containsBrandedObjectNumber(normalized)) {
+        pushIssue(issues, {
+          code: 'branded_object_number_in_field',
+          severity: 'error',
+          detail: `Entity welfare reclassification record ${id || '(unknown)'} transitionHistory contains a branded object number.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+    }
+  }
+}
+
+function resolveConfidence(
+  record: EntityWelfareReclassificationRecord,
+  policy: ReclassificationPressureProjectionPolicy
+): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (redactedFields.has('confidence')) {
+    return null
+  }
+
+  const confidence = record.confidence ?? null
+  if (
+    confidence !== null &&
+    policy.minimumConfidence !== undefined &&
+    confidence < policy.minimumConfidence
+  ) {
+    return null
+  }
+
+  if (policy.redactUnknown === true && unknownFields.includes('confidence')) {
+    return null
+  }
+
+  return confidence
+}
+
+function resolveStaffMoraleForecast(record: EntityWelfareReclassificationRecord): number {
+  const base =
+    record.reclassificationState === 'approved'
+      ? 0.58
+      : record.reclassificationState === 'pending'
+        ? 0.44
+        : record.reclassificationState === 'denied'
+          ? 0.36
+          : 0.4
+
+  const dispositionLift = record.proposedDisposition === 'cooperative' ? 0.12 : 0
+  const evidenceLift = hasNonEmptyEvidenceBundles(record) ? 0.06 : -0.08
+  const revisionLift = hasContainmentRevision(record) ? 0.05 : 0
+
+  return roundUnit(base + dispositionLift + evidenceLift + revisionLift)
+}
+
+function resolveLiabilityForecast(
+  record: EntityWelfareReclassificationRecord,
+  policy: ReclassificationPressureProjectionPolicy
+): number {
+  const gateWeight = record.reviewGate ? REVIEW_GATE_LIABILITY_WEIGHT[record.reviewGate] : 0.5
+  const debtLift = normalizeToken(record.welfareDebtRef ?? '').length > 0 ? 0.18 : 0
+  const hostilePriorLift = isHostilePriorLabel(record.priorThreatLabel) ? 0.14 : 0.04
+  const terminalLift = TERMINAL_STATES.has(record.reclassificationState) ? 0.08 : 0
+  const amplification = policy.liabilityAmplification ?? 1
+
+  return roundUnit((gateWeight + debtLift + hostilePriorLift + terminalLift) * amplification)
+}
+
+function resolvePublicRiskForecast(record: EntityWelfareReclassificationRecord): number {
+  const dispositionRisk = DISPOSITION_PUBLIC_RISK_WEIGHT[record.proposedDisposition]
+  const pendingUncertainty = record.reclassificationState === 'pending' ? 0.08 : 0
+  const deniedBacklash = record.reclassificationState === 'denied' ? 0.1 : 0
+  const revisionRelief = hasContainmentRevision(record) ? -0.06 : 0
+
+  return roundUnit(dispositionRisk + pendingUncertainty + deniedBacklash + revisionRelief)
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isProposedDisposition(value: string): value is ProposedDisposition {
+  return PROPOSED_DISPOSITION_SET.has(value)
+}
+
+export function isReviewGate(value: string): value is ReviewGate {
+  return REVIEW_GATE_SET.has(value)
+}
+
+export function isReclassificationState(value: string): value is ReclassificationState {
+  return RECLASSIFICATION_STATE_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateEntityWelfareReclassificationRecord(
+  record: EntityWelfareReclassificationRecord
+): EntityWelfareReclassificationValidationResult {
+  const issues: EntityWelfareReclassificationValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const priorThreatLabel = normalizeToken(record.priorThreatLabel)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Entity welfare reclassification record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Entity welfare reclassification record is missing label.',
+    })
+  }
+
+  if (!priorThreatLabel) {
+    pushIssue(issues, {
+      code: 'missing_prior_threat_label',
+      severity: 'error',
+      detail: 'Entity welfare reclassification record is missing priorThreatLabel.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isProposedDisposition(record.proposedDisposition)) {
+    pushIssue(issues, {
+      code: 'invalid_proposed_disposition',
+      severity: 'error',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} has invalid proposedDisposition ${String(record.proposedDisposition)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.reviewGate !== undefined && !isReviewGate(record.reviewGate)) {
+    pushIssue(issues, {
+      code: 'invalid_review_gate',
+      severity: 'error',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} has invalid reviewGate ${String(record.reviewGate)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isReclassificationState(record.reclassificationState)) {
+    pushIssue(issues, {
+      code: 'invalid_reclassification_state',
+      severity: 'error',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} has invalid reclassificationState ${String(record.reclassificationState)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} confidence must be between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const ref of asStringArray(record.evidenceBundleRefs)) {
+    if (!normalizeToken(ref)) {
+      pushIssue(issues, {
+        code: 'empty_evidence_bundle_ref',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} evidenceBundleRefs contains an empty ref.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const entry of asTransitionHistory(record.transitionHistory)) {
+    if (!entry || typeof entry !== 'object') {
+      pushIssue(issues, {
+        code: 'invalid_transition_history_entry',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} transitionHistory contains invalid entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
+    if (!isReclassificationState(entry.fromState) || !isReclassificationState(entry.toState)) {
+      pushIssue(issues, {
+        code: 'invalid_transition_history_state',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} transitionHistory contains invalid state.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!isFiniteWeek(entry.week)) {
+      pushIssue(issues, {
+        code: 'invalid_transition_history_week',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} transitionHistory contains invalid week.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (entry.reviewGate !== undefined && !isReviewGate(entry.reviewGate)) {
+      pushIssue(issues, {
+        code: 'invalid_transition_history_entry',
+        severity: 'error',
+        detail: `Entity welfare reclassification record ${id || '(unknown)'} transitionHistory contains invalid reviewGate.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  scanForbiddenTokens(issues, id, label, record)
+
+  if (TERMINAL_STATES.has(record.reclassificationState) && !hasReviewArtifact(record)) {
+    pushIssue(issues, {
+      code: 'terminal_state_without_review_artifact',
+      severity: 'error',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} in ${record.reclassificationState} requires reviewArtifactRef.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.reclassificationState === 'approved' && !hasNonEmptyEvidenceBundles(record)) {
+    pushIssue(issues, {
+      code: 'approved_without_evidence_bundles',
+      severity: 'error',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} approval requires non-empty evidenceBundleRefs.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.reclassificationState === 'approved' &&
+    dispositionSoftensFromHostilePosture(record) &&
+    !hasContainmentRevision(record)
+  ) {
+    pushIssue(issues, {
+      code: 'approved_without_containment_revision',
+      severity: 'warning',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} approved softening from hostile posture should include containmentRevisionRefs.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (TERMINAL_STATES.has(record.reclassificationState) && !hasReviewGate(record)) {
+    pushIssue(issues, {
+      code: 'terminal_state_without_review_gate',
+      severity: 'warning',
+      detail: `Entity welfare reclassification record ${id || '(unknown)'} in ${record.reclassificationState} should declare reviewGate on record or history.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Projects staff morale, liability, and public-risk pressure from record-derived fields.
+ * Does not assert hidden dossier truth or automatic sympathy-based reclassification.
+ */
+export function projectReclassificationPressure(
+  record: EntityWelfareReclassificationRecord,
+  policy: ReclassificationPressureProjectionPolicy = {}
+): ReclassificationPressureProjection {
+  const recordId = normalizeToken(record.id) || '(unknown)'
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = sortedStringArray(record.unknownFields)
+  const confidence = resolveConfidence(record, policy)
+
+  const moraleRedacted =
+    redactedFields.has('staffMoraleForecast') ||
+    (policy.redactUnknown === true && unknownFields.includes('staffMoraleForecast'))
+  const liabilityRedacted =
+    redactedFields.has('liabilityForecast') ||
+    (policy.redactUnknown === true && unknownFields.includes('liabilityForecast'))
+  const publicRiskRedacted =
+    redactedFields.has('publicRiskForecast') ||
+    (policy.redactUnknown === true && unknownFields.includes('publicRiskForecast'))
+
+  const staffMoraleForecast = moraleRedacted ? null : resolveStaffMoraleForecast(record)
+  const liabilityForecast = liabilityRedacted ? null : resolveLiabilityForecast(record, policy)
+  const publicRiskForecast = publicRiskRedacted ? null : resolvePublicRiskForecast(record)
+
+  const welfareDebtLinked = normalizeToken(record.welfareDebtRef ?? '').length > 0
+  const redacted =
+    moraleRedacted &&
+    liabilityRedacted &&
+    publicRiskRedacted &&
+    (confidence === null || redactedFields.has('confidence'))
+
+  return Object.freeze({
+    recordId,
+    label: normalizeToken(record.label) || '(unknown)',
+    reclassificationState: isReclassificationState(record.reclassificationState)
+      ? record.reclassificationState
+      : 'pending',
+    staffMoraleForecast,
+    liabilityForecast,
+    publicRiskForecast,
+    welfareDebtLinked,
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
+function defineRecord(record: EntityWelfareReclassificationRecord): EntityWelfareReclassificationRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Pending → approved with ethics review ref and containment revision. */
+export const PENDING_TO_APPROVED_FIXTURE: EntityWelfareReclassificationRecord = defineRecord({
+  id: 'reclass:field-observation-custody-shift',
+  label: 'Field observation custody shift',
+  summary: 'Behavioral evidence supports cooperative custody after hostile initial classification.',
+  priorThreatLabel: 'hostile-predator',
+  proposedDisposition: 'cooperative',
+  welfareDebtRef: 'welfare-debt:coercive-restraint-ledger-12',
+  reviewGate: 'ethics',
+  reviewArtifactRef: 'review:ethics-board-packet-44',
+  reclassificationState: 'approved',
+  evidenceBundleRefs: [
+    'evidence:behavioral-observation-week-9',
+    'evidence:veterinary-vitals-week-10',
+  ],
+  containmentRevisionRefs: ['revision:reduce-force-containment-tier-2'],
+  transitionHistory: [
+    {
+      fromState: 'pending',
+      toState: 'approved',
+      week: 11,
+      reviewGate: 'ethics',
+      reviewArtifactRef: 'review:ethics-board-packet-44',
+      note: 'Ethics board approves cooperative custody with revised containment posture.',
+    },
+  ],
+  confidence: 0.67,
+})
+
+/** Hostile threat label drift toward cooperative disposition with welfare debt hook. */
+export const HOSTILE_TO_COOPERATIVE_FIXTURE: EntityWelfareReclassificationRecord = defineRecord({
+  id: 'reclass:apex-threat-behavior-reassessment',
+  label: 'Apex threat behavior reassessment',
+  summary: 'Repeated non-aggressive contact pattern triggers disposition review and debt accounting hook.',
+  priorThreatLabel: 'hostile-apex-threat',
+  proposedDisposition: 'cooperative',
+  welfareDebtRef: 'welfare-debt:forced-sedation-cycle-3',
+  reviewGate: 'psych',
+  reviewArtifactRef: 'review:psych-panel-summary-19',
+  reclassificationState: 'approved',
+  evidenceBundleRefs: ['evidence:contact-log-week-14', 'evidence:stress-marker-trend-week-15'],
+  containmentRevisionRefs: ['revision:social-enrichment-pilot'],
+  transitionHistory: [
+    {
+      fromState: 'pending',
+      toState: 'approved',
+      week: 16,
+      reviewGate: 'psych',
+      reviewArtifactRef: 'review:psych-panel-summary-19',
+      note: 'Psych panel confirms cooperative disposition with accumulated welfare debt noted.',
+    },
+  ],
+  confidence: 0.61,
+})

--- a/src/domain/entityWelfareReclassificationRegistry.ts
+++ b/src/domain/entityWelfareReclassificationRegistry.ts
@@ -166,7 +166,7 @@ const DISPOSITION_PUBLIC_RISK_WEIGHT: Readonly<Record<ProposedDisposition, numbe
 }
 
 export const FRANCHISE_TOKEN_PATTERN =
-  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest|broken masquerade|masquerade breach)\b/i
+  /(?:\b(?:scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|group of interest|broken masquerade|masquerade breach)\b|goi-)/i
 
 export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
 
@@ -300,6 +300,10 @@ function clampUnit(value: number): number {
 }
 
 function roundUnit(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
   return Math.round(clampUnit(value) * 1000) / 1000
 }
 
@@ -481,19 +485,40 @@ function resolveLiabilityForecast(
   record: EntityWelfareReclassificationRecord,
   policy: ReclassificationPressureProjectionPolicy
 ): number {
-  const gateWeight = record.reviewGate ? REVIEW_GATE_LIABILITY_WEIGHT[record.reviewGate] : 0.5
+  const gateWeight =
+    record.reviewGate !== undefined && isReviewGate(record.reviewGate)
+      ? REVIEW_GATE_LIABILITY_WEIGHT[record.reviewGate]
+      : 0.5
   const debtLift = normalizeToken(record.welfareDebtRef ?? '').length > 0 ? 0.18 : 0
   const hostilePriorLift = isHostilePriorLabel(record.priorThreatLabel) ? 0.14 : 0.04
-  const terminalLift = TERMINAL_STATES.has(record.reclassificationState) ? 0.08 : 0
-  const amplification = policy.liabilityAmplification ?? 1
+  const terminalLift =
+    isReclassificationState(record.reclassificationState) &&
+    TERMINAL_STATES.has(record.reclassificationState)
+      ? 0.08
+      : 0
+  const amplification =
+    typeof policy.liabilityAmplification === 'number' &&
+    Number.isFinite(policy.liabilityAmplification)
+      ? policy.liabilityAmplification
+      : 1
 
   return roundUnit((gateWeight + debtLift + hostilePriorLift + terminalLift) * amplification)
 }
 
 function resolvePublicRiskForecast(record: EntityWelfareReclassificationRecord): number {
-  const dispositionRisk = DISPOSITION_PUBLIC_RISK_WEIGHT[record.proposedDisposition]
-  const pendingUncertainty = record.reclassificationState === 'pending' ? 0.08 : 0
-  const deniedBacklash = record.reclassificationState === 'denied' ? 0.1 : 0
+  const dispositionRisk = isProposedDisposition(record.proposedDisposition)
+    ? DISPOSITION_PUBLIC_RISK_WEIGHT[record.proposedDisposition]
+    : DISPOSITION_PUBLIC_RISK_WEIGHT.unknown
+  const pendingUncertainty =
+    isReclassificationState(record.reclassificationState) &&
+    record.reclassificationState === 'pending'
+      ? 0.08
+      : 0
+  const deniedBacklash =
+    isReclassificationState(record.reclassificationState) &&
+    record.reclassificationState === 'denied'
+      ? 0.1
+      : 0
   const revisionRelief = hasContainmentRevision(record) ? -0.06 : 0
 
   return roundUnit(dispositionRisk + pendingUncertainty + deniedBacklash + revisionRelief)
@@ -503,16 +528,16 @@ function resolvePublicRiskForecast(record: EntityWelfareReclassificationRecord):
 // Type guards
 // ---------------------------------------------------------------------------
 
-export function isProposedDisposition(value: string): value is ProposedDisposition {
-  return PROPOSED_DISPOSITION_SET.has(value)
+export function isProposedDisposition(value: unknown): value is ProposedDisposition {
+  return typeof value === 'string' && PROPOSED_DISPOSITION_SET.has(value)
 }
 
-export function isReviewGate(value: string): value is ReviewGate {
-  return REVIEW_GATE_SET.has(value)
+export function isReviewGate(value: unknown): value is ReviewGate {
+  return typeof value === 'string' && REVIEW_GATE_SET.has(value)
 }
 
-export function isReclassificationState(value: string): value is ReclassificationState {
-  return RECLASSIFICATION_STATE_SET.has(value)
+export function isReclassificationState(value: unknown): value is ReclassificationState {
+  return typeof value === 'string' && RECLASSIFICATION_STATE_SET.has(value)
 }
 
 // ---------------------------------------------------------------------------
@@ -712,10 +737,11 @@ export function projectReclassificationPressure(
 
   const welfareDebtLinked = normalizeToken(record.welfareDebtRef ?? '').length > 0
   const redacted =
-    moraleRedacted &&
-    liabilityRedacted &&
-    publicRiskRedacted &&
-    (confidence === null || redactedFields.has('confidence'))
+    moraleRedacted ||
+    liabilityRedacted ||
+    publicRiskRedacted ||
+    redactedFields.has('confidence') ||
+    (confidence === null && record.confidence !== undefined && policy.minimumConfidence !== undefined)
 
   return Object.freeze({
     recordId,

--- a/src/test/entityWelfareReclassificationRegistry.test.ts
+++ b/src/test/entityWelfareReclassificationRegistry.test.ts
@@ -166,13 +166,56 @@ describe('entityWelfareReclassificationRegistry (SPE-2114 slice 1)', () => {
   })
 
   it('redacts pressure forecasts when policy requests unknown redaction', () => {
-    const projection = projectReclassificationPressure(PENDING_TO_APPROVED_FIXTURE, {
-      redactUnknown: true,
+    const projection = projectReclassificationPressure(
+      {
+        ...PENDING_TO_APPROVED_FIXTURE,
+        unknownFields: ['staffMoraleForecast', 'liabilityForecast', 'publicRiskForecast'],
+      },
+      {
+        redactUnknown: true,
+      }
+    )
+
+    expect(projection.staffMoraleForecast).toBeNull()
+    expect(projection.liabilityForecast).toBeNull()
+    expect(projection.publicRiskForecast).toBeNull()
+    expect(projection.redacted).toBe(true)
+  })
+
+  it('marks projection redacted when only one forecast field is hidden', () => {
+    const projection = projectReclassificationPressure({
+      ...PENDING_TO_APPROVED_FIXTURE,
+      redactedFields: ['staffMoraleForecast'],
     })
 
-    expect(projection.staffMoraleForecast).not.toBeNull()
+    expect(projection.staffMoraleForecast).toBeNull()
     expect(projection.liabilityForecast).not.toBeNull()
-    expect(projection.publicRiskForecast).not.toBeNull()
+    expect(projection.redacted).toBe(true)
+  })
+
+  it('errors on goi- franchise token prefix in record label', () => {
+    const result = validateEntityWelfareReclassificationRecord(
+      baseRecord({
+        label: 'goi-arcadia custody review',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+
+  it('keeps projection finite when record union fields are invalid', () => {
+    const projection = projectReclassificationPressure(
+      baseRecord({
+        reviewGate: 'invalid-gate' as EntityWelfareReclassificationRecord['reviewGate'],
+        proposedDisposition: 'invalid-disposition' as EntityWelfareReclassificationRecord['proposedDisposition'],
+        reclassificationState: 'invalid-state' as EntityWelfareReclassificationRecord['reclassificationState'],
+      })
+    )
+
+    expect(Number.isFinite(projection.liabilityForecast)).toBe(true)
+    expect(Number.isFinite(projection.publicRiskForecast)).toBe(true)
+    expect(projection.reclassificationState).toBe('pending')
   })
 
   it('returns byte-stable validation results on repeated calls', () => {

--- a/src/test/entityWelfareReclassificationRegistry.test.ts
+++ b/src/test/entityWelfareReclassificationRegistry.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HOSTILE_TO_COOPERATIVE_FIXTURE,
+  PENDING_TO_APPROVED_FIXTURE,
+  PROPOSED_DISPOSITIONS,
+  RECLASSIFICATION_STATES,
+  REVIEW_GATES,
+  projectReclassificationPressure,
+  validateEntityWelfareReclassificationRecord,
+  type EntityWelfareReclassificationRecord,
+} from '../domain/entityWelfareReclassificationRegistry'
+
+function baseRecord(
+  overrides: Partial<EntityWelfareReclassificationRecord> = {}
+): EntityWelfareReclassificationRecord {
+  return {
+    id: 'reclass:test-base',
+    label: 'Test base record',
+    priorThreatLabel: 'provisional-threat',
+    proposedDisposition: 'unknown',
+    reclassificationState: 'pending',
+    ...overrides,
+  }
+}
+
+describe('entityWelfareReclassificationRegistry (SPE-2114 slice 1)', () => {
+  it('validates fixture with pending → approved ethics review and containment revision', () => {
+    const result = validateEntityWelfareReclassificationRecord(PENDING_TO_APPROVED_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toHaveLength(0)
+    expect(PENDING_TO_APPROVED_FIXTURE.reclassificationState).toBe('approved')
+    expect(PENDING_TO_APPROVED_FIXTURE.reviewGate).toBe('ethics')
+    expect(PENDING_TO_APPROVED_FIXTURE.reviewArtifactRef).toBe('review:ethics-board-packet-44')
+    expect(PENDING_TO_APPROVED_FIXTURE.containmentRevisionRefs).toEqual([
+      'revision:reduce-force-containment-tier-2',
+    ])
+    expect(PENDING_TO_APPROVED_FIXTURE.transitionHistory?.[0]).toEqual(
+      expect.objectContaining({
+        fromState: 'pending',
+        toState: 'approved',
+        reviewGate: 'ethics',
+        reviewArtifactRef: 'review:ethics-board-packet-44',
+      })
+    )
+  })
+
+  it('validates hostile → cooperative fixture with welfare debt accumulation hook', () => {
+    const result = validateEntityWelfareReclassificationRecord(HOSTILE_TO_COOPERATIVE_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(HOSTILE_TO_COOPERATIVE_FIXTURE.priorThreatLabel).toMatch(/hostile/i)
+    expect(HOSTILE_TO_COOPERATIVE_FIXTURE.proposedDisposition).toBe('cooperative')
+    expect(HOSTILE_TO_COOPERATIVE_FIXTURE.welfareDebtRef).toMatch(/^welfare-debt:/)
+    expect(result.issues).toHaveLength(0)
+  })
+
+  it('errors when approved without reviewGate artifact', () => {
+    const result = validateEntityWelfareReclassificationRecord(
+      baseRecord({
+        reclassificationState: 'approved',
+        reviewGate: 'ethics',
+        evidenceBundleRefs: ['evidence:behavior-week-3'],
+        containmentRevisionRefs: ['revision:soft-custody'],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'terminal_state_without_review_artifact',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('errors when denied without review artifact', () => {
+    const result = validateEntityWelfareReclassificationRecord(
+      baseRecord({
+        reclassificationState: 'denied',
+        reviewGate: 'executive',
+        evidenceBundleRefs: ['evidence:insufficient-behavior-week-2'],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'terminal_state_without_review_artifact',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('errors when approved without evidence bundles', () => {
+    const result = validateEntityWelfareReclassificationRecord(
+      baseRecord({
+        reclassificationState: 'approved',
+        reviewGate: 'ethics',
+        reviewArtifactRef: 'review:ethics-packet-1',
+        containmentRevisionRefs: ['revision:soft-custody'],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'approved_without_evidence_bundles',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('warns when approved softening from hostile posture lacks containment revision', () => {
+    const result = validateEntityWelfareReclassificationRecord(
+      baseRecord({
+        priorThreatLabel: 'hostile-predator',
+        proposedDisposition: 'cooperative',
+        reclassificationState: 'approved',
+        reviewGate: 'ethics',
+        reviewArtifactRef: 'review:ethics-packet-2',
+        evidenceBundleRefs: ['evidence:behavior-week-4'],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'approved_without_containment_revision',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('errors on franchise label token in record fields', () => {
+    const result = validateEntityWelfareReclassificationRecord(
+      baseRecord({
+        label: 'Foundation custody review',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+
+  it('errors on branded object number in record id', () => {
+    const result = validateEntityWelfareReclassificationRecord(
+      baseRecord({
+        id: 'reclass:SCP-1731',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'branded_object_number_in_id')).toBe(true)
+  })
+
+  it('projects reclassification pressure with welfare debt linkage', () => {
+    const projection = projectReclassificationPressure(HOSTILE_TO_COOPERATIVE_FIXTURE)
+
+    expect(projection.recordId).toBe('reclass:apex-threat-behavior-reassessment')
+    expect(projection.welfareDebtLinked).toBe(true)
+    expect(projection.staffMoraleForecast).toBeGreaterThan(0)
+    expect(projection.liabilityForecast).toBeGreaterThan(0)
+    expect(projection.publicRiskForecast).toBeLessThan(0.5)
+    expect(projection.label).not.toMatch(/foundation|scp|masquerade/i)
+  })
+
+  it('redacts pressure forecasts when policy requests unknown redaction', () => {
+    const projection = projectReclassificationPressure(PENDING_TO_APPROVED_FIXTURE, {
+      redactUnknown: true,
+    })
+
+    expect(projection.staffMoraleForecast).not.toBeNull()
+    expect(projection.liabilityForecast).not.toBeNull()
+    expect(projection.publicRiskForecast).not.toBeNull()
+  })
+
+  it('returns byte-stable validation results on repeated calls', () => {
+    const first = validateEntityWelfareReclassificationRecord(PENDING_TO_APPROVED_FIXTURE)
+    const second = validateEntityWelfareReclassificationRecord(PENDING_TO_APPROVED_FIXTURE)
+
+    expect(first).toEqual(second)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+
+  it('exports stable union catalogs', () => {
+    expect(PROPOSED_DISPOSITIONS).toEqual([
+      'hostile',
+      'cooperative',
+      'medical',
+      'sapient_remains',
+      'unknown',
+    ])
+    expect(REVIEW_GATES).toEqual(['ethics', 'veterinary', 'psych', 'executive'])
+    expect(RECLASSIFICATION_STATES).toEqual(['pending', 'approved', 'denied', 'reverted'])
+  })
+})


### PR DESCRIPTION
## Summary
- Add pure deterministic entity welfare reclassification registry for threat-label drift and disposition review (SPE-2114, parent SPE-1046).
- Ship validation (terminal states require review artifact + evidence; franchise/branded object-number lint), pressure projection (staff morale, liability, public risk), fixtures, and 12 targeted tests.
- Add planning/entity-welfare-reclassification-registry-slice-1.md.

## Linear
- Slice: [SPE-2114](https://linear.app/spectranoir/issue/SPE-2114)
- Parent: [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)

## Validation
- [x] npm run test:run -- src/test/entityWelfareReclassificationRegistry.test.ts (12 passed)
- [x] npm run lint -- src/domain/entityWelfareReclassificationRegistry.ts src/test/entityWelfareReclassificationRegistry.test.ts

## Docs updated
- planning/entity-welfare-reclassification-registry-slice-1.md

## Parent status
- SPE-1046 remains open (affiliation wire-up, SPE-1888, SPE-1203, SPE-1310 deferred).

Made with [Cursor](https://cursor.com)