### PR TITLE
feat(SPE-2302): hidden-state modality matrix slice 10 — out-of-phase presence

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -8,7 +8,7 @@ This file is the **canonical ordered queue** for concrete engineering and design
 
 From `README.md` **Current design notes**:
 
-- Concealment activation stack and hidden-modality matrix slices 1–9 shipped (SPE-2281–SPE-2290 / PR #2403–#2423); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open for deferred anti-scan / out-of-phase families only — see Shipped table and active queue below.
+- Concealment activation stack and hidden-modality matrix slices 1–9 shipped (SPE-2281–SPE-2290 / PR #2403–#2423); slice 10 out-of-phase / liminal presence ([SPE-2302](https://linear.app/spectranoir/issue/SPE-2302)) in flight; [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open for deferred anti-scan families — see Shipped table and active queue below.
 - Intake registry wave shipped on `main` through adjacent tier SPE-2123 (SPE-2104–SPE-2123 / PR #2428–#2442); [SPE-854](https://linear.app/spectranoir/issue/SPE-854), [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309), [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889), and [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) parents remain open.
 - Shared explanatory ownership stays in the domain wherever possible.
 - Prefer compact reusable rules vocabularies over bespoke subsystem logic.

--- a/planning/hidden-modality-matrix-post-matrix-queue.md
+++ b/planning/hidden-modality-matrix-post-matrix-queue.md
@@ -14,7 +14,7 @@ Routing doc for optional modality families after matrix slices 1–6 shipped. **
 | 6     | SPE-2286 | #2415  | Mode-specific tells / observer threshold   |
 | —     | SPE-2287 | #2417  | Docs reconciliation (not runtime)          |
 
-Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) remains **Backlog** — post-matrix optional families shipped; deferred anti-scan / out-of-phase families and mission-triage chips remain out of scope.
+Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) remains **Backlog** — post-matrix optional families through slice 10 shipped or in flight; deferred anti-scan compartments and mission-triage chips remain out of scope.
 
 ## Post-matrix queue (complete)
 

--- a/planning/hidden-modality-matrix-post-matrix-queue.md
+++ b/planning/hidden-modality-matrix-post-matrix-queue.md
@@ -23,17 +23,17 @@ Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) remains **Backlog**
 | 1     | 7     | SPE-2288 | Signature masking         | `planning/hidden-modality-matrix-slice-7.md` (shipped PR #2421) |
 | 2     | 8     | SPE-2289 | False-detection output    | `planning/hidden-modality-matrix-slice-8.md` (shipped PR #2422) |
 | 3     | 9     | SPE-2290 | Glamour / presentation overlay | `planning/hidden-modality-matrix-slice-9.md` (shipped PR #2423) |
-| —     | —     | SPE-2291 | Docs reconciliation       | `planning/backlog.md` handoff (PR pending) |
+| 4     | 10    | SPE-2302 | Out-of-phase / liminal presence | `planning/hidden-modality-matrix-slice-10.md` (in progress) |
+| —     | —     | SPE-2291 | Docs reconciliation       | `planning/backlog.md` handoff (shipped) |
 
 ### Repo anchors (post-queue)
 
-- `HiddenStateModalityKind`: `none`, `concealed_presence`, `false_position`, `disguised_identity`, `signature_masking`, `false_detection_output`, `glamour_overlay` — see `src/domain/hiddenStateModality.ts`.
-- Authored layers distinct from rating layers: `layer:authored-signature-mask`, `layer:authored-false-detection`, `layer:authored-glamour`.
+- `HiddenStateModalityKind`: `none`, `concealed_presence`, `false_position`, `disguised_identity`, `signature_masking`, `false_detection_output`, `glamour_overlay`, `out_of_phase_presence` — see `src/domain/hiddenStateModality.ts`.
+- Authored layers distinct from rating layers: `layer:authored-signature-mask`, `layer:authored-false-detection`, `layer:authored-glamour`, `layer:authored-out-of-phase`.
 - Rating-derived `layer:glamour` and `layer:signature-mask` remain in `concealmentLayersFromRating`.
 
 ### Explicitly deferred (not in queue)
 
-- Out-of-phase / liminal presence
 - Anti-scan compartments (dead zones, Faraday, warded volumes)
 - Mission triage illusion/tell chips
 - Full SPE-70 parent Done (evaluate after owner review of deferred families)

--- a/planning/hidden-modality-matrix-slice-10.md
+++ b/planning/hidden-modality-matrix-slice-10.md
@@ -1,0 +1,105 @@
+# SPE-70 — Hidden-state modality matrix slice 10 (out-of-phase / liminal presence)
+
+One-page implementation plan. Linear: [SPE-2302](https://linear.app/spectranoir/issue/SPE-2302) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Follows shipped [SPE-2290](https://linear.app/spectranoir/issue/SPE-2290) (PR #2423).
+
+| Field      | Value                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2302 — Hidden-state modality matrix slice 10](https://linear.app/spectranoir/issue/SPE-2302) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70)                                                |
+| **Branch** | `jamesdyedbq/spe-2302-hidden-state-modality-matrix-slice-10-out-of-phase-presence`                 |
+| **Status** | In progress                                                                                          |
+
+## Goal
+
+Add **out-of-phase / liminal presence** as a seventh case-authored `HiddenStateModalityKind` so the target registers only when route or liminal-frequency alignment matches — otherwise presence stays absent or partial and route caution / scouting score adjust deterministically.
+
+## Prerequisite (on `main` @ `50bcf3af`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Modality compose     | `hiddenStateModality.ts`, `resolveScoutingWithCaseHiddenState`         |
+| Post-matrix slices 7–9 | `signature_masking`, `false_detection_output`, `glamour_overlay`   |
+| Weekly orchestration | `evaluateHiddenStateScoutingWithRevealPayload`                         |
+| Modality report copy | `detectionScanReportNotes.ts`                                          |
+| Route caution signal | `scoutingReconCacheScoreAdjustment` (SPE-2284)                         |
+
+## Gap (pre-slice)
+
+- No `out_of_phase_presence` family in `HiddenStateModalityKind`.
+- No authored `layer:authored-out-of-phase`.
+- No route/frequency gate on scouting truth `present`.
+- No modality report prefix for liminal / out-of-phase readouts.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Extend `HiddenStateModalityKind` with `out_of_phase_presence`                                                                        | Anti-scan compartment families                |
+| Authored activation via `modality-out-of-phase` and/or `liminal-presence`                                                          | Mission triage UI                             |
+| Modality layer **`layer:authored-out-of-phase`** (distinct from slices 7–9)                                                          | Full SPE-70 parent Done                       |
+| Route/frequency gate: `route` on case + `liminal-frequency` or route token on team tags                                            | Per-channel observer matrix                   |
+| Misaligned: `present: false` + route-caution score delta; aligned: partial presence projection                                       | RNG / probabilistic outputs                   |
+| Report prefix **`Out-of-phase readout:`**                                                                                          | Removing slices 7–9 behavior                  |
+| Unit + `advanceWeek` integration tests                                                                                             | Template-wide migration beyond 2–3 fixtures   |
+
+## Modality contract (deterministic)
+
+### Activation (authored)
+
+- Tag `modality-out-of-phase` or `liminal-presence` while `hiddenState` is non-`revealed`.
+- Resolver priority (stable): `displaced` > `disguised_identity` > `false_detection_output` > `signature_masking` > `glamour_overlay` > **`out_of_phase_presence`** > `concealed_presence`.
+
+### Route / frequency alignment
+
+- Case may set `route` (e.g. `ritual-corridor-alpha`).
+- **Aligned** when team tags include `liminal-frequency`, or when `route` is set and team tags include that route token; when `route` is unset, `liminal-frequency` alone aligns.
+- **Misaligned**: truth `present: false`; scan shows absent-route readout; bounded score delta + route-caution reason.
+- **Aligned**: truth `present: true`; layer blocks category/hostility/exact_identity; presence projection `liminal trace contact`.
+
+### Counter-reveal
+
+- `counterDetection: true` strips `layer:authored-out-of-phase` without solving other modality families.
+
+### Player-facing output
+
+- Prefix: `Out-of-phase readout:`.
+- One deterministic sentence when modality active; dedupe via existing `resolutionReasons` guard.
+
+## Acceptance
+
+- [ ] Authored fixture: misaligned route shows absent presence + route caution; aligned shows liminal trace without revealing `hiddenState`.
+- [ ] Distinct `DetectionScanResult` from glamour and concealed fixtures in shared compose path.
+- [ ] Counter-detection strips out-of-phase layer only; slices 1–9 regression unchanged.
+- [ ] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Modality resolver** — tag activation, priority vs slice 9.
+2. **Truth + layer compose** — route gate on `present` + counter-reveal strip.
+3. **Report copy** — prefix + append dedupe.
+4. **Score adjustment** — misaligned route caution in weekly orchestration.
+5. **`advanceWeek`** — one integration fixture for out-of-phase readout.
+6. **Regression** — glamour, signature-mask, tells, recon cache unchanged.
+
+## File touch list (expected)
+
+| Area           | Files                                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| Modality       | `src/domain/hiddenStateModality.ts`                                                           |
+| Compose        | `src/domain/revealPayloadScoutingIntegration.ts`                                              |
+| Report copy    | `src/domain/detectionScanReportNotes.ts`                                                      |
+| Orchestration  | `src/domain/caseResolutionOrchestration.ts`                                                   |
+| Tests          | `src/test/hiddenStateModality.test.ts`, `src/test/advanceWeek.hiddenStateScouting.test.ts`   |
+| Docs           | `planning/hidden-modality-matrix-post-matrix-queue.md`, `planning/backlog.md`                 |
+
+## Out of scope (parent closure)
+
+- Anti-scan compartments (dead zones, Faraday, warded volumes)
+- Full SPE-70 parent Done
+- Mission triage chips
+
+## See also
+
+- `architecture/hidden-state-displacement-counter-detection.md` — Out-of-phase / liminal presence vocabulary
+- `planning/hidden-modality-matrix-slice-9.md`
+- `planning/hidden-modality-matrix-post-matrix-queue.md`

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -186,7 +186,16 @@ export function resolveAssignedCaseForWeek(
     )
   }
   const reconCacheScore = scoutingReconCacheScoreAdjustment(resolvedEffectiveCase)
-  const outOfPhaseScore = outOfPhaseScoutingScoreAdjustment(resolvedEffectiveCase, supportTags)
+  const scoutingAlignmentTags = [
+    ...new Set([
+      ...supportTags,
+      ...assignedAgents.flatMap((agent) => agent.tags ?? []),
+    ]),
+  ]
+  const outOfPhaseScore = outOfPhaseScoutingScoreAdjustment(
+    resolvedEffectiveCase,
+    scoutingAlignmentTags
+  )
   const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(resolvedEffectiveCase)
   const stealthLeaveBehindMission = evaluateStealthLeaveBehindMissionPressure(resolvedEffectiveCase)
   const scoreAdjustment =

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -14,6 +14,7 @@ import {
   applyHiddenStateIllusionLifecyclePass,
   buildIllusionLifecycleContext,
 } from './hiddenStateIllusionLifecycle'
+import { outOfPhaseScoutingScoreAdjustment } from './hiddenStateModality'
 import { evaluateHiddenStateModalityTell } from './hiddenStateModalityTells'
 import type { HiddenStateModalityTellResult } from './hiddenStateModalityTells'
 import {
@@ -185,6 +186,7 @@ export function resolveAssignedCaseForWeek(
     )
   }
   const reconCacheScore = scoutingReconCacheScoreAdjustment(resolvedEffectiveCase)
+  const outOfPhaseScore = outOfPhaseScoutingScoreAdjustment(resolvedEffectiveCase, supportTags)
   const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(resolvedEffectiveCase)
   const stealthLeaveBehindMission = evaluateStealthLeaveBehindMissionPressure(resolvedEffectiveCase)
   const scoreAdjustment =
@@ -193,7 +195,8 @@ export function resolveAssignedCaseForWeek(
     hiddenStateModalityTell.scoreAdjustment +
     infiltrationStageMission.scoreAdjustment +
     stealthLeaveBehindMission.scoreAdjustment +
-    reconCacheScore.delta
+    reconCacheScore.delta +
+    outOfPhaseScore.delta
   const scoreAdjustmentReason = [
     ...factionContext.reasons,
     behaviorValidation.scoreAdjustmentReason,
@@ -201,6 +204,7 @@ export function resolveAssignedCaseForWeek(
     infiltrationStageMission.scoreAdjustmentReason,
     stealthLeaveBehindMission.scoreAdjustmentReason,
     reconCacheScore.reason,
+    outOfPhaseScore.reason,
   ]
     .filter(Boolean)
     .join(' / ')

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -36,6 +36,7 @@ export const COVER_SCAN_READOUT_PREFIX = 'Cover readout:'
 export const SIGNATURE_MASK_SCAN_READOUT_PREFIX = 'Signature mask readout:'
 export const FALSE_DETECTION_SCAN_READOUT_PREFIX = 'False-detection readout:'
 export const GLAMOUR_SCAN_READOUT_PREFIX = 'Glamour readout:'
+export const OUT_OF_PHASE_SCAN_READOUT_PREFIX = 'Out-of-phase readout:'
 
 export const DETECTION_SCAN_READOUT_PREFIXES = [
   DETECTION_SCAN_READOUT_PREFIX,
@@ -45,6 +46,7 @@ export const DETECTION_SCAN_READOUT_PREFIXES = [
   SIGNATURE_MASK_SCAN_READOUT_PREFIX,
   FALSE_DETECTION_SCAN_READOUT_PREFIX,
   GLAMOUR_SCAN_READOUT_PREFIX,
+  OUT_OF_PHASE_SCAN_READOUT_PREFIX,
   FABRICATED_CONTACT_READOUT_PREFIX,
   STRUCTURAL_ILLUSION_READOUT_PREFIX,
 ] as const
@@ -65,6 +67,8 @@ export function detectionScanReadoutPrefixForModality(
       return FALSE_DETECTION_SCAN_READOUT_PREFIX
     case 'glamour_overlay':
       return GLAMOUR_SCAN_READOUT_PREFIX
+    case 'out_of_phase_presence':
+      return OUT_OF_PHASE_SCAN_READOUT_PREFIX
     case 'none':
       return DETECTION_SCAN_READOUT_PREFIX
     default: {
@@ -145,6 +149,10 @@ export function shouldAppendHiddenStateScoutingReportNote(
 
   const illusionPhase = caseData?.hiddenStateIllusionState?.phase
   if (illusionPhase === 'active' || illusionPhase === 'disproved') {
+    return orderedPlayerFacingValues(scouting.detectionScan).length > 0
+  }
+
+  if (modality === 'out_of_phase_presence') {
     return orderedPlayerFacingValues(scouting.detectionScan).length > 0
   }
 

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -35,10 +35,14 @@ export type HiddenStateModalityKind =
   | 'signature_masking'
   | 'false_detection_output'
   | 'glamour_overlay'
+  | 'out_of_phase_presence'
 
 export const MODALITY_SIGNATURE_MASK_TAG = 'modality-signature-mask'
 export const MODALITY_FALSE_DETECTION_TAG = 'modality-false-detection'
 export const MODALITY_GLAMOUR_TAG = 'modality-glamour'
+export const MODALITY_OUT_OF_PHASE_TAG = 'modality-out-of-phase'
+export const LIMINAL_PRESENCE_TAG = 'liminal-presence'
+export const LIMINAL_FREQUENCY_TAG = 'liminal-frequency'
 export const PRESENTATION_OVERLAY_TAG = 'presentation-overlay'
 export const INSTRUMENTATION_ATTACK_TAG = 'instrumentation-attack'
 
@@ -52,6 +56,13 @@ export const GLAMOUR_OVERLAY_HOSTILITY_SKEW = 'dormant presentation'
 /** Player-facing fabricated readouts when false-detection modality is active. */
 export const FALSE_DETECTION_FABRICATED_PRESENCE = 'fabricated maintenance contact'
 export const FALSE_DETECTION_FABRICATED_CATEGORY = 'instrumented false contact'
+
+/** Player-facing readouts when out-of-phase presence is active. */
+export const OUT_OF_PHASE_ABSENT_ROUTE_SKEW = 'no contact on filed route'
+export const OUT_OF_PHASE_PARTIAL_PRESENCE_SKEW = 'liminal trace contact'
+
+/** Bounded weekly score delta when out-of-phase target is absent on the filed route. */
+export const OUT_OF_PHASE_ROUTE_CAUTION_SCORE_DELTA = 0.25
 
 const CONCEALED_PRESENCE_LAYER: ConcealmentLayer = {
   id: 'layer:concealed-presence',
@@ -83,6 +94,11 @@ const GLAMOUR_OVERLAY_LAYER: ConcealmentLayer = {
   blockedTiers: ['category', 'hostility', 'exact_identity'],
 }
 
+const OUT_OF_PHASE_LAYER: ConcealmentLayer = {
+  id: 'layer:authored-out-of-phase',
+  blockedTiers: ['category', 'hostility', 'exact_identity'],
+}
+
 const DISGUISE_SIGNAL_TAGS = ['infiltration', 'disguise', 'covert', 'stealth'] as const
 
 function caseModalityTagSet(caseData: CaseInstance): Set<string> {
@@ -107,6 +123,55 @@ export function caseHasGlamourOverlayModality(caseData: CaseInstance): boolean {
   const tags = caseModalityTagSet(caseData)
 
   return tags.has(MODALITY_GLAMOUR_TAG) || tags.has(PRESENTATION_OVERLAY_TAG)
+}
+
+export function caseHasOutOfPhasePresenceModality(caseData: CaseInstance): boolean {
+  const tags = caseModalityTagSet(caseData)
+
+  return tags.has(MODALITY_OUT_OF_PHASE_TAG) || tags.has(LIMINAL_PRESENCE_TAG)
+}
+
+/** True when scouting team tags satisfy the case route or liminal-frequency gate. */
+export function isOutOfPhasePresenceAligned(
+  caseData: CaseInstance,
+  teamTags: readonly string[]
+): boolean {
+  const tagSet = new Set(teamTags)
+  if (tagSet.has(LIMINAL_FREQUENCY_TAG)) {
+    return true
+  }
+
+  const route = caseData.route?.trim()
+  if (route === undefined || route.length === 0) {
+    return false
+  }
+
+  return tagSet.has(route)
+}
+
+export interface OutOfPhaseScoutingScoreAdjustment {
+  readonly delta: number
+  readonly reason?: string
+}
+
+export function outOfPhaseScoutingScoreAdjustment(
+  caseData: CaseInstance,
+  teamTags: readonly string[]
+): OutOfPhaseScoutingScoreAdjustment {
+  if (resolveHiddenStateModality(caseData) !== 'out_of_phase_presence') {
+    return { delta: 0 }
+  }
+
+  if (isOutOfPhasePresenceAligned(caseData, teamTags)) {
+    return { delta: 0 }
+  }
+
+  const routeLabel = caseData.route?.trim() ?? 'filed route'
+
+  return {
+    delta: OUT_OF_PHASE_ROUTE_CAUTION_SCORE_DELTA,
+    reason: `Out-of-phase target absent on ${routeLabel} — route caution.`,
+  }
 }
 
 export function caseHasDisguiseSignals(caseData: CaseInstance): boolean {
@@ -144,6 +209,10 @@ export function resolveHiddenStateModality(caseData: CaseInstance): HiddenStateM
     return 'glamour_overlay'
   }
 
+  if (caseHasOutOfPhasePresenceModality(caseData)) {
+    return 'out_of_phase_presence'
+  }
+
   return 'concealed_presence'
 }
 
@@ -163,6 +232,8 @@ export function hiddenStateModalityLayer(
       return FALSE_DETECTION_LAYER
     case 'glamour_overlay':
       return GLAMOUR_OVERLAY_LAYER
+    case 'out_of_phase_presence':
+      return OUT_OF_PHASE_LAYER
     case 'none':
       return null
     default: {
@@ -245,6 +316,12 @@ export function buildSubjectTruthFromCaseHiddenState(
   const modalityLayer = hiddenStateModalityLayer(modality)
   const resolvedSubject = resolveScoutingSubjectForCase(caseData, subject, modality)
   let present = resolveSubjectPresent(resolvedSubject)
+  if (
+    modality === 'out_of_phase_presence' &&
+    !isOutOfPhasePresenceAligned(caseData, scoutingInput.teamTags ?? [])
+  ) {
+    present = false
+  }
   if (shouldWithholdCanonicalSubjectForIllusion(caseData)) {
     present = false
   }
@@ -371,6 +448,39 @@ export function applyGlamourOverlayScanProjection(scan: DetectionScanResult): De
     }
 
     return field
+  })
+
+  return {
+    ...scan,
+    fields,
+  }
+}
+
+/** Player-facing scan projection for out-of-phase presence without mutating canonical truth tiers. */
+export function applyOutOfPhaseScanProjection(
+  scan: DetectionScanResult,
+  caseData: CaseInstance,
+  teamTags: readonly string[]
+): DetectionScanResult {
+  const aligned = isOutOfPhasePresenceAligned(caseData, teamTags)
+  const fields = scan.fields.map((field) => {
+    if (field.tier !== 'presence') {
+      return field
+    }
+
+    if (!aligned) {
+      return {
+        ...field,
+        playerFacingValue: OUT_OF_PHASE_ABSENT_ROUTE_SKEW,
+        ambiguous: true,
+      }
+    }
+
+    return {
+      ...field,
+      playerFacingValue: OUT_OF_PHASE_PARTIAL_PRESENCE_SKEW,
+      ambiguous: true,
+    }
   })
 
   return {

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -166,7 +166,7 @@ export function outOfPhaseScoutingScoreAdjustment(
     return { delta: 0 }
   }
 
-  const routeLabel = caseData.route?.trim() ?? 'filed route'
+  const routeLabel = caseData.route?.trim() || 'filed route'
 
   return {
     delta: OUT_OF_PHASE_ROUTE_CAUTION_SCORE_DELTA,

--- a/src/domain/hiddenStateModalityTells.ts
+++ b/src/domain/hiddenStateModalityTells.ts
@@ -150,6 +150,7 @@ export function tellReadoutPrefixForModality(modality: HiddenStateModalityKind):
       return SIGNATURE_MASK_TELL_READOUT_PREFIX
     case 'false_detection_output':
     case 'glamour_overlay':
+    case 'out_of_phase_presence':
     case 'none':
       return null
     default: {

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -24,6 +24,7 @@ import {
   applyFalsePositionScanProjection,
   applyFalseDetectionScanProjection,
   applyGlamourOverlayScanProjection,
+  applyOutOfPhaseScanProjection,
   applySignatureMaskScanProjection,
   buildSubjectTruthFromCaseHiddenState,
   resolveHiddenStateModality,
@@ -328,6 +329,10 @@ export function resolveScoutingWithCaseHiddenState(
 
   if (modality === 'glamour_overlay') {
     detectionScan = applyGlamourOverlayScanProjection(detectionScan)
+  }
+
+  if (modality === 'out_of_phase_presence') {
+    detectionScan = applyOutOfPhaseScanProjection(detectionScan, input.caseData, input.teamTags)
   }
 
   if (

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -332,7 +332,11 @@ export function resolveScoutingWithCaseHiddenState(
   }
 
   if (modality === 'out_of_phase_presence') {
-    detectionScan = applyOutOfPhaseScanProjection(detectionScan, input.caseData, input.teamTags)
+    detectionScan = applyOutOfPhaseScanProjection(
+      detectionScan,
+      input.caseData,
+      input.teamTags ?? []
+    )
   }
 
   if (

--- a/src/test/advanceWeek.hiddenStateScouting.test.ts
+++ b/src/test/advanceWeek.hiddenStateScouting.test.ts
@@ -9,12 +9,15 @@ import {
   SIGNATURE_MASK_SCAN_READOUT_PREFIX,
   FALSE_DETECTION_SCAN_READOUT_PREFIX,
   GLAMOUR_SCAN_READOUT_PREFIX,
+  OUT_OF_PHASE_SCAN_READOUT_PREFIX,
 } from '../domain/detectionScanReportNotes'
 import {
   MODALITY_FALSE_DETECTION_TAG,
   MODALITY_GLAMOUR_TAG,
+  MODALITY_OUT_OF_PHASE_TAG,
   MODALITY_SIGNATURE_MASK_TAG,
   GLAMOUR_OVERLAY_CATEGORY_SKEW,
+  OUT_OF_PHASE_ABSENT_ROUTE_SKEW,
 } from '../domain/hiddenStateModality'
 import { TELL_ROUTE_TIMING_TAG, TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
 import { resolveAssignedCaseForWeek } from '../domain/caseResolutionOrchestration'
@@ -378,6 +381,55 @@ describe('advanceWeek hidden-state scouting report copy (SPE-2283)', () => {
       snapshot?.missionResult?.explanationNotes.some((note) =>
         note.includes(GLAMOUR_OVERLAY_CATEGORY_SKEW)
       )
+    ).toBe(true)
+    expect(snapshot?.hiddenState).not.toBe('revealed')
+  })
+
+  it('surfaces out-of-phase readout and route caution without revealing hidden state', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_out_of_phase_readout', 60)
+    const team: Team = {
+      id: 'team-out-of-phase-readout',
+      name: 'Out-of-phase readout team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-concealed-readout'] = tuneConcealedInvestigationCase(state, team.id, {
+      tags: [MODALITY_OUT_OF_PHASE_TAG],
+      route: 'ritual-corridor-alpha',
+      counterDetection: false,
+    })
+
+    const preAdvance = resolveAssignedCaseForWeek(state.cases['case-concealed-readout'], state, () => 0.5)
+    expect(preAdvance.hiddenStateScouting?.active).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const snapshot =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-concealed-readout']
+
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) =>
+        note.includes(OUT_OF_PHASE_SCAN_READOUT_PREFIX)
+      )
+    ).toBe(true)
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) =>
+        note.includes(OUT_OF_PHASE_ABSENT_ROUTE_SKEW)
+      )
+    ).toBe(true)
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) => note.includes('route caution'))
     ).toBe(true)
     expect(snapshot?.hiddenState).not.toBe('revealed')
   })

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -9,6 +9,7 @@ import {
   detectionScanReadoutPrefixForModality,
   DISPLACEMENT_SCAN_READOUT_PREFIX,
   GLAMOUR_SCAN_READOUT_PREFIX,
+  OUT_OF_PHASE_SCAN_READOUT_PREFIX,
   formatDetectionScanSummary,
   shouldAppendDetectionScanReportNote,
   shouldAppendModalityTellReportNote,
@@ -70,6 +71,9 @@ describe('detectionScanReportNotes', () => {
     )
     expect(detectionScanReadoutPrefixForModality('disguised_identity')).toBe(COVER_SCAN_READOUT_PREFIX)
     expect(detectionScanReadoutPrefixForModality('glamour_overlay')).toBe(GLAMOUR_SCAN_READOUT_PREFIX)
+    expect(detectionScanReadoutPrefixForModality('out_of_phase_presence')).toBe(
+      OUT_OF_PHASE_SCAN_READOUT_PREFIX
+    )
   })
 
   it('appends counter-detection peel suffix when layers were stripped', () => {

--- a/src/test/hiddenStateModality.test.ts
+++ b/src/test/hiddenStateModality.test.ts
@@ -665,7 +665,7 @@ describe('hiddenStateModality (SPE-2281)', () => {
     )
 
     expect(truth.present).toBe(true)
-    expect(isOutOfPhasePresenceAligned(caseData, ['liminal-frequency'])).toBe(true)
+    expect(isOutOfPhasePresenceAligned(caseData, [LIMINAL_FREQUENCY_TAG])).toBe(true)
   })
 
   it('projects out-of-phase readouts for misaligned and aligned presence', () => {
@@ -742,6 +742,17 @@ describe('hiddenStateModality (SPE-2281)', () => {
     expect(
       outOfPhaseScoutingScoreAdjustment(caseData, [LIMINAL_FREQUENCY_TAG]).delta
     ).toBe(0)
+  })
+
+  it('suppresses route-caution score when alignment comes from agent tags only', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_OUT_OF_PHASE_TAG],
+      route: 'ritual-corridor-alpha',
+    })
+
+    expect(outOfPhaseScoutingScoreAdjustment(caseData, []).delta).toBe(0.25)
+    expect(outOfPhaseScoutingScoreAdjustment(caseData, [LIMINAL_FREQUENCY_TAG]).delta).toBe(0)
   })
 
   it('includes out-of-phase presence in distinct modality compose path', () => {

--- a/src/test/hiddenStateModality.test.ts
+++ b/src/test/hiddenStateModality.test.ts
@@ -3,7 +3,15 @@ import {
   applyFalsePositionScanProjection,
   applyFalseDetectionScanProjection,
   applyGlamourOverlayScanProjection,
+  applyOutOfPhaseScanProjection,
   applySignatureMaskScanProjection,
+  isOutOfPhasePresenceAligned,
+  LIMINAL_FREQUENCY_TAG,
+  LIMINAL_PRESENCE_TAG,
+  MODALITY_OUT_OF_PHASE_TAG,
+  OUT_OF_PHASE_ABSENT_ROUTE_SKEW,
+  OUT_OF_PHASE_PARTIAL_PRESENCE_SKEW,
+  outOfPhaseScoutingScoreAdjustment,
   buildSubjectTruthFromCaseHiddenState,
   formatDecoyLocusLabel,
   FALSE_DETECTION_FABRICATED_CATEGORY,
@@ -161,6 +169,34 @@ describe('hiddenStateModality (SPE-2281)', () => {
         })
       )
     ).toBe('false_detection_output')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [MODALITY_OUT_OF_PHASE_TAG],
+        })
+      )
+    ).toBe('out_of_phase_presence')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [LIMINAL_PRESENCE_TAG],
+        })
+      )
+    ).toBe('out_of_phase_presence')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [MODALITY_GLAMOUR_TAG, MODALITY_OUT_OF_PHASE_TAG],
+        })
+      )
+    ).toBe('glamour_overlay')
+  })
+
+  it('maps out-of-phase presence to authored out-of-phase layer', () => {
+    expect(hiddenStateModalityLayer('out_of_phase_presence')?.id).toBe('layer:authored-out-of-phase')
   })
 
   it('maps glamour overlay to authored glamour layer', () => {
@@ -602,6 +638,142 @@ describe('hiddenStateModality (SPE-2281)', () => {
     expect(truth.concealmentLayers.some((layer) => layer.id === 'layer:authored-glamour')).toBe(
       false
     )
+  })
+
+  it('withholds presence when out-of-phase route is misaligned', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_OUT_OF_PHASE_TAG],
+      route: 'ritual-corridor-alpha',
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(caseData, SCOUTING_INPUT, SUBJECT)
+
+    expect(truth.present).toBe(false)
+    expect(truth.concealmentLayers[0]?.id).toBe('layer:authored-out-of-phase')
+  })
+
+  it('keeps presence when out-of-phase route or frequency is aligned', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_OUT_OF_PHASE_TAG],
+      route: 'ritual-corridor-alpha',
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(
+      caseData,
+      { ...SCOUTING_INPUT, teamTags: ['ritual-corridor-alpha'] },
+      SUBJECT
+    )
+
+    expect(truth.present).toBe(true)
+    expect(isOutOfPhasePresenceAligned(caseData, ['liminal-frequency'])).toBe(true)
+  })
+
+  it('projects out-of-phase readouts for misaligned and aligned presence', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_OUT_OF_PHASE_TAG],
+      route: 'ritual-corridor-alpha',
+    })
+    const misalignedTruth = buildSubjectTruthFromCaseHiddenState(
+      caseData,
+      SCOUTING_LOW_CONCEALMENT,
+      SUBJECT
+    )
+    const misalignedScan = applyOutOfPhaseScanProjection(
+      resolveDetectionScan(misalignedTruth, { family: 'presence_sweep' }),
+      caseData,
+      SCOUTING_LOW_CONCEALMENT.teamTags
+    )
+
+    expect(
+      misalignedScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(OUT_OF_PHASE_ABSENT_ROUTE_SKEW)
+
+    const alignedTruth = buildSubjectTruthFromCaseHiddenState(
+      caseData,
+      { ...SCOUTING_LOW_CONCEALMENT, teamTags: [LIMINAL_FREQUENCY_TAG] },
+      SUBJECT
+    )
+    const alignedScan = applyOutOfPhaseScanProjection(
+      resolveDetectionScan(alignedTruth, { family: 'category_pass' }),
+      caseData,
+      [LIMINAL_FREQUENCY_TAG]
+    )
+
+    expect(
+      alignedScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(OUT_OF_PHASE_PARTIAL_PRESENCE_SKEW)
+    expect(alignedScan.fields.some((field) => field.tier === 'category')).toBe(false)
+  })
+
+  it('strips out-of-phase layer on counter-detection without solving other families', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      counterDetection: true,
+      tags: [MODALITY_OUT_OF_PHASE_TAG],
+      route: 'ritual-corridor-alpha',
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(
+      caseData,
+      { ...SCOUTING_INPUT, teamTags: [LIMINAL_FREQUENCY_TAG] },
+      SUBJECT
+    )
+    const scanInput = scoutingOutcomeToDetectionScanForCase(
+      { outcome: 'strong', revealed: true, withheld: false },
+      caseData
+    )
+
+    const scan = resolveDetectionScan(truth, scanInput)
+    expect(scan.strippedLayerIds).toEqual(['layer:authored-out-of-phase'])
+    expect(detectionScanTierOrder(scan)).not.toContain('exact_identity')
+  })
+
+  it('applies route-caution score adjustment when out-of-phase presence is misaligned', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_OUT_OF_PHASE_TAG],
+      route: 'ritual-corridor-alpha',
+    })
+
+    expect(outOfPhaseScoutingScoreAdjustment(caseData, SCOUTING_INPUT.teamTags).delta).toBe(0.25)
+    expect(outOfPhaseScoutingScoreAdjustment(caseData, SCOUTING_INPUT.teamTags).reason).toContain(
+      'route caution'
+    )
+    expect(
+      outOfPhaseScoutingScoreAdjustment(caseData, [LIMINAL_FREQUENCY_TAG]).delta
+    ).toBe(0)
+  })
+
+  it('includes out-of-phase presence in distinct modality compose path', () => {
+    const outOfPhase = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_OUT_OF_PHASE_TAG],
+        route: 'ritual-corridor-alpha',
+      }),
+    })
+    const glamourOverlay = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_GLAMOUR_TAG],
+      }),
+    })
+
+    expect(
+      outOfPhase.detectionScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(OUT_OF_PHASE_ABSENT_ROUTE_SKEW)
+    expect(
+      outOfPhase.detectionScan.remainingConcealmentLayers.some(
+        (layer) => layer.id === 'layer:authored-out-of-phase'
+      )
+    ).toBe(true)
+    expect(
+      glamourOverlay.detectionScan.fields.find((field) => field.tier === 'category')?.playerFacingValue
+    ).toBe(GLAMOUR_OVERLAY_CATEGORY_SKEW)
   })
 
   it('preserves legacy scouting fields while attaching modality-aware detection scans', () => {


### PR DESCRIPTION
## Summary

- Adds `out_of_phase_presence` as a seventh case-authored `HiddenStateModalityKind` with tags `modality-out-of-phase` / `liminal-presence` and authored layer `layer:authored-out-of-phase`.
- Route/frequency gate: misaligned scouting withholds `present` and applies a bounded route-caution score delta; aligned scouting shows liminal trace presence with deeper tiers blocked until counter-reveal.
- Report copy prefix `Out-of-phase readout:` wired through weekly orchestration; slice doc and post-matrix queue updated.

## Linear

- **Slice:** [SPE-2302](https://linear.app/spectranoir/issue/SPE-2302) — Hidden-state modality matrix slice 10 (out-of-phase / liminal presence)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70) — remains open (anti-scan compartments deferred)

## Validation

- `npm run lint`
- `npm run test:run -- src/test/hiddenStateModality.test.ts src/test/advanceWeek.hiddenStateScouting.test.ts src/test/detectionScanReportNotes.test.ts`

## Docs updated

- `planning/hidden-modality-matrix-slice-10.md` (new)
- `planning/hidden-modality-matrix-post-matrix-queue.md`
- `planning/backlog.md`

## Parent status

SPE-70 parent stays **Backlog** — only out-of-phase family shipped in this PR; anti-scan compartments remain deferred.