### PR TITLE
feat(SPE-2304): mission routing hydration intake linkage (SPE-854 slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -145,6 +145,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-weekly-hook-slice-8.md`                  | **Shipped**    | SPE-2299 / PR #2461; dedicated `information_intake.verification` report note type + UI bucket under SPE-854.                                        |
 | `information-intake-weekly-hook-slice-9.md`                  | **Shipped**    | SPE-2300 / PR #2463; dynamic intake narrative templates from case outcome metadata under SPE-854.                                                    |
 | `information-intake-parent-integration-slice-1.md`           | **Shipped**    | SPE-2301 / PR #2465; mixed-source intake → mission triage/routing under SPE-854.                                                                    |
+| `information-intake-parent-integration-slice-2.md`           | **In Progress** | SPE-2304; mission routing hydrate intake-linked triage refresh under SPE-854.                                                                      |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-parent-integration-slice-1.md
+++ b/planning/information-intake-parent-integration-slice-1.md
@@ -51,7 +51,7 @@ Wire persisted `informationIntakeReports` into mission intake triage and routing
 | ---- | --------------- | ------------ |
 | Full parent SPE-854 acceptance (remaining acceptance bullets) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Slice 1 covers routing integration only |
 | UI surfacing of intake signals on Cases triage panel | SPE-16 or UX child | Domain-only slice |
-| Hydration path `sanitizePersistedMissionRoutingState` intake linkage | Follow-up child | `normalizeMissionRecord` recomputes live state |
+| Hydration path `sanitizePersistedMissionRoutingState` intake linkage | [SPE-2304](https://linear.app/spectranoir/issue/SPE-2304) | `planning/information-intake-parent-integration-slice-2.md` |
 
 ## Parent
 

--- a/planning/information-intake-parent-integration-slice-2.md
+++ b/planning/information-intake-parent-integration-slice-2.md
@@ -1,0 +1,57 @@
+# SPE-854 — Mission routing hydration intake linkage (parent slice 2)
+
+One-page implementation plan. Linear: [SPE-2304](https://linear.app/spectranoir/issue/SPE-2304). Deferred from [SPE-2301](https://linear.app/spectranoir/issue/SPE-2301) / `planning/information-intake-parent-integration-slice-1.md`.
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2304 — Mission routing hydration intake linkage — parent slice 2](https://linear.app/spectranoir/issue/SPE-2304) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine |
+| **Branch** | `spe-854-information-intake-parent-integration-slice-2` |
+| **Status** | **In Progress** |
+
+## Goal
+
+On save hydration, recompute intake-linked triage fields (`triageScore`, `priorityReasonCodes`, `intakeSource`) from live `informationIntakeReports` and case tags. Do not serve stale persisted routing scores or reason codes when intake state changed.
+
+## Prerequisite (slice 1 on `main`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Live intake triage | `triageMission` + `deriveMissionIntakeInformationSignals` (SPE-2301) |
+| Intake persistence | `sanitizeInformationIntakeReports` hydrate path (SPE-2293) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `SanitizeMissionRoutingContext` + hydrate triage baseline | Weekly intake tick / narrative templates (SPE-2295–2300) |
+| `normalizeMissionRecord` intake-linked triage refresh | Cases triage UI layout |
+| `sanitizePersistedMissionRoutingState` post-sanitize refresh | `InformationIntakeReportRecord` schema |
+| `runTransfer` hydrate wiring | Parent SPE-854 Done |
+
+## Acceptance
+
+- [ ] Canal-bridge linked mission: save round-trip restores live `triageScore` and `intake-*` reason codes
+- [ ] Unlinked mission: persisted triage fields unchanged after hydrate
+- [ ] Player disposition / `triageIgnored` preserved on hydrate
+- [ ] `npm run test:run -- src/test/missionIntakeInformationRouting.integration.test.ts src/test/missionIntakeRouting.hydration.test.ts` and `npm run lint` pass
+
+## File touch list
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/missionIntakeRouting.ts`, `src/domain/missionIntakeInformationRouting.ts` |
+| Hydrate | `src/app/store/runTransfer.ts` |
+| Tests | `src/test/missionIntakeRouting.hydration.test.ts` |
+| Plan | `planning/information-intake-parent-integration-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Full parent SPE-854 acceptance (remaining bullets) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) | Hydration linkage only |
+| UI surfacing of intake signals on Cases triage panel | SPE-16 or UX child | Domain-only slice |
+
+## Parent
+
+Keep [SPE-854](https://linear.app/spectranoir/issue/SPE-854) tracking open per team convention until full parent acceptance ships; slice 2 does not close the parent.

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -49,6 +49,7 @@ import { normalizeCaseInstance } from '../../domain/case/normalizeCase'
 import { sanitizeDistrictScheduleState } from '../../domain/districtSchedule'
 import { normalizeMissionIntelRecord } from '../../domain/intel'
 import {
+  reconcileHydratedMissionRoutingTriage,
   sanitizePersistedMissionRoutingState,
 } from '../../domain/missionIntakeRouting'
 import { sanitizePersistedPartyCardState } from '../../domain/partyCards/sanitize'
@@ -8398,6 +8399,7 @@ export function hydrateGame(
     teams,
     squadKitTemplates
   )
+  const hydrationFunding = sanitizeInteger(game.funding as number | undefined, fallback.funding, 0)
   const gameOver = typeof game.gameOver === 'boolean' ? game.gameOver : fallback.gameOver
   const gameOverReason = sanitizeGameOverReason(
     gameOver,
@@ -8479,6 +8481,12 @@ export function hydrateGame(
         cases: normalizedCases,
         teams,
         week,
+        informationIntakeReports,
+        agents,
+        config,
+        funding: hydrationFunding,
+        agency: fallback.agency,
+        supportStaff: staff,
       }),
       replacementPressureState: sanitizeReplacementPressureState(game.replacementPressureState),
       districtScheduleState: sanitizeDistrictScheduleState(game.districtScheduleState, week),
@@ -8596,6 +8604,14 @@ export function hydrateGame(
       agents,
     }),
   })
+
+  hydrated = {
+    ...hydrated,
+    missionRouting: reconcileHydratedMissionRoutingTriage(hydratedBase.missionRouting, hydrated.missionRouting, {
+      cases: normalizedCases,
+      informationIntakeReports,
+    }),
+  }
 
   if (!legitimacy) {
     delete hydrated.legitimacy

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -8400,6 +8400,46 @@ export function hydrateGame(
     squadKitTemplates
   )
   const hydrationFunding = sanitizeInteger(game.funding as number | undefined, fallback.funding, 0)
+  const hydrationContainmentRating = sanitizeInteger(
+    game.containmentRating as number | undefined,
+    fallback.containmentRating,
+    0
+  )
+  const hydrationClearanceLevel = reconcileHydratedClearanceLevel(
+    sanitizeInteger(game.clearanceLevel as number | undefined, fallback.clearanceLevel, 1),
+    hydrationContainmentRating,
+    config.clearanceThresholds
+  )
+  const hydrationSupportAvailable = reconcileHydratedSupportAvailable(
+    game.supportAvailable,
+    isRecord(game.agency) ? game.agency.supportAvailable : undefined,
+    fallback.supportAvailable
+  )
+  const hydrationCoordinationFriction = reconcileHydratedCoordinationFriction(
+    game.coordinationFrictionActive,
+    game.coordinationFrictionReason,
+    isRecord(game.agency) ? game.agency.coordinationFrictionActive : undefined,
+    isRecord(game.agency) ? game.agency.coordinationFrictionReason : undefined,
+    {
+      coordinationFrictionActive: fallback.coordinationFrictionActive,
+      coordinationFrictionReason: fallback.coordinationFrictionReason,
+    }
+  )
+  const hydrationSupportStaff = sanitizeSupportStaffSummary(game.supportStaff)
+  const hydrationAgency =
+    sanitizeAgencyState(
+      game.agency ?? fallback.agency,
+      {
+        containmentRating: hydrationContainmentRating,
+        clearanceLevel: hydrationClearanceLevel,
+        funding: hydrationFunding,
+        supportAvailable: hydrationSupportAvailable,
+        coordinationFrictionActive: hydrationCoordinationFriction.coordinationFrictionActive,
+        coordinationFrictionReason: hydrationCoordinationFriction.coordinationFrictionReason,
+      },
+      config,
+      week
+    ) ?? fallback.agency
   const gameOver = typeof game.gameOver === 'boolean' ? game.gameOver : fallback.gameOver
   const gameOverReason = sanitizeGameOverReason(
     gameOver,
@@ -8485,8 +8525,8 @@ export function hydrateGame(
         agents,
         config,
         funding: hydrationFunding,
-        agency: fallback.agency,
-        supportStaff: staff,
+        agency: hydrationAgency,
+        supportStaff: hydrationSupportStaff,
       }),
       replacementPressureState: sanitizeReplacementPressureState(game.replacementPressureState),
       districtScheduleState: sanitizeDistrictScheduleState(game.districtScheduleState, week),
@@ -8507,17 +8547,9 @@ export function hydrateGame(
       factions,
       externalSupportAssets,
       academyTier,
-      containmentRating: sanitizeInteger(
-        game.containmentRating as number | undefined,
-        fallback.containmentRating,
-        0
-      ),
-      clearanceLevel: sanitizeInteger(
-        game.clearanceLevel as number | undefined,
-        fallback.clearanceLevel,
-        1
-      ),
-      funding: sanitizeInteger(game.funding as number | undefined, fallback.funding, 0),
+      containmentRating: hydrationContainmentRating,
+      clearanceLevel: hydrationClearanceLevel,
+      funding: hydrationFunding,
       emergencyGrayMarketWaiverWeek: sanitizeEmergencyGrayMarketWaiverWeek(
         game.emergencyGrayMarketWaiverWeek,
         week
@@ -8529,36 +8561,14 @@ export function hydrateGame(
       templates: fallback.templates,
     }) as GameState
 
-  const containmentRating = sanitizeInteger(
-    game.containmentRating as number | undefined,
-    fallback.containmentRating,
-    0
-  )
-  const clearanceLevel = reconcileHydratedClearanceLevel(
-    sanitizeInteger(game.clearanceLevel as number | undefined, fallback.clearanceLevel, 1),
-    containmentRating,
-    config.clearanceThresholds
-  )
-  const funding = sanitizeInteger(game.funding as number | undefined, fallback.funding, 0)
-  const supportAvailable = reconcileHydratedSupportAvailable(
-    game.supportAvailable,
-    isRecord(game.agency) ? game.agency.supportAvailable : undefined,
-    fallback.supportAvailable
-  )
-  const coordinationFriction = reconcileHydratedCoordinationFriction(
-    game.coordinationFrictionActive,
-    game.coordinationFrictionReason,
-    isRecord(game.agency) ? game.agency.coordinationFrictionActive : undefined,
-    isRecord(game.agency) ? game.agency.coordinationFrictionReason : undefined,
-    {
-      coordinationFrictionActive: fallback.coordinationFrictionActive,
-      coordinationFrictionReason: fallback.coordinationFrictionReason,
-    }
-  )
-  const coordinationFrictionActive = coordinationFriction.coordinationFrictionActive
-  const coordinationFrictionReason = coordinationFriction.coordinationFrictionReason
+  const containmentRating = hydrationContainmentRating
+  const clearanceLevel = hydrationClearanceLevel
+  const funding = hydrationFunding
+  const supportAvailable = hydrationSupportAvailable
+  const coordinationFrictionActive = hydrationCoordinationFriction.coordinationFrictionActive
+  const coordinationFrictionReason = hydrationCoordinationFriction.coordinationFrictionReason
   const legitimacy = sanitizeLegitimacyState(game.legitimacy)
-  const supportStaff = sanitizeSupportStaffSummary(game.supportStaff)
+  const supportStaff = hydrationSupportStaff
   const globalPressureScalars = sanitizePersistedGlobalPressureScalars({
     globalPressure: game.globalPressure,
     globalEscalationLevel: game.globalEscalationLevel,
@@ -8566,19 +8576,7 @@ export function hydrateGame(
     globalTimePressure: game.globalTimePressure,
   })
 
-  const agency = sanitizeAgencyState(
-    game.agency ?? fallback.agency,
-    {
-      containmentRating,
-      clearanceLevel,
-      funding,
-      supportAvailable,
-      coordinationFrictionActive,
-      coordinationFrictionReason,
-    },
-    hydratedBase.config,
-    week
-  )
+  const agency = hydrationAgency
 
   const responseGrid = sanitizePersistedResponseGrid(game.responseGrid, {
     templates: fallback.templates,

--- a/src/domain/missionIntakeInformationRouting.ts
+++ b/src/domain/missionIntakeInformationRouting.ts
@@ -88,6 +88,14 @@ function clampInteger(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, Math.trunc(value)))
 }
 
+/** True when persisted intake reports link to this mission (non-neutral intake routing signals). */
+export function missionHasLinkedIntakeReports(
+  state: Pick<GameState, 'informationIntakeReports'>,
+  currentCase: Pick<CaseInstance, 'id' | 'tags'>
+): boolean {
+  return deriveMissionIntakeInformationSignals(state, currentCase).linkedReportCount > 0
+}
+
 export function deriveMissionIntakeInformationSignals(
   state: Pick<GameState, 'informationIntakeReports'>,
   currentCase: Pick<CaseInstance, 'id' | 'tags' | 'contract' | 'stage' | 'factionId'>

--- a/src/domain/missionIntakeInformationRouting.ts
+++ b/src/domain/missionIntakeInformationRouting.ts
@@ -93,7 +93,7 @@ export function missionHasLinkedIntakeReports(
   state: Pick<GameState, 'informationIntakeReports'>,
   currentCase: Pick<CaseInstance, 'id' | 'tags'>
 ): boolean {
-  return deriveMissionIntakeInformationSignals(state, currentCase).linkedReportCount > 0
+  return listInformationIntakeReportsForMission(state, currentCase).length > 0
 }
 
 export function deriveMissionIntakeInformationSignals(

--- a/src/domain/missionIntakeRouting.ts
+++ b/src/domain/missionIntakeRouting.ts
@@ -10,7 +10,10 @@ import {
   rankBestAvailableTeams,
   validateTeamComposition,
 } from './teamComposition'
-import { deriveMissionIntakeInformationSignals } from './missionIntakeInformationRouting'
+import {
+  deriveMissionIntakeInformationSignals,
+  missionHasLinkedIntakeReports,
+} from './missionIntakeInformationRouting'
 import type {
   Agent,
   CaseInstance,
@@ -710,6 +713,7 @@ function normalizeMissionRecord(
 ): MissionRoutingRecord {
   const triage = triageMission(state, caseData)
   const routing = routeMission(state, caseData.id)
+  const intakeLinked = missionHasLinkedIntakeReports(state, caseData)
 
   return {
     missionId: caseData.id,
@@ -731,9 +735,11 @@ function normalizeMissionRecord(
     preferredTags: [...caseData.preferredTags],
     assignedTeamIds: [...caseData.assignedTeamIds],
     intakeSource: sanitizeIntakeSource(deriveMissionIntakeSource(caseData, state)),
-    priority: sanitizePriority(existing?.priority ?? triage.priority),
-    priorityReasonCodes: uniqueSortedStrings(existing?.priorityReasonCodes ?? triage.reasonCodes),
-    triageScore: clampInteger(existing?.triageScore ?? triage.score, 0, 100),
+    priority: sanitizePriority(intakeLinked ? triage.priority : (existing?.priority ?? triage.priority)),
+    priorityReasonCodes: uniqueSortedStrings(
+      intakeLinked ? triage.reasonCodes : (existing?.priorityReasonCodes ?? triage.reasonCodes)
+    ),
+    triageScore: clampInteger(intakeLinked ? triage.score : (existing?.triageScore ?? triage.score), 0, 100),
     routingState: sanitizeRoutingStateKind(
       isMissionTriageDispositionActive(existing, state.week) &&
         existing?.playerDisposition &&
@@ -1109,10 +1115,116 @@ function sanitizeMissionRoutingRecord(
   }
 }
 
+export type MissionRoutingHydrationTriageContext = Pick<
+  GameState,
+  | 'week'
+  | 'cases'
+  | 'teams'
+  | 'agents'
+  | 'agency'
+  | 'config'
+  | 'funding'
+  | 'supportStaff'
+  | 'informationIntakeReports'
+>
+
 export interface SanitizeMissionRoutingContext {
   cases: GameState['cases']
   teams: GameState['teams']
   week: number
+  informationIntakeReports?: GameState['informationIntakeReports']
+  agents?: GameState['agents']
+  agency?: GameState['agency']
+  config?: GameState['config']
+  funding?: number
+  supportStaff?: GameState['supportStaff']
+}
+
+function buildHydrationTriageState(context: SanitizeMissionRoutingContext): GameState | null {
+  if (!context.agents || !context.config || !context.agency) {
+    return null
+  }
+
+  return {
+    week: context.week,
+    cases: context.cases,
+    teams: context.teams,
+    agents: context.agents,
+    agency: context.agency,
+    config: context.config,
+    funding: context.funding ?? 0,
+    supportStaff: context.supportStaff,
+    informationIntakeReports: context.informationIntakeReports ?? {},
+  } as GameState
+}
+
+/**
+ * After attrition-derived `recomputeMissionRouting`, restore sanitized triage fields for
+ * missions without linked intake so hydrate does not drift persisted scores.
+ */
+export function reconcileHydratedMissionRoutingTriage(
+  sanitized: MissionRoutingState | undefined,
+  recomputed: MissionRoutingState | undefined,
+  context: Pick<GameState, 'cases' | 'informationIntakeReports'>
+): MissionRoutingState | undefined {
+  if (!recomputed) {
+    return recomputed
+  }
+
+  if (!sanitized) {
+    return recomputed
+  }
+
+  const missions = Object.fromEntries(
+    Object.entries(recomputed.missions).map(([missionId, mission]) => {
+      const currentCase = context.cases[missionId]
+      if (!currentCase || missionHasLinkedIntakeReports(context, currentCase)) {
+        return [missionId, mission] as const
+      }
+
+      const prior = sanitized.missions[missionId]
+      if (!prior) {
+        return [missionId, mission] as const
+      }
+
+      return [
+        missionId,
+        {
+          ...mission,
+          triageScore: prior.triageScore,
+          priority: prior.priority,
+          priorityReasonCodes: [...prior.priorityReasonCodes],
+          intakeSource: prior.intakeSource,
+        },
+      ] as const
+    })
+  )
+
+  return {
+    ...recomputed,
+    missions,
+  }
+}
+
+function refreshIntakeLinkedMissionRoutingRecord(
+  context: SanitizeMissionRoutingContext,
+  record: MissionRoutingRecord
+): MissionRoutingRecord {
+  const triageState = buildHydrationTriageState(context)
+  const currentCase = context.cases[record.missionId]
+  if (!triageState || !currentCase || !missionHasLinkedIntakeReports(triageState, currentCase)) {
+    return record
+  }
+
+  const triage = triageMission(triageState, currentCase)
+
+  return {
+    ...record,
+    intakeSource: sanitizeIntakeSource(deriveMissionIntakeSource(currentCase, triageState)),
+    triageScore: triage.score,
+    priority: triage.priority,
+    priorityReasonCodes: triage.reasonCodes,
+  }
 }
 
 /**
@@ -1165,16 +1277,22 @@ export function sanitizePersistedMissionRoutingState(
     Number.MAX_SAFE_INTEGER
   )
 
+  const refreshedMissions = Object.fromEntries(
+    orderedMissionIds
+      .map((missionId) => {
+        const record = missions[missionId]
+        if (!record) {
+          return null
+        }
+
+        return [missionId, refreshIntakeLinkedMissionRoutingRecord(context, record)] as const
+      })
+      .filter((entry): entry is readonly [Id, MissionRoutingRecord] => entry !== null)
+  )
+
   return {
     orderedMissionIds,
-    missions: Object.fromEntries(
-      orderedMissionIds
-        .map((missionId) => {
-          const record = missions[missionId]
-          return record ? ([missionId, record] as const) : null
-        })
-        .filter((entry): entry is readonly [Id, MissionRoutingRecord] => entry !== null)
-    ),
+    missions: refreshedMissions,
     nextGeneratedSequence,
   }
 }

--- a/src/domain/missionIntakeRouting.ts
+++ b/src/domain/missionIntakeRouting.ts
@@ -1140,7 +1140,9 @@ export interface SanitizeMissionRoutingContext {
   supportStaff?: GameState['supportStaff']
 }
 
-function buildHydrationTriageState(context: SanitizeMissionRoutingContext): GameState | null {
+function buildHydrationTriageState(
+  context: SanitizeMissionRoutingContext
+): MissionRoutingHydrationTriageContext | null {
   if (!context.agents || !context.config || !context.agency) {
     return null
   }
@@ -1155,7 +1157,7 @@ function buildHydrationTriageState(context: SanitizeMissionRoutingContext): Game
     funding: context.funding ?? 0,
     supportStaff: context.supportStaff,
     informationIntakeReports: context.informationIntakeReports ?? {},
-  } as GameState
+  }
 }
 
 /**
@@ -1216,11 +1218,13 @@ function refreshIntakeLinkedMissionRoutingRecord(
     return record
   }
 
-  const triage = triageMission(triageState, currentCase)
+  const triage = triageMission(triageState as GameState, currentCase)
 
   return {
     ...record,
-    intakeSource: sanitizeIntakeSource(deriveMissionIntakeSource(currentCase, triageState)),
+    intakeSource: sanitizeIntakeSource(
+      deriveMissionIntakeSource(currentCase, triageState as Pick<GameState, 'informationIntakeReports'>)
+    ),
     triageScore: triage.score,
     priority: triage.priority,
     priorityReasonCodes: triage.reasonCodes,

--- a/src/test/missionIntakeRouting.hydration.test.ts
+++ b/src/test/missionIntakeRouting.hydration.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { createStartingState } from '../data/startingState'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { normalizeMissionRoutingState, triageMission } from '../domain/missionIntakeRouting'
+
+const CANAL_BRIDGE_TOPIC = 'topic:canal-bridge-incident'
+
+const canalBridgeFixtures = [
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+]
+
+describe('mission intake routing hydration (SPE-854 parent slice 2)', () => {
+  it('refreshes stale triage score and intake reason codes after save round-trip when intake is linked', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+
+    const mission = createStarterCase({
+      id: 'case-hydrate-intake-linked',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+    state.cases[mission.id] = mission
+
+    const liveTriage = triageMission(state, mission)
+    expect(liveTriage.reasonCodes).toContain('intake-linked-reports')
+
+    state.missionRouting = {
+      orderedMissionIds: [mission.id],
+      missions: {
+        [mission.id]: {
+          missionId: mission.id,
+          templateId: mission.templateId,
+          category: 'strategic_opportunity',
+          kind: mission.kind,
+          status: mission.status,
+          generatedWeek: state.week,
+          deadlineRemaining: mission.deadlineRemaining,
+          durationWeeks: mission.durationWeeks,
+          stage: mission.stage,
+          difficulty: { ...mission.difficulty },
+          weights: { ...mission.weights },
+          requiredRoles: [...(mission.requiredRoles ?? [])],
+          requiredTags: [...mission.requiredTags],
+          preferredTags: [...mission.preferredTags],
+          assignedTeamIds: [],
+          intakeSource: 'scripted',
+          priority: 'low',
+          priorityReasonCodes: ['urgency-low'],
+          triageScore: 1,
+          routingState: 'pending_triage',
+          routingBlockers: [],
+          lastCandidateTeamIds: [],
+          lastRejectedTeamIds: [],
+        },
+      },
+      nextGeneratedSequence: 2,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+    const hydratedMission = loaded.missionRouting?.missions[mission.id]
+
+    expect(hydratedMission?.triageScore).toBe(liveTriage.score)
+    expect(hydratedMission?.priorityReasonCodes).toEqual(liveTriage.reasonCodes)
+    expect(hydratedMission?.intakeSource).toBe('pressure')
+    expect(hydratedMission?.priorityReasonCodes).toContain('intake-verification-conflict')
+  })
+
+  it('keeps persisted triage fields for missions without linked intake reports', () => {
+    const state = createStartingState()
+    const missionId = 'case-001'
+    const staleScore = 3
+    const staleReasonCodes = ['urgency-low', 'custom-stale-marker']
+
+    state.missionRouting = normalizeMissionRoutingState(state)
+    state.missionRouting = {
+      ...state.missionRouting!,
+      missions: {
+        ...state.missionRouting!.missions,
+        [missionId]: {
+          ...state.missionRouting!.missions[missionId]!,
+          triageScore: staleScore,
+          priorityReasonCodes: staleReasonCodes,
+          priority: 'low',
+        },
+      },
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.missionRouting?.missions[missionId]?.triageScore).toBe(staleScore)
+    expect(loaded.missionRouting?.missions[missionId]?.priorityReasonCodes).toEqual(
+      [...staleReasonCodes].sort((left, right) => left.localeCompare(right))
+    )
+  })
+
+  it('hydrates intake-linked triage through import parsing without clobbering player disposition', () => {
+    const fallback = createStartingState()
+    const mission = createStarterCase({
+      id: 'case-hydrate-disposition',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        templates: undefined,
+        week: fallback.week,
+        informationIntakeReports: Object.fromEntries(
+          canalBridgeFixtures.map((report) => [report.id, report])
+        ),
+        cases: {
+          ...fallback.cases,
+          [mission.id]: mission,
+        },
+        missionRouting: {
+          orderedMissionIds: [mission.id],
+          missions: {
+            [mission.id]: {
+              missionId: mission.id,
+              templateId: mission.templateId,
+              category: 'strategic_opportunity',
+              kind: mission.kind,
+              status: mission.status,
+              generatedWeek: fallback.week,
+              deadlineRemaining: mission.deadlineRemaining,
+              durationWeeks: mission.durationWeeks,
+              stage: mission.stage,
+              difficulty: { ...mission.difficulty },
+              weights: { ...mission.weights },
+              requiredRoles: [],
+              requiredTags: [...mission.requiredTags],
+              preferredTags: [...mission.preferredTags],
+              assignedTeamIds: [],
+              intakeSource: 'scripted',
+              priority: 'low',
+              priorityReasonCodes: [],
+              triageScore: 0,
+              routingState: 'deferred',
+              routingBlockers: [],
+              playerDisposition: 'defer',
+              playerDispositionWeek: fallback.week,
+              lastCandidateTeamIds: [],
+              lastRejectedTeamIds: [],
+            },
+          },
+          nextGeneratedSequence: 2,
+        },
+      },
+      fallback
+    )
+
+    const liveTriage = triageMission(hydrated, mission)
+    const record = hydrated.missionRouting?.missions[mission.id]
+
+    expect(record?.triageScore).toBe(liveTriage.score)
+    expect(record?.priorityReasonCodes).toEqual(liveTriage.reasonCodes)
+    expect(record?.playerDisposition).toBe('defer')
+    expect(record?.playerDispositionWeek).toBe(fallback.week)
+    expect(record?.routingState).toBe('deferred')
+  })
+})


### PR DESCRIPTION
## Summary

- Extend mission routing sanitize/hydrate to pass sanitized \informationIntakeReports\ and a triage baseline; refresh \	riageScore\, \priorityReasonCodes\, and \intakeSource\ when intake reports link to a mission.
- Fix \
ormalizeMissionRecord\ to prefer live triage output over stale persisted values when intake is linked.
- After attrition-derived routing recompute on hydrate, restore sanitized triage fields for missions without linked intake so unlinked missions stay stable on load.
- Add hydration round-trip tests (canal-bridge fixtures, disposition preservation).

## Linear

- **Slice:** [SPE-2304](https://linear.app/spectranoir/issue/SPE-2304) — Mission routing hydration intake linkage — parent slice 2
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (remains open)

## Validation

- \
pm run test:run -- src/test/missionIntakeInformationRouting.integration.test.ts src/test/missionIntakeRouting.hydration.test.ts\
- \
pm run lint\

## Docs

- \planning/information-intake-parent-integration-slice-2.md\
- \planning/backlog.md\ shipped table row

Made with [Cursor](https://cursor.com)