### PR TITLE
feat(SPE-2294): topic intake coverage composition (slice 3)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -137,6 +137,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-report-slice-1.md`                     | **Shipped**    | SPE-2292 / PR #2444; incoming report schema + verification progression under SPE-854.                                                               |
 | `public-signal-coverage-slice-1.md`                        | **Shipped**    | SPE-2092 / PR #2445; institutional vs public channel coverage evaluator under SPE-854.                                                              |
 | `information-intake-report-persistence-slice-2.md`         | **Shipped**    | SPE-2293 / PR #2447; GameState persistence + sanitize/hydration for intake reports under SPE-854.                                                    |
+| `information-intake-coverage-compose-slice-3.md`             | **In Progress** | SPE-2294; topic intake coverage composition (`projectChannelFlagsFromIntakeReports` + `evaluateTopicIntakeCoverage`) under SPE-854.                  |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-coverage-compose-slice-3.md
+++ b/planning/information-intake-coverage-compose-slice-3.md
@@ -1,0 +1,54 @@
+# SPE-854 — Topic intake coverage composition slice 3
+
+One-page implementation plan. Linear: child under [SPE-854](https://linear.app/spectranoir/issue/SPE-854). Follows [SPE-2292](https://linear.app/spectranoir/issue/SPE-2292), [SPE-2293](https://linear.app/spectranoir/issue/SPE-2293), and [SPE-2092](https://linear.app/spectranoir/issue/SPE-2092).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2294 — Topic intake coverage composition (slice 3)](https://linear.app/spectranoir/issue/SPE-2294)       |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine       |
+| **Branch** | `spe-854-topic-intake-coverage-compose-slice-3`                                                            |
+| **Status** | **Ready for PR**                                                                                           |
+
+## Goal
+
+Compose persisted intake reports into public-signal coverage evaluation for a topic — project channel flags from mixed `initialSourceClass` values, summarize verification bands, and delegate to `evaluatePublicSignalCoverage`.
+
+## Prerequisite (on `main` @ `ea649362`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake report model  | `src/domain/informationIntakeReport.ts` (SPE-2292)                     |
+| Intake persistence   | `informationIntakeReports` on GameState (SPE-2293)                     |
+| Public signal coverage | `src/domain/publicSignalCoverage.ts` (SPE-2092)                        |
+| Fixtures             | `IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE`, `PUBLIC_RUMOR_CONFLICT_FIXTURE`, `FORMAL_ALERT_PARTIAL_FIXTURE` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `projectChannelFlagsFromIntakeReports(reports)` in `publicSignalCoverage.ts` | GameState persistence changes                 |
+| `evaluateTopicIntakeCoverage(input)` — filter, summarize, project, evaluate | Weekly `advanceWeek` hook                     |
+| Derive crawler/inference bands from intake summary when not overridden | UI / report copy                              |
+| Focused tests in `src/test/publicSignalCoverage.test.ts`             | SPE-854 parent Done                           |
+| Slice doc (this file)                                              | `runTransfer` changes                         |
+
+## Acceptance
+
+- [x] Mixed-source fixtures project institutional + public channel flags deterministically
+- [x] Canal-bridge fixture trio → conflicting verification + partial_public or blind_spot band as appropriate
+- [x] Empty topic report map → sparse safe defaults without throw
+- [x] Structured reasons merge intake summary tokens with coverage reasons (sorted)
+- [x] Repeated evaluation is byte-stable
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publicSignalCoverage.ts`                                  |
+| Tests  | `src/test/publicSignalCoverage.test.ts`                               |
+| Plan   | `planning/information-intake-coverage-compose-slice-3.md`, `planning/backlog.md` |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress**.

--- a/src/domain/publicSignalCoverage.ts
+++ b/src/domain/publicSignalCoverage.ts
@@ -1,10 +1,19 @@
 /**
  * SPE-2092 slice 1: public signal coverage evaluator.
+ * SPE-854 slice 3: topic intake coverage composition.
  *
  * Pure deterministic helper scoring institutional versus ambient public-signal
  * channel coverage for a topic/district — distinct from intake report verification
  * (SPE-2292) and intel distortion (SPE-22).
  */
+
+import type {
+  InformationIntakeReportRecord,
+  InformationIntakeReportsMap,
+  IntakeSourceClass,
+  MixedSourceIntakeSummary,
+} from './informationIntakeReport'
+import { summarizeMixedSourceIntake } from './informationIntakeReport'
 
 // ---------------------------------------------------------------------------
 // Bands and channel flags
@@ -332,7 +341,227 @@ function buildStructuredReasons(input: {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Intake → channel projection (SPE-854 slice 3)
+// ---------------------------------------------------------------------------
+
+export interface ProjectedChannelFlags {
+  readonly institutionalChannels: InstitutionalChannelFlags
+  readonly publicChannels: PublicChannelFlags
+}
+
+export interface TopicIntakeCoverageRequest {
+  readonly topicId?: string
+  readonly districtId?: string
+  readonly reports?: readonly InformationIntakeReportRecord[] | InformationIntakeReportsMap
+  readonly crawlerReachBand?: CrawlerReachBand
+  readonly inferenceModelBand?: InferenceModelBand
+}
+
+export interface TopicIntakeCoverageResult extends PublicSignalCoverageResult {
+  readonly intakeSummary: MixedSourceIntakeSummary
+  readonly projectedChannelFlags: ProjectedChannelFlags
+}
+
+const INSTITUTIONAL_SOURCE_CLASSES: Readonly<Partial<Record<IntakeSourceClass, keyof InstitutionalChannelFlags>>> =
+  {
+    formal_alert: 'formalAlert',
+    partner_channel: 'partnerChannel',
+    technical_trace: 'technicalTrace',
+    archive_signature: 'agencyCanonicalFeed',
+  }
+
+const PUBLIC_SOURCE_CLASSES: Readonly<Partial<Record<IntakeSourceClass, keyof PublicChannelFlags>>> = {
+  public_signal: 'ambientSocialSignal',
+  media_trace: 'mediaTrace',
+  rumor_chain: 'rumorChain',
+  field_witness: 'communityPatternMatching',
+  off_channel: 'ambientSocialSignal',
+}
+
+const PUBLIC_DENSITY_SOURCE_CLASSES = new Set<IntakeSourceClass>([
+  'public_signal',
+  'media_trace',
+  'rumor_chain',
+  'field_witness',
+  'off_channel',
+])
+
+function collectIntakeSourceClasses(reports: readonly InformationIntakeReportRecord[]): IntakeSourceClass[] {
+  const classes: IntakeSourceClass[] = []
+
+  for (const report of reports) {
+    classes.push(report.initialSourceClass)
+
+    for (const event of report.corroborationHistory) {
+      classes.push(event.sourceClass)
+    }
+  }
+
+  return classes
+}
+
+function applySourceClassToFlags(
+  sourceClass: IntakeSourceClass,
+  institutional: InstitutionalChannelFlags,
+  publicChannels: PublicChannelFlags
+) {
+  const institutionalKey = INSTITUTIONAL_SOURCE_CLASSES[sourceClass]
+  if (institutionalKey) {
+    institutional[institutionalKey] = true
+  }
+
+  const publicKey = PUBLIC_SOURCE_CLASSES[sourceClass]
+  if (publicKey) {
+    publicChannels[publicKey] = true
+  }
+
+  if (sourceClass === 'public_signal') {
+    publicChannels.communityPatternMatching = true
+  }
+}
+
+export function projectChannelFlagsFromIntakeReports(
+  reports: readonly InformationIntakeReportRecord[]
+): ProjectedChannelFlags {
+  const institutionalChannels: InstitutionalChannelFlags = {}
+  const publicChannels: PublicChannelFlags = {}
+
+  for (const sourceClass of collectIntakeSourceClasses(reports)) {
+    applySourceClassToFlags(sourceClass, institutionalChannels, publicChannels)
+  }
+
+  const publicDensityCount = reports.filter((report) =>
+    PUBLIC_DENSITY_SOURCE_CLASSES.has(report.initialSourceClass)
+  ).length
+  const rumorReportCount = reports.filter((report) => report.rumorRisk !== 'none').length
+
+  if (publicDensityCount >= 2 || rumorReportCount >= 2) {
+    publicChannels.grassrootsDensityHigh = true
+  }
+
+  return {
+    institutionalChannels,
+    publicChannels,
+  }
+}
+
+function resolveTopicReports(
+  reports: TopicIntakeCoverageRequest['reports'],
+  topicId: string
+): InformationIntakeReportRecord[] {
+  if (!reports) {
+    return []
+  }
+
+  const list = Array.isArray(reports) ? [...reports] : Object.values(reports)
+
+  if (!topicId) {
+    return list
+  }
+
+  return list.filter((report) => normalizeToken(report.topicRef) === topicId)
+}
+
+function deriveCrawlerReachBandFromIntake(input: {
+  projected: ProjectedChannelFlags
+  intakeSummary: MixedSourceIntakeSummary
+}): CrawlerReachBand {
+  const institutionalCount = countInstitutionalChannels(input.projected.institutionalChannels)
+  const publicCount = countPublicChannels(input.projected.publicChannels)
+  const publicWeight = computePublicActivityWeight(publicCount, input.projected.publicChannels)
+
+  if (institutionalCount === 0 && publicWeight > 0) {
+    return 'none'
+  }
+
+  if (input.intakeSummary.hasIncompleteIntake && publicCount > 0) {
+    return 'low'
+  }
+
+  if (institutionalCount > 0 && publicCount === 0 && !input.intakeSummary.hasIncompleteIntake) {
+    return 'high'
+  }
+
+  return 'medium'
+}
+
+function deriveInferenceModelBandFromIntake(intakeSummary: MixedSourceIntakeSummary): InferenceModelBand {
+  if (intakeSummary.hasConflictingVerification) {
+    return 'low'
+  }
+
+  if (intakeSummary.dominantVerificationStatus === 'escalated_confidence') {
+    return 'high'
+  }
+
+  if (
+    intakeSummary.dominantVerificationStatus === 'verified' &&
+    !intakeSummary.hasIncompleteIntake
+  ) {
+    return 'moderate'
+  }
+
+  if (intakeSummary.hasIncompleteIntake) {
+    return 'opaque'
+  }
+
+  return 'moderate'
+}
+
+function mergeStructuredReasons(
+  coverageReasons: readonly string[],
+  intakeReasons: readonly string[]
+): readonly string[] {
+  const merged = [
+    ...coverageReasons,
+    ...intakeReasons.map((reason) => `intake:${reason}`),
+  ]
+
+  return [...new Set(merged)].sort((left, right) => left.localeCompare(right))
+}
+
+export function evaluateTopicIntakeCoverage(
+  input: TopicIntakeCoverageRequest = {}
+): TopicIntakeCoverageResult {
+  const requestedTopicId = normalizeToken(input.topicId)
+  const topicReports = resolveTopicReports(input.reports, requestedTopicId)
+  const topicId =
+    requestedTopicId ||
+    normalizeToken(topicReports[0]?.topicRef) ||
+    '(unknown-topic)'
+
+  const intakeSummary = summarizeMixedSourceIntake(topicReports)
+  const projectedChannelFlags = projectChannelFlagsFromIntakeReports(topicReports)
+
+  const crawlerReachBand =
+    input.crawlerReachBand ??
+    deriveCrawlerReachBandFromIntake({ projected: projectedChannelFlags, intakeSummary })
+  const inferenceModelBand =
+    input.inferenceModelBand ?? deriveInferenceModelBandFromIntake(intakeSummary)
+
+  const coverage = evaluatePublicSignalCoverage({
+    topicId,
+    districtId: input.districtId,
+    institutionalChannels: projectedChannelFlags.institutionalChannels,
+    publicChannels: projectedChannelFlags.publicChannels,
+    crawlerReachBand,
+    inferenceModelBand,
+  })
+
+  return {
+    ...coverage,
+    topicId,
+    structuredReasons: mergeStructuredReasons(coverage.structuredReasons, intakeSummary.structuredReasons),
+    intakeSummary: {
+      ...intakeSummary,
+      topicRef: topicId,
+    },
+    projectedChannelFlags,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public signal coverage evaluator
 // ---------------------------------------------------------------------------
 
 export function evaluatePublicSignalCoverage(

--- a/src/domain/publicSignalCoverage.ts
+++ b/src/domain/publicSignalCoverage.ts
@@ -402,8 +402,8 @@ function collectIntakeSourceClasses(reports: readonly InformationIntakeReportRec
 
 function applySourceClassToFlags(
   sourceClass: IntakeSourceClass,
-  institutional: InstitutionalChannelFlags,
-  publicChannels: PublicChannelFlags
+  institutional: Record<string, boolean>,
+  publicChannels: Record<string, boolean>
 ) {
   const institutionalKey = INSTITUTIONAL_SOURCE_CLASSES[sourceClass]
   if (institutionalKey) {
@@ -423,8 +423,8 @@ function applySourceClassToFlags(
 export function projectChannelFlagsFromIntakeReports(
   reports: readonly InformationIntakeReportRecord[]
 ): ProjectedChannelFlags {
-  const institutionalChannels: InstitutionalChannelFlags = {}
-  const publicChannels: PublicChannelFlags = {}
+  const institutionalChannels: Record<string, boolean> = {}
+  const publicChannels: Record<string, boolean> = {}
 
   for (const sourceClass of collectIntakeSourceClasses(reports)) {
     applySourceClassToFlags(sourceClass, institutionalChannels, publicChannels)
@@ -440,26 +440,47 @@ export function projectChannelFlagsFromIntakeReports(
   }
 
   return {
-    institutionalChannels,
-    publicChannels,
+    institutionalChannels: institutionalChannels as InstitutionalChannelFlags,
+    publicChannels: publicChannels as PublicChannelFlags,
   }
+}
+
+function listIntakeReports(
+  reports: TopicIntakeCoverageRequest['reports']
+): InformationIntakeReportRecord[] {
+  if (!reports) {
+    return []
+  }
+
+  return Array.isArray(reports) ? [...reports] : Object.values(reports)
 }
 
 function resolveTopicReports(
   reports: TopicIntakeCoverageRequest['reports'],
   topicId: string
 ): InformationIntakeReportRecord[] {
-  if (!reports) {
+  const list = listIntakeReports(reports)
+
+  if (!topicId) {
     return []
   }
 
-  const list = Array.isArray(reports) ? [...reports] : Object.values(reports)
-
-  if (!topicId) {
-    return list
-  }
-
   return list.filter((report) => normalizeToken(report.topicRef) === topicId)
+}
+
+function normalizeIntakeSummaryTopicRef(
+  summary: MixedSourceIntakeSummary,
+  topicId: string
+): MixedSourceIntakeSummary {
+  const structuredReasons = summary.structuredReasons
+    .map((reason) => (reason.startsWith('topic:') ? `topic:${topicId}` : reason))
+    .sort((left, right) => left.localeCompare(right))
+
+  return {
+    ...summary,
+    topicRef: topicId,
+    structuredReasons,
+  }
 }
 
 function deriveCrawlerReachBandFromIntake(input: {
@@ -524,13 +545,17 @@ export function evaluateTopicIntakeCoverage(
   input: TopicIntakeCoverageRequest = {}
 ): TopicIntakeCoverageResult {
   const requestedTopicId = normalizeToken(input.topicId)
-  const topicReports = resolveTopicReports(input.reports, requestedTopicId)
+  const allReports = listIntakeReports(input.reports)
   const topicId =
     requestedTopicId ||
-    normalizeToken(topicReports[0]?.topicRef) ||
+    normalizeToken(allReports[0]?.topicRef) ||
     '(unknown-topic)'
 
-  const intakeSummary = summarizeMixedSourceIntake(topicReports)
+  const topicReports = resolveTopicReports(input.reports, topicId)
+  const intakeSummary = normalizeIntakeSummaryTopicRef(
+    summarizeMixedSourceIntake(topicReports),
+    topicId
+  )
   const projectedChannelFlags = projectChannelFlagsFromIntakeReports(topicReports)
 
   const crawlerReachBand =
@@ -552,10 +577,7 @@ export function evaluateTopicIntakeCoverage(
     ...coverage,
     topicId,
     structuredReasons: mergeStructuredReasons(coverage.structuredReasons, intakeSummary.structuredReasons),
-    intakeSummary: {
-      ...intakeSummary,
-      topicRef: topicId,
-    },
+    intakeSummary,
     projectedChannelFlags,
   }
 }

--- a/src/test/publicSignalCoverage.test.ts
+++ b/src/test/publicSignalCoverage.test.ts
@@ -7,10 +7,17 @@ import {
   PARTIAL_PUBLIC_COVERAGE_REQUEST,
   PUBLIC_SIGNAL_COVERAGE_BANDS,
   evaluatePublicSignalCoverage,
+  evaluateTopicIntakeCoverage,
   isCrawlerReachBand,
   isInferenceModelBand,
   isPublicSignalCoverageBand,
+  projectChannelFlagsFromIntakeReports,
 } from '../domain/publicSignalCoverage'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
 
 describe('publicSignalCoverage (SPE-2092 slice 1)', () => {
   it('exposes canonical coverage, crawler, and inference unions', () => {
@@ -115,5 +122,116 @@ describe('publicSignalCoverage (SPE-2092 slice 1)', () => {
     const sorted = [...result.structuredReasons].sort((left, right) => left.localeCompare(right))
 
     expect(result.structuredReasons).toEqual(sorted)
+  })
+})
+
+describe('topicIntakeCoverage (SPE-854 slice 3)', () => {
+  const canalBridgeFixtures = [
+    IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+    PUBLIC_RUMOR_CONFLICT_FIXTURE,
+    FORMAL_ALERT_PARTIAL_FIXTURE,
+  ]
+
+  it('projects institutional and public channel flags from mixed intake source classes', () => {
+    const projected = projectChannelFlagsFromIntakeReports(canalBridgeFixtures)
+
+    expect(projected.institutionalChannels).toMatchObject({
+      formalAlert: true,
+      technicalTrace: true,
+      agencyCanonicalFeed: true,
+    })
+    expect(projected.publicChannels).toMatchObject({
+      rumorChain: true,
+      grassrootsDensityHigh: true,
+    })
+  })
+
+  it('composes canal-bridge fixtures into partial_public coverage with verification conflict', () => {
+    const result = evaluateTopicIntakeCoverage({
+      topicId: 'topic:canal-bridge-incident',
+      districtId: 'district:riverside-east',
+      reports: canalBridgeFixtures,
+    })
+
+    expect(result.coverageBand).toBe('partial_public')
+    expect(result.intakeSummary.reportCount).toBe(3)
+    expect(result.intakeSummary.hasConflictingVerification).toBe(true)
+    expect(result.intakeSummary.hasIncompleteIntake).toBe(true)
+    expect(result.structuredReasons).toContain('intake:verification_conflict')
+    expect(result.structuredReasons).toContain('intake:rumor_separated')
+    expect(result.summary.institutionalChannelCount).toBeGreaterThan(0)
+    expect(result.summary.publicChannelCount).toBeGreaterThan(0)
+  })
+
+  it('returns blind_spot when only public-source reports exist for a topic', () => {
+    const result = evaluateTopicIntakeCoverage({
+      topicId: 'topic:canal-bridge-incident',
+      districtId: 'district:riverside-east',
+      reports: [PUBLIC_RUMOR_CONFLICT_FIXTURE],
+    })
+
+    expect(result.coverageBand).toBe('blind_spot')
+    expect(result.intakeSummary.reportCount).toBe(1)
+    expect(result.projectedChannelFlags.institutionalChannels).toEqual({})
+    expect(result.structuredReasons).toContain('institutional_channel_gap')
+  })
+
+  it('defaults safely for empty topic report map without throwing', () => {
+    const result = evaluateTopicIntakeCoverage({
+      topicId: 'topic:empty',
+      districtId: 'district:test',
+      reports: {},
+    })
+
+    expect(result.coverageBand).toBe('partial_public')
+    expect(result.intakeSummary.reportCount).toBe(0)
+    expect(result.structuredReasons).toContain('sparse_input_defaults')
+    expect(result.confidencePenalty).toBeLessThanOrEqual(0.15)
+  })
+
+  it('filters report map entries by topic id before composing coverage', () => {
+    const result = evaluateTopicIntakeCoverage({
+      topicId: 'topic:canal-bridge-incident',
+      reports: {
+        [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+        'intake:other-topic': {
+          ...PUBLIC_RUMOR_CONFLICT_FIXTURE,
+          id: 'intake:other-topic',
+          topicRef: 'topic:warehouse-cluster',
+        },
+      },
+    })
+
+    expect(result.intakeSummary.reportCount).toBe(1)
+    expect(result.coverageBand).toBe('institutional_only')
+  })
+
+  it('honors explicit crawler and inference band overrides', () => {
+    const derived = evaluateTopicIntakeCoverage({
+      topicId: 'topic:canal-bridge-incident',
+      reports: canalBridgeFixtures,
+    })
+    const overridden = evaluateTopicIntakeCoverage({
+      topicId: 'topic:canal-bridge-incident',
+      reports: canalBridgeFixtures,
+      crawlerReachBand: 'high',
+      inferenceModelBand: 'high',
+    })
+
+    expect(overridden.structuredReasons).toContain('crawler:high')
+    expect(overridden.structuredReasons).toContain('inference:high')
+    expect(overridden.falseNegativeRisk).not.toBe(derived.falseNegativeRisk)
+  })
+
+  it('returns byte-stable output across repeated evaluation', () => {
+    const input = {
+      topicId: 'topic:canal-bridge-incident',
+      districtId: 'district:riverside-east',
+      reports: canalBridgeFixtures,
+    }
+    const first = evaluateTopicIntakeCoverage(input)
+    const second = evaluateTopicIntakeCoverage(input)
+
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first))
   })
 })

--- a/src/test/publicSignalCoverage.test.ts
+++ b/src/test/publicSignalCoverage.test.ts
@@ -185,8 +185,27 @@ describe('topicIntakeCoverage (SPE-854 slice 3)', () => {
 
     expect(result.coverageBand).toBe('partial_public')
     expect(result.intakeSummary.reportCount).toBe(0)
+    expect(result.intakeSummary.topicRef).toBe('topic:empty')
+    expect(result.structuredReasons).toContain('intake:topic:topic:empty')
     expect(result.structuredReasons).toContain('sparse_input_defaults')
     expect(result.confidencePenalty).toBeLessThanOrEqual(0.15)
+  })
+
+  it('scopes to the first report topic when topic id is omitted from a multi-topic map', () => {
+    const result = evaluateTopicIntakeCoverage({
+      reports: {
+        [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+        'intake:other-topic': {
+          ...PUBLIC_RUMOR_CONFLICT_FIXTURE,
+          id: 'intake:other-topic',
+          topicRef: 'topic:warehouse-cluster',
+        },
+      },
+    })
+
+    expect(result.topicId).toBe('topic:canal-bridge-incident')
+    expect(result.intakeSummary.reportCount).toBe(1)
+    expect(result.structuredReasons).toContain('intake:topic:topic:canal-bridge-incident')
   })
 
   it('filters report map entries by topic id before composing coverage', () => {


### PR DESCRIPTION
## Summary

- Add projectChannelFlagsFromIntakeReports to map mixed IntakeSourceClass values (including corroboration history) onto institutional/public channel flags.
- Add evaluateTopicIntakeCoverage to filter topic reports, summarize mixed-source intake, derive crawler/inference bands, and compose evaluatePublicSignalCoverage.
- Add focused unit tests composing canal-bridge intake fixtures with coverage bands.

## Linear mapping

- **Slice issue:** [SPE-2294](https://linear.app/spectranoir/issue/SPE-2294) — Topic intake coverage composition (slice 3)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (remains **In Progress**)
- **Prerequisites shipped:** SPE-2292 (schema), SPE-2293 (persistence), SPE-2092 (coverage evaluator)

## What shipped

Pure domain composition in src/domain/publicSignalCoverage.ts; no GameState persistence, weekly sim hooks, or UI changes.

## Validation

- 
pm run test:run -- src/test/publicSignalCoverage.test.ts
- 
pm run lint

## Docs updated

- planning/information-intake-coverage-compose-slice-3.md
- planning/backlog.md (slice row)

## Parent status

SPE-854 parent remains open — slice 3 is one integration step, not full parent acceptance.

Made with [Cursor](https://cursor.com)