### PR TITLE
feat(SPE-2305): infiltration encounter content slice 3 — report copy depth

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -8,7 +8,7 @@ This file is the **canonical ordered queue** for concrete engineering and design
 
 From `README.md` **Current design notes**:
 
-- Concealment activation stack and hidden-modality matrix slices 1–10 shipped (SPE-2281–SPE-2302 / PR #2403–#2467); slice 11 anti-scan compartments in flight ([SPE-2303](https://linear.app/spectranoir/issue/SPE-2303)); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open for mission-triage chips only after slice 11 — see Shipped table and active queue below.
+- Concealment activation stack and hidden-modality matrix slices 1–11 shipped (SPE-2281–SPE-2303 / PR #2403–#2469); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open for mission-triage chips only — see Shipped table and active queue below.
 - Intake registry wave shipped on `main` through adjacent tier SPE-2123 (SPE-2104–SPE-2123 / PR #2428–#2442); [SPE-854](https://linear.app/spectranoir/issue/SPE-854), [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309), [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889), and [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) parents remain open.
 - Shared explanatory ownership stays in the domain wherever possible.
 - Prefer compact reusable rules vocabularies over bespoke subsystem logic.
@@ -17,7 +17,7 @@ From `README.md` **Current design notes**:
 ## Active queue (highest leverage first — reorder as needed)
 
 1. **Information intake ([SPE-854](https://linear.app/spectranoir/issue/SPE-854))** — Adjacent intake registry wave **complete** through SPE-2123 (SPE-2104–SPE-2123). No further SPE-21xx slice rows in `planning/harvest-reconciliation-index.md`; pick next work from backlog item 2, parent integration slices, or backlog grooming. Parents [SPE-854](https://linear.app/spectranoir/issue/SPE-854), [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889), [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109), and [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) stay open.
-2. **Infiltration optional content depth** — Batch-4 probe/cover/leave-behind and report copy slice complete (`src/domain/infiltrationEncounterReportNotes.ts`). Further authored content only; not new probe mechanics.
+2. **Infiltration optional content depth** — Batch-4 probe/cover/leave-behind stacks and report copy shipped (SPE-2250 slices 1–2); slice 3 report encounter depth in flight ([SPE-2305](https://linear.app/spectranoir/issue/SPE-2305)). Authored copy only; not new probe mechanics.
 3. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
 
 ## Recommended next step (agent handoff)
@@ -102,6 +102,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `infiltration-case-prep-slice.md`                         | **Shipped**    | SPE-521 prep panel; keep for patterns.                                                                                                              |
 | `infiltration-encounter-content-slice-1.md`               | **Shipped**    | SPE-2250 stack slice 1.                                                                                                                             |
 | `infiltration-encounter-content-slice-2.md`               | **Shipped**    | SPE-2250 stack slice 2.                                                                                                                             |
+| `infiltration-encounter-content-slice-3.md`               | **In progress** | SPE-2305; optional report encounter copy depth.                                                                                                    |
 | `investigation-question-case-prep-slice.md`               | **Shipped**    | SPE-626 UI; links forward to concealment prep.                                                                                                      |
 | `mission-triage-covert-prep-slice.md`                     | **Shipped**    | SPE-2255 slice 1.                                                                                                                                   |
 | `mission-triage-deferral-compare-slice.md`                | **Shipped**    | SPE-2256 slice 2.                                                                                                                                   |

--- a/planning/infiltration-encounter-content-slice-3.md
+++ b/planning/infiltration-encounter-content-slice-3.md
@@ -1,0 +1,90 @@
+# Infiltration encounter/content slice 3 (optional report copy depth)
+
+One-page implementation plan. Linear: [SPE-2305](https://linear.app/spectranoir/issue/SPE-2305) (child under [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250)). Follows shipped template stacks in slices 1–2 and report-copy module from SPE-2250.
+
+| Field      | Value                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2305 — Infiltration encounter content slice 3](https://linear.app/spectranoir/issue/SPE-2305) |
+| **Parent** | [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250)                                            |
+| **Branch** | `jamesdyedbq/spe-2305-infiltration-encounter-content-slice-3-report-copy-depth`                      |
+| **Status** | In progress — PR pending                                                                                          |
+
+## Goal
+
+Deepen **player-facing weekly infiltration report copy** with deterministic encounter flavor — probe-action operational detail, stage observer pressure, and cover-role friction — without new probe mechanics or template migrations.
+
+## Prerequisite (on `main`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Batch-4 template stacks | `planning/infiltration-encounter-content-slice-1.md`, slice 2 |
+| Report copy module | `src/domain/infiltrationEncounterReportNotes.ts` |
+| Weekly wire-up | `advanceWeek` → `infiltration.weekly_encounter`, threshold enrich |
+
+## Gap (pre-slice)
+
+- Weekly summaries list prep action and tracks but lack operational encounter detail.
+- Threshold enrichments prefix prep context only; no stage or cover-role observer flavor.
+- Cover roles appear as labels without situational friction copy.
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| Probe-action encounter detail lines (`probe_access` / `probe_route` / `cleanup`) | New probe track mechanics |
+| Stage observer clauses for `exposed` and `violent` | Template catalog migrations |
+| Cover-role observer friction when `claimedRole` is set | Case prep UI changes |
+| Wire into weekly + threshold formatters | `infiltrationProbe.ts` threshold math |
+| Unit + `advanceWeek` integration tests | Mission triage layout |
+
+## Copy contract (deterministic)
+
+### Probe-action encounter detail
+
+One sentence per `InfiltrationProbeAction`, appended after the prep clause in weekly summaries and threshold enrichments.
+
+### Stage observer pressure
+
+- `probing`: no extra clause (track line suffices).
+- `exposed`: observers treat cover as doubtful.
+- `violent`: site security shifts toward force response.
+
+### Cover-role friction
+
+When `coverRole` is set, one role-specific observer-friction sentence after the cover posture clause.
+
+## Acceptance
+
+- [x] Weekly summary includes probe-action detail and cover-role friction when applicable.
+- [x] Exposed/violent stages add observer pressure clause in weekly and enriched threshold notes.
+- [x] Existing SPE-2250 substrings preserved; targeted tests green.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## TDD order
+
+1. **Encounter detail** — per-action copy + formatter.
+2. **Stage observer** — exposed/violent clauses only.
+3. **Cover friction** — per-role copy when role present.
+4. **Weekly summary compose** — wire clauses in stable order.
+5. **Threshold enrich** — same flavor in enriched threshold path.
+6. **`advanceWeek`** — one integration assertion for new copy in `infiltration.weekly_encounter`.
+
+## File touch list (expected)
+
+| Area | Files |
+| ---- | ----- |
+| Report copy | `src/domain/infiltrationEncounterReportNotes.ts` |
+| Tests | `src/test/infiltrationEncounterReportNotes.test.ts`, `src/test/infiltrationEncounterReportCopy.test.ts` |
+| Docs | `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| ---- | ----- | --- |
+| Additional template probe/cover stacks | SPE-2250 follow-up | Out of slice 3 copy-only boundary |
+| Case prep UI encounter summaries | SPE-521 follow-up | UI not in scope |
+
+## See also
+
+- `planning/infiltration-encounter-content-slice-2.md`
+- `src/domain/infiltrationEncounterReportNotes.ts`

--- a/src/domain/infiltrationEncounterReportNotes.ts
+++ b/src/domain/infiltrationEncounterReportNotes.ts
@@ -223,7 +223,7 @@ export function enrichInfiltrationThresholdSummary(
   context: InfiltrationEncounterReportContext
 ): string {
   const prepLead = formatProbeActionClause(context).replace(/\.$/, '')
-  const encounterDetail = formatProbeEncounterDetailClause(context).trim()
+  const encounterDetail = formatProbeEncounterDetailClause(context).trim().replace(/\.$/, '')
   return `${prepLead}; ${encounterDetail}; ${baseSummary}${formatCoverClause(context)}${formatCoverRoleFrictionClause(context)}${formatLeaveBehindClause(context)}${formatStageObserverClause(context)}${formatTrackClause(context)}`
 }
 

--- a/src/domain/infiltrationEncounterReportNotes.ts
+++ b/src/domain/infiltrationEncounterReportNotes.ts
@@ -33,6 +33,31 @@ export const INFILTRATION_STAGE_LABELS: Record<InfiltrationStage, string> = {
   violent: 'violent escalation',
 }
 
+/** Deterministic operational detail per weekly probe action (report-facing). */
+export const INFILTRATION_PROBE_ENCOUNTER_DETAILS: Record<InfiltrationProbeAction, string> = {
+  probe_access: 'Operators exercised badge chains and restricted corridors.',
+  probe_route: 'Operators mapped patrol gaps and service routes.',
+  cleanup: 'Operators burned back-channel contacts to reduce scrutiny.',
+}
+
+/** Observer pressure when infiltration stage is no longer routine probing. */
+export const INFILTRATION_STAGE_OBSERVER_CLAUSES: Record<
+  Exclude<InfiltrationStage, 'probing'>,
+  string
+> = {
+  exposed: 'Local observers treat the claimed role as doubtful.',
+  violent: 'Site security posture shifted toward force response.',
+}
+
+/** Role-specific observer friction when cover posture is active. */
+export const INFILTRATION_COVER_ROLE_OBSERVER_FRICTION: Record<InfiltrationCoverRole, string> = {
+  uniform_guard: 'Checkpoint staff compare badge sequences against shift rosters.',
+  civilian_staff: 'Supervisors cross-check staff badges against room assignments.',
+  courier: 'Receiving clerks verify delivery manifests against courier credentials.',
+  maintenance: 'Facilities leads question tool manifests and work-order timing.',
+  official_inspector: 'Site liaisons demand inspection paperwork before granting access.',
+}
+
 export type InfiltrationProbeActionSource = 'override' | 'authored' | 'heuristic'
 
 export interface InfiltrationEncounterReportContext {
@@ -145,6 +170,26 @@ function formatCoverClause(context: InfiltrationEncounterReportContext) {
   return ` Cover posture: ${INFILTRATION_COVER_ROLE_LABELS[context.coverRole]}.`
 }
 
+function formatProbeEncounterDetailClause(context: InfiltrationEncounterReportContext) {
+  return ` ${INFILTRATION_PROBE_ENCOUNTER_DETAILS[context.probeAction]}`
+}
+
+function formatCoverRoleFrictionClause(context: InfiltrationEncounterReportContext) {
+  if (context.coverRole === undefined) {
+    return ''
+  }
+
+  return ` ${INFILTRATION_COVER_ROLE_OBSERVER_FRICTION[context.coverRole]}`
+}
+
+function formatStageObserverClause(context: InfiltrationEncounterReportContext) {
+  if (context.stage === 'probing') {
+    return ''
+  }
+
+  return ` ${INFILTRATION_STAGE_OBSERVER_CLAUSES[context.stage]}`
+}
+
 function formatLeaveBehindClause(context: InfiltrationEncounterReportContext) {
   if (!context.leaveBehindLabel) {
     return ''
@@ -163,8 +208,11 @@ export function formatInfiltrationWeeklyEncounterSummary(
 ): string {
   return (
     formatProbeActionClause(context) +
+    formatProbeEncounterDetailClause(context) +
     formatCoverClause(context) +
+    formatCoverRoleFrictionClause(context) +
     formatLeaveBehindClause(context) +
+    formatStageObserverClause(context) +
     formatTrackClause(context)
   )
 }
@@ -175,7 +223,8 @@ export function enrichInfiltrationThresholdSummary(
   context: InfiltrationEncounterReportContext
 ): string {
   const prepLead = formatProbeActionClause(context).replace(/\.$/, '')
-  return `${prepLead}; ${baseSummary}${formatCoverClause(context)}${formatLeaveBehindClause(context)}${formatTrackClause(context)}`
+  const encounterDetail = formatProbeEncounterDetailClause(context).trim()
+  return `${prepLead}; ${encounterDetail}; ${baseSummary}${formatCoverClause(context)}${formatCoverRoleFrictionClause(context)}${formatLeaveBehindClause(context)}${formatStageObserverClause(context)}${formatTrackClause(context)}`
 }
 
 export function formatInfiltrationLeaveBehindTradeoffSummary(

--- a/src/test/infiltrationEncounterReportCopy.test.ts
+++ b/src/test/infiltrationEncounterReportCopy.test.ts
@@ -49,6 +49,7 @@ describe('infiltrationEncounterReportCopy', () => {
     expect(summary).toContain('uniform guard cover')
     expect(summary).toContain('Expose cooperating witness')
     expect(summary).toContain('access probe')
+    expect(summary).toContain('badge chains and restricted corridors')
   })
 
   it('prefixes threshold summaries with weekly prep context', () => {
@@ -116,6 +117,7 @@ describe('infiltrationEncounterReportCopy', () => {
 
     const weeklyNote = report?.notes.find((note) => note.type === 'infiltration.weekly_encounter')
     expect(weeklyNote?.content).toContain('Public Safety Briefing')
+    expect(weeklyNote?.content).toMatch(/badge chains|patrol gaps|back-channel contacts/)
     expect(weeklyNote?.metadata?.probeAction).toBeDefined()
   })
 

--- a/src/test/infiltrationEncounterReportNotes.test.ts
+++ b/src/test/infiltrationEncounterReportNotes.test.ts
@@ -66,10 +66,57 @@ describe('infiltrationEncounterReportNotes', () => {
     const enriched = enrichInfiltrationThresholdSummary('Observers intensified scrutiny.', context)
 
     expect(enriched).toContain('Authored probe plan')
+    expect(enriched).toContain('badge chains and restricted corridors')
     expect(enriched).toContain('uniform guard cover')
+    expect(enriched).toContain('Checkpoint staff compare badge sequences')
     expect(enriched).toContain('Burn field tool')
     expect(enriched).toContain('Observers intensified scrutiny')
     expect(enriched).toContain('10% probe / 20% awareness')
+  })
+
+  it('adds probe-action encounter detail and cover-role friction to weekly summaries', () => {
+    const context = buildInfiltrationEncounterReportContext(createCovertCase())!
+    const summary = formatInfiltrationWeeklyEncounterSummary(context)
+
+    expect(summary).toContain('badge chains and restricted corridors')
+    expect(summary).toContain('Checkpoint staff compare badge sequences')
+  })
+
+  it('adds stage observer pressure for exposed and violent tracks', () => {
+    const exposed = buildInfiltrationEncounterReportContext({
+      ...createCovertCase(),
+      infiltrationStage: 'exposed',
+    })!
+    expect(formatInfiltrationWeeklyEncounterSummary(exposed)).toContain(
+      'Local observers treat the claimed role as doubtful'
+    )
+
+    const violent = buildInfiltrationEncounterReportContext({
+      ...createCovertCase(),
+      infiltrationStage: 'violent',
+    })!
+    expect(formatInfiltrationWeeklyEncounterSummary(violent)).toContain(
+      'Site security posture shifted toward force response'
+    )
+  })
+
+  it('selects distinct encounter detail per probe action', () => {
+    const access = buildInfiltrationEncounterReportContext({
+      ...createCovertCase(),
+      infiltrationProbePlan: { defaultAction: 'probe_access' },
+    })!
+    const route = buildInfiltrationEncounterReportContext({
+      ...createCovertCase(),
+      infiltrationProbePlan: { defaultAction: 'probe_route' },
+    })!
+    const cleanup = buildInfiltrationEncounterReportContext({
+      ...createCovertCase(),
+      infiltrationWeeklyProbeActionOverride: 'cleanup',
+    })!
+
+    expect(formatInfiltrationWeeklyEncounterSummary(access)).toContain('restricted corridors')
+    expect(formatInfiltrationWeeklyEncounterSummary(route)).toContain('patrol gaps and service routes')
+    expect(formatInfiltrationWeeklyEncounterSummary(cleanup)).toContain('back-channel contacts')
   })
 
   it('formats leave-behind tradeoff with score pressure and optional custody strain', () => {

--- a/src/test/infiltrationEncounterReportNotes.test.ts
+++ b/src/test/infiltrationEncounterReportNotes.test.ts
@@ -72,6 +72,7 @@ describe('infiltrationEncounterReportNotes', () => {
     expect(enriched).toContain('Burn field tool')
     expect(enriched).toContain('Observers intensified scrutiny')
     expect(enriched).toContain('10% probe / 20% awareness')
+    expect(enriched).not.toContain('.;')
   })
 
   it('adds probe-action encounter detail and cover-role friction to weekly summaries', () => {


### PR DESCRIPTION
## Summary

- **Linear:** [SPE-2305](https://linear.app/spectranoir/issue/SPE-2305) (child of [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250))
- **Parent:** SPE-2250 — infiltration encounter/content follow-through
- Adds deterministic encounter depth copy to `infiltrationEncounterReportNotes.ts`: probe-action operational detail, cover-role observer friction, and stage observer pressure for `exposed` / `violent`.
- Wires new clauses into weekly encounter summaries and threshold enrichments; no probe mechanics or template changes.

## What shipped

- Authored copy tables: `INFILTRATION_PROBE_ENCOUNTER_DETAILS`, `INFILTRATION_COVER_ROLE_OBSERVER_FRICTION`, `INFILTRATION_STAGE_OBSERVER_CLAUSES`
- Formatter integration in `formatInfiltrationWeeklyEncounterSummary` and `enrichInfiltrationThresholdSummary`
- Slice doc: `planning/infiltration-encounter-content-slice-3.md`
- Backlog reconciliation (SPE-2303 shipped; SPE-2305 in flight)

## Validation

- `npm run test:run -- src/test/infiltrationEncounterReportNotes.test.ts src/test/infiltrationEncounterReportCopy.test.ts` — 16 passed
- `npm run lint` — clean

## Docs updated

- `planning/infiltration-encounter-content-slice-3.md`
- `planning/backlog.md`

## Parent status

- SPE-2250 remains **Done** (slice 3 is optional depth follow-up)
- SPE-521 parent unchanged (Backlog)
