### PR TITLE
feat(SPE-2122): mass anomalous population emergence registry (slice 1)

### DIFF
--- a/planning/mass-anomalous-population-emergence-registry-slice-1.md
+++ b/planning/mass-anomalous-population-emergence-registry-slice-1.md
@@ -1,0 +1,108 @@
+# SPE-2122 — Mass anomalous population emergence registry slice 1
+
+One-page implementation plan. Linear: [SPE-2122](https://linear.app/spectranoir/issue/SPE-2122) (child under [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109)). Follows shipped [SPE-2121](https://linear.app/spectranoir/issue/SPE-2121) (alternate-reality threshold route registry).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2122 — Mass anomalous population emergence registry — registration, triage, and governance surge (slice 1)](https://linear.app/spectranoir/issue/SPE-2122) |
+| **Parent** | [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) — Public disclosure state registry |
+| **Branch** | `jamesdyedbq/spe-2122-mass-anomalous-population-emergence-registry-registration` |
+| **Status** | **In Progress** |
+
+## Goal
+
+Add a pure deterministic **mass anomalous population emergence registry** for single events that instantly create large newly anomalous public populations requiring registration, education, triage, rights review, and security surge capacity.
+
+## Prerequisite (on `main` @ `0c375c93`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Threshold routes     | `src/domain/alternateRealityThresholdRouteRegistry.ts` (SPE-2121 / PR #2440) |
+| Public disclosure    | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109 / PR #2430) |
+| Harvest batch        | `starter-picks-routing-65` (C50) in `planning/harvest-reconciliation-index.md` |
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `PopulationEmergenceId` + `PopulationEmergenceRecord` in `src/domain/massAnomalousPopulationEmergenceRegistry.ts`              | GameState persistence                         |
+| emergenceMagnitudeBand, newlyAnomalousCountEstimate, registrationBacklogWeeks, governanceMode, triageLanes, rightsReviewQueueRefs, publicEducationBurden, securitySurgeRefs | SPE-2109 disclosure state machine wire-up     |
+| `validatePopulationEmergenceRecord(record)` — global + secrecy_restore warning; national without security surge warning; token guards | SPE-1046 affiliation bulk updates             |
+| `projectGovernanceSurge(record, policy)` — institutional capacity forecast with governance-mode education elevation               | Full SPE-2109 parent Done                     |
+| Focused tests in `src/test/massAnomalousPopulationEmergenceRegistry.test.ts`                                                       | Live population simulator                     |
+
+## Record contract (deterministic)
+
+### Core fields
+
+- **emergenceMagnitudeBand** — `local`, `regional`, `national`, `global`.
+- **newlyAnomalousCountEstimate** — non-negative integer population estimate.
+- **registrationBacklogWeeks** — non-negative weeks of registration backlog.
+- **governanceMode** — `secrecy_restore`, `managed_disclosure`, `collapsed_masquerade`.
+- **triageLanes** — non-empty string lane identifiers for positive managed-disclosure fixtures.
+- **rightsReviewQueueRefs** — optional ordered queue refs.
+- **publicEducationBurden** — unit score 0..1.
+- **securitySurgeRefs** — optional surge capacity refs.
+- **confidence / unknown / redacted** — projection legibility without omniscient labels.
+
+### Validation rules (examples)
+
+- Missing `id` or `label` → error.
+- Invalid union values → error.
+- `global` magnitude with `secrecy_restore` governance → warning.
+- `national` magnitude with empty `securitySurgeRefs` → warning.
+- Franchise / wiki / branded object-number token in id/label/nested refs → error.
+
+### Projection (`projectGovernanceSurge`)
+
+- Inputs: record + optional policy (`currentWeek`, `minimumConfidence`, `redactUnknown`, `suppressHiddenConflictLabels`).
+- Outputs: surge band, capacity pressure scores, triage lane symptom entries, and **effective** public education burden (elevated under `collapsed_masquerade`).
+- Deterministic mapping from magnitude + governance mode + backlog to institutional capacity forecast.
+
+## Acceptance
+
+- [x] Fixture: managed_disclosure with registration backlog and triage lanes.
+- [x] Fixture: collapsed_masquerade elevates publicEducationBurden in projection.
+- [x] Negative: national magnitude with no securitySurgeRefs → warning.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Schema + types** — unions, record shape, exported fixtures.
+2. **Validation** — positive fixtures + global/secrecy warning + national/surge warning.
+3. **Projection** — `projectGovernanceSurge` with governance-mode education elevation.
+4. **Regression** — sibling registry tests unchanged.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/massAnomalousPopulationEmergenceRegistry.ts`            |
+| Tests  | `src/test/massAnomalousPopulationEmergenceRegistry.test.ts`         |
+| Plan   | `planning/mass-anomalous-population-emergence-registry-slice-1.md`  |
+
+## Branch
+
+`jamesdyedbq/spe-2122-mass-anomalous-population-emergence-registry-registration`
+
+## Boundary notes
+
+| Related issue | Relationship |
+| ------------- | ------------ |
+| [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) | Parent — public disclosure awareness and normalization inputs; wire-up deferred. |
+| [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) | Myth/truth split — pairs conceptually, no runtime coupling this slice. |
+| [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) | Affiliation bulk updates deferred. |
+| [SPE-2141](https://linear.app/spectranoir/issue/SPE-2141) | Mass population **transport** incident registry — logistics surge, not emergence registration. |
+
+## Out of scope (parent closure)
+
+- Full SPE-2109 parent Done
+- Disclosure state machine wire-up
+- SPE-1046 affiliation bulk updates
+
+## See also
+
+- `planning/harvest-reconciliation-index.md` — adjacent intake tier row for SPE-2122
+- `src/domain/alternateRealityThresholdRouteRegistry.ts` — immediate predecessor registry conventions (SPE-2121)
+- `planning/alternate-reality-threshold-route-registry-slice-1.md` — predecessor slice pattern

--- a/src/domain/massAnomalousPopulationEmergenceRegistry.ts
+++ b/src/domain/massAnomalousPopulationEmergenceRegistry.ts
@@ -1,0 +1,892 @@
+/**
+ * SPE-2122 slice 1: mass anomalous population emergence registry.
+ *
+ * Pure deterministic registry for single events that instantly create large
+ * newly anomalous public populations requiring registration, triage, rights
+ * review, education burden, and security surge capacity.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type PopulationEmergenceId = string
+
+export type EmergenceMagnitudeBand = 'local' | 'regional' | 'national' | 'global'
+
+export const EMERGENCE_MAGNITUDE_BANDS: readonly EmergenceMagnitudeBand[] = [
+  'local',
+  'regional',
+  'national',
+  'global',
+] as const
+
+export type GovernanceMode = 'secrecy_restore' | 'managed_disclosure' | 'collapsed_masquerade'
+
+export const GOVERNANCE_MODES: readonly GovernanceMode[] = [
+  'secrecy_restore',
+  'managed_disclosure',
+  'collapsed_masquerade',
+] as const
+
+export type GovernanceSurgeBand = 'low' | 'elevated' | 'critical'
+
+export const GOVERNANCE_SURGE_BANDS: readonly GovernanceSurgeBand[] = [
+  'low',
+  'elevated',
+  'critical',
+] as const
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface PopulationEmergenceRecord {
+  readonly id: PopulationEmergenceId
+  readonly label: string
+  readonly summary?: string
+  readonly emergenceMagnitudeBand: EmergenceMagnitudeBand
+  readonly newlyAnomalousCountEstimate: number
+  readonly registrationBacklogWeeks: number
+  readonly governanceMode: GovernanceMode
+  readonly triageLanes: readonly string[]
+  readonly rightsReviewQueueRefs?: readonly string[]
+  readonly publicEducationBurden: number
+  readonly securitySurgeRefs?: readonly string[]
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type PopulationEmergenceValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'invalid_emergence_magnitude_band'
+  | 'invalid_governance_mode'
+  | 'invalid_newly_anomalous_count_estimate'
+  | 'invalid_registration_backlog_weeks'
+  | 'invalid_public_education_burden'
+  | 'invalid_confidence'
+  | 'invalid_triage_lanes'
+  | 'invalid_triage_lane'
+  | 'empty_triage_lane'
+  | 'invalid_rights_review_queue_refs'
+  | 'invalid_rights_review_queue_ref'
+  | 'empty_rights_review_queue_ref'
+  | 'invalid_security_surge_refs'
+  | 'invalid_security_surge_ref'
+  | 'empty_security_surge_ref'
+  | 'global_magnitude_with_secrecy_restore'
+  | 'national_magnitude_without_security_surge'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_field'
+
+export interface PopulationEmergenceValidationIssue {
+  readonly code: PopulationEmergenceValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface PopulationEmergenceValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly PopulationEmergenceValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Projection
+// ---------------------------------------------------------------------------
+
+export interface GovernanceSurgeProjectionPolicy {
+  readonly currentWeek?: number
+  readonly minimumConfidence?: number
+  readonly redactUnknown?: boolean
+  readonly suppressHiddenConflictLabels?: boolean
+}
+
+export interface TriageLaneSymptom {
+  readonly lane: string
+  readonly symptomDescriptor: string
+  readonly capacityGapHint: string | null
+}
+
+export interface GovernanceSurgeProjection {
+  readonly recordId: PopulationEmergenceId
+  readonly label: string
+  readonly emergenceMagnitudeBand: EmergenceMagnitudeBand
+  readonly governanceMode: GovernanceMode
+  readonly recordedPublicEducationBurden: number | null
+  readonly effectivePublicEducationBurden: number | null
+  readonly projectedRegistrationPressure: number | null
+  readonly projectedRightsReviewPressure: number | null
+  readonly governanceSurgeBand: GovernanceSurgeBand | null
+  readonly triageLaneSymptoms: readonly TriageLaneSymptom[]
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const MAGNITUDE_BAND_SET = new Set<string>(EMERGENCE_MAGNITUDE_BANDS)
+const GOVERNANCE_MODE_SET = new Set<string>(GOVERNANCE_MODES)
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /(?:\b(?:scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|group of interest|broken masquerade|masquerade breach|wiki\.|wikidot)\b|goi-)/i
+
+export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
+
+const MAGNITUDE_PRESSURE: Readonly<Record<EmergenceMagnitudeBand, number>> = {
+  local: 0.12,
+  regional: 0.28,
+  national: 0.52,
+  global: 0.78,
+}
+
+const GOVERNANCE_MODE_PRESSURE: Readonly<Record<GovernanceMode, number>> = {
+  secrecy_restore: 0.08,
+  managed_disclosure: 0.18,
+  collapsed_masquerade: 0.32,
+}
+
+const GOVERNANCE_MODE_EDUCATION_ELEVATION: Readonly<Record<GovernanceMode, number>> = {
+  secrecy_restore: 0,
+  managed_disclosure: 0.04,
+  collapsed_masquerade: 0.18,
+}
+
+const TRIAGE_LANE_SYMPTOM_PREFIX = 'Institutional triage lane pressure observed at'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return Object.freeze(
+    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function pushIssue(
+  issues: PopulationEmergenceValidationIssue[],
+  issue: PopulationEmergenceValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: PopulationEmergenceValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function isValidNonNegativeInteger(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && Number.isInteger(value)
+}
+
+function isValidNonNegativeNumber(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function roundUnit(value: number): number {
+  return Math.round(value * 1000) / 1000
+}
+
+function freezeValidationResult(
+  issues: PopulationEmergenceValidationIssue[]
+): PopulationEmergenceValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function hasNonEmptyRefArray(value: unknown): boolean {
+  return asStringArray(value).some((ref) => normalizeToken(ref).length > 0)
+}
+
+function validateRequiredStringRefArray(
+  issues: PopulationEmergenceValidationIssue[],
+  id: string,
+  fieldName: string,
+  value: unknown,
+  invalidArrayCode: PopulationEmergenceValidationCode,
+  invalidEntryCode: PopulationEmergenceValidationCode,
+  emptyEntryCode: PopulationEmergenceValidationCode
+) {
+  if (!Array.isArray(value)) {
+    pushIssue(issues, {
+      code: invalidArrayCode,
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} ${fieldName} must be an array.`,
+      relatedIds: id ? [id] : undefined,
+    })
+    return
+  }
+
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      pushIssue(issues, {
+        code: invalidEntryCode,
+        severity: 'error',
+        detail: `Population emergence record ${id || '(unknown)'} ${fieldName} contains a non-string entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
+    if (!normalizeToken(entry)) {
+      pushIssue(issues, {
+        code: emptyEntryCode,
+        severity: 'error',
+        detail: `Population emergence record ${id || '(unknown)'} ${fieldName} contains an empty entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+}
+
+function validateOptionalStringRefArray(
+  issues: PopulationEmergenceValidationIssue[],
+  id: string,
+  fieldName: string,
+  value: unknown,
+  invalidArrayCode: PopulationEmergenceValidationCode,
+  invalidEntryCode: PopulationEmergenceValidationCode,
+  emptyEntryCode: PopulationEmergenceValidationCode
+) {
+  if (value === undefined) {
+    return
+  }
+
+  validateRequiredStringRefArray(
+    issues,
+    id,
+    fieldName,
+    value,
+    invalidArrayCode,
+    invalidEntryCode,
+    emptyEntryCode
+  )
+}
+
+function scanStringFieldTokens(
+  issues: PopulationEmergenceValidationIssue[],
+  id: string,
+  field: string,
+  value: string
+) {
+  const token = normalizeToken(value)
+  if (!token) {
+    return
+  }
+
+  if (containsFranchiseToken(token)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_field',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(token)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_field',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} field ${field} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function scanRefArrayTokens(
+  issues: PopulationEmergenceValidationIssue[],
+  id: string,
+  field: string,
+  refs: readonly string[]
+) {
+  for (const ref of refs) {
+    scanStringFieldTokens(issues, id, field, ref)
+  }
+}
+
+function scanForbiddenTokens(
+  issues: PopulationEmergenceValidationIssue[],
+  id: string,
+  label: string,
+  record: PopulationEmergenceRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Population emergence record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Population emergence record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Population emergence record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Population emergence record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.summary) {
+    scanStringFieldTokens(issues, id, 'summary', record.summary)
+  }
+
+  scanRefArrayTokens(issues, id, 'triageLanes', asStringArray(record.triageLanes))
+  scanRefArrayTokens(
+    issues,
+    id,
+    'rightsReviewQueueRefs',
+    asStringArray(record.rightsReviewQueueRefs)
+  )
+  scanRefArrayTokens(issues, id, 'securitySurgeRefs', asStringArray(record.securitySurgeRefs))
+}
+
+function resolveConfidence(
+  record: PopulationEmergenceRecord,
+  policy: GovernanceSurgeProjectionPolicy
+): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (redactedFields.has('confidence')) {
+    return null
+  }
+
+  const confidence = record.confidence ?? null
+  if (
+    confidence !== null &&
+    policy.minimumConfidence !== undefined &&
+    confidence < policy.minimumConfidence
+  ) {
+    return null
+  }
+
+  if (policy.redactUnknown === true && unknownFields.includes('confidence')) {
+    return null
+  }
+
+  return confidence
+}
+
+function resolveGovernanceSurgeBand(score: number | null): GovernanceSurgeBand | null {
+  if (score === null) {
+    return null
+  }
+
+  if (score < 0.34) {
+    return 'low'
+  }
+
+  if (score < 0.67) {
+    return 'elevated'
+  }
+
+  return 'critical'
+}
+
+function masksProjectionInput(
+  field: string,
+  redactedFields: ReadonlySet<string>,
+  unknownFields: readonly string[],
+  policy: GovernanceSurgeProjectionPolicy
+): boolean {
+  return (
+    redactedFields.has(field) ||
+    (policy.redactUnknown === true && unknownFields.includes(field))
+  )
+}
+
+function resolveEffectivePublicEducationBurden(
+  record: PopulationEmergenceRecord,
+  policy: GovernanceSurgeProjectionPolicy
+): { recorded: number | null; effective: number | null } {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (
+    masksProjectionInput('publicEducationBurden', redactedFields, unknownFields, policy) ||
+    masksProjectionInput('governanceMode', redactedFields, unknownFields, policy)
+  ) {
+    return { recorded: null, effective: null }
+  }
+
+  const recorded = isValidUnitScore(record.publicEducationBurden)
+    ? record.publicEducationBurden
+    : null
+
+  if (recorded === null) {
+    return { recorded: null, effective: null }
+  }
+
+  const governanceMode = isGovernanceMode(record.governanceMode)
+    ? record.governanceMode
+    : 'managed_disclosure'
+  const elevation = GOVERNANCE_MODE_EDUCATION_ELEVATION[governanceMode]
+
+  return {
+    recorded,
+    effective: roundUnit(Math.min(1, recorded + elevation)),
+  }
+}
+
+function resolveCapacityPressures(
+  record: PopulationEmergenceRecord,
+  policy: GovernanceSurgeProjectionPolicy
+): {
+  registrationPressure: number | null
+  rightsReviewPressure: number | null
+  surgeScore: number | null
+} {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  const pressureFields = [
+    'emergenceMagnitudeBand',
+    'registrationBacklogWeeks',
+    'governanceMode',
+    'newlyAnomalousCountEstimate',
+    'triageLanes',
+    'rightsReviewQueueRefs',
+    'securitySurgeRefs',
+  ] as const
+
+  if (
+    pressureFields.some((field) =>
+      masksProjectionInput(field, redactedFields, unknownFields, policy)
+    )
+  ) {
+    return {
+      registrationPressure: null,
+      rightsReviewPressure: null,
+      surgeScore: null,
+    }
+  }
+
+  const magnitudeBand = isEmergenceMagnitudeBand(record.emergenceMagnitudeBand)
+    ? record.emergenceMagnitudeBand
+    : 'local'
+  const governanceMode = isGovernanceMode(record.governanceMode)
+    ? record.governanceMode
+    : 'managed_disclosure'
+
+  const currentWeek =
+    typeof policy.currentWeek === 'number' && Number.isFinite(policy.currentWeek)
+      ? Math.max(0, Math.trunc(policy.currentWeek))
+      : 0
+
+  const backlogWeeks = isValidNonNegativeNumber(record.registrationBacklogWeeks)
+    ? record.registrationBacklogWeeks
+    : 0
+  const populationEstimate = isValidNonNegativeInteger(record.newlyAnomalousCountEstimate)
+    ? record.newlyAnomalousCountEstimate
+    : 0
+
+  const backlogPressure = Math.min(0.25, backlogWeeks * 0.02)
+  const populationPressure = Math.min(0.2, populationEstimate / 500_000)
+  const triageLanePressure = Math.min(0.15, asStringArray(record.triageLanes).length * 0.03)
+  const rightsQueuePressure = Math.min(
+    0.12,
+    asStringArray(record.rightsReviewQueueRefs).filter((ref) => normalizeToken(ref).length > 0)
+      .length * 0.04
+  )
+  const surgeMitigation = hasNonEmptyRefArray(record.securitySurgeRefs) ? 0.08 : 0
+  const weekDrift = currentWeek * 0.005
+
+  const basePressure =
+    MAGNITUDE_PRESSURE[magnitudeBand] +
+    GOVERNANCE_MODE_PRESSURE[governanceMode] +
+    backlogPressure +
+    populationPressure +
+    triageLanePressure +
+    weekDrift -
+    surgeMitigation
+
+  const registrationPressure = roundUnit(Math.max(0, Math.min(1, basePressure)))
+  const rightsReviewPressure = roundUnit(
+    Math.max(0, Math.min(1, basePressure * 0.75 + rightsQueuePressure))
+  )
+  const surgeScore = roundUnit(Math.max(0, Math.min(1, basePressure + rightsQueuePressure * 0.5)))
+
+  return {
+    registrationPressure,
+    rightsReviewPressure,
+    surgeScore,
+  }
+}
+
+function resolveCapacityGapHint(
+  record: PopulationEmergenceRecord,
+  lane: string,
+  policy: GovernanceSurgeProjectionPolicy
+): string | null {
+  if (policy.suppressHiddenConflictLabels === true) {
+    return null
+  }
+
+  const magnitudeBand = isEmergenceMagnitudeBand(record.emergenceMagnitudeBand)
+    ? record.emergenceMagnitudeBand
+    : 'local'
+  return `capacity_gap:${magnitudeBand}:${normalizeToken(lane) || 'unknown_lane'}`
+}
+
+function buildTriageLaneSymptoms(
+  record: PopulationEmergenceRecord,
+  policy: GovernanceSurgeProjectionPolicy
+): readonly TriageLaneSymptom[] {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (
+    masksProjectionInput('triageLanes', redactedFields, unknownFields, policy) ||
+    masksProjectionInput('emergenceMagnitudeBand', redactedFields, unknownFields, policy)
+  ) {
+    return Object.freeze([])
+  }
+
+  const lanes = asStringArray(record.triageLanes)
+    .map((lane) => normalizeToken(lane))
+    .filter((lane) => lane.length > 0)
+    .sort((left, right) => left.localeCompare(right))
+
+  return Object.freeze(
+    lanes.map((lane) =>
+      Object.freeze({
+        lane,
+        symptomDescriptor: `${TRIAGE_LANE_SYMPTOM_PREFIX} ${lane}`,
+        capacityGapHint: resolveCapacityGapHint(record, lane, policy),
+      })
+    )
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isEmergenceMagnitudeBand(value: unknown): value is EmergenceMagnitudeBand {
+  return typeof value === 'string' && MAGNITUDE_BAND_SET.has(value)
+}
+
+export function isGovernanceMode(value: unknown): value is GovernanceMode {
+  return typeof value === 'string' && GOVERNANCE_MODE_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validatePopulationEmergenceRecord(
+  record: PopulationEmergenceRecord
+): PopulationEmergenceValidationResult {
+  const issues: PopulationEmergenceValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Population emergence record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Population emergence record is missing label.',
+    })
+  }
+
+  if (!isEmergenceMagnitudeBand(record.emergenceMagnitudeBand)) {
+    pushIssue(issues, {
+      code: 'invalid_emergence_magnitude_band',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} has invalid emergenceMagnitudeBand ${String(record.emergenceMagnitudeBand)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isGovernanceMode(record.governanceMode)) {
+    pushIssue(issues, {
+      code: 'invalid_governance_mode',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} has invalid governanceMode ${String(record.governanceMode)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidNonNegativeInteger(record.newlyAnomalousCountEstimate)) {
+    pushIssue(issues, {
+      code: 'invalid_newly_anomalous_count_estimate',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} newlyAnomalousCountEstimate must be a non-negative integer.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidNonNegativeNumber(record.registrationBacklogWeeks)) {
+    pushIssue(issues, {
+      code: 'invalid_registration_backlog_weeks',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} registrationBacklogWeeks must be a non-negative number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.publicEducationBurden)) {
+    pushIssue(issues, {
+      code: 'invalid_public_education_burden',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} publicEducationBurden must be between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} confidence must be between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  validateRequiredStringRefArray(
+    issues,
+    id,
+    'triageLanes',
+    record.triageLanes,
+    'invalid_triage_lanes',
+    'invalid_triage_lane',
+    'empty_triage_lane'
+  )
+
+  validateOptionalStringRefArray(
+    issues,
+    id,
+    'rightsReviewQueueRefs',
+    record.rightsReviewQueueRefs,
+    'invalid_rights_review_queue_refs',
+    'invalid_rights_review_queue_ref',
+    'empty_rights_review_queue_ref'
+  )
+
+  validateOptionalStringRefArray(
+    issues,
+    id,
+    'securitySurgeRefs',
+    record.securitySurgeRefs,
+    'invalid_security_surge_refs',
+    'invalid_security_surge_ref',
+    'empty_security_surge_ref'
+  )
+
+  scanForbiddenTokens(issues, id, label, record)
+
+  if (
+    record.emergenceMagnitudeBand === 'global' &&
+    record.governanceMode === 'secrecy_restore'
+  ) {
+    pushIssue(issues, {
+      code: 'global_magnitude_with_secrecy_restore',
+      severity: 'warning',
+      detail: `Population emergence record ${id || '(unknown)'} is global magnitude but governanceMode is secrecy_restore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.emergenceMagnitudeBand === 'national' &&
+    !hasNonEmptyRefArray(record.securitySurgeRefs)
+  ) {
+    pushIssue(issues, {
+      code: 'national_magnitude_without_security_surge',
+      severity: 'warning',
+      detail: `Population emergence record ${id || '(unknown)'} is national magnitude but declares no securitySurgeRefs.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Projects deterministic governance surge capacity for registration, rights review,
+ * and public education burden. SPE-2109 disclosure wire-up remains deferred.
+ */
+export function projectGovernanceSurge(
+  record: PopulationEmergenceRecord,
+  policy: GovernanceSurgeProjectionPolicy = {}
+): GovernanceSurgeProjection {
+  const recordId = normalizeToken(record.id) || '(unknown)'
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = sortedStringArray(record.unknownFields)
+  const confidence = resolveConfidence(record, policy)
+  const { recorded, effective } = resolveEffectivePublicEducationBurden(record, policy)
+  const { registrationPressure, rightsReviewPressure, surgeScore } = resolveCapacityPressures(
+    record,
+    policy
+  )
+
+  const triageRedacted =
+    redactedFields.has('triageLanes') ||
+    (policy.redactUnknown === true && unknownFields.includes('triageLanes'))
+
+  const triageLaneSymptoms = triageRedacted
+    ? Object.freeze([])
+    : buildTriageLaneSymptoms(record, policy)
+
+  const redacted =
+    triageRedacted ||
+    recorded === null ||
+    effective === null ||
+    registrationPressure === null ||
+    rightsReviewPressure === null ||
+    surgeScore === null ||
+    redactedFields.has('confidence') ||
+    (policy.redactUnknown === true && unknownFields.includes('confidence')) ||
+    (confidence === null &&
+      record.confidence !== undefined &&
+      policy.minimumConfidence !== undefined)
+
+  return Object.freeze({
+    recordId,
+    label: normalizeToken(record.label) || '(unknown)',
+    emergenceMagnitudeBand: isEmergenceMagnitudeBand(record.emergenceMagnitudeBand)
+      ? record.emergenceMagnitudeBand
+      : 'local',
+    governanceMode: isGovernanceMode(record.governanceMode)
+      ? record.governanceMode
+      : 'managed_disclosure',
+    recordedPublicEducationBurden: recorded,
+    effectivePublicEducationBurden: effective,
+    projectedRegistrationPressure: registrationPressure,
+    projectedRightsReviewPressure: rightsReviewPressure,
+    governanceSurgeBand: resolveGovernanceSurgeBand(surgeScore),
+    triageLaneSymptoms,
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
+function defineRecord(record: PopulationEmergenceRecord): PopulationEmergenceRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Managed disclosure with registration backlog and active triage lanes. */
+export const MANAGED_DISCLOSURE_BACKLOG_FIXTURE: PopulationEmergenceRecord = defineRecord({
+  id: 'population-emergence:managed-disclosure-wave-3',
+  label: 'Managed disclosure registration surge',
+  summary:
+    'Regional emergence under managed disclosure with registration backlog and triage lanes.',
+  emergenceMagnitudeBand: 'regional',
+  newlyAnomalousCountEstimate: 48_000,
+  registrationBacklogWeeks: 6,
+  governanceMode: 'managed_disclosure',
+  triageLanes: ['lane:registration-intake', 'lane:medical-screening', 'lane:rights-review'],
+  rightsReviewQueueRefs: ['queue:rights-review-alpha'],
+  publicEducationBurden: 0.42,
+  securitySurgeRefs: ['surge:regional-security-cell-2'],
+  confidence: 0.79,
+})
+
+/** Collapsed masquerade with education burden elevated by governance-mode projection. */
+export const COLLAPSED_MASQUERADE_EDUCATION_FIXTURE: PopulationEmergenceRecord = defineRecord({
+  id: 'population-emergence:collapsed-masquerade-education',
+  label: 'Collapsed masquerade public education surge',
+  summary:
+    'National emergence after masquerade collapse with high public education burden baseline.',
+  emergenceMagnitudeBand: 'national',
+  newlyAnomalousCountEstimate: 210_000,
+  registrationBacklogWeeks: 10,
+  governanceMode: 'collapsed_masquerade',
+  triageLanes: ['lane:public-education', 'lane:community-stabilization'],
+  rightsReviewQueueRefs: ['queue:rights-review-national-1', 'queue:rights-review-national-2'],
+  publicEducationBurden: 0.55,
+  securitySurgeRefs: ['surge:national-response-brigade'],
+  confidence: 0.74,
+})

--- a/src/domain/massAnomalousPopulationEmergenceRegistry.ts
+++ b/src/domain/massAnomalousPopulationEmergenceRegistry.ts
@@ -74,6 +74,7 @@ export type PopulationEmergenceValidationCode =
   | 'invalid_triage_lanes'
   | 'invalid_triage_lane'
   | 'empty_triage_lane'
+  | 'empty_triage_lanes'
   | 'invalid_rights_review_queue_refs'
   | 'invalid_rights_review_queue_ref'
   | 'empty_rights_review_queue_ref'
@@ -744,6 +745,18 @@ export function validatePopulationEmergenceRecord(
     'empty_triage_lane'
   )
 
+  if (
+    Array.isArray(record.triageLanes) &&
+    !asStringArray(record.triageLanes).some((lane) => normalizeToken(lane).length > 0)
+  ) {
+    pushIssue(issues, {
+      code: 'empty_triage_lanes',
+      severity: 'error',
+      detail: `Population emergence record ${id || '(unknown)'} triageLanes must include at least one lane.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
   validateOptionalStringRefArray(
     issues,
     id,
@@ -819,13 +832,31 @@ export function projectGovernanceSurge(
     ? Object.freeze([])
     : buildTriageLaneSymptoms(record, policy)
 
+  const educationBurdenRedacted =
+    redactedFields.has('publicEducationBurden') ||
+    redactedFields.has('governanceMode') ||
+    (policy.redactUnknown === true &&
+      (unknownFields.includes('publicEducationBurden') ||
+        unknownFields.includes('governanceMode')))
+
+  const capacityRedacted = (
+    [
+      'emergenceMagnitudeBand',
+      'registrationBacklogWeeks',
+      'governanceMode',
+      'newlyAnomalousCountEstimate',
+      'triageLanes',
+      'rightsReviewQueueRefs',
+      'securitySurgeRefs',
+    ] as const
+  ).some((field) =>
+    masksProjectionInput(field, redactedFields, unknownFields, policy)
+  )
+
   const redacted =
     triageRedacted ||
-    recorded === null ||
-    effective === null ||
-    registrationPressure === null ||
-    rightsReviewPressure === null ||
-    surgeScore === null ||
+    educationBurdenRedacted ||
+    capacityRedacted ||
     redactedFields.has('confidence') ||
     (policy.redactUnknown === true && unknownFields.includes('confidence')) ||
     (confidence === null &&

--- a/src/test/massAnomalousPopulationEmergenceRegistry.test.ts
+++ b/src/test/massAnomalousPopulationEmergenceRegistry.test.ts
@@ -116,6 +116,17 @@ describe('massAnomalousPopulationEmergenceRegistry (SPE-2122 slice 1)', () => {
     expect(result.issues.some((issue) => issue.code === 'invalid_triage_lanes')).toBe(true)
   })
 
+  it('errors when triageLanes is an empty array', () => {
+    const result = validatePopulationEmergenceRecord(
+      baseRecord({
+        triageLanes: [],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'empty_triage_lanes')).toBe(true)
+  })
+
   it('errors on franchise token in record id', () => {
     const result = validatePopulationEmergenceRecord(
       baseRecord({

--- a/src/test/massAnomalousPopulationEmergenceRegistry.test.ts
+++ b/src/test/massAnomalousPopulationEmergenceRegistry.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COLLAPSED_MASQUERADE_EDUCATION_FIXTURE,
+  EMERGENCE_MAGNITUDE_BANDS,
+  GOVERNANCE_MODES,
+  GOVERNANCE_SURGE_BANDS,
+  MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+  projectGovernanceSurge,
+  validatePopulationEmergenceRecord,
+  type PopulationEmergenceRecord,
+} from '../domain/massAnomalousPopulationEmergenceRegistry'
+
+function baseRecord(
+  overrides: Partial<PopulationEmergenceRecord> = {}
+): PopulationEmergenceRecord {
+  return {
+    id: 'population-emergence:test-base',
+    label: 'Test population emergence',
+    emergenceMagnitudeBand: 'local',
+    newlyAnomalousCountEstimate: 1200,
+    registrationBacklogWeeks: 2,
+    governanceMode: 'managed_disclosure',
+    triageLanes: ['lane:registration-intake'],
+    publicEducationBurden: 0.3,
+    ...overrides,
+  }
+}
+
+describe('massAnomalousPopulationEmergenceRegistry (SPE-2122 slice 1)', () => {
+  it('validates managed disclosure fixture with registration backlog and triage lanes', () => {
+    const result = validatePopulationEmergenceRecord(MANAGED_DISCLOSURE_BACKLOG_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(MANAGED_DISCLOSURE_BACKLOG_FIXTURE.governanceMode).toBe('managed_disclosure')
+    expect(MANAGED_DISCLOSURE_BACKLOG_FIXTURE.registrationBacklogWeeks).toBeGreaterThan(0)
+    expect(MANAGED_DISCLOSURE_BACKLOG_FIXTURE.triageLanes.length).toBeGreaterThan(0)
+  })
+
+  it('projects governance surge with triage lane symptoms for managed disclosure', () => {
+    const projection = projectGovernanceSurge(MANAGED_DISCLOSURE_BACKLOG_FIXTURE, {
+      currentWeek: 4,
+    })
+
+    expect(projection.triageLaneSymptoms.length).toBe(3)
+    expect(projection.triageLaneSymptoms[0]?.symptomDescriptor).toContain(
+      'Institutional triage lane pressure observed at'
+    )
+    expect(projection.projectedRegistrationPressure).not.toBeNull()
+    expect(projection.governanceSurgeBand).not.toBeNull()
+  })
+
+  it('elevates publicEducationBurden under collapsed_masquerade in projection', () => {
+    const projection = projectGovernanceSurge(COLLAPSED_MASQUERADE_EDUCATION_FIXTURE)
+
+    expect(projection.recordedPublicEducationBurden).toBe(0.55)
+    expect(projection.effectivePublicEducationBurden).not.toBeNull()
+    expect(projection.effectivePublicEducationBurden!).toBeGreaterThan(
+      projection.recordedPublicEducationBurden!
+    )
+    expect(COLLAPSED_MASQUERADE_EDUCATION_FIXTURE.governanceMode).toBe('collapsed_masquerade')
+  })
+
+  it('validates collapsed masquerade fixture', () => {
+    const result = validatePopulationEmergenceRecord(COLLAPSED_MASQUERADE_EDUCATION_FIXTURE)
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('warns when national magnitude has no securitySurgeRefs', () => {
+    const result = validatePopulationEmergenceRecord(
+      baseRecord({
+        emergenceMagnitudeBand: 'national',
+        securitySurgeRefs: undefined,
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(
+      result.issues.some((issue) => issue.code === 'national_magnitude_without_security_surge')
+    ).toBe(true)
+  })
+
+  it('warns when global magnitude uses secrecy_restore governance', () => {
+    const result = validatePopulationEmergenceRecord(
+      baseRecord({
+        emergenceMagnitudeBand: 'global',
+        governanceMode: 'secrecy_restore',
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(
+      result.issues.some((issue) => issue.code === 'global_magnitude_with_secrecy_restore')
+    ).toBe(true)
+  })
+
+  it('errors when id is missing', () => {
+    const result = validatePopulationEmergenceRecord(
+      baseRecord({
+        id: '   ',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'missing_id')).toBe(true)
+  })
+
+  it('errors when triageLanes is not an array', () => {
+    const result = validatePopulationEmergenceRecord(
+      baseRecord({
+        triageLanes: 'lane:registration-intake' as unknown as readonly string[],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'invalid_triage_lanes')).toBe(true)
+  })
+
+  it('errors on franchise token in record id', () => {
+    const result = validatePopulationEmergenceRecord(
+      baseRecord({
+        id: 'population-emergence:foundation-surge',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_id')).toBe(true)
+  })
+
+  it('errors on branded object number in rightsReviewQueueRefs', () => {
+    const result = validatePopulationEmergenceRecord(
+      baseRecord({
+        rightsReviewQueueRefs: ['queue:SCP-173-rights-review'],
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'branded_object_number_in_field')).toBe(
+      true
+    )
+  })
+
+  it('redacts capacity pressures when emergenceMagnitudeBand is unknown to policy', () => {
+    const projection = projectGovernanceSurge(
+      {
+        ...MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+        unknownFields: ['emergenceMagnitudeBand'],
+      },
+      {
+        redactUnknown: true,
+      }
+    )
+
+    expect(projection.projectedRegistrationPressure).toBeNull()
+    expect(projection.projectedRightsReviewPressure).toBeNull()
+    expect(projection.governanceSurgeBand).toBeNull()
+  })
+
+  it('redacts triage lane symptoms when policy requests unknown redaction', () => {
+    const projection = projectGovernanceSurge(
+      {
+        ...MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+        unknownFields: ['triageLanes'],
+      },
+      {
+        redactUnknown: true,
+      }
+    )
+
+    expect(projection.triageLaneSymptoms).toHaveLength(0)
+    expect(projection.redacted).toBe(true)
+  })
+
+  it('suppresses capacity gap hints when hidden conflict labels are suppressed', () => {
+    const projection = projectGovernanceSurge(MANAGED_DISCLOSURE_BACKLOG_FIXTURE, {
+      suppressHiddenConflictLabels: true,
+    })
+
+    expect(projection.triageLaneSymptoms.every((entry) => entry.capacityGapHint === null)).toBe(
+      true
+    )
+  })
+
+  it('returns byte-stable validation results on repeated calls', () => {
+    const first = validatePopulationEmergenceRecord(COLLAPSED_MASQUERADE_EDUCATION_FIXTURE)
+    const second = validatePopulationEmergenceRecord(COLLAPSED_MASQUERADE_EDUCATION_FIXTURE)
+
+    expect(first).toEqual(second)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+
+  it('exports stable union catalogs', () => {
+    expect(EMERGENCE_MAGNITUDE_BANDS).toEqual(['local', 'regional', 'national', 'global'])
+    expect(GOVERNANCE_MODES).toEqual([
+      'secrecy_restore',
+      'managed_disclosure',
+      'collapsed_masquerade',
+    ])
+    expect(GOVERNANCE_SURGE_BANDS).toEqual(['low', 'elevated', 'critical'])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds pure deterministic `massAnomalousPopulationEmergenceRegistry` for single-event mass anomalous population emergence (registration backlog, triage lanes, rights review queues, governance modes, security surge refs).
- Implements `validatePopulationEmergenceRecord` (global + secrecy_restore warning; national without security surge warning; franchise token guardrails) and `projectGovernanceSurge` (institutional capacity forecast with collapsed_masquerade education burden elevation).
- Adds focused Vitest coverage and slice plan doc.

## Linear

- **Slice:** [SPE-2122](https://linear.app/spectranoir/issue/SPE-2122) — Mass anomalous population emergence registry — registration, triage, and governance surge (slice 1)
- **Parent:** [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) — Public disclosure state registry (**remains open**)

## What shipped

- `src/domain/massAnomalousPopulationEmergenceRegistry.ts`
- `src/test/massAnomalousPopulationEmergenceRegistry.test.ts`
- `planning/mass-anomalous-population-emergence-registry-slice-1.md`

## Test plan

- [x] `npm run lint`
- [x] `npm run test:run -- src/test/massAnomalousPopulationEmergenceRegistry.test.ts` (15 tests)

## Docs updated

- `planning/mass-anomalous-population-emergence-registry-slice-1.md`