### PR TITLE
SPE-2309: MVP weekly loop proof slice 3 (triage + intake persistence)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,11 +16,11 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **MVP weekly loop proof slice 3** — Extend SPE-2251 integration harness toward `planning/mvp-scope.md` §8 Claims 1–2 and 6 (triage/deployment + multi-week carryover with intake verification where applicable). Owner creates Linear child when starting; plan anchor `planning/mvp-weekly-loop-proof-slice-1.md` + grooming record `planning/scope-discipline-grooming-pass.md`.
+1. *(in flight — SPE-2309)* **MVP weekly loop proof slice 3** — Extend SPE-2251 harness: triage + intake verification in multi-week save/load (`planning/mvp-weekly-loop-proof-slice-3.md`).
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `17df0ed3`. Scope-discipline grooming pass **shipped** (`planning/scope-discipline-grooming-pass.md`). SPE-2250 batch-4+ **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md`. **Next:** MVP loop proof slice 3 (above) unless owner reprioritizes.
+On `main` @ `967e9e55`. Scope-discipline grooming pass **shipped** (`planning/scope-discipline-grooming-pass.md`, PR #2480). **In flight:** MVP loop proof slice 3 ([SPE-2309](https://linear.app/spectranoir/issue/SPE-2309), branch `spe-2251-mvp-weekly-loop-proof-slice-3`). After merge: pick next item from grooming pass / backlog unless owner reprioritizes.
 
 ## Blocked / waiting
 

--- a/planning/mvp-weekly-loop-proof-slice-1.md
+++ b/planning/mvp-weekly-loop-proof-slice-1.md
@@ -135,6 +135,10 @@ Reuse helpers from:
 
 Persistence reload + 4-week fixture: `src/test/weeklyMvpLoopProof.slice2.integration.test.ts`.
 
+## Slice 3 (in flight)
+
+Triage routing + intake verification notes in multi-week save/load: `planning/mvp-weekly-loop-proof-slice-3.md`, [SPE-2309](https://linear.app/spectranoir/issue/SPE-2309), `src/test/weeklyMvpLoopProof.slice3.integration.test.ts`.
+
 ## Related follow-up (shipped)
 
 ### Infiltration encounter report copy (SPE-2250)

--- a/planning/mvp-weekly-loop-proof-slice-3.md
+++ b/planning/mvp-weekly-loop-proof-slice-3.md
@@ -1,0 +1,51 @@
+# MVP weekly loop proof — slice 3 (triage + intake persistence)
+
+## Status
+
+| Field | Value |
+| --- | --- |
+| **Linear (slice)** | [SPE-2309](https://linear.app/spectranoir/issue/SPE-2309) — MVP weekly loop proof (slice 3 — triage + intake persistence) |
+| **Linear (parent)** | [SPE-2251](https://linear.app/spectranoir/issue/SPE-2251) — MVP weekly loop proof (slice 1) |
+| **Branch** | `spe-2251-mvp-weekly-loop-proof-slice-3` from `main` @ `967e9e55` |
+| **MVP claims** | `planning/mvp-scope.md` §8 Claims 1, 2, 6 |
+
+## Goal
+
+Extend the SPE-2251 `weeklyMvpLoopProof` harness so one deterministic flow proves:
+
+- **Claim 1** — triage matters: linked intake raises covert mission triage score vs the same mission without intake; reason codes include verification conflict.
+- **Claim 2 (partial)** — deployment/prep carryover remains covered by slices 1–2; slice 3 adds institutional intake signals in the weekly path.
+- **Claim 6** — next week changed: triage routing and intake verification notes persist through `advanceWeek` + save/load across multiple weeks.
+
+## Boundary
+
+- `src/test/helpers/weeklyMvpLoopProof.ts` + `src/test/weeklyMvpLoopProof.slice3.integration.test.ts` only unless a real persistence gap is found.
+- No new domain rules, registry waves, triage UI layout refresh, or compare-top-2 triage UI.
+- Reuse SPE-854 intake fixtures and `missionIntakeRouting` / `advanceWeek` intake corroboration (no UI click path).
+
+## Implementation
+
+| Area | Files |
+| --- | --- |
+| Helper hooks | `applyWeeklyMvpLoopIntakeAndTriage`, `readWeeklyMvpLoopTriageScores`, `MVP_LOOP_INTAKE_TOPIC` |
+| Tests | `src/test/weeklyMvpLoopProof.slice3.integration.test.ts` |
+
+## Acceptance
+
+- [ ] Slice 3 integration tests pass in `npm run test:run`
+- [ ] Full suite green
+- [ ] `npm run lint` green on touched files
+- [ ] PR links SPE-2309; parent SPE-2251 stays open until milestone 6 proof is complete
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full triage UI click path / compare-top-2 | Mission triage refresh (backlog blocked) | Out of slice — domain APIs only |
+| Milestone 6 “proof complete” parent closure | SPE-2251 umbrella / grooming | Requires additional claims beyond slice 3 |
+
+## See also
+
+- `planning/mvp-weekly-loop-proof-slice-1.md` (slices 1–2 shipped)
+- `planning/scope-discipline-grooming-pass.md` § Phase 4
+- `planning/backlog.md` active queue

--- a/src/test/helpers/weeklyMvpLoopProof.ts
+++ b/src/test/helpers/weeklyMvpLoopProof.ts
@@ -117,7 +117,7 @@ function buildMvpLoopIntakeReports(): Record<string, InformationIntakeReportReco
 
 /**
  * Links mixed-source intake to the covert case topic and recomputes mission routing
- * for triage assertions (SPE-2251 slice 3).
+ * for triage assertions (SPE-2309 slice 3).
  */
 export function applyWeeklyMvpLoopIntakeAndTriage(state: GameState): GameState {
   const covertCase = state.cases[MVP_LOOP_PROOF_CASE_ID]
@@ -138,7 +138,10 @@ export function applyWeeklyMvpLoopIntakeAndTriage(state: GameState): GameState {
       ...state.cases,
       [MVP_LOOP_PROOF_CASE_ID]: taggedCovert,
     },
-    informationIntakeReports: buildMvpLoopIntakeReports(),
+    informationIntakeReports: {
+      ...state.informationIntakeReports,
+      ...buildMvpLoopIntakeReports(),
+    },
   }
 
   return {

--- a/src/test/helpers/weeklyMvpLoopProof.ts
+++ b/src/test/helpers/weeklyMvpLoopProof.ts
@@ -1,9 +1,15 @@
 import { createStartingState } from '../../data/startingState'
 import { caseTemplateMap } from '../../data/caseTemplates'
 import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  type InformationIntakeReportRecord,
+} from '../../domain/informationIntakeReport'
+import {
   applySuccessfulInvestigation,
   askInvestigationQuestion,
 } from '../../domain/investigationEconomy'
+import { triageMission, recomputeMissionRouting } from '../../domain/missionIntakeRouting'
 import type { GameState } from '../../domain/models'
 import { assignTeam } from '../../domain/sim/assign'
 import { createStarterCase } from '../../domain/templates/startingCases'
@@ -11,6 +17,7 @@ import { createStarterCase } from '../../domain/templates/startingCases'
 export const MVP_LOOP_PROOF_CASE_ID = 'case-mvp-covert'
 export const MVP_LOOP_PROOF_TEMPLATE_ID = 'ops-004'
 export const MVP_LOOP_FORENSIC_QUESTION_ID = 'forensic.present-signature'
+export const MVP_LOOP_INTAKE_TOPIC = 'topic:mvp-covert-incident'
 
 export interface WeeklyMvpLoopProofFixture {
   readonly state: GameState
@@ -91,4 +98,67 @@ export function applyWeeklyMvpLoopPrepFlags(state: GameState): GameState {
       [`conceal.case.${MVP_LOOP_PROOF_CASE_ID}`]: true,
     },
   }
+}
+
+function buildMvpLoopIntakeReports(): Record<string, InformationIntakeReportRecord> {
+  const topicRef = MVP_LOOP_INTAKE_TOPIC
+
+  return {
+    [FORMAL_ALERT_PARTIAL_FIXTURE.id]: {
+      ...FORMAL_ALERT_PARTIAL_FIXTURE,
+      topicRef,
+    },
+    [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: {
+      ...PUBLIC_RUMOR_CONFLICT_FIXTURE,
+      topicRef,
+    },
+  }
+}
+
+/**
+ * Links mixed-source intake to the covert case topic and recomputes mission routing
+ * for triage assertions (SPE-2251 slice 3).
+ */
+export function applyWeeklyMvpLoopIntakeAndTriage(state: GameState): GameState {
+  const covertCase = state.cases[MVP_LOOP_PROOF_CASE_ID]
+  if (!covertCase) {
+    throw new Error('Expected covert MVP loop case before intake/triage wiring')
+  }
+
+  const taggedCovert = {
+    ...covertCase,
+    tags: [...new Set([...covertCase.tags, MVP_LOOP_INTAKE_TOPIC])],
+    weeksRemaining: Math.max(covertCase.weeksRemaining ?? 0, 5),
+  }
+
+  const withCase: GameState = {
+    ...state,
+    agency: state.agency ? { ...state.agency, supportAvailable: 5 } : state.agency,
+    cases: {
+      ...state.cases,
+      [MVP_LOOP_PROOF_CASE_ID]: taggedCovert,
+    },
+    informationIntakeReports: buildMvpLoopIntakeReports(),
+  }
+
+  return {
+    ...withCase,
+    missionRouting: recomputeMissionRouting(withCase),
+  }
+}
+
+/** Live triage scores for the same covert mission with and without linked intake (Claim 1). */
+export function readWeeklyMvpLoopTriageScores(state: GameState) {
+  const covertCase = state.cases[MVP_LOOP_PROOF_CASE_ID]
+  if (!covertCase) {
+    throw new Error('Expected covert MVP loop case for triage reads')
+  }
+
+  const withoutIntake = triageMission(
+    { ...state, informationIntakeReports: {} },
+    covertCase
+  )
+  const withIntake = triageMission(state, covertCase)
+
+  return { withoutIntake, withIntake }
 }

--- a/src/test/weeklyMvpLoopProof.slice3.integration.test.ts
+++ b/src/test/weeklyMvpLoopProof.slice3.integration.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { FORMAL_ALERT_PARTIAL_FIXTURE } from '../domain/informationIntakeReport'
+import { triageMission } from '../domain/missionIntakeRouting'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import {
+  applyWeeklyMvpLoopIntakeAndTriage,
+  applyWeeklyMvpLoopPrepFlags,
+  createWeeklyMvpLoopProofFixture,
+  MVP_LOOP_PROOF_CASE_ID,
+  readWeeklyMvpLoopTriageScores,
+} from './helpers/weeklyMvpLoopProof'
+
+describe('MVP weekly loop proof (slice 3)', () => {
+  it('raises covert triage when intake is linked and refreshes routing after save/load', () => {
+    const { state: week0 } = createWeeklyMvpLoopProofFixture()
+    const startWeek = week0.week
+    let state = applyWeeklyMvpLoopIntakeAndTriage(week0)
+
+    const liveScores = readWeeklyMvpLoopTriageScores(state)
+    expect(liveScores.withIntake.score).toBeGreaterThan(liveScores.withoutIntake.score)
+    expect(liveScores.withIntake.reasonCodes).toContain('intake-linked-reports')
+    expect(liveScores.withIntake.reasonCodes).toContain('intake-verification-conflict')
+
+    const covertRouting = state.missionRouting?.missions[MVP_LOOP_PROOF_CASE_ID]
+    expect(covertRouting?.triageScore).toBe(liveScores.withIntake.score)
+    expect(covertRouting?.priorityReasonCodes).toContain('intake-verification-conflict')
+
+    state = applyWeeklyMvpLoopPrepFlags(state)
+    const week1 = advanceWeek(state)
+    expect(week1.gameOver).toBe(false)
+    expect(week1.week).toBe(startWeek + 1)
+
+    const midSave = loadGameSave(serializeGameSave(week1))
+    const reloadedCovertCase = midSave.cases[MVP_LOOP_PROOF_CASE_ID]
+    expect(reloadedCovertCase).toBeDefined()
+    const liveAfterReload = triageMission(midSave, reloadedCovertCase!)
+    const reloadedCovert = midSave.missionRouting?.missions[MVP_LOOP_PROOF_CASE_ID]
+    expect(reloadedCovert?.triageScore).toBe(liveAfterReload.score)
+    expect(reloadedCovert?.priorityReasonCodes).toEqual(liveAfterReload.reasonCodes)
+    expect(reloadedCovert?.priorityReasonCodes).toContain('intake-linked-reports')
+    expect(reloadedCovert?.priorityReasonCodes).toContain('intake-verification-conflict')
+
+    const week2 = advanceWeek(applyWeeklyMvpLoopPrepFlags(midSave))
+    expect(week2.gameOver).toBe(false)
+    expect(week2.week).toBe(week1.week + 1)
+    expect(week2.week).toBeGreaterThan(startWeek)
+    expect(week2.reports.length).toBeGreaterThan(week1.reports.length)
+    expect(week2.informationIntakeReports?.[FORMAL_ALERT_PARTIAL_FIXTURE.id]).toBeDefined()
+  })
+
+  it('surfaces intake verification report notes through multi-week advance and persistence reload', () => {
+    const { state: week0 } = createWeeklyMvpLoopProofFixture()
+    const startWeek = week0.week
+    const state = applyWeeklyMvpLoopIntakeAndTriage(week0)
+
+    const week1 = advanceWeek(applyWeeklyMvpLoopPrepFlags(state))
+    expect(week1.gameOver).toBe(false)
+    const intakeNotesWeek1 =
+      week1.reports[week1.reports.length - 1]?.notes.filter(
+        (note) => note.type === 'information_intake.verification'
+      ) ?? []
+    expect(intakeNotesWeek1.length).toBeGreaterThan(0)
+    expect(
+      intakeNotesWeek1.some((note) => note.content.includes(FORMAL_ALERT_PARTIAL_FIXTURE.label))
+    ).toBe(true)
+
+    const reloaded = loadGameSave(serializeGameSave(week1))
+    expect(reloaded.informationIntakeReports?.[FORMAL_ALERT_PARTIAL_FIXTURE.id]).toBeDefined()
+
+    const week2 = advanceWeek(applyWeeklyMvpLoopPrepFlags(reloaded))
+    expect(week2.gameOver).toBe(false)
+    expect(week2.week).toBe(week1.week + 1)
+    expect(week2.week).toBeGreaterThan(startWeek)
+
+    const allIntakeNotes = week2.reports.flatMap((report) =>
+      report.notes.filter((note) => note.type === 'information_intake.verification')
+    )
+    expect(allIntakeNotes.length).toBeGreaterThanOrEqual(intakeNotesWeek1.length)
+    expect(week2.reports.length).toBeGreaterThan(week1.reports.length)
+
+    const formalReport = week2.informationIntakeReports?.[FORMAL_ALERT_PARTIAL_FIXTURE.id]
+    const corroborationEvents = formalReport?.corroborationHistory.length ?? 0
+    const contradictionEvents = formalReport?.contradictionHistory.length ?? 0
+    expect(corroborationEvents + contradictionEvents).toBeGreaterThan(0)
+  })
+})

--- a/src/test/weeklyMvpLoopProof.slice3.integration.test.ts
+++ b/src/test/weeklyMvpLoopProof.slice3.integration.test.ts
@@ -56,10 +56,10 @@ describe('MVP weekly loop proof (slice 3)', () => {
 
     const week1 = advanceWeek(applyWeeklyMvpLoopPrepFlags(state))
     expect(week1.gameOver).toBe(false)
-    const intakeNotesWeek1 =
-      week1.reports[week1.reports.length - 1]?.notes.filter(
-        (note) => note.type === 'information_intake.verification'
-      ) ?? []
+    const intakeNotesWeek1 = week1.reports.flatMap(
+      (report) =>
+        report.notes?.filter((note) => note.type === 'information_intake.verification') ?? []
+    )
     expect(intakeNotesWeek1.length).toBeGreaterThan(0)
     expect(
       intakeNotesWeek1.some((note) => note.content.includes(FORMAL_ALERT_PARTIAL_FIXTURE.label))
@@ -73,8 +73,9 @@ describe('MVP weekly loop proof (slice 3)', () => {
     expect(week2.week).toBe(week1.week + 1)
     expect(week2.week).toBeGreaterThan(startWeek)
 
-    const allIntakeNotes = week2.reports.flatMap((report) =>
-      report.notes.filter((note) => note.type === 'information_intake.verification')
+    const allIntakeNotes = week2.reports.flatMap(
+      (report) =>
+        report.notes?.filter((note) => note.type === 'information_intake.verification') ?? []
     )
     expect(allIntakeNotes.length).toBeGreaterThanOrEqual(intakeNotesWeek1.length)
     expect(week2.reports.length).toBeGreaterThan(week1.reports.length)


### PR DESCRIPTION
## Summary

- Extends SPE-2251 `weeklyMvpLoopProof` harness with slice 3 integration tests for MVP scope Claims 1, 2 (partial), and 6.
- Helper hooks wire mixed-source intake to the covert fixture, recompute mission routing, and compare triage with vs without linked intake.
- Asserts save/load refreshes triage reason codes and that `information_intake.verification` report notes appear across multi-week `advanceWeek` paths.

## Linear

- **Slice:** [SPE-2309](https://linear.app/spectranoir/issue/SPE-2309) — MVP weekly loop proof (slice 3 — triage + intake persistence)
- **Parent:** [SPE-2251](https://linear.app/spectranoir/issue/SPE-2251) — remains open (milestone 6 proof not complete)

## What shipped

- `src/test/weeklyMvpLoopProof.slice3.integration.test.ts`
- `src/test/helpers/weeklyMvpLoopProof.ts` — `applyWeeklyMvpLoopIntakeAndTriage`, `readWeeklyMvpLoopTriageScores`
- `planning/mvp-weekly-loop-proof-slice-3.md`
- Backlog handoff SHA → `967e9e55`

## Validation

- `npm run test:run -- src/test/weeklyMvpLoopProof.slice3.integration.test.ts`
- `npm run test:run -- src/test/weeklyMvpLoopProof.integration.test.ts src/test/weeklyMvpLoopProof.slice2.integration.test.ts`
- `npm run lint` on touched test files
- Full `npm run test:run` (4727 passed; one `sim.validation` timeout on first run, passed on targeted retry — likely flaky under load)

## Docs updated

- `planning/mvp-weekly-loop-proof-slice-3.md` (new)
- `planning/mvp-weekly-loop-proof-slice-1.md` (slice 3 pointer)
- `planning/backlog.md` (handoff SHA + in-flight note)

## Parent status

SPE-2251 parent stays **open** — slice 3 does not close milestone 6 MVP proof umbrella.