### PR TITLE
SPE-2315: extranormal event weekly monitoring advance hook (slice 3)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,13 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Registry slice-3+ (next)** — [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) disposition weekly hook (slice 3+) or [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) extranormal weekly monitoring hook (registry persistence wave complete).
+1. **Registry slice-3+ (next)** — [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) disposition weekly hook (slice 3+); extranormal monitoring hook in PR ([SPE-2315](https://linear.app/spectranoir/issue/SPE-2315)).
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `91c902f4` (post–SPE-2314 merge, PR #2492). [SPE-2314](https://linear.app/spectranoir/issue/SPE-2314) **Done** — minor anomaly item persistence shipped. **Next:** registry slice-3 weekly hooks (SPE-2104 disposition or SPE-2105 monitoring); create Linear child + slice doc per owner.
+On `main` @ `79ff0fbf`. [SPE-2315](https://linear.app/spectranoir/issue/SPE-2315) extranormal weekly monitoring hook **In PR** (`planning/extranormal-event-registry-slice-3.md`). **Next:** [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) disposition weekly hook (slice 3+) or unexplained-location slice 3+ per registry wave.
 
 ## Blocked / waiting
 
@@ -120,6 +120,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `mvp-weekly-loop-proof-slice-1.md`                        | **Shipped**    | SPE-2251 slice 1; see Shipped MVP loop proof.                                                                                                       |
 | `mvp-weekly-loop-proof-slice-4.md`                        | **Shipped**    | [SPE-2310](https://linear.app/spectranoir/issue/SPE-2310) / PR #2484 — Claims 3–4.                                                                    |
 | `mvp-weekly-loop-proof-slice-5.md`                        | **Shipped**    | [SPE-2311](https://linear.app/spectranoir/issue/SPE-2311) / PR #2486 — Claims 5–6; closes SPE-2251 harness.                                          |
+| `extranormal-event-registry-slice-3.md`                   | **In PR**      | [SPE-2315](https://linear.app/spectranoir/issue/SPE-2315) — weekly `monitoringUntilWeek` / `monitor_only` advance hook for SPE-2105.                  |
 | `extranormal-event-registry-slice-2.md`                   | **Shipped**    | [SPE-2312](https://linear.app/spectranoir/issue/SPE-2312) / PR #2488 — GameState persistence for SPE-2105 records.                                      |
 | `unexplained-location-registry-slice-2.md`                | **Shipped**    | [SPE-2313](https://linear.app/spectranoir/issue/SPE-2313) / PR #2490 — GameState persistence for SPE-2106 records.                                      |
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                                                                                                           |

--- a/planning/extranormal-event-registry-slice-3.md
+++ b/planning/extranormal-event-registry-slice-3.md
@@ -1,0 +1,62 @@
+# SPE-2105 — Extranormal event registry weekly monitoring hook (slice 3)
+
+One-page implementation plan. Linear: child under [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105). Follows shipped slice 2 (`planning/extranormal-event-registry-slice-2.md`, PR #2488).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2315 — Extranormal event registry weekly monitoring/closure advance hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2315) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) — registry anchor (slice 1–2 shipped)            |
+| **Branch** | `spe-2105-extranormal-event-registry-weekly-monitoring-slice-3`                                          |
+| **Base `main` SHA** | `79ff0fbf`                                                                                          |
+
+## Goal
+
+Wire persisted `extranormalEventRecords` into `advanceWeek` so monitoring windows expire deterministically and `monitor_only` closure advances when the until-week is reached.
+
+## Prerequisite (on `main` @ `79ff0fbf`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/extranormalEventRegistry.ts` (SPE-2105 / PR #2426)         |
+| Persistence          | `extranormalEventRecords` on `GameState` (SPE-2312 / PR #2488)       |
+| Intake weekly hook pattern | `src/domain/informationIntakeWeeklyCorroboration.ts` + `advanceWeek` post-`finalizeEvents` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyExtranormalEventMonitoringTick` in domain module         | New persistence fields, UI, report notes      |
+| Call from `advanceWeek` after week increment (`result.week`)       | Minor-anomaly / unexplained-location hooks    |
+| Targeted domain + `advanceWeek` integration tests                    | Intake ↔ extranormal cross-link               |
+| Slice doc (this file) + backlog handoff                              | SPE-2105 parent Done / SPE-88 parent closure  |
+
+## Acceptance
+
+- [x] Empty `extranormalEventRecords` map is a no-op without throw
+- [x] Records with `monitoringUntilWeek` unchanged while `week < monitoringUntilWeek`
+- [x] When `week >= monitoringUntilWeek`, `monitoringUntilWeek` is cleared (byte-stable other fields)
+- [x] `monitor_only` advances to `sourceless_closed` when monitoring expires
+- [x] Re-applying tick for same post-expiry week is idempotent
+- [x] `npm run lint` + targeted tests + persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/extranormalEventWeeklyMonitoring.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/extranormalEventWeeklyMonitoring.test.ts`, `src/test/advanceWeek.extranormalEvent.integration.test.ts` |
+| Plan   | `planning/extranormal-event-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Intake report ↔ extranormal event linkage | SPE-854 follow-up | Out of weekly-hook boundary |
+| Case escalation transitions from extranormal records | Case lifecycle owners | Slice 3 monitoring expiry only |
+| Cover-story matcher / event board UI | Downstream UX owners | Explicitly out of slice |
+
+## See also
+
+- `planning/extranormal-event-registry-slice-2.md`
+- `planning/information-intake-weekly-hook-slice-4.md`

--- a/src/domain/extranormalEventWeeklyMonitoring.ts
+++ b/src/domain/extranormalEventWeeklyMonitoring.ts
@@ -56,8 +56,8 @@ export function advanceExtranormalEventRecordMonitoringForWeek(
 
   const nextClosureState = resolveClosureStateAfterMonitoringExpiry(record.closureState)
 
-  const withoutMonitoring = { ...record }
-  delete (withoutMonitoring as Partial<ExtranormalEventRecord>).monitoringUntilWeek
+  const { monitoringUntilWeek: _monitoringUntilWeek, ...withoutMonitoring } = record
+  void _monitoringUntilWeek
   const candidate: ExtranormalEventRecord = {
     ...withoutMonitoring,
     ...(nextClosureState !== undefined ? { closureState: nextClosureState } : {}),

--- a/src/domain/extranormalEventWeeklyMonitoring.ts
+++ b/src/domain/extranormalEventWeeklyMonitoring.ts
@@ -1,0 +1,105 @@
+/**
+ * SPE-2105 slice 3: weekly monitoring-until / closureState advance for persisted extranormal events.
+ *
+ * Pure deterministic tick: when the simulation week reaches monitoringUntilWeek, clear the
+ * monitoring window and advance monitor_only closure to sourceless_closed. Does not mutate
+ * unrelated fields or rewrite mistaken history beyond the bounded monitoring contract.
+ */
+
+import {
+  validateExtranormalEventRecord,
+  type ExtranormalEventRecord,
+  type ExtranormalEventRecordsMap,
+  type ExtranormalClosureState,
+} from './extranormalEventRegistry'
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function freezeRecord(record: ExtranormalEventRecord): ExtranormalEventRecord {
+  return Object.freeze({ ...record })
+}
+
+function resolveClosureStateAfterMonitoringExpiry(
+  closureState: ExtranormalClosureState | undefined
+): ExtranormalClosureState | undefined {
+  if (closureState === 'monitor_only') {
+    return 'sourceless_closed'
+  }
+
+  return closureState
+}
+
+/**
+ * Advances one record when the simulation week has reached its monitoring-until week.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceExtranormalEventRecordMonitoringForWeek(
+  record: ExtranormalEventRecord,
+  week: number
+): ExtranormalEventRecord {
+  const normalizedWeek = normalizeWeek(week)
+  const monitoringUntilWeek = record.monitoringUntilWeek
+
+  if (!isFiniteWeek(monitoringUntilWeek) || normalizedWeek < monitoringUntilWeek) {
+    return record
+  }
+
+  const nextClosureState = resolveClosureStateAfterMonitoringExpiry(record.closureState)
+
+  const withoutMonitoring = { ...record }
+  delete (withoutMonitoring as Partial<ExtranormalEventRecord>).monitoringUntilWeek
+  const candidate: ExtranormalEventRecord = {
+    ...withoutMonitoring,
+    ...(nextClosureState !== undefined ? { closureState: nextClosureState } : {}),
+  }
+
+  if (!validateExtranormalEventRecord(candidate).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly monitoring/closure pass over persisted extranormal event records.
+ * Empty map is a no-op. Re-applying after monitoring has expired is idempotent.
+ */
+export function applyWeeklyExtranormalEventMonitoringTick(
+  records: ExtranormalEventRecordsMap | null | undefined,
+  week: number
+): ExtranormalEventRecordsMap {
+  const safeRecords = records ?? {}
+  const eventIds = Object.keys(safeRecords)
+  if (eventIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: ExtranormalEventRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const eventId of eventIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[eventId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceExtranormalEventRecordMonitoringForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[eventId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -262,6 +262,7 @@ import {
   type AuthoredCivicAuthoritySourceInput,
   type CompactCivicAuthorityConsequencePacket,
 } from '../civicConsequenceNetwork'
+import { applyWeeklyExtranormalEventMonitoringTick } from '../extranormalEventWeeklyMonitoring'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
 import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
@@ -4482,6 +4483,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       }
       result.reports = reports
     }
+  }
+
+  // SPE-2105 slice 3: expire extranormal monitoring windows and advance monitor_only closure.
+  const priorExtranormalEvents = inputWeeklyState.extranormalEventRecords ?? {}
+  if (Object.keys(priorExtranormalEvents).length > 0) {
+    outputWeeklyState.extranormalEventRecords = applyWeeklyExtranormalEventMonitoringTick(
+      priorExtranormalEvents,
+      result.week
+    )
   }
 
   // SPE-1265: Decay rumor packets each week; drop packets below the 0.05 signal threshold.

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4486,10 +4486,10 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   }
 
   // SPE-2105 slice 3: expire extranormal monitoring windows and advance monitor_only closure.
-  const priorExtranormalEvents = inputWeeklyState.extranormalEventRecords ?? {}
-  if (Object.keys(priorExtranormalEvents).length > 0) {
+  const currentExtranormalEvents = outputWeeklyState.extranormalEventRecords ?? {}
+  if (Object.keys(currentExtranormalEvents).length > 0) {
     outputWeeklyState.extranormalEventRecords = applyWeeklyExtranormalEventMonitoringTick(
-      priorExtranormalEvents,
+      currentExtranormalEvents,
       result.week
     )
   }

--- a/src/test/advanceWeek.extranormalEvent.integration.test.ts
+++ b/src/test/advanceWeek.extranormalEvent.integration.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  BRIEF_COVER_UP_EVENT_FIXTURE,
+  BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+} from '../domain/extranormalEventRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek extranormal event monitoring integration (SPE-2105 slice 3)', () => {
+  it('is a no-op for an empty extranormal event map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.extranormalEventRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.extranormalEventRecords).toEqual({})
+  })
+
+  it('retains monitoringUntilWeek before the until-week after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 36
+    state.extranormalEventRecords = {
+      [BRIEF_COVER_UP_EVENT_FIXTURE.id]: BRIEF_COVER_UP_EVENT_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const event = nextState.extranormalEventRecords?.[BRIEF_COVER_UP_EVENT_FIXTURE.id]
+
+    expect(nextState.week).toBe(37)
+    expect(event?.monitoringUntilWeek).toBe(38)
+    expect(event?.closureState).toBe('sourceless_closed')
+  })
+
+  it('clears monitoringUntilWeek when advanceWeek reaches the until-week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 38
+    state.extranormalEventRecords = {
+      [BRIEF_COVER_UP_EVENT_FIXTURE.id]: BRIEF_COVER_UP_EVENT_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const event = nextState.extranormalEventRecords?.[BRIEF_COVER_UP_EVENT_FIXTURE.id]
+
+    expect(nextState.week).toBe(39)
+    expect(event?.monitoringUntilWeek).toBeUndefined()
+    expect(event?.closureState).toBe('sourceless_closed')
+    expect(event?.similarEventCluster).toEqual(BRIEF_COVER_UP_EVENT_FIXTURE.similarEventCluster)
+  })
+
+  it('preserves cluster refs byte-stable through advanceWeek monitoring expiry', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 40
+    state.extranormalEventRecords = {
+      [BRIEF_COVER_UP_EVENT_WITH_CLUSTER.id]: BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+    }
+
+    const nextState = advanceWeek(state)
+    const event = nextState.extranormalEventRecords?.[BRIEF_COVER_UP_EVENT_WITH_CLUSTER.id]
+
+    expect(event?.monitoringUntilWeek).toBeUndefined()
+    expect(event?.similarEventCluster).toEqual(BRIEF_COVER_UP_EVENT_WITH_CLUSTER.similarEventCluster)
+    expect(event?.observerClassTags).toEqual(BRIEF_COVER_UP_EVENT_WITH_CLUSTER.observerClassTags)
+  })
+})

--- a/src/test/extranormalEventWeeklyMonitoring.test.ts
+++ b/src/test/extranormalEventWeeklyMonitoring.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BRIEF_COVER_UP_EVENT_FIXTURE,
+  type ExtranormalEventRecord,
+} from '../domain/extranormalEventRegistry'
+import {
+  advanceExtranormalEventRecordMonitoringForWeek,
+  applyWeeklyExtranormalEventMonitoringTick,
+} from '../domain/extranormalEventWeeklyMonitoring'
+
+function monitorOnlyRecord(overrides: Partial<ExtranormalEventRecord> = {}): ExtranormalEventRecord {
+  return {
+    id: 'event:monitor-only-test',
+    label: 'Monitor-only test event',
+    occurrenceWindow: { startWeek: 4 },
+    effectDomainTags: ['spatial'],
+    affectedAreaGeometry: 'room',
+    populationSelectors: [{ kind: 'location', value: 'test-room' }],
+    coverStoryCode: 'cover-test',
+    witnessPlan: 'witness-test',
+    monitoringUntilWeek: 10,
+    closureState: 'monitor_only',
+    ...overrides,
+  }
+}
+
+describe('extranormalEventWeeklyMonitoring (SPE-2105 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklyExtranormalEventMonitoringTick({}, 12)).toEqual({})
+    expect(applyWeeklyExtranormalEventMonitoringTick(undefined, 12)).toEqual({})
+  })
+
+  it('leaves monitoringUntilWeek unchanged while week is before the until-week', () => {
+    const record = BRIEF_COVER_UP_EVENT_FIXTURE
+    const advanced = advanceExtranormalEventRecordMonitoringForWeek(record, 37)
+
+    expect(advanced).toBe(record)
+    expect(advanced.monitoringUntilWeek).toBe(38)
+    expect(advanced.closureState).toBe('sourceless_closed')
+  })
+
+  it('clears monitoringUntilWeek when week reaches the until-week', () => {
+    const record = BRIEF_COVER_UP_EVENT_FIXTURE
+    const advanced = advanceExtranormalEventRecordMonitoringForWeek(record, 38)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.monitoringUntilWeek).toBeUndefined()
+    expect(advanced.closureState).toBe('sourceless_closed')
+    expect(advanced.resolved).toBe(true)
+    expect(advanced.coverStoryCode).toBe(record.coverStoryCode)
+  })
+
+  it('advances monitor_only to sourceless_closed when monitoring expires', () => {
+    const record = monitorOnlyRecord()
+    const advanced = advanceExtranormalEventRecordMonitoringForWeek(record, 10)
+
+    expect(advanced.closureState).toBe('sourceless_closed')
+    expect(advanced.monitoringUntilWeek).toBeUndefined()
+  })
+
+  it('is idempotent when re-applied after monitoring has expired', () => {
+    const record = BRIEF_COVER_UP_EVENT_FIXTURE
+    const once = advanceExtranormalEventRecordMonitoringForWeek(record, 40)
+    const twice = advanceExtranormalEventRecordMonitoringForWeek(once, 40)
+
+    expect(twice).toBe(once)
+  })
+
+  it('applies tick in stable id order without mutating unrelated records', () => {
+    const monitorRecord = monitorOnlyRecord({ monitoringUntilWeek: 5 })
+    const briefRecord = BRIEF_COVER_UP_EVENT_FIXTURE
+    const map = {
+      [briefRecord.id]: briefRecord,
+      [monitorRecord.id]: monitorRecord,
+    }
+
+    const next = applyWeeklyExtranormalEventMonitoringTick(map, 6)
+
+    expect(next[briefRecord.id]).toBe(briefRecord)
+    expect(next[monitorRecord.id]?.closureState).toBe('sourceless_closed')
+    expect(next[monitorRecord.id]?.monitoringUntilWeek).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyExtranormalEventMonitoringTick` to expire `monitoringUntilWeek` when `advanceWeek` reaches the until-week and advance `monitor_only` to `sourceless_closed`.
- Wire the tick into `advanceWeek` post-`finalizeEvents` using `result.week` (same cadence as civic packet decay).
- Add domain unit tests and `advanceWeek` integration tests; persistence regression unchanged.

## Linear

- **Slice:** [SPE-2315](https://linear.app/spectranoir/issue/SPE-2315)
- **Parent:** [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) (registry anchor; remains **Done** — slice 1–2 only)
- **Umbrella:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — not reopened

## Shipped

- Pure weekly orchestration for persisted `extranormalEventRecords` only
- No new persistence fields, UI, or sibling registry hooks

## Validation

- `npm run lint`
- `npm run test:run -- src/test/extranormalEventWeeklyMonitoring.test.ts src/test/advanceWeek.extranormalEvent.integration.test.ts src/test/extranormalEventRegistryPersistence.test.ts`

## Docs

- `planning/extranormal-event-registry-slice-3.md`
- `planning/backlog.md` handoff

## Parent status

SPE-2105 stays **Done** (schema + persistence shipped). Deferred intake cross-link and case escalation remain on follow-up owners per slice doc.

Made with [Cursor](https://cursor.com)