### PR TITLE
feat(SPE-2115): contained-person therapeutic care schedule registry (slice 1)

### DIFF
--- a/planning/contained-person-therapeutic-care-registry-slice-1.md
+++ b/planning/contained-person-therapeutic-care-registry-slice-1.md
@@ -1,0 +1,125 @@
+# SPE-2115 — Contained-person therapeutic care schedule registry slice 1
+
+One-page implementation plan. Linear: [SPE-2115](https://linear.app/spectranoir/issue/SPE-2115) (child under [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889)). Follows shipped [SPE-2114](https://linear.app/spectranoir/issue/SPE-2114) (entity welfare reclassification registry).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2115 — Contained-person therapeutic care schedule registry (slice 1)](https://linear.app/spectranoir/issue/SPE-2115) |
+| **Parent** | [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889) — Contained-person condition bundle and integrated health model |
+| **Branch** | `jamesdyedbq/spe-2115-contained-person-therapeutic-care-schedule-registry-slice-1`                         |
+| **Status** | In Progress                                                                                                |
+
+## Goal
+
+Add a pure deterministic **contained-person therapeutic care schedule registry** for cooperative human subjects and person-like entities requiring ongoing psychological or medical mediation as containment infrastructure — without importing external object numbers or franchise labels.
+
+## Prerequisite (on `main` @ `7da4a060`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Entity welfare reclassification | `src/domain/entityWelfareReclassificationRegistry.ts` (SPE-2114 / PR #2433) |
+| Visual-trigger hazard | `src/domain/visualTriggerHazardRegistry.ts` (SPE-2111 / PR #2432)   |
+| Pattern source series | `src/domain/patternSourceSeriesRegistry.ts` (SPE-2110)               |
+| Intake registry wave | SPE-2104 / SPE-2105 / SPE-2106 / SPE-2108 / SPE-2109 sibling patterns |
+| Harvest batch        | `starter-picks-routing-65` (C29) in `planning/harvest-reconciliation-index.md` |
+
+## Gap (pre-slice)
+
+- No bounded schema for psych/medical care cadence, mediated channel state, or missed-session compliance tracking.
+- No deterministic validation for suspended channels without documented cause or franchise tokens in CP-neutral fields.
+- No care-compliance breach risk projection helper.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `TherapeuticCareScheduleId` + `TherapeuticCareScheduleRecord` in `src/domain/containedPersonTherapeuticCareRegistry.ts`              | GameState persistence                         |
+| subjectRef, careMode, cadence, channelState, missedSessionStreak, staffAssigneeRefs, containmentDependency, suspensionCauseRef      | SPE-1889 integrated health bundle wire-up     |
+| `validateTherapeuticCareScheduleRecord(record)` — franchise token → error; suspended without cause → warning                       | SPE-1046 detainee / patient status classes    |
+| `projectCareComplianceRisk(record, policy)` — breach probability from missed sessions and channel degradation                        | Full SPE-1889 parent Done                     |
+| Focused tests in `src/test/containedPersonTherapeuticCareRegistry.test.ts`                                                         | Field UI                                      |
+
+## Record contract (deterministic)
+
+### Core fields
+
+- **subjectRef** — contained-person or person-like entity ref (CP-neutral internal id).
+- **careMode** — `psych_screening`, `mediated_audio`, `visitation_ban`, `cooperative_checkin`.
+- **cadence** — `weekly`, `biweekly`.
+- **channelState** — `active`, `degraded`, `suspended`.
+- **missedSessionStreak** — non-negative integer; primary compliance risk input.
+- **staffAssigneeRefs** — optional non-empty staff refs for accountability.
+- **containmentDependency** — boolean; when true, care failure may trigger lockdown escalation hook (field only in slice 1).
+- **suspensionCauseRef** — required when `channelState` is `suspended` (documented cause ref); absence → warning.
+- **confidence / unknown / redacted** — projection legibility without dumping hidden dossier truth.
+
+### Validation rules (examples)
+
+- Missing `id` or `label` → error.
+- Invalid `careMode`, `cadence`, or `channelState` → error.
+- Negative or non-integer `missedSessionStreak` → error.
+- `channelState: suspended` without `suspensionCauseRef` → warning.
+- `channelState: active` with `cadence` declared but zero sessions implied and high missed streak → warning (operational inconsistency).
+- Franchise / wiki / branded object-number token in id or CP-neutral field → error.
+
+### Projection (`projectCareComplianceRisk`)
+
+- Inputs: record + optional policy (`minimumConfidence`, `redactUnknown`, `lockdownAmplification`).
+- Outputs: `recordId`, `label`, `careMode`, `channelState`, `complianceRiskScore` (0..1), `lockdownEscalationLikely`, `missedSessionStreak`, `confidence`, `redacted`, `unknownFields`.
+- Deterministic weights: higher streak + `degraded` channel + `containmentDependency` raise score; `suspended` with documented cause lowers immediate breach vs undocumented suspension.
+
+## Acceptance
+
+- [x] Fixture: weekly psych screening with two-way mediated channel active.
+- [x] Fixture: missedSessionStreak triggers elevated compliance risk.
+- [x] Negative: active channel with suspended cadence inconsistency or suspended without cause → warning.
+- [x] Negative: franchise token in label → validation error.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Schema + types** — unions, record shape, exported fixtures (`WEEKLY_PSYCH_SCREENING_FIXTURE`, `MISSED_STREAK_ELEVATED_RISK_FIXTURE`).
+2. **Validation** — positive fixtures + negative lint cases (franchise token, suspended without cause).
+3. **Projection** — `projectCareComplianceRisk` streak and channel-state weighting.
+4. **Regression** — sibling registry tests unchanged.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/containedPersonTherapeuticCareRegistry.ts`                |
+| Tests  | `src/test/containedPersonTherapeuticCareRegistry.test.ts`             |
+| Plan   | `planning/contained-person-therapeutic-care-registry-slice-1.md`      |
+
+## Branch
+
+`jamesdyedbq/spe-2115-contained-person-therapeutic-care-schedule-registry-slice-1`
+
+## Out of scope (parent closure)
+
+- Full SPE-1889 parent Done
+- GameState persistence and weekly orchestration wiring
+- SPE-1046 detainee / patient status classes
+
+## See also
+
+- `planning/harvest-reconciliation-index.md` — adjacent intake tier row for SPE-2115
+- `src/domain/entityWelfareReclassificationRegistry.ts` — validation + projection conventions (SPE-2114)
+- `src/domain/publicDisclosureStateRegistry.ts` — franchise token scan pattern (SPE-2109)
+
+---
+
+## Post-ship doc hygiene (mandatory after merge)
+
+Complete in the **same PR** as implementation or an immediate docs-only follow-up before starting SPE-2116.
+
+- [ ] **`planning/contained-person-therapeutic-care-registry-slice-1.md`** — set Status to **Shipped — PR #____**; check acceptance boxes.
+- [ ] **`planning/entity-welfare-reclassification-registry-slice-1.md`** — set Status to **Shipped — PR #2433** (currently stale: In Progress).
+- [ ] **`planning/backlog.md`**
+  - Active queue: registry wave complete through SPE-2115; next adjacent tier [SPE-2116](https://linear.app/spectranoir/issue/SPE-2116).
+  - Recommended next step: handoff to SPE-2116 after SPE-2115 merge.
+  - Shipped table: add SPE-2115 row with module + PR.
+  - Planning slice index: add `contained-person-therapeutic-care-registry-slice-1.md` as **Shipped**.
+- [ ] **Linear** — SPE-2115 → Done + comment (PR URL, what shipped, validation). Parent SPE-1889 stays Backlog; parent SPE-854 stays In Progress.
+- [ ] **Next agent handoff** — `On main @ <sha>. Next: SPE-2116 — naming-hazard descriptor registry — branch jamesdyedbq/spe-2116-naming-hazard-descriptor-registry-safe-labels-and-reference`.

--- a/src/domain/containedPersonTherapeuticCareRegistry.ts
+++ b/src/domain/containedPersonTherapeuticCareRegistry.ts
@@ -1,0 +1,589 @@
+/**
+ * SPE-2115 slice 1: contained-person therapeutic care schedule registry.
+ *
+ * Pure deterministic registry for cooperative human subjects and person-like
+ * entities requiring ongoing psychological or medical mediation as containment
+ * infrastructure — distinct from integrated health bundle wire-up (SPE-1889).
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type TherapeuticCareScheduleId = string
+
+export type CareMode = 'psych_screening' | 'mediated_audio' | 'visitation_ban' | 'cooperative_checkin'
+
+export const CARE_MODES: readonly CareMode[] = [
+  'psych_screening',
+  'mediated_audio',
+  'visitation_ban',
+  'cooperative_checkin',
+] as const
+
+export type CareCadence = 'weekly' | 'biweekly'
+
+export const CARE_CADENCES: readonly CareCadence[] = ['weekly', 'biweekly'] as const
+
+export type ChannelState = 'active' | 'degraded' | 'suspended'
+
+export const CHANNEL_STATES: readonly ChannelState[] = ['active', 'degraded', 'suspended'] as const
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface TherapeuticCareScheduleRecord {
+  readonly id: TherapeuticCareScheduleId
+  readonly label: string
+  readonly summary?: string
+  readonly subjectRef: string
+  readonly careMode: CareMode
+  readonly cadence: CareCadence
+  readonly channelState: ChannelState
+  readonly missedSessionStreak: number
+  readonly staffAssigneeRefs?: readonly string[]
+  readonly containmentDependency?: boolean
+  readonly suspensionCauseRef?: string
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type TherapeuticCareScheduleValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_subject_ref'
+  | 'invalid_care_mode'
+  | 'invalid_cadence'
+  | 'invalid_channel_state'
+  | 'invalid_missed_session_streak'
+  | 'invalid_confidence'
+  | 'empty_staff_assignee_ref'
+  | 'suspended_without_documented_cause'
+  | 'active_channel_with_operational_inconsistency'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_field'
+
+export interface TherapeuticCareScheduleValidationIssue {
+  readonly code: TherapeuticCareScheduleValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface TherapeuticCareScheduleValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly TherapeuticCareScheduleValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Compliance projection
+// ---------------------------------------------------------------------------
+
+export interface CareComplianceRiskProjectionPolicy {
+  readonly minimumConfidence?: number
+  readonly redactUnknown?: boolean
+  readonly lockdownAmplification?: number
+}
+
+export interface CareComplianceRiskProjection {
+  readonly recordId: TherapeuticCareScheduleId
+  readonly label: string
+  readonly careMode: CareMode
+  readonly channelState: ChannelState
+  readonly complianceRiskScore: number | null
+  readonly lockdownEscalationLikely: boolean
+  readonly missedSessionStreak: number
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const CARE_MODE_SET = new Set<string>(CARE_MODES)
+const CARE_CADENCE_SET = new Set<string>(CARE_CADENCES)
+const CHANNEL_STATE_SET = new Set<string>(CHANNEL_STATES)
+
+const HIGH_MISSED_STREAK_THRESHOLD = 2
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /(?:\b(?:scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|group of interest|broken masquerade|masquerade breach)\b|goi-)/i
+
+export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
+
+const CHANNEL_STATE_RISK_BUMP: Readonly<Record<ChannelState, number>> = {
+  active: 0,
+  degraded: 0.12,
+  suspended: 0.04,
+}
+
+const CARE_MODE_RISK_WEIGHT: Readonly<Record<CareMode, number>> = {
+  psych_screening: 0.08,
+  mediated_audio: 0.06,
+  visitation_ban: 0.1,
+  cooperative_checkin: 0.05,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return Object.freeze(
+    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function pushIssue(
+  issues: TherapeuticCareScheduleValidationIssue[],
+  issue: TherapeuticCareScheduleValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: TherapeuticCareScheduleValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function freezeValidationResult(
+  issues: TherapeuticCareScheduleValidationIssue[]
+): TherapeuticCareScheduleValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function clampUnit(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+function roundUnit(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.round(clampUnit(value) * 1000) / 1000
+}
+
+function hasDocumentedSuspensionCause(record: TherapeuticCareScheduleRecord): boolean {
+  return normalizeToken(record.suspensionCauseRef ?? '').length > 0
+}
+
+function scanForbiddenTokens(
+  issues: TherapeuticCareScheduleValidationIssue[],
+  id: string,
+  label: string,
+  record: TherapeuticCareScheduleRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Therapeutic care schedule record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Therapeutic care schedule record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Therapeutic care schedule record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Therapeutic care schedule record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const stringFields: Array<{ field: string; value: string | undefined }> = [
+    { field: 'summary', value: record.summary },
+    { field: 'subjectRef', value: record.subjectRef },
+    { field: 'suspensionCauseRef', value: record.suspensionCauseRef },
+  ]
+
+  for (const { field, value } of stringFields) {
+    const token = normalizeToken(value ?? '')
+    if (!token) {
+      continue
+    }
+
+    if (containsFranchiseToken(token)) {
+      pushIssue(issues, {
+        code: 'franchise_token_in_field',
+        severity: 'error',
+        detail: `Therapeutic care schedule record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (containsBrandedObjectNumber(token)) {
+      pushIssue(issues, {
+        code: 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Therapeutic care schedule record ${id || '(unknown)'} field ${field} contains a branded object number.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const ref of asStringArray(record.staffAssigneeRefs)) {
+    const token = normalizeToken(ref)
+    if (token && (containsFranchiseToken(token) || containsBrandedObjectNumber(token))) {
+      pushIssue(issues, {
+        code: containsFranchiseToken(token) ? 'franchise_token_in_field' : 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Therapeutic care schedule record ${id || '(unknown)'} staffAssigneeRefs contains a forbidden token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+}
+
+function resolveConfidence(
+  record: TherapeuticCareScheduleRecord,
+  policy: CareComplianceRiskProjectionPolicy
+): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (redactedFields.has('confidence')) {
+    return null
+  }
+
+  const confidence = record.confidence ?? null
+  if (
+    confidence !== null &&
+    policy.minimumConfidence !== undefined &&
+    confidence < policy.minimumConfidence
+  ) {
+    return null
+  }
+
+  if (policy.redactUnknown === true && unknownFields.includes('confidence')) {
+    return null
+  }
+
+  return confidence
+}
+
+function resolveComplianceRiskScore(
+  record: TherapeuticCareScheduleRecord,
+  policy: CareComplianceRiskProjectionPolicy
+): number {
+  const streak = isNonNegativeInteger(record.missedSessionStreak) ? record.missedSessionStreak : 0
+  const channelState = isChannelState(record.channelState) ? record.channelState : 'active'
+  const careMode = isCareMode(record.careMode) ? record.careMode : 'cooperative_checkin'
+
+  let score = Math.min(1, streak * 0.18)
+  score += CHANNEL_STATE_RISK_BUMP[channelState]
+  score += CARE_MODE_RISK_WEIGHT[careMode]
+
+  if (channelState === 'suspended' && !hasDocumentedSuspensionCause(record)) {
+    score += 0.08
+  }
+
+  if (record.containmentDependency === true) {
+    const amplification =
+      typeof policy.lockdownAmplification === 'number' &&
+      Number.isFinite(policy.lockdownAmplification)
+        ? policy.lockdownAmplification
+        : 1.15
+    score *= amplification
+  }
+
+  return roundUnit(score)
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isCareMode(value: unknown): value is CareMode {
+  return typeof value === 'string' && CARE_MODE_SET.has(value)
+}
+
+export function isCareCadence(value: unknown): value is CareCadence {
+  return typeof value === 'string' && CARE_CADENCE_SET.has(value)
+}
+
+export function isChannelState(value: unknown): value is ChannelState {
+  return typeof value === 'string' && CHANNEL_STATE_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateTherapeuticCareScheduleRecord(
+  record: TherapeuticCareScheduleRecord
+): TherapeuticCareScheduleValidationResult {
+  const issues: TherapeuticCareScheduleValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const subjectRef = normalizeToken(record.subjectRef)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Therapeutic care schedule record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Therapeutic care schedule record is missing label.',
+    })
+  }
+
+  if (!subjectRef) {
+    pushIssue(issues, {
+      code: 'missing_subject_ref',
+      severity: 'error',
+      detail: 'Therapeutic care schedule record is missing subjectRef.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isCareMode(record.careMode)) {
+    pushIssue(issues, {
+      code: 'invalid_care_mode',
+      severity: 'error',
+      detail: `Therapeutic care schedule record ${id || '(unknown)'} has invalid careMode ${String(record.careMode)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isCareCadence(record.cadence)) {
+    pushIssue(issues, {
+      code: 'invalid_cadence',
+      severity: 'error',
+      detail: `Therapeutic care schedule record ${id || '(unknown)'} has invalid cadence ${String(record.cadence)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isChannelState(record.channelState)) {
+    pushIssue(issues, {
+      code: 'invalid_channel_state',
+      severity: 'error',
+      detail: `Therapeutic care schedule record ${id || '(unknown)'} has invalid channelState ${String(record.channelState)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isNonNegativeInteger(record.missedSessionStreak)) {
+    pushIssue(issues, {
+      code: 'invalid_missed_session_streak',
+      severity: 'error',
+      detail: `Therapeutic care schedule record ${id || '(unknown)'} missedSessionStreak must be a non-negative integer.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Therapeutic care schedule record ${id || '(unknown)'} confidence must be between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const ref of asStringArray(record.staffAssigneeRefs)) {
+    if (!normalizeToken(ref)) {
+      pushIssue(issues, {
+        code: 'empty_staff_assignee_ref',
+        severity: 'error',
+        detail: `Therapeutic care schedule record ${id || '(unknown)'} staffAssigneeRefs contains an empty ref.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  scanForbiddenTokens(issues, id, label, record)
+
+  if (record.channelState === 'suspended' && !hasDocumentedSuspensionCause(record)) {
+    pushIssue(issues, {
+      code: 'suspended_without_documented_cause',
+      severity: 'warning',
+      detail: `Therapeutic care schedule record ${id || '(unknown)'} is suspended without suspensionCauseRef.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.channelState === 'active' &&
+    isNonNegativeInteger(record.missedSessionStreak) &&
+    record.missedSessionStreak >= HIGH_MISSED_STREAK_THRESHOLD
+  ) {
+    pushIssue(issues, {
+      code: 'active_channel_with_operational_inconsistency',
+      severity: 'warning',
+      detail: `Therapeutic care schedule record ${id || '(unknown)'} reports active channel with elevated missedSessionStreak.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Projects care-compliance breach risk from record-derived fields.
+ * Does not assert hidden dossier truth or automatic lockdown escalation.
+ */
+export function projectCareComplianceRisk(
+  record: TherapeuticCareScheduleRecord,
+  policy: CareComplianceRiskProjectionPolicy = {}
+): CareComplianceRiskProjection {
+  const recordId = normalizeToken(record.id) || '(unknown)'
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = sortedStringArray(record.unknownFields)
+  const confidence = resolveConfidence(record, policy)
+
+  const complianceRedacted =
+    redactedFields.has('complianceRiskScore') ||
+    (policy.redactUnknown === true && unknownFields.includes('complianceRiskScore'))
+
+  const streak = isNonNegativeInteger(record.missedSessionStreak) ? record.missedSessionStreak : 0
+  const complianceRiskScore = complianceRedacted ? null : resolveComplianceRiskScore(record, policy)
+  const lockdownEscalationLikely =
+    record.containmentDependency === true &&
+    streak >= HIGH_MISSED_STREAK_THRESHOLD &&
+    (record.channelState === 'degraded' || record.channelState === 'suspended')
+
+  const redacted =
+    complianceRedacted ||
+    redactedFields.has('confidence') ||
+    (confidence === null && record.confidence !== undefined && policy.minimumConfidence !== undefined)
+
+  return Object.freeze({
+    recordId,
+    label: normalizeToken(record.label) || '(unknown)',
+    careMode: isCareMode(record.careMode) ? record.careMode : 'cooperative_checkin',
+    channelState: isChannelState(record.channelState) ? record.channelState : 'active',
+    complianceRiskScore,
+    lockdownEscalationLikely,
+    missedSessionStreak: streak,
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
+function defineRecord(record: TherapeuticCareScheduleRecord): TherapeuticCareScheduleRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Weekly psych screening with two-way mediated channel active. */
+export const WEEKLY_PSYCH_SCREENING_FIXTURE: TherapeuticCareScheduleRecord = defineRecord({
+  id: 'care-schedule:cooperative-subject-psych-weekly',
+  label: 'Cooperative subject weekly psych screening',
+  summary: 'Two-way mediated psych screening channel for cooperative contained subject.',
+  subjectRef: 'subject:cooperative-field-asset-17',
+  careMode: 'psych_screening',
+  cadence: 'weekly',
+  channelState: 'active',
+  missedSessionStreak: 0,
+  staffAssigneeRefs: ['staff:psych-mediator-4', 'staff:custody-liaison-2'],
+  containmentDependency: false,
+  confidence: 0.88,
+})
+
+/** Missed sessions with degraded channel and containment dependency. */
+export const MISSED_STREAK_ELEVATED_RISK_FIXTURE: TherapeuticCareScheduleRecord = defineRecord({
+  id: 'care-schedule:cooperative-checkin-compliance-drift',
+  label: 'Cooperative check-in compliance drift',
+  summary: 'Repeated missed cooperative check-ins with degraded mediated channel.',
+  subjectRef: 'subject:cooperative-field-asset-22',
+  careMode: 'cooperative_checkin',
+  cadence: 'biweekly',
+  channelState: 'degraded',
+  missedSessionStreak: 3,
+  staffAssigneeRefs: ['staff:custody-liaison-7'],
+  containmentDependency: true,
+  confidence: 0.71,
+})

--- a/src/test/containedPersonTherapeuticCareRegistry.test.ts
+++ b/src/test/containedPersonTherapeuticCareRegistry.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CARE_CADENCES,
+  CARE_MODES,
+  CHANNEL_STATES,
+  MISSED_STREAK_ELEVATED_RISK_FIXTURE,
+  WEEKLY_PSYCH_SCREENING_FIXTURE,
+  projectCareComplianceRisk,
+  validateTherapeuticCareScheduleRecord,
+  type TherapeuticCareScheduleRecord,
+} from '../domain/containedPersonTherapeuticCareRegistry'
+
+function baseRecord(
+  overrides: Partial<TherapeuticCareScheduleRecord> = {}
+): TherapeuticCareScheduleRecord {
+  return {
+    id: 'care-schedule:test-base',
+    label: 'Test base record',
+    subjectRef: 'subject:test-base',
+    careMode: 'cooperative_checkin',
+    cadence: 'weekly',
+    channelState: 'active',
+    missedSessionStreak: 0,
+    ...overrides,
+  }
+}
+
+describe('containedPersonTherapeuticCareRegistry (SPE-2115 slice 1)', () => {
+  it('validates weekly psych screening fixture with active mediated channel', () => {
+    const result = validateTherapeuticCareScheduleRecord(WEEKLY_PSYCH_SCREENING_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toHaveLength(0)
+    expect(WEEKLY_PSYCH_SCREENING_FIXTURE.careMode).toBe('psych_screening')
+    expect(WEEKLY_PSYCH_SCREENING_FIXTURE.cadence).toBe('weekly')
+    expect(WEEKLY_PSYCH_SCREENING_FIXTURE.channelState).toBe('active')
+    expect(WEEKLY_PSYCH_SCREENING_FIXTURE.staffAssigneeRefs).toEqual([
+      'staff:psych-mediator-4',
+      'staff:custody-liaison-2',
+    ])
+  })
+
+  it('validates missed streak fixture', () => {
+    const result = validateTherapeuticCareScheduleRecord(MISSED_STREAK_ELEVATED_RISK_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(MISSED_STREAK_ELEVATED_RISK_FIXTURE.missedSessionStreak).toBe(3)
+    expect(MISSED_STREAK_ELEVATED_RISK_FIXTURE.containmentDependency).toBe(true)
+  })
+
+  it('projects elevated compliance risk when missedSessionStreak is high', () => {
+    const baseline = projectCareComplianceRisk(WEEKLY_PSYCH_SCREENING_FIXTURE)
+    const elevated = projectCareComplianceRisk(MISSED_STREAK_ELEVATED_RISK_FIXTURE)
+
+    expect(baseline.complianceRiskScore).not.toBeNull()
+    expect(elevated.complianceRiskScore).not.toBeNull()
+    expect(elevated.complianceRiskScore!).toBeGreaterThan(baseline.complianceRiskScore!)
+    expect(elevated.lockdownEscalationLikely).toBe(true)
+  })
+
+  it('warns when suspended without documented cause', () => {
+    const result = validateTherapeuticCareScheduleRecord(
+      baseRecord({
+        channelState: 'suspended',
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'suspended_without_documented_cause',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('warns when active channel has elevated missed session streak', () => {
+    const result = validateTherapeuticCareScheduleRecord(
+      baseRecord({
+        channelState: 'active',
+        missedSessionStreak: 3,
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'active_channel_with_operational_inconsistency',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('errors on franchise label token in record fields', () => {
+    const result = validateTherapeuticCareScheduleRecord(
+      baseRecord({
+        label: 'Foundation psych screening schedule',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+
+  it('errors on branded object number in record id', () => {
+    const result = validateTherapeuticCareScheduleRecord(
+      baseRecord({
+        id: 'care-schedule:SCP-049-care',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'branded_object_number_in_id')).toBe(true)
+  })
+
+  it('errors on invalid missed session streak', () => {
+    const result = validateTherapeuticCareScheduleRecord(
+      baseRecord({
+        missedSessionStreak: -1,
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid_missed_session_streak',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('redacts compliance risk when policy requests unknown redaction', () => {
+    const projection = projectCareComplianceRisk(
+      {
+        ...MISSED_STREAK_ELEVATED_RISK_FIXTURE,
+        unknownFields: ['complianceRiskScore'],
+      },
+      {
+        redactUnknown: true,
+      }
+    )
+
+    expect(projection.complianceRiskScore).toBeNull()
+    expect(projection.redacted).toBe(true)
+  })
+
+  it('returns byte-stable validation results on repeated calls', () => {
+    const first = validateTherapeuticCareScheduleRecord(WEEKLY_PSYCH_SCREENING_FIXTURE)
+    const second = validateTherapeuticCareScheduleRecord(WEEKLY_PSYCH_SCREENING_FIXTURE)
+
+    expect(first).toEqual(second)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+
+  it('exports stable union catalogs', () => {
+    expect(CARE_MODES).toEqual([
+      'psych_screening',
+      'mediated_audio',
+      'visitation_ban',
+      'cooperative_checkin',
+    ])
+    expect(CARE_CADENCES).toEqual(['weekly', 'biweekly'])
+    expect(CHANNEL_STATES).toEqual(['active', 'degraded', 'suspended'])
+  })
+})


### PR DESCRIPTION
## Summary
- Add pure deterministic contained-person therapeutic care schedule registry (SPE-2115).
- Parent: SPE-1889 (stays open). Umbrella: SPE-854 (stays open).
- Domain module: containedPersonTherapeuticCareRegistry.ts with validate + projectCareComplianceRisk.
- Focused tests (11) and slice plan.

## Linear
- Slice: [SPE-2115](https://linear.app/spectranoir/issue/SPE-2115)
- Parent: [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889)

## Validation
- npm run test:run -- src/test/containedPersonTherapeuticCareRegistry.test.ts
- npm run lint

## Docs updated
- planning/contained-person-therapeutic-care-registry-slice-1.md

## Parent status
SPE-1889 remains open (slice 1 only).

Made with [Cursor](https://cursor.com)