### PR TITLE
feat(SPE-2295): weekly intake corroboration advanceWeek hook (slice 4)

### DIFF
--- a/.cursor/rules/implementation-lite.mdc
+++ b/.cursor/rules/implementation-lite.mdc
@@ -34,6 +34,19 @@ Do not:
 
 If the issue boundary is unclear, stop and report the ambiguity instead of guessing.
 
+## Deferred work recording (mandatory)
+
+When scope is intentionally **out of slice** or **not done this session**, record it durably in the **same session** — not only in chat or closeout prose.
+
+Minimum (pick all that apply):
+
+1. **Slice doc** — `## Deferred` table: item, suggested owner issue, why deferred.
+2. **Linear** — comment on the **parent** or a **new/existing child** in Backlog with mechanic + boundary (not a one-liner).
+3. **Parent stays open** — do not mark the umbrella Done while deferred items satisfy parent acceptance.
+4. **Closeout** — `Remaining risks or deferred work` must match what was written to (1) and (2).
+
+Chat and session memory do **not** substitute for (1)–(2). Full checklist: `docs/agent-session-closeout.md` § Deferred work recording.
+
 ## Pre-coding summary
 
 Before substantive edits, inspect relevant files, tests, docs, routes, state models, schemas, fixtures, and patterns. Confirm status: **already complete**, **partially complete**, **incorrectly implemented**, or **blocked**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,4 +85,5 @@ All scripts are documented in `README.md` under the **Scripts** section and in `
 - **Implementation lite (default coding):** tracked `.cursor/rules/implementation-lite.mdc` (`alwaysApply: true`); paste duplicate from `docs/cursor-implementation-lite-user-rules-snippet.md` into Cursor User Rules if needed.
 - **Pre-ship audit:** before commit/PR — six iterative passes + validation until clean; `docs/agent-pre-ship-audit.md`; User Rules paste: `docs/cursor-pre-ship-audit-user-rules-snippet.md`.
 - **Session closeout:** after commit + Linear on a slice, plan the next issue only — final response format in `docs/agent-session-closeout.md`; User Rules paste: `docs/cursor-session-closeout-user-rules-snippet.md`.
+- **Deferred work:** same session — slice doc `## Deferred` + Linear parent/child comment; see `docs/agent-session-closeout.md` § Deferred work recording and `.cursor/rules/implementation-lite.mdc`.
 - **Backlog hygiene passes:** paste from `docs/cursor-backlog-hygiene-user-rules-snippet.md` (optional local `.cursor/rules/backlog-hygiene.mdc`; grooming only, not implementation).

--- a/docs/agent-session-closeout.md
+++ b/docs/agent-session-closeout.md
@@ -28,6 +28,25 @@ When the current slice is shipped (commit + push + PR) and Linear reflects the t
 
 ---
 
+## Deferred work recording (mandatory)
+
+Agents do not retain deferred work across new chats. When something is **out of slice** or **left for later**, write it down in the **same session** before ending:
+
+| Where | What to write |
+| ----- | --------------- |
+| **Active slice doc** | `## Deferred` — bullet or table: item, target Linear issue (or “create child”), one-line boundary |
+| **Linear parent or child** | Comment with mechanic, repo anchor, fold-in vs new child — not “deferred to later” alone |
+| **Parent issue** | Keep **In Progress** / **Backlog** until parent acceptance is truly met |
+| **This closeout block** | `Remaining risks or deferred work` must match the slice doc + Linear comment |
+
+Optional: add a **Backlog** row in `planning/backlog.md` when the next slice is already named.
+
+**Do not** rely on: chat history, PR description only, GitHub linkback bots, or closeout text with no slice/Linear anchor.
+
+Tracked rule: `.cursor/rules/implementation-lite.mdc` § Deferred work recording.
+
+---
+
 ## Session rules (closeout)
 
 - Do not expand the current issue.  

--- a/docs/agent-session-handoff.md
+++ b/docs/agent-session-handoff.md
@@ -35,7 +35,7 @@ One agent session on the **same branch** is fine (implement, CI, review). Start 
 
 1. `planning/backlog.md` or assigned Linear issue.
 2. `planning/<topic>-slice.md` for bounded scope.
-3. **Linear lifecycle** — mandatory every session (`AGENTS.md` + `.cursor/rules/linear-always-update.mdc`): In Progress before work → **pre-ship audit** (six passes + clean validation, `docs/agent-pre-ship-audit.md`) → **commit + push + open PR** (ship loop) → closeout next-issue plan only → Done on merge + comment what shipped. **Harvest triage:** `docs/harvest-candidate-triage-agent.md`; Linear owner comments must include **mechanic + boundary + fold-in vs child reasoning** (`docs/harvest-fold-in-linear-comments.md`); owner map QA: `docs/harvest-mirror-owner-map-qa.md` — same session as mirror, not deferred.
+3. **Linear lifecycle** — mandatory every session (`AGENTS.md` + `.cursor/rules/linear-always-update.mdc`): In Progress before work → **pre-ship audit** (six passes + clean validation, `docs/agent-pre-ship-audit.md`) → **commit + push + open PR** (ship loop) → closeout next-issue plan only → Done on merge + comment what shipped. **Deferred work:** record in slice doc `## Deferred` + Linear comment same session (`docs/agent-session-closeout.md` § Deferred work recording; `implementation-lite.mdc`). **Harvest triage:** `docs/harvest-candidate-triage-agent.md`; Linear owner comments must include **mechanic + boundary + fold-in vs child reasoning** (`docs/harvest-fold-in-linear-comments.md`); owner map QA: `docs/harvest-mirror-owner-map-qa.md` — same session as mirror, not deferred.
 
 ## Session closeout (agents)
 

--- a/docs/cursor-session-closeout-user-rules-snippet.md
+++ b/docs/cursor-session-closeout-user-rules-snippet.md
@@ -13,3 +13,5 @@ Next-issue plan must include: (1) issue ID and title, (2) smallest correct bound
 End the session using **only** the final response structure in `docs/agent-session-closeout.md` (Current issue status → Changes made → Audit passes → Validation → Remaining risks → Next issue implementation plan).
 
 Do not expand the current issue. Do not implement the next issue. Do not mark complete unless the full issue boundary is satisfied. Keep parent issues open for child slices only. Prefer small deterministic testable changes. Preserve mistaken records + later corrections; do not silent overwrite.
+
+When deferring work: same session, record in the slice doc `## Deferred` + Linear parent/child comment (mechanic + boundary). Chat alone is not enough. See `docs/agent-session-closeout.md` § Deferred work recording.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -138,6 +138,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `public-signal-coverage-slice-1.md`                        | **Shipped**    | SPE-2092 / PR #2445; institutional vs public channel coverage evaluator under SPE-854.                                                              |
 | `information-intake-report-persistence-slice-2.md`         | **Shipped**    | SPE-2293 / PR #2447; GameState persistence + sanitize/hydration for intake reports under SPE-854.                                                    |
 | `information-intake-coverage-compose-slice-3.md`             | **Shipped**    | SPE-2294 / PR #2449; topic intake coverage composition under SPE-854.                                                                                |
+| `information-intake-weekly-hook-slice-4.md`                  | **In PR**      | SPE-2295; weekly `advanceWeek` corroboration/contradiction hook for persisted intake reports under SPE-854.                                          |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-weekly-hook-slice-4.md
+++ b/planning/information-intake-weekly-hook-slice-4.md
@@ -1,0 +1,53 @@
+# SPE-854 — Weekly intake corroboration hook slice 4
+
+One-page implementation plan. Linear: child under [SPE-854](https://linear.app/spectranoir/issue/SPE-854). Follows [SPE-2292](https://linear.app/spectranoir/issue/SPE-2292), [SPE-2293](https://linear.app/spectranoir/issue/SPE-2293), and [SPE-2294](https://linear.app/spectranoir/issue/SPE-2294).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2295 — Weekly intake corroboration advanceWeek hook (slice 4)](https://linear.app/spectranoir/issue/SPE-2295) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine       |
+| **Branch** | `spe-854-information-intake-weekly-hook-slice-4`                                                           |
+| **Status** | **In PR** (branch `spe-854-information-intake-weekly-hook-slice-4`)                                        |
+
+## Goal
+
+Wire persisted `informationIntakeReports` into `advanceWeek` so reports accumulate corroboration/contradiction events each week via deterministic transition helpers.
+
+## Prerequisite (on `main` @ `8c66029e`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake report model  | `src/domain/informationIntakeReport.ts` (SPE-2292)                     |
+| Intake persistence   | `informationIntakeReports` on GameState (SPE-2293)                     |
+| Topic coverage compose | `evaluateTopicIntakeCoverage` in `publicSignalCoverage.ts` (SPE-2294) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyIntakeCorroborationTick` + authored fixture event stub | New schema, UI, report copy                   |
+| Call from `advanceWeek` after case resolution (post-`finalizeEvents`) | SPE-854 parent Done                           |
+| `advanceWeek.informationIntake.integration.test.ts`                | `runTransfer` sanitize contract changes       |
+| Slice doc (this file) + backlog row on PR open                       | Full narrative corroboration generator        |
+|                                                                    | `evaluateTopicIntakeCoverage` API changes     |
+
+## Acceptance
+
+- [x] Seeded `informationIntakeReports` gain deterministic weekly corroboration/contradiction history via `advanceWeek`
+- [x] Empty map no-op without throw
+- [x] Re-applying same weekly event id is idempotent
+- [x] `retainedDespiteContradiction` paths honored on contradiction ticks
+- [x] Optional: `evaluateTopicIntakeCoverage` reflects post-week verification band shift
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/informationIntakeWeeklyCorroboration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/advanceWeek.informationIntake.integration.test.ts`          |
+| Plan   | `planning/information-intake-weekly-hook-slice-4.md`, `planning/backlog.md` |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress**.

--- a/planning/information-intake-weekly-hook-slice-4.md
+++ b/planning/information-intake-weekly-hook-slice-4.md
@@ -48,6 +48,15 @@ Wire persisted `informationIntakeReports` into `advanceWeek` so reports accumula
 | Tests  | `src/test/advanceWeek.informationIntake.integration.test.ts`          |
 | Plan   | `planning/information-intake-weekly-hook-slice-4.md`, `planning/backlog.md` |
 
+## Deferred (recorded for follow-up)
+
+| Item | Suggested owner | Why deferred (slice 4 boundary) |
+| ---- | --------------- | --------------------------------- |
+| Case/topic-linked corroboration sources (derive events from sim state, not fixture ids) | New SPE-854 child | Slice 4 stub only; hook must not assume case linkage yet |
+| Full narrative corroboration generator | New SPE-854 child | Authored fixture events per report id for deterministic tests |
+| Intake verification UI / report copy surfaces | SPE-854 or adjacent UX owner | Explicitly out of slice 4 |
+| Parent SPE-854 acceptance (mixed-source incident, operational routing) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Slices 1–4 are domain/persistence/hook only |
+
 ## Parent
 
 Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress**.

--- a/src/domain/informationIntakeWeeklyCorroboration.ts
+++ b/src/domain/informationIntakeWeeklyCorroboration.ts
@@ -1,0 +1,190 @@
+/**
+ * SPE-854 slice 4: weekly corroboration/contradiction tick for persisted intake reports.
+ *
+ * Deterministic authored fixture events per report id (plus a bounded fallback for
+ * unknown reports). Not a full narrative generator — slice boundary stub only.
+ */
+
+import {
+  applyContradictionEvent,
+  applyCorroborationEvent,
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  type ContradictionEvent,
+  type CorroborationEvent,
+  type InformationIntakeReportRecord,
+  type InformationIntakeReportsMap,
+} from './informationIntakeReport'
+
+type WeeklyIntakeSyntheticEvent =
+  | { readonly kind: 'corroboration'; readonly event: CorroborationEvent }
+  | { readonly kind: 'contradiction'; readonly event: ContradictionEvent }
+
+export function buildWeeklyIntakeSyntheticEventId(
+  reportId: string,
+  week: number,
+  kind: 'corroboration' | 'contradiction'
+): string {
+  return `weekly-intake:${kind}:${reportId}:w${normalizeWeek(week)}`
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week) || week < 0) {
+    return 0
+  }
+
+  return Math.trunc(week)
+}
+
+function stableOrdinalFromId(id: string): number {
+  let hash = 0
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (hash + id.charCodeAt(index) * (index + 1)) % 997
+  }
+
+  return hash
+}
+
+function resolveAuthoredWeeklySyntheticEvent(
+  report: InformationIntakeReportRecord,
+  week: number
+): WeeklyIntakeSyntheticEvent | null {
+  const normalizedWeek = normalizeWeek(week)
+
+  switch (report.id) {
+    case IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id:
+      if (normalizedWeek % 2 === 0) {
+        return null
+      }
+
+      return {
+        kind: 'corroboration',
+        event: {
+          eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'corroboration'),
+          week: normalizedWeek,
+          sourceRef: `witness:weekly-archive-review-${normalizedWeek}`,
+          sourceClass: 'field_witness',
+          weight: 0.2,
+          note: 'Weekly field review cross-checks archive residue claim.',
+        },
+      }
+
+    case PUBLIC_RUMOR_CONFLICT_FIXTURE.id:
+      if (normalizedWeek % 4 === 0) {
+        return {
+          kind: 'contradiction',
+          event: {
+            eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'contradiction'),
+            week: normalizedWeek,
+            sourceRef: `audit:weekly-rumor-baseline-${normalizedWeek}`,
+            severity: 'minor',
+            note: 'Weekly baseline audit flags rumor timing conflict.',
+          },
+        }
+      }
+
+      return {
+        kind: 'corroboration',
+        event: {
+          eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'corroboration'),
+          week: normalizedWeek,
+          sourceRef: `witness:weekly-rumor-corroboration-${normalizedWeek}`,
+          sourceClass: 'field_witness',
+          weight: 0.18,
+        },
+      }
+
+    case FORMAL_ALERT_PARTIAL_FIXTURE.id:
+      return {
+        kind: 'corroboration',
+        event: {
+          eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'corroboration'),
+          week: normalizedWeek,
+          sourceRef: `sensor:weekly-thermal-grid-${normalizedWeek}`,
+          sourceClass: 'technical_trace',
+          weight: 0.22,
+          note: 'Weekly grid thermal corroboration tick.',
+        },
+      }
+
+    default:
+      return resolveFallbackWeeklySyntheticEvent(report, normalizedWeek)
+  }
+}
+
+function resolveFallbackWeeklySyntheticEvent(
+  report: InformationIntakeReportRecord,
+  week: number
+): WeeklyIntakeSyntheticEvent | null {
+  const phase = (week + stableOrdinalFromId(report.id)) % 6
+
+  if (phase === 0) {
+    return {
+      kind: 'contradiction',
+      event: {
+        eventId: buildWeeklyIntakeSyntheticEventId(report.id, week, 'contradiction'),
+        week,
+        sourceRef: `audit:weekly-intake-${report.topicRef}`,
+        severity: 'minor',
+      },
+    }
+  }
+
+  if (phase === 1 || phase === 3) {
+    const sourceClass =
+      report.initialSourceClass === 'rumor_chain' || report.initialSourceClass === 'public_signal'
+        ? 'public_signal'
+        : 'partner_channel'
+
+    return {
+      kind: 'corroboration',
+      event: {
+        eventId: buildWeeklyIntakeSyntheticEventId(report.id, week, 'corroboration'),
+        week,
+        sourceRef: `source:weekly-intake-${report.topicRef}`,
+        sourceClass,
+        weight: phase === 3 ? 0.2 : 0.15,
+      },
+    }
+  }
+
+  return null
+}
+
+/**
+ * Applies one weekly corroboration/contradiction pass over persisted intake reports.
+ * Empty map is a no-op. Re-applying for the same week is idempotent (stable event ids).
+ */
+export function applyWeeklyIntakeCorroborationTick(
+  reports: InformationIntakeReportsMap,
+  week: number
+): InformationIntakeReportsMap {
+  const reportIds = Object.keys(reports)
+  if (reportIds.length === 0) {
+    return reports
+  }
+
+  const next: InformationIntakeReportsMap = { ...reports }
+
+  for (const reportId of reportIds.sort((left, right) => left.localeCompare(right))) {
+    const report = reports[reportId]
+    if (!report) {
+      continue
+    }
+
+    const synthetic = resolveAuthoredWeeklySyntheticEvent(report, week)
+    if (!synthetic) {
+      continue
+    }
+
+    const transition =
+      synthetic.kind === 'corroboration'
+        ? applyCorroborationEvent(report, synthetic.event)
+        : applyContradictionEvent(report, synthetic.event)
+
+    next[reportId] = transition.report
+  }
+
+  return next
+}

--- a/src/domain/informationIntakeWeeklyCorroboration.ts
+++ b/src/domain/informationIntakeWeeklyCorroboration.ts
@@ -30,11 +30,11 @@ export function buildWeeklyIntakeSyntheticEventId(
 }
 
 function normalizeWeek(week: number): number {
-  if (!Number.isFinite(week) || week < 0) {
-    return 0
+  if (!Number.isFinite(week)) {
+    return 1
   }
 
-  return Math.trunc(week)
+  return Math.max(1, Math.trunc(week))
 }
 
 function stableOrdinalFromId(id: string): number {
@@ -157,18 +157,19 @@ function resolveFallbackWeeklySyntheticEvent(
  * Empty map is a no-op. Re-applying for the same week is idempotent (stable event ids).
  */
 export function applyWeeklyIntakeCorroborationTick(
-  reports: InformationIntakeReportsMap,
+  reports: InformationIntakeReportsMap | null | undefined,
   week: number
 ): InformationIntakeReportsMap {
-  const reportIds = Object.keys(reports)
+  const safeReports = reports ?? {}
+  const reportIds = Object.keys(safeReports)
   if (reportIds.length === 0) {
-    return reports
+    return safeReports
   }
 
-  const next: InformationIntakeReportsMap = { ...reports }
+  const next: InformationIntakeReportsMap = { ...safeReports }
 
   for (const reportId of reportIds.sort((left, right) => left.localeCompare(right))) {
-    const report = reports[reportId]
+    const report = safeReports[reportId]
     if (!report) {
       continue
     }

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -262,6 +262,7 @@ import {
   type AuthoredCivicAuthoritySourceInput,
   type CompactCivicAuthorityConsequencePacket,
 } from '../civicConsequenceNetwork'
+import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
 import { decayCreditPackets, type CivicCreditPacket } from '../civicCreditChannel'
 import { decayAccessPackets, type CivicAccessPacket } from '../civicAccessChannel'
@@ -4409,6 +4410,10 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   const agencyMetrics = updateAgencyMetrics(context, builtReport)
 
   const result = finalizeEvents(context, builtReport, agencyMetrics)
+
+  // SPE-854 slice 4: accumulate weekly corroboration/contradiction on persisted intake reports.
+  const intakeCorroborationWeek = sourceState.week
+
   // Patch: preserve unknown fields from input state for testability (e.g., damagedEquipmentQueue)
   const stateWithUnknownFields = state as unknown as Record<string, unknown>
   const resultWithUnknownFields = result as unknown as Record<string, unknown>
@@ -4444,6 +4449,14 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.civicAuthoritySources = mergedAuthoritySources
   } else if ('civicAuthoritySources' in outputWeeklyState) {
     delete resultWithUnknownFields.civicAuthoritySources
+  }
+
+  const priorIntakeReports = inputWeeklyState.informationIntakeReports ?? {}
+  if (Object.keys(priorIntakeReports).length > 0) {
+    outputWeeklyState.informationIntakeReports = applyWeeklyIntakeCorroborationTick(
+      priorIntakeReports,
+      intakeCorroborationWeek
+    )
   }
 
   // SPE-1265: Decay rumor packets each week; drop packets below the 0.05 signal threshold.

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import {
+  applyWeeklyIntakeCorroborationTick,
+  buildWeeklyIntakeSyntheticEventId,
+} from '../domain/informationIntakeWeeklyCorroboration'
+import { evaluateTopicIntakeCoverage } from '../domain/publicSignalCoverage'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek information intake corroboration integration (SPE-854 slice 4)', () => {
+  it('is a no-op for an empty intake report map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.informationIntakeReports = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.informationIntakeReports).toEqual({})
+  })
+
+  it('accumulates deterministic weekly corroboration on persisted reports after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    const week = state.week
+
+    state.informationIntakeReports = {
+      [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+      [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const rumorReport = nextState.informationIntakeReports?.[PUBLIC_RUMOR_CONFLICT_FIXTURE.id]
+    const formalReport = nextState.informationIntakeReports?.[FORMAL_ALERT_PARTIAL_FIXTURE.id]
+
+    expect(rumorReport).toBeDefined()
+    expect(formalReport).toBeDefined()
+
+    const expectedRumorEventId = buildWeeklyIntakeSyntheticEventId(
+      PUBLIC_RUMOR_CONFLICT_FIXTURE.id,
+      week,
+      week % 4 === 0 ? 'contradiction' : 'corroboration'
+    )
+
+    if (week % 4 === 0) {
+      expect(rumorReport?.contradictionHistory.map((event) => event.eventId)).toContain(
+        expectedRumorEventId
+      )
+      expect(rumorReport?.retainedDespiteContradiction).toBe(true)
+      expect(rumorReport?.contradictionHistory).toHaveLength(1)
+    } else {
+      expect(rumorReport?.corroborationHistory.map((event) => event.eventId)).toContain(
+        expectedRumorEventId
+      )
+      expect(rumorReport?.corroborationHistory).toHaveLength(1)
+      expect(rumorReport?.verificationStatus).toBe('unverified')
+    }
+
+    const expectedFormalEventId = buildWeeklyIntakeSyntheticEventId(
+      FORMAL_ALERT_PARTIAL_FIXTURE.id,
+      week,
+      'corroboration'
+    )
+    expect(formalReport?.corroborationHistory.map((event) => event.eventId)).toContain(
+      expectedFormalEventId
+    )
+    expect(formalReport?.corroborationHistory).toHaveLength(
+      FORMAL_ALERT_PARTIAL_FIXTURE.corroborationHistory.length + 1
+    )
+  })
+
+  it('is idempotent when the same weekly synthetic event id is re-applied', () => {
+    const week = 5
+    const reports = {
+      [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+    }
+
+    const first = applyWeeklyIntakeCorroborationTick(reports, week)
+    const second = applyWeeklyIntakeCorroborationTick(first, week)
+
+    expect(second).toEqual(first)
+  })
+
+  it('shifts topic intake coverage band after weekly corroboration on formal alert', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+
+    state.informationIntakeReports = {
+      [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+    }
+
+    const beforeCoverage = evaluateTopicIntakeCoverage({
+      topicId: FORMAL_ALERT_PARTIAL_FIXTURE.topicRef,
+      reports: state.informationIntakeReports,
+    })
+
+    const nextState = advanceWeek(state)
+    const afterCoverage = evaluateTopicIntakeCoverage({
+      topicId: FORMAL_ALERT_PARTIAL_FIXTURE.topicRef,
+      reports: nextState.informationIntakeReports,
+    })
+
+    expect(beforeCoverage.intakeSummary.dominantVerificationStatus).toBe('partially_corroborated')
+    expect(afterCoverage.intakeSummary.dominantVerificationStatus).toBe('verified')
+    expect(afterCoverage.intakeSummary.hasIncompleteIntake).toBe(false)
+  })
+})

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -82,6 +82,11 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
     )
   })
 
+  it('treats null or undefined report maps as empty without throwing', () => {
+    expect(applyWeeklyIntakeCorroborationTick(null, 3)).toEqual({})
+    expect(applyWeeklyIntakeCorroborationTick(undefined, 3)).toEqual({})
+  })
+
   it('is idempotent when the same weekly synthetic event id is re-applied', () => {
     const week = 5
     const reports = {


### PR DESCRIPTION
## Summary

- Add \pplyWeeklyIntakeCorroborationTick\ with deterministic authored fixture corroboration/contradiction events per report id (bounded fallback for unknown reports).
- Wire hook in \dvanceWeek\ after \inalizeEvents\, stamping events with the resolving week (\sourceState.week\).
- Integration tests cover empty-map no-op, post-week history updates, idempotent re-application, and \evaluateTopicIntakeCoverage\ verification band shift.

## Linear

- **Slice:** [SPE-2295](https://linear.app/spectranoir/issue/SPE-2295) — Weekly intake corroboration advanceWeek hook (slice 4)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — remains **In Progress** (parent acceptance bar not satisfied)

## What shipped

- \src/domain/informationIntakeWeeklyCorroboration.ts\
- \dvanceWeek\ persistence of updated \informationIntakeReports\
- \src/test/advanceWeek.informationIntake.integration.test.ts\
- \planning/information-intake-weekly-hook-slice-4.md\, backlog row

## Validation

- \
pm run test:run -- src/test/advanceWeek.informationIntake.integration.test.ts\
- \
pm run test:run -- src/test/informationIntakeReportPersistence.test.ts\
- \
pm run lint\ (changed files)

## Docs updated

- \planning/information-intake-weekly-hook-slice-4.md\
- \planning/backlog.md\

## Out of scope

- No schema/UI/runTransfer changes; no \evaluateTopicIntakeCoverage\ API changes.

Made with [Cursor](https://cursor.com)