### PR TITLE
feat(SPE-2316): minor anomaly item weekly disposition advance hook (slice 3)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,13 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Registry slice-3+ (next)** — [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) disposition weekly hook (slice 3+) or [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) unexplained-location weekly lifecycle.
+1. **Registry slice-3+ (next)** — [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) unexplained-location weekly lifecycle (SPE-2104 slice 3 in PR).
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `91fa6cf7` (post–SPE-2315 merge, PR #2494). [SPE-2315](https://linear.app/spectranoir/issue/SPE-2315) **Done** — extranormal weekly monitoring hook shipped. **Next:** [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) disposition weekly hook (slice 3+) per registry wave.
+On `main` @ `ae78790b`. [SPE-2315](https://linear.app/spectranoir/issue/SPE-2315) **Done** (PR #2494). [SPE-2316](https://linear.app/spectranoir/issue/SPE-2316) **In Progress** — minor-anomaly weekly disposition hook. **Next:** [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) unexplained-location weekly lifecycle.
 
 ## Blocked / waiting
 
@@ -138,6 +138,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `extranormal-event-registry-slice-1.md`                   | **Shipped**    | SPE-2105 / PR #2426; brief incident intake schema.                                                                                                  |
 | `minor-anomaly-item-registry-slice-1.md`                  | **Shipped**    | SPE-2104 / PR #2428; low-priority item intake schema.                                                                                               |
 | `minor-anomaly-item-registry-slice-2.md`                  | **Shipped**    | SPE-2314 / PR #2492; `minorAnomalyItemRecords` GameState persistence.                                                                               |
+| `minor-anomaly-item-registry-slice-3.md`                  | **In Progress** | SPE-2316 — weekly disposition/custody advance hook for SPE-2104.                                                                                    |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |
 | `public-disclosure-state-registry-slice-1.md`             | **Shipped**    | SPE-2109 / PR #2430; awareness levels, fallout timeline, regional trust — post-secrecy campaign slice 1.                                              |
 | `pattern-source-series-registry-slice-1.md`               | **Shipped**    | SPE-2110 / PR #2431; series-hub intake metadata and processing queue projection.                                                                      |

--- a/planning/minor-anomaly-item-registry-slice-3.md
+++ b/planning/minor-anomaly-item-registry-slice-3.md
@@ -1,0 +1,65 @@
+# SPE-2104 — Minor anomaly item registry weekly disposition hook (slice 3)
+
+One-page implementation plan. Linear: child under [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104). Follows shipped slice 2 (`planning/minor-anomaly-item-registry-slice-2.md`, PR #2492).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2316 — Minor anomaly item registry weekly disposition/custody advance hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2316) |
+| **Status** | **In Progress** — PR pending                                                                               |
+| **Parent** | [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) — registry anchor (slice 1–2 shipped)          |
+| **Branch** | `spe-2104-minor-anomaly-item-registry-weekly-disposition-slice-3`                                          |
+| **Base `main` SHA** | `ae78790b`                                                                                          |
+
+## Goal
+
+Wire persisted `minorAnomalyItemRecords` into `advanceWeek` so custody review due weeks (derived from `staffNoteProvenance` hooks) advance intake dispositions deterministically with append-only `statusHistory`.
+
+## Prerequisite (on `main` @ `ae78790b`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/minorAnomalyItemRegistry.ts` (SPE-2104 / PR #2428)         |
+| Persistence          | `minorAnomalyItemRecords` on `GameState` (SPE-2314 / PR #2492)       |
+| Sibling weekly hook  | `src/domain/extranormalEventWeeklyMonitoring.ts` (SPE-2315 / PR #2494) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyMinorAnomalyItemDispositionTick` in domain module        | New persistence fields, UI, report notes      |
+| One disposition step per item per tick when `week >= custodyReviewDueWeek` | Extranormal / unexplained-location hooks |
+| Default chain: `recovered` → `pending_review` → `stored`; legacy `status` overrides target when valid | SPE-88 parent Done / SPE-1310 case lifecycle |
+| Call from `advanceWeek` after week increment (`result.week`), read `outputWeeklyState` | Storage policy (SPE-1314) |
+| Targeted domain + `advanceWeek` integration tests                    | Intake ↔ minor-item cross-link                |
+| Slice doc (this file) + backlog handoff                              |                                               |
+
+## Acceptance
+
+- [x] Empty `minorAnomalyItemRecords` map is a no-op without throw
+- [x] Items unchanged while `week < custodyReviewDueWeek` (max `staffNoteProvenance.week`)
+- [x] `recovered` / `pending_review` advance one step when due; append-only `statusHistory`
+- [x] Legacy `status` schedules target disposition when valid and distinct from current
+- [x] Invalid post-transition record left unchanged (validation gate; destroyed requires auth ref)
+- [x] Re-applying tick for same week after advance is idempotent (one step per item per week)
+- [x] `npm run lint` + targeted tests + persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/minorAnomalyItemWeeklyDisposition.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/minorAnomalyItemWeeklyDisposition.test.ts`, `src/test/advanceWeek.minorAnomalyItem.integration.test.ts` |
+| Plan   | `planning/minor-anomaly-item-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| `stored` → `assigned` / `staff_use` automation | SPE-1314 / follow-up | Out of intake custody-review boundary |
+| Intake report ↔ minor item linkage | SPE-854 follow-up | Out of weekly-hook boundary |
+| Case escalation from minor items | SPE-1310 | Slice 3 custody advance only |
+
+## See also
+
+- `planning/minor-anomaly-item-registry-slice-2.md`
+- `planning/extranormal-event-registry-slice-3.md`

--- a/src/domain/minorAnomalyItemWeeklyDisposition.ts
+++ b/src/domain/minorAnomalyItemWeeklyDisposition.ts
@@ -1,0 +1,208 @@
+/**
+ * SPE-2104 slice 3: weekly disposition / custody advance for persisted minor anomaly items.
+ *
+ * Pure deterministic tick: when the simulation week reaches the custody-review due week
+ * (max staffNoteProvenance.week), advance one intake disposition step with append-only
+ * statusHistory. Does not add persistence fields or rewrite prior history entries.
+ */
+
+import {
+  validateMinorAnomalyRecord,
+  isMinorAnomalyDisposition,
+  type MinorAnomalyDisposition,
+  type MinorAnomalyItemRecordsMap,
+  type MinorAnomalyRecord,
+  type MinorAnomalyStatusHistoryEntry,
+} from './minorAnomalyItemRegistry'
+
+const DEFAULT_DISPOSITION_ADVANCE: Partial<
+  Record<MinorAnomalyDisposition, MinorAnomalyDisposition>
+> = {
+  recovered: 'pending_review',
+  pending_review: 'stored',
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function freezeRecord(record: MinorAnomalyRecord): MinorAnomalyRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Max staff-note week on the record; undefined when no hook declares a week. */
+export function resolveMinorAnomalyCustodyReviewDueWeek(
+  record: MinorAnomalyRecord
+): number | undefined {
+  const hooks = record.staffNoteProvenance ?? []
+  let dueWeek: number | undefined
+
+  for (const hook of hooks) {
+    if (!hook || hook.week === undefined || !isFiniteWeek(hook.week)) {
+      continue
+    }
+
+    dueWeek = dueWeek === undefined ? hook.week : Math.max(dueWeek, hook.week)
+  }
+
+  return dueWeek
+}
+
+function recordMatchesLastHistoryDisposition(record: MinorAnomalyRecord): boolean {
+  const history = record.statusHistory ?? []
+  if (history.length === 0) {
+    return true
+  }
+
+  const last = history[history.length - 1]
+  return last?.toDisposition === record.disposition
+}
+
+function alreadyAdvancedDispositionThisWeek(
+  record: MinorAnomalyRecord,
+  week: number
+): boolean {
+  const history = record.statusHistory ?? []
+  const last = history[history.length - 1]
+  return last?.week === week
+}
+
+function resolveScheduledTargetDisposition(
+  record: MinorAnomalyRecord
+): MinorAnomalyDisposition | undefined {
+  const statusToken = normalizeToken(record.status ?? '')
+  if (
+    statusToken &&
+    isMinorAnomalyDisposition(statusToken) &&
+    statusToken !== record.disposition
+  ) {
+    return statusToken
+  }
+
+  return DEFAULT_DISPOSITION_ADVANCE[record.disposition]
+}
+
+function appendStatusHistoryEntry(
+  record: MinorAnomalyRecord,
+  fromDisposition: MinorAnomalyDisposition,
+  toDisposition: MinorAnomalyDisposition,
+  week: number
+): readonly MinorAnomalyStatusHistoryEntry[] {
+  const prior = record.statusHistory ?? []
+  const entry: MinorAnomalyStatusHistoryEntry = {
+    fromDisposition,
+    toDisposition,
+    week,
+    note: 'Weekly custody review disposition advance.',
+  }
+
+  return Object.freeze([...prior, entry])
+}
+
+/**
+ * Advances one record when the simulation week has reached its custody-review due week.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceMinorAnomalyItemRecordDispositionForWeek(
+  record: MinorAnomalyRecord,
+  week: number
+): MinorAnomalyRecord {
+  const normalizedWeek = normalizeWeek(week)
+  const dueWeek = resolveMinorAnomalyCustodyReviewDueWeek(record)
+
+  if (dueWeek === undefined || normalizedWeek < dueWeek) {
+    return record
+  }
+
+  if (!recordMatchesLastHistoryDisposition(record)) {
+    return record
+  }
+
+  if (alreadyAdvancedDispositionThisWeek(record, normalizedWeek)) {
+    return record
+  }
+
+  const targetDisposition = resolveScheduledTargetDisposition(record)
+  if (!targetDisposition || targetDisposition === record.disposition) {
+    return record
+  }
+
+  const nextHistory = appendStatusHistoryEntry(
+    record,
+    record.disposition,
+    targetDisposition,
+    normalizedWeek
+  )
+
+  const statusToken = normalizeToken(record.status ?? '')
+  const clearStatus = statusToken === targetDisposition
+
+  const withAdvance: MinorAnomalyRecord = {
+    ...record,
+    disposition: targetDisposition,
+    statusHistory: nextHistory,
+  }
+
+  const candidate = clearStatus
+    ? (() => {
+        const { status: _status, ...withoutStatus } = withAdvance
+        void _status
+        return withoutStatus
+      })()
+    : withAdvance
+
+  const validationPolicy =
+    targetDisposition === 'destroyed' ? { requireDestructionAuthorization: true } : {}
+
+  if (!validateMinorAnomalyRecord(candidate, validationPolicy).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly disposition/custody pass over persisted minor anomaly item records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklyMinorAnomalyItemDispositionTick(
+  records: MinorAnomalyItemRecordsMap | null | undefined,
+  week: number
+): MinorAnomalyItemRecordsMap {
+  const safeRecords = records ?? {}
+  const itemIds = Object.keys(safeRecords)
+  if (itemIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: MinorAnomalyItemRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const itemId of itemIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[itemId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceMinorAnomalyItemRecordDispositionForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[itemId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -263,6 +263,7 @@ import {
   type CompactCivicAuthorityConsequencePacket,
 } from '../civicConsequenceNetwork'
 import { applyWeeklyExtranormalEventMonitoringTick } from '../extranormalEventWeeklyMonitoring'
+import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
 import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
@@ -4490,6 +4491,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   if (Object.keys(currentExtranormalEvents).length > 0) {
     outputWeeklyState.extranormalEventRecords = applyWeeklyExtranormalEventMonitoringTick(
       currentExtranormalEvents,
+      result.week
+    )
+  }
+
+  // SPE-2104 slice 3: advance intake disposition when custody review due week is reached.
+  const currentMinorAnomalyItems = outputWeeklyState.minorAnomalyItemRecords ?? {}
+  if (Object.keys(currentMinorAnomalyItems).length > 0) {
+    outputWeeklyState.minorAnomalyItemRecords = applyWeeklyMinorAnomalyItemDispositionTick(
+      currentMinorAnomalyItems,
       result.week
     )
   }

--- a/src/test/advanceWeek.minorAnomalyItem.integration.test.ts
+++ b/src/test/advanceWeek.minorAnomalyItem.integration.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  DISPOSITION_CHAIN_ITEM_FIXTURE,
+  FALSE_POSITIVE_ITEM_FIXTURE,
+  type MinorAnomalyRecord,
+} from '../domain/minorAnomalyItemRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+function intakeRecord(overrides: Partial<MinorAnomalyRecord> = {}): MinorAnomalyRecord {
+  return {
+    id: 'item:advance-week-intake',
+    label: 'Advance week intake item',
+    disposition: 'recovered',
+    latentRiskScore: 11,
+    staffNoteProvenance: [{ noteRef: 'note:advance-week-intake', week: 4 }],
+    ...overrides,
+  }
+}
+
+describe('advanceWeek minor anomaly item disposition integration (SPE-2104 slice 3)', () => {
+  it('is a no-op for an empty minor anomaly item map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.minorAnomalyItemRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.minorAnomalyItemRecords).toEqual({})
+  })
+
+  it('retains recovered disposition before the custody review due week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 2
+    const record = intakeRecord()
+    state.minorAnomalyItemRecords = { [record.id]: record }
+
+    const nextState = advanceWeek(state)
+    const item = nextState.minorAnomalyItemRecords?.[record.id]
+
+    expect(nextState.week).toBe(3)
+    expect(item?.disposition).toBe('recovered')
+    expect(item?.statusHistory).toBeUndefined()
+  })
+
+  it('advances recovered to pending_review when advanceWeek reaches the due week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 3
+    const record = intakeRecord()
+    state.minorAnomalyItemRecords = { [record.id]: record }
+
+    const nextState = advanceWeek(state)
+    const item = nextState.minorAnomalyItemRecords?.[record.id]
+
+    expect(nextState.week).toBe(4)
+    expect(item?.disposition).toBe('pending_review')
+    expect(item?.statusHistory?.[0]).toEqual(
+      expect.objectContaining({
+        fromDisposition: 'recovered',
+        toDisposition: 'pending_review',
+        week: 4,
+      })
+    )
+  })
+
+  it('advances pending_review to stored on a later advanceWeek after intake review', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    const record = intakeRecord({ disposition: 'pending_review' })
+    state.minorAnomalyItemRecords = { [record.id]: record }
+
+    const nextState = advanceWeek(state)
+    const item = nextState.minorAnomalyItemRecords?.[record.id]
+
+    expect(nextState.week).toBe(5)
+    expect(item?.disposition).toBe('stored')
+  })
+
+  it('preserves terminal fixture fields byte-stable through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 20
+    state.minorAnomalyItemRecords = {
+      [DISPOSITION_CHAIN_ITEM_FIXTURE.id]: DISPOSITION_CHAIN_ITEM_FIXTURE,
+      [FALSE_POSITIVE_ITEM_FIXTURE.id]: FALSE_POSITIVE_ITEM_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.minorAnomalyItemRecords?.[DISPOSITION_CHAIN_ITEM_FIXTURE.id]).toEqual(
+      DISPOSITION_CHAIN_ITEM_FIXTURE
+    )
+    expect(nextState.minorAnomalyItemRecords?.[FALSE_POSITIVE_ITEM_FIXTURE.id]).toEqual(
+      FALSE_POSITIVE_ITEM_FIXTURE
+    )
+  })
+})

--- a/src/test/minorAnomalyItemWeeklyDisposition.test.ts
+++ b/src/test/minorAnomalyItemWeeklyDisposition.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DISPOSITION_CHAIN_ITEM_FIXTURE,
+  FALSE_POSITIVE_ITEM_FIXTURE,
+  type MinorAnomalyRecord,
+} from '../domain/minorAnomalyItemRegistry'
+import {
+  advanceMinorAnomalyItemRecordDispositionForWeek,
+  applyWeeklyMinorAnomalyItemDispositionTick,
+  resolveMinorAnomalyCustodyReviewDueWeek,
+} from '../domain/minorAnomalyItemWeeklyDisposition'
+
+function intakeRecord(overrides: Partial<MinorAnomalyRecord> = {}): MinorAnomalyRecord {
+  return {
+    id: 'item:intake-test',
+    label: 'Intake test item',
+    disposition: 'recovered',
+    latentRiskScore: 8,
+    staffNoteProvenance: [{ noteRef: 'note:intake-1', week: 10 }],
+    ...overrides,
+  }
+}
+
+describe('minorAnomalyItemWeeklyDisposition (SPE-2104 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklyMinorAnomalyItemDispositionTick({}, 12)).toEqual({})
+    expect(applyWeeklyMinorAnomalyItemDispositionTick(undefined, 12)).toEqual({})
+  })
+
+  it('resolves custody review due week from staff note provenance', () => {
+    const record = intakeRecord({
+      staffNoteProvenance: [
+        { noteRef: 'note:a', week: 4 },
+        { noteRef: 'note:b', week: 9 },
+      ],
+    })
+
+    expect(resolveMinorAnomalyCustodyReviewDueWeek(record)).toBe(9)
+  })
+
+  it('leaves disposition unchanged while week is before the due week', () => {
+    const record = intakeRecord({ disposition: 'pending_review' })
+    const advanced = advanceMinorAnomalyItemRecordDispositionForWeek(record, 9)
+
+    expect(advanced).toBe(record)
+    expect(advanced.disposition).toBe('pending_review')
+  })
+
+  it('advances recovered to pending_review when week reaches the due week', () => {
+    const record = intakeRecord()
+    const advanced = advanceMinorAnomalyItemRecordDispositionForWeek(record, 10)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.disposition).toBe('pending_review')
+    expect(advanced.statusHistory).toEqual([
+      {
+        fromDisposition: 'recovered',
+        toDisposition: 'pending_review',
+        week: 10,
+        note: 'Weekly custody review disposition advance.',
+      },
+    ])
+  })
+
+  it('advances pending_review to stored on a later week with one step per tick', () => {
+    const record = intakeRecord({ disposition: 'pending_review' })
+    const advanced = advanceMinorAnomalyItemRecordDispositionForWeek(record, 10)
+
+    expect(advanced.disposition).toBe('stored')
+    expect(advanced.statusHistory?.[0]?.toDisposition).toBe('stored')
+  })
+
+  it('applies legacy status as the scheduled target disposition', () => {
+    const record = intakeRecord({
+      disposition: 'pending_review',
+      status: 'assigned',
+      staffNoteProvenance: [{ noteRef: 'note:route-1', week: 8 }],
+    })
+
+    const advanced = advanceMinorAnomalyItemRecordDispositionForWeek(record, 8)
+
+    expect(advanced.disposition).toBe('assigned')
+    expect(advanced.status).toBeUndefined()
+    expect(advanced.statusHistory).toEqual([
+      {
+        fromDisposition: 'pending_review',
+        toDisposition: 'assigned',
+        week: 8,
+        note: 'Weekly custody review disposition advance.',
+      },
+    ])
+  })
+
+  it('does not advance destroyed without authorization when policy would fail', () => {
+    const record = intakeRecord({
+      disposition: 'pending_review',
+      status: 'destroyed',
+      staffNoteProvenance: [{ noteRef: 'note:destroy-route', week: 5 }],
+    })
+
+    const advanced = advanceMinorAnomalyItemRecordDispositionForWeek(record, 5)
+
+    expect(advanced).toBe(record)
+  })
+
+  it('is idempotent when re-applied after disposition has advanced', () => {
+    const record = intakeRecord()
+    const once = advanceMinorAnomalyItemRecordDispositionForWeek(record, 11)
+    const twice = advanceMinorAnomalyItemRecordDispositionForWeek(once, 11)
+
+    expect(twice).toBe(once)
+  })
+
+  it('appends history without rewriting prior entries', () => {
+    const record = intakeRecord({
+      disposition: 'stored',
+      statusHistory: [
+        { fromDisposition: 'recovered', toDisposition: 'stored', week: 9, note: 'Logged in vault.' },
+      ],
+      staffNoteProvenance: [{ noteRef: 'note:follow-up', week: 12 }],
+      status: 'assigned',
+    })
+
+    const advanced = advanceMinorAnomalyItemRecordDispositionForWeek(record, 12)
+
+    expect(advanced.statusHistory).toEqual([
+      { fromDisposition: 'recovered', toDisposition: 'stored', week: 9, note: 'Logged in vault.' },
+      {
+        fromDisposition: 'stored',
+        toDisposition: 'assigned',
+        week: 12,
+        note: 'Weekly custody review disposition advance.',
+      },
+    ])
+  })
+
+  it('leaves terminal fixture records unchanged', () => {
+    const chain = advanceMinorAnomalyItemRecordDispositionForWeek(DISPOSITION_CHAIN_ITEM_FIXTURE, 50)
+    const falsePositive = advanceMinorAnomalyItemRecordDispositionForWeek(
+      FALSE_POSITIVE_ITEM_FIXTURE,
+      50
+    )
+
+    expect(chain).toBe(DISPOSITION_CHAIN_ITEM_FIXTURE)
+    expect(falsePositive).toBe(FALSE_POSITIVE_ITEM_FIXTURE)
+  })
+
+  it('applies tick in stable id order without mutating unrelated records', () => {
+    const dueRecord = intakeRecord({ id: 'item:due', disposition: 'pending_review' })
+    const terminalRecord = DISPOSITION_CHAIN_ITEM_FIXTURE
+    const map = {
+      [terminalRecord.id]: terminalRecord,
+      [dueRecord.id]: dueRecord,
+    }
+
+    const next = applyWeeklyMinorAnomalyItemDispositionTick(map, 10)
+
+    expect(next[terminalRecord.id]).toBe(terminalRecord)
+    expect(next[dueRecord.id]?.disposition).toBe('stored')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyMinorAnomalyItemDispositionTick` to advance intake dispositions when `advanceWeek` reaches the custody-review due week (max `staffNoteProvenance.week`).
- Default chain: `recovered` → `pending_review` → `stored`; legacy `status` overrides the target when valid. One step per item per simulation week; append-only `statusHistory`.
- Wire the tick into `advanceWeek` post-`finalizeEvents` using `result.week`, reading `outputWeeklyState.minorAnomalyItemRecords`.

## Linear

- **Slice:** [SPE-2316](https://linear.app/spectranoir/issue/SPE-2316)
- **Parent:** [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) (registry anchor; remains **Done** — slice 1–2 only)
- **Umbrella:** [SPE-88](https://linear.app/spectranoir/issue/SPE-88) — not reopened

## Shipped

- Pure weekly orchestration for persisted `minorAnomalyItemRecords` only
- No new persistence fields, UI, or sibling registry hooks

## Validation

- `npm run lint`
- `npm run test:run -- src/test/minorAnomalyItemWeeklyDisposition.test.ts src/test/advanceWeek.minorAnomalyItem.integration.test.ts src/test/minorAnomalyItemRegistryPersistence.test.ts`

## Docs

- `planning/minor-anomaly-item-registry-slice-3.md`
- `planning/backlog.md` handoff

## Parent status

SPE-2104 stays **Done** (schema + persistence shipped). Deferred storage policy and case lifecycle remain on follow-up owners per slice doc.