### PR TITLE
feat(SPE-2314): minor anomaly item registry GameState persistence (slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,13 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Registry slice-2+ (next)** — [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) minor anomaly item persistence (slice 2); then SPE-2105 slice 3 weekly hook or other intake-registry parents. Owner creates Linear child.
+1. **Registry slice-3+ (next)** — [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) disposition weekly hook (slice 3+) or [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) extranormal weekly monitoring hook after [SPE-2314](https://linear.app/spectranoir/issue/SPE-2314) persistence merges.
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `ae5354f5` (post–SPE-2313 merge, PR #2490). [SPE-2313](https://linear.app/spectranoir/issue/SPE-2313) **Done** — unexplained location persistence. **Next:** [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) minor anomaly persistence (`planning/minor-anomaly-item-registry-slice-2.md` when created); defer SPE-2105 slice 3 until sibling registry wave completes.
+On `main` @ `97463533`. [SPE-2314](https://linear.app/spectranoir/issue/SPE-2314) **In Progress** — minor anomaly item persistence (`planning/minor-anomaly-item-registry-slice-2.md`). **Next after merge:** registry slice-3 weekly hooks (SPE-2104 / SPE-2105) or other intake-registry parents.
 
 ## Blocked / waiting
 
@@ -136,6 +136,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `hidden-modality-matrix-slice-9.md`                       | **Shipped**    | SPE-2290 / PR #2423; glamour / presentation overlay modality.                                                                                        |
 | `extranormal-event-registry-slice-1.md`                   | **Shipped**    | SPE-2105 / PR #2426; brief incident intake schema.                                                                                                  |
 | `minor-anomaly-item-registry-slice-1.md`                  | **Shipped**    | SPE-2104 / PR #2428; low-priority item intake schema.                                                                                               |
+| `minor-anomaly-item-registry-slice-2.md`                  | **In Progress** | SPE-2314; `minorAnomalyItemRecords` GameState persistence.                                                                                          |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |
 | `public-disclosure-state-registry-slice-1.md`             | **Shipped**    | SPE-2109 / PR #2430; awareness levels, fallout timeline, regional trust — post-secrecy campaign slice 1.                                              |
 | `pattern-source-series-registry-slice-1.md`               | **Shipped**    | SPE-2110 / PR #2431; series-hub intake metadata and processing queue projection.                                                                      |

--- a/planning/minor-anomaly-item-registry-slice-2.md
+++ b/planning/minor-anomaly-item-registry-slice-2.md
@@ -1,0 +1,65 @@
+# SPE-88 — Minor anomaly item registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: child under [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) / [SPE-88](https://linear.app/spectranoir/issue/SPE-88). Follows shipped slice 1 (`planning/minor-anomaly-item-registry-slice-1.md`, PR #2428).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2314 — Minor anomaly item registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2314) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) — Minor anomaly item registry; umbrella [SPE-88](https://linear.app/spectranoir/issue/SPE-88) |
+| **Branch** | `spe-2104-minor-anomaly-item-registry-persistence-slice-2`                                                 |
+| **Base `main` SHA** | `97463533`                                                                                          |
+
+## Goal
+
+Persist validated `MinorAnomalyRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Slice 1 deferred persistence; disposition weekly hooks and case lifecycle are out of scope.
+
+## Prerequisite (on `main` @ `97463533`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/minorAnomalyItemRegistry.ts` (SPE-2104 / PR #2428)         |
+| Fixtures             | `DISPOSITION_CHAIN_ITEM_FIXTURE`, `FALSE_POSITIVE_ITEM_FIXTURE`        |
+| Sibling persistence  | `extranormalEventRecords` (SPE-2312), `unexplainedLocationRecords` (SPE-2313) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `minorAnomalyItemRecords` on `GameState`                           | Weekly disposition advance hook               |
+| `sanitizeMinorAnomalyItemRecords` + `runTransfer` hydrate wire      | UI / compendium / map board                   |
+| `validateMinorAnomalyRecord` on hydrate; drop invalid, no throw    | Case lifecycle wire-up (SPE-1310)             |
+| Default `{}` in `createStartingState`                              | SPE-88 parent Done                            |
+| Sanitize unit tests + save/import round-trip (byte-stable)         | SPE-2105 slice 3 weekly hook                  |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] `statusHistory` byte-stable after round-trip
+- [x] Optional `investigationRef` / `destructionAuthorizationRef` preserved when valid
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/minorAnomalyItemRegistry.ts`, `src/domain/models.ts`      |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/minorAnomalyItemRegistryPersistence.test.ts`                |
+| Plan   | `planning/minor-anomaly-item-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Weekly disposition / custody advance hook | SPE-2104 slice 3+ | Persistence must land before orchestration |
+| Storage policy enforcement | SPE-1314 | Out of persistence-only boundary |
+| Extranormal event weekly monitoring hook | SPE-2105 slice 3 | Separate parent; unblocked after registry wave |
+
+## See also
+
+- `planning/unexplained-location-registry-slice-2.md`
+- `planning/extranormal-event-registry-slice-2.md`
+- `planning/minor-anomaly-item-registry-slice-1.md`

--- a/planning/unexplained-location-registry-slice-2.md
+++ b/planning/unexplained-location-registry-slice-2.md
@@ -54,7 +54,7 @@ Persist validated `UnexplainedLocationRecord` entries on `GameState` with saniti
 | Item | Owner | Why |
 | --- | --- | --- |
 | Weekly lifecycle / monitoring cadence advance | SPE-2106 slice 3+ | Persistence must land before orchestration |
-| Minor anomaly item persistence | SPE-2104 slice 2 | One registry per PR |
+| Minor anomaly item persistence | [SPE-2314](https://linear.app/spectranoir/issue/SPE-2314) | Sibling registry wave; SPE-2106 slice 3+ owns weekly lifecycle hook |
 | Extranormal event weekly monitoring hook | SPE-2105 slice 3 | Separate parent; unblocked on main |
 
 ## See also

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -195,6 +195,7 @@ import { sanitizeKnowledgeStateMap } from '../../domain/knowledge/sanitize'
 import { sanitizeInformationIntakeReports } from '../../domain/informationIntakeReport'
 import { sanitizeExtranormalEventRecords } from '../../domain/extranormalEventRegistry'
 import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLocationRegistry'
+import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
 import {
   buildCandidateEvaluation,
   deriveCandidateCostEstimate,
@@ -8375,6 +8376,10 @@ export function hydrateGame(
     game.unexplainedLocationRecords,
     fallback.unexplainedLocationRecords ?? {}
   )
+  const minorAnomalyItemRecords = sanitizeMinorAnomalyItemRecords(
+    game.minorAnomalyItemRecords,
+    fallback.minorAnomalyItemRecords ?? {}
+  )
   const factions = hasPersistedFactions
     ? sanitizeFactionsMap(game.factions, fallback.factions)
     : fallback.factions
@@ -8494,6 +8499,7 @@ export function hydrateGame(
       informationIntakeReports,
       extranormalEventRecords,
       unexplainedLocationRecords,
+      minorAnomalyItemRecords,
       candidates,
       recruitmentPool,
       teams,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -42,6 +42,7 @@ const startingStateTemplate: GameState = {
   informationIntakeReports: {},
   extranormalEventRecords: {},
   unexplainedLocationRecords: {},
+  minorAnomalyItemRecords: {},
   factions: createInitialFactionState(),
 
   agency: {

--- a/src/domain/minorAnomalyItemRegistry.ts
+++ b/src/domain/minorAnomalyItemRegistry.ts
@@ -524,6 +524,194 @@ export function projectMinorAnomalyForOperator(
   })
 }
 
+// ---------------------------------------------------------------------------
+// Persistence (SPE-2104 slice 2)
+// ---------------------------------------------------------------------------
+
+export type MinorAnomalyItemRecordsMap = Record<MinorAnomalyItemId, MinorAnomalyRecord>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function uniqueSorted(values: readonly string[]) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return uniqueSorted(
+    value.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry)
+  )
+}
+
+function parseStatusHistory(value: unknown): readonly MinorAnomalyStatusHistoryEntry[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const history: MinorAnomalyStatusHistoryEntry[] = []
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const fromDisposition = typeof entry.fromDisposition === 'string' ? entry.fromDisposition : ''
+    const toDisposition = typeof entry.toDisposition === 'string' ? entry.toDisposition : ''
+    const week = entry.week
+    const note =
+      typeof entry.note === 'string' && entry.note.trim().length > 0 ? entry.note.trim() : undefined
+
+    if (
+      !isMinorAnomalyDisposition(fromDisposition) ||
+      !isMinorAnomalyDisposition(toDisposition) ||
+      !isFiniteWeek(week)
+    ) {
+      continue
+    }
+
+    history.push({
+      fromDisposition,
+      toDisposition,
+      week,
+      ...(note ? { note } : {}),
+    })
+  }
+
+  return history
+}
+
+function parseStaffNoteProvenance(value: unknown): readonly StaffNoteProvenanceHook[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const hooks: StaffNoteProvenanceHook[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const noteRef = normalizeToken(entry.noteRef)
+    if (!noteRef || seen.has(noteRef)) {
+      continue
+    }
+
+    const authorRef = normalizeToken(entry.authorRef ?? '') || undefined
+    const week = entry.week
+
+    if (week !== undefined && !isFiniteWeek(week)) {
+      continue
+    }
+
+    seen.add(noteRef)
+    hooks.push({
+      noteRef,
+      ...(authorRef ? { authorRef } : {}),
+      ...(week !== undefined ? { week } : {}),
+    })
+  }
+
+  return hooks
+}
+
+function sanitizeMinorAnomalyItemRecordEntry(value: unknown): MinorAnomalyRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const disposition = typeof value.disposition === 'string' ? value.disposition : ''
+
+  if (!id || !label || !isMinorAnomalyDisposition(disposition)) {
+    return null
+  }
+
+  const latentRiskScore = value.latentRiskScore
+  if (!isValidLatentRiskScore(latentRiskScore)) {
+    return null
+  }
+
+  const statusHistory = parseStatusHistory(value.statusHistory)
+  const staffNoteProvenance = parseStaffNoteProvenance(value.staffNoteProvenance)
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+
+  const descriptionStub =
+    typeof value.descriptionStub === 'string' && value.descriptionStub.trim().length > 0
+      ? value.descriptionStub.trim()
+      : undefined
+  const recoverySiteRef = normalizeToken(value.recoverySiteRef ?? '') || undefined
+  const suspectedOriginRef = normalizeToken(value.suspectedOriginRef ?? '') || undefined
+  const currentCustodyRef = normalizeToken(value.currentCustodyRef ?? '') || undefined
+  const status = normalizeToken(value.status ?? '') || undefined
+  const destructionAuthorizationRef =
+    normalizeToken(value.destructionAuthorizationRef ?? '') || undefined
+  const investigationRef = normalizeToken(value.investigationRef ?? '') || undefined
+  const publicDisruptionRef = normalizeToken(value.publicDisruptionRef ?? '') || undefined
+  const lowValue = value.lowValue === true ? true : undefined
+  const confidence = value.confidence
+
+  const record: MinorAnomalyRecord = {
+    id,
+    label,
+    disposition,
+    latentRiskScore,
+    ...(descriptionStub ? { descriptionStub } : {}),
+    ...(recoverySiteRef ? { recoverySiteRef } : {}),
+    ...(suspectedOriginRef ? { suspectedOriginRef } : {}),
+    ...(currentCustodyRef ? { currentCustodyRef } : {}),
+    ...(status ? { status } : {}),
+    ...(statusHistory.length > 0 ? { statusHistory } : {}),
+    ...(lowValue ? { lowValue } : {}),
+    ...(isValidUnitInterval(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+    ...(destructionAuthorizationRef ? { destructionAuthorizationRef } : {}),
+    ...(investigationRef ? { investigationRef } : {}),
+    ...(publicDisruptionRef ? { publicDisruptionRef } : {}),
+    ...(staffNoteProvenance.length > 0 ? { staffNoteProvenance } : {}),
+  }
+
+  if (!validateMinorAnomalyRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical item map keyed by item id; drops invalid and duplicate-id entries. */
+export function sanitizeMinorAnomalyItemRecords(
+  value: unknown,
+  fallback: MinorAnomalyItemRecordsMap = {}
+): MinorAnomalyItemRecordsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: MinorAnomalyItemRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeMinorAnomalyItemRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 function defineItem(record: MinorAnomalyRecord): MinorAnomalyRecord {
   return Object.freeze({ ...record })
 }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -246,6 +246,7 @@ import type { KnowledgeState, KnowledgeStateMap } from './knowledge'
 import type { InformationIntakeReportRecord } from './informationIntakeReport'
 import type { ExtranormalEventRecord } from './extranormalEventRegistry'
 import type { UnexplainedLocationRecord } from './unexplainedLocationRegistry'
+import type { MinorAnomalyRecord } from './minorAnomalyItemRegistry'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
 import type { SquadKitAssignment } from './squadKitAssignment'
@@ -2553,6 +2554,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   unexplainedLocationRecords?: Record<string, UnexplainedLocationRecord>
+
+  /**
+   * SPE-2104 slice 2: persisted low-priority minor anomaly item records (keyed by item id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  minorAnomalyItemRecords?: Record<string, MinorAnomalyRecord>
 
   /** Optional active compromised-authority runtime packet (SPE-746). */
   compromisedAuthority?: CompromisedAuthorityState

--- a/src/test/minorAnomalyItemRegistryPersistence.test.ts
+++ b/src/test/minorAnomalyItemRegistryPersistence.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  DISPOSITION_CHAIN_ITEM_FIXTURE,
+  FALSE_POSITIVE_ITEM_FIXTURE,
+  sanitizeMinorAnomalyItemRecords,
+} from '../domain/minorAnomalyItemRegistry'
+
+describe('minorAnomalyItemRegistry persistence (SPE-2104 slice 2)', () => {
+  it('defaults starting state to an empty minor anomaly item map', () => {
+    expect(createStartingState().minorAnomalyItemRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeMinorAnomalyItemRecords(
+      {
+        valid: DISPOSITION_CHAIN_ITEM_FIXTURE,
+        falsePositive: FALSE_POSITIVE_ITEM_FIXTURE,
+        'wrong-key': {
+          ...FALSE_POSITIVE_ITEM_FIXTURE,
+          id: 'item:ceramic-whistle-fragment',
+        },
+        duplicate: {
+          ...DISPOSITION_CHAIN_ITEM_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          disposition: 'recovered',
+          latentRiskScore: 5,
+        },
+        missingHistory: {
+          id: 'item:no-history',
+          label: 'No history',
+          disposition: 'staff_use',
+          latentRiskScore: 8,
+        },
+        falsePositiveMissingInvestigation: {
+          id: 'item:missing-investigation',
+          label: 'Missing investigation',
+          disposition: 'false_positive_returned',
+          latentRiskScore: 2,
+          statusHistory: [
+            {
+              fromDisposition: 'under_investigation',
+              toDisposition: 'false_positive_returned',
+              week: 4,
+            },
+          ],
+        },
+        invalidRisk: {
+          id: 'item:bad-risk',
+          label: 'Bad risk',
+          disposition: 'recovered',
+          latentRiskScore: 200,
+        },
+        invalidDisposition: {
+          id: 'item:bad-disposition',
+          label: 'Bad disposition',
+          disposition: 'not-a-disposition',
+          latentRiskScore: 5,
+        },
+        destroyedMissingHistory: {
+          id: 'item:destroyed-no-history',
+          label: 'Destroyed without history',
+          disposition: 'destroyed',
+          latentRiskScore: 20,
+          destructionAuthorizationRef: 'auth:destruction-order-9',
+        },
+        invalidHistoryDisposition: {
+          id: 'item:bad-history',
+          label: 'Bad history',
+          disposition: 'stored',
+          latentRiskScore: 6,
+          statusHistory: [
+            { fromDisposition: 'recovered', toDisposition: 'not-valid', week: 3 },
+            { fromDisposition: 'recovered', toDisposition: 'stored', week: 4 },
+          ],
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['item:ceramic-whistle-fragment']).toEqual(DISPOSITION_CHAIN_ITEM_FIXTURE)
+    expect(sanitized['item:brass-key-blank']).toEqual(FALSE_POSITIVE_ITEM_FIXTURE)
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.missingHistory).toBeUndefined()
+    expect(sanitized.falsePositiveMissingInvestigation).toBeUndefined()
+    expect(sanitized.invalidRisk).toBeUndefined()
+    expect(sanitized.invalidDisposition).toBeUndefined()
+    expect(sanitized.destroyedMissingHistory).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['item:bad-history']).toEqual({
+      id: 'item:bad-history',
+      label: 'Bad history',
+      disposition: 'stored',
+      latentRiskScore: 6,
+      statusHistory: [{ fromDisposition: 'recovered', toDisposition: 'stored', week: 4 }],
+    })
+    expect(Object.keys(sanitized)).toHaveLength(3)
+  })
+
+  it('round-trips fixture items with statusHistory and investigationRef byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.minorAnomalyItemRecords = {
+      [DISPOSITION_CHAIN_ITEM_FIXTURE.id]: DISPOSITION_CHAIN_ITEM_FIXTURE,
+      [FALSE_POSITIVE_ITEM_FIXTURE.id]: FALSE_POSITIVE_ITEM_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.minorAnomalyItemRecords).toEqual(state.minorAnomalyItemRecords)
+    expect(
+      loaded.minorAnomalyItemRecords?.[DISPOSITION_CHAIN_ITEM_FIXTURE.id]?.statusHistory
+    ).toEqual(DISPOSITION_CHAIN_ITEM_FIXTURE.statusHistory)
+    expect(
+      loaded.minorAnomalyItemRecords?.[FALSE_POSITIVE_ITEM_FIXTURE.id]?.investigationRef
+    ).toEqual(FALSE_POSITIVE_ITEM_FIXTURE.investigationRef)
+  })
+
+  it('hydrates persisted minor anomaly items through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        minorAnomalyItemRecords: {
+          [DISPOSITION_CHAIN_ITEM_FIXTURE.id]: DISPOSITION_CHAIN_ITEM_FIXTURE,
+          invalid: {
+            id: 'item:invalid',
+            label: 'Invalid',
+            disposition: 'staff_use',
+            latentRiskScore: 4,
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.minorAnomalyItemRecords).toEqual({
+      [DISPOSITION_CHAIN_ITEM_FIXTURE.id]: DISPOSITION_CHAIN_ITEM_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `minorAnomalyItemRecords` to `GameState` with default `{}` in `createStartingState`.
- Wire `sanitizeMinorAnomalyItemRecords` through `hydrateGame` (`runTransfer`), gated by `validateMinorAnomalyRecord` (drops invalid/duplicate-id entries without throw).
- Add persistence tests: starting default, sanitize edge cases, save/load round-trip, hydrate import path.

## Linear

- **Slice:** [SPE-2314](https://linear.app/spectranoir/issue/SPE-2314) — Minor anomaly item registry GameState persistence (slice 2)
- **Parent:** [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) — Minor anomaly item registry (slice 1 schema)
- **Umbrella:** [SPE-88](https://linear.app/spectranoir/issue/SPE-88) — remains open

## What shipped

- `MinorAnomalyItemRecordsMap` + sanitize/hydrate helpers in `src/domain/minorAnomalyItemRegistry.ts`
- `GameState.minorAnomalyItemRecords` in `models.ts`, `startingState.ts`, `runTransfer.ts`
- `src/test/minorAnomalyItemRegistryPersistence.test.ts`
- `planning/minor-anomaly-item-registry-slice-2.md`, backlog handoff update

## Out of scope

- Weekly disposition hooks, case lifecycle (SPE-1310), compendium UI, SPE-2105 slice 3 weekly hook

## Validation

- `npm run test:run -- src/test/minorAnomalyItemRegistryPersistence.test.ts`
- `npm run lint`

## Docs

- `planning/minor-anomaly-item-registry-slice-2.md`
- `planning/backlog.md` (active queue / handoff)
- `planning/unexplained-location-registry-slice-2.md` (deferred cross-ref)

## Parent status

SPE-2104 stays open until slice 3+ orchestration; SPE-88 parent unchanged.
