### PR TITLE
SPE-2299: dedicated intake verification report note type (slice 8)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -142,6 +142,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-weekly-hook-slice-5.md`                  | **Shipped**    | SPE-2296 / PR #2451; case/topic-linked weekly corroboration source derivation under SPE-854.                                                        |
 | `information-intake-weekly-hook-slice-6.md`                  | **Shipped**    | SPE-2297 / PR #2455; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                          |
 | `information-intake-weekly-hook-slice-7.md`                  | **Shipped**    | SPE-2298 / PR #2459; weekly intake verification narratives in report notes under SPE-854.                                                            |
+| `information-intake-weekly-hook-slice-8.md`                  | **In Progress** | SPE-2299; dedicated `information_intake.verification` report note type + UI bucket under SPE-854.                                                  |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-weekly-hook-slice-8.md
+++ b/planning/information-intake-weekly-hook-slice-8.md
@@ -1,0 +1,58 @@
+# SPE-854 — Dedicated intake verification report note type (slice 8)
+
+One-page implementation plan. Linear: [SPE-2299](https://linear.app/spectranoir/issue/SPE-2299). Follows shipped [SPE-2298](https://linear.app/spectranoir/issue/SPE-2298) (slice 7).
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2299 — Dedicated intake verification report note type (slice 8)](https://linear.app/spectranoir/issue/SPE-2299) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
+| **Branch** | `spe-854-information-intake-weekly-hook-slice-8` |
+| **Status** | **In Progress** |
+
+## Goal
+
+Add dedicated `information_intake.verification` report note type with UI categorization bucket; switch weekly intake verification note builder from `system.week_delta`.
+
+## Prerequisite (on `main` @ `6ea29a57f541585d14836d3ebe5f0c3d0cc91297`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Weekly intake verification report notes | `src/domain/informationIntakeWeeklyReportNotes.ts` (SPE-2298) |
+| Weekly intake tick in `advanceWeek` | `src/domain/sim/advanceWeek.ts` (SPE-2295+) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `ReportNoteType` union + audit registry | `InformationIntakeReportRecord` schema changes |
+| `runTransfer` hydration allowlist + metadata keys | Intake tick order changes |
+| `reportNoteView` `information_intake` category bucket | Parent SPE-854 closure |
+| Switch intake note builder from `system.week_delta` | UI copy beyond categorization |
+| Integration + audit/view tests | Dynamic narrative templates from case outcome metadata |
+
+## Acceptance
+
+- [ ] Intake verification notes use `information_intake.verification` with bounded metadata
+- [ ] Audit registry, `REPORT_NOTE_TYPES`, and `reportNoteView` stay aligned (39 types)
+- [ ] `npm run test:run -- src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts src/test/advanceWeek.informationIntake.integration.test.ts` and `npm run lint` pass
+
+## File touch list (expected)
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/models.ts`, `src/domain/informationIntakeWeeklyReportNotes.ts` |
+| Store | `src/app/store/runTransfer.ts` |
+| UI | `src/features/report/reportNoteView.ts` |
+| Tests | `src/test/reportNoteTypeAudit.test.ts`, `src/features/report/reportNoteView.test.ts`, `src/test/advanceWeek.informationIntake.integration.test.ts` |
+| Plan | `planning/information-intake-weekly-hook-slice-8.md`, `planning/backlog.md` |
+
+## Deferred (recorded for follow-up)
+
+| Item | Suggested owner | Why deferred (slice 8 boundary) |
+| ---- | --------------- | ----------------------------- |
+| Dynamic narrative templates from case outcome metadata | SPE-854 child | Slice 8 types/categorizes existing bounded narratives only |
+| Parent SPE-854 acceptance (mixed-source incident + operational routing) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Child slice only |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **Backlog** until full parent acceptance ships.

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -321,6 +321,7 @@ export const REPORT_NOTE_TYPES = [
   'hub.opportunity',
   'hub.rumor',
   'system.equipment_recovered',
+  'information_intake.verification',
 ] as const satisfies readonly ReportNoteType[]
 
 const REPORT_NOTE_METADATA_MAX_KEYS = 32
@@ -578,6 +579,13 @@ const REPORT_NOTE_METADATA_ALLOWLIST: Partial<Record<ReportNoteType, readonly st
   ],
   'hub.opportunity': ['label', 'summary', 'week'],
   'hub.rumor': ['label', 'summary', 'week'],
+  'information_intake.verification': [
+    'reportId',
+    'reportLabel',
+    'eventKind',
+    'verificationStatus',
+    'week',
+  ],
 }
 
 const FALLBACK_WEEKLY_DIRECTIVE_ID = getWeeklyDirectiveDefinitions()[0]?.id ?? 'intel-surge'

--- a/src/domain/informationIntakeWeeklyReportNotes.ts
+++ b/src/domain/informationIntakeWeeklyReportNotes.ts
@@ -171,8 +171,14 @@ export function buildWeeklyIntakeVerificationReportNotes(input: {
           input.week,
           sequence,
           input.baseTimestamp,
-          'system.week_delta',
-          { delta: content }
+          'information_intake.verification',
+          {
+            reportId,
+            reportLabel: nextReport.label,
+            eventKind: added.kind,
+            verificationStatus: nextReport.verificationStatus,
+            week: input.week,
+          }
         )
       )
       sequence += 1

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1491,6 +1491,7 @@ export type ReportNoteType =
   | 'hub.opportunity'
   | 'hub.rumor'
   | 'system.equipment_recovered'
+  | 'information_intake.verification'
 
 export type ReportNoteMetadataValue =
   | string

--- a/src/features/report/reportNoteView.test.ts
+++ b/src/features/report/reportNoteView.test.ts
@@ -56,6 +56,7 @@ const EXPECTED_CATEGORY_BY_TYPE = {
   'concealment.activated': 'system',
   'hub.opportunity': 'system',
   'hub.rumor': 'system',
+  'information_intake.verification': 'information_intake',
 } satisfies Record<ReportNoteType, ReportNoteCategory>
 
 describe('reportNoteView', () => {
@@ -106,6 +107,7 @@ describe('reportNoteView', () => {
 
   it('exposes stable category labels', () => {
     expect(REPORT_NOTE_CATEGORY_LABELS.incident_response).toBe('Incident response')
+    expect(REPORT_NOTE_CATEGORY_LABELS.information_intake).toBe('Information intake')
     expect(REPORT_NOTE_CATEGORY_LABELS.system).toBe('System')
   })
 })

--- a/src/features/report/reportNoteView.ts
+++ b/src/features/report/reportNoteView.ts
@@ -1,13 +1,21 @@
 import type { ReportNote, ReportNoteType } from '../../domain/models'
 
-export type ReportNoteCategory = 'incident_response' | 'recruitment' | 'system' | 'uncategorized'
+export type ReportNoteCategory =
+  | 'incident_response'
+  | 'recruitment'
+  | 'information_intake'
+  | 'system'
+  | 'uncategorized'
 
 export const REPORT_NOTE_CATEGORY_LABELS: Record<ReportNoteCategory, string> = {
   incident_response: 'Incident response',
   recruitment: 'Recruitment',
+  information_intake: 'Information intake',
   system: 'System',
   uncategorized: 'Uncategorized',
 }
+
+const INFORMATION_INTAKE_NOTE_TYPES: ReportNoteType[] = ['information_intake.verification']
 
 const INCIDENT_NOTE_TYPES: ReportNoteType[] = [
   'case.resolved',
@@ -59,6 +67,10 @@ const SYSTEM_NOTE_TYPES: ReportNoteType[] = [
 export function getReportNoteCategory(note: ReportNote): ReportNoteCategory {
   if (note.type !== undefined && RECRUITMENT_NOTE_TYPES.includes(note.type)) {
     return 'recruitment'
+  }
+
+  if (note.type !== undefined && INFORMATION_INTAKE_NOTE_TYPES.includes(note.type)) {
+    return 'information_intake'
   }
 
   if (note.type !== undefined && SYSTEM_NOTE_TYPES.includes(note.type)) {

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -175,7 +175,7 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
       note.content.includes(FORMAL_ALERT_PARTIAL_FIXTURE.label)
     )
     expect(formalNote).toBeDefined()
-    expect(formalNote?.type).toBe('system.week_delta')
+    expect(formalNote?.type).toBe('information_intake.verification')
     expect(formalNote?.content).toMatch(/corroboration \(.+; .+\)\./)
 
     const nextLinkedReport = nextState.informationIntakeReports?.[FORMAL_ALERT_PARTIAL_FIXTURE.id]

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -48,6 +48,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
   'hub.opportunity': { status: 'active', producer: 'hubReportNotes', category: 'system' },
   'hub.rumor': { status: 'active', producer: 'hubReportNotes', category: 'system' },
   'system.equipment_recovered': { status: 'active', producer: 'advanceWeek', category: 'system' },
+  'information_intake.verification': {
+    status: 'active',
+    producer: 'informationIntakeWeeklyReportNotes',
+    category: 'information_intake',
+  },
 } as const satisfies Record<
   ReportNoteType,
   { status: 'active' | 'future-reserved' | 'stale'; producer: string; category: string }
@@ -59,7 +64,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(38)
+    expect(entries).toHaveLength(39)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Add `information_intake.verification` to `ReportNoteType` with audit registry, `runTransfer` hydration allowlist, and bounded metadata keys (`reportId`, `reportLabel`, `eventKind`, `verificationStatus`, `week`).
- Add `information_intake` UI category bucket in `reportNoteView` for report note filtering.
- Switch `buildWeeklyIntakeVerificationReportNotes` from `system.week_delta` to the dedicated note type.

## Linear mapping

- **Slice:** [SPE-2299](https://linear.app/spectranoir/issue/SPE-2299) — Dedicated intake verification report note type (slice 8)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (remains open)

## Validation

- `npm run test:run -- src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts src/test/advanceWeek.informationIntake.integration.test.ts`
- `npm run test:run -- src/app/store/runTransfer.test.ts -t "502 keeps REPORT_NOTE_TYPES"`
- `npm run lint`

## Docs updated

- `planning/information-intake-weekly-hook-slice-8.md`
- `planning/backlog.md`

## Parent status

Parent SPE-854 remains open — child slice only; dynamic narrative templates and full parent acceptance deferred.
