### PR TITLE
SPE-2300: dynamic intake narrative templates from case outcome metadata (slice 9)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -142,7 +142,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-weekly-hook-slice-5.md`                  | **Shipped**    | SPE-2296 / PR #2451; case/topic-linked weekly corroboration source derivation under SPE-854.                                                        |
 | `information-intake-weekly-hook-slice-6.md`                  | **Shipped**    | SPE-2297 / PR #2455; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                          |
 | `information-intake-weekly-hook-slice-7.md`                  | **Shipped**    | SPE-2298 / PR #2459; weekly intake verification narratives in report notes under SPE-854.                                                            |
-| `information-intake-weekly-hook-slice-8.md`                  | **In Progress** | SPE-2299; dedicated `information_intake.verification` report note type + UI bucket under SPE-854.                                                  |
+| `information-intake-weekly-hook-slice-8.md`                  | **Shipped**    | SPE-2299 / PR #2461; dedicated `information_intake.verification` report note type + UI bucket under SPE-854.                                        |
+| `information-intake-weekly-hook-slice-9.md`                  | **In Progress** | SPE-2300; dynamic intake narrative templates from case outcome metadata under SPE-854.                                                              |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-weekly-hook-slice-8.md
+++ b/planning/information-intake-weekly-hook-slice-8.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2299](https://linear.app/spectranoir/
 | **Linear** | [SPE-2299 — Dedicated intake verification report note type (slice 8)](https://linear.app/spectranoir/issue/SPE-2299) |
 | **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
 | **Branch** | `spe-854-information-intake-weekly-hook-slice-8` |
-| **Status** | **In Progress** |
+| **Status** | **Shipped** (PR #2461) |
 
 ## Goal
 

--- a/planning/information-intake-weekly-hook-slice-9.md
+++ b/planning/information-intake-weekly-hook-slice-9.md
@@ -1,0 +1,56 @@
+# SPE-854 — Dynamic intake narrative templates from case outcome metadata (slice 9)
+
+One-page implementation plan. Linear: [SPE-2300](https://linear.app/spectranoir/issue/SPE-2300). Follows shipped [SPE-2299](https://linear.app/spectranoir/issue/SPE-2299) (slice 8).
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2300 — Dynamic intake narrative templates from case outcome metadata (slice 9)](https://linear.app/spectranoir/issue/SPE-2300) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
+| **Branch** | `spe-854-information-intake-weekly-hook-slice-9` |
+| **Status** | **In Progress** |
+
+## Goal
+
+Derive weekly intake corroboration/contradiction narrative content from linked case outcome metadata (stage, resolution/status, topic tags) instead of only humanizing bounded sourceRef tokens.
+
+## Prerequisite (on `main` @ `ec57221d`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Dedicated intake verification report note type | `src/domain/informationIntakeWeeklyReportNotes.ts` (SPE-2299) |
+| Narrative source-ref generator + case/topic linkage | `src/domain/informationIntakeWeeklyCorroboration.ts` (SPE-2297 / SPE-2296) |
+| Weekly intake tick in `advanceWeek` | `src/domain/sim/advanceWeek.ts` (SPE-2295+) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| Template derivation helper from case outcome metadata | `InformationIntakeReportRecord` schema changes |
+| Wire into weekly corroboration source-ref + report note paths | Report note type / UI categorization changes |
+| Integration + focused unit tests | Intake tick order changes |
+| Slice doc + backlog row | Parent SPE-854 closure |
+
+## Acceptance
+
+- [ ] Narrative tokens reflect linked case stage, status, and topic tags when available
+- [ ] Deterministic fallback when metadata is partial or missing
+- [ ] Existing idempotence and integration assertions preserved
+- [ ] `npm run test:run -- src/test/informationIntakeWeeklyNarrativeTemplates.test.ts src/test/advanceWeek.informationIntake.integration.test.ts src/test/reportNoteTypeAudit.test.ts` and `npm run lint` pass
+
+## File touch list (expected)
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/informationIntakeWeeklyNarrativeTemplates.ts`, `src/domain/informationIntakeWeeklyCorroboration.ts`, `src/domain/informationIntakeWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests | `src/test/informationIntakeWeeklyNarrativeTemplates.test.ts`, `src/test/advanceWeek.informationIntake.integration.test.ts` |
+| Plan | `planning/information-intake-weekly-hook-slice-9.md`, `planning/backlog.md` |
+
+## Deferred (recorded for follow-up)
+
+| Item | Suggested owner | Why deferred (slice 9 boundary) |
+| ---- | --------------- | ----------------------------- |
+| Parent SPE-854 acceptance (mixed-source incident + operational routing) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Child slice only |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **Backlog** until full parent acceptance ships (parent closure still deferred).

--- a/src/domain/informationIntakeWeeklyCorroboration.ts
+++ b/src/domain/informationIntakeWeeklyCorroboration.ts
@@ -14,6 +14,13 @@ import {
   type InformationIntakeReportsMap,
   type IntakeSourceClass,
 } from './informationIntakeReport'
+import {
+  buildWeeklyIntakeCaseOutcomeMetadata,
+  selectWeeklyIntakeContradictionCueToken,
+  selectWeeklyIntakeContradictionDisputeToken,
+  selectWeeklyIntakeCorroborationChannelToken,
+  selectWeeklyIntakeCorroborationTraceToken,
+} from './informationIntakeWeeklyNarrativeTemplates'
 import type { CaseInstance } from './models'
 
 type WeeklyIntakeSyntheticEvent =
@@ -22,7 +29,14 @@ type WeeklyIntakeSyntheticEvent =
 
 type WeeklyCorroborationCaseContext = Pick<
   CaseInstance,
-  'id' | 'templateId' | 'title' | 'status' | 'tags' | 'requiredTags' | 'preferredTags'
+  | 'id'
+  | 'templateId'
+  | 'title'
+  | 'status'
+  | 'stage'
+  | 'tags'
+  | 'requiredTags'
+  | 'preferredTags'
 >
 
 export function buildWeeklyIntakeSyntheticEventId(
@@ -148,32 +162,30 @@ function resolveCorroborationSourceClass(
   }
 }
 
-function pickNarrativeToken(tokens: readonly string[], reportId: string, week: number, offset: number): string {
-  if (tokens.length === 0) {
-    return 'baseline'
-  }
-
-  const index = (stableOrdinalFromId(reportId) + normalizeWeek(week) + offset) % tokens.length
-  return tokens[index] ?? 'baseline'
-}
-
 function buildWeeklyContradictionSourceRef(
   normalizedTopic: string,
   caseSegment: string,
   report: InformationIntakeReportRecord,
   week: number,
-  hasLinkedCases: boolean
+  hasLinkedCases: boolean,
+  linkedCaseIds: readonly string[],
+  cases: readonly WeeklyCorroborationCaseContext[]
 ): string {
-  const disputeTokens = hasLinkedCases
-    ? ['conflict-window', 'witness-mismatch', 'timeline-drift']
-    : ['confidence-drop', 'signal-gap', 'unsupported-claim']
-  const dispute = pickNarrativeToken(disputeTokens, report.id, week, 0)
-  const sourceCue = pickNarrativeToken(
-    ['audit-trace', 'triage-review', 'cross-check'],
-    report.id,
+  const metadata = buildWeeklyIntakeCaseOutcomeMetadata(linkedCaseIds, cases)
+  const dispute = selectWeeklyIntakeContradictionDisputeToken({
+    metadata,
+    hasLinkedCases,
+    reportId: report.id,
     week,
-    report.topicRef.length
-  )
+    offset: 0,
+  })
+  const sourceCue = selectWeeklyIntakeContradictionCueToken({
+    metadata,
+    hasLinkedCases,
+    reportId: report.id,
+    week,
+    offset: report.topicRef.length,
+  })
   return `audit:weekly-intake:${normalizedTopic}:${caseSegment}:dispute-${dispute}:cue-${sourceCue}`
 }
 
@@ -182,14 +194,25 @@ function buildWeeklyCorroborationSourceRef(
   caseSegment: string,
   report: InformationIntakeReportRecord,
   week: number,
-  hasLinkedCases: boolean
+  hasLinkedCases: boolean,
+  linkedCaseIds: readonly string[],
+  cases: readonly WeeklyCorroborationCaseContext[]
 ): string {
-  const traceTokens = hasLinkedCases
-    ? ['linked-case', 'coincident-signal', 'field-alignment']
-    : ['ambient-signal', 'community-thread', 'partner-check']
-  const channelTokens = ['routing-sync', 'watchlist-match', 'pattern-stability']
-  const trace = pickNarrativeToken(traceTokens, report.id, week, 1)
-  const channel = pickNarrativeToken(channelTokens, report.id, week, report.topicRef.length + 1)
+  const metadata = buildWeeklyIntakeCaseOutcomeMetadata(linkedCaseIds, cases)
+  const trace = selectWeeklyIntakeCorroborationTraceToken({
+    metadata,
+    hasLinkedCases,
+    reportId: report.id,
+    week,
+    offset: 1,
+  })
+  const channel = selectWeeklyIntakeCorroborationChannelToken({
+    metadata,
+    hasLinkedCases,
+    reportId: report.id,
+    week,
+    offset: report.topicRef.length + 1,
+  })
   return `source:weekly-intake:${normalizedTopic}:${caseSegment}:trace-${trace}:channel-${channel}`
 }
 
@@ -216,7 +239,9 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
           caseSegment,
           report,
           normalizedWeek,
-          hasLinkedCases
+          hasLinkedCases,
+          linkedCaseIds,
+          cases
         ),
         severity: hasLinkedCases ? 'minor' : 'major',
       },
@@ -249,7 +274,9 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
           caseSegment,
           report,
           normalizedWeek,
-          hasLinkedCases
+          hasLinkedCases,
+          linkedCaseIds,
+          cases
         ),
         sourceClass,
         weight: baseWeight,
@@ -268,7 +295,9 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
           caseSegment,
           report,
           normalizedWeek,
-          hasLinkedCases
+          hasLinkedCases,
+          linkedCaseIds,
+          cases
         ),
         sourceClass: 'technical_trace',
         weight: 0.22,
@@ -286,7 +315,9 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
         caseSegment,
         report,
         normalizedWeek,
-        hasLinkedCases
+        hasLinkedCases,
+        linkedCaseIds,
+        cases
       ),
       sourceClass: resolveCorroborationSourceClass(report.initialSourceClass, hasLinkedCases),
       weight: hasLinkedCases ? 0.16 : 0.12,

--- a/src/domain/informationIntakeWeeklyCorroboration.ts
+++ b/src/domain/informationIntakeWeeklyCorroboration.ts
@@ -169,9 +169,10 @@ function buildWeeklyContradictionSourceRef(
   week: number,
   hasLinkedCases: boolean,
   linkedCaseIds: readonly string[],
-  cases: readonly WeeklyCorroborationCaseContext[]
+  linkingCases: readonly WeeklyCorroborationCaseContext[],
+  outcomeCases: readonly WeeklyCorroborationCaseContext[]
 ): string {
-  const metadata = buildWeeklyIntakeCaseOutcomeMetadata(linkedCaseIds, cases)
+  const metadata = buildWeeklyIntakeCaseOutcomeMetadata(linkedCaseIds, outcomeCases)
   const dispute = selectWeeklyIntakeContradictionDisputeToken({
     metadata,
     hasLinkedCases,
@@ -196,9 +197,10 @@ function buildWeeklyCorroborationSourceRef(
   week: number,
   hasLinkedCases: boolean,
   linkedCaseIds: readonly string[],
-  cases: readonly WeeklyCorroborationCaseContext[]
+  linkingCases: readonly WeeklyCorroborationCaseContext[],
+  outcomeCases: readonly WeeklyCorroborationCaseContext[]
 ): string {
-  const metadata = buildWeeklyIntakeCaseOutcomeMetadata(linkedCaseIds, cases)
+  const metadata = buildWeeklyIntakeCaseOutcomeMetadata(linkedCaseIds, outcomeCases)
   const trace = selectWeeklyIntakeCorroborationTraceToken({
     metadata,
     hasLinkedCases,
@@ -219,10 +221,11 @@ function buildWeeklyCorroborationSourceRef(
 function resolveCaseTopicLinkedWeeklySyntheticEvent(
   report: InformationIntakeReportRecord,
   week: number,
-  cases: readonly WeeklyCorroborationCaseContext[]
+  linkingCases: readonly WeeklyCorroborationCaseContext[],
+  outcomeCases: readonly WeeklyCorroborationCaseContext[] = linkingCases
 ): WeeklyIntakeSyntheticEvent | null {
   const normalizedWeek = normalizeWeek(week)
-  const linkedCaseIds = getMatchingCaseIds(report, cases)
+  const linkedCaseIds = getMatchingCaseIds(report, linkingCases)
   const hasLinkedCases = linkedCaseIds.length > 0
   const phase = (normalizedWeek + stableOrdinalFromId(report.id) + linkedCaseIds.length) % 6
   const normalizedTopic = normalizeToken(report.topicRef)
@@ -241,7 +244,8 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
           normalizedWeek,
           hasLinkedCases,
           linkedCaseIds,
-          cases
+          linkingCases,
+          outcomeCases
         ),
         severity: hasLinkedCases ? 'minor' : 'major',
       },
@@ -276,7 +280,8 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
           normalizedWeek,
           hasLinkedCases,
           linkedCaseIds,
-          cases
+          linkingCases,
+          outcomeCases
         ),
         sourceClass,
         weight: baseWeight,
@@ -297,7 +302,8 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
           normalizedWeek,
           hasLinkedCases,
           linkedCaseIds,
-          cases
+          linkingCases,
+          outcomeCases
         ),
         sourceClass: 'technical_trace',
         weight: 0.22,
@@ -317,7 +323,8 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
         normalizedWeek,
         hasLinkedCases,
         linkedCaseIds,
-        cases
+        linkingCases,
+        outcomeCases
       ),
       sourceClass: resolveCorroborationSourceClass(report.initialSourceClass, hasLinkedCases),
       weight: hasLinkedCases ? 0.16 : 0.12,
@@ -332,10 +339,12 @@ function resolveCaseTopicLinkedWeeklySyntheticEvent(
 export function applyWeeklyIntakeCorroborationTick(
   reports: InformationIntakeReportsMap | null | undefined,
   week: number,
-  casesById?: Record<string, WeeklyCorroborationCaseContext> | null
+  casesById?: Record<string, WeeklyCorroborationCaseContext> | null,
+  outcomeCasesById?: Record<string, WeeklyCorroborationCaseContext> | null
 ): InformationIntakeReportsMap {
   const safeReports = reports ?? {}
-  const cases = Object.values(casesById ?? {})
+  const linkingCases = Object.values(casesById ?? {})
+  const outcomeCases = Object.values(outcomeCasesById ?? casesById ?? {})
   const reportIds = Object.keys(safeReports)
   if (reportIds.length === 0) {
     return safeReports
@@ -349,7 +358,12 @@ export function applyWeeklyIntakeCorroborationTick(
       continue
     }
 
-    const synthetic = resolveCaseTopicLinkedWeeklySyntheticEvent(report, week, cases)
+    const synthetic = resolveCaseTopicLinkedWeeklySyntheticEvent(
+      report,
+      week,
+      linkingCases,
+      outcomeCases
+    )
     if (!synthetic) {
       continue
     }

--- a/src/domain/informationIntakeWeeklyNarrativeTemplates.ts
+++ b/src/domain/informationIntakeWeeklyNarrativeTemplates.ts
@@ -1,0 +1,377 @@
+/**
+ * SPE-854 slice 9: derive weekly intake narrative segments from linked case outcome metadata.
+ *
+ * Uses stage, resolution (status), and topic tags to select corroboration/contradiction narrative
+ * tokens deterministically. Falls back to bounded sourceRef segments when metadata is absent.
+ */
+
+import type { CaseStatus } from './models'
+
+export type WeeklyIntakeCaseOutcomeMetadata = {
+  readonly primaryCaseId: string
+  readonly stage: number
+  readonly resolution: CaseStatus
+  readonly topicTags: readonly string[]
+}
+
+export type WeeklyIntakeNarrativeEventKind = 'corroboration' | 'contradiction'
+
+type WeeklyIntakeCaseOutcomeSource = {
+  readonly id: string
+  readonly stage?: number
+  readonly status?: CaseStatus
+  readonly tags?: readonly string[]
+  readonly requiredTags?: readonly string[]
+  readonly preferredTags?: readonly string[]
+}
+
+const UNLINKED_CORROBORATION_TRACE_TOKENS = [
+  'ambient-signal',
+  'community-thread',
+  'partner-check',
+] as const
+
+const LINKED_CORROBORATION_TRACE_TOKENS_BY_STAGE = {
+  early: ['initial-signal', 'emerging-pattern', 'first-contact'],
+  mid: ['linked-case', 'coincident-signal', 'field-alignment'],
+  late: ['deep-corroboration', 'multi-source-lock', 'escalation-confirm'],
+} as const
+
+const UNLINKED_CORROBORATION_CHANNEL_TOKENS = [
+  'routing-sync',
+  'watchlist-match',
+  'pattern-stability',
+] as const
+
+const OPEN_CORROBORATION_CHANNEL_TOKENS = [
+  'watchlist-match',
+  'routing-sync',
+  'pattern-stability',
+] as const
+
+const IN_PROGRESS_CORROBORATION_CHANNEL_TOKENS = [
+  'active-case-sync',
+  'field-routing',
+  'priority-channel',
+] as const
+
+const UNLINKED_CONTRADICTION_DISPUTE_TOKENS = [
+  'confidence-drop',
+  'signal-gap',
+  'unsupported-claim',
+] as const
+
+const LINKED_CONTRADICTION_DISPUTE_TOKENS_BY_STAGE = {
+  early: ['confidence-drop', 'signal-gap', 'unsupported-claim'],
+  mid: ['witness-mismatch', 'timeline-drift', 'conflict-window'],
+  late: ['escalation-drift', 'conflict-window', 'witness-mismatch'],
+} as const
+
+const OPEN_CONTRADICTION_CUE_TOKENS = ['audit-trace', 'triage-review', 'cross-check'] as const
+
+const IN_PROGRESS_CONTRADICTION_CUE_TOKENS = [
+  'cross-check',
+  'case-review',
+  'field-audit',
+] as const
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function stableOrdinalFromId(id: string): number {
+  let hash = 0
+  for (let index = 0; index < id.length; index += 1) {
+    hash = (hash + id.charCodeAt(index) * (index + 1)) % 997
+  }
+
+  return hash
+}
+
+function normalizeTopicTag(value: string): string | null {
+  const normalized = value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  if (normalized.length < 4) {
+    return null
+  }
+
+  return normalized
+}
+
+function collectTopicTags(source: WeeklyIntakeCaseOutcomeSource): string[] {
+  const tags = new Set<string>()
+  const addTag = (value: string) => {
+    const normalized = normalizeTopicTag(value)
+    if (normalized) {
+      tags.add(normalized)
+    }
+  }
+
+  for (const tag of source.tags ?? []) addTag(tag)
+  for (const tag of source.requiredTags ?? []) addTag(tag)
+  for (const tag of source.preferredTags ?? []) addTag(tag)
+
+  return [...tags].sort((left, right) => left.localeCompare(right))
+}
+
+function normalizeStage(stage: number | undefined): number {
+  if (stage === undefined || !Number.isFinite(stage)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(stage))
+}
+
+function normalizeResolution(status: CaseStatus | undefined): CaseStatus {
+  if (status === 'in_progress' || status === 'resolved') {
+    return status
+  }
+
+  return 'open'
+}
+
+function stageBand(stage: number): keyof typeof LINKED_CORROBORATION_TRACE_TOKENS_BY_STAGE {
+  if (stage <= 2) {
+    return 'early'
+  }
+
+  if (stage <= 4) {
+    return 'mid'
+  }
+
+  return 'late'
+}
+
+function pickDeterministicToken(
+  tokens: readonly string[],
+  reportId: string,
+  week: number,
+  offset: number
+): string {
+  if (tokens.length === 0) {
+    return 'baseline'
+  }
+
+  const index = (stableOrdinalFromId(reportId) + normalizeWeek(week) + offset) % tokens.length
+  return tokens[index] ?? 'baseline'
+}
+
+/**
+ * Builds outcome metadata for the primary linked case (first sorted id) plus merged topic tags.
+ */
+export function buildWeeklyIntakeCaseOutcomeMetadata(
+  linkedCaseIds: readonly string[],
+  cases: readonly WeeklyIntakeCaseOutcomeSource[]
+): WeeklyIntakeCaseOutcomeMetadata | null {
+  if (linkedCaseIds.length === 0) {
+    return null
+  }
+
+  const casesById = new Map(cases.map((currentCase) => [currentCase.id, currentCase]))
+  const sortedLinkedIds = [...linkedCaseIds].sort((left, right) => left.localeCompare(right))
+  const primaryCase = casesById.get(sortedLinkedIds[0] ?? '')
+  if (!primaryCase) {
+    return null
+  }
+
+  const mergedTopicTags = new Set<string>()
+  for (const caseId of sortedLinkedIds) {
+    const linkedCase = casesById.get(caseId)
+    if (!linkedCase) {
+      continue
+    }
+
+    for (const tag of collectTopicTags(linkedCase)) {
+      mergedTopicTags.add(tag)
+    }
+  }
+
+  return {
+    primaryCaseId: primaryCase.id,
+    stage: normalizeStage(primaryCase.stage),
+    resolution: normalizeResolution(primaryCase.status),
+    topicTags: [...mergedTopicTags].sort((left, right) => left.localeCompare(right)),
+  }
+}
+
+function withTopicTagTokens(
+  baseTokens: readonly string[],
+  topicTags: readonly string[],
+  reportId: string,
+  week: number
+): readonly string[] {
+  if (topicTags.length === 0) {
+    return baseTokens
+  }
+
+  const tagToken = pickDeterministicToken(topicTags, reportId, week, topicTags.length)
+  return [...baseTokens, `topic-${tagToken}`]
+}
+
+export function selectWeeklyIntakeCorroborationTraceToken(input: {
+  metadata: WeeklyIntakeCaseOutcomeMetadata | null
+  hasLinkedCases: boolean
+  reportId: string
+  week: number
+  offset: number
+}): string {
+  const tokens = input.hasLinkedCases
+    ? input.metadata
+      ? LINKED_CORROBORATION_TRACE_TOKENS_BY_STAGE[stageBand(input.metadata.stage)]
+      : (['linked-case', 'coincident-signal', 'field-alignment'] as const)
+    : UNLINKED_CORROBORATION_TRACE_TOKENS
+
+  return pickDeterministicToken(tokens, input.reportId, input.week, input.offset)
+}
+
+export function selectWeeklyIntakeCorroborationChannelToken(input: {
+  metadata: WeeklyIntakeCaseOutcomeMetadata | null
+  hasLinkedCases: boolean
+  reportId: string
+  week: number
+  offset: number
+}): string {
+  let tokens: readonly string[] = UNLINKED_CORROBORATION_CHANNEL_TOKENS
+
+  if (input.hasLinkedCases && input.metadata) {
+    tokens =
+      input.metadata.resolution === 'in_progress'
+        ? IN_PROGRESS_CORROBORATION_CHANNEL_TOKENS
+        : OPEN_CORROBORATION_CHANNEL_TOKENS
+    tokens = withTopicTagTokens(tokens, input.metadata.topicTags, input.reportId, input.week)
+  }
+
+  return pickDeterministicToken(tokens, input.reportId, input.week, input.offset)
+}
+
+export function selectWeeklyIntakeContradictionDisputeToken(input: {
+  metadata: WeeklyIntakeCaseOutcomeMetadata | null
+  hasLinkedCases: boolean
+  reportId: string
+  week: number
+  offset: number
+}): string {
+  const tokens = input.hasLinkedCases
+    ? input.metadata
+      ? LINKED_CONTRADICTION_DISPUTE_TOKENS_BY_STAGE[stageBand(input.metadata.stage)]
+      : (['conflict-window', 'witness-mismatch', 'timeline-drift'] as const)
+    : UNLINKED_CONTRADICTION_DISPUTE_TOKENS
+
+  return pickDeterministicToken(tokens, input.reportId, input.week, input.offset)
+}
+
+export function selectWeeklyIntakeContradictionCueToken(input: {
+  metadata: WeeklyIntakeCaseOutcomeMetadata | null
+  hasLinkedCases: boolean
+  reportId: string
+  week: number
+  offset: number
+}): string {
+  let tokens: readonly string[] = OPEN_CONTRADICTION_CUE_TOKENS
+
+  if (input.hasLinkedCases && input.metadata?.resolution === 'in_progress') {
+    tokens = IN_PROGRESS_CONTRADICTION_CUE_TOKENS
+  }
+
+  if (input.hasLinkedCases && input.metadata && input.metadata.topicTags.length > 0) {
+    tokens = withTopicTagTokens(tokens, input.metadata.topicTags, input.reportId, input.week)
+  }
+
+  return pickDeterministicToken(tokens, input.reportId, input.week, input.offset)
+}
+
+export type WeeklyIntakeNarrativeSegments = {
+  readonly trace?: string
+  readonly channel?: string
+  readonly dispute?: string
+  readonly cue?: string
+}
+
+const NARRATIVE_SEGMENT_PATTERNS = {
+  trace: /:trace-([^:]+)/,
+  channel: /:channel-([^:]+)/,
+  dispute: /:dispute-([^:]+)/,
+  cue: /:cue-([^:]+)/,
+} as const
+
+export function extractWeeklyIntakeNarrativeSegmentsFromSourceRef(
+  sourceRef: string
+): WeeklyIntakeNarrativeSegments {
+  const trace = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.trace)?.[1]
+  const channel = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.channel)?.[1]
+  const dispute = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.dispute)?.[1]
+  const cue = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.cue)?.[1]
+
+  return {
+    ...(trace ? { trace } : {}),
+    ...(channel ? { channel } : {}),
+    ...(dispute ? { dispute } : {}),
+    ...(cue ? { cue } : {}),
+  }
+}
+
+/**
+ * Derives narrative segment labels from case outcome metadata, falling back to sourceRef tokens.
+ */
+export function deriveWeeklyIntakeNarrativeSegments(input: {
+  sourceRef: string
+  eventKind: WeeklyIntakeNarrativeEventKind
+  metadata: WeeklyIntakeCaseOutcomeMetadata | null
+  hasLinkedCases: boolean
+  reportId: string
+  week: number
+}): WeeklyIntakeNarrativeSegments {
+  const fromSourceRef = extractWeeklyIntakeNarrativeSegmentsFromSourceRef(input.sourceRef)
+
+  if (input.eventKind === 'corroboration') {
+    return {
+      trace:
+        fromSourceRef.trace ??
+        selectWeeklyIntakeCorroborationTraceToken({
+          metadata: input.metadata,
+          hasLinkedCases: input.hasLinkedCases,
+          reportId: input.reportId,
+          week: input.week,
+          offset: 1,
+        }),
+      channel:
+        fromSourceRef.channel ??
+        selectWeeklyIntakeCorroborationChannelToken({
+          metadata: input.metadata,
+          hasLinkedCases: input.hasLinkedCases,
+          reportId: input.reportId,
+          week: input.week,
+          offset: input.sourceRef.length + 1,
+        }),
+    }
+  }
+
+  return {
+    dispute:
+      fromSourceRef.dispute ??
+      selectWeeklyIntakeContradictionDisputeToken({
+        metadata: input.metadata,
+        hasLinkedCases: input.hasLinkedCases,
+        reportId: input.reportId,
+        week: input.week,
+        offset: 0,
+      }),
+    cue:
+      fromSourceRef.cue ??
+      selectWeeklyIntakeContradictionCueToken({
+        metadata: input.metadata,
+        hasLinkedCases: input.hasLinkedCases,
+        reportId: input.reportId,
+        week: input.week,
+        offset: input.sourceRef.length,
+      }),
+  }
+}

--- a/src/domain/informationIntakeWeeklyNarrativeTemplates.ts
+++ b/src/domain/informationIntakeWeeklyNarrativeTemplates.ts
@@ -328,8 +328,10 @@ export function deriveWeeklyIntakeNarrativeSegments(input: {
   hasLinkedCases: boolean
   reportId: string
   week: number
+  topicRef?: string
 }): WeeklyIntakeNarrativeSegments {
   const fromSourceRef = extractWeeklyIntakeNarrativeSegmentsFromSourceRef(input.sourceRef)
+  const topicRefLength = input.topicRef?.length ?? 0
 
   if (input.eventKind === 'corroboration') {
     return {
@@ -349,7 +351,7 @@ export function deriveWeeklyIntakeNarrativeSegments(input: {
           hasLinkedCases: input.hasLinkedCases,
           reportId: input.reportId,
           week: input.week,
-          offset: input.sourceRef.length + 1,
+          offset: topicRefLength + 1,
         }),
     }
   }
@@ -371,7 +373,7 @@ export function deriveWeeklyIntakeNarrativeSegments(input: {
         hasLinkedCases: input.hasLinkedCases,
         reportId: input.reportId,
         week: input.week,
-        offset: input.sourceRef.length,
+        offset: topicRefLength,
       }),
   }
 }

--- a/src/domain/informationIntakeWeeklyReportNotes.ts
+++ b/src/domain/informationIntakeWeeklyReportNotes.ts
@@ -12,24 +12,23 @@ import type {
   InformationIntakeReportsMap,
   InformationVerificationStatus,
 } from './informationIntakeReport'
-import type { ReportNote } from './models'
+import {
+  buildWeeklyIntakeCaseOutcomeMetadata,
+  deriveWeeklyIntakeNarrativeSegments,
+  extractWeeklyIntakeNarrativeSegmentsFromSourceRef,
+  type WeeklyIntakeNarrativeSegments,
+} from './informationIntakeWeeklyNarrativeTemplates'
+import type { CaseInstance, ReportNote } from './models'
 import { createDeterministicReportNote } from './reportNotes'
 
 const WEEKLY_SYNTHETIC_EVENT_ID_PREFIX = 'weekly-intake:'
 
-const NARRATIVE_SEGMENT_PATTERNS = {
-  trace: /:trace-([^:]+)/,
-  channel: /:channel-([^:]+)/,
-  dispute: /:dispute-([^:]+)/,
-  cue: /:cue-([^:]+)/,
-} as const
+export type { WeeklyIntakeNarrativeSegments }
 
-export type WeeklyIntakeNarrativeSegments = {
-  readonly trace?: string
-  readonly channel?: string
-  readonly dispute?: string
-  readonly cue?: string
-}
+type WeeklyIntakeReportCaseContext = Pick<
+  CaseInstance,
+  'id' | 'stage' | 'status' | 'tags' | 'requiredTags' | 'preferredTags'
+>
 
 type WeeklyIntakeVerificationEventRef =
   | { readonly kind: 'corroboration'; readonly event: CorroborationEvent }
@@ -40,21 +39,73 @@ function humanizeNarrativeToken(token: string): string {
 }
 
 export function extractWeeklyIntakeNarrativeSegments(sourceRef: string): WeeklyIntakeNarrativeSegments {
-  const trace = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.trace)?.[1]
-  const channel = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.channel)?.[1]
-  const dispute = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.dispute)?.[1]
-  const cue = sourceRef.match(NARRATIVE_SEGMENT_PATTERNS.cue)?.[1]
-
-  return {
-    ...(trace ? { trace } : {}),
-    ...(channel ? { channel } : {}),
-    ...(dispute ? { dispute } : {}),
-    ...(cue ? { cue } : {}),
-  }
+  return extractWeeklyIntakeNarrativeSegmentsFromSourceRef(sourceRef)
 }
 
 function isWeeklySyntheticEventId(eventId: string): boolean {
   return eventId.startsWith(WEEKLY_SYNTHETIC_EVENT_ID_PREFIX)
+}
+
+function extractLinkedCaseIdsFromSourceRef(sourceRef: string): readonly string[] {
+  const weeklyIntakeMatch = sourceRef.match(/:weekly-intake:[^:]+:([^:]+):/)
+  const caseSegment = weeklyIntakeMatch?.[1]
+  if (!caseSegment || caseSegment === 'no-case-link') {
+    return []
+  }
+
+  return caseSegment
+    .split('+')
+    .map((caseId) => caseId.trim())
+    .filter((caseId) => caseId.length > 0)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function resolveLinkedCaseIdsForReport(
+  report: InformationIntakeReportRecord,
+  sourceRef: string,
+  casesById: Record<string, WeeklyIntakeReportCaseContext> | null | undefined
+): readonly string[] {
+  const fromSourceRef = extractLinkedCaseIdsFromSourceRef(sourceRef)
+  if (fromSourceRef.length > 0) {
+    return fromSourceRef
+  }
+
+  const cases = Object.values(casesById ?? {})
+  if (cases.length === 0) {
+    return []
+  }
+
+  const normalizedTopicRef = report.topicRef.trim().toLowerCase()
+  const exactMatches = cases
+    .filter((currentCase) => currentCase.id.trim().toLowerCase() === normalizedTopicRef)
+    .map((currentCase) => currentCase.id)
+    .sort((left, right) => left.localeCompare(right))
+
+  if (exactMatches.length > 0) {
+    return exactMatches
+  }
+
+  return []
+}
+
+function resolveWeeklyIntakeNarrativeSegments(input: {
+  report: InformationIntakeReportRecord
+  eventKind: 'corroboration' | 'contradiction'
+  sourceRef: string
+  week: number
+  casesById: Record<string, WeeklyIntakeReportCaseContext> | null | undefined
+}): WeeklyIntakeNarrativeSegments {
+  const linkedCaseIds = resolveLinkedCaseIdsForReport(input.report, input.sourceRef, input.casesById)
+  const metadata = buildWeeklyIntakeCaseOutcomeMetadata(linkedCaseIds, Object.values(input.casesById ?? {}))
+
+  return deriveWeeklyIntakeNarrativeSegments({
+    sourceRef: input.sourceRef,
+    eventKind: input.eventKind,
+    metadata,
+    hasLinkedCases: linkedCaseIds.length > 0,
+    reportId: input.report.id,
+    week: input.week,
+  })
 }
 
 function formatVerificationStatusLabel(status: InformationVerificationStatus): string {
@@ -141,6 +192,7 @@ export function buildWeeklyIntakeVerificationReportNotes(input: {
   week: number
   sequenceStart: number
   baseTimestamp?: number
+  casesById?: Record<string, WeeklyIntakeReportCaseContext> | null
 }): ReportNote[] {
   const priorReports = input.priorReports ?? {}
   const nextReports = input.nextReports ?? {}
@@ -159,7 +211,13 @@ export function buildWeeklyIntakeVerificationReportNotes(input: {
     addedEvents.sort((left, right) => left.event.eventId.localeCompare(right.event.eventId))
 
     for (const added of addedEvents) {
-      const segments = extractWeeklyIntakeNarrativeSegments(added.event.sourceRef)
+      const segments = resolveWeeklyIntakeNarrativeSegments({
+        report: nextReport,
+        eventKind: added.kind,
+        sourceRef: added.event.sourceRef,
+        week: input.week,
+        casesById: input.casesById,
+      })
       const content =
         added.kind === 'corroboration'
           ? formatCorroborationNoteContent(nextReport, segments)

--- a/src/domain/informationIntakeWeeklyReportNotes.ts
+++ b/src/domain/informationIntakeWeeklyReportNotes.ts
@@ -47,8 +47,8 @@ function isWeeklySyntheticEventId(eventId: string): boolean {
 }
 
 function extractLinkedCaseIdsFromSourceRef(sourceRef: string): readonly string[] {
-  const weeklyIntakeMatch = sourceRef.match(/:weekly-intake:[^:]+:([^:]+):/)
-  const caseSegment = weeklyIntakeMatch?.[1]
+  const parts = sourceRef.split(':')
+  const caseSegment = parts[1] === 'weekly-intake' ? parts[3] : undefined
   if (!caseSegment || caseSegment === 'no-case-link') {
     return []
   }
@@ -105,6 +105,7 @@ function resolveWeeklyIntakeNarrativeSegments(input: {
     hasLinkedCases: linkedCaseIds.length > 0,
     reportId: input.report.id,
     week: input.week,
+    topicRef: input.report.topicRef,
   })
 }
 

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4457,7 +4457,8 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     const nextIntakeReports = applyWeeklyIntakeCorroborationTick(
       priorIntakeReports,
       intakeCorroborationWeek,
-      inputWeeklyState.cases
+      inputWeeklyState.cases,
+      outputWeeklyState.cases
     )
     outputWeeklyState.informationIntakeReports = nextIntakeReports
 
@@ -4469,7 +4470,7 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       week: intakeCorroborationWeek,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,
-      casesById: inputWeeklyState.cases,
+      casesById: outputWeeklyState.cases,
     })
     if (intakeVerificationNotes.length > 0 && result.reports.length > 0) {
       const reports = [...result.reports]

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4469,6 +4469,7 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       week: intakeCorroborationWeek,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,
+      casesById: inputWeeklyState.cases,
     })
     if (intakeVerificationNotes.length > 0 && result.reports.length > 0) {
       const reports = [...result.reports]

--- a/src/test/advanceWeek.informationIntake.integration.test.ts
+++ b/src/test/advanceWeek.informationIntake.integration.test.ts
@@ -137,6 +137,54 @@ describe('advanceWeek information intake corroboration integration (SPE-854 slic
     expect(contradictionEvent?.sourceRef).toContain(':cue-')
   })
 
+  it('uses linked case stage and status metadata in corroboration narrative tokens', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    const linkedCase = Object.values(state.cases)[0]
+    linkedCase.stage = 6
+    linkedCase.status = 'in_progress'
+    linkedCase.tags = ['occult', 'investigation']
+    const week = state.week
+
+    const linkedReport = createInformationIntakeReport({
+      id: 'intake:metadata-linked-case',
+      label: 'Metadata-linked corroboration probe',
+      topicRef: linkedCase.id,
+      initialSourceClass: 'formal_alert',
+      credibility: 'high',
+      plausibility: 'plausible',
+      rumorRisk: 'low',
+    })
+
+    state.informationIntakeReports = {
+      [linkedReport.id]: linkedReport,
+    }
+
+    const nextState = advanceWeek(state)
+    const nextLinkedReport = nextState.informationIntakeReports?.[linkedReport.id]
+    expect(nextLinkedReport).toBeDefined()
+
+    const corroborationEventId = buildWeeklyIntakeSyntheticEventId(linkedReport.id, week, 'corroboration')
+    const corroborationEvent = nextLinkedReport?.corroborationHistory.find(
+      (event) => event.eventId === corroborationEventId
+    )
+
+    if (corroborationEvent) {
+      expect(corroborationEvent.sourceRef).toMatch(/:trace-(deep-corroboration|multi-source-lock|escalation-confirm)/)
+      expect(corroborationEvent.sourceRef).toMatch(
+        /:channel-(active-case-sync|field-routing|priority-channel|topic-occult|topic-investigation)/
+      )
+    } else {
+      const contradictionEventId = buildWeeklyIntakeSyntheticEventId(linkedReport.id, week, 'contradiction')
+      const contradictionEvent = nextLinkedReport?.contradictionHistory.find(
+        (event) => event.eventId === contradictionEventId
+      )
+      expect(contradictionEvent?.sourceRef).toMatch(
+        /:dispute-(escalation-drift|conflict-window|witness-mismatch)/
+      )
+    }
+  })
+
   it('treats null or undefined report maps as empty without throwing', () => {
     expect(applyWeeklyIntakeCorroborationTick(null, 3)).toEqual({})
     expect(applyWeeklyIntakeCorroborationTick(undefined, 3)).toEqual({})

--- a/src/test/informationIntakeWeeklyNarrativeTemplates.test.ts
+++ b/src/test/informationIntakeWeeklyNarrativeTemplates.test.ts
@@ -115,15 +115,27 @@ describe('informationIntakeWeeklyNarrativeTemplates (SPE-854 slice 9)', () => {
     expect(derived.channel).toBeTruthy()
   })
 
-  it('falls back to unlinked token pools when metadata is absent', () => {
-    const trace = selectWeeklyIntakeCorroborationTraceToken({
+  it('uses topicRef length for fallback channel/cue offsets to match generation', () => {
+    const topicRef = 'district-alpha'
+    const derived = deriveWeeklyIntakeNarrativeSegments({
+      sourceRef: 'source:weekly-intake:topic:case-001:trace-:channel-',
+      eventKind: 'corroboration',
       metadata: null,
       hasLinkedCases: false,
-      reportId: 'intake:rumor',
-      week: 1,
-      offset: 0,
+      reportId: 'intake:probe',
+      week: 3,
+      topicRef,
     })
 
-    expect(['ambient-signal', 'community-thread', 'partner-check']).toContain(trace)
+    expect(derived.trace).toBeTruthy()
+    expect(derived.channel).toBeTruthy()
+  })
+
+  it('extracts linked case ids from colon-delimited weekly intake source refs', () => {
+    const sourceRef = 'source:weekly-intake:formal-alert:case-alpha+case-beta:trace-linked-case:channel-watchlist-match'
+    const segments = extractWeeklyIntakeNarrativeSegmentsFromSourceRef(sourceRef)
+
+    expect(segments.trace).toBe('linked-case')
+    expect(segments.channel).toBe('watchlist-match')
   })
 })

--- a/src/test/informationIntakeWeeklyNarrativeTemplates.test.ts
+++ b/src/test/informationIntakeWeeklyNarrativeTemplates.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildWeeklyIntakeCaseOutcomeMetadata,
+  deriveWeeklyIntakeNarrativeSegments,
+  extractWeeklyIntakeNarrativeSegmentsFromSourceRef,
+  selectWeeklyIntakeCorroborationChannelToken,
+  selectWeeklyIntakeCorroborationTraceToken,
+} from '../domain/informationIntakeWeeklyNarrativeTemplates'
+
+describe('informationIntakeWeeklyNarrativeTemplates (SPE-854 slice 9)', () => {
+  it('builds outcome metadata from the primary linked case and merged topic tags', () => {
+    const metadata = buildWeeklyIntakeCaseOutcomeMetadata(['case-beta', 'case-alpha'], [
+      {
+        id: 'case-alpha',
+        stage: 3,
+        status: 'in_progress',
+        tags: ['occult'],
+        requiredTags: ['investigation'],
+        preferredTags: [],
+      },
+      {
+        id: 'case-beta',
+        stage: 1,
+        status: 'open',
+        tags: ['urban'],
+        requiredTags: [],
+        preferredTags: [],
+      },
+    ])
+
+    expect(metadata).toEqual({
+      primaryCaseId: 'case-alpha',
+      stage: 3,
+      resolution: 'in_progress',
+      topicTags: ['investigation', 'occult', 'urban'],
+    })
+  })
+
+  it('returns null metadata when no linked cases are provided', () => {
+    expect(buildWeeklyIntakeCaseOutcomeMetadata([], [])).toBeNull()
+  })
+
+  it('selects stage-aware corroboration trace tokens for linked cases', () => {
+    const earlyTrace = selectWeeklyIntakeCorroborationTraceToken({
+      metadata: {
+        primaryCaseId: 'case-1',
+        stage: 1,
+        resolution: 'open',
+        topicTags: [],
+      },
+      hasLinkedCases: true,
+      reportId: 'intake:formal-alert',
+      week: 4,
+      offset: 1,
+    })
+    const lateTrace = selectWeeklyIntakeCorroborationTraceToken({
+      metadata: {
+        primaryCaseId: 'case-1',
+        stage: 6,
+        resolution: 'open',
+        topicTags: [],
+      },
+      hasLinkedCases: true,
+      reportId: 'intake:formal-alert',
+      week: 4,
+      offset: 1,
+    })
+
+    expect(['initial-signal', 'emerging-pattern', 'first-contact']).toContain(earlyTrace)
+    expect(['deep-corroboration', 'multi-source-lock', 'escalation-confirm']).toContain(lateTrace)
+  })
+
+  it('includes topic-tag channel tokens for in-progress linked cases', () => {
+    const channel = selectWeeklyIntakeCorroborationChannelToken({
+      metadata: {
+        primaryCaseId: 'case-1',
+        stage: 2,
+        resolution: 'in_progress',
+        topicTags: ['occult'],
+      },
+      hasLinkedCases: true,
+      reportId: 'intake:linked-case',
+      week: 2,
+      offset: 3,
+    })
+
+    expect(['active-case-sync', 'field-routing', 'priority-channel', 'topic-occult']).toContain(channel)
+  })
+
+  it('derives narrative segments from sourceRef and falls back when segments are missing', () => {
+    const sourceRef =
+      'source:weekly-intake:formal-alert:case-001:trace-linked-case:channel-watchlist-match'
+    const fromSourceRef = extractWeeklyIntakeNarrativeSegmentsFromSourceRef(sourceRef)
+
+    expect(fromSourceRef).toEqual({
+      trace: 'linked-case',
+      channel: 'watchlist-match',
+    })
+
+    const derived = deriveWeeklyIntakeNarrativeSegments({
+      sourceRef: 'source:weekly-intake:topic:case-001:trace-:channel-',
+      eventKind: 'corroboration',
+      metadata: {
+        primaryCaseId: 'case-001',
+        stage: 4,
+        resolution: 'open',
+        topicTags: ['occult'],
+      },
+      hasLinkedCases: true,
+      reportId: 'intake:probe',
+      week: 3,
+    })
+
+    expect(derived.trace).toBeTruthy()
+    expect(derived.channel).toBeTruthy()
+  })
+
+  it('falls back to unlinked token pools when metadata is absent', () => {
+    const trace = selectWeeklyIntakeCorroborationTraceToken({
+      metadata: null,
+      hasLinkedCases: false,
+      reportId: 'intake:rumor',
+      week: 1,
+      offset: 0,
+    })
+
+    expect(['ambient-signal', 'community-thread', 'partner-check']).toContain(trace)
+  })
+})


### PR DESCRIPTION
## Summary

- Add \informationIntakeWeeklyNarrativeTemplates\ helper to derive corroboration/contradiction narrative tokens from linked case outcome metadata (stage, resolution/status, topic tags) with deterministic fallback when metadata is partial or missing.
- Wire metadata-driven token selection into weekly corroboration source-ref generation and weekly intake verification report notes (\dvanceWeek\ passes \casesById\).
- Extend integration and unit tests; update slice-9 plan/backlog and mark slice-8 doc shipped (PR #2461).

## Linear mapping

- **Slice issue:** [SPE-2300](https://linear.app/spectranoir/issue/SPE-2300)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — remains open (parent acceptance still deferred)

## What shipped

- \src/domain/informationIntakeWeeklyNarrativeTemplates.ts\ — template derivation + token selectors
- \src/domain/informationIntakeWeeklyCorroboration.ts\ — metadata-informed source refs
- \src/domain/informationIntakeWeeklyReportNotes.ts\ — derive segments from metadata + sourceRef
- \src/domain/sim/advanceWeek.ts\ — pass cases into report note builder
- Tests: \informationIntakeWeeklyNarrativeTemplates.test.ts\, extended \dvanceWeek.informationIntake.integration.test.ts\
- Docs: \planning/information-intake-weekly-hook-slice-9.md\, backlog row; slice-8 status → Shipped

## Validation

- \
pm run test:run -- src/test/informationIntakeWeeklyNarrativeTemplates.test.ts src/test/advanceWeek.informationIntake.integration.test.ts src/test/reportNoteTypeAudit.test.ts\
- \
pm run lint\

## Parent remains open

SPE-854 parent acceptance (mixed-source incident + operational routing) is **not** closed by this child slice.

Made with [Cursor](https://cursor.com)