### PR TITLE
feat(SPE-2307): mission triage intake signal chips (slice 8 UX)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -21,11 +21,11 @@ From `README.md` **Current design notes**:
 
 ## Recommended next step (agent handoff)
 
-PR #2475 merged. On `main` @ `5fbd9c2f`. SPE-2306 shipped. Next: pick from `planning/backlog.md` active queue (infiltration optional depth, or SPE-854 intake signal chips deferred to SPE-16).
+PR #2475 merged. On `main` @ `25eee991`. SPE-2306 shipped. **Next:** infiltration optional depth or SPE-2307 intake triage chips (in PR).
 
 ## Blocked / waiting
 
-- **Mission triage full refresh** — Slices 1–7 shipped (covert row signals, deferral compare, split layout, status-bar tail, disposition actions, list scan chips, modality tell/illusion chips); further triage expansion (compare-top-2, bulk actions, spec §13 grouping) deferred until triage UI is again the primary implementation target — see `ux/mission-triage.md` spec status block.
+- **Mission triage full refresh** — Slices 1–8 shipped or in PR (covert row signals, deferral compare, split layout, status-bar tail, disposition actions, list scan chips, modality tell/illusion chips, intake signal chips); further triage expansion (compare-top-2, bulk actions, spec §13 grouping) deferred until triage UI is again the primary implementation target — see `ux/mission-triage.md` spec status block.
 - **Core UX specs — mission triage** — Operations Report + navigation map for batch-4 covert notes and report week prev/next are closed (`ux/operations-report.md` §5.3.1, `ux/navigation-map.md` §3.5.1–3.5.2). Residual triage expansion remains blocked per slice boundary above.
 
 ## Shipped (May 2026)
@@ -111,6 +111,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `mission-triage-disposition-slice.md`                     | **Shipped**    | SPE-16 slice 5 disposition.                                                                                                                         |
 | `mission-triage-list-scan-slice.md`                       | **Shipped**    | SPE-2259 slice 6; parent SPE-16 Done.                                                                                                               |
 | `mission-triage-modality-signal-slice.md`                 | **Shipped**    | SPE-2306 slice 7 / PR #2475; tell/illusion triage chips under SPE-70.                                                                               |
+| `mission-triage-intake-signal-slice.md`                   | **In PR**      | SPE-2307 slice 8; intake reason-code triage chips under SPE-16.                                                                                     |
 | `mvp-weekly-loop-proof-slice-1.md`                        | **Shipped**    | SPE-2251 slice 1; see Shipped MVP loop proof.                                                                                                       |
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                                                                                                           |
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -21,7 +21,7 @@ From `README.md` **Current design notes**:
 
 ## Recommended next step (agent handoff)
 
-PR #2471 merged. On `main` @ `f730ca14`. SPE-854 parent Done; SPE-70 tell/illusion triage chips next — see `planning/mission-triage-modality-signal-slice.md` ([SPE-2306](https://linear.app/spectranoir/issue/SPE-2306)).
+PR #2475 merged. On `main` @ `5fbd9c2f`. SPE-2306 shipped. Next: pick from `planning/backlog.md` active queue (infiltration optional depth, or SPE-854 intake signal chips deferred to SPE-16).
 
 ## Blocked / waiting
 
@@ -110,7 +110,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `mission-triage-status-bar-slice.md`                      | **Shipped**    | SPE-2258 slice 4.                                                                                                                                   |
 | `mission-triage-disposition-slice.md`                     | **Shipped**    | SPE-16 slice 5 disposition.                                                                                                                         |
 | `mission-triage-list-scan-slice.md`                       | **Shipped**    | SPE-2259 slice 6; parent SPE-16 Done.                                                                                                               |
-| `mission-triage-modality-signal-slice.md`                 | **In progress** | SPE-2306 slice 7; tell/illusion triage chips under SPE-70.                                                                                          |
+| `mission-triage-modality-signal-slice.md`                 | **Shipped**    | SPE-2306 slice 7 / PR #2475; tell/illusion triage chips under SPE-70.                                                                               |
 | `mvp-weekly-loop-proof-slice-1.md`                        | **Shipped**    | SPE-2251 slice 1; see Shipped MVP loop proof.                                                                                                       |
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                                                                                                           |
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |

--- a/planning/mission-triage-intake-signal-slice.md
+++ b/planning/mission-triage-intake-signal-slice.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2307](https://linear.app/spectranoir/
 | **Linear** | [SPE-2307 — Mission triage intake signal chips (slice 8 UX)](https://linear.app/spectranoir/issue/SPE-2307) |
 | **Parent** | [SPE-16](https://linear.app/spectranoir/issue/SPE-16) — Mission Intake, Triage, & Routing |
 | **Branch** | `spe-2307-mission-triage-intake-signal-chips` |
-| **Status** | **In PR** |
+| **Status** | **In PR** — https://github.com/JamesJedi420/containment-protocol/pull/2477 |
 
 ## Goal
 

--- a/planning/mission-triage-intake-signal-slice.md
+++ b/planning/mission-triage-intake-signal-slice.md
@@ -1,0 +1,61 @@
+# SPE-2307 — Mission triage intake signal chips (slice 8 UX)
+
+One-page implementation plan. Linear: [SPE-2307](https://linear.app/spectranoir/issue/SPE-2307). Deferred from [SPE-2301](https://linear.app/spectranoir/issue/SPE-2301) / [SPE-2304](https://linear.app/spectranoir/issue/SPE-2304) / `planning/information-intake-parent-integration-slice-1.md`.
+
+| Field      | Value |
+| ---------- | ----- |
+| **Linear** | [SPE-2307 — Mission triage intake signal chips (slice 8 UX)](https://linear.app/spectranoir/issue/SPE-2307) |
+| **Parent** | [SPE-16](https://linear.app/spectranoir/issue/SPE-16) — Mission Intake, Triage, & Routing |
+| **Branch** | `spe-2307-mission-triage-intake-signal-chips` |
+| **Status** | **In PR** |
+
+## Goal
+
+Surface bounded **intake-* reason codes** as read-only chips on the compact `/cases` triage list and detail panel — reusing shipped domain helpers without weekly-hook or routing core changes.
+
+## Prerequisite (on `main` @ `25eee991`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Intake routing signals | `deriveMissionIntakeInformationSignals` (SPE-2301) |
+| Hydration linkage | `sanitizePersistedMissionRoutingState` intake refresh (SPE-2304) |
+| List scan chips | `buildMissionTriageListRowChips` (SPE-2259 / slice 6) |
+| Modality chips pattern | `missionTriageModalitySignalView.ts` (SPE-2306 / slice 7) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `missionTriageIntakeSignalView.ts` — intake marker builder (max 2 markers) | `missionIntakeInformationRouting.ts` core changes |
+| Chip integration in `missionTriageLayoutView.ts` + `caseView.ts` | Weekly intake tick / registry wave |
+| `includeIntakeSignals` on triage list/detail consumers | Compare-top-2 / bulk actions |
+| Targeted Vitest (canal-bridge fixture) | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) parent reopen |
+
+## Acceptance
+
+- [ ] Canal-bridge linked mission shows intake chips on list row (`Intake: conflict`, `Intake: incomplete`)
+- [ ] Unlinked missions show no intake chips
+- [ ] Resolved missions hide intake markers
+- [ ] Chips derive from live `informationIntakeReports`, not stale persisted routing codes
+- [ ] `npm run lint` + targeted Vitest green
+
+## File touch list
+
+| Area | Files |
+| ---- | ----- |
+| View | `src/features/cases/missionTriageIntakeSignalView.ts` |
+| Wiring | `caseView.ts`, `missionTriageLayoutView.ts`, `CasesPage.tsx`, `ShellStatusBar.tsx` |
+| Tests | `src/test/missionTriageIntakeSignalView.test.ts` |
+| Docs | `planning/mission-triage-intake-signal-slice.md`, `planning/backlog.md`, `ux/mission-triage.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| ---- | ----- | --- |
+| Raise global row chip cap above 5 | SPE-16 | Intake capped locally at 2; busy rows may still drop modality/covert chips |
+| Full SPE-16 parent Done | SPE-16 | Chips-only slice; parent stays Backlog |
+| Compare-top-2 / bulk actions | SPE-16 | Out of slice boundary |
+
+## Parent
+
+Keep [SPE-16](https://linear.app/spectranoir/issue/SPE-16) **Backlog** — slice 8 is child evidence only.

--- a/planning/mission-triage-modality-signal-slice.md
+++ b/planning/mission-triage-modality-signal-slice.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2306](https://linear.app/spectranoir/
 | **Linear** | [SPE-2306 — Mission triage illusion/tell signal chips](https://linear.app/spectranoir/issue/SPE-2306) |
 | **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) |
 | **Branch** | `spe-2306-mission-triage-modality-signal-chips` |
-| **Status** | In progress |
+| **Status** | Shipped — SPE-2306 / PR #2475 |
 
 ## Goal
 

--- a/src/components/layout/ShellStatusBar.tsx
+++ b/src/components/layout/ShellStatusBar.tsx
@@ -36,6 +36,7 @@ export function ShellStatusBar() {
 
     const triageViewOptions = {
       includeCovertPrepSignals: true as const,
+      includeIntakeSignals: true as const,
       includeModalitySignals: true as const,
     }
     const filters = normalizeCaseListFilters(

--- a/src/features/cases/CasesPage.tsx
+++ b/src/features/cases/CasesPage.tsx
@@ -98,6 +98,7 @@ export default function CasesPage() {
   const searchParamsString = searchParams.toString()
   const triageViewOptions = {
     includeCovertPrepSignals: true as const,
+    includeIntakeSignals: true as const,
     includeModalitySignals: true as const,
   }
   const filters = normalizeCaseListFilters(

--- a/src/features/cases/caseView.ts
+++ b/src/features/cases/caseView.ts
@@ -31,6 +31,10 @@ import {
   type MissionTriageCovertPrepSignals,
 } from './missionTriageCovertPrepView'
 import {
+  buildMissionTriageIntakeSignals,
+  type MissionTriageIntakeSignals,
+} from './missionTriageIntakeSignalView'
+import {
   buildMissionTriageModalitySignals,
   type MissionTriageModalitySignals,
 } from './missionTriageModalitySignalView'
@@ -87,6 +91,7 @@ export interface CaseListItemView {
   isRaidAtCapacity: boolean
   triageIgnored: boolean
   covertPrepSignals: MissionTriageCovertPrepSignals
+  intakeSignals: MissionTriageIntakeSignals
   modalitySignals: MissionTriageModalitySignals
   deferralCompare: MissionTriageDeferralCompareView
 }
@@ -104,6 +109,7 @@ export const DEFAULT_CASE_LIST_FILTERS: CaseListFilters = {
 
 export interface CaseListItemViewOptions {
   readonly includeCovertPrepSignals?: boolean
+  readonly includeIntakeSignals?: boolean
   readonly includeModalitySignals?: boolean
 }
 
@@ -206,6 +212,10 @@ export function getCaseListItemView(
     options?.includeCovertPrepSignals === true
       ? buildMissionTriageCovertPrepSignals(currentCase, game)
       : { visible: false, markers: [] }
+  const intakeSignals =
+    options?.includeIntakeSignals === true
+      ? buildMissionTriageIntakeSignals(currentCase, game)
+      : { visible: false, markers: [] }
   const modalitySignals =
     options?.includeModalitySignals === true
       ? buildMissionTriageModalitySignals(currentCase, game, assignedTeams)
@@ -237,6 +247,7 @@ export function getCaseListItemView(
     isRaidAtCapacity,
     triageIgnored: isMissionTriageIgnoredThisWeek(game, currentCase.id),
     covertPrepSignals,
+    intakeSignals,
     modalitySignals,
     deferralCompare:
       options?.includeCovertPrepSignals === true

--- a/src/features/cases/missionTriageIntakeSignalView.ts
+++ b/src/features/cases/missionTriageIntakeSignalView.ts
@@ -1,0 +1,164 @@
+import { deriveMissionIntakeInformationSignals } from '../../domain/missionIntakeInformationRouting'
+import type { CaseInstance, GameState } from '../../domain/models'
+
+const MAX_INTAKE_MARKERS = 2
+
+const MARKER_STYLES = {
+  conflict: 'border-rose-500/40 bg-rose-500/10 text-rose-100',
+  blindSpot: 'border-orange-500/40 bg-orange-500/10 text-orange-100',
+  incomplete: 'border-amber-500/40 bg-amber-500/10 text-amber-100',
+  linked: 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100',
+  default: 'border-teal-500/40 bg-teal-500/10 text-teal-100',
+} as const
+
+/** Higher priority codes surface first when the row chip cap binds. */
+const INTAKE_REASON_PRIORITY: readonly string[] = [
+  'intake-verification-conflict',
+  'intake-coverage-blind-spot',
+  'intake-incomplete',
+  'intake-coverage-public-led',
+  'intake-nonstandard-hook',
+  'intake-rumor-separated',
+  'intake-verification-corroborated',
+  'intake-linked-reports',
+]
+
+export interface MissionTriageIntakeSignalMarker {
+  readonly id: string
+  readonly label: string
+  readonly className: string
+  readonly title?: string
+}
+
+export interface MissionTriageIntakeSignals {
+  readonly visible: boolean
+  readonly markers: readonly MissionTriageIntakeSignalMarker[]
+}
+
+function pushMarker(
+  markers: MissionTriageIntakeSignalMarker[],
+  marker: MissionTriageIntakeSignalMarker
+) {
+  if (markers.length >= MAX_INTAKE_MARKERS) {
+    return
+  }
+
+  markers.push(marker)
+}
+
+function intakeChipLabel(reasonCode: string): string {
+  switch (reasonCode) {
+    case 'intake-verification-conflict':
+      return 'Intake: conflict'
+    case 'intake-coverage-blind-spot':
+      return 'Intake: blind spot'
+    case 'intake-incomplete':
+      return 'Intake: incomplete'
+    case 'intake-coverage-public-led':
+      return 'Intake: public-led'
+    case 'intake-nonstandard-hook':
+      return 'Intake: pressure hook'
+    case 'intake-rumor-separated':
+      return 'Intake: rumor split'
+    case 'intake-verification-corroborated':
+      return 'Intake: corroborated'
+    case 'intake-linked-reports':
+      return 'Intake: linked'
+    default:
+      if (reasonCode.startsWith('intake-coverage-')) {
+        return 'Intake: coverage gap'
+      }
+
+      return 'Intake: signal'
+  }
+}
+
+function intakeChipTitle(reasonCode: string, linkedReportCount: number): string | undefined {
+  switch (reasonCode) {
+    case 'intake-verification-conflict':
+      return 'Linked intake reports disagree on verification status.'
+    case 'intake-coverage-blind-spot':
+      return 'Linked intake coverage leaves a blind spot on this topic.'
+    case 'intake-incomplete':
+      return 'Linked intake reports remain partially verified or incomplete.'
+    case 'intake-coverage-public-led':
+      return 'Public-led intake coverage is shaping triage priority.'
+    case 'intake-nonstandard-hook':
+      return 'Mixed-source intake maps this mission to a pressure intake hook.'
+    case 'intake-rumor-separated':
+      return 'Rumor-class intake was separated from formal verification lanes.'
+    case 'intake-verification-corroborated':
+      return 'Dominant linked intake verification is corroborated or escalated.'
+    case 'intake-linked-reports':
+      return `${linkedReportCount} information intake report${linkedReportCount === 1 ? '' : 's'} link to this mission.`
+    default:
+      if (reasonCode.startsWith('intake-coverage-')) {
+        return 'Linked intake coverage band adjusts triage priority.'
+      }
+
+      return undefined
+  }
+}
+
+function intakeChipClassName(reasonCode: string): string {
+  switch (reasonCode) {
+    case 'intake-verification-conflict':
+      return MARKER_STYLES.conflict
+    case 'intake-coverage-blind-spot':
+      return MARKER_STYLES.blindSpot
+    case 'intake-incomplete':
+      return MARKER_STYLES.incomplete
+    case 'intake-linked-reports':
+      return MARKER_STYLES.linked
+    default:
+      return MARKER_STYLES.default
+  }
+}
+
+function sortedIntakeReasonCodes(reasonCodes: readonly string[]): string[] {
+  const intakeCodes = reasonCodes.filter((code) => code.startsWith('intake-'))
+  const priorityIndex = new Map(INTAKE_REASON_PRIORITY.map((code, index) => [code, index]))
+
+  return [...intakeCodes].sort((left, right) => {
+    const leftPriority = priorityIndex.get(left) ?? Number.MAX_SAFE_INTEGER
+    const rightPriority = priorityIndex.get(right) ?? Number.MAX_SAFE_INTEGER
+
+    if (leftPriority !== rightPriority) {
+      return leftPriority - rightPriority
+    }
+
+    return left.localeCompare(right)
+  })
+}
+
+export function buildMissionTriageIntakeSignals(
+  caseData: CaseInstance,
+  game: GameState
+): MissionTriageIntakeSignals {
+  const resolvedCase = game.cases[caseData.id] ?? caseData
+
+  if (resolvedCase.status === 'resolved') {
+    return { visible: false, markers: [] }
+  }
+
+  const signals = deriveMissionIntakeInformationSignals(game, resolvedCase)
+  if (signals.reasonCodes.length === 0) {
+    return { visible: false, markers: [] }
+  }
+
+  const markers: MissionTriageIntakeSignalMarker[] = []
+
+  for (const reasonCode of sortedIntakeReasonCodes(signals.reasonCodes)) {
+    pushMarker(markers, {
+      id: reasonCode,
+      label: intakeChipLabel(reasonCode),
+      className: intakeChipClassName(reasonCode),
+      title: intakeChipTitle(reasonCode, signals.linkedReportCount),
+    })
+  }
+
+  return {
+    visible: markers.length > 0,
+    markers,
+  }
+}

--- a/src/features/cases/missionTriageIntakeSignalView.ts
+++ b/src/features/cases/missionTriageIntakeSignalView.ts
@@ -23,6 +23,10 @@ const INTAKE_REASON_PRIORITY: readonly string[] = [
   'intake-linked-reports',
 ]
 
+const INTAKE_REASON_PRIORITY_INDEX = new Map(
+  INTAKE_REASON_PRIORITY.map((code, index) => [code, index])
+)
+
 export interface MissionTriageIntakeSignalMarker {
   readonly id: string
   readonly label: string
@@ -90,7 +94,7 @@ function intakeChipTitle(reasonCode: string, linkedReportCount: number): string 
     case 'intake-verification-corroborated':
       return 'Dominant linked intake verification is corroborated or escalated.'
     case 'intake-linked-reports':
-      return `${linkedReportCount} information intake report${linkedReportCount === 1 ? '' : 's'} link to this mission.`
+      return `${linkedReportCount} information intake report${linkedReportCount === 1 ? '' : 's'} linked to this mission.`
     default:
       if (reasonCode.startsWith('intake-coverage-')) {
         return 'Linked intake coverage band adjusts triage priority.'
@@ -117,11 +121,10 @@ function intakeChipClassName(reasonCode: string): string {
 
 function sortedIntakeReasonCodes(reasonCodes: readonly string[]): string[] {
   const intakeCodes = reasonCodes.filter((code) => code.startsWith('intake-'))
-  const priorityIndex = new Map(INTAKE_REASON_PRIORITY.map((code, index) => [code, index]))
 
   return [...intakeCodes].sort((left, right) => {
-    const leftPriority = priorityIndex.get(left) ?? Number.MAX_SAFE_INTEGER
-    const rightPriority = priorityIndex.get(right) ?? Number.MAX_SAFE_INTEGER
+    const leftPriority = INTAKE_REASON_PRIORITY_INDEX.get(left) ?? Number.MAX_SAFE_INTEGER
+    const rightPriority = INTAKE_REASON_PRIORITY_INDEX.get(right) ?? Number.MAX_SAFE_INTEGER
 
     if (leftPriority !== rightPriority) {
       return leftPriority - rightPriority
@@ -149,6 +152,10 @@ export function buildMissionTriageIntakeSignals(
   const markers: MissionTriageIntakeSignalMarker[] = []
 
   for (const reasonCode of sortedIntakeReasonCodes(signals.reasonCodes)) {
+    if (markers.length >= MAX_INTAKE_MARKERS) {
+      break
+    }
+
     pushMarker(markers, {
       id: reasonCode,
       label: intakeChipLabel(reasonCode),

--- a/src/features/cases/missionTriageLayoutView.ts
+++ b/src/features/cases/missionTriageLayoutView.ts
@@ -148,6 +148,15 @@ export function buildMissionTriageListRowChips(
 
   appendUrgencyListRowChips(chips, view)
 
+  for (const marker of view.intakeSignals.markers) {
+    pushListRowChip(chips, {
+      id: marker.id,
+      label: marker.label,
+      className: marker.className,
+      title: marker.title,
+    })
+  }
+
   for (const marker of view.modalitySignals.markers) {
     pushListRowChip(chips, {
       id: marker.id,

--- a/src/test/missionTriageIntakeSignalView.test.ts
+++ b/src/test/missionTriageIntakeSignalView.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { createStarterCase } from '../domain/templates/startingCases'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import { getCaseListItemView } from '../features/cases/caseView'
+import { buildMissionTriageDispositionView } from '../features/cases/missionTriageDispositionView'
+import { buildMissionTriageIntakeSignals } from '../features/cases/missionTriageIntakeSignalView'
+import { buildMissionTriageListRowChips } from '../features/cases/missionTriageLayoutView'
+
+const CANAL_BRIDGE_TOPIC = 'topic:canal-bridge-incident'
+
+const canalBridgeFixtures = [
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+]
+
+describe('missionTriageIntakeSignalView', () => {
+  it('surfaces prioritized intake markers for linked canal-bridge intake', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+
+    const mission = createStarterCase({
+      id: 'case-intake-chip-canal-bridge',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+    state.cases[mission.id] = mission
+
+    const signals = buildMissionTriageIntakeSignals(mission, state)
+
+    expect(signals.visible).toBe(true)
+    expect(signals.markers.map((marker) => marker.label)).toEqual([
+      'Intake: conflict',
+      'Intake: incomplete',
+    ])
+    expect(signals.markers[0]?.title).toContain('disagree')
+  })
+
+  it('returns neutral markers when no intake reports link to the mission', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = {
+      [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+    }
+
+    const mission = state.cases['case-001']
+    const signals = buildMissionTriageIntakeSignals(mission, state)
+
+    expect(signals).toEqual({ visible: false, markers: [] })
+  })
+
+  it('hides intake markers on resolved cases', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+
+    const mission = createStarterCase({
+      id: 'case-intake-chip-resolved',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+      status: 'resolved',
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+    state.cases[mission.id] = mission
+
+    expect(buildMissionTriageIntakeSignals(mission, state).visible).toBe(false)
+  })
+
+  it('integrates intake chips into list row chip builder', () => {
+    const state = createStartingState()
+    state.informationIntakeReports = Object.fromEntries(
+      canalBridgeFixtures.map((report) => [report.id, report])
+    )
+
+    const mission = createStarterCase({
+      id: 'case-intake-chip-row',
+      templateId: 'puzzle_whispering_archive',
+      stage: 1,
+    })
+    mission.factionId = undefined
+    mission.tags = [...mission.tags, CANAL_BRIDGE_TOPIC]
+    state.cases[mission.id] = mission
+
+    const view = getCaseListItemView(mission, state, {
+      includeCovertPrepSignals: true,
+      includeIntakeSignals: true,
+      includeModalitySignals: true,
+    })
+    const chips = buildMissionTriageListRowChips(
+      view,
+      buildMissionTriageDispositionView(view, state)
+    )
+
+    expect(chips.some((chip) => chip.label === 'Intake: conflict')).toBe(true)
+    expect(chips.some((chip) => chip.label === 'Intake: incomplete')).toBe(true)
+  })
+})

--- a/ux/mission-triage.md
+++ b/ux/mission-triage.md
@@ -44,6 +44,8 @@ This spec is for:
 
 **Slice 7 shipped (SPE-2306):** Compact triage list rows also show read-only hidden-state **modality tell** and **illusion** signal chips via `buildMissionTriageModalitySignals` (reuses `hiddenStateModalityTells.ts` / `hiddenStateIllusionLifecycle.ts`). Plan: `planning/mission-triage-modality-signal-slice.md`.
 
+**Slice 8 shipped (SPE-2307):** Compact triage list rows also show read-only **information intake** signal chips via `buildMissionTriageIntakeSignals` (reuses `deriveMissionIntakeInformationSignals` / SPE-2301–2304). Plan: `planning/mission-triage-intake-signal-slice.md`.
+
 **Still deferred (follow-up slices):**
 
 - Additional triage UX expansion beyond shipped slices 1–7 (compare-top-2 on list, bulk actions, spec §13 visual grouping)


### PR DESCRIPTION
## Summary
- Add `buildMissionTriageIntakeSignals` to map live `intake-*` reason codes from `deriveMissionIntakeInformationSignals` into read-only triage list/detail chips (max 2 markers, priority-ordered).
- Wire `includeIntakeSignals` through `caseView`, `missionTriageLayoutView`, `CasesPage`, and `ShellStatusBar` (intake chips slot after urgency, before modality).

## Linear
- **Slice:** [SPE-2307](https://linear.app/spectranoir/issue/SPE-2307) — Mission triage intake signal chips (slice 8 UX)
- **Parent:** [SPE-16](https://linear.app/spectranoir/issue/SPE-16) (stays Backlog)
- **Related:** [SPE-2301](https://linear.app/spectranoir/issue/SPE-2301), [SPE-2304](https://linear.app/spectranoir/issue/SPE-2304); [SPE-854](https://linear.app/spectranoir/issue/SPE-854) Done — not reopened

## What shipped
- Deferred UX from information-intake parent integration slices: canal-bridge linked missions show chips such as Intake: conflict / Intake: incomplete; unlinked and resolved missions stay neutral.

## Validation
- `npm run test:run -- src/test/missionTriageIntakeSignalView.test.ts src/test/missionTriageLayoutView.test.ts`
- `npm run lint`

## Docs updated
- `planning/mission-triage-intake-signal-slice.md`
- `planning/backlog.md`
- `ux/mission-triage.md` spec status (slice 8)

## Parent remains open
SPE-16 stays Backlog (chips-only child evidence).