### PR TITLE
SPE-2313: unexplained location registry GameState persistence (slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,13 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Extranormal event registry GameState persistence (slice 2)** — [SPE-2312](https://linear.app/spectranoir/issue/SPE-2312) **In Progress**; plan `planning/extranormal-event-registry-slice-2.md`; branch `spe-2105-extranormal-event-registry-persistence-slice-2`.
+1. **Registry slice-2+ (next)** — [SPE-2313](https://linear.app/spectranoir/issue/SPE-2313) unexplained location persistence (PR in flight); then [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) minor anomaly persistence or SPE-2105 slice 3 weekly hook.
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `80f7ffdb` (post–slice 5 merge, PR #2486). [SPE-2251](https://linear.app/spectranoir/issue/SPE-2251) **Done** — Claims 1–6 test-backed at harness granularity. **Next:** extranormal event registry persistence slice 2 (`planning/extranormal-event-registry-slice-2.md`, branch `spe-2105-extranormal-event-registry-persistence-slice-2`). Sibling intake registries (SPE-2106, SPE-2104) defer slice-2 until this pattern lands.
+Branch `spe-2106-unexplained-location-registry-persistence-slice-2` — [SPE-2313](https://linear.app/spectranoir/issue/SPE-2313) **In Progress**. After merge: [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) minor anomaly persistence or SPE-2105 slice 3 weekly hook (`planning/extranormal-event-registry-slice-2.md` deferred table).
 
 ## Blocked / waiting
 
@@ -58,6 +58,7 @@ On `main` @ `80f7ffdb` (post–slice 5 merge, PR #2486). [SPE-2251](https://line
 | **Recurrent catastrophe amelioration registry ([SPE-2117](https://linear.app/spectranoir/issue/SPE-2117))** | Slice 1 shipped (PR #2436); `src/domain/recurrentCatastropheAmeliorationRegistry.ts`; see `planning/recurrent-catastrophe-amelioration-registry-slice-1.md`. Parent [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) stays open. |
 | **Mass anomalous population emergence registry ([SPE-2122](https://linear.app/spectranoir/issue/SPE-2122))** | Slice 1 shipped (PR #2441); `src/domain/massAnomalousPopulationEmergenceRegistry.ts`; see `planning/mass-anomalous-population-emergence-registry-slice-1.md`. Parent [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) stays open. |
 | **Rule-document compliance containment registry ([SPE-2123](https://linear.app/spectranoir/issue/SPE-2123))** | Slice 1 shipped (PR #2442); `src/domain/ruleDocumentComplianceContainmentRegistry.ts`; see `planning/rule-document-compliance-containment-registry-slice-1.md`. Parent [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) stays open. |
+| **Extranormal event registry persistence ([SPE-2312](https://linear.app/spectranoir/issue/SPE-2312))** | [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) slice 2 — `extranormalEventRecords` on GameState (PR #2488); see `planning/extranormal-event-registry-slice-2.md`. |
 
 ## Harvest reconciliation (SCP-9995 — May 2026)
 
@@ -118,7 +119,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `mvp-weekly-loop-proof-slice-1.md`                        | **Shipped**    | SPE-2251 slice 1; see Shipped MVP loop proof.                                                                                                       |
 | `mvp-weekly-loop-proof-slice-4.md`                        | **Shipped**    | [SPE-2310](https://linear.app/spectranoir/issue/SPE-2310) / PR #2484 — Claims 3–4.                                                                    |
 | `mvp-weekly-loop-proof-slice-5.md`                        | **Shipped**    | [SPE-2311](https://linear.app/spectranoir/issue/SPE-2311) / PR #2486 — Claims 5–6; closes SPE-2251 harness.                                          |
-| `extranormal-event-registry-slice-2.md`                   | **Queued**     | GameState persistence for SPE-2105 records; create Linear child when starting.                                                                          |
+| `extranormal-event-registry-slice-2.md`                   | **Shipped**    | [SPE-2312](https://linear.app/spectranoir/issue/SPE-2312) / PR #2488 — GameState persistence for SPE-2105 records.                                      |
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                                                                                                           |
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |
 | `hidden-modality-matrix-slice-1.md`                       | **Shipped**    | SPE-2281 / PR #2403; domain compose.                                                                                                                |

--- a/planning/extranormal-event-registry-slice-2.md
+++ b/planning/extranormal-event-registry-slice-2.md
@@ -5,7 +5,7 @@ One-page implementation plan. Linear: child under [SPE-854](https://linear.app/s
 | Field      | Value                                                                                                      |
 | ---------- | ---------------------------------------------------------------------------------------------------------- |
 | **Linear** | [SPE-2312 — Extranormal event registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2312) |
-| **Status** | **In Progress**                                                                                            |
+| **Status** | **Shipped** — PR #2488 @ `017ec758`                                                                        |
 | **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (Done); registry anchor [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) |
 | **Branch** | `spe-2105-extranormal-event-registry-persistence-slice-2`                                                  |
 | **Base `main` SHA** | `80f7ffdb`                                                                                          |

--- a/planning/unexplained-location-registry-slice-2.md
+++ b/planning/unexplained-location-registry-slice-2.md
@@ -1,0 +1,63 @@
+# SPE-88 — Unexplained location registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: child under [SPE-88](https://linear.app/spectranoir/issue/SPE-88) / [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106). Follows shipped slice 1 (`planning` harvest mirror + PR #2427).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2313 — Unexplained location registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2313) |
+| **Status** | In progress                                                                                                |
+| **Parent** | [SPE-88](https://linear.app/spectranoir/issue/SPE-88) — Anomaly compendium umbrella; registry anchor [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) |
+| **Branch** | `spe-2106-unexplained-location-registry-persistence-slice-2`                                             |
+| **Base `main` SHA** | `017ec758`                                                                                          |
+
+## Goal
+
+Persist validated `UnexplainedLocationRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Slice 1 deferred persistence; weekly lifecycle orchestration is out of scope.
+
+## Prerequisite (on `main` @ `017ec758`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/unexplainedLocationRegistry.ts` (SPE-2106 / PR #2427)        |
+| Fixtures             | `REMOTE_MONITOR_SITE_FIXTURE`, `LIFECYCLE_CHAIN_LOCATION_FIXTURE`      |
+| Sibling persistence  | `extranormalEventRecords` pattern (SPE-2312 / PR #2488)                |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `unexplainedLocationRecords` on `GameState`                        | Weekly lifecycle advance hook                 |
+| `sanitizeUnexplainedLocationRecords` + `runTransfer` hydrate wire  | UI / map board                                |
+| `validateUnexplainedLocationRecord` on hydrate; drop invalid, no throw | Minor anomaly persistence (SPE-2104)     |
+| Default `{}` in `createStartingState`                              | SPE-88 parent Done                            |
+| Sanitize unit tests + save/import round-trip (byte-stable)         | SPE-2105 slice 3 weekly hook                  |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] `statusHistory` byte-stable after round-trip
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/unexplainedLocationRegistry.ts`, `src/domain/models.ts`   |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/unexplainedLocationRegistryPersistence.test.ts`              |
+| Plan   | `planning/unexplained-location-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Weekly lifecycle / monitoring cadence advance | SPE-2106 slice 3+ | Persistence must land before orchestration |
+| Minor anomaly item persistence | SPE-2104 slice 2 | One registry per PR |
+| Extranormal event weekly monitoring hook | SPE-2105 slice 3 | Separate parent; unblocked on main |
+
+## See also
+
+- `planning/extranormal-event-registry-slice-2.md`
+- `planning/minor-anomaly-item-registry-slice-1.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -194,6 +194,7 @@ import { getKnowledgeKey } from '../../domain/knowledge'
 import { sanitizeKnowledgeStateMap } from '../../domain/knowledge/sanitize'
 import { sanitizeInformationIntakeReports } from '../../domain/informationIntakeReport'
 import { sanitizeExtranormalEventRecords } from '../../domain/extranormalEventRegistry'
+import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLocationRegistry'
 import {
   buildCandidateEvaluation,
   deriveCandidateCostEstimate,
@@ -8370,6 +8371,10 @@ export function hydrateGame(
     game.extranormalEventRecords,
     fallback.extranormalEventRecords ?? {}
   )
+  const unexplainedLocationRecords = sanitizeUnexplainedLocationRecords(
+    game.unexplainedLocationRecords,
+    fallback.unexplainedLocationRecords ?? {}
+  )
   const factions = hasPersistedFactions
     ? sanitizeFactionsMap(game.factions, fallback.factions)
     : fallback.factions
@@ -8488,6 +8493,7 @@ export function hydrateGame(
       knowledge,
       informationIntakeReports,
       extranormalEventRecords,
+      unexplainedLocationRecords,
       candidates,
       recruitmentPool,
       teams,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -41,6 +41,7 @@ const startingStateTemplate: GameState = {
   knowledge: startingKnowledge,
   informationIntakeReports: {},
   extranormalEventRecords: {},
+  unexplainedLocationRecords: {},
   factions: createInitialFactionState(),
 
   agency: {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -245,6 +245,7 @@ import type { BeliefTrackState } from './beliefTracks'
 import type { KnowledgeState, KnowledgeStateMap } from './knowledge'
 import type { InformationIntakeReportRecord } from './informationIntakeReport'
 import type { ExtranormalEventRecord } from './extranormalEventRegistry'
+import type { UnexplainedLocationRecord } from './unexplainedLocationRegistry'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
 import type { SquadKitAssignment } from './squadKitAssignment'
@@ -2546,6 +2547,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   extranormalEventRecords?: Record<string, ExtranormalEventRecord>
+
+  /**
+   * SPE-2106 slice 2: persisted low-threat unexplained location records (keyed by location id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  unexplainedLocationRecords?: Record<string, UnexplainedLocationRecord>
 
   /** Optional active compromised-authority runtime packet (SPE-746). */
   compromisedAuthority?: CompromisedAuthorityState

--- a/src/domain/unexplainedLocationRegistry.ts
+++ b/src/domain/unexplainedLocationRegistry.ts
@@ -709,6 +709,279 @@ export function projectUnexplainedLocationForMap(
   })
 }
 
+// ---------------------------------------------------------------------------
+// Persistence (SPE-2106 slice 2)
+// ---------------------------------------------------------------------------
+
+export type UnexplainedLocationRecordsMap = Record<UnexplainedLocationId, UnexplainedLocationRecord>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function uniqueSorted(values: readonly string[]) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return uniqueSorted(
+    value.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry)
+  )
+}
+
+function parseEffectDomainTags(value: unknown): readonly EffectDomainTag[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const tags: EffectDomainTag[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !isEffectDomainTag(entry) || seen.has(entry)) {
+      continue
+    }
+
+    seen.add(entry)
+    tags.push(entry)
+  }
+
+  return tags
+}
+
+function parsePopulationSelectors(value: unknown): readonly PopulationSelector[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const selectors: PopulationSelector[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const kind = typeof entry.kind === 'string' ? entry.kind : ''
+    const selectorValue = normalizeToken(entry.value)
+    if (!isPopulationSelectorKind(kind) || !selectorValue) {
+      continue
+    }
+
+    const key = `${kind}:${selectorValue}`
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    selectors.push({ kind, value: selectorValue })
+  }
+
+  return selectors
+}
+
+function parseSecurityControlTags(value: unknown): readonly SecurityControlTag[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const tags: SecurityControlTag[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !isSecurityControlTag(entry) || seen.has(entry)) {
+      continue
+    }
+
+    seen.add(entry)
+    tags.push(entry)
+  }
+
+  return tags
+}
+
+function parseStatusHistory(value: unknown): readonly UnexplainedLocationStatusHistoryEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const history: UnexplainedLocationStatusHistoryEntry[] = []
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const fromState = typeof entry.fromState === 'string' ? entry.fromState : ''
+    const toState = typeof entry.toState === 'string' ? entry.toState : ''
+    const week = entry.week
+    const note =
+      typeof entry.note === 'string' && entry.note.trim().length > 0 ? entry.note.trim() : undefined
+
+    if (
+      !isUnexplainedLocationLifecycleState(fromState) ||
+      !isUnexplainedLocationLifecycleState(toState) ||
+      !isFiniteWeek(week)
+    ) {
+      continue
+    }
+
+    history.push({
+      fromState,
+      toState,
+      week,
+      ...(note ? { note } : {}),
+    })
+  }
+
+  return history
+}
+
+function parseUpdateLedger(value: unknown): readonly UnexplainedLocationUpdateLedgerEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const ledger: UnexplainedLocationUpdateLedgerEntry[] = []
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const week = entry.week
+    const field = normalizeToken(entry.field)
+    const note =
+      typeof entry.note === 'string' && entry.note.trim().length > 0 ? entry.note.trim() : undefined
+
+    if (!isFiniteWeek(week) || !field) {
+      continue
+    }
+
+    ledger.push({
+      week,
+      field,
+      ...(note ? { note } : {}),
+    })
+  }
+
+  return ledger
+}
+
+function sanitizeUnexplainedLocationRecordEntry(value: unknown): UnexplainedLocationRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const effectGeometry = typeof value.effectGeometry === 'string' ? value.effectGeometry : ''
+  const effectDomainTags = parseEffectDomainTags(value.effectDomainTags)
+  const populationSelectors = parsePopulationSelectors(value.populationSelectors)
+  const lifecycleState = typeof value.lifecycleState === 'string' ? value.lifecycleState : ''
+  const latentSeverityScore = value.latentSeverityScore
+
+  if (
+    !id ||
+    !label ||
+    !isEffectGeometry(effectGeometry) ||
+    !isUnexplainedLocationLifecycleState(lifecycleState) ||
+    !isValidSeverityScore(latentSeverityScore)
+  ) {
+    return null
+  }
+
+  const securityControlTags = parseSecurityControlTags(value.securityControlTags)
+  const statusHistory = parseStatusHistory(value.statusHistory)
+  const updateLedger = parseUpdateLedger(value.updateLedger)
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+  const disputedFields = parseStringList(value.disputedFields)
+  const contradictionRefs = parseStringList(value.contradictionRefs)
+
+  const descriptionStub =
+    typeof value.descriptionStub === 'string' && value.descriptionStub.trim().length > 0
+      ? value.descriptionStub.trim()
+      : undefined
+  const coverStoryCode = normalizeToken(value.coverStoryCode ?? '') || undefined
+  const mapLayerPolicy = normalizeToken(value.mapLayerPolicy ?? '') || undefined
+  const locationTag = normalizeToken(value.locationTag ?? '') || undefined
+  const neutralizationAuthorizationRef =
+    normalizeToken(value.neutralizationAuthorizationRef ?? '') || undefined
+
+  const discoveryWeek = value.discoveryWeek
+  const containmentWeek = value.containmentWeek
+  const monitoringCadenceWeeks = value.monitoringCadenceWeeks
+  const accessProbability = value.accessProbability
+  const confidence = value.confidence
+  const lowPriority = value.lowPriority === true ? true : undefined
+
+  const record: UnexplainedLocationRecord = {
+    id,
+    label,
+    effectGeometry,
+    effectDomainTags,
+    populationSelectors,
+    lifecycleState,
+    latentSeverityScore,
+    ...(descriptionStub ? { descriptionStub } : {}),
+    ...(isFiniteWeek(discoveryWeek) ? { discoveryWeek } : {}),
+    ...(isFiniteWeek(containmentWeek) ? { containmentWeek } : {}),
+    ...(securityControlTags.length > 0 ? { securityControlTags } : {}),
+    ...(coverStoryCode ? { coverStoryCode } : {}),
+    ...(isFiniteWeek(monitoringCadenceWeeks) && monitoringCadenceWeeks !== 0
+      ? { monitoringCadenceWeeks }
+      : {}),
+    ...(isValidUnitInterval(accessProbability) ? { accessProbability } : {}),
+    ...(lowPriority ? { lowPriority } : {}),
+    ...(isValidUnitInterval(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+    ...(disputedFields.length > 0 ? { disputedFields } : {}),
+    ...(contradictionRefs.length > 0 ? { contradictionRefs } : {}),
+    ...(neutralizationAuthorizationRef ? { neutralizationAuthorizationRef } : {}),
+    ...(mapLayerPolicy ? { mapLayerPolicy } : {}),
+    ...(locationTag ? { locationTag } : {}),
+    ...(statusHistory.length > 0 ? { statusHistory } : {}),
+    ...(updateLedger.length > 0 ? { updateLedger } : {}),
+  }
+
+  if (!validateUnexplainedLocationRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical location map keyed by location id; drops invalid and duplicate-id entries. */
+export function sanitizeUnexplainedLocationRecords(
+  value: unknown,
+  fallback: UnexplainedLocationRecordsMap = {}
+): UnexplainedLocationRecordsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: UnexplainedLocationRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeUnexplainedLocationRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 function defineLocation(record: UnexplainedLocationRecord): UnexplainedLocationRecord {
   return Object.freeze({ ...record })
 }

--- a/src/test/unexplainedLocationRegistryPersistence.test.ts
+++ b/src/test/unexplainedLocationRegistryPersistence.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+  REMOTE_MONITOR_SITE_FIXTURE,
+  sanitizeUnexplainedLocationRecords,
+} from '../domain/unexplainedLocationRegistry'
+
+describe('unexplainedLocationRegistry persistence (SPE-2106 slice 2)', () => {
+  it('defaults starting state to an empty unexplained location map', () => {
+    expect(createStartingState().unexplainedLocationRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeUnexplainedLocationRecords(
+      {
+        valid: REMOTE_MONITOR_SITE_FIXTURE,
+        lifecycle: LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+        'wrong-key': {
+          ...LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+          id: 'location:remote-ridge-station',
+        },
+        duplicate: {
+          ...REMOTE_MONITOR_SITE_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          effectGeometry: 'room',
+          effectDomainTags: ['spatial'],
+          populationSelectors: [{ kind: 'location', value: 'x' }],
+          lifecycleState: 'active',
+          latentSeverityScore: 10,
+        },
+        invalidGeometry: {
+          id: 'location:bad-geometry',
+          label: 'Bad geometry',
+          effectGeometry: 'not-a-geometry',
+          effectDomainTags: ['spatial'],
+          populationSelectors: [{ kind: 'location', value: 'room-a' }],
+          lifecycleState: 'active',
+          latentSeverityScore: 12,
+        },
+        invalidLifecycle: {
+          id: 'location:bad-lifecycle',
+          label: 'Bad lifecycle',
+          effectGeometry: 'room',
+          effectDomainTags: ['spatial'],
+          populationSelectors: [{ kind: 'location', value: 'room-b' }],
+          lifecycleState: 'not-a-state',
+          latentSeverityScore: 8,
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['location:remote-ridge-station']).toEqual(REMOTE_MONITOR_SITE_FIXTURE)
+    expect(sanitized['location:canal-pump-house']).toEqual(LIFECYCLE_CHAIN_LOCATION_FIXTURE)
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.invalidGeometry).toBeUndefined()
+    expect(sanitized.invalidLifecycle).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(Object.keys(sanitized)).toHaveLength(2)
+  })
+
+  it('round-trips fixture locations with statusHistory byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.unexplainedLocationRecords = {
+      [REMOTE_MONITOR_SITE_FIXTURE.id]: REMOTE_MONITOR_SITE_FIXTURE,
+      [LIFECYCLE_CHAIN_LOCATION_FIXTURE.id]: LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.unexplainedLocationRecords).toEqual(state.unexplainedLocationRecords)
+    expect(
+      loaded.unexplainedLocationRecords?.[LIFECYCLE_CHAIN_LOCATION_FIXTURE.id]?.statusHistory
+    ).toEqual(LIFECYCLE_CHAIN_LOCATION_FIXTURE.statusHistory)
+  })
+
+  it('hydrates persisted unexplained locations through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        unexplainedLocationRecords: {
+          [REMOTE_MONITOR_SITE_FIXTURE.id]: REMOTE_MONITOR_SITE_FIXTURE,
+          invalid: {
+            id: 'location:invalid',
+            label: 'Invalid lifecycle',
+            effectGeometry: 'room',
+            effectDomainTags: ['spatial'],
+            populationSelectors: [{ kind: 'location', value: 'room-c' }],
+            lifecycleState: 'not-a-state',
+            latentSeverityScore: 5,
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.unexplainedLocationRecords).toEqual({
+      [REMOTE_MONITOR_SITE_FIXTURE.id]: REMOTE_MONITOR_SITE_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Linear

- **Slice:** [SPE-2313](https://linear.app/spectranoir/issue/SPE-2313) — Unexplained location registry GameState persistence (slice 2)
- **Parent:** [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) — unexplained location registry (slice 1 shipped)
- **Umbrella:** [SPE-88](https://linear.app/spectranoir/issue/SPE-88) — stays open

## Summary

- Add unexplainedLocationRecords on GameState with sanitizeUnexplainedLocationRecords wired through unTransfer hydration.
- Default empty map in createStartingState.
- Persistence tests: sanitize drops invalid/duplicate ids; fixtures round-trip save/load with statusHistory byte-stable.

## Out of scope

- Weekly lifecycle orchestration (SPE-2106 slice 3+)
- Minor anomaly persistence (SPE-2104 slice 2)
- SPE-2105 slice 3 weekly monitoring hook

## Validation

- 
pm run test:run -- src/test/unexplainedLocationRegistryPersistence.test.ts
- 
pm run lint

## Docs

- planning/unexplained-location-registry-slice-2.md
- planning/backlog.md handoff updated

## Parent status

SPE-88 and SPE-2106 remain open (persistence slice only).

Made with [Cursor](https://cursor.com)