### PR TITLE
feat(SPE-2116): naming-hazard descriptor registry — safe labels and reference (slice 1)

### DIFF
--- a/planning/naming-hazard-descriptor-registry-slice-1.md
+++ b/planning/naming-hazard-descriptor-registry-slice-1.md
@@ -1,0 +1,107 @@
+# SPE-2108 — Naming-hazard descriptor registry slice 1
+
+One-page implementation plan. Linear: [SPE-2116](https://linear.app/spectranoir/issue/SPE-2116) (child under [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108)). Follows shipped [SPE-2115](https://linear.app/spectranoir/issue/SPE-2115) (contained-person therapeutic care registry).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2116 — Naming-hazard descriptor registry — safe labels and reference constraints (slice 1)](https://linear.app/spectranoir/issue/SPE-2116) |
+| **Parent** | [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108) — Self-censoring information registry |
+| **Branch** | `jamesdyedbq/spe-2116-naming-hazard-descriptor-registry-safe-labels-and-reference`                         |
+| **Status** | **In Progress** — implementation on branch |
+
+## Goal
+
+Add a pure deterministic **naming-hazard descriptor registry** so locations, entities, and landmarks that cannot be safely named use approved surrogate descriptors in UI, maps, briefings, and file labels — without importing external canon names.
+
+## Prerequisite (on `main` @ `7df49452`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Contained-person care | `src/domain/containedPersonTherapeuticCareRegistry.ts` (SPE-2115 / PR #2434) |
+| Self-censoring info  | `src/domain/selfCensoringInformationRegistry.ts` (SPE-2108)               |
+| Intake registry wave | SPE-2104–SPE-2115 sibling patterns                                       |
+| Harvest batch        | `starter-picks-routing-65` (C28, C19) in `planning/harvest-reconciliation-index.md` |
+
+## Gap (pre-slice)
+
+- No bounded schema for true-name prohibition, safe descriptor pools, or reference constraints.
+- No deterministic validation for empty pools when naming is forbidden or compulsive-phrase briefing lint.
+- No `projectSafeLabel` helper for dossier/map/briefing/file_label surfaces.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `NamingHazardDescriptorId` + `NamingHazardDescriptorRecord` in `src/domain/namingHazardDescriptorRegistry.ts`                      | GameState persistence                         |
+| trueNameForbidden, safeDescriptorPool, referenceConstraints, uiSubstitutionPolicy, mapLabelMode, compulsivePhraseWatchlist         | Investigation UI substitution               |
+| `validateNamingHazardDescriptorRecord(record)` — empty pool when forbidden → error; compulsive_phrase_risk briefing lint         | Procedural naming integration (SPE-76)        |
+| `projectSafeLabel(record, context)` — substituted label for dossier/map/briefing/file_label contexts                               | Name-taxonomy targeting (SPE-456)             |
+| Focused tests in `src/test/namingHazardDescriptorRegistry.test.ts`                                                                 | Full SPE-2108 parent Done                     |
+
+## Record contract (deterministic)
+
+### Core fields
+
+- **trueNameForbidden** — when true, only safeDescriptorPool entries may surface in player-facing projection.
+- **safeDescriptorPool** — approved surrogate strings; non-empty required when trueNameForbidden.
+- **referenceConstraints** — `no_titles`, `no_designations`, `no_proper_nouns`, `compulsive_phrase_risk`.
+- **uiSubstitutionPolicy** — `pool_descriptor`, `pool_with_grid_fallback`, `grid_ref`, `redacted`.
+- **mapLabelMode** — `descriptor_only`, `grid_ref`, `redacted`.
+- **compulsivePhraseWatchlist** — optional corruption detector phrases for briefing lint.
+- **briefingTemplateSnippet** — optional authoring preview scanned when compulsive_phrase_risk is active.
+- **confidence / unknown / redacted** — projection legibility without dumping hidden dossier truth.
+
+### Validation rules (examples)
+
+- Missing `id` or `label` → error.
+- `trueNameForbidden` with empty `safeDescriptorPool` → error.
+- Invalid union values, empty pool entries, duplicate pool entries → error.
+- `compulsive_phrase_risk` without watchlist → warning.
+- Watchlist phrase present in `briefingTemplateSnippet` → warning.
+- Franchise / wiki / branded object-number token in id or CP-neutral field → error.
+
+### Projection (`projectSafeLabel`)
+
+- Inputs: record + context (`surface`, optional `gridRef`, `descriptorIndex`, `templateText`).
+- Map + `descriptor_only` + `pool_with_grid_fallback` uses pool descriptor, falls back to `gridRef`.
+- `redacted` map mode or `redacted` policy returns deterministic redacted placeholder.
+- Never emits player-facing true names in slice 1 fixtures.
+
+## Acceptance
+
+- [x] Fixture: descriptor_only map labels with grid_ref fallback.
+- [x] Fixture: compulsive_phrase_risk triggers lint on briefing template.
+- [x] Negative: trueNameForbidden with empty safeDescriptorPool → error.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Schema + types** — unions, record shape, exported fixtures.
+2. **Validation** — positive fixtures + negative lint cases.
+3. **Projection** — `projectSafeLabel` descriptor and grid fallback paths.
+4. **Regression** — sibling registry tests unchanged.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/namingHazardDescriptorRegistry.ts`                        |
+| Tests  | `src/test/namingHazardDescriptorRegistry.test.ts`                     |
+| Plan   | `planning/naming-hazard-descriptor-registry-slice-1.md`               |
+
+## Branch
+
+`jamesdyedbq/spe-2116-naming-hazard-descriptor-registry-safe-labels-and-reference`
+
+## Out of scope (parent closure)
+
+- Full SPE-2108 parent Done
+- GameState persistence and weekly orchestration wiring
+- SPE-76 procedural naming, SPE-456 name-taxonomy targeting, investigation UI substitution
+
+## See also
+
+- `planning/harvest-reconciliation-index.md` — adjacent intake tier row for SPE-2116
+- `src/domain/selfCensoringInformationRegistry.ts` — parent chain validation conventions (SPE-2108)
+- `architecture/procedural-naming-layered-identity.md` — SPE-76 boundary (distinct from this registry)

--- a/src/domain/namingHazardDescriptorRegistry.ts
+++ b/src/domain/namingHazardDescriptorRegistry.ts
@@ -1,0 +1,687 @@
+/**
+ * SPE-2116 slice 1: naming-hazard descriptor registry.
+ *
+ * Pure deterministic registry for locations, entities, and landmarks that
+ * cannot be safely named — surrogate descriptors for UI, maps, briefings,
+ * and file labels — distinct from procedural naming generation (SPE-76).
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type NamingHazardDescriptorId = string
+
+export type ReferenceConstraint =
+  | 'no_titles'
+  | 'no_designations'
+  | 'no_proper_nouns'
+  | 'compulsive_phrase_risk'
+
+export const REFERENCE_CONSTRAINTS: readonly ReferenceConstraint[] = [
+  'no_titles',
+  'no_designations',
+  'no_proper_nouns',
+  'compulsive_phrase_risk',
+] as const
+
+export type UiSubstitutionPolicy =
+  | 'pool_descriptor'
+  | 'pool_with_grid_fallback'
+  | 'grid_ref'
+  | 'redacted'
+
+export const UI_SUBSTITUTION_POLICIES: readonly UiSubstitutionPolicy[] = [
+  'pool_descriptor',
+  'pool_with_grid_fallback',
+  'grid_ref',
+  'redacted',
+] as const
+
+export type MapLabelMode = 'descriptor_only' | 'grid_ref' | 'redacted'
+
+export const MAP_LABEL_MODES: readonly MapLabelMode[] = [
+  'descriptor_only',
+  'grid_ref',
+  'redacted',
+] as const
+
+export type SafeLabelSurface = 'dossier' | 'map' | 'briefing' | 'file_label'
+
+export const SAFE_LABEL_SURFACES: readonly SafeLabelSurface[] = [
+  'dossier',
+  'map',
+  'briefing',
+  'file_label',
+] as const
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface NamingHazardDescriptorRecord {
+  readonly id: NamingHazardDescriptorId
+  readonly label: string
+  readonly summary?: string
+  readonly trueNameForbidden: boolean
+  readonly safeDescriptorPool: readonly string[]
+  readonly referenceConstraints?: readonly ReferenceConstraint[]
+  readonly uiSubstitutionPolicy: UiSubstitutionPolicy
+  readonly mapLabelMode: MapLabelMode
+  readonly compulsivePhraseWatchlist?: readonly string[]
+  readonly briefingTemplateSnippet?: string
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type NamingHazardDescriptorValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'empty_safe_descriptor_pool_when_forbidden'
+  | 'empty_safe_descriptor_entry'
+  | 'duplicate_safe_descriptor_entry'
+  | 'invalid_reference_constraint'
+  | 'invalid_ui_substitution_policy'
+  | 'invalid_map_label_mode'
+  | 'invalid_confidence'
+  | 'compulsive_phrase_risk_without_watchlist'
+  | 'compulsive_phrase_in_briefing_template'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_field'
+
+export interface NamingHazardDescriptorValidationIssue {
+  readonly code: NamingHazardDescriptorValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface NamingHazardDescriptorValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly NamingHazardDescriptorValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Safe label projection
+// ---------------------------------------------------------------------------
+
+export interface SafeLabelProjectionContext {
+  readonly surface: SafeLabelSurface
+  readonly gridRef?: string
+  readonly descriptorIndex?: number
+  readonly templateText?: string
+}
+
+export interface SafeLabelProjection {
+  readonly recordId: NamingHazardDescriptorId
+  readonly surface: SafeLabelSurface
+  readonly safeLabel: string
+  readonly usedGridFallback: boolean
+  readonly redacted: boolean
+  readonly descriptorIndex: number | null
+  readonly confidence: number | null
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const REFERENCE_CONSTRAINT_SET = new Set<string>(REFERENCE_CONSTRAINTS)
+const UI_SUBSTITUTION_POLICY_SET = new Set<string>(UI_SUBSTITUTION_POLICIES)
+const MAP_LABEL_MODE_SET = new Set<string>(MAP_LABEL_MODES)
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /(?:\b(?:scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|group of interest|broken masquerade|masquerade breach)\b|goi-)/i
+
+export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
+
+const REDACTED_LABEL = '[REDACTED]'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return Object.freeze(
+    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function pushIssue(
+  issues: NamingHazardDescriptorValidationIssue[],
+  issue: NamingHazardDescriptorValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: NamingHazardDescriptorValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function freezeValidationResult(
+  issues: NamingHazardDescriptorValidationIssue[]
+): NamingHazardDescriptorValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function hasReferenceConstraint(
+  record: NamingHazardDescriptorRecord,
+  constraint: ReferenceConstraint
+): boolean {
+  return asStringArray(record.referenceConstraints).includes(constraint)
+}
+
+function normalizedPool(record: NamingHazardDescriptorRecord): readonly string[] {
+  return asStringArray(record.safeDescriptorPool)
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => entry.length > 0)
+}
+
+function scanForbiddenTokens(
+  issues: NamingHazardDescriptorValidationIssue[],
+  id: string,
+  label: string,
+  record: NamingHazardDescriptorRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const stringFields: Array<{ field: string; value: string | undefined }> = [
+    { field: 'summary', value: record.summary },
+    { field: 'briefingTemplateSnippet', value: record.briefingTemplateSnippet },
+  ]
+
+  for (const { field, value } of stringFields) {
+    const token = normalizeToken(value ?? '')
+    if (!token) {
+      continue
+    }
+
+    if (containsFranchiseToken(token)) {
+      pushIssue(issues, {
+        code: 'franchise_token_in_field',
+        severity: 'error',
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (containsBrandedObjectNumber(token)) {
+      pushIssue(issues, {
+        code: 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} field ${field} contains a branded object number.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const descriptor of normalizedPool(record)) {
+    if (containsFranchiseToken(descriptor) || containsBrandedObjectNumber(descriptor)) {
+      pushIssue(issues, {
+        code: containsFranchiseToken(descriptor)
+          ? 'franchise_token_in_field'
+          : 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} safeDescriptorPool contains a forbidden token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+}
+
+function scanCompulsivePhraseLint(
+  issues: NamingHazardDescriptorValidationIssue[],
+  id: string,
+  record: NamingHazardDescriptorRecord
+) {
+  if (!hasReferenceConstraint(record, 'compulsive_phrase_risk')) {
+    return
+  }
+
+  const watchlist = asStringArray(record.compulsivePhraseWatchlist)
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => entry.length > 0)
+
+  if (watchlist.length === 0) {
+    pushIssue(issues, {
+      code: 'compulsive_phrase_risk_without_watchlist',
+      severity: 'warning',
+      detail: `Naming-hazard descriptor record ${id || '(unknown)'} declares compulsive_phrase_risk without compulsivePhraseWatchlist entries.`,
+      relatedIds: id ? [id] : undefined,
+    })
+    return
+  }
+
+  const template = normalizeToken(record.briefingTemplateSnippet ?? '')
+  if (!template) {
+    return
+  }
+
+  const matchedPhrase = watchlist.find((phrase) =>
+    template.toLocaleLowerCase().includes(phrase.toLocaleLowerCase())
+  )
+
+  if (matchedPhrase) {
+    pushIssue(issues, {
+      code: 'compulsive_phrase_in_briefing_template',
+      severity: 'warning',
+      detail: `Naming-hazard descriptor record ${id || '(unknown)'} briefing template contains watchlisted compulsive phrase "${matchedPhrase}".`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function resolveConfidence(record: NamingHazardDescriptorRecord): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  if (redactedFields.has('confidence')) {
+    return null
+  }
+
+  return record.confidence ?? null
+}
+
+function resolveDescriptorFromPool(
+  record: NamingHazardDescriptorRecord,
+  descriptorIndex?: number
+): { descriptor: string | null; index: number | null } {
+  const pool = normalizedPool(record)
+  if (pool.length === 0) {
+    return { descriptor: null, index: null }
+  }
+
+  const index =
+    typeof descriptorIndex === 'number' &&
+    Number.isInteger(descriptorIndex) &&
+    descriptorIndex >= 0 &&
+    descriptorIndex < pool.length
+      ? descriptorIndex
+      : 0
+
+  return { descriptor: pool[index] ?? null, index }
+}
+
+function resolveGridRef(context: SafeLabelProjectionContext): string | null {
+  const gridRef = normalizeToken(context.gridRef ?? '')
+  return gridRef.length > 0 ? gridRef : null
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isReferenceConstraint(value: unknown): value is ReferenceConstraint {
+  return typeof value === 'string' && REFERENCE_CONSTRAINT_SET.has(value)
+}
+
+export function isUiSubstitutionPolicy(value: unknown): value is UiSubstitutionPolicy {
+  return typeof value === 'string' && UI_SUBSTITUTION_POLICY_SET.has(value)
+}
+
+export function isMapLabelMode(value: unknown): value is MapLabelMode {
+  return typeof value === 'string' && MAP_LABEL_MODE_SET.has(value)
+}
+
+export function isSafeLabelSurface(value: unknown): value is SafeLabelSurface {
+  return typeof value === 'string' && SAFE_LABEL_SURFACES.includes(value as SafeLabelSurface)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateNamingHazardDescriptorRecord(
+  record: NamingHazardDescriptorRecord
+): NamingHazardDescriptorValidationResult {
+  const issues: NamingHazardDescriptorValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const pool = normalizedPool(record)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Naming-hazard descriptor record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Naming-hazard descriptor record is missing label.',
+    })
+  }
+
+  if (record.trueNameForbidden && pool.length === 0) {
+    pushIssue(issues, {
+      code: 'empty_safe_descriptor_pool_when_forbidden',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record ${id || '(unknown)'} forbids true names but safeDescriptorPool is empty.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const entry of asStringArray(record.safeDescriptorPool)) {
+    if (!normalizeToken(entry)) {
+      pushIssue(issues, {
+        code: 'empty_safe_descriptor_entry',
+        severity: 'error',
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} safeDescriptorPool contains an empty entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  const seenDescriptors = new Set<string>()
+  for (const entry of pool) {
+    const key = entry.toLocaleLowerCase()
+    if (seenDescriptors.has(key)) {
+      pushIssue(issues, {
+        code: 'duplicate_safe_descriptor_entry',
+        severity: 'error',
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} safeDescriptorPool contains duplicate descriptor "${entry}".`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+    seenDescriptors.add(key)
+  }
+
+  for (const constraint of asStringArray(record.referenceConstraints)) {
+    if (!isReferenceConstraint(constraint)) {
+      pushIssue(issues, {
+        code: 'invalid_reference_constraint',
+        severity: 'error',
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} has invalid reference constraint ${String(constraint)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  if (!isUiSubstitutionPolicy(record.uiSubstitutionPolicy)) {
+    pushIssue(issues, {
+      code: 'invalid_ui_substitution_policy',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record ${id || '(unknown)'} has invalid uiSubstitutionPolicy ${String(record.uiSubstitutionPolicy)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isMapLabelMode(record.mapLabelMode)) {
+    pushIssue(issues, {
+      code: 'invalid_map_label_mode',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record ${id || '(unknown)'} has invalid mapLabelMode ${String(record.mapLabelMode)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Naming-hazard descriptor record ${id || '(unknown)'} confidence must be between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanForbiddenTokens(issues, id, label, record)
+  scanCompulsivePhraseLint(issues, id, record)
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Projects a safe surrogate label for dossier, map, briefing, or file_label surfaces.
+ * Never emits undisclosed true names when trueNameForbidden is set.
+ */
+export function projectSafeLabel(
+  record: NamingHazardDescriptorRecord,
+  context: SafeLabelProjectionContext
+): SafeLabelProjection {
+  const recordId = normalizeToken(record.id) || '(unknown)'
+  const unknownFields = sortedStringArray(record.unknownFields)
+  const confidence = resolveConfidence(record)
+  const gridRef = resolveGridRef(context)
+
+  if (
+    record.uiSubstitutionPolicy === 'redacted' ||
+    record.mapLabelMode === 'redacted' ||
+    context.surface === 'map' && record.mapLabelMode === 'redacted'
+  ) {
+    return Object.freeze({
+      recordId,
+      surface: context.surface,
+      safeLabel: REDACTED_LABEL,
+      usedGridFallback: false,
+      redacted: true,
+      descriptorIndex: null,
+      confidence,
+      unknownFields,
+    })
+  }
+
+  if (context.surface === 'map' && record.mapLabelMode === 'grid_ref') {
+    return Object.freeze({
+      recordId,
+      surface: context.surface,
+      safeLabel: gridRef ?? REDACTED_LABEL,
+      usedGridFallback: gridRef !== null,
+      redacted: gridRef === null,
+      descriptorIndex: null,
+      confidence,
+      unknownFields,
+    })
+  }
+
+  const { descriptor, index } = resolveDescriptorFromPool(record, context.descriptorIndex)
+
+  if (context.surface === 'map' && record.mapLabelMode === 'descriptor_only') {
+    if (descriptor) {
+      return Object.freeze({
+        recordId,
+        surface: context.surface,
+        safeLabel: descriptor,
+        usedGridFallback: false,
+        redacted: false,
+        descriptorIndex: index,
+        confidence,
+        unknownFields,
+      })
+    }
+
+    if (
+      record.uiSubstitutionPolicy === 'pool_with_grid_fallback' &&
+      gridRef !== null
+    ) {
+      return Object.freeze({
+        recordId,
+        surface: context.surface,
+        safeLabel: gridRef,
+        usedGridFallback: true,
+        redacted: false,
+        descriptorIndex: null,
+        confidence,
+        unknownFields,
+      })
+    }
+  }
+
+  if (record.uiSubstitutionPolicy === 'grid_ref') {
+    return Object.freeze({
+      recordId,
+      surface: context.surface,
+      safeLabel: gridRef ?? REDACTED_LABEL,
+      usedGridFallback: gridRef !== null,
+      redacted: gridRef === null,
+      descriptorIndex: null,
+      confidence,
+      unknownFields,
+    })
+  }
+
+  if (descriptor) {
+    return Object.freeze({
+      recordId,
+      surface: context.surface,
+      safeLabel: descriptor,
+      usedGridFallback: false,
+      redacted: false,
+      descriptorIndex: index,
+      confidence,
+      unknownFields,
+    })
+  }
+
+  if (record.uiSubstitutionPolicy === 'pool_with_grid_fallback' && gridRef !== null) {
+    return Object.freeze({
+      recordId,
+      surface: context.surface,
+      safeLabel: gridRef,
+      usedGridFallback: true,
+      redacted: false,
+      descriptorIndex: null,
+      confidence,
+      unknownFields,
+    })
+  }
+
+  return Object.freeze({
+    recordId,
+    surface: context.surface,
+    safeLabel: record.trueNameForbidden ? REDACTED_LABEL : normalizeToken(record.label) || REDACTED_LABEL,
+    usedGridFallback: false,
+    redacted: record.trueNameForbidden,
+    descriptorIndex: null,
+    confidence,
+    unknownFields,
+  })
+}
+
+function defineRecord(record: NamingHazardDescriptorRecord): NamingHazardDescriptorRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Map surface uses descriptor_only with grid_ref fallback when pool index unavailable. */
+export const DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE: NamingHazardDescriptorRecord = defineRecord({
+  id: 'naming-hazard:coastal-approach-ward',
+  label: 'Coastal approach ward naming hazard',
+  summary: 'Landmark cannot be safely named; map uses approved descriptors with grid fallback.',
+  trueNameForbidden: true,
+  safeDescriptorPool: ['North quarry overlook', 'Grid sector approach lane'],
+  referenceConstraints: ['no_proper_nouns', 'no_designations'],
+  uiSubstitutionPolicy: 'pool_with_grid_fallback',
+  mapLabelMode: 'descriptor_only',
+  confidence: 0.84,
+})
+
+/** Compulsive phrase risk with briefing template lint. */
+export const COMPULSIVE_PHRASE_BRIEFING_FIXTURE: NamingHazardDescriptorRecord = defineRecord({
+  id: 'naming-hazard:archive-reading-room',
+  label: 'Archive reading room naming hazard',
+  summary: 'Briefing templates must avoid compulsive invocation phrases.',
+  trueNameForbidden: true,
+  safeDescriptorPool: ['Reading room annex B', 'Stack corridor east wing'],
+  referenceConstraints: ['no_titles', 'compulsive_phrase_risk'],
+  uiSubstitutionPolicy: 'pool_descriptor',
+  mapLabelMode: 'descriptor_only',
+  compulsivePhraseWatchlist: ['speak the bound name', 'recite the full title'],
+  briefingTemplateSnippet:
+    'Do not speak the bound name during intake; use approved descriptors only.',
+  confidence: 0.79,
+})

--- a/src/domain/namingHazardDescriptorRegistry.ts
+++ b/src/domain/namingHazardDescriptorRegistry.ts
@@ -141,7 +141,7 @@ const UI_SUBSTITUTION_POLICY_SET = new Set<string>(UI_SUBSTITUTION_POLICIES)
 const MAP_LABEL_MODE_SET = new Set<string>(MAP_LABEL_MODES)
 
 export const FRANCHISE_TOKEN_PATTERN =
-  /(?:\b(?:scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|group of interest|broken masquerade|masquerade breach)\b|goi-)/i
+  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest|broken masquerade|masquerade breach|wiki\.|wikidot)\b/i
 
 export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
 
@@ -311,13 +311,20 @@ function scanForbiddenTokens(
   }
 
   for (const descriptor of normalizedPool(record)) {
-    if (containsFranchiseToken(descriptor) || containsBrandedObjectNumber(descriptor)) {
+    if (containsFranchiseToken(descriptor)) {
       pushIssue(issues, {
-        code: containsFranchiseToken(descriptor)
-          ? 'franchise_token_in_field'
-          : 'branded_object_number_in_field',
+        code: 'franchise_token_in_field',
         severity: 'error',
-        detail: `Naming-hazard descriptor record ${id || '(unknown)'} safeDescriptorPool contains a forbidden token.`,
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} safeDescriptorPool contains a franchise or source-literal token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (containsBrandedObjectNumber(descriptor)) {
+      pushIssue(issues, {
+        code: 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Naming-hazard descriptor record ${id || '(unknown)'} safeDescriptorPool contains a branded object number.`,
         relatedIds: id ? [id] : undefined,
       })
     }
@@ -541,8 +548,7 @@ export function projectSafeLabel(
 
   if (
     record.uiSubstitutionPolicy === 'redacted' ||
-    record.mapLabelMode === 'redacted' ||
-    context.surface === 'map' && record.mapLabelMode === 'redacted'
+    (context.surface === 'map' && record.mapLabelMode === 'redacted')
   ) {
     return Object.freeze({
       recordId,

--- a/src/test/namingHazardDescriptorRegistry.test.ts
+++ b/src/test/namingHazardDescriptorRegistry.test.ts
@@ -112,6 +112,32 @@ describe('namingHazardDescriptorRegistry (SPE-2116 slice 1)', () => {
     expect(projection.redacted).toBe(false)
   })
 
+  it('restricts mapLabelMode redacted to map surface only', () => {
+    const record = baseRecord({
+      mapLabelMode: 'redacted',
+      uiSubstitutionPolicy: 'pool_descriptor',
+    })
+
+    const mapProjection = projectSafeLabel(record, { surface: 'map' })
+    const briefingProjection = projectSafeLabel(record, { surface: 'briefing' })
+
+    expect(mapProjection.safeLabel).toBe('[REDACTED]')
+    expect(mapProjection.redacted).toBe(true)
+    expect(briefingProjection.safeLabel).toBe('Approved surrogate label')
+    expect(briefingProjection.redacted).toBe(false)
+  })
+
+  it('errors on wiki token in safe descriptor pool entry', () => {
+    const result = validateNamingHazardDescriptorRecord(
+      baseRecord({
+        safeDescriptorPool: ['See wiki.scpfoundation.net for details'],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_field')).toBe(true)
+  })
+
   it('errors on franchise token in record label', () => {
     const result = validateNamingHazardDescriptorRecord(
       baseRecord({

--- a/src/test/namingHazardDescriptorRegistry.test.ts
+++ b/src/test/namingHazardDescriptorRegistry.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPULSIVE_PHRASE_BRIEFING_FIXTURE,
+  DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+  MAP_LABEL_MODES,
+  REFERENCE_CONSTRAINTS,
+  SAFE_LABEL_SURFACES,
+  UI_SUBSTITUTION_POLICIES,
+  projectSafeLabel,
+  validateNamingHazardDescriptorRecord,
+  type NamingHazardDescriptorRecord,
+} from '../domain/namingHazardDescriptorRegistry'
+
+function baseRecord(
+  overrides: Partial<NamingHazardDescriptorRecord> = {}
+): NamingHazardDescriptorRecord {
+  return {
+    id: 'naming-hazard:test-base',
+    label: 'Test naming hazard record',
+    trueNameForbidden: true,
+    safeDescriptorPool: ['Approved surrogate label'],
+    uiSubstitutionPolicy: 'pool_descriptor',
+    mapLabelMode: 'descriptor_only',
+    ...overrides,
+  }
+}
+
+describe('namingHazardDescriptorRegistry (SPE-2116 slice 1)', () => {
+  it('validates descriptor_only map fixture with safe descriptor pool', () => {
+    const result = validateNamingHazardDescriptorRecord(DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.mapLabelMode).toBe('descriptor_only')
+    expect(DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.uiSubstitutionPolicy).toBe('pool_with_grid_fallback')
+  })
+
+  it('projects descriptor_only map labels with grid_ref fallback', () => {
+    const descriptorProjection = projectSafeLabel(DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE, {
+      surface: 'map',
+    })
+
+    expect(descriptorProjection.safeLabel).toBe('North quarry overlook')
+    expect(descriptorProjection.usedGridFallback).toBe(false)
+    expect(descriptorProjection.redacted).toBe(false)
+
+    const gridFallbackRecord = baseRecord({
+      trueNameForbidden: false,
+      safeDescriptorPool: [],
+      uiSubstitutionPolicy: 'pool_with_grid_fallback',
+      mapLabelMode: 'descriptor_only',
+    })
+
+    const fallbackProjection = projectSafeLabel(gridFallbackRecord, {
+      surface: 'map',
+      gridRef: 'GRID-NE-14',
+    })
+
+    expect(fallbackProjection.safeLabel).toBe('GRID-NE-14')
+    expect(fallbackProjection.usedGridFallback).toBe(true)
+  })
+
+  it('warns when compulsive_phrase_risk briefing template contains watchlisted phrase', () => {
+    const result = validateNamingHazardDescriptorRecord(COMPULSIVE_PHRASE_BRIEFING_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'compulsive_phrase_in_briefing_template',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('errors when trueNameForbidden with empty safeDescriptorPool', () => {
+    const result = validateNamingHazardDescriptorRecord(
+      baseRecord({
+        safeDescriptorPool: [],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'empty_safe_descriptor_pool_when_forbidden',
+        severity: 'error',
+      }),
+    ])
+  })
+
+  it('warns when compulsive_phrase_risk is declared without watchlist', () => {
+    const result = validateNamingHazardDescriptorRecord(
+      baseRecord({
+        referenceConstraints: ['compulsive_phrase_risk'],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'compulsive_phrase_risk_without_watchlist',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('projects briefing surface from safe descriptor pool', () => {
+    const projection = projectSafeLabel(COMPULSIVE_PHRASE_BRIEFING_FIXTURE, {
+      surface: 'briefing',
+    })
+
+    expect(projection.safeLabel).toBe('Reading room annex B')
+    expect(projection.redacted).toBe(false)
+  })
+
+  it('errors on franchise token in record label', () => {
+    const result = validateNamingHazardDescriptorRecord(
+      baseRecord({
+        label: 'Foundation naming hazard record',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+
+  it('errors on branded object number in record id', () => {
+    const result = validateNamingHazardDescriptorRecord(
+      baseRecord({
+        id: 'naming-hazard:SCP-096-site',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'branded_object_number_in_id')).toBe(true)
+  })
+
+  it('returns byte-stable validation results on repeated calls', () => {
+    const first = validateNamingHazardDescriptorRecord(DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE)
+    const second = validateNamingHazardDescriptorRecord(DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE)
+
+    expect(first).toEqual(second)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+
+  it('exports stable union catalogs', () => {
+    expect(REFERENCE_CONSTRAINTS).toEqual([
+      'no_titles',
+      'no_designations',
+      'no_proper_nouns',
+      'compulsive_phrase_risk',
+    ])
+    expect(UI_SUBSTITUTION_POLICIES).toEqual([
+      'pool_descriptor',
+      'pool_with_grid_fallback',
+      'grid_ref',
+      'redacted',
+    ])
+    expect(MAP_LABEL_MODES).toEqual(['descriptor_only', 'grid_ref', 'redacted'])
+    expect(SAFE_LABEL_SURFACES).toEqual(['dossier', 'map', 'briefing', 'file_label'])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds pure deterministic 
amingHazardDescriptorRegistry.ts for locations/entities/landmarks that cannot be safely named — surrogate descriptors for UI, maps, briefings, and file labels.
- Implements alidateNamingHazardDescriptorRecord (empty pool when forbidden, compulsive-phrase briefing lint, franchise token scan) and projectSafeLabel (descriptor-only map labels with grid-ref fallback).
- Adds slice plan and focused tests (10 cases).

## Linear

- **Slice:** [SPE-2116](https://linear.app/spectranoir/issue/SPE-2116) — Naming-hazard descriptor registry — safe labels and reference constraints (slice 1)
- **Parent:** [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108) — Self-censoring information registry (stays open)
- **Grandparent chain:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) information intake (stays open)

## What shipped

- src/domain/namingHazardDescriptorRegistry.ts
- src/test/namingHazardDescriptorRegistry.test.ts
- planning/naming-hazard-descriptor-registry-slice-1.md

## Validation

- [x] 
pm run lint
- [x] 
pm run test:run -- src/test/namingHazardDescriptorRegistry.test.ts (10/10)

## Docs updated

- planning/naming-hazard-descriptor-registry-slice-1.md

## Parent status

SPE-2108 remains open — slice 1 only; no GameState/UI/SPE-76 wire-up.

Made with [Cursor](https://cursor.com)