### PR TITLE
feat(SPE-2293): information intake report GameState persistence (slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -135,7 +135,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `mass-anomalous-population-emergence-registry-slice-1.md` | **Shipped**    | SPE-2122 / PR #2441; population emergence registration, triage, governance surge projection.                                                          |
 | `rule-document-compliance-containment-registry-slice-1.md` | **Shipped**    | SPE-2123 / PR #2442; written-conduct binding, compliance decay, breach consequence validation.                                                        |
 | `information-intake-report-slice-1.md`                     | **Shipped**    | SPE-2292 / PR #2444; incoming report schema + verification progression under SPE-854.                                                               |
-| `public-signal-coverage-slice-1.md`                        | **In progress** | SPE-2092 / branch `spe-2092-public-signal-coverage-slice-1`; institutional vs public channel coverage evaluator under SPE-854.                      |
+| `public-signal-coverage-slice-1.md`                        | **Shipped**    | SPE-2092 / PR #2445; institutional vs public channel coverage evaluator under SPE-854.                                                              |
+| `information-intake-report-persistence-slice-2.md`         | **In progress** | SPE-2293; GameState persistence + sanitize/hydration for intake reports under SPE-854.                                                              |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -136,7 +136,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `rule-document-compliance-containment-registry-slice-1.md` | **Shipped**    | SPE-2123 / PR #2442; written-conduct binding, compliance decay, breach consequence validation.                                                        |
 | `information-intake-report-slice-1.md`                     | **Shipped**    | SPE-2292 / PR #2444; incoming report schema + verification progression under SPE-854.                                                               |
 | `public-signal-coverage-slice-1.md`                        | **Shipped**    | SPE-2092 / PR #2445; institutional vs public channel coverage evaluator under SPE-854.                                                              |
-| `information-intake-report-persistence-slice-2.md`         | **In progress** | SPE-2293; GameState persistence + sanitize/hydration for intake reports under SPE-854.                                                              |
+| `information-intake-report-persistence-slice-2.md`         | **Ready for PR** | SPE-2293 / PR #2447; GameState persistence + sanitize/hydration for intake reports under SPE-854.                                                    |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-report-persistence-slice-2.md
+++ b/planning/information-intake-report-persistence-slice-2.md
@@ -1,0 +1,57 @@
+# SPE-854 — Information intake report persistence slice 2
+
+One-page implementation plan. Linear: child under [SPE-854](https://linear.app/spectranoir/issue/SPE-854). Follows [SPE-2292](https://linear.app/spectranoir/issue/SPE-2292) (schema) and [SPE-2092](https://linear.app/spectranoir/issue/SPE-2092) (coverage evaluator).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2293 — Information intake report GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2293) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine       |
+| **Branch** | `spe-854-information-intake-report-persistence-slice-2`                                                    |
+| **Status** | **Ready for PR**                                                                                           |
+
+## Goal
+
+Persist `InformationIntakeReportRecord` on `GameState` with sanitize/hydration and save round-trip tests. SPE-2292 deferred persistence; SPE-2092 coverage composition is slice 3.
+
+## Prerequisite (on `main` @ `3d8c1a7b`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake report model  | `src/domain/informationIntakeReport.ts` (SPE-2292 / PR #2444)          |
+| Public signal coverage | `src/domain/publicSignalCoverage.ts` (SPE-2092 / PR #2445)            |
+| Fixtures             | `IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE`, `PUBLIC_RUMOR_CONFLICT_FIXTURE`, `FORMAL_ALERT_PARTIAL_FIXTURE` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `informationIntakeReports` on `GameState`                                                                                          | Weekly `advanceWeek` corroboration hook       |
+| `sanitizeInformationIntakeReports` + `runTransfer` hydrate wire                                                                     | UI / report copy                              |
+| `validateInformationIntakeReport` on hydrate; drop invalid, no throw                                                                | `evaluateTopicIntakeCoverage` + `publicSignalCoverage` compose (slice 3) |
+| Default `{}` in `createStartingState`                                                                                              | SPE-854 parent Done                           |
+| Sanitize unit tests + save/import round-trip (history byte-stable)                                                                  |                                               |
+
+## Acceptance
+
+- [x] Valid report round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] Corroboration/contradiction history preserved byte-stable after round-trip
+- [x] `npm run lint` + targeted tests + relevant save/hydration tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/informationIntakeReport.ts`, `src/domain/models.ts`       |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/informationIntakeReportPersistence.test.ts`                 |
+| Plan   | `planning/information-intake-report-persistence-slice-2.md`, `planning/backlog.md` |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress**.
+
+## Deferred slice 3
+
+Pure domain: `projectChannelFlagsFromIntakeReports` + `evaluateTopicIntakeCoverage` using `summarizeMixedSourceIntake` + `evaluatePublicSignalCoverage`.

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -191,6 +191,7 @@ import { isDistortionState, propagateDistortion } from '../../domain/shared/dist
 import { createDefaultPowerImpactSummary } from '../../domain/teamSimulation'
 import { getKnowledgeKey } from '../../domain/knowledge'
 import { sanitizeKnowledgeStateMap } from '../../domain/knowledge/sanitize'
+import { sanitizeInformationIntakeReports } from '../../domain/informationIntakeReport'
 import {
   buildCandidateEvaluation,
   deriveCandidateCostEstimate,
@@ -8351,6 +8352,10 @@ export function hydrateGame(
     campaignWeek: week,
     knownTeamIds: new Set(Object.keys(teams)),
   })
+  const informationIntakeReports = sanitizeInformationIntakeReports(
+    game.informationIntakeReports,
+    fallback.informationIntakeReports ?? {}
+  )
   const factions = hasPersistedFactions
     ? sanitizeFactionsMap(game.factions, fallback.factions)
     : fallback.factions
@@ -8426,6 +8431,7 @@ export function hydrateGame(
       agents,
       staff,
       knowledge,
+      informationIntakeReports,
       candidates,
       recruitmentPool,
       teams,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -39,6 +39,7 @@ const startingStateTemplate: GameState = {
   partyCards: createStartingPartyCardState(),
 
   knowledge: startingKnowledge,
+  informationIntakeReports: {},
   factions: createInitialFactionState(),
 
   agency: {

--- a/src/domain/informationIntakeReport.ts
+++ b/src/domain/informationIntakeReport.ts
@@ -932,11 +932,13 @@ function parseCorroborationEvent(value: unknown): CorroborationEvent | null {
     return null
   }
 
-  if (!isIntakeSourceClass(value.sourceClass)) {
+  const sourceClass = typeof value.sourceClass === 'string' ? value.sourceClass : ''
+  if (!isIntakeSourceClass(sourceClass)) {
     return null
   }
 
-  if (!Number.isFinite(value.weight) || value.weight < 0 || value.weight > 1) {
+  const weight = typeof value.weight === 'number' ? value.weight : NaN
+  if (!Number.isFinite(weight) || weight < 0 || weight > 1) {
     return null
   }
 
@@ -947,8 +949,8 @@ function parseCorroborationEvent(value: unknown): CorroborationEvent | null {
     eventId,
     week: value.week,
     sourceRef,
-    sourceClass: value.sourceClass,
-    weight: value.weight,
+    sourceClass,
+    weight,
     ...(note ? { note } : {}),
   }
 }
@@ -964,7 +966,7 @@ function parseContradictionEvent(value: unknown): ContradictionEvent | null {
     return null
   }
 
-  if (value.severity !== 'minor' && value.severity !== 'major') {
+  if (typeof value.severity !== 'string' || (value.severity !== 'minor' && value.severity !== 'major')) {
     return null
   }
 
@@ -1030,19 +1032,27 @@ function sanitizeInformationIntakeReportEntry(value: unknown): InformationIntake
   const id = normalizeToken(value.id)
   const label = normalizeToken(value.label)
   const topicRef = normalizeToken(value.topicRef)
+  const initialSourceClass =
+    typeof value.initialSourceClass === 'string' ? value.initialSourceClass : ''
+  const verificationStatus =
+    typeof value.verificationStatus === 'string' ? value.verificationStatus : ''
+  const credibility = typeof value.credibility === 'string' ? value.credibility : ''
+  const plausibility = typeof value.plausibility === 'string' ? value.plausibility : ''
+  const rumorRisk = typeof value.rumorRisk === 'string' ? value.rumorRisk : ''
+  const confidenceScore = typeof value.confidenceScore === 'number' ? value.confidenceScore : NaN
 
   if (
     !id ||
     !label ||
     !topicRef ||
-    !isIntakeSourceClass(value.initialSourceClass) ||
-    !isInformationVerificationStatus(value.verificationStatus) ||
-    !isCredibilityBand(value.credibility) ||
-    !isPlausibilityBand(value.plausibility) ||
-    !isRumorRiskBand(value.rumorRisk) ||
-    !Number.isFinite(value.confidenceScore) ||
-    value.confidenceScore < 0 ||
-    value.confidenceScore > 1
+    !isIntakeSourceClass(initialSourceClass) ||
+    !isInformationVerificationStatus(verificationStatus) ||
+    !isCredibilityBand(credibility) ||
+    !isPlausibilityBand(plausibility) ||
+    !isRumorRiskBand(rumorRisk) ||
+    !Number.isFinite(confidenceScore) ||
+    confidenceScore < 0 ||
+    confidenceScore > 1
   ) {
     return null
   }
@@ -1059,12 +1069,12 @@ function sanitizeInformationIntakeReportEntry(value: unknown): InformationIntake
     id,
     label,
     topicRef,
-    initialSourceClass: value.initialSourceClass,
-    credibility: value.credibility,
-    plausibility: value.plausibility,
-    rumorRisk: value.rumorRisk,
-    verificationStatus: value.verificationStatus,
-    confidenceScore: value.confidenceScore,
+    initialSourceClass,
+    credibility,
+    plausibility,
+    rumorRisk,
+    verificationStatus,
+    confidenceScore,
     corroborationHistory,
     contradictionHistory,
     retainedDespiteContradiction,

--- a/src/domain/informationIntakeReport.ts
+++ b/src/domain/informationIntakeReport.ts
@@ -910,3 +910,195 @@ export function summarizeMixedSourceIntake(
     structuredReasons,
   }
 }
+
+// ---------------------------------------------------------------------------
+// Persistence sanitize (SPE-854 slice 2)
+// ---------------------------------------------------------------------------
+
+export type InformationIntakeReportsMap = Record<string, InformationIntakeReportRecord>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseCorroborationEvent(value: unknown): CorroborationEvent | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const eventId = normalizeToken(value.eventId)
+  const sourceRef = normalizeToken(value.sourceRef)
+  if (!eventId || !sourceRef || !isFiniteWeek(value.week)) {
+    return null
+  }
+
+  if (!isIntakeSourceClass(value.sourceClass)) {
+    return null
+  }
+
+  if (!Number.isFinite(value.weight) || value.weight < 0 || value.weight > 1) {
+    return null
+  }
+
+  const note =
+    typeof value.note === 'string' && value.note.trim().length > 0 ? value.note.trim() : undefined
+
+  return {
+    eventId,
+    week: value.week,
+    sourceRef,
+    sourceClass: value.sourceClass,
+    weight: value.weight,
+    ...(note ? { note } : {}),
+  }
+}
+
+function parseContradictionEvent(value: unknown): ContradictionEvent | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const eventId = normalizeToken(value.eventId)
+  const sourceRef = normalizeToken(value.sourceRef)
+  if (!eventId || !sourceRef || !isFiniteWeek(value.week)) {
+    return null
+  }
+
+  if (value.severity !== 'minor' && value.severity !== 'major') {
+    return null
+  }
+
+  const note =
+    typeof value.note === 'string' && value.note.trim().length > 0 ? value.note.trim() : undefined
+
+  return {
+    eventId,
+    week: value.week,
+    sourceRef,
+    severity: value.severity,
+    ...(note ? { note } : {}),
+  }
+}
+
+function parseCorroborationHistory(value: unknown): readonly CorroborationEvent[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const events: CorroborationEvent[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    const parsed = parseCorroborationEvent(entry)
+    if (!parsed || seen.has(parsed.eventId)) {
+      continue
+    }
+
+    seen.add(parsed.eventId)
+    events.push(parsed)
+  }
+
+  return events
+}
+
+function parseContradictionHistory(value: unknown): readonly ContradictionEvent[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const events: ContradictionEvent[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    const parsed = parseContradictionEvent(entry)
+    if (!parsed || seen.has(parsed.eventId)) {
+      continue
+    }
+
+    seen.add(parsed.eventId)
+    events.push(parsed)
+  }
+
+  return events
+}
+
+function sanitizeInformationIntakeReportEntry(value: unknown): InformationIntakeReportRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const topicRef = normalizeToken(value.topicRef)
+
+  if (
+    !id ||
+    !label ||
+    !topicRef ||
+    !isIntakeSourceClass(value.initialSourceClass) ||
+    !isInformationVerificationStatus(value.verificationStatus) ||
+    !isCredibilityBand(value.credibility) ||
+    !isPlausibilityBand(value.plausibility) ||
+    !isRumorRiskBand(value.rumorRisk) ||
+    !Number.isFinite(value.confidenceScore) ||
+    value.confidenceScore < 0 ||
+    value.confidenceScore > 1
+  ) {
+    return null
+  }
+
+  const corroborationHistory = parseCorroborationHistory(value.corroborationHistory)
+  const contradictionHistory = parseContradictionHistory(value.contradictionHistory)
+  const retainedDespiteContradiction = value.retainedDespiteContradiction === true
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+
+  const record: InformationIntakeReportRecord = {
+    id,
+    label,
+    topicRef,
+    initialSourceClass: value.initialSourceClass,
+    credibility: value.credibility,
+    plausibility: value.plausibility,
+    rumorRisk: value.rumorRisk,
+    verificationStatus: value.verificationStatus,
+    confidenceScore: value.confidenceScore,
+    corroborationHistory,
+    contradictionHistory,
+    retainedDespiteContradiction,
+    ...(summary ? { summary } : {}),
+  }
+
+  if (!validateInformationIntakeReport(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical report map keyed by report id; drops invalid and duplicate-id entries. */
+export function sanitizeInformationIntakeReports(
+  value: unknown,
+  fallback: InformationIntakeReportsMap = {}
+): InformationIntakeReportsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: InformationIntakeReportsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeInformationIntakeReportEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -243,6 +243,7 @@ import type {
 } from './agent/models'
 import type { BeliefTrackState } from './beliefTracks'
 import type { KnowledgeState, KnowledgeStateMap } from './knowledge'
+import type { InformationIntakeReportRecord } from './informationIntakeReport'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
 import type { SquadKitAssignment } from './squadKitAssignment'
@@ -2529,6 +2530,12 @@ export interface GameState {
 
   /** Canonical persistent knowledge-state map (keyed by entity/subject) */
   knowledge: KnowledgeStateMap
+
+  /**
+   * SPE-854 slice 2: persisted incoming incident intake reports (keyed by report id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  informationIntakeReports?: Record<string, InformationIntakeReportRecord>
 
   /** Optional active compromised-authority runtime packet (SPE-746). */
   compromisedAuthority?: CompromisedAuthorityState

--- a/src/test/informationIntakeReportPersistence.test.ts
+++ b/src/test/informationIntakeReportPersistence.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  sanitizeInformationIntakeReports,
+} from '../domain/informationIntakeReport'
+
+describe('informationIntakeReport persistence (SPE-854 slice 2)', () => {
+  it('defaults starting state to an empty intake report map', () => {
+    expect(createStartingState().informationIntakeReports).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeInformationIntakeReports(
+      {
+        valid: FORMAL_ALERT_PARTIAL_FIXTURE,
+        'wrong-key': {
+          ...PUBLIC_RUMOR_CONFLICT_FIXTURE,
+          id: 'intake:public-rumor-early',
+        },
+        duplicate: {
+          ...PUBLIC_RUMOR_CONFLICT_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          topicRef: 'topic:x',
+          initialSourceClass: 'formal_alert',
+          credibility: 'medium',
+          plausibility: 'plausible',
+          rumorRisk: 'none',
+          verificationStatus: 'unverified',
+          confidenceScore: 0.5,
+          corroborationHistory: [],
+          contradictionHistory: [],
+          retainedDespiteContradiction: true,
+        },
+        franchise: {
+          ...IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+          id: 'intake:scp-bad',
+          label: 'SCP breach rumor',
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['intake:formal-sensor-trace']).toEqual(FORMAL_ALERT_PARTIAL_FIXTURE)
+    expect(sanitized['intake:public-rumor-early']).toEqual(PUBLIC_RUMOR_CONFLICT_FIXTURE)
+    expect(sanitized['intake:scp-bad']).toBeUndefined()
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(Object.keys(sanitized)).toHaveLength(2)
+  })
+
+  it('round-trips fixture reports with corroboration history byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = {
+      [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+      [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.informationIntakeReports).toEqual(state.informationIntakeReports)
+    expect(loaded.informationIntakeReports?.[FORMAL_ALERT_PARTIAL_FIXTURE.id]?.corroborationHistory).toEqual(
+      FORMAL_ALERT_PARTIAL_FIXTURE.corroborationHistory
+    )
+  })
+
+  it('hydrates persisted intake reports through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        templates: undefined,
+        informationIntakeReports: {
+          [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+          corrupt: {
+            id: 'intake:bad',
+            verificationStatus: 'explosive',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.informationIntakeReports).toEqual({
+      [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Linear

- **Slice:** [SPE-2293 — Information intake report GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2293)
- **Parent:** [SPE-854 — Information intake and verification engine](https://linear.app/spectranoir/issue/SPE-854) (stays **In Progress**)
- **Siblings (Done):** [SPE-2292](https://linear.app/spectranoir/issue/SPE-2292) (PR #2444), [SPE-2092](https://linear.app/spectranoir/issue/SPE-2092) (PR #2445)

## Summary

- Add `informationIntakeReports` on `GameState` with default `{}` in `createStartingState`.
- Implement `sanitizeInformationIntakeReports` in `src/domain/informationIntakeReport.ts`; wire hydration in `runTransfer.ts` (validate on hydrate, drop invalid/duplicate ids, no throw).
- Tests: sanitize unit coverage + save/load and `hydrateGame` round-trip with `FORMAL_ALERT_PARTIAL_FIXTURE` (corroboration history byte-stable).

## Validation

- `npm run test:run -- src/test/informationIntakeReportPersistence.test.ts` — pass (4 tests)
- `npm run lint` — pass

## Docs

- `planning/information-intake-report-persistence-slice-2.md` (new)
- `planning/backlog.md` slice index row (in progress until merge)

## Parent status

SPE-854 remains open; slice 3 (topic intake coverage compose with `publicSignalCoverage`) is deferred.

Made with [Cursor](https://cursor.com)