### PR TITLE
feat(SPE-2306): mission triage modality tell and illusion signal chips

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -8,26 +8,25 @@ This file is the **canonical ordered queue** for concrete engineering and design
 
 From `README.md` **Current design notes**:
 
-- Concealment activation stack and hidden-modality matrix slices 1–11 shipped (SPE-2281–SPE-2303 / PR #2403–#2469); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open for mission-triage chips only — see Shipped table and active queue below.
-- Intake registry wave shipped on `main` through adjacent tier SPE-2123 (SPE-2104–SPE-2123 / PR #2428–#2442); [SPE-854](https://linear.app/spectranoir/issue/SPE-854), [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309), [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889), and [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) parents remain open.
+- Concealment activation stack and hidden-modality matrix slices 1–11 shipped (SPE-2281–SPE-2303 / PR #2403–#2469); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open — mission-triage tell/illusion chips shipped in SPE-2306; see Shipped table and active queue below.
+- Intake registry wave and [SPE-854](https://linear.app/spectranoir/issue/SPE-854) parent integration slices 1–2 shipped (SPE-2292–SPE-2304 / PR #2444–#2471); parent [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **Done** on Linear. [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309), [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889), and [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) parents remain open.
 - Shared explanatory ownership stays in the domain wherever possible.
 - Prefer compact reusable rules vocabularies over bespoke subsystem logic.
 - Optional modules integrate through explicit contracts, not shared mutable state.
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Information intake ([SPE-854](https://linear.app/spectranoir/issue/SPE-854))** — Adjacent intake registry wave **complete** through SPE-2123 (SPE-2104–SPE-2123). No further SPE-21xx slice rows in `planning/harvest-reconciliation-index.md`; pick next work from backlog item 2, parent integration slices, or backlog grooming. Parents [SPE-854](https://linear.app/spectranoir/issue/SPE-854), [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889), [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109), and [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) stay open.
-2. **Infiltration optional content depth** — Report encounter copy slice 3 shipped ([SPE-2305](https://linear.app/spectranoir/issue/SPE-2305) / PR #2473). Further optional template stacks or prep UI copy under [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250) / [SPE-521](https://linear.app/spectranoir/issue/SPE-521) when narratively warranted.
-3. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
+1. **Infiltration optional content depth** — Report encounter copy slice 3 shipped ([SPE-2305](https://linear.app/spectranoir/issue/SPE-2305) / PR #2473). Further optional template stacks or prep UI copy under [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250) / [SPE-521](https://linear.app/spectranoir/issue/SPE-521) when narratively warranted.
+2. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
 
 ## Recommended next step (agent handoff)
 
-PR #2442 merged. On `main` @ `335bf788` after pull. Adjacent intake registry wave complete through SPE-2123. Next: pick from `planning/backlog.md` active queue (no unshipped SPE-21xx row in `planning/harvest-reconciliation-index.md`).
+PR #2471 merged. On `main` @ `f730ca14`. SPE-854 parent Done; SPE-70 tell/illusion triage chips next — see `planning/mission-triage-modality-signal-slice.md` ([SPE-2306](https://linear.app/spectranoir/issue/SPE-2306)).
 
 ## Blocked / waiting
 
-- **Mission triage full refresh** — Mission-triage slices 1–6 shipped (covert row signals, deferral compare, split layout, status-bar tail, disposition actions, list scan chips); further triage expansion deferred until triage UI is the primary implementation target — see `ux/mission-triage.md` spec status block.
-- **Core UX specs — mission triage** — Operations Report + navigation map for batch-4 covert notes and report week prev/next are closed (`ux/operations-report.md` §5.3.1, `ux/navigation-map.md` §3.5.1–3.5.2). Mission Triage full refresh remains blocked on triage UI being the implementation target.
+- **Mission triage full refresh** — Slices 1–7 shipped (covert row signals, deferral compare, split layout, status-bar tail, disposition actions, list scan chips, modality tell/illusion chips); further triage expansion (compare-top-2, bulk actions, spec §13 grouping) deferred until triage UI is again the primary implementation target — see `ux/mission-triage.md` spec status block.
+- **Core UX specs — mission triage** — Operations Report + navigation map for batch-4 covert notes and report week prev/next are closed (`ux/operations-report.md` §5.3.1, `ux/navigation-map.md` §3.5.1–3.5.2). Residual triage expansion remains blocked per slice boundary above.
 
 ## Shipped (May 2026)
 
@@ -111,6 +110,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `mission-triage-status-bar-slice.md`                      | **Shipped**    | SPE-2258 slice 4.                                                                                                                                   |
 | `mission-triage-disposition-slice.md`                     | **Shipped**    | SPE-16 slice 5 disposition.                                                                                                                         |
 | `mission-triage-list-scan-slice.md`                       | **Shipped**    | SPE-2259 slice 6; parent SPE-16 Done.                                                                                                               |
+| `mission-triage-modality-signal-slice.md`                 | **In progress** | SPE-2306 slice 7; tell/illusion triage chips under SPE-70.                                                                                          |
 | `mvp-weekly-loop-proof-slice-1.md`                        | **Shipped**    | SPE-2251 slice 1; see Shipped MVP loop proof.                                                                                                       |
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                                                                                                           |
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |

--- a/planning/hidden-modality-matrix-post-matrix-queue.md
+++ b/planning/hidden-modality-matrix-post-matrix-queue.md
@@ -35,7 +35,7 @@ Parent [SPE-70](https://linear.app/spectranoir/issue/SPE-70) remains **Backlog**
 
 ### Explicitly deferred (not in queue)
 
-- Mission triage illusion/tell chips
+- ~~Mission triage illusion/tell chips~~ → shipped SPE-2306 / `planning/mission-triage-modality-signal-slice.md`
 - Full SPE-70 parent Done (evaluate after owner review of deferred families)
 
 ## Agent handoff template (next runtime slice)

--- a/planning/mission-triage-modality-signal-slice.md
+++ b/planning/mission-triage-modality-signal-slice.md
@@ -1,0 +1,61 @@
+# SPE-70 — Mission triage illusion/tell signal chips (SPE-2306)
+
+One-page implementation plan. Linear: [SPE-2306](https://linear.app/spectranoir/issue/SPE-2306) (child under [SPE-70](https://linear.app/spectranoir/issue/SPE-70)). Deferred from shipped [SPE-2303](https://linear.app/spectranoir/issue/SPE-2303) / `planning/hidden-modality-matrix-slice-11.md`.
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2306 — Mission triage illusion/tell signal chips](https://linear.app/spectranoir/issue/SPE-2306) |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
+| **Branch** | `spe-2306-mission-triage-modality-signal-chips` |
+| **Status** | In progress |
+
+## Goal
+
+Surface bounded **modality tell** and **illusion lifecycle** signals as read-only chips on the compact `/cases` triage list — reusing shipped domain helpers without new modality mechanics or layout refresh.
+
+## Prerequisite (on `main` @ `f730ca14`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Modality tells | `hiddenStateModalityTells.ts` (SPE-2286) |
+| Illusion lifecycle | `hiddenStateIllusionLifecycle.ts` (SPE-2285) |
+| List scan chips | `buildMissionTriageListRowChips` (SPE-2259 / slice 6) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `missionTriageModalitySignalView.ts` — tell + illusion markers | New modality families |
+| Chip integration in `missionTriageLayoutView.ts` | Full triage layout / bulk actions |
+| `CaseListItemView.modalitySignals` when triage options enabled | Orchestration / weekly tick changes |
+| Targeted Vitest | SPE-854 intake UI (parent Done) |
+| Slice doc + backlog shipped row | SPE-70 parent Done (chips only) |
+
+## Acceptance
+
+- [ ] Open case with authored tell tags shows preview tell chip on list row
+- [ ] Assigned in-progress case shows active tell chip when `evaluateHiddenStateModalityTell` fires
+- [ ] False-entity / structural-illusion cases show illusion chips (active + disproved)
+- [ ] Resolved cases hide modality markers
+- [ ] `npm run lint` + targeted `npm run test:run` green
+
+## File touch list
+
+| Area | Files |
+| ---- | ----- |
+| View | `src/features/cases/missionTriageModalitySignalView.ts` |
+| Wiring | `caseView.ts`, `missionTriageLayoutView.ts`, `CasesPage.tsx`, `ShellStatusBar.tsx` |
+| Tests | `src/test/missionTriageModalitySignalView.test.ts` |
+| Docs | `planning/mission-triage-modality-signal-slice.md`, `planning/backlog.md`, `ux/mission-triage.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| ---- | ----- | --- |
+| Full SPE-70 parent Done | SPE-70 | Chips only; parent may stay Backlog |
+| Mission triage compare-top-2 / bulk actions | SPE-16 | Out of slice boundary |
+| SPE-854 intake signal chips on triage | SPE-16 or UX child | Separate deferred row from parent integration slices |
+
+## Parent
+
+Keep [SPE-70](https://linear.app/spectranoir/issue/SPE-70) **Backlog** until owner evaluates parent closure after chips ship.

--- a/src/components/layout/ShellStatusBar.tsx
+++ b/src/components/layout/ShellStatusBar.tsx
@@ -34,7 +34,10 @@ export function ShellStatusBar() {
       return []
     }
 
-    const triageViewOptions = { includeCovertPrepSignals: true as const }
+    const triageViewOptions = {
+      includeCovertPrepSignals: true as const,
+      includeModalitySignals: true as const,
+    }
     const filters = normalizeCaseListFilters(
       game,
       readCaseListFilters(searchParams),

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -96,7 +96,10 @@ export default function CasesPage() {
   >({})
   const [selectedContractId, setSelectedContractId] = useState<string | null>(null)
   const searchParamsString = searchParams.toString()
-  const triageViewOptions = { includeCovertPrepSignals: true as const }
+  const triageViewOptions = {
+    includeCovertPrepSignals: true as const,
+    includeModalitySignals: true as const,
+  }
   const filters = normalizeCaseListFilters(
     game,
     readCaseListFilters(searchParams),

--- a/src/features/cases/caseView.ts
+++ b/src/features/cases/caseView.ts
@@ -30,6 +30,10 @@ import {
   buildMissionTriageCovertPrepSignals,
   type MissionTriageCovertPrepSignals,
 } from './missionTriageCovertPrepView'
+import {
+  buildMissionTriageModalitySignals,
+  type MissionTriageModalitySignals,
+} from './missionTriageModalitySignalView'
 
 export const CASE_STATUS_FILTERS = ['all', 'open', 'in_progress', 'resolved'] as const
 export const CASE_MODE_FILTERS = ['all', 'threshold', 'probability', 'deterministic'] as const
@@ -83,6 +87,7 @@ export interface CaseListItemView {
   isRaidAtCapacity: boolean
   triageIgnored: boolean
   covertPrepSignals: MissionTriageCovertPrepSignals
+  modalitySignals: MissionTriageModalitySignals
   deferralCompare: MissionTriageDeferralCompareView
 }
 
@@ -99,6 +104,7 @@ export const DEFAULT_CASE_LIST_FILTERS: CaseListFilters = {
 
 export interface CaseListItemViewOptions {
   readonly includeCovertPrepSignals?: boolean
+  readonly includeModalitySignals?: boolean
 }
 
 export function getCaseListItemView(
@@ -200,6 +206,10 @@ export function getCaseListItemView(
     options?.includeCovertPrepSignals === true
       ? buildMissionTriageCovertPrepSignals(currentCase, game)
       : { visible: false, markers: [] }
+  const modalitySignals =
+    options?.includeModalitySignals === true
+      ? buildMissionTriageModalitySignals(currentCase, game, assignedTeams)
+      : { visible: false, markers: [] }
 
   return {
     currentCase,
@@ -227,6 +237,7 @@ export function getCaseListItemView(
     isRaidAtCapacity,
     triageIgnored: isMissionTriageIgnoredThisWeek(game, currentCase.id),
     covertPrepSignals,
+    modalitySignals,
     deferralCompare:
       options?.includeCovertPrepSignals === true
         ? buildMissionTriageDeferralCompareView(currentCase, game, { covertPrepSignals })

--- a/src/features/cases/missionTriageLayoutView.ts
+++ b/src/features/cases/missionTriageLayoutView.ts
@@ -148,6 +148,15 @@ export function buildMissionTriageListRowChips(
 
   appendUrgencyListRowChips(chips, view)
 
+  for (const marker of view.modalitySignals.markers) {
+    pushListRowChip(chips, {
+      id: marker.id,
+      label: marker.label,
+      className: marker.className,
+      title: marker.title,
+    })
+  }
+
   for (const marker of view.covertPrepSignals.markers) {
     pushListRowChip(chips, {
       id: marker.id,

--- a/src/features/cases/missionTriageModalitySignalView.ts
+++ b/src/features/cases/missionTriageModalitySignalView.ts
@@ -16,6 +16,7 @@ import {
 } from '../../domain/hiddenStateIllusionLifecycle'
 import { resolveHiddenStateModality } from '../../domain/hiddenStateModality'
 import type { Agent, CaseInstance, GameState, Team } from '../../domain/models'
+import { getUniqueTeamMembers } from '../../domain/teamSimulation'
 
 const MAX_MODALITY_MARKERS = 2
 
@@ -48,19 +49,16 @@ function pushMarker(
   markers.push(marker)
 }
 
-function agentsForTeams(game: GameState, teams: readonly Team[]): Agent[] {
-  const agents: Agent[] = []
-
-  for (const team of teams) {
-    for (const agentId of team.agentIds) {
-      const agent = game.agents[agentId]
-      if (agent) {
-        agents.push(agent)
-      }
-    }
+function agentsForAssignedTeams(game: GameState, teams: readonly Team[]): Agent[] {
+  if (teams.length === 0) {
+    return []
   }
 
-  return agents
+  return getUniqueTeamMembers(
+    teams.map((team) => team.id),
+    game.teams,
+    game.agents
+  )
 }
 
 function caseTagSet(caseData: CaseInstance): Set<string> {
@@ -178,13 +176,16 @@ function appendTellMarker(
         })
       : null
 
-  if (tell?.active === true && tell.kind !== undefined) {
-    pushMarker(markers, {
-      id: `tell:${tell.kind}`,
-      label: tellChipLabel(tell.kind),
-      className: MARKER_STYLES.tell,
-      title: tell.readoutLine,
-    })
+  if (assignedAgents.length > 0) {
+    if (tell?.active === true && tell.kind !== undefined) {
+      pushMarker(markers, {
+        id: `tell:${tell.kind}`,
+        label: tellChipLabel(tell.kind),
+        className: MARKER_STYLES.tell,
+        title: tell.readoutLine,
+      })
+    }
+
     return
   }
 
@@ -215,7 +216,7 @@ export function buildMissionTriageModalitySignals(
   const markers: MissionTriageModalitySignalMarker[] = []
 
   appendIllusionMarker(markers, resolvedCase)
-  appendTellMarker(markers, resolvedCase, agentsForTeams(game, assignedTeams))
+  appendTellMarker(markers, resolvedCase, agentsForAssignedTeams(game, assignedTeams))
 
   return {
     visible: markers.length > 0,

--- a/src/features/cases/missionTriageModalitySignalView.ts
+++ b/src/features/cases/missionTriageModalitySignalView.ts
@@ -1,0 +1,224 @@
+import { evaluateBehaviorWeightedDisguiseValidation } from '../../domain/disguiseValidation'
+import {
+  formatModalityTellReadout,
+  evaluateHiddenStateModalityTell,
+  TELL_METADATA_SPOOF_TAG,
+  TELL_ROUTE_TIMING_TAG,
+  TELL_SIGNATURE_DRIFT_TAG,
+  TELL_SPEECH_CADENCE_TAG,
+  TELL_THERMAL_RESIDUAL_TAG,
+  type HiddenStateTellKind,
+} from '../../domain/hiddenStateModalityTells'
+import {
+  resolveIllusionKindFromCase,
+  type HiddenStateIllusionKind,
+  type HiddenStateIllusionPhase,
+} from '../../domain/hiddenStateIllusionLifecycle'
+import { resolveHiddenStateModality } from '../../domain/hiddenStateModality'
+import type { Agent, CaseInstance, GameState, Team } from '../../domain/models'
+
+const MAX_MODALITY_MARKERS = 2
+
+const MARKER_STYLES = {
+  tell: 'border-indigo-500/40 bg-indigo-500/10 text-indigo-100',
+  illusionActive: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+  illusionDisproved: 'border-rose-400/30 bg-rose-400/5 text-rose-200',
+} as const
+
+export interface MissionTriageModalitySignalMarker {
+  readonly id: string
+  readonly label: string
+  readonly className: string
+  readonly title?: string
+}
+
+export interface MissionTriageModalitySignals {
+  readonly visible: boolean
+  readonly markers: readonly MissionTriageModalitySignalMarker[]
+}
+
+function pushMarker(
+  markers: MissionTriageModalitySignalMarker[],
+  marker: MissionTriageModalitySignalMarker
+) {
+  if (markers.length >= MAX_MODALITY_MARKERS) {
+    return
+  }
+
+  markers.push(marker)
+}
+
+function agentsForTeams(game: GameState, teams: readonly Team[]): Agent[] {
+  const agents: Agent[] = []
+
+  for (const team of teams) {
+    for (const agentId of team.agentIds) {
+      const agent = game.agents[agentId]
+      if (agent) {
+        agents.push(agent)
+      }
+    }
+  }
+
+  return agents
+}
+
+function caseTagSet(caseData: CaseInstance): Set<string> {
+  return new Set([
+    ...(caseData.tags ?? []),
+    ...(caseData.requiredTags ?? []),
+    ...(caseData.preferredTags ?? []),
+  ])
+}
+
+function tellKindForAuthoredTags(
+  caseData: CaseInstance
+): HiddenStateTellKind | null {
+  const modality = resolveHiddenStateModality(caseData)
+  const tags = caseTagSet(caseData)
+
+  if (modality === 'disguised_identity') {
+    if (tags.has(TELL_SPEECH_CADENCE_TAG)) {
+      return 'speech_cadence'
+    }
+
+    if (tags.has(TELL_METADATA_SPOOF_TAG)) {
+      return 'metadata_spoof'
+    }
+  }
+
+  if (modality === 'false_position' && tags.has(TELL_ROUTE_TIMING_TAG)) {
+    return 'route_timing'
+  }
+
+  if (modality === 'signature_masking' && tags.has(TELL_SIGNATURE_DRIFT_TAG)) {
+    return 'signature_drift'
+  }
+
+  if (modality === 'concealed_presence' && tags.has(TELL_THERMAL_RESIDUAL_TAG)) {
+    return 'thermal_residual'
+  }
+
+  return null
+}
+
+function tellChipLabel(kind: HiddenStateTellKind): string {
+  switch (kind) {
+    case 'thermal_residual':
+      return 'Tell: thermal'
+    case 'route_timing':
+      return 'Tell: routing'
+    case 'speech_cadence':
+      return 'Tell: cadence'
+    case 'metadata_spoof':
+      return 'Tell: metadata'
+    case 'signature_drift':
+      return 'Tell: signature'
+    default: {
+      const _exhaustive: never = kind
+      return _exhaustive
+    }
+  }
+}
+
+function illusionChipLabel(
+  kind: HiddenStateIllusionKind,
+  phase: HiddenStateIllusionPhase
+): string {
+  if (phase === 'disproved') {
+    return 'Illusion disproved'
+  }
+
+  return kind === 'false_entity' ? 'False contact' : 'False terrain'
+}
+
+function appendIllusionMarker(
+  markers: MissionTriageModalitySignalMarker[],
+  caseData: CaseInstance
+) {
+  const kind = resolveIllusionKindFromCase(caseData)
+  if (kind === null) {
+    return
+  }
+
+  const phase = caseData.hiddenStateIllusionState?.phase ?? 'active'
+  if (phase === 'collapsed') {
+    return
+  }
+
+  pushMarker(markers, {
+    id: `illusion:${kind}:${phase}`,
+    label: illusionChipLabel(kind, phase),
+    className:
+      phase === 'disproved' ? MARKER_STYLES.illusionDisproved : MARKER_STYLES.illusionActive,
+    title:
+      phase === 'disproved'
+        ? caseData.hiddenStateIllusionState?.disproofReason
+        : kind === 'false_entity'
+          ? 'Authored false-entity overlay may project fabricated contact readouts.'
+          : 'Authored structural illusion may mislocate terrain or route anchors.',
+  })
+}
+
+function appendTellMarker(
+  markers: MissionTriageModalitySignalMarker[],
+  caseData: CaseInstance,
+  assignedAgents: readonly Agent[]
+) {
+  const disguiseValidation = evaluateBehaviorWeightedDisguiseValidation(caseData, [
+    ...assignedAgents,
+  ])
+
+  const tell =
+    assignedAgents.length > 0
+      ? evaluateHiddenStateModalityTell({
+          caseData,
+          agents: assignedAgents,
+          disguiseValidationActive: disguiseValidation.active,
+        })
+      : null
+
+  if (tell?.active === true && tell.kind !== undefined) {
+    pushMarker(markers, {
+      id: `tell:${tell.kind}`,
+      label: tellChipLabel(tell.kind),
+      className: MARKER_STYLES.tell,
+      title: tell.readoutLine,
+    })
+    return
+  }
+
+  const previewKind = tellKindForAuthoredTags(caseData)
+  if (previewKind === null) {
+    return
+  }
+
+  pushMarker(markers, {
+    id: `tell-preview:${previewKind}`,
+    label: tellChipLabel(previewKind),
+    className: MARKER_STYLES.tell,
+    title: formatModalityTellReadout(previewKind, caseData),
+  })
+}
+
+export function buildMissionTriageModalitySignals(
+  caseData: CaseInstance,
+  game: GameState,
+  assignedTeams: readonly Team[] = []
+): MissionTriageModalitySignals {
+  const resolvedCase = game.cases[caseData.id] ?? caseData
+
+  if (resolvedCase.status === 'resolved') {
+    return { visible: false, markers: [] }
+  }
+
+  const markers: MissionTriageModalitySignalMarker[] = []
+
+  appendIllusionMarker(markers, resolvedCase)
+  appendTellMarker(markers, resolvedCase, agentsForTeams(game, assignedTeams))
+
+  return {
+    visible: markers.length > 0,
+    markers,
+  }
+}

--- a/src/test/missionTriageModalitySignalView.test.ts
+++ b/src/test/missionTriageModalitySignalView.test.ts
@@ -4,7 +4,10 @@ import { buildMissionTriageModalitySignals } from '../features/cases/missionTria
 import { buildMissionTriageListRowChips } from '../features/cases/missionTriageLayoutView'
 import { buildMissionTriageDispositionView } from '../features/cases/missionTriageDispositionView'
 import { getCaseListItemView } from '../features/cases/caseView'
-import { TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
+import {
+  OBSERVER_THRESHOLD_STRICT_TAG,
+  TELL_THERMAL_RESIDUAL_TAG,
+} from '../domain/hiddenStateModalityTells'
 import type { Agent, CaseInstance } from '../domain/models'
 import { createStarterCase } from '../domain/templates/startingCases'
 
@@ -60,7 +63,7 @@ describe('missionTriageModalitySignalView (SPE-2306)', () => {
     expect(signals.markers[0]?.title).toContain('Residual signature')
   })
 
-  it('shows active tell chip when assigned team agents satisfy observer gate', () => {
+  it('shows active tell chip when assigned team agents detect the tell', () => {
     const game = createStartingState()
     const teamId = Object.keys(game.teams)[0]!
     const agent = makeObserver('agent-tell', 70)
@@ -81,6 +84,30 @@ describe('missionTriageModalitySignalView (SPE-2306)', () => {
     const signals = buildMissionTriageModalitySignals(caseData, game, [game.teams[teamId]!])
 
     expect(signals.markers.some((marker) => marker.id === 'tell:thermal_residual')).toBe(true)
+  })
+
+  it('hides tell chip when assigned team fails observer-threshold gate (no preview fallback)', () => {
+    const game = createStartingState()
+    const teamId = Object.keys(game.teams)[0]!
+    const agent = makeObserver('agent-tell-strong', 60)
+    game.agents = { [agent.id]: agent }
+    game.teams = {
+      ...game.teams,
+      [teamId]: { ...game.teams[teamId]!, agentIds: [agent.id] },
+    }
+
+    const caseData = createHiddenCase({
+      id: 'case-tell-gated',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG, OBSERVER_THRESHOLD_STRICT_TAG],
+      difficulty: { combat: 0, investigation: 15, utility: 0, social: 0 },
+    })
+    game.cases = { [caseData.id]: caseData }
+
+    const signals = buildMissionTriageModalitySignals(caseData, game, [game.teams[teamId]!])
+
+    expect(signals.markers.some((marker) => marker.id.startsWith('tell'))).toBe(false)
   })
 
   it('shows illusion chips for active and disproved phases', () => {

--- a/src/test/missionTriageModalitySignalView.test.ts
+++ b/src/test/missionTriageModalitySignalView.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { buildMissionTriageModalitySignals } from '../features/cases/missionTriageModalitySignalView'
+import { buildMissionTriageListRowChips } from '../features/cases/missionTriageLayoutView'
+import { buildMissionTriageDispositionView } from '../features/cases/missionTriageDispositionView'
+import { getCaseListItemView } from '../features/cases/caseView'
+import { TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
+import type { Agent, CaseInstance } from '../domain/models'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createHiddenCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
+  return {
+    ...createStarterCase({
+      id: 'case-modality-tell',
+      templateId: 'combat_vampire_nest',
+    }),
+    mode: 'threshold',
+    hiddenState: 'hidden',
+    detectionConfidence: 0.2,
+    counterDetection: false,
+    tags: ['concealment'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+    infiltrationCoverProfile: undefined,
+    infiltrationProbePlan: undefined,
+    weights: { combat: 0, investigation: 0.4, utility: 0, social: 0 },
+    difficulty: { combat: 0, investigation: 40, utility: 0, social: 0 },
+    ...overrides,
+  }
+}
+
+function makeObserver(id: string, investigation: number): Agent {
+  return {
+    id,
+    name: id,
+    role: 'medium',
+    baseStats: { combat: 10, investigation, utility: 40, social: 40 },
+    tags: ['medium'],
+    relationships: {},
+    fatigue: 0,
+    status: 'active',
+  }
+}
+
+describe('missionTriageModalitySignalView (SPE-2306)', () => {
+  it('shows preview tell chip for open case with authored tell tags', () => {
+    const game = createStartingState()
+    const caseData = createHiddenCase({
+      id: 'case-tell-open',
+      status: 'open',
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+    })
+    game.cases = { [caseData.id]: caseData }
+
+    const signals = buildMissionTriageModalitySignals(caseData, game)
+
+    expect(signals.visible).toBe(true)
+    expect(signals.markers[0]?.label).toBe('Tell: thermal')
+    expect(signals.markers[0]?.title).toContain('Residual signature')
+  })
+
+  it('shows active tell chip when assigned team agents satisfy observer gate', () => {
+    const game = createStartingState()
+    const teamId = Object.keys(game.teams)[0]!
+    const agent = makeObserver('agent-tell', 70)
+    game.agents = { [agent.id]: agent }
+    game.teams = {
+      ...game.teams,
+      [teamId]: { ...game.teams[teamId]!, agentIds: [agent.id] },
+    }
+
+    const caseData = createHiddenCase({
+      id: 'case-tell-assigned',
+      status: 'in_progress',
+      assignedTeamIds: [teamId],
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+    })
+    game.cases = { [caseData.id]: caseData }
+
+    const signals = buildMissionTriageModalitySignals(caseData, game, [game.teams[teamId]!])
+
+    expect(signals.markers.some((marker) => marker.id === 'tell:thermal_residual')).toBe(true)
+  })
+
+  it('shows illusion chips for active and disproved phases', () => {
+    const game = createStartingState()
+
+    const activeCase = createHiddenCase({
+      id: 'case-false-entity',
+      status: 'open',
+      tags: ['false-entity'],
+    })
+    const disprovedCase = createHiddenCase({
+      id: 'case-illusion-disproved',
+      status: 'in_progress',
+      hiddenState: 'displaced',
+      tags: ['structural-illusion'],
+      hiddenStateIllusionState: {
+        kind: 'structural_illusion',
+        phase: 'disproved',
+        anchorLabel: 'false terrain anchor',
+        disproofReason: 'Route traversal exposed the false terrain anchor.',
+      },
+    })
+    game.cases = {
+      [activeCase.id]: activeCase,
+      [disprovedCase.id]: disprovedCase,
+    }
+
+    expect(buildMissionTriageModalitySignals(activeCase, game).markers[0]?.label).toBe(
+      'False contact'
+    )
+    expect(buildMissionTriageModalitySignals(disprovedCase, game).markers[0]?.label).toBe(
+      'Illusion disproved'
+    )
+  })
+
+  it('hides modality markers on resolved cases', () => {
+    const game = createStartingState()
+    const caseData = createHiddenCase({
+      id: 'case-resolved',
+      status: 'resolved',
+      tags: ['false-entity'],
+    })
+    game.cases = { [caseData.id]: caseData }
+
+    expect(buildMissionTriageModalitySignals(caseData, game).visible).toBe(false)
+  })
+
+  it('integrates modality chips into list row chip builder', () => {
+    const game = createStartingState()
+    const caseData = createHiddenCase({
+      id: 'case-chip-row',
+      status: 'open',
+      tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+    })
+    game.cases = { [caseData.id]: caseData }
+
+    const view = getCaseListItemView(caseData, game, {
+      includeCovertPrepSignals: true,
+      includeModalitySignals: true,
+    })
+    const chips = buildMissionTriageListRowChips(
+      view,
+      buildMissionTriageDispositionView(view, game)
+    )
+
+    expect(chips.some((chip) => chip.label === 'Tell: thermal')).toBe(true)
+  })
+})

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -42,9 +42,11 @@ This spec is for:
 
 **Slice 6 shipped (SPE-2259):** Compact triage list rows show disposition + urgency + covert-prep chips via `buildMissionTriageListRowChips` and `MissionTriageListRow`. Plan: `planning/mission-triage-list-scan-slice.md`.
 
+**Slice 7 shipped (SPE-2306):** Compact triage list rows also show read-only hidden-state **modality tell** and **illusion** signal chips via `buildMissionTriageModalitySignals` (reuses `hiddenStateModalityTells.ts` / `hiddenStateIllusionLifecycle.ts`). Plan: `planning/mission-triage-modality-signal-slice.md`.
+
 **Still deferred (follow-up slices):**
 
-- Additional triage UX expansion beyond shipped slices 1–6 (compare-top-2 on list, bulk actions, spec §13 visual grouping)
+- Additional triage UX expansion beyond shipped slices 1–7 (compare-top-2 on list, bulk actions, spec §13 visual grouping)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add \uildMissionTriageModalitySignals\ to surface read-only **modality tell** and **illusion lifecycle** chips on compact \/cases\ triage list rows (SPE-70 follow-up deferred from hidden-modality slice 11).
- Wire chips through \CaseListItemView.modalitySignals\ and \uildMissionTriageListRowChips\ (slice 6 pattern); no new modality mechanics or orchestration changes.
- Reconcile backlog/ux docs: SPE-854 parent Done on Linear; triage slice 7 documented.

## Linear mapping

- **Slice:** [SPE-2306](https://linear.app/spectranoir/issue/SPE-2306) — Mission triage illusion/tell signal chips
- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70) — Hidden-State, Displacement, & Counter-Detection Layer (remains Backlog)
- **Not in scope:** SPE-854 intake UI (parent Done); full triage layout refresh

## Test plan

- [x] \
pm run test:run -- src/test/missionTriageModalitySignalView.test.ts src/test/missionTriageLayoutView.test.ts\
- [x] \
pm run lint\

## Docs updated

- \planning/mission-triage-modality-signal-slice.md\
- \planning/backlog.md\
- \planning/hidden-modality-matrix-post-matrix-queue.md\
- \ux/mission-triage.md\

## Parent status

SPE-70 stays **Backlog** (chips only; parent closure still deferred).

Made with [Cursor](https://cursor.com)