### PR TITLE
feat(SPE-2303): hidden-state modality matrix slice 11 — anti-scan compartments

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -8,7 +8,7 @@ This file is the **canonical ordered queue** for concrete engineering and design
 
 From `README.md` **Current design notes**:
 
-- Concealment activation stack and hidden-modality matrix slices 1–10 shipped (SPE-2281–SPE-2302 / PR #2403–#2467); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open for deferred anti-scan families only — see Shipped table and active queue below.
+- Concealment activation stack and hidden-modality matrix slices 1–10 shipped (SPE-2281–SPE-2302 / PR #2403–#2467); slice 11 anti-scan compartments in flight ([SPE-2303](https://linear.app/spectranoir/issue/SPE-2303)); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open for mission-triage chips only after slice 11 — see Shipped table and active queue below.
 - Intake registry wave shipped on `main` through adjacent tier SPE-2123 (SPE-2104–SPE-2123 / PR #2428–#2442); [SPE-854](https://linear.app/spectranoir/issue/SPE-854), [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309), [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889), and [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) parents remain open.
 - Shared explanatory ownership stays in the domain wherever possible.
 - Prefer compact reusable rules vocabularies over bespoke subsystem logic.

--- a/planning/hidden-modality-matrix-post-matrix-queue.md
+++ b/planning/hidden-modality-matrix-post-matrix-queue.md
@@ -14,7 +14,7 @@ Routing doc for optional modality families after matrix slices 1–6 shipped. **
 | 6     | SPE-2286 | #2415  | Mode-specific tells / observer threshold   |
 | —     | SPE-2287 | #2417  | Docs reconciliation (not runtime)          |
 
-Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) remains **Backlog** — post-matrix optional families through slice 10 shipped or in flight; deferred anti-scan compartments and mission-triage chips remain out of scope.
+Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) remains **Backlog** — post-matrix optional families through slice 11 in flight; mission-triage chips remain out of scope.
 
 ## Post-matrix queue (complete)
 
@@ -24,17 +24,17 @@ Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) remains **Backlog**
 | 2     | 8     | SPE-2289 | False-detection output    | `planning/hidden-modality-matrix-slice-8.md` (shipped PR #2422) |
 | 3     | 9     | SPE-2290 | Glamour / presentation overlay | `planning/hidden-modality-matrix-slice-9.md` (shipped PR #2423) |
 | 4     | 10    | SPE-2302 | Out-of-phase / liminal presence | `planning/hidden-modality-matrix-slice-10.md` (shipped PR #2467) |
+| 5     | 11    | SPE-2303 | Anti-scan compartments          | `planning/hidden-modality-matrix-slice-11.md` (in flight) |
 | —     | —     | SPE-2291 | Docs reconciliation       | `planning/backlog.md` handoff (shipped) |
 
 ### Repo anchors (post-queue)
 
-- `HiddenStateModalityKind`: `none`, `concealed_presence`, `false_position`, `disguised_identity`, `signature_masking`, `false_detection_output`, `glamour_overlay`, `out_of_phase_presence` — see `src/domain/hiddenStateModality.ts`.
-- Authored layers distinct from rating layers: `layer:authored-signature-mask`, `layer:authored-false-detection`, `layer:authored-glamour`, `layer:authored-out-of-phase`.
+- `HiddenStateModalityKind`: `none`, `concealed_presence`, `false_position`, `disguised_identity`, `signature_masking`, `false_detection_output`, `glamour_overlay`, `out_of_phase_presence`, `anti_scan_compartment` — see `src/domain/hiddenStateModality.ts`.
+- Authored layers distinct from rating layers: `layer:authored-signature-mask`, `layer:authored-false-detection`, `layer:authored-glamour`, `layer:authored-out-of-phase`, `layer:authored-anti-scan`.
 - Rating-derived `layer:glamour` and `layer:signature-mask` remain in `concealmentLayersFromRating`.
 
 ### Explicitly deferred (not in queue)
 
-- Anti-scan compartments (dead zones, Faraday, warded volumes)
 - Mission triage illusion/tell chips
 - Full SPE-70 parent Done (evaluate after owner review of deferred families)
 

--- a/planning/hidden-modality-matrix-slice-11.md
+++ b/planning/hidden-modality-matrix-slice-11.md
@@ -1,0 +1,106 @@
+# SPE-70 — Hidden-state modality matrix slice 11 (anti-scan compartments)
+
+One-page implementation plan. Linear: [SPE-2303](https://linear.app/spectranoir/issue/SPE-2303) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Follows shipped [SPE-2302](https://linear.app/spectranoir/issue/SPE-2302) (PR #2467).
+
+| Field      | Value                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2303 — Hidden-state modality matrix slice 11](https://linear.app/spectranoir/issue/SPE-2303) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70)                                                |
+| **Branch** | `jamesdyedbq/spe-2303-hidden-state-modality-matrix-slice-11-anti-scan-compartments`                 |
+| **Status** | In progress                                                                                          |
+
+## Goal
+
+Add **anti-scan compartments** (dead zones, Faraday, warded volumes) as an eighth case-authored `HiddenStateModalityKind` so tiered scans **degrade by policy** when bypass counterplay is absent — bounded score caution and distinct readouts, not RNG and not generic concealed presence.
+
+## Prerequisite (on `main` @ `566170bf`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Modality compose     | `hiddenStateModality.ts`, `resolveScoutingWithCaseHiddenState`         |
+| Post-matrix slices 7–10 | through `out_of_phase_presence`                                     |
+| Weekly orchestration | `evaluateHiddenStateScoutingWithRevealPayload`                         |
+| Modality report copy | `detectionScanReportNotes.ts`                                          |
+| Route caution signal | `outOfPhaseScoutingScoreAdjustment`, recon cache caution               |
+
+## Gap (pre-slice)
+
+- No `anti_scan_compartment` family in `HiddenStateModalityKind`.
+- No authored `layer:authored-anti-scan`.
+- No bypass/compartment gate on scan degradation.
+- No modality report prefix for anti-scan readouts.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Extend `HiddenStateModalityKind` with `anti_scan_compartment`                                                                      | Mission triage UI                             |
+| Authored activation via `modality-anti-scan` and/or `anti-scan-compartment`                                                        | Full SPE-70 parent Done                       |
+| Modality layer **`layer:authored-anti-scan`** (distinct from slice 10)                                                             | Per-channel observer matrix                   |
+| Bypass gate: `scan-bypass` / `em-sweep` or case `compartment` token on team tags                                                   | RNG / probabilistic outputs                   |
+| Misaligned: degraded presence projection + scan-caution score delta; aligned: partial clearance readout                            | Removing slices 7–10 behavior                 |
+| Report prefix **`Anti-scan readout:`**                                                                                             | Template-wide migration beyond 2–3 fixtures   |
+| Unit + `advanceWeek` integration tests                                                                                             | Intake weekly-hook stack (SPE-2292–SPE-2301)  |
+
+## Modality contract (deterministic)
+
+### Activation (authored)
+
+- Tag `modality-anti-scan` or `anti-scan-compartment` while `hiddenState` is non-`revealed`.
+- Resolver priority (stable): `displaced` > `disguised_identity` > `false_detection_output` > `signature_masking` > `glamour_overlay` > `out_of_phase_presence` > **`anti_scan_compartment`** > `concealed_presence`.
+
+### Bypass / compartment alignment
+
+- Case may set `compartment` (e.g. `warded-volume-alpha`).
+- **Aligned** when team tags include `scan-bypass`, `em-sweep`, or (when `compartment` is set) that compartment token.
+- **Misaligned**: truth `present` unchanged; scan projection uses degraded presence skew; bounded score delta + scan-caution reason.
+
+### Counter-reveal
+
+- `counterDetection: true` strips `layer:authored-anti-scan` without solving other modality families.
+
+### Player-facing output
+
+- Prefix: `Anti-scan readout:`.
+- One deterministic sentence when modality active; dedupe via existing `resolutionReasons` guard.
+
+## Acceptance
+
+- [x] Authored fixture: misaligned compartment shows degraded presence + scan caution; bypass shows clearance readout without revealing `hiddenState`.
+- [x] Distinct `DetectionScanResult` from out-of-phase and concealed fixtures in shared compose path.
+- [x] Counter-detection strips anti-scan layer only; slices 1–10 regression unchanged.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Modality resolver** — tag activation, priority vs slice 10.
+2. **Truth + layer compose** — authored layer + counter-reveal strip.
+3. **Scan projection** — misaligned degraded vs aligned partial readout.
+4. **Report copy** — prefix + append dedupe.
+5. **Score adjustment** — misaligned scan caution in weekly orchestration.
+6. **`advanceWeek`** — one integration fixture for anti-scan readout.
+7. **Regression** — out-of-phase, glamour, recon cache unchanged.
+
+## File touch list (expected)
+
+| Area           | Files                                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| Modality       | `src/domain/hiddenStateModality.ts`                                                           |
+| Compose        | `src/domain/revealPayloadScoutingIntegration.ts`                                              |
+| Report copy    | `src/domain/detectionScanReportNotes.ts`                                                      |
+| Orchestration  | `src/domain/caseResolutionOrchestration.ts`                                                   |
+| Tests          | `src/test/hiddenStateModality.test.ts`, `src/test/advanceWeek.hiddenStateScouting.test.ts`   |
+| Docs           | `planning/hidden-modality-matrix-post-matrix-queue.md`, `planning/backlog.md`                 |
+
+## Deferred
+
+| Item | Owner | Why |
+| ---- | ----- | --- |
+| Mission triage illusion/tell chips | SPE-70 follow-up | Out of slice 11 boundary |
+| Full SPE-70 parent Done | SPE-70 | Deferred families after slice 11 |
+
+## See also
+
+- `architecture/hidden-state-displacement-counter-detection.md` — Anti-scan compartment vocabulary
+- `planning/hidden-modality-matrix-slice-10.md`
+- `planning/hidden-modality-matrix-post-matrix-queue.md`

--- a/src/domain/case/normalizeCase.ts
+++ b/src/domain/case/normalizeCase.ts
@@ -473,7 +473,12 @@ function sanitizeHiddenDisplacementFields(
   fallback: CaseInstance
 ): Pick<
   CaseInstance,
-  'hiddenState' | 'detectionConfidence' | 'counterDetection' | 'displacementTarget' | 'route'
+  | 'hiddenState'
+  | 'detectionConfidence'
+  | 'counterDetection'
+  | 'displacementTarget'
+  | 'route'
+  | 'compartment'
 > {
   const resolvedHiddenState = isOneOf(entry.hiddenState, CASE_HIDDEN_STATES)
     ? entry.hiddenState
@@ -487,6 +492,7 @@ function sanitizeHiddenDisplacementFields(
         : fallback.displacementTarget ?? null
 
   let route = sanitizeOptionalRouteField(entry.route, fallback.route ?? null)
+  let compartment = sanitizeOptionalRouteField(entry.compartment, fallback.compartment ?? null)
 
   let hiddenState = resolvedHiddenState
   let detectionConfidence =
@@ -508,10 +514,14 @@ function sanitizeHiddenDisplacementFields(
     if (hiddenState !== 'displaced' && route !== null && route !== undefined) {
       route = hiddenState === 'hidden' || hiddenState === 'revealed' ? route : null
     }
+    if (compartment !== null && compartment !== undefined) {
+      compartment = hiddenState === 'hidden' || hiddenState === 'revealed' ? compartment : null
+    }
   } else if (!displacementTarget) {
     hiddenState = 'revealed'
     displacementTarget = undefined
     route = null
+    compartment = null
   }
 
   if (hiddenState === 'revealed' && detectionConfidence === undefined) {
@@ -532,6 +542,7 @@ function sanitizeHiddenDisplacementFields(
     ...(counterDetection !== undefined ? { counterDetection } : {}),
     ...(displacementTarget !== undefined ? { displacementTarget } : {}),
     ...(route !== undefined ? { route } : {}),
+    ...(compartment !== undefined ? { compartment } : {}),
   }
 }
 

--- a/src/domain/caseResolutionOrchestration.ts
+++ b/src/domain/caseResolutionOrchestration.ts
@@ -14,7 +14,10 @@ import {
   applyHiddenStateIllusionLifecyclePass,
   buildIllusionLifecycleContext,
 } from './hiddenStateIllusionLifecycle'
-import { outOfPhaseScoutingScoreAdjustment } from './hiddenStateModality'
+import {
+  antiScanCompartmentScoutingScoreAdjustment,
+  outOfPhaseScoutingScoreAdjustment,
+} from './hiddenStateModality'
 import { evaluateHiddenStateModalityTell } from './hiddenStateModalityTells'
 import type { HiddenStateModalityTellResult } from './hiddenStateModalityTells'
 import {
@@ -196,6 +199,10 @@ export function resolveAssignedCaseForWeek(
     resolvedEffectiveCase,
     scoutingAlignmentTags
   )
+  const antiScanScore = antiScanCompartmentScoutingScoreAdjustment(
+    resolvedEffectiveCase,
+    scoutingAlignmentTags
+  )
   const infiltrationStageMission = evaluateInfiltrationStageMissionPressure(resolvedEffectiveCase)
   const stealthLeaveBehindMission = evaluateStealthLeaveBehindMissionPressure(resolvedEffectiveCase)
   const scoreAdjustment =
@@ -205,7 +212,8 @@ export function resolveAssignedCaseForWeek(
     infiltrationStageMission.scoreAdjustment +
     stealthLeaveBehindMission.scoreAdjustment +
     reconCacheScore.delta +
-    outOfPhaseScore.delta
+    outOfPhaseScore.delta +
+    antiScanScore.delta
   const scoreAdjustmentReason = [
     ...factionContext.reasons,
     behaviorValidation.scoreAdjustmentReason,
@@ -214,6 +222,7 @@ export function resolveAssignedCaseForWeek(
     stealthLeaveBehindMission.scoreAdjustmentReason,
     reconCacheScore.reason,
     outOfPhaseScore.reason,
+    antiScanScore.reason,
   ]
     .filter(Boolean)
     .join(' / ')

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -156,7 +156,7 @@ export function shouldAppendHiddenStateScoutingReportNote(
     return orderedPlayerFacingValues(scouting.detectionScan).length > 0
   }
 
-  if (modality === 'out_of_phase_presence' || modality === 'anti_scan_compartment') {
+  if (modality === 'out_of_phase_presence') {
     return orderedPlayerFacingValues(scouting.detectionScan).length > 0
   }
 

--- a/src/domain/detectionScanReportNotes.ts
+++ b/src/domain/detectionScanReportNotes.ts
@@ -37,6 +37,7 @@ export const SIGNATURE_MASK_SCAN_READOUT_PREFIX = 'Signature mask readout:'
 export const FALSE_DETECTION_SCAN_READOUT_PREFIX = 'False-detection readout:'
 export const GLAMOUR_SCAN_READOUT_PREFIX = 'Glamour readout:'
 export const OUT_OF_PHASE_SCAN_READOUT_PREFIX = 'Out-of-phase readout:'
+export const ANTI_SCAN_SCAN_READOUT_PREFIX = 'Anti-scan readout:'
 
 export const DETECTION_SCAN_READOUT_PREFIXES = [
   DETECTION_SCAN_READOUT_PREFIX,
@@ -47,6 +48,7 @@ export const DETECTION_SCAN_READOUT_PREFIXES = [
   FALSE_DETECTION_SCAN_READOUT_PREFIX,
   GLAMOUR_SCAN_READOUT_PREFIX,
   OUT_OF_PHASE_SCAN_READOUT_PREFIX,
+  ANTI_SCAN_SCAN_READOUT_PREFIX,
   FABRICATED_CONTACT_READOUT_PREFIX,
   STRUCTURAL_ILLUSION_READOUT_PREFIX,
 ] as const
@@ -69,6 +71,8 @@ export function detectionScanReadoutPrefixForModality(
       return GLAMOUR_SCAN_READOUT_PREFIX
     case 'out_of_phase_presence':
       return OUT_OF_PHASE_SCAN_READOUT_PREFIX
+    case 'anti_scan_compartment':
+      return ANTI_SCAN_SCAN_READOUT_PREFIX
     case 'none':
       return DETECTION_SCAN_READOUT_PREFIX
     default: {
@@ -152,7 +156,7 @@ export function shouldAppendHiddenStateScoutingReportNote(
     return orderedPlayerFacingValues(scouting.detectionScan).length > 0
   }
 
-  if (modality === 'out_of_phase_presence') {
+  if (modality === 'out_of_phase_presence' || modality === 'anti_scan_compartment') {
     return orderedPlayerFacingValues(scouting.detectionScan).length > 0
   }
 

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -540,6 +540,10 @@ export function applyAntiScanCompartmentScanProjection(
       return field
     }
 
+    if (field.internalValue === false) {
+      return field
+    }
+
     if (!aligned) {
       return {
         ...field,

--- a/src/domain/hiddenStateModality.ts
+++ b/src/domain/hiddenStateModality.ts
@@ -36,6 +36,7 @@ export type HiddenStateModalityKind =
   | 'false_detection_output'
   | 'glamour_overlay'
   | 'out_of_phase_presence'
+  | 'anti_scan_compartment'
 
 export const MODALITY_SIGNATURE_MASK_TAG = 'modality-signature-mask'
 export const MODALITY_FALSE_DETECTION_TAG = 'modality-false-detection'
@@ -43,6 +44,10 @@ export const MODALITY_GLAMOUR_TAG = 'modality-glamour'
 export const MODALITY_OUT_OF_PHASE_TAG = 'modality-out-of-phase'
 export const LIMINAL_PRESENCE_TAG = 'liminal-presence'
 export const LIMINAL_FREQUENCY_TAG = 'liminal-frequency'
+export const MODALITY_ANTI_SCAN_TAG = 'modality-anti-scan'
+export const ANTI_SCAN_COMPARTMENT_TAG = 'anti-scan-compartment'
+export const SCAN_BYPASS_TAG = 'scan-bypass'
+export const EM_SWEEP_TAG = 'em-sweep'
 export const PRESENTATION_OVERLAY_TAG = 'presentation-overlay'
 export const INSTRUMENTATION_ATTACK_TAG = 'instrumentation-attack'
 
@@ -63,6 +68,13 @@ export const OUT_OF_PHASE_PARTIAL_PRESENCE_SKEW = 'liminal trace contact'
 
 /** Bounded weekly score delta when out-of-phase target is absent on the filed route. */
 export const OUT_OF_PHASE_ROUTE_CAUTION_SCORE_DELTA = 0.25
+
+/** Player-facing readouts when anti-scan compartment modality is active. */
+export const ANTI_SCAN_DEGRADED_PRESENCE_SKEW = 'degraded contact through warded volume'
+export const ANTI_SCAN_PARTIAL_PRESENCE_SKEW = 'confirmed contact past compartment screening'
+
+/** Bounded weekly score delta when anti-scan bypass policy is not satisfied. */
+export const ANTI_SCAN_COMPARTMENT_CAUTION_SCORE_DELTA = 0.3
 
 const CONCEALED_PRESENCE_LAYER: ConcealmentLayer = {
   id: 'layer:concealed-presence',
@@ -99,6 +111,11 @@ const OUT_OF_PHASE_LAYER: ConcealmentLayer = {
   blockedTiers: ['category', 'hostility', 'exact_identity'],
 }
 
+const ANTI_SCAN_COMPARTMENT_LAYER: ConcealmentLayer = {
+  id: 'layer:authored-anti-scan',
+  blockedTiers: ['category', 'hostility', 'exact_identity'],
+}
+
 const DISGUISE_SIGNAL_TAGS = ['infiltration', 'disguise', 'covert', 'stealth'] as const
 
 function caseModalityTagSet(caseData: CaseInstance): Set<string> {
@@ -129,6 +146,55 @@ export function caseHasOutOfPhasePresenceModality(caseData: CaseInstance): boole
   const tags = caseModalityTagSet(caseData)
 
   return tags.has(MODALITY_OUT_OF_PHASE_TAG) || tags.has(LIMINAL_PRESENCE_TAG)
+}
+
+export function caseHasAntiScanCompartmentModality(caseData: CaseInstance): boolean {
+  const tags = caseModalityTagSet(caseData)
+
+  return tags.has(MODALITY_ANTI_SCAN_TAG) || tags.has(ANTI_SCAN_COMPARTMENT_TAG)
+}
+
+/** True when scouting team tags satisfy bypass or compartment-entry policy. */
+export function isAntiScanCompartmentAligned(
+  caseData: CaseInstance,
+  teamTags: readonly string[]
+): boolean {
+  const tagSet = new Set(teamTags)
+  if (tagSet.has(SCAN_BYPASS_TAG) || tagSet.has(EM_SWEEP_TAG)) {
+    return true
+  }
+
+  const compartment = caseData.compartment?.trim()
+  if (compartment === undefined || compartment.length === 0) {
+    return false
+  }
+
+  return tagSet.has(compartment)
+}
+
+export interface AntiScanScoutingScoreAdjustment {
+  readonly delta: number
+  readonly reason?: string
+}
+
+export function antiScanCompartmentScoutingScoreAdjustment(
+  caseData: CaseInstance,
+  teamTags: readonly string[]
+): AntiScanScoutingScoreAdjustment {
+  if (resolveHiddenStateModality(caseData) !== 'anti_scan_compartment') {
+    return { delta: 0 }
+  }
+
+  if (isAntiScanCompartmentAligned(caseData, teamTags)) {
+    return { delta: 0 }
+  }
+
+  const compartmentLabel = caseData.compartment?.trim() || 'warded volume'
+
+  return {
+    delta: ANTI_SCAN_COMPARTMENT_CAUTION_SCORE_DELTA,
+    reason: `Anti-scan compartment ${compartmentLabel} — scan caution.`,
+  }
 }
 
 /** True when scouting team tags satisfy the case route or liminal-frequency gate. */
@@ -213,6 +279,10 @@ export function resolveHiddenStateModality(caseData: CaseInstance): HiddenStateM
     return 'out_of_phase_presence'
   }
 
+  if (caseHasAntiScanCompartmentModality(caseData)) {
+    return 'anti_scan_compartment'
+  }
+
   return 'concealed_presence'
 }
 
@@ -234,6 +304,8 @@ export function hiddenStateModalityLayer(
       return GLAMOUR_OVERLAY_LAYER
     case 'out_of_phase_presence':
       return OUT_OF_PHASE_LAYER
+    case 'anti_scan_compartment':
+      return ANTI_SCAN_COMPARTMENT_LAYER
     case 'none':
       return null
     default: {
@@ -448,6 +520,39 @@ export function applyGlamourOverlayScanProjection(scan: DetectionScanResult): De
     }
 
     return field
+  })
+
+  return {
+    ...scan,
+    fields,
+  }
+}
+
+/** Player-facing scan projection for anti-scan compartments without mutating canonical truth tiers. */
+export function applyAntiScanCompartmentScanProjection(
+  scan: DetectionScanResult,
+  caseData: CaseInstance,
+  teamTags: readonly string[]
+): DetectionScanResult {
+  const aligned = isAntiScanCompartmentAligned(caseData, teamTags)
+  const fields = scan.fields.map((field) => {
+    if (field.tier !== 'presence') {
+      return field
+    }
+
+    if (!aligned) {
+      return {
+        ...field,
+        playerFacingValue: ANTI_SCAN_DEGRADED_PRESENCE_SKEW,
+        ambiguous: true,
+      }
+    }
+
+    return {
+      ...field,
+      playerFacingValue: ANTI_SCAN_PARTIAL_PRESENCE_SKEW,
+      ambiguous: true,
+    }
   })
 
   return {

--- a/src/domain/hiddenStateModalityTells.ts
+++ b/src/domain/hiddenStateModalityTells.ts
@@ -151,6 +151,7 @@ export function tellReadoutPrefixForModality(modality: HiddenStateModalityKind):
     case 'false_detection_output':
     case 'glamour_overlay':
     case 'out_of_phase_presence':
+    case 'anti_scan_compartment':
     case 'none':
       return null
     default: {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1341,6 +1341,8 @@ export interface CaseInstance {
   counterDetection?: boolean
   displacementTarget?: Id | null
   route?: string | null
+  /** SPE-2303: authored anti-scan compartment token for bypass alignment (mirrors `route`). */
+  compartment?: string | null
   /** SPE-2284: known-but-unresolved hidden-state scouting nodes across weekly passes. */
   hiddenStateScoutingReconCache?: import('./hiddenStateScoutingReconCache').HiddenStateScoutingReconCache
   /** SPE-2285: false-entity / structural-illusion lifecycle overlay. */

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -21,6 +21,7 @@ import {
   resolveIllusionKindFromCase,
 } from './hiddenStateIllusionLifecycle'
 import {
+  applyAntiScanCompartmentScanProjection,
   applyFalsePositionScanProjection,
   applyFalseDetectionScanProjection,
   applyGlamourOverlayScanProjection,
@@ -333,6 +334,14 @@ export function resolveScoutingWithCaseHiddenState(
 
   if (modality === 'out_of_phase_presence') {
     detectionScan = applyOutOfPhaseScanProjection(
+      detectionScan,
+      input.caseData,
+      input.teamTags ?? []
+    )
+  }
+
+  if (modality === 'anti_scan_compartment') {
+    detectionScan = applyAntiScanCompartmentScanProjection(
       detectionScan,
       input.caseData,
       input.teamTags ?? []

--- a/src/domain/revealPayloadScoutingIntegration.ts
+++ b/src/domain/revealPayloadScoutingIntegration.ts
@@ -28,6 +28,7 @@ import {
   applyOutOfPhaseScanProjection,
   applySignatureMaskScanProjection,
   buildSubjectTruthFromCaseHiddenState,
+  isAntiScanCompartmentAligned,
   resolveHiddenStateModality,
   scoutingOutcomeToDetectionScanForCase,
 } from './hiddenStateModality'
@@ -311,10 +312,16 @@ export function resolveScoutingWithCaseHiddenState(
 ): ScoutingRevealIntegrationResult {
   const scouting = resolveScouting(input)
   const truth = buildSubjectTruthFromCaseHiddenState(input.caseData, input, input.subject)
-  const scanInput = scoutingOutcomeToDetectionScanForCase(scouting, input.caseData)
-  let detectionScan = resolveDetectionScan(truth, scanInput)
-
+  const teamTags = input.teamTags ?? []
   const modality = resolveHiddenStateModality(input.caseData)
+  let scanInput = scoutingOutcomeToDetectionScanForCase(scouting, input.caseData)
+  if (
+    modality === 'anti_scan_compartment' &&
+    !isAntiScanCompartmentAligned(input.caseData, teamTags)
+  ) {
+    scanInput = { family: 'presence_sweep' }
+  }
+  let detectionScan = resolveDetectionScan(truth, scanInput)
 
   if (modality === 'false_position') {
     detectionScan = applyFalsePositionScanProjection(detectionScan, input.caseData)

--- a/src/test/advanceWeek.hiddenStateScouting.test.ts
+++ b/src/test/advanceWeek.hiddenStateScouting.test.ts
@@ -10,8 +10,11 @@ import {
   FALSE_DETECTION_SCAN_READOUT_PREFIX,
   GLAMOUR_SCAN_READOUT_PREFIX,
   OUT_OF_PHASE_SCAN_READOUT_PREFIX,
+  ANTI_SCAN_SCAN_READOUT_PREFIX,
 } from '../domain/detectionScanReportNotes'
 import {
+  ANTI_SCAN_DEGRADED_PRESENCE_SKEW,
+  MODALITY_ANTI_SCAN_TAG,
   MODALITY_FALSE_DETECTION_TAG,
   MODALITY_GLAMOUR_TAG,
   MODALITY_OUT_OF_PHASE_TAG,
@@ -430,6 +433,55 @@ describe('advanceWeek hidden-state scouting report copy (SPE-2283)', () => {
     ).toBe(true)
     expect(
       snapshot?.missionResult?.explanationNotes.some((note) => note.includes('route caution'))
+    ).toBe(true)
+    expect(snapshot?.hiddenState).not.toBe('revealed')
+  })
+
+  it('surfaces anti-scan readout and scan caution without revealing hidden state', () => {
+    const state = createStartingState()
+    const observer = createReconObserver('a_anti_scan_readout', 60)
+    const team: Team = {
+      id: 'team-anti-scan-readout',
+      name: 'Anti-scan readout team',
+      agentIds: [observer.id],
+      tags: [],
+    }
+    state.agents[observer.id] = observer
+    state.teams[team.id] = team
+    state.reports = []
+
+    for (const currentCase of Object.values(state.cases)) {
+      currentCase.status = 'open'
+      currentCase.assignedTeamIds = []
+      currentCase.requiredTags = []
+      currentCase.preferredTags = []
+    }
+
+    state.cases['case-concealed-readout'] = tuneConcealedInvestigationCase(state, team.id, {
+      tags: [MODALITY_ANTI_SCAN_TAG],
+      compartment: 'warded-volume-alpha',
+      counterDetection: false,
+    })
+
+    const preAdvance = resolveAssignedCaseForWeek(state.cases['case-concealed-readout'], state, () => 0.5)
+    expect(preAdvance.hiddenStateScouting?.active).toBe(true)
+
+    const nextState = advanceWeek(state)
+    const snapshot =
+      nextState.reports[nextState.reports.length - 1].caseSnapshots?.['case-concealed-readout']
+
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) =>
+        note.includes(ANTI_SCAN_SCAN_READOUT_PREFIX)
+      )
+    ).toBe(true)
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) =>
+        note.includes(ANTI_SCAN_DEGRADED_PRESENCE_SKEW)
+      )
+    ).toBe(true)
+    expect(
+      snapshot?.missionResult?.explanationNotes.some((note) => note.includes('scan caution'))
     ).toBe(true)
     expect(snapshot?.hiddenState).not.toBe('revealed')
   })

--- a/src/test/detectionScanReportNotes.test.ts
+++ b/src/test/detectionScanReportNotes.test.ts
@@ -10,6 +10,7 @@ import {
   DISPLACEMENT_SCAN_READOUT_PREFIX,
   GLAMOUR_SCAN_READOUT_PREFIX,
   OUT_OF_PHASE_SCAN_READOUT_PREFIX,
+  ANTI_SCAN_SCAN_READOUT_PREFIX,
   formatDetectionScanSummary,
   shouldAppendDetectionScanReportNote,
   shouldAppendModalityTellReportNote,
@@ -73,6 +74,9 @@ describe('detectionScanReportNotes', () => {
     expect(detectionScanReadoutPrefixForModality('glamour_overlay')).toBe(GLAMOUR_SCAN_READOUT_PREFIX)
     expect(detectionScanReadoutPrefixForModality('out_of_phase_presence')).toBe(
       OUT_OF_PHASE_SCAN_READOUT_PREFIX
+    )
+    expect(detectionScanReadoutPrefixForModality('anti_scan_compartment')).toBe(
+      ANTI_SCAN_SCAN_READOUT_PREFIX
     )
   })
 

--- a/src/test/hiddenStateModality.test.ts
+++ b/src/test/hiddenStateModality.test.ts
@@ -3,15 +3,24 @@ import {
   applyFalsePositionScanProjection,
   applyFalseDetectionScanProjection,
   applyGlamourOverlayScanProjection,
+  applyAntiScanCompartmentScanProjection,
   applyOutOfPhaseScanProjection,
   applySignatureMaskScanProjection,
+  ANTI_SCAN_COMPARTMENT_TAG,
+  ANTI_SCAN_DEGRADED_PRESENCE_SKEW,
+  ANTI_SCAN_PARTIAL_PRESENCE_SKEW,
+  antiScanCompartmentScoutingScoreAdjustment,
+  EM_SWEEP_TAG,
+  isAntiScanCompartmentAligned,
   isOutOfPhasePresenceAligned,
   LIMINAL_FREQUENCY_TAG,
   LIMINAL_PRESENCE_TAG,
+  MODALITY_ANTI_SCAN_TAG,
   MODALITY_OUT_OF_PHASE_TAG,
   OUT_OF_PHASE_ABSENT_ROUTE_SKEW,
   OUT_OF_PHASE_PARTIAL_PRESENCE_SKEW,
   outOfPhaseScoutingScoreAdjustment,
+  SCAN_BYPASS_TAG,
   buildSubjectTruthFromCaseHiddenState,
   formatDecoyLocusLabel,
   FALSE_DETECTION_FABRICATED_CATEGORY,
@@ -193,6 +202,34 @@ describe('hiddenStateModality (SPE-2281)', () => {
         })
       )
     ).toBe('glamour_overlay')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [MODALITY_ANTI_SCAN_TAG],
+        })
+      )
+    ).toBe('anti_scan_compartment')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [ANTI_SCAN_COMPARTMENT_TAG],
+        })
+      )
+    ).toBe('anti_scan_compartment')
+    expect(
+      resolveHiddenStateModality(
+        createModalityCase({
+          hiddenState: 'hidden',
+          tags: [MODALITY_OUT_OF_PHASE_TAG, MODALITY_ANTI_SCAN_TAG],
+        })
+      )
+    ).toBe('out_of_phase_presence')
+  })
+
+  it('maps anti-scan compartment to authored anti-scan layer', () => {
+    expect(hiddenStateModalityLayer('anti_scan_compartment')?.id).toBe('layer:authored-anti-scan')
   })
 
   it('maps out-of-phase presence to authored out-of-phase layer', () => {
@@ -753,6 +790,125 @@ describe('hiddenStateModality (SPE-2281)', () => {
 
     expect(outOfPhaseScoutingScoreAdjustment(caseData, []).delta).toBe(0.25)
     expect(outOfPhaseScoutingScoreAdjustment(caseData, [LIMINAL_FREQUENCY_TAG]).delta).toBe(0)
+  })
+
+  it('projects anti-scan readouts for misaligned and aligned bypass', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_ANTI_SCAN_TAG],
+      compartment: 'warded-volume-alpha',
+    })
+    const misalignedTruth = buildSubjectTruthFromCaseHiddenState(
+      caseData,
+      SCOUTING_LOW_CONCEALMENT,
+      SUBJECT
+    )
+    const misalignedScan = applyAntiScanCompartmentScanProjection(
+      resolveDetectionScan(misalignedTruth, { family: 'presence_sweep' }),
+      caseData,
+      SCOUTING_LOW_CONCEALMENT.teamTags
+    )
+
+    expect(misalignedTruth.present).toBe(true)
+    expect(
+      misalignedScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(ANTI_SCAN_DEGRADED_PRESENCE_SKEW)
+
+    const alignedTruth = buildSubjectTruthFromCaseHiddenState(
+      caseData,
+      { ...SCOUTING_LOW_CONCEALMENT, teamTags: [SCAN_BYPASS_TAG] },
+      SUBJECT
+    )
+    const alignedScan = applyAntiScanCompartmentScanProjection(
+      resolveDetectionScan(alignedTruth, { family: 'category_pass' }),
+      caseData,
+      [SCAN_BYPASS_TAG]
+    )
+
+    expect(
+      alignedScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(ANTI_SCAN_PARTIAL_PRESENCE_SKEW)
+    expect(isAntiScanCompartmentAligned(caseData, [EM_SWEEP_TAG])).toBe(true)
+    expect(
+      isAntiScanCompartmentAligned(caseData, ['warded-volume-alpha'])
+    ).toBe(true)
+  })
+
+  it('strips anti-scan layer on counter-detection without solving other families', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      counterDetection: true,
+      tags: [MODALITY_ANTI_SCAN_TAG],
+      compartment: 'warded-volume-alpha',
+    })
+    const truth = buildSubjectTruthFromCaseHiddenState(
+      caseData,
+      { ...SCOUTING_INPUT, teamTags: [SCAN_BYPASS_TAG] },
+      SUBJECT
+    )
+    const scanInput = scoutingOutcomeToDetectionScanForCase(
+      { outcome: 'strong', revealed: true, withheld: false },
+      caseData
+    )
+
+    const scan = resolveDetectionScan(truth, scanInput)
+    expect(scan.strippedLayerIds).toEqual(['layer:authored-anti-scan'])
+  })
+
+  it('applies scan-caution score adjustment when anti-scan bypass is misaligned', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_ANTI_SCAN_TAG],
+      compartment: 'warded-volume-alpha',
+    })
+
+    expect(antiScanCompartmentScoutingScoreAdjustment(caseData, SCOUTING_INPUT.teamTags).delta).toBe(
+      0.3
+    )
+    expect(
+      antiScanCompartmentScoutingScoreAdjustment(caseData, SCOUTING_INPUT.teamTags).reason
+    ).toContain('scan caution')
+    expect(antiScanCompartmentScoutingScoreAdjustment(caseData, [SCAN_BYPASS_TAG]).delta).toBe(0)
+  })
+
+  it('includes anti-scan compartment in distinct modality compose path', () => {
+    const antiScan = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_ANTI_SCAN_TAG],
+        compartment: 'warded-volume-alpha',
+      }),
+    })
+    const outOfPhase = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData: createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_OUT_OF_PHASE_TAG],
+        route: 'ritual-corridor-alpha',
+      }),
+    })
+
+    expect(
+      antiScan.detectionScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(ANTI_SCAN_DEGRADED_PRESENCE_SKEW)
+    const antiScanTruth = buildSubjectTruthFromCaseHiddenState(
+      createModalityCase({
+        hiddenState: 'hidden',
+        tags: [MODALITY_ANTI_SCAN_TAG],
+        compartment: 'warded-volume-alpha',
+      }),
+      SCOUTING_LOW_CONCEALMENT,
+      SUBJECT
+    )
+    expect(
+      antiScanTruth.concealmentLayers.some((layer) => layer.id === 'layer:authored-anti-scan')
+    ).toBe(true)
+    expect(
+      outOfPhase.detectionScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(OUT_OF_PHASE_ABSENT_ROUTE_SKEW)
   })
 
   it('includes out-of-phase presence in distinct modality compose path', () => {

--- a/src/test/hiddenStateModality.test.ts
+++ b/src/test/hiddenStateModality.test.ts
@@ -871,6 +871,31 @@ describe('hiddenStateModality (SPE-2281)', () => {
     expect(antiScanCompartmentScoutingScoreAdjustment(caseData, [SCAN_BYPASS_TAG]).delta).toBe(0)
   })
 
+  it('limits misaligned anti-scan compose path to presence tier on strong scouting', () => {
+    const caseData = createModalityCase({
+      hiddenState: 'hidden',
+      tags: [MODALITY_ANTI_SCAN_TAG],
+      compartment: 'warded-volume-alpha',
+    })
+    const integrated = resolveScoutingWithCaseHiddenState({
+      ...SCOUTING_LOW_CONCEALMENT,
+      subject: SUBJECT,
+      caseData,
+      teamTags: SCOUTING_LOW_CONCEALMENT.teamTags,
+    })
+
+    expect(integrated.outcome).toBe('strong')
+    expect(detectionScanTierOrder(integrated.detectionScan)).toEqual(['presence'])
+    expect(
+      integrated.detectionScan.fields.find((field) => field.tier === 'presence')?.playerFacingValue
+    ).toBe(ANTI_SCAN_DEGRADED_PRESENCE_SKEW)
+    expect(
+      integrated.detectionScan.remainingConcealmentLayers.some(
+        (layer) => layer.id === 'layer:authored-anti-scan'
+      )
+    ).toBe(true)
+  })
+
   it('includes anti-scan compartment in distinct modality compose path', () => {
     const antiScan = resolveScoutingWithCaseHiddenState({
       ...SCOUTING_LOW_CONCEALMENT,


### PR DESCRIPTION
## Summary

- Adds eighth `HiddenStateModalityKind` **`anti_scan_compartment`** with authored layer `layer:authored-anti-scan`, bypass policy (`scan-bypass` / `em-sweep` or case `compartment` token), degraded vs partial presence projections, **`Anti-scan readout:`** report prefix, and weekly scan-caution score adjustment.
- Mirrors slice 10 wiring in compose, orchestration, and tests; cases without anti-scan tags keep prior modality resolution (byte-stable triage).

## Linear

- **Slice:** [SPE-2303](https://linear.app/spectranoir/issue/SPE-2303/hidden-state-modality-matrix-slice-11-anti-scan-compartments)
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70/hidden-state-displacement-and-counter-detection-layer) — remains **Backlog** (mission-triage chips still deferred)

## Shipped

- `anti_scan_compartment` resolver priority after `out_of_phase_presence`
- Policy-gated scan degradation (not RNG); counter-reveal strips only `layer:authored-anti-scan`
- `planning/hidden-modality-matrix-slice-11.md`; post-matrix queue + backlog context updated

## Validation

- `npm run lint`
- `npm run test:run -- src/test/hiddenStateModality.test.ts src/test/advanceWeek.hiddenStateScouting.test.ts src/test/detectionScanReportNotes.test.ts src/test/revealPayloadOrchestration.test.ts src/test/hiddenStateModalityTells.test.ts src/test/hiddenStateScoutingReconCache.test.ts`

## Docs updated

- `planning/hidden-modality-matrix-slice-11.md`
- `planning/hidden-modality-matrix-post-matrix-queue.md`
- `planning/backlog.md`

## Deferred (out of slice)

- Mission triage illusion/tell chips
- Full SPE-70 parent Done
- Intake weekly-hook stack (SPE-2292–SPE-2301)