### PR TITLE
feat(SPE-2301): mixed-source intake mission routing integration (SPE-854 parent slice 1)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -143,7 +143,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-weekly-hook-slice-6.md`                  | **Shipped**    | SPE-2297 / PR #2455; deterministic narrative corroboration/contradiction source-ref generator under SPE-854.                                          |
 | `information-intake-weekly-hook-slice-7.md`                  | **Shipped**    | SPE-2298 / PR #2459; weekly intake verification narratives in report notes under SPE-854.                                                            |
 | `information-intake-weekly-hook-slice-8.md`                  | **Shipped**    | SPE-2299 / PR #2461; dedicated `information_intake.verification` report note type + UI bucket under SPE-854.                                        |
-| `information-intake-weekly-hook-slice-9.md`                  | **In Progress** | SPE-2300; dynamic intake narrative templates from case outcome metadata under SPE-854.                                                              |
+| `information-intake-weekly-hook-slice-9.md`                  | **Shipped**    | SPE-2300 / PR #2463; dynamic intake narrative templates from case outcome metadata under SPE-854.                                                    |
+| `information-intake-parent-integration-slice-1.md`           | **In Progress** | SPE-2301; mixed-source intake → mission triage/routing under SPE-854.                                                                               |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-parent-integration-slice-1.md
+++ b/planning/information-intake-parent-integration-slice-1.md
@@ -1,0 +1,58 @@
+# SPE-854 — Mixed-source intake mission routing integration (parent slice 1)
+
+One-page implementation plan. Linear: [SPE-2301](https://linear.app/spectranoir/issue/SPE-2301). Follows shipped weekly-hook slices [SPE-2292](https://linear.app/spectranoir/issue/SPE-2292)–[SPE-2300](https://linear.app/spectranoir/issue/SPE-2300).
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2301 — Mixed-source intake mission routing integration (parent slice 1)](https://linear.app/spectranoir/issue/SPE-2301) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
+| **Branch** | `spe-854-information-intake-parent-integration-slice-1` |
+| **Status** | **In Progress** |
+
+## Goal
+
+Wire persisted `informationIntakeReports` into mission intake triage and routing so mixed-source verification and coverage signals adjust operational priority and intake source — without reopening weekly-hook mechanics.
+
+## Prerequisite (on `main` @ `6b537551`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Intake report model + persistence | `informationIntakeReport.ts`, GameState (SPE-2292 / SPE-2293) |
+| Topic coverage compose | `evaluateTopicIntakeCoverage` (SPE-2294) |
+| Weekly corroboration + report notes | SPE-2295–SPE-2300 |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `missionIntakeInformationRouting.ts` — topic key resolution, report linkage, routing signals | New registry rows |
+| `triageMission` score + `intake-*` reason codes | UI copy / triage panel layout |
+| `deriveMissionIntakeSource(state)` nonstandard hook → `pressure` | Weekly tick / narrative template changes |
+| Integration tests | Parent SPE-854 Done |
+
+## Acceptance
+
+- [ ] Canal-bridge mixed fixtures linked via `topic:` tag raise triage score and emit `intake-*` reason codes
+- [ ] Conflicting incomplete intake maps to `pressure` when case would otherwise be `scripted`
+- [ ] Missions without linked reports remain triage-stable
+- [ ] `npm run test:run -- src/test/missionIntakeInformationRouting.integration.test.ts src/test/mission.intake.triage.routing.test.ts src/test/reportNoteTypeAudit.test.ts` and `npm run lint` pass
+
+## File touch list
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/missionIntakeInformationRouting.ts`, `src/domain/missionIntakeRouting.ts` |
+| Tests | `src/test/missionIntakeInformationRouting.integration.test.ts` |
+| Plan | `planning/information-intake-parent-integration-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Full parent SPE-854 acceptance (remaining acceptance bullets) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Slice 1 covers routing integration only |
+| UI surfacing of intake signals on Cases triage panel | SPE-16 or UX child | Domain-only slice |
+| Hydration path `sanitizePersistedMissionRoutingState` intake linkage | Follow-up child | `normalizeMissionRecord` recomputes live state |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress** until full parent acceptance ships.

--- a/planning/information-intake-weekly-hook-slice-9.md
+++ b/planning/information-intake-weekly-hook-slice-9.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2300](https://linear.app/spectranoir/
 | **Linear** | [SPE-2300 — Dynamic intake narrative templates from case outcome metadata (slice 9)](https://linear.app/spectranoir/issue/SPE-2300) |
 | **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
 | **Branch** | `spe-854-information-intake-weekly-hook-slice-9` |
-| **Status** | **Shipped** (PR #2463) |
+| **Status** | **Shipped** (PR #2463; `main` @ `6b537551`) |
 
 ## Goal
 
@@ -53,4 +53,4 @@ Derive weekly intake corroboration/contradiction narrative content from linked c
 
 ## Parent
 
-Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **Backlog** until full parent acceptance ships (parent closure still deferred).
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **In Progress** until full parent acceptance ships (parent closure still deferred).

--- a/src/domain/missionIntakeInformationRouting.ts
+++ b/src/domain/missionIntakeInformationRouting.ts
@@ -1,0 +1,166 @@
+/**
+ * SPE-854 parent integration slice 1: mixed-source intake → mission triage/routing.
+ *
+ * Links persisted information intake reports to mission cases and surfaces
+ * operational signals through triage score adjustments and reason codes.
+ */
+
+import type { InformationIntakeReportRecord } from './informationIntakeReport'
+import {
+  evaluateTopicIntakeCoverage,
+  type PublicSignalCoverageBand,
+} from './publicSignalCoverage'
+import type { CaseInstance, GameState, MissionIntakeSource } from './models'
+
+function normalizeToken(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim().toLowerCase()
+}
+
+export function resolveMissionIntakeTopicKeys(
+  currentCase: Pick<CaseInstance, 'id' | 'tags'>
+): readonly string[] {
+  const keys = new Set<string>([normalizeToken(currentCase.id)])
+
+  for (const tag of currentCase.tags) {
+    const normalized = normalizeToken(tag)
+    if (!normalized) {
+      continue
+    }
+
+    keys.add(normalized)
+    keys.add(normalized.startsWith('topic:') ? normalized : `topic:${normalized}`)
+  }
+
+  return [...keys].sort((left, right) => left.localeCompare(right))
+}
+
+export function listInformationIntakeReportsForMission(
+  state: Pick<GameState, 'informationIntakeReports'>,
+  currentCase: Pick<CaseInstance, 'id' | 'tags'>
+): InformationIntakeReportRecord[] {
+  const reports = state.informationIntakeReports
+  if (!reports) {
+    return []
+  }
+
+  const topicKeys = new Set(resolveMissionIntakeTopicKeys(currentCase))
+  const linked: InformationIntakeReportRecord[] = []
+
+  for (const report of Object.values(reports)) {
+    const topicRef = normalizeToken(report.topicRef)
+    if (topicKeys.has(topicRef)) {
+      linked.push(report)
+    }
+  }
+
+  return linked.sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export interface MissionIntakeInformationRoutingSignals {
+  readonly linkedReportCount: number
+  readonly coverageBand: PublicSignalCoverageBand | null
+  readonly scoreAdjustment: number
+  readonly reasonCodes: string[]
+  readonly intakeSourceOverride: MissionIntakeSource | null
+}
+
+const NEUTRAL_SIGNALS: MissionIntakeInformationRoutingSignals = {
+  linkedReportCount: 0,
+  coverageBand: null,
+  scoreAdjustment: 0,
+  reasonCodes: [],
+  intakeSourceOverride: null,
+}
+
+function coverageReasonCode(band: PublicSignalCoverageBand): string {
+  return `intake-coverage-${band.replace(/_/g, '-')}`
+}
+
+function clampInteger(value: number, min: number, max: number) {
+  if (!Number.isFinite(value)) {
+    return min
+  }
+
+  return Math.max(min, Math.min(max, Math.trunc(value)))
+}
+
+export function deriveMissionIntakeInformationSignals(
+  state: Pick<GameState, 'informationIntakeReports'>,
+  currentCase: Pick<CaseInstance, 'id' | 'tags' | 'contract' | 'stage' | 'factionId'>
+): MissionIntakeInformationRoutingSignals {
+  const linkedReports = listInformationIntakeReportsForMission(state, currentCase)
+  if (linkedReports.length === 0) {
+    return NEUTRAL_SIGNALS
+  }
+
+  const primaryTopicRef = normalizeToken(linkedReports[0]?.topicRef) || currentCase.id
+  const coverage = evaluateTopicIntakeCoverage({
+    topicId: primaryTopicRef,
+    reports: linkedReports,
+  })
+  const summary = coverage.intakeSummary
+
+  let scoreAdjustment = 0
+  const reasonCodes: string[] = ['intake-linked-reports']
+
+  if (summary.hasConflictingVerification) {
+    scoreAdjustment += 6
+    reasonCodes.push('intake-verification-conflict')
+  }
+
+  if (summary.hasIncompleteIntake) {
+    scoreAdjustment += 4
+    reasonCodes.push('intake-incomplete')
+  }
+
+  if (coverage.coverageBand === 'blind_spot') {
+    scoreAdjustment += 5
+    reasonCodes.push('intake-coverage-blind-spot')
+  } else if (coverage.coverageBand === 'public_led') {
+    scoreAdjustment += 3
+    reasonCodes.push('intake-coverage-public-led')
+  } else {
+    reasonCodes.push(coverageReasonCode(coverage.coverageBand))
+  }
+
+  if (
+    summary.dominantVerificationStatus === 'verified' ||
+    summary.dominantVerificationStatus === 'escalated_confidence'
+  ) {
+    scoreAdjustment -= 2
+    reasonCodes.push('intake-verification-corroborated')
+  }
+
+  if (summary.rumorSeparatedCount > 0) {
+    reasonCodes.push('intake-rumor-separated')
+  }
+
+  let intakeSourceOverride: MissionIntakeSource | null = null
+  const wouldDefaultToScripted =
+    !currentCase.contract &&
+    currentCase.stage <= 1 &&
+    !currentCase.factionId &&
+    !currentCase.id.startsWith('case-spawned-')
+
+  if (
+    wouldDefaultToScripted &&
+    (coverage.coverageBand === 'blind_spot' ||
+      coverage.coverageBand === 'public_led' ||
+      summary.hasConflictingVerification)
+  ) {
+    intakeSourceOverride = 'pressure'
+    reasonCodes.push('intake-nonstandard-hook')
+  }
+
+  return {
+    linkedReportCount: linkedReports.length,
+    coverageBand: coverage.coverageBand,
+    scoreAdjustment: clampInteger(scoreAdjustment, -8, 18),
+    reasonCodes: [...new Set(reasonCodes)].sort((left, right) => left.localeCompare(right)),
+    intakeSourceOverride,
+  }
+}

--- a/src/domain/missionIntakeInformationRouting.ts
+++ b/src/domain/missionIntakeInformationRouting.ts
@@ -7,7 +7,7 @@
 
 import type { InformationIntakeReportRecord } from './informationIntakeReport'
 import {
-  evaluateTopicIntakeCoverage,
+  evaluateTopicIntakeCoverageFromLinkedReports,
   type PublicSignalCoverageBand,
 } from './publicSignalCoverage'
 import type { CaseInstance, GameState, MissionIntakeSource } from './models'
@@ -25,7 +25,7 @@ export function resolveMissionIntakeTopicKeys(
 ): readonly string[] {
   const keys = new Set<string>([normalizeToken(currentCase.id)])
 
-  for (const tag of currentCase.tags) {
+  for (const tag of currentCase.tags ?? []) {
     const normalized = normalizeToken(tag)
     if (!normalized) {
       continue
@@ -97,11 +97,8 @@ export function deriveMissionIntakeInformationSignals(
     return NEUTRAL_SIGNALS
   }
 
-  const primaryTopicRef = normalizeToken(linkedReports[0]?.topicRef) || currentCase.id
-  const coverage = evaluateTopicIntakeCoverage({
-    topicId: primaryTopicRef,
-    reports: linkedReports,
-  })
+  const topicLabel = normalizeToken(currentCase.id) || normalizeToken(linkedReports[0]?.topicRef)
+  const coverage = evaluateTopicIntakeCoverageFromLinkedReports(topicLabel, linkedReports)
   const summary = coverage.intakeSummary
 
   let scoreAdjustment = 0

--- a/src/domain/missionIntakeRouting.ts
+++ b/src/domain/missionIntakeRouting.ts
@@ -10,6 +10,7 @@ import {
   rankBestAvailableTeams,
   validateTeamComposition,
 } from './teamComposition'
+import { deriveMissionIntakeInformationSignals } from './missionIntakeInformationRouting'
 import type {
   Agent,
   CaseInstance,
@@ -102,7 +103,10 @@ export function deriveMissionCategory(currentCase: CaseInstance): MissionCategor
   return 'strategic_opportunity'
 }
 
-export function deriveMissionIntakeSource(currentCase: CaseInstance): MissionIntakeSource {
+export function deriveMissionIntakeSource(
+  currentCase: CaseInstance,
+  state?: Pick<GameState, 'informationIntakeReports'>
+): MissionIntakeSource {
   if (currentCase.contract) {
     return 'contract'
   }
@@ -121,6 +125,13 @@ export function deriveMissionIntakeSource(currentCase: CaseInstance): MissionInt
 
   if (currentCase.factionId) {
     return 'faction'
+  }
+
+  if (state) {
+    const intakeSignals = deriveMissionIntakeInformationSignals(state, currentCase)
+    if (intakeSignals.intakeSourceOverride) {
+      return intakeSignals.intakeSourceOverride
+    }
   }
 
   return 'scripted'
@@ -193,6 +204,8 @@ export function triageMission(state: GameState, currentCase: CaseInstance): Miss
   const budgetPenalty = clampInteger(fundingPressure.deploymentTriagePenalty, 0, 10)
   const attritionPenalty = clampInteger(attritionPressure.deploymentTriagePenalty, 0, 8)
 
+  const intakeSignals = deriveMissionIntakeInformationSignals(state, currentCase)
+
   const score = clampInteger(
     urgency +
       threatSeverity +
@@ -201,12 +214,14 @@ export function triageMission(state: GameState, currentCase: CaseInstance): Miss
       capacityPenalty -
       intelRisk -
       budgetPenalty -
-      attritionPenalty,
+      attritionPenalty +
+      intakeSignals.scoreAdjustment,
     0,
     100
   )
 
   const reasonCodes = uniqueSortedStrings([
+    ...intakeSignals.reasonCodes,
     urgency >= 24 ? 'urgency-high' : urgency >= 12 ? 'urgency-medium' : 'urgency-low',
     threatSeverity >= 18 ? 'threat-high' : threatSeverity >= 10 ? 'threat-medium' : 'threat-low',
     escalationRisk >= 14 ? 'escalation-high' : escalationRisk >= 7 ? 'escalation-medium' : 'escalation-low',
@@ -715,7 +730,9 @@ function normalizeMissionRecord(
     requiredTags: [...caseData.requiredTags],
     preferredTags: [...caseData.preferredTags],
     assignedTeamIds: [...caseData.assignedTeamIds],
-    intakeSource: sanitizeIntakeSource(existing?.intakeSource ?? deriveMissionIntakeSource(caseData)),
+    intakeSource: sanitizeIntakeSource(
+      existing?.intakeSource ?? deriveMissionIntakeSource(caseData, state)
+    ),
     priority: sanitizePriority(existing?.priority ?? triage.priority),
     priorityReasonCodes: uniqueSortedStrings(existing?.priorityReasonCodes ?? triage.reasonCodes),
     triageScore: clampInteger(existing?.triageScore ?? triage.score, 0, 100),

--- a/src/domain/missionIntakeRouting.ts
+++ b/src/domain/missionIntakeRouting.ts
@@ -730,9 +730,7 @@ function normalizeMissionRecord(
     requiredTags: [...caseData.requiredTags],
     preferredTags: [...caseData.preferredTags],
     assignedTeamIds: [...caseData.assignedTeamIds],
-    intakeSource: sanitizeIntakeSource(
-      existing?.intakeSource ?? deriveMissionIntakeSource(caseData, state)
-    ),
+    intakeSource: sanitizeIntakeSource(deriveMissionIntakeSource(caseData, state)),
     priority: sanitizePriority(existing?.priority ?? triage.priority),
     priorityReasonCodes: uniqueSortedStrings(existing?.priorityReasonCodes ?? triage.reasonCodes),
     triageScore: clampInteger(existing?.triageScore ?? triage.score, 0, 100),

--- a/src/domain/publicSignalCoverage.ts
+++ b/src/domain/publicSignalCoverage.ts
@@ -541,6 +541,42 @@ function mergeStructuredReasons(
   return [...new Set(merged)].sort((left, right) => left.localeCompare(right))
 }
 
+export function evaluateTopicIntakeCoverageFromLinkedReports(
+  topicId: string,
+  linkedReports: readonly InformationIntakeReportRecord[],
+  input: Pick<TopicIntakeCoverageRequest, 'districtId' | 'crawlerReachBand' | 'inferenceModelBand'> = {}
+): TopicIntakeCoverageResult {
+  const normalizedTopicId = normalizeToken(topicId) || '(unknown-topic)'
+  const intakeSummary = normalizeIntakeSummaryTopicRef(
+    summarizeMixedSourceIntake(linkedReports),
+    normalizedTopicId
+  )
+  const projectedChannelFlags = projectChannelFlagsFromIntakeReports(linkedReports)
+
+  const crawlerReachBand =
+    input.crawlerReachBand ??
+    deriveCrawlerReachBandFromIntake({ projected: projectedChannelFlags, intakeSummary })
+  const inferenceModelBand =
+    input.inferenceModelBand ?? deriveInferenceModelBandFromIntake(intakeSummary)
+
+  const coverage = evaluatePublicSignalCoverage({
+    topicId: normalizedTopicId,
+    districtId: input.districtId,
+    institutionalChannels: projectedChannelFlags.institutionalChannels,
+    publicChannels: projectedChannelFlags.publicChannels,
+    crawlerReachBand,
+    inferenceModelBand,
+  })
+
+  return {
+    ...coverage,
+    topicId: normalizedTopicId,
+    structuredReasons: mergeStructuredReasons(coverage.structuredReasons, intakeSummary.structuredReasons),
+    intakeSummary,
+    projectedChannelFlags,
+  }
+}
+
 export function evaluateTopicIntakeCoverage(
   input: TopicIntakeCoverageRequest = {}
 ): TopicIntakeCoverageResult {
@@ -552,34 +588,12 @@ export function evaluateTopicIntakeCoverage(
     '(unknown-topic)'
 
   const topicReports = resolveTopicReports(input.reports, topicId)
-  const intakeSummary = normalizeIntakeSummaryTopicRef(
-    summarizeMixedSourceIntake(topicReports),
-    topicId
-  )
-  const projectedChannelFlags = projectChannelFlagsFromIntakeReports(topicReports)
 
-  const crawlerReachBand =
-    input.crawlerReachBand ??
-    deriveCrawlerReachBandFromIntake({ projected: projectedChannelFlags, intakeSummary })
-  const inferenceModelBand =
-    input.inferenceModelBand ?? deriveInferenceModelBandFromIntake(intakeSummary)
-
-  const coverage = evaluatePublicSignalCoverage({
-    topicId,
+  return evaluateTopicIntakeCoverageFromLinkedReports(topicId, topicReports, {
     districtId: input.districtId,
-    institutionalChannels: projectedChannelFlags.institutionalChannels,
-    publicChannels: projectedChannelFlags.publicChannels,
-    crawlerReachBand,
-    inferenceModelBand,
+    crawlerReachBand: input.crawlerReachBand,
+    inferenceModelBand: input.inferenceModelBand,
   })
-
-  return {
-    ...coverage,
-    topicId,
-    structuredReasons: mergeStructuredReasons(coverage.structuredReasons, intakeSummary.structuredReasons),
-    intakeSummary,
-    projectedChannelFlags,
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test/missionIntakeInformationRouting.integration.test.ts
+++ b/src/test/missionIntakeInformationRouting.integration.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { createStarterCase } from '../domain/templates/startingCases'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import {
+  deriveMissionIntakeInformationSignals,
+  listInformationIntakeReportsForMission,
+} from '../domain/missionIntakeInformationRouting'
+import {
+  deriveMissionIntakeSource,
+  recomputeMissionRouting,
+  triageMission,
+} from '../domain/missionIntakeRouting'
+
+const CANAL_BRIDGE_TOPIC = 'topic:canal-bridge-incident'
+
+const canalBridgeFixtures = [
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+]
+
+describe('mission intake information routing integration (SPE-854 parent slice 1)', () => {
+  it('links intake reports to missions via topic tags', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+
+    const mission = {
+      ...state.cases['case-001'],
+      tags: [...state.cases['case-001'].tags, CANAL_BRIDGE_TOPIC],
+    }
+
+    const linked = listInformationIntakeReportsForMission(state, mission)
+    expect(linked).toHaveLength(3)
+    expect(linked.map((report) => report.id).sort()).toEqual(
+      canalBridgeFixtures.map((report) => report.id).sort()
+    )
+  })
+
+  it('raises triage score and surfaces intake reason codes for mixed-source canal-bridge intake', () => {
+    const state = createStartingState()
+    const baselineMission = createStarterCase({
+      id: 'case-intake-triage-baseline',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    baselineMission.factionId = undefined
+    const baseline = triageMission(state, baselineMission)
+
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+    const linkedMission = {
+      ...baselineMission,
+      tags: [...baselineMission.tags, CANAL_BRIDGE_TOPIC],
+    }
+
+    const withIntake = triageMission(state, linkedMission)
+
+    expect(withIntake.score).toBeGreaterThan(baseline.score)
+    expect(withIntake.reasonCodes).toContain('intake-linked-reports')
+    expect(withIntake.reasonCodes).toContain('intake-verification-conflict')
+    expect(withIntake.reasonCodes).toContain('intake-incomplete')
+    expect(withIntake.reasonCodes).toContain('intake-rumor-separated')
+    expect(withIntake.reasonCodes).toContain('intake-nonstandard-hook')
+  })
+
+  it('maps conflicting public-led intake to pressure intake source for scripted missions', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+
+    const mission = createStarterCase({
+      id: 'case-intake-source-routing',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+
+    expect(deriveMissionIntakeSource(mission)).toBe('scripted')
+    expect(deriveMissionIntakeSource(mission, state)).toBe('pressure')
+
+    const routing = recomputeMissionRouting({
+      ...state,
+      cases: {
+        ...state.cases,
+        [mission.id]: mission,
+      },
+    })
+
+    expect(routing.missions[mission.id]?.intakeSource).toBe('pressure')
+    expect(routing.missions[mission.id]?.priorityReasonCodes).toContain('intake-linked-reports')
+  })
+
+  it('returns neutral signals when no reports link to the mission', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = {
+      [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+    }
+
+    const mission = state.cases['case-001']
+    const signals = deriveMissionIntakeInformationSignals(state, mission)
+
+    expect(signals).toEqual({
+      linkedReportCount: 0,
+      coverageBand: null,
+      scoreAdjustment: 0,
+      reasonCodes: [],
+      intakeSourceOverride: null,
+    })
+    expect(triageMission(state, mission)).toEqual(triageMission({ ...state, informationIntakeReports: {} }, mission))
+  })
+})

--- a/src/test/missionIntakeInformationRouting.integration.test.ts
+++ b/src/test/missionIntakeInformationRouting.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { createStarterCase } from '../domain/templates/startingCases'
 import {
+  createInformationIntakeReport,
   FORMAL_ALERT_PARTIAL_FIXTURE,
   IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
   PUBLIC_RUMOR_CONFLICT_FIXTURE,
@@ -12,6 +13,7 @@ import {
 } from '../domain/missionIntakeInformationRouting'
 import {
   deriveMissionIntakeSource,
+  normalizeMissionRoutingState,
   recomputeMissionRouting,
   triageMission,
 } from '../domain/missionIntakeRouting'
@@ -98,6 +100,81 @@ describe('mission intake information routing integration (SPE-854 parent slice 1
 
     expect(routing.missions[mission.id]?.intakeSource).toBe('pressure')
     expect(routing.missions[mission.id]?.priorityReasonCodes).toContain('intake-linked-reports')
+  })
+
+  it('evaluates coverage across linked reports with different topic refs', () => {
+    const state = createStartingState()
+    const missionId = 'case-mixed-topic-refs'
+
+    const reportOnCaseId = createInformationIntakeReport({
+      id: 'intake:case-id-link',
+      label: 'Case-id linked formal trace',
+      topicRef: missionId,
+      initialSourceClass: 'formal_alert',
+      credibility: 'institutional',
+      plausibility: 'plausible',
+      rumorRisk: 'none',
+      verificationStatus: 'partially_corroborated',
+      confidenceScore: 0.55,
+    })
+
+    state.informationIntakeReports = {
+      [reportOnCaseId.id]: reportOnCaseId,
+      [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+      [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: {
+        ...IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+        topicRef: CANAL_BRIDGE_TOPIC,
+      },
+    }
+
+    const mission = createStarterCase({
+      id: missionId,
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+
+    const signals = deriveMissionIntakeInformationSignals(state, mission)
+
+    expect(signals.linkedReportCount).toBe(3)
+    expect(signals.reasonCodes).toContain('intake-verification-conflict')
+    expect(signals.reasonCodes).toContain('intake-rumor-separated')
+  })
+
+  it('recomputes intakeSource when persisted routing had scripted before reports linked', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+
+    const mission = createStarterCase({
+      id: 'case-intake-source-recompute',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+
+    state.cases[mission.id] = mission
+    state.missionRouting = normalizeMissionRoutingState({
+      ...state,
+      cases: { ...state.cases, [mission.id]: mission },
+    })
+    state.missionRouting = {
+      ...state.missionRouting!,
+      missions: {
+        ...state.missionRouting!.missions,
+        [mission.id]: {
+          ...state.missionRouting!.missions[mission.id]!,
+          intakeSource: 'scripted',
+        },
+      },
+    }
+
+    const routing = recomputeMissionRouting(state)
+
+    expect(routing.missions[mission.id]?.intakeSource).toBe('pressure')
   })
 
   it('returns neutral signals when no reports link to the mission', () => {


### PR DESCRIPTION
## Summary

- Add `missionIntakeInformationRouting` to link persisted `informationIntakeReports` to missions via case id and `topic:` tags.
- Integrate mixed-source coverage/verification signals into `triageMission` (score adjustment + `intake-*` reason codes) and `deriveMissionIntakeSource` (nonstandard public hook → `pressure`).
- Slice doc and backlog index updates; weekly-hook slice 9 marked shipped.

## Linear

- **Slice:** [SPE-2301](https://linear.app/spectranoir/issue/SPE-2301) — Mixed-source intake mission routing integration (parent slice 1)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (stays **In Progress**; parent acceptance not complete)

## What shipped

- Domain bridge from intake reports → mission triage score/reason codes and intake source override
- Parent-scoped integration tests (canal-bridge mixed fixtures)

## Validation

- `npm run test:run -- src/test/missionIntakeInformationRouting.integration.test.ts src/test/mission.intake.triage.routing.test.ts src/test/reportNoteTypeAudit.test.ts`
- `npm run lint`

## Docs

- `planning/information-intake-parent-integration-slice-1.md`
- `planning/backlog.md` (slice index)

## Parent status

Parent **SPE-854** remains open — this slice covers downstream routing integration only; remaining parent acceptance bullets deferred per slice doc.

Made with [Cursor](https://cursor.com)