### PR TITLE
feat(SPE-2092): public signal coverage evaluator (slice 1)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -134,7 +134,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `recurrent-catastrophe-amelioration-registry-slice-1.md`  | **Shipped**    | SPE-2117 / PR #2436; recurrence cycles, prevention ceiling, amelioration tactics.                                                                     |
 | `mass-anomalous-population-emergence-registry-slice-1.md` | **Shipped**    | SPE-2122 / PR #2441; population emergence registration, triage, governance surge projection.                                                          |
 | `rule-document-compliance-containment-registry-slice-1.md` | **Shipped**    | SPE-2123 / PR #2442; written-conduct binding, compliance decay, breach consequence validation.                                                        |
-| `information-intake-report-slice-1.md`                     | **In progress** | SPE-2292 / branch `spe-854-information-intake-report-slice-1`; incoming report schema + verification progression under SPE-854.                      |
+| `information-intake-report-slice-1.md`                     | **Shipped**    | SPE-2292 / PR #2444; incoming report schema + verification progression under SPE-854.                                                               |
+| `public-signal-coverage-slice-1.md`                        | **In progress** | SPE-2092 / branch `spe-2092-public-signal-coverage-slice-1`; institutional vs public channel coverage evaluator under SPE-854.                      |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/public-signal-coverage-slice-1.md
+++ b/planning/public-signal-coverage-slice-1.md
@@ -1,0 +1,46 @@
+# SPE-854 — Public signal coverage slice 1
+
+One-page implementation plan. Linear: child under [SPE-854](https://linear.app/spectranoir/issue/SPE-854). Follows [SPE-2292](https://linear.app/spectranoir/issue/SPE-2292) information intake report slice.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2092 — Public signal coverage evaluator (slice 1)](https://linear.app/spectranoir/issue/SPE-2092)       |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine       |
+| **Branch** | `spe-2092-public-signal-coverage-slice-1`                                                                  |
+| **Status** | **Ready for PR**                                                                                         |
+
+## Goal
+
+Add a pure deterministic helper that scores how well a district or case topic is covered by **institutional intake channels** versus **ambient public-signal channels**, including crawler reach gaps and low-interpretability inference blind spots.
+
+## Prerequisite (on `main` @ `5a72e72d`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake report model  | `src/domain/informationIntakeReport.ts` (SPE-2292)                     |
+| Intake registry wave | SPE-2104–SPE-2123 sibling `*Registry.ts` patterns                        |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `evaluatePublicSignalCoverage(input)` in `src/domain/publicSignalCoverage.ts` | GameState persistence                         |
+| Institutional + public channel flag structs, crawler/inference bands | Weekly `advanceWeek` hook                     |
+| `coverageBand`, `confidencePenalty`, `falseNegativeRisk`, sorted `structuredReasons` | UI / report copy                              |
+| Focused tests in `src/test/publicSignalCoverage.test.ts`             | SPE-854 parent Done                             |
+|                                                                 | SPE-1043 district baseline wiring             |
+|                                                                 | SPE-1552 rumor feed consumption               |
+|                                                                 | Full intake verification integration          |
+
+## Acceptance
+
+- [x] Blind-spot fixture: high public activity + zero institutional → `blind_spot`, `falseNegativeRisk > 0`
+- [x] Institutional-led fixture: institutional only → `institutional_only`, minimal penalty
+- [x] Partial fixture: mixed channels → `partial_public`, bounded `confidencePenalty`
+- [x] Invalid/sparse input defaults safely without throw
+- [x] Repeated evaluation is byte-stable
+- [x] `npm run lint` + targeted tests green
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress**.

--- a/src/domain/publicSignalCoverage.ts
+++ b/src/domain/publicSignalCoverage.ts
@@ -1,0 +1,416 @@
+/**
+ * SPE-2092 slice 1: public signal coverage evaluator.
+ *
+ * Pure deterministic helper scoring institutional versus ambient public-signal
+ * channel coverage for a topic/district — distinct from intake report verification
+ * (SPE-2292) and intel distortion (SPE-22).
+ */
+
+// ---------------------------------------------------------------------------
+// Bands and channel flags
+// ---------------------------------------------------------------------------
+
+export type CrawlerReachBand = 'none' | 'low' | 'medium' | 'high'
+
+export const CRAWLER_REACH_BANDS: readonly CrawlerReachBand[] = [
+  'none',
+  'low',
+  'medium',
+  'high',
+] as const
+
+export type InferenceModelBand = 'opaque' | 'low' | 'moderate' | 'high'
+
+export const INFERENCE_MODEL_BANDS: readonly InferenceModelBand[] = [
+  'opaque',
+  'low',
+  'moderate',
+  'high',
+] as const
+
+export type PublicSignalCoverageBand =
+  | 'institutional_only'
+  | 'partial_public'
+  | 'public_led'
+  | 'blind_spot'
+
+export const PUBLIC_SIGNAL_COVERAGE_BANDS: readonly PublicSignalCoverageBand[] = [
+  'institutional_only',
+  'partial_public',
+  'public_led',
+  'blind_spot',
+] as const
+
+export interface InstitutionalChannelFlags {
+  readonly formalAlert?: boolean
+  readonly partnerChannel?: boolean
+  readonly technicalTrace?: boolean
+  readonly agencyCanonicalFeed?: boolean
+}
+
+export interface PublicChannelFlags {
+  readonly communityPatternMatching?: boolean
+  readonly ambientSocialSignal?: boolean
+  readonly mediaTrace?: boolean
+  readonly rumorChain?: boolean
+  /** Grassroots optimization / community pattern density — not literal OSINT tooling. */
+  readonly grassrootsDensityHigh?: boolean
+}
+
+export interface PublicSignalCoverageRequest {
+  readonly topicId?: string
+  readonly districtId?: string
+  readonly institutionalChannels?: InstitutionalChannelFlags
+  readonly publicChannels?: PublicChannelFlags
+  readonly crawlerReachBand?: CrawlerReachBand
+  readonly inferenceModelBand?: InferenceModelBand
+}
+
+export interface PublicSignalCoverageSummary {
+  readonly institutionalChannelCount: number
+  readonly publicChannelCount: number
+  readonly publicActivityWeight: number
+}
+
+export interface PublicSignalCoverageResult {
+  readonly topicId: string
+  readonly districtId: string
+  readonly coverageBand: PublicSignalCoverageBand
+  readonly confidencePenalty: number
+  readonly falseNegativeRisk: number
+  readonly structuredReasons: readonly string[]
+  readonly summary: PublicSignalCoverageSummary
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const CRAWLER_REACH_SET = new Set<string>(CRAWLER_REACH_BANDS)
+const INFERENCE_MODEL_SET = new Set<string>(INFERENCE_MODEL_BANDS)
+
+const BASE_CONFIDENCE_PENALTY: Record<PublicSignalCoverageBand, number> = {
+  institutional_only: 0,
+  partial_public: 0.22,
+  public_led: 0.38,
+  blind_spot: 0.52,
+}
+
+const BASE_FALSE_NEGATIVE_RISK: Record<PublicSignalCoverageBand, number> = {
+  institutional_only: 0.04,
+  partial_public: 0.18,
+  public_led: 0.32,
+  blind_spot: 0.48,
+}
+
+const CRAWLER_FALSE_NEGATIVE_ADD: Record<CrawlerReachBand, number> = {
+  none: 0.16,
+  low: 0.1,
+  medium: 0.05,
+  high: 0,
+}
+
+const INFERENCE_CONFIDENCE_PENALTY_ADD: Record<InferenceModelBand, number> = {
+  opaque: 0.14,
+  low: 0.09,
+  moderate: 0.04,
+  high: 0,
+}
+
+const PUBLIC_ACTIVITY_GRASSROOTS_WEIGHT = 2
+const PUBLIC_LED_RATIO_THRESHOLD = 2
+const PARTIAL_PUBLIC_MAX_CONFIDENCE_PENALTY = 0.45
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const BLIND_SPOT_COVERAGE_REQUEST: PublicSignalCoverageRequest = {
+  topicId: 'topic:canal-bridge-incident',
+  districtId: 'district:riverside-east',
+  institutionalChannels: {},
+  publicChannels: {
+    communityPatternMatching: true,
+    ambientSocialSignal: true,
+    rumorChain: true,
+    grassrootsDensityHigh: true,
+  },
+  crawlerReachBand: 'none',
+  inferenceModelBand: 'opaque',
+}
+
+export const INSTITUTIONAL_ONLY_COVERAGE_REQUEST: PublicSignalCoverageRequest = {
+  topicId: 'topic:canal-bridge-incident',
+  districtId: 'district:riverside-east',
+  institutionalChannels: {
+    formalAlert: true,
+    partnerChannel: true,
+    technicalTrace: true,
+    agencyCanonicalFeed: true,
+  },
+  publicChannels: {},
+  crawlerReachBand: 'high',
+  inferenceModelBand: 'high',
+}
+
+export const PARTIAL_PUBLIC_COVERAGE_REQUEST: PublicSignalCoverageRequest = {
+  topicId: 'topic:canal-bridge-incident',
+  districtId: 'district:riverside-east',
+  institutionalChannels: {
+    formalAlert: true,
+    technicalTrace: true,
+  },
+  publicChannels: {
+    communityPatternMatching: true,
+    mediaTrace: true,
+  },
+  crawlerReachBand: 'medium',
+  inferenceModelBand: 'moderate',
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isCrawlerReachBand(value: string): value is CrawlerReachBand {
+  return CRAWLER_REACH_SET.has(value)
+}
+
+export function isInferenceModelBand(value: string): value is InferenceModelBand {
+  return INFERENCE_MODEL_SET.has(value)
+}
+
+export function isPublicSignalCoverageBand(value: string): value is PublicSignalCoverageBand {
+  return PUBLIC_SIGNAL_COVERAGE_BANDS.includes(value as PublicSignalCoverageBand)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function clamp01(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  if (value < 0) {
+    return 0
+  }
+
+  if (value > 1) {
+    return 1
+  }
+
+  return value
+}
+
+function roundScore(value: number) {
+  return Math.round(clamp01(value) * 1000) / 1000
+}
+
+function countTrueFlags(flags: Record<string, boolean | undefined> | undefined) {
+  if (!flags) {
+    return 0
+  }
+
+  return Object.values(flags).filter((value) => value === true).length
+}
+
+function countInstitutionalChannels(flags: InstitutionalChannelFlags | undefined) {
+  return countTrueFlags(flags)
+}
+
+function countPublicChannels(flags: PublicChannelFlags | undefined) {
+  if (!flags) {
+    return 0
+  }
+
+  let count = 0
+  if (flags.communityPatternMatching === true) count += 1
+  if (flags.ambientSocialSignal === true) count += 1
+  if (flags.mediaTrace === true) count += 1
+  if (flags.rumorChain === true) count += 1
+  return count
+}
+
+function computePublicActivityWeight(
+  publicChannelCount: number,
+  flags: PublicChannelFlags | undefined
+) {
+  const grassrootsBoost =
+    flags?.grassrootsDensityHigh === true ? PUBLIC_ACTIVITY_GRASSROOTS_WEIGHT : 0
+
+  return publicChannelCount + grassrootsBoost
+}
+
+function resolveCrawlerReachBand(value: unknown): CrawlerReachBand {
+  const token = normalizeToken(value)
+  return isCrawlerReachBand(token) ? token : 'medium'
+}
+
+function resolveInferenceModelBand(value: unknown): InferenceModelBand {
+  const token = normalizeToken(value)
+  return isInferenceModelBand(token) ? token : 'moderate'
+}
+
+function resolveCoverageBand(input: {
+  institutionalChannelCount: number
+  publicActivityWeight: number
+  sparseInput: boolean
+}): PublicSignalCoverageBand {
+  if (input.sparseInput) {
+    return 'partial_public'
+  }
+
+  const { institutionalChannelCount, publicActivityWeight } = input
+
+  if (institutionalChannelCount === 0 && publicActivityWeight > 0) {
+    return 'blind_spot'
+  }
+
+  if (institutionalChannelCount > 0 && publicActivityWeight === 0) {
+    return 'institutional_only'
+  }
+
+  if (institutionalChannelCount > 0 && publicActivityWeight > 0) {
+    if (publicActivityWeight >= institutionalChannelCount * PUBLIC_LED_RATIO_THRESHOLD) {
+      return 'public_led'
+    }
+
+    return 'partial_public'
+  }
+
+  return 'partial_public'
+}
+
+function buildStructuredReasons(input: {
+  topicId: string
+  districtId: string
+  coverageBand: PublicSignalCoverageBand
+  institutionalChannelCount: number
+  publicChannelCount: number
+  publicActivityWeight: number
+  crawlerReachBand: CrawlerReachBand
+  inferenceModelBand: InferenceModelBand
+  sparseInput: boolean
+  missingInstitutionalChannels: boolean
+  lowCrawlerReach: boolean
+  lowInferenceInterpretability: boolean
+}): readonly string[] {
+  const reasons = [
+    `band:${input.coverageBand}`,
+    `topic:${input.topicId}`,
+    `district:${input.districtId}`,
+    `channel:institutional_count:${input.institutionalChannelCount}`,
+    `channel:public_count:${input.publicChannelCount}`,
+    `channel:public_activity_weight:${input.publicActivityWeight}`,
+    `crawler:${input.crawlerReachBand}`,
+    `inference:${input.inferenceModelBand}`,
+  ]
+
+  if (input.sparseInput) {
+    reasons.push('sparse_input_defaults')
+  }
+
+  if (input.missingInstitutionalChannels) {
+    reasons.push('institutional_channel_gap')
+  }
+
+  if (input.lowCrawlerReach) {
+    reasons.push('crawler_blind_spot')
+  }
+
+  if (input.lowInferenceInterpretability) {
+    reasons.push('inference_interpretability_low')
+  }
+
+  return reasons.sort((left, right) => left.localeCompare(right))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function evaluatePublicSignalCoverage(
+  input: PublicSignalCoverageRequest = {}
+): PublicSignalCoverageResult {
+  const topicId = normalizeToken(input.topicId) || '(unknown-topic)'
+  const districtId = normalizeToken(input.districtId) || '(unknown-district)'
+
+  const institutionalChannelCount = countInstitutionalChannels(input.institutionalChannels)
+  const publicChannelCount = countPublicChannels(input.publicChannels)
+  const publicActivityWeight = computePublicActivityWeight(
+    publicChannelCount,
+    input.publicChannels
+  )
+
+  const sparseInput =
+    institutionalChannelCount === 0 &&
+    publicChannelCount === 0 &&
+    input.publicChannels?.grassrootsDensityHigh !== true
+
+  const crawlerReachBand = resolveCrawlerReachBand(input.crawlerReachBand)
+  const inferenceModelBand = resolveInferenceModelBand(input.inferenceModelBand)
+
+  const coverageBand = resolveCoverageBand({
+    institutionalChannelCount,
+    publicActivityWeight,
+    sparseInput,
+  })
+
+  const missingInstitutionalChannels = institutionalChannelCount === 0 && publicActivityWeight > 0
+  const lowCrawlerReach = crawlerReachBand === 'none' || crawlerReachBand === 'low'
+  const lowInferenceInterpretability =
+    inferenceModelBand === 'opaque' || inferenceModelBand === 'low'
+
+  let confidencePenalty =
+    BASE_CONFIDENCE_PENALTY[coverageBand] + INFERENCE_CONFIDENCE_PENALTY_ADD[inferenceModelBand]
+
+  if (coverageBand === 'partial_public') {
+    confidencePenalty = Math.min(confidencePenalty, PARTIAL_PUBLIC_MAX_CONFIDENCE_PENALTY)
+  }
+
+  let falseNegativeRisk = BASE_FALSE_NEGATIVE_RISK[coverageBand]
+
+  if (publicActivityWeight > 0) {
+    falseNegativeRisk += CRAWLER_FALSE_NEGATIVE_ADD[crawlerReachBand]
+  }
+
+  if (sparseInput) {
+    confidencePenalty = Math.min(confidencePenalty, 0.12)
+    falseNegativeRisk = Math.min(falseNegativeRisk, 0.15)
+  }
+
+  const structuredReasons = buildStructuredReasons({
+    topicId,
+    districtId,
+    coverageBand,
+    institutionalChannelCount,
+    publicChannelCount,
+    publicActivityWeight,
+    crawlerReachBand,
+    inferenceModelBand,
+    sparseInput,
+    missingInstitutionalChannels,
+    lowCrawlerReach,
+    lowInferenceInterpretability,
+  })
+
+  return {
+    topicId,
+    districtId,
+    coverageBand,
+    confidencePenalty: roundScore(confidencePenalty),
+    falseNegativeRisk: roundScore(falseNegativeRisk),
+    structuredReasons,
+    summary: {
+      institutionalChannelCount,
+      publicChannelCount,
+      publicActivityWeight,
+    },
+  }
+}

--- a/src/test/publicSignalCoverage.test.ts
+++ b/src/test/publicSignalCoverage.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BLIND_SPOT_COVERAGE_REQUEST,
+  CRAWLER_REACH_BANDS,
+  INFERENCE_MODEL_BANDS,
+  INSTITUTIONAL_ONLY_COVERAGE_REQUEST,
+  PARTIAL_PUBLIC_COVERAGE_REQUEST,
+  PUBLIC_SIGNAL_COVERAGE_BANDS,
+  evaluatePublicSignalCoverage,
+  isCrawlerReachBand,
+  isInferenceModelBand,
+  isPublicSignalCoverageBand,
+} from '../domain/publicSignalCoverage'
+
+describe('publicSignalCoverage (SPE-2092 slice 1)', () => {
+  it('exposes canonical coverage, crawler, and inference unions', () => {
+    expect(PUBLIC_SIGNAL_COVERAGE_BANDS).toEqual([
+      'institutional_only',
+      'partial_public',
+      'public_led',
+      'blind_spot',
+    ])
+    expect(CRAWLER_REACH_BANDS).toEqual(['none', 'low', 'medium', 'high'])
+    expect(INFERENCE_MODEL_BANDS).toEqual(['opaque', 'low', 'moderate', 'high'])
+    expect(isPublicSignalCoverageBand('blind_spot')).toBe(true)
+    expect(isPublicSignalCoverageBand('unknown')).toBe(false)
+    expect(isCrawlerReachBand('medium')).toBe(true)
+    expect(isInferenceModelBand('opaque')).toBe(true)
+  })
+
+  it('flags blind spot when public activity is high and institutional channels are absent', () => {
+    const result = evaluatePublicSignalCoverage(BLIND_SPOT_COVERAGE_REQUEST)
+
+    expect(result.coverageBand).toBe('blind_spot')
+    expect(result.falseNegativeRisk).toBeGreaterThan(0)
+    expect(result.confidencePenalty).toBeGreaterThan(0)
+    expect(result.structuredReasons).toContain('institutional_channel_gap')
+    expect(result.structuredReasons).toContain('crawler_blind_spot')
+    expect(result.summary.publicActivityWeight).toBeGreaterThan(0)
+    expect(result.summary.institutionalChannelCount).toBe(0)
+  })
+
+  it('returns institutional_only with minimal penalty when only institutional channels are active', () => {
+    const result = evaluatePublicSignalCoverage(INSTITUTIONAL_ONLY_COVERAGE_REQUEST)
+
+    expect(result.coverageBand).toBe('institutional_only')
+    expect(result.confidencePenalty).toBeLessThanOrEqual(0.05)
+    expect(result.falseNegativeRisk).toBeLessThanOrEqual(0.1)
+    expect(result.summary.institutionalChannelCount).toBe(4)
+    expect(result.summary.publicChannelCount).toBe(0)
+  })
+
+  it('returns partial_public with bounded confidence penalty for mixed channel coverage', () => {
+    const result = evaluatePublicSignalCoverage(PARTIAL_PUBLIC_COVERAGE_REQUEST)
+
+    expect(result.coverageBand).toBe('partial_public')
+    expect(result.confidencePenalty).toBeGreaterThan(0)
+    expect(result.confidencePenalty).toBeLessThanOrEqual(0.45)
+    expect(result.summary.institutionalChannelCount).toBeGreaterThan(0)
+    expect(result.summary.publicChannelCount).toBeGreaterThan(0)
+  })
+
+  it('defaults safely for sparse or invalid input without throwing', () => {
+    const sparse = evaluatePublicSignalCoverage({})
+    const invalidBands = evaluatePublicSignalCoverage({
+      topicId: 'topic:test',
+      districtId: 'district:test',
+      crawlerReachBand: 'invalid' as 'none',
+      inferenceModelBand: 'invalid' as 'opaque',
+    })
+
+    expect(sparse.coverageBand).toBe('partial_public')
+    expect(sparse.structuredReasons).toContain('sparse_input_defaults')
+    expect(sparse.confidencePenalty).toBeLessThanOrEqual(0.15)
+    expect(sparse.falseNegativeRisk).toBeLessThanOrEqual(0.2)
+
+    expect(invalidBands.coverageBand).toBe('partial_public')
+    expect(invalidBands.structuredReasons.some((reason) => reason.startsWith('crawler:'))).toBe(
+      true
+    )
+    expect(
+      invalidBands.structuredReasons.some((reason) => reason.startsWith('inference:'))
+    ).toBe(true)
+  })
+
+  it('classifies public_led when public activity dominates institutional channels', () => {
+    const result = evaluatePublicSignalCoverage({
+      topicId: 'topic:warehouse-cluster',
+      districtId: 'district:industrial-north',
+      institutionalChannels: { formalAlert: true },
+      publicChannels: {
+        communityPatternMatching: true,
+        ambientSocialSignal: true,
+        mediaTrace: true,
+        rumorChain: true,
+        grassrootsDensityHigh: true,
+      },
+      crawlerReachBand: 'low',
+      inferenceModelBand: 'low',
+    })
+
+    expect(result.coverageBand).toBe('public_led')
+    expect(result.falseNegativeRisk).toBeGreaterThan(result.confidencePenalty * 0.5)
+  })
+
+  it('returns byte-stable output across repeated evaluation', () => {
+    const first = evaluatePublicSignalCoverage(PARTIAL_PUBLIC_COVERAGE_REQUEST)
+    const second = evaluatePublicSignalCoverage(PARTIAL_PUBLIC_COVERAGE_REQUEST)
+
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first))
+  })
+
+  it('sorts structured reasons deterministically', () => {
+    const result = evaluatePublicSignalCoverage(BLIND_SPOT_COVERAGE_REQUEST)
+    const sorted = [...result.structuredReasons].sort((left, right) => left.localeCompare(right))
+
+    expect(result.structuredReasons).toEqual(sorted)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `evaluatePublicSignalCoverage` in `src/domain/publicSignalCoverage.ts` — deterministic institutional vs public channel coverage bands, confidence penalty, false-negative risk, and sorted structured reasons.
- Targeted tests and slice plan under SPE-854 information intake umbrella.

## Linear

- **Slice:** [SPE-2092](https://linear.app/spectranoir/issue/SPE-2092) — Public signal coverage evaluator (slice 1)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (stays open)

## What shipped

- `src/domain/publicSignalCoverage.ts` — channel flags, crawler/inference bands, evaluator + fixtures
- `src/test/publicSignalCoverage.test.ts` — blind spot, institutional-only, partial, public-led, sparse input, idempotency
- `planning/public-signal-coverage-slice-1.md`

## Validation

- `npm run lint`
- `npm run test:run -- src/test/publicSignalCoverage.test.ts`

## Docs updated

- `planning/public-signal-coverage-slice-1.md`
- `planning/backlog.md` (slice index)

## Parent status

SPE-854 remains open — no GameState, UI, or weekly hook in this slice.