### PR TITLE
feat(SPE-2308): infiltration case prep encounter preview

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,12 +16,12 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Infiltration optional content depth** — Report encounter copy slice 3 shipped ([SPE-2305](https://linear.app/spectranoir/issue/SPE-2305) / PR #2473). Further optional template stacks or prep UI copy under [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250) / [SPE-521](https://linear.app/spectranoir/issue/SPE-521) when narratively warranted.
+1. **Infiltration optional content depth** — Prep encounter preview shipped ([SPE-2308](https://linear.app/spectranoir/issue/SPE-2308)); report copy slice 3 ([SPE-2305](https://linear.app/spectranoir/issue/SPE-2305) / PR #2473). Further optional template stacks beyond batch-4 under [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250) when narratively warranted.
 2. **Scope discipline** — Resist broadening planning into too many simultaneous future branches until the central machine is more real (`planning/roadmap.md` §15).
 
 ## Recommended next step (agent handoff)
 
-PR #2477 merged. On `main` @ `72c22086`. SPE-2307 shipped. **Next:** infiltration optional depth per active queue.
+On `main` @ `12fa92d9`. **Next:** optional batch-4+ template infiltration stacks (SPE-2250) when narratively warranted; SPE-2308 prep preview in PR.
 
 ## Blocked / waiting
 

--- a/planning/infiltration-case-prep-encounter-preview-slice.md
+++ b/planning/infiltration-case-prep-encounter-preview-slice.md
@@ -1,0 +1,48 @@
+# Infiltration case prep encounter preview (SPE-521 UI slice)
+
+One-page implementation plan. Linear: [SPE-2308](https://linear.app/spectranoir/issue/SPE-2308) (child under [SPE-521](https://linear.app/spectranoir/issue/SPE-521)). Follows shipped report copy depth [SPE-2305](https://linear.app/spectranoir/issue/SPE-2305) / `planning/infiltration-encounter-content-slice-3.md`.
+
+| Field      | Value                                                                 |
+| ---------- | --------------------------------------------------------------------- |
+| **Linear** | [SPE-2308 — Infiltration case prep encounter preview](https://linear.app/spectranoir/issue/SPE-2308) |
+| **Parent** | [SPE-521](https://linear.app/spectranoir/issue/SPE-521)               |
+| **Branch** | `jamesdyedbq/spe-521-infiltration-case-prep-encounter-preview`        |
+| **Status** | In progress                                                           |
+
+## Goal
+
+Show **deterministic encounter preview bullets** on the infiltration case-prep panel so players see the same operational flavor as weekly reports before `advanceWeek` — without duplicating full report sentences.
+
+## Prerequisite (on `main`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Report encounter copy | `src/domain/infiltrationEncounterReportNotes.ts` (SPE-2305) |
+| Case prep panel | `src/features/cases/InfiltrationCasePrepPanel.tsx`, `infiltrationCasePrepView.ts` |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `buildInfiltrationPrepEncounterNotes` reusing report constants | New probe mechanics |
+| `encounterPreviewNotes` on prep view + panel section | Template catalog migrations |
+| Unit tests for note composition | Mission triage changes |
+
+## Acceptance
+
+- [x] Prep panel shows encounter preview for eligible cases with at least probe-action detail
+- [x] Notes use effective weekly probe action (override when set)
+- [x] Stage observer + cover friction + leave-behind lines match report constants
+- [x] `npm run lint` + targeted `npm run test:run` green
+
+## Deferred
+
+| Item | Owner | Why |
+| ---- | ----- | --- |
+| Additional template probe/cover stacks beyond batch-4 | SPE-2250 follow-up | Content-only; no narratively urgent templates queued |
+| Full parent SPE-521 encounter-state / guides scope | SPE-521 parent | Out of optional-depth queue item |
+
+## See also
+
+- `planning/infiltration-case-prep-slice.md`
+- `planning/infiltration-encounter-content-slice-3.md`

--- a/planning/infiltration-encounter-content-slice-3.md
+++ b/planning/infiltration-encounter-content-slice-3.md
@@ -82,7 +82,7 @@ When `coverRole` is set, one role-specific observer-friction sentence after the 
 | Item | Owner | Why |
 | ---- | ----- | --- |
 | Additional template probe/cover stacks | SPE-2250 follow-up | Out of slice 3 copy-only boundary |
-| Case prep UI encounter summaries | SPE-521 follow-up | UI not in scope |
+| Case prep UI encounter summaries | [SPE-2308](https://linear.app/spectranoir/issue/SPE-2308) | Shipped in prep encounter preview slice |
 
 ## See also
 

--- a/src/domain/infiltrationEncounterReportNotes.ts
+++ b/src/domain/infiltrationEncounterReportNotes.ts
@@ -275,6 +275,35 @@ export function shouldEmitInfiltrationWeeklyEncounterNote(caseData: CaseInstance
   return isInfiltrationProbeEligible(caseData)
 }
 
+/**
+ * Prep-panel encounter preview bullets — same constants as weekly report copy,
+ * without post-tick or threshold-prefixed sentences.
+ */
+export function buildInfiltrationPrepEncounterNotes(
+  caseData: CaseInstance
+): readonly string[] {
+  const context = buildInfiltrationEncounterReportContext(caseData)
+  if (context === undefined) {
+    return []
+  }
+
+  const notes: string[] = [INFILTRATION_PROBE_ENCOUNTER_DETAILS[context.probeAction]]
+
+  if (context.coverRole !== undefined) {
+    notes.push(INFILTRATION_COVER_ROLE_OBSERVER_FRICTION[context.coverRole])
+  }
+
+  if (context.stage !== 'probing') {
+    notes.push(INFILTRATION_STAGE_OBSERVER_CLAUSES[context.stage])
+  }
+
+  if (context.leaveBehindLabel) {
+    notes.push(`Staged leave-behind: ${context.leaveBehindLabel}.`)
+  }
+
+  return notes
+}
+
 /** Context after a probe tick — uses post-tick tracks and stage on the merged case. */
 export function buildInfiltrationEncounterReportContextAfterProbe(
   caseBeforeTick: CaseInstance,

--- a/src/features/cases/CaseDetailPage.test.tsx
+++ b/src/features/cases/CaseDetailPage.test.tsx
@@ -236,15 +236,19 @@ it('shows stealth leave-behind tradeoff selection for eligible in-progress hidde
   const weeklyPrep = screen.getByRole('region', { name: /weekly case prep/i })
 
   expect(within(weeklyPrep).getAllByLabelText(/forensic investigation budget/i)).toHaveLength(1)
-  expect(within(weeklyPrep).getByText(/leave forensic trace/i)).toBeInTheDocument()
-  expect(within(weeklyPrep).getByRole('button', { name: /selected/i })).toBeInTheDocument()
 
-  const burnRow = within(weeklyPrep).getByText(/burn field tool/i).closest('li')
+  const leaveBehindGroup = within(weeklyPrep).getByRole('group', {
+    name: /stealth leave-behind tradeoff/i,
+  })
+  expect(within(leaveBehindGroup).getByText(/leave forensic trace/i)).toBeInTheDocument()
+  expect(within(leaveBehindGroup).getByRole('button', { name: /selected/i })).toBeInTheDocument()
+
+  const burnRow = within(leaveBehindGroup).getByText(/burn field tool/i).closest('li')
   expect(burnRow).not.toBeNull()
   await user.click(within(burnRow as HTMLElement).getByRole('button', { name: /^select$/i }))
 
-  expect(within(weeklyPrep).getByText(/burn field tool/i)).toBeInTheDocument()
-  expect(within(weeklyPrep).getAllByRole('button', { name: /selected/i })).toHaveLength(1)
+  expect(within(leaveBehindGroup).getByText(/burn field tool/i)).toBeInTheDocument()
+  expect(within(leaveBehindGroup).getAllByRole('button', { name: /selected/i })).toHaveLength(1)
   expect(useGameStore.getState().game.cases['case-stealth-ui']?.stealthLeaveBehindId).toBe(
     'leave-behind:burn-tool'
   )

--- a/src/features/cases/InfiltrationCasePrepPanel.tsx
+++ b/src/features/cases/InfiltrationCasePrepPanel.tsx
@@ -37,6 +37,8 @@ export function InfiltrationCasePrepPanel({
 
       <TrackSummary view={view} />
 
+      {view.encounterPreviewNotes.length > 0 ? <EncounterPreview view={view} /> : null}
+
       {view.coverRoleLabel ? <CoverSummary view={view} /> : null}
 
       <section className="space-y-2" aria-label="Weekly probe action">
@@ -125,6 +127,19 @@ function TrackSummary({ view }: { view: InfiltrationCasePrepView }) {
       <p className="text-xs opacity-55">
         Complication band begins at {view.awarenessComplicationBandPercent}% awareness.
       </p>
+    </section>
+  )
+}
+
+function EncounterPreview({ view }: { view: InfiltrationCasePrepView }) {
+  return (
+    <section className="space-y-1" aria-label="Encounter preview">
+      <p className="text-xs uppercase tracking-wide opacity-50">Encounter preview</p>
+      <ul className="list-disc space-y-1 pl-5 text-xs opacity-70">
+        {view.encounterPreviewNotes.map((note) => (
+          <li key={note}>{note}</li>
+        ))}
+      </ul>
     </section>
   )
 }

--- a/src/features/cases/infiltrationCasePrepView.ts
+++ b/src/features/cases/infiltrationCasePrepView.ts
@@ -10,6 +10,7 @@ import {
   type InfiltrationProbeAction,
   type InfiltrationStage,
 } from '../../domain/infiltrationProbe'
+import { buildInfiltrationPrepEncounterNotes } from '../../domain/infiltrationEncounterReportNotes'
 import { readInfiltrationWeeklyProbeActionOverride } from '../../domain/infiltrationProbeOverride'
 import type { CaseInstance } from '../../domain/models'
 
@@ -65,6 +66,7 @@ export interface InfiltrationCasePrepView {
   readonly effectiveActionLabel: string
   readonly actionOptions: readonly InfiltrationProbeActionOptionView[]
   readonly usingOverride: boolean
+  readonly encounterPreviewNotes: readonly string[]
 }
 
 export function canShowInfiltrationCasePrepOnCase(caseData: CaseInstance) {
@@ -137,6 +139,7 @@ export function buildInfiltrationCasePrepView(caseData: CaseInstance): Infiltrat
       effectiveActionLabel: INFILTRATION_PROBE_ACTION_LABELS.probe_access,
       actionOptions: emptyOptions,
       usingOverride: false,
+      encounterPreviewNotes: [],
     }
   }
 
@@ -177,5 +180,6 @@ export function buildInfiltrationCasePrepView(caseData: CaseInstance): Infiltrat
       selected: overrideAction === id,
     })),
     usingOverride: overrideAction !== undefined,
+    encounterPreviewNotes: buildInfiltrationPrepEncounterNotes(caseData),
   }
 }

--- a/src/test/infiltrationCasePrepView.test.ts
+++ b/src/test/infiltrationCasePrepView.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { copyInfiltrationProbePlan } from '../domain/infiltrationProbe'
 import {
+  INFILTRATION_COVER_ROLE_OBSERVER_FRICTION,
+  INFILTRATION_PROBE_ENCOUNTER_DETAILS,
+  INFILTRATION_STAGE_OBSERVER_CLAUSES,
+} from '../domain/infiltrationEncounterReportNotes'
+import {
   buildInfiltrationCasePrepView,
   canShowInfiltrationCasePrepOnCase,
 } from '../features/cases/infiltrationCasePrepView'
@@ -47,5 +52,28 @@ describe('infiltrationCasePrepView', () => {
     expect(view.plannedAction).toBe('probe_access')
     expect(view.coverStrainNotes.length).toBeGreaterThan(0)
     expect(view.hasCoverStrain).toBe(true)
+  })
+
+  it('surfaces encounter preview notes from report copy constants', () => {
+    const view = buildInfiltrationCasePrepView(createEligibleCase())
+
+    expect(view.encounterPreviewNotes).toContain(
+      INFILTRATION_PROBE_ENCOUNTER_DETAILS.probe_route
+    )
+    expect(view.encounterPreviewNotes).toContain(
+      INFILTRATION_COVER_ROLE_OBSERVER_FRICTION.uniform_guard
+    )
+    expect(view.encounterPreviewNotes).not.toContain(
+      INFILTRATION_STAGE_OBSERVER_CLAUSES.exposed
+    )
+  })
+
+  it('includes stage observer pressure when infiltration stage is exposed', () => {
+    const view = buildInfiltrationCasePrepView({
+      ...createEligibleCase(),
+      infiltrationStage: 'exposed',
+    })
+
+    expect(view.encounterPreviewNotes).toContain(INFILTRATION_STAGE_OBSERVER_CLAUSES.exposed)
   })
 })

--- a/src/test/infiltrationEncounterReportNotes.test.ts
+++ b/src/test/infiltrationEncounterReportNotes.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   buildInfiltrationEncounterReportContext,
   buildInfiltrationEncounterReportContextAfterProbe,
+  buildInfiltrationPrepEncounterNotes,
+  INFILTRATION_COVER_ROLE_OBSERVER_FRICTION,
+  INFILTRATION_PROBE_ENCOUNTER_DETAILS,
   enrichInfiltrationThresholdSummary,
   formatInfiltrationLeaveBehindTradeoffSummary,
   formatInfiltrationWeeklyEncounterSummary,
@@ -149,6 +152,20 @@ describe('infiltrationEncounterReportNotes', () => {
         preferredTags: [],
       })
     ).toBe(false)
+  })
+
+  it('builds prep encounter preview bullets without weekly report framing', () => {
+    const caseData = createCovertCase()
+    const context = buildInfiltrationEncounterReportContext(caseData)!
+    const notes = buildInfiltrationPrepEncounterNotes(caseData)
+
+    expect(notes[0]).toBe(INFILTRATION_PROBE_ENCOUNTER_DETAILS[context.probeAction])
+    if (context.coverRole !== undefined) {
+      expect(notes).toContain(INFILTRATION_COVER_ROLE_OBSERVER_FRICTION[context.coverRole])
+    }
+    expect(notes).toContain('Staged leave-behind: Burn field tool.')
+    expect(notes.join(' ')).not.toContain('Authored probe plan')
+    expect(notes.join(' ')).not.toContain('Tracks at')
   })
 
   it('omits cover and leave-behind clauses when absent', () => {


### PR DESCRIPTION
## Summary

- Add `buildInfiltrationPrepEncounterNotes` reusing SPE-2305 encounter copy constants (probe-action detail, cover-role friction, stage observer pressure, staged leave-behind label).
- Show an **Encounter preview** section on `InfiltrationCasePrepPanel` via `encounterPreviewNotes` on the prep view.
- Slice plan: `planning/infiltration-case-prep-encounter-preview-slice.md`; backlog queue updated.

## Linear

- **Slice:** [SPE-2308](https://linear.app/spectranoir/issue/SPE-2308)
- **Parent:** [SPE-521](https://linear.app/spectranoir/issue/SPE-521) (stays open — broader parent scope)
- **Related:** [SPE-2250](https://linear.app/spectranoir/issue/SPE-2250) report-copy follow-through

## Test plan

- [x] `npm run test:run` — `infiltrationCasePrepView.test.ts`, `infiltrationEncounterReportNotes.test.ts`, `CaseDetailPage.test.tsx`
- [x] `npm run lint`

## Docs

- `planning/infiltration-case-prep-encounter-preview-slice.md` (new)
- `planning/backlog.md`, `planning/infiltration-encounter-content-slice-3.md` deferred row

Parent SPE-521 remains open.