### PR TITLE
feat(SPE-2298): weekly intake verification narratives in report notes (slice 7)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -140,7 +140,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-coverage-compose-slice-3.md`             | **Shipped**    | SPE-2294 / PR #2449; topic intake coverage composition under SPE-854.                                                                                |
 | `information-intake-weekly-hook-slice-4.md`                  | **Shipped**    | SPE-2295 / PR #2450; weekly `advanceWeek` corroboration/contradiction hook for persisted intake reports under SPE-854.                              |
 | `information-intake-weekly-hook-slice-5.md`                  | **Shipped**    | SPE-2296 / PR #2451; case/topic-linked weekly corroboration source derivation under SPE-854.                                                        |
-| `information-intake-weekly-hook-slice-6.md`                  | **In Progress** | SPE-2297; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                                   |
+| `information-intake-weekly-hook-slice-6.md`                  | **Shipped**    | SPE-2297 / PR #2455; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                          |
+| `information-intake-weekly-hook-slice-7.md`                  | **In Progress**| SPE-2298; weekly intake verification narratives in report notes under SPE-854.                                                                      |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-weekly-hook-slice-7.md
+++ b/planning/information-intake-weekly-hook-slice-7.md
@@ -1,0 +1,57 @@
+# SPE-854 — Weekly intake verification report notes (slice 7)
+
+One-page implementation plan. Linear: [SPE-2298](https://linear.app/spectranoir/issue/SPE-2298). Follows shipped [SPE-2297](https://linear.app/spectranoir/issue/SPE-2297) (slice 6).
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2298 — Weekly intake verification narratives in report notes (slice 7)](https://linear.app/spectranoir/issue/SPE-2298) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
+| **Branch** | `spe-854-information-intake-weekly-hook-slice-7` |
+| **Status** | **In Progress** |
+
+## Goal
+
+Project weekly intake verification narratives into weekly report notes using persisted corroboration/contradiction history and narrative `sourceRef` segments — domain-only; no `InformationIntakeReportRecord` schema changes.
+
+## Prerequisite (on `main` @ `cd8f368217c89000c9fb7e2bca5172e9a0b1892e`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Narrative source-ref generator | `src/domain/informationIntakeWeeklyCorroboration.ts` (SPE-2297) |
+| Weekly intake tick in `advanceWeek` | `src/domain/sim/advanceWeek.ts` (SPE-2295+) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `buildWeeklyIntakeVerificationReportNotes` + narrative segment parsing | `InformationIntakeReportRecord` schema changes |
+| Append notes to current weekly report after intake tick (preserve tick order) | UI report surfacing |
+| Integration tests on `advanceWeek` intake path | Parent SPE-854 closure |
+| Slice doc + backlog row | Dynamic templates from case outcome metadata |
+
+## Acceptance
+
+- [ ] Weekly report includes deterministic intake verification notes when synthetic events are added this tick
+- [ ] Note content reflects `trace-*` / `channel-*` or `dispute-*` / `cue-*` segments from `sourceRef`
+- [ ] Notes use `system.week_delta` with bounded metadata (`delta` only)
+- [ ] `npm run test:run -- src/test/advanceWeek.informationIntake.integration.test.ts` and `npm run lint` pass
+
+## File touch list (expected)
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/informationIntakeWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests | `src/test/advanceWeek.informationIntake.integration.test.ts` |
+| Plan | `planning/information-intake-weekly-hook-slice-7.md`, `planning/backlog.md` |
+
+## Deferred (recorded for follow-up)
+
+| Item | Suggested owner | Why deferred (slice 7 boundary) |
+| ---- | --------------- | ----------------------------- |
+| Dedicated `information_intake.verification` report note type + UI bucket | SPE-854 child | Slice 7 uses existing `system.week_delta` metadata allowlist |
+| Dynamic narrative templates from case outcome metadata | SPE-854 child | Slice 7 humanizes bounded deterministic tokens only |
+| Parent SPE-854 acceptance (mixed-source incident + operational routing) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Child slice only |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress** (or **Backlog** per team convention) until full parent acceptance ships.

--- a/src/domain/informationIntakeWeeklyReportNotes.ts
+++ b/src/domain/informationIntakeWeeklyReportNotes.ts
@@ -63,7 +63,6 @@ function formatVerificationStatusLabel(status: InformationVerificationStatus): s
 
 function formatCorroborationNoteContent(
   report: InformationIntakeReportRecord,
-  event: CorroborationEvent,
   segments: WeeklyIntakeNarrativeSegments
 ): string {
   const traceLabel = segments.trace ? humanizeNarrativeToken(segments.trace) : 'ambient trace'
@@ -157,15 +156,13 @@ export function buildWeeklyIntakeVerificationReportNotes(input: {
     }
 
     const addedEvents = collectAddedWeeklySyntheticEvents(priorReports[reportId], nextReport, input.week)
-    const sortedEvents = [...addedEvents].sort((left, right) =>
-      left.event.eventId.localeCompare(right.event.eventId)
-    )
+    addedEvents.sort((left, right) => left.event.eventId.localeCompare(right.event.eventId))
 
-    for (const added of sortedEvents) {
+    for (const added of addedEvents) {
       const segments = extractWeeklyIntakeNarrativeSegments(added.event.sourceRef)
       const content =
         added.kind === 'corroboration'
-          ? formatCorroborationNoteContent(nextReport, added.event, segments)
+          ? formatCorroborationNoteContent(nextReport, segments)
           : formatContradictionNoteContent(nextReport, added.event, segments)
 
       notes.push(

--- a/src/domain/informationIntakeWeeklyReportNotes.ts
+++ b/src/domain/informationIntakeWeeklyReportNotes.ts
@@ -1,0 +1,186 @@
+/**
+ * SPE-854 slice 7: surface weekly intake verification narratives in weekly report notes.
+ *
+ * Projects synthetic corroboration/contradiction events (and narrative sourceRef segments)
+ * into deterministic report notes — no InformationIntakeReportRecord schema changes.
+ */
+
+import type {
+  ContradictionEvent,
+  CorroborationEvent,
+  InformationIntakeReportRecord,
+  InformationIntakeReportsMap,
+  InformationVerificationStatus,
+} from './informationIntakeReport'
+import type { ReportNote } from './models'
+import { createDeterministicReportNote } from './reportNotes'
+
+const WEEKLY_SYNTHETIC_EVENT_ID_PREFIX = 'weekly-intake:'
+
+const NARRATIVE_SEGMENT_PATTERNS = {
+  trace: /:trace-([^:]+)/,
+  channel: /:channel-([^:]+)/,
+  dispute: /:dispute-([^:]+)/,
+  cue: /:cue-([^:]+)/,
+} as const
+
+export type WeeklyIntakeNarrativeSegments = {
+  readonly trace?: string
+  readonly channel?: string
+  readonly dispute?: string
+  readonly cue?: string
+}
+
+type WeeklyIntakeVerificationEventRef =
+  | { readonly kind: 'corroboration'; readonly event: CorroborationEvent }
+  | { readonly kind: 'contradiction'; readonly event: ContradictionEvent }
+
+function humanizeNarrativeToken(token: string): string {
+  return token.replace(/-/g, ' ')
+}
+
+export function extractWeeklyIntakeNarrativeSegments(sourceRef: string): WeeklyIntakeNarrativeSegments {
+  const trace = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.trace)?.[1]
+  const channel = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.channel)?.[1]
+  const dispute = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.dispute)?.[1]
+  const cue = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.cue)?.[1]
+
+  return {
+    ...(trace ? { trace } : {}),
+    ...(channel ? { channel } : {}),
+    ...(dispute ? { dispute } : {}),
+    ...(cue ? { cue } : {}),
+  }
+}
+
+function isWeeklySyntheticEventId(eventId: string): boolean {
+  return eventId.startsWith(WEEKLY_SYNTHETIC_EVENT_ID_PREFIX)
+}
+
+function formatVerificationStatusLabel(status: InformationVerificationStatus): string {
+  return status.replace(/_/g, ' ')
+}
+
+function formatCorroborationNoteContent(
+  report: InformationIntakeReportRecord,
+  event: CorroborationEvent,
+  segments: WeeklyIntakeNarrativeSegments
+): string {
+  const traceLabel = segments.trace ? humanizeNarrativeToken(segments.trace) : 'ambient trace'
+  const channelLabel = segments.channel ? humanizeNarrativeToken(segments.channel) : 'routing channel'
+  return `Intake verification — ${report.label}: corroboration (${traceLabel}; ${channelLabel}). Status: ${formatVerificationStatusLabel(report.verificationStatus)}.`
+}
+
+function formatContradictionNoteContent(
+  report: InformationIntakeReportRecord,
+  event: ContradictionEvent,
+  segments: WeeklyIntakeNarrativeSegments
+): string {
+  const disputeLabel = segments.dispute ? humanizeNarrativeToken(segments.dispute) : 'signal dispute'
+  const cueLabel = segments.cue ? humanizeNarrativeToken(segments.cue) : 'audit cue'
+  const severityLabel = event.severity === 'major' ? 'major' : 'minor'
+  return `Intake verification — ${report.label}: ${severityLabel} contradiction (${disputeLabel}; ${cueLabel}). Status: ${formatVerificationStatusLabel(report.verificationStatus)}.`
+}
+
+function collectPriorWeeklySyntheticEventIds(report: InformationIntakeReportRecord | undefined): Set<string> {
+  const ids = new Set<string>()
+  if (!report) {
+    return ids
+  }
+
+  for (const event of report.corroborationHistory) {
+    if (isWeeklySyntheticEventId(event.eventId)) {
+      ids.add(event.eventId)
+    }
+  }
+  for (const event of report.contradictionHistory) {
+    if (isWeeklySyntheticEventId(event.eventId)) {
+      ids.add(event.eventId)
+    }
+  }
+
+  return ids
+}
+
+function collectAddedWeeklySyntheticEvents(
+  priorReport: InformationIntakeReportRecord | undefined,
+  nextReport: InformationIntakeReportRecord,
+  week: number
+): WeeklyIntakeVerificationEventRef[] {
+  const priorIds = collectPriorWeeklySyntheticEventIds(priorReport)
+  const added: WeeklyIntakeVerificationEventRef[] = []
+
+  for (const event of nextReport.corroborationHistory) {
+    if (
+      event.week === week &&
+      isWeeklySyntheticEventId(event.eventId) &&
+      !priorIds.has(event.eventId)
+    ) {
+      added.push({ kind: 'corroboration', event })
+    }
+  }
+
+  for (const event of nextReport.contradictionHistory) {
+    if (
+      event.week === week &&
+      isWeeklySyntheticEventId(event.eventId) &&
+      !priorIds.has(event.eventId)
+    ) {
+      added.push({ kind: 'contradiction', event })
+    }
+  }
+
+  return added
+}
+
+/**
+ * Builds deterministic weekly report notes for intake verification events added this tick.
+ */
+export function buildWeeklyIntakeVerificationReportNotes(input: {
+  priorReports: InformationIntakeReportsMap | null | undefined
+  nextReports: InformationIntakeReportsMap | null | undefined
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const priorReports = input.priorReports ?? {}
+  const nextReports = input.nextReports ?? {}
+  const reportIds = Object.keys(nextReports).sort((left, right) => left.localeCompare(right))
+
+  const notes: ReportNote[] = []
+  let sequence = input.sequenceStart
+
+  for (const reportId of reportIds) {
+    const nextReport = nextReports[reportId]
+    if (!nextReport) {
+      continue
+    }
+
+    const addedEvents = collectAddedWeeklySyntheticEvents(priorReports[reportId], nextReport, input.week)
+    const sortedEvents = [...addedEvents].sort((left, right) =>
+      left.event.eventId.localeCompare(right.event.eventId)
+    )
+
+    for (const added of sortedEvents) {
+      const segments = extractWeeklyIntakeNarrativeSegments(added.event.sourceRef)
+      const content =
+        added.kind === 'corroboration'
+          ? formatCorroborationNoteContent(nextReport, added.event, segments)
+          : formatContradictionNoteContent(nextReport, added.event, segments)
+
+      notes.push(
+        createDeterministicReportNote(
+          content,
+          input.week,
+          sequence,
+          input.baseTimestamp,
+          'system.week_delta',
+          { delta: content }
+        )
+      )
+      sequence += 1
+    }
+  }
+
+  return notes
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4462,11 +4462,12 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.informationIntakeReports = nextIntakeReports
 
     // SPE-854 slice 7: project weekly intake verification narratives into report notes.
+    const lastWeeklyReport = result.reports[result.reports.length - 1]
     const intakeVerificationNotes = buildWeeklyIntakeVerificationReportNotes({
       priorReports: priorIntakeReports,
       nextReports: nextIntakeReports,
       week: intakeCorroborationWeek,
-      sequenceStart: (result.reports.at(-1)?.notes.length ?? 0) + 1,
+      sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,
     })
     if (intakeVerificationNotes.length > 0 && result.reports.length > 0) {

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -263,6 +263,7 @@ import {
   type CompactCivicAuthorityConsequencePacket,
 } from '../civicConsequenceNetwork'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
+import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
 import { decayCreditPackets, type CivicCreditPacket } from '../civicCreditChannel'
 import { decayAccessPackets, type CivicAccessPacket } from '../civicAccessChannel'
@@ -4453,11 +4454,31 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
 
   const priorIntakeReports = inputWeeklyState.informationIntakeReports ?? {}
   if (Object.keys(priorIntakeReports).length > 0) {
-    outputWeeklyState.informationIntakeReports = applyWeeklyIntakeCorroborationTick(
+    const nextIntakeReports = applyWeeklyIntakeCorroborationTick(
       priorIntakeReports,
       intakeCorroborationWeek,
       inputWeeklyState.cases
     )
+    outputWeeklyState.informationIntakeReports = nextIntakeReports
+
+    // SPE-854 slice 7: project weekly intake verification narratives into report notes.
+    const intakeVerificationNotes = buildWeeklyIntakeVerificationReportNotes({
+      priorReports: priorIntakeReports,
+      nextReports: nextIntakeReports,
+      week: intakeCorroborationWeek,
+      sequenceStart: (result.reports.at(-1)?.notes.length ?? 0) + 1,
+      baseTimestamp: noteBaseTimestamp,
+    })
+    if (intakeVerificationNotes.length > 0 && result.reports.length > 0) {
+      const reports = [...result.reports]
+      const lastReportIndex = reports.length - 1
+      const lastReport = reports[lastReportIndex]
+      reports[lastReportIndex] = {
+        ...lastReport,
+        notes: [...(lastReport.notes ?? []), ...intakeVerificationNotes],
+      }
+      result.reports = reports
+    }
   }
 
   // SPE-1265: Decay rumor packets each week; drop packets below the 0.05 signal threshold.

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -154,6 +154,47 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
     expect(second).toEqual(first)
   })
 
+  it('surfaces weekly intake verification narratives in the weekly report notes', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+
+    state.informationIntakeReports = {
+      [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports.at(-1)
+
+    expect(weeklyReport).toBeDefined()
+    const intakeNotes =
+      weeklyReport?.notes.filter((note) => note.content.includes('Intake verification —')) ?? []
+
+    expect(intakeNotes.length).toBeGreaterThan(0)
+
+    const formalNote = intakeNotes.find((note) =>
+      note.content.includes(FORMAL_ALERT_PARTIAL_FIXTURE.label)
+    )
+    expect(formalNote).toBeDefined()
+    expect(formalNote?.type).toBe('system.week_delta')
+    expect(formalNote?.content).toMatch(/corroboration \(.+; .+\)\./)
+
+    const nextLinkedReport = nextState.informationIntakeReports?.[FORMAL_ALERT_PARTIAL_FIXTURE.id]
+    const corroborationEvent = nextLinkedReport?.corroborationHistory.find((event) =>
+      event.eventId.startsWith('weekly-intake:')
+    )
+    expect(corroborationEvent).toBeDefined()
+    if (corroborationEvent) {
+      const traceMatch = corroborationEvent.sourceRef.match(/:trace-([^:]+)/)
+      const channelMatch = corroborationEvent.sourceRef.match(/:channel-([^:]+)/)
+      if (traceMatch?.[1]) {
+        expect(formalNote?.content).toContain(traceMatch[1].replace(/-/g, ' '))
+      }
+      if (channelMatch?.[1]) {
+        expect(formalNote?.content).toContain(channelMatch[1].replace(/-/g, ' '))
+      }
+    }
+  })
+
   it('shifts topic intake coverage band after weekly corroboration on formal alert', () => {
     const state = createStartingState()
     freezeCasesForQuietWeek(state)

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -163,7 +163,7 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
     }
 
     const nextState = advanceWeek(state)
-    const weeklyReport = nextState.reports.at(-1)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
 
     expect(weeklyReport).toBeDefined()
     const intakeNotes =


### PR DESCRIPTION
## Summary

- Add `buildWeeklyIntakeVerificationReportNotes` to project weekly synthetic corroboration/contradiction events into deterministic weekly report notes using narrative `sourceRef` segments (`trace-*`, `channel-*`, `dispute-*`, `cue-*`).
- Wire in `advanceWeek` immediately after `applyWeeklyIntakeCorroborationTick` (tick order unchanged).
- Integration test asserts intake verification notes appear on the weekly report with humanized narrative tokens.

## Linear

- **Slice:** [SPE-2298](https://linear.app/spectranoir/issue/SPE-2298) — Weekly intake verification narratives in report notes (slice 7)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — remains open (child slice only)

## Validation

- `npm run test:run -- src/test/advanceWeek.informationIntake.integration.test.ts`
- `npm run lint`

## Docs

- `planning/information-intake-weekly-hook-slice-7.md`
- `planning/backlog.md` (slice 6 shipped, slice 7 in progress)

## Deferred (out of slice)

- Dedicated `information_intake.verification` report note type + UI bucket
- Dynamic narrative templates from case outcome metadata
- Parent SPE-854 full acceptance

Made with [Cursor](https://cursor.com)