### PR TITLE
feat(SPE-2297): deterministic weekly intake narrative source refs

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -138,7 +138,9 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `public-signal-coverage-slice-1.md`                        | **Shipped**    | SPE-2092 / PR #2445; institutional vs public channel coverage evaluator under SPE-854.                                                              |
 | `information-intake-report-persistence-slice-2.md`         | **Shipped**    | SPE-2293 / PR #2447; GameState persistence + sanitize/hydration for intake reports under SPE-854.                                                    |
 | `information-intake-coverage-compose-slice-3.md`             | **Shipped**    | SPE-2294 / PR #2449; topic intake coverage composition under SPE-854.                                                                                |
-| `information-intake-weekly-hook-slice-4.md`                  | **In PR**      | SPE-2295; weekly `advanceWeek` corroboration/contradiction hook for persisted intake reports under SPE-854.                                          |
+| `information-intake-weekly-hook-slice-4.md`                  | **Shipped**    | SPE-2295 / PR #2450; weekly `advanceWeek` corroboration/contradiction hook for persisted intake reports under SPE-854.                              |
+| `information-intake-weekly-hook-slice-5.md`                  | **Shipped**    | SPE-2296 / PR #2451; case/topic-linked weekly corroboration source derivation under SPE-854.                                                        |
+| `information-intake-weekly-hook-slice-6.md`                  | **In Progress**| SPE-2297; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                                    |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -140,7 +140,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-coverage-compose-slice-3.md`             | **Shipped**    | SPE-2294 / PR #2449; topic intake coverage composition under SPE-854.                                                                                |
 | `information-intake-weekly-hook-slice-4.md`                  | **Shipped**    | SPE-2295 / PR #2450; weekly `advanceWeek` corroboration/contradiction hook for persisted intake reports under SPE-854.                              |
 | `information-intake-weekly-hook-slice-5.md`                  | **Shipped**    | SPE-2296 / PR #2451; case/topic-linked weekly corroboration source derivation under SPE-854.                                                        |
-| `information-intake-weekly-hook-slice-6.md`                  | **In Progress**| SPE-2297; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                                    |
+| `information-intake-weekly-hook-slice-6.md`                  | **In Progress** | SPE-2297; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                                   |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-weekly-hook-slice-5.md
+++ b/planning/information-intake-weekly-hook-slice-5.md
@@ -1,0 +1,55 @@
+# SPE-854 — Weekly intake corroboration hook slice 5
+
+One-page implementation plan. Linear: [SPE-2296](https://linear.app/spectranoir/issue/SPE-2296). Follows [SPE-2295](https://linear.app/spectranoir/issue/SPE-2295).
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2296 — Case/topic-linked weekly corroboration source derivation (slice 5)](https://linear.app/spectranoir/issue/SPE-2296) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
+| **Branch** | `spe-2296-case-topic-linked-weekly-corroboration-source-derivation-slice-5` |
+| **Status** | **Shipped** (PR #2453) |
+
+## Goal
+
+Derive weekly intake corroboration/contradiction synthetic events from case/topic simulation state instead of fixture-id-only stubs, while preserving deterministic event ids and weekly idempotence.
+
+## Prerequisite (on `main` @ SPE-2295 merge)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Weekly hook in `advanceWeek` | `src/domain/sim/advanceWeek.ts` (SPE-2295) |
+| Weekly tick helper | `src/domain/informationIntakeWeeklyCorroboration.ts` (SPE-2295) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| Case/topic token matching and linked-case segments in weekly synthetic events | Full narrative corroboration generator |
+| Pass `cases` from `advanceWeek` into weekly tick | UI/report copy surfaces |
+| Integration test for linked case/topic source refs | Parent SPE-854 closure |
+
+## Acceptance
+
+- [x] Weekly events reference linked case ids in `sourceRef` when topic matches open case state
+- [x] Deterministic phase selection from report id, week, and linked-case count
+- [x] Existing idempotence and empty-map behavior preserved
+- [x] `npm run lint` + targeted intake integration tests green
+
+## File touch list (shipped)
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/informationIntakeWeeklyCorroboration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests | `src/test/advanceWeek.informationIntake.integration.test.ts` |
+| Plan | `planning/information-intake-weekly-hook-slice-5.md`, `planning/backlog.md` |
+
+## Deferred (recorded for follow-up)
+
+| Item | Suggested owner | Why deferred (slice 5 boundary) |
+| ---- | --------------- | -------------------------------- |
+| Full narrative corroboration generator | SPE-2297 | Slice 5 derives linkage only; narrative token segments deferred |
+| Intake verification UI / report copy surfaces | SPE-854 or adjacent UX owner | Domain-only slice |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress**.

--- a/planning/information-intake-weekly-hook-slice-6.md
+++ b/planning/information-intake-weekly-hook-slice-6.md
@@ -1,0 +1,58 @@
+# SPE-854 — Weekly intake corroboration hook slice 6
+
+One-page implementation plan. Linear: [SPE-2297](https://linear.app/spectranoir/issue/SPE-2297). Follows [SPE-2295](https://linear.app/spectranoir/issue/SPE-2295) and [SPE-2296](https://linear.app/spectranoir/issue/SPE-2296).
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2297 — Weekly intake narrative corroboration generator (slice 6)](https://linear.app/spectranoir/issue/SPE-2297) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
+| **Branch** | `spe-2297-weekly-intake-narrative-corroboration-generator-slice-6` |
+| **Status** | **In Progress** |
+
+## Goal
+
+Upgrade weekly synthetic corroboration/contradiction `sourceRef` values from plain deterministic stubs to deterministic narrative segments while preserving event id stability, idempotence, and case/topic linkage behavior from slice 5.
+
+## Prerequisite (on `main` @ `87182eb10446f59e82a5e6ae42dfbe58bb6b8f51`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Weekly hook in `advanceWeek` | `src/domain/sim/advanceWeek.ts` (SPE-2295) |
+| Case/topic-linked source derivation | `src/domain/informationIntakeWeeklyCorroboration.ts` (SPE-2296) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| Deterministic narrative token helpers for corroboration and contradiction source refs | New report schema fields |
+| Preserve existing event ids and weekly idempotence | `advanceWeek` orchestration changes |
+| Focused integration assertions for narrative source-ref segments | UI/report copy surfaces |
+| Slice doc + backlog row update | Parent SPE-854 closure |
+
+## Acceptance
+
+- [ ] Corroboration events include deterministic narrative `sourceRef` segments (`trace-*`, `channel-*`)
+- [ ] Contradiction events include deterministic narrative `sourceRef` segments (`dispute-*`, `cue-*`)
+- [ ] Existing case/topic link component remains in source refs
+- [ ] Reapplying same weekly input remains idempotent
+- [ ] `npm run test:run -- src/test/advanceWeek.informationIntake.integration.test.ts` and `npm run lint` pass
+
+## File touch list (expected)
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/informationIntakeWeeklyCorroboration.ts` |
+| Tests | `src/test/advanceWeek.informationIntake.integration.test.ts` |
+| Plan | `planning/information-intake-weekly-hook-slice-6.md`, `planning/backlog.md` |
+
+## Deferred (recorded for follow-up)
+
+| Item | Suggested owner | Why deferred (slice 6 boundary) |
+| ---- | --------------- | -------------------------------- |
+| Narrative text surfaced in player-facing weekly reports | SPE-854 child | Slice 6 only enriches source refs on domain events |
+| Dynamic narrative templates derived from case outcome metadata | SPE-854 child | Slice 6 keeps bounded deterministic token sets |
+| Parent SPE-854 acceptance (mixed-source incident + operational routing) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Child slice only |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress**.

--- a/src/domain/informationIntakeWeeklyCorroboration.ts
+++ b/src/domain/informationIntakeWeeklyCorroboration.ts
@@ -148,6 +148,51 @@ function resolveCorroborationSourceClass(
   }
 }
 
+function pickNarrativeToken(tokens: readonly string[], reportId: string, week: number, offset: number): string {
+  if (tokens.length === 0) {
+    return 'baseline'
+  }
+
+  const index = (stableOrdinalFromId(reportId) + normalizeWeek(week) + offset) % tokens.length
+  return tokens[index] ?? 'baseline'
+}
+
+function buildWeeklyContradictionSourceRef(
+  normalizedTopic: string,
+  caseSegment: string,
+  report: InformationIntakeReportRecord,
+  week: number,
+  hasLinkedCases: boolean
+): string {
+  const disputeTokens = hasLinkedCases
+    ? ['conflict-window', 'witness-mismatch', 'timeline-drift']
+    : ['confidence-drop', 'signal-gap', 'unsupported-claim']
+  const dispute = pickNarrativeToken(disputeTokens, report.id, week, 0)
+  const sourceCue = pickNarrativeToken(
+    ['audit-trace', 'triage-review', 'cross-check'],
+    report.id,
+    week,
+    report.topicRef.length
+  )
+  return `audit:weekly-intake:${normalizedTopic}:${caseSegment}:dispute-${dispute}:cue-${sourceCue}`
+}
+
+function buildWeeklyCorroborationSourceRef(
+  normalizedTopic: string,
+  caseSegment: string,
+  report: InformationIntakeReportRecord,
+  week: number,
+  hasLinkedCases: boolean
+): string {
+  const traceTokens = hasLinkedCases
+    ? ['linked-case', 'coincident-signal', 'field-alignment']
+    : ['ambient-signal', 'community-thread', 'partner-check']
+  const channelTokens = ['routing-sync', 'watchlist-match', 'pattern-stability']
+  const trace = pickNarrativeToken(traceTokens, report.id, week, 1)
+  const channel = pickNarrativeToken(channelTokens, report.id, week, report.topicRef.length + 1)
+  return `source:weekly-intake:${normalizedTopic}:${caseSegment}:trace-${trace}:channel-${channel}`
+}
+
 function resolveCaseTopicLinkedWeeklySyntheticEvent(
   report: InformationIntakeReportRecord,
   week: number,
@@ -166,7 +211,13 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
       event: {
         eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'contradiction'),
         week: normalizedWeek,
-        sourceRef: `audit:weekly-intake:${normalizedTopic}:${caseSegment}`,
+        sourceRef: buildWeeklyContradictionSourceRef(
+          normalizedTopic,
+          caseSegment,
+          report,
+          normalizedWeek,
+          hasLinkedCases
+        ),
         severity: hasLinkedCases ? 'minor' : 'major',
       },
     }
@@ -193,7 +244,13 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
       event: {
         eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'corroboration'),
         week: normalizedWeek,
-        sourceRef: `source:weekly-intake:${normalizedTopic}:${caseSegment}`,
+        sourceRef: buildWeeklyCorroborationSourceRef(
+          normalizedTopic,
+          caseSegment,
+          report,
+          normalizedWeek,
+          hasLinkedCases
+        ),
         sourceClass,
         weight: baseWeight,
       },
@@ -206,7 +263,13 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
       event: {
         eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'corroboration'),
         week: normalizedWeek,
-        sourceRef: `source:weekly-intake:${normalizedTopic}:${caseSegment}`,
+        sourceRef: buildWeeklyCorroborationSourceRef(
+          normalizedTopic,
+          caseSegment,
+          report,
+          normalizedWeek,
+          hasLinkedCases
+        ),
         sourceClass: 'technical_trace',
         weight: 0.22,
       },
@@ -218,7 +281,13 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
     event: {
       eventId: buildWeeklyIntakeSyntheticEventId(report.id, normalizedWeek, 'corroboration'),
       week: normalizedWeek,
-      sourceRef: `source:weekly-intake:${normalizedTopic}:${caseSegment}`,
+      sourceRef: buildWeeklyCorroborationSourceRef(
+        normalizedTopic,
+        caseSegment,
+        report,
+        normalizedWeek,
+        hasLinkedCases
+      ),
       sourceClass: resolveCorroborationSourceClass(report.initialSourceClass, hasLinkedCases),
       weight: hasLinkedCases ? 0.16 : 0.12,
     },

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -121,6 +121,7 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
       expect(corroborationEvent.sourceRef).toContain(linkedCase.id)
       expect(corroborationEvent.sourceRef).toContain('weekly-intake')
       expect(corroborationEvent.sourceRef).toContain(':trace-')
+      expect(corroborationEvent.sourceRef).toContain(':channel-')
       return
     }
 
@@ -133,6 +134,7 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
     expect(contradictionEvent?.sourceRef).toContain(linkedCase.id)
     expect(contradictionEvent?.sourceRef).toContain('weekly-intake')
     expect(contradictionEvent?.sourceRef).toContain(':dispute-')
+    expect(contradictionEvent?.sourceRef).toContain(':cue-')
   })
 
   it('treats null or undefined report maps as empty without throwing', () => {

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -120,6 +120,7 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
     if (corroborationEvent) {
       expect(corroborationEvent.sourceRef).toContain(linkedCase.id)
       expect(corroborationEvent.sourceRef).toContain('weekly-intake')
+      expect(corroborationEvent.sourceRef).toContain(':trace-')
       return
     }
 
@@ -131,6 +132,7 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
     expect(contradictionEvent).toBeDefined()
     expect(contradictionEvent?.sourceRef).toContain(linkedCase.id)
     expect(contradictionEvent?.sourceRef).toContain('weekly-intake')
+    expect(contradictionEvent?.sourceRef).toContain(':dispute-')
   })
 
   it('treats null or undefined report maps as empty without throwing', () => {


### PR DESCRIPTION
## Summary
- Canonical Linear issue: SPE-2297 (child of SPE-854)
- Replace weekly intake corroboration/contradiction `sourceRef` stubs with deterministic narrative token builders while preserving case/topic linkage and stable event IDs
- Add integration assertions for `:trace-` and `:dispute-` segments and add slice/backlog planning updates (`planning/information-intake-weekly-hook-slice-6.md`, `planning/backlog.md`)

## Issue mapping
- Parent: SPE-854
- Child shipped by this PR: SPE-2297
- Prior child context: SPE-2295, SPE-2296
- Parent remains open: yes

## Validation
- `npm run test:run -- src/test/advanceWeek.informationIntake.integration.test.ts`
- `npm run lint`

## Docs updated
- `planning/information-intake-weekly-hook-slice-6.md`
- `planning/backlog.md`