### PR TITLE
SPE-2317: unexplained location weekly lifecycle advance hook (slice 3)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,13 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Registry slice-3+ (next)** — [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) unexplained-location weekly lifecycle.
+1. **Registry slice-3+ (next)** — pick next intake-registry or compendium follow-up after [SPE-2317](https://linear.app/spectranoir/issue/SPE-2317) merges (unexplained-location weekly lifecycle in PR).
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `a84e293e` (post–SPE-2316 merge, PR #2496). [SPE-2316](https://linear.app/spectranoir/issue/SPE-2316) **Done** — minor-anomaly weekly disposition hook shipped. **Next:** [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) unexplained-location weekly lifecycle.
+On `main` @ `4045c2b8`. [SPE-2317](https://linear.app/spectranoir/issue/SPE-2317) **In Progress** — unexplained-location weekly lifecycle hook (slice 3). [SPE-2316](https://linear.app/spectranoir/issue/SPE-2316) **Done** (PR #2496).
 
 ## Blocked / waiting
 
@@ -123,6 +123,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `extranormal-event-registry-slice-3.md`                   | **Shipped**    | [SPE-2315](https://linear.app/spectranoir/issue/SPE-2315) / PR #2494 — weekly monitoring/closure advance hook for SPE-2105.                           |
 | `extranormal-event-registry-slice-2.md`                   | **Shipped**    | [SPE-2312](https://linear.app/spectranoir/issue/SPE-2312) / PR #2488 — GameState persistence for SPE-2105 records.                                      |
 | `unexplained-location-registry-slice-2.md`                | **Shipped**    | [SPE-2313](https://linear.app/spectranoir/issue/SPE-2313) / PR #2490 — GameState persistence for SPE-2106 records.                                      |
+| `unexplained-location-registry-slice-3.md`                | **In Progress** | [SPE-2317](https://linear.app/spectranoir/issue/SPE-2317) — weekly monitoring-cadence lifecycle advance hook for SPE-2106.                            |
 | `operations-route-drill-down-slice.md`                    | **Shipped**    | SPE-2248 / PR drill-down.                                                                                                                           |
 | `report-week-navigation-slice.md`                         | **Shipped**    | Route and week navigation (PR #2329, [SPE-2248](https://linear.app/spectranoir/issue/SPE-2248) drill-down sibling); acceptance checkboxes complete. |
 | `hidden-modality-matrix-slice-1.md`                       | **Shipped**    | SPE-2281 / PR #2403; domain compose.                                                                                                                |

--- a/planning/unexplained-location-registry-slice-3.md
+++ b/planning/unexplained-location-registry-slice-3.md
@@ -1,0 +1,67 @@
+# SPE-2106 — Unexplained location registry weekly lifecycle hook (slice 3)
+
+One-page implementation plan. Linear: child under [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106). Follows shipped slice 2 (`planning/unexplained-location-registry-slice-2.md`, PR #2490).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2317 — Unexplained location registry weekly lifecycle/monitoring cadence advance hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2317) |
+| **Status** | **In Progress** — PR pending                                                                               |
+| **Parent** | [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) — registry anchor (slice 1–2 shipped)          |
+| **Branch** | `spe-2106-unexplained-location-registry-weekly-lifecycle-slice-3`                                          |
+| **Base `main` SHA** | `4045c2b8`                                                                                          |
+
+## Goal
+
+Wire persisted `unexplainedLocationRecords` into `advanceWeek` so monitoring-cadence due weeks advance site lifecycle states deterministically with append-only `statusHistory`.
+
+## Prerequisite (on `main` @ `4045c2b8`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/unexplainedLocationRegistry.ts` (SPE-2106 / PR #2427)        |
+| Persistence          | `unexplainedLocationRecords` on `GameState` (SPE-2313 / PR #2490)       |
+| Sibling weekly hooks | `extranormalEventWeeklyMonitoring.ts` (SPE-2315), `minorAnomalyItemWeeklyDisposition.ts` (SPE-2316) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyUnexplainedLocationLifecycleTick` in domain module       | New persistence fields, UI, report notes      |
+| Due week = max(`discoveryWeek`, `containmentWeek`, last `statusHistory.week`) + `monitoringCadenceWeeks` | Minor-anomaly / extranormal hooks |
+| Default chain: `active` → `monitor_only` → `archived`; `utility_use` → `archived` | SPE-88 parent Done / SPE-1310 case lifecycle |
+| One lifecycle step per location per tick when `week >= dueWeek`      | Intake ↔ location cross-link                  |
+| Call from `advanceWeek` after week increment (`result.week`), read `outputWeeklyState` | Storage policy (SPE-1314) |
+| Targeted domain + `advanceWeek` integration tests                    |                                               |
+| Slice doc (this file) + backlog handoff                              |                                               |
+
+## Acceptance
+
+- [x] Empty `unexplainedLocationRecords` map is a no-op without throw
+- [x] Locations unchanged while `week < monitoringDueWeek`
+- [x] `active` advances to `monitor_only` when due; `monitor_only` / `utility_use` advance to `archived` when due
+- [x] Append-only `statusHistory`; one step per location per week; idempotent re-apply
+- [x] Terminal fixtures (`LIFECYCLE_CHAIN`, `REMOTE_MONITOR` when not due) byte-stable through tick
+- [x] Neutralized without authorization does not advance under strict validation
+- [x] `npm run lint` + targeted tests + persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/unexplainedLocationWeeklyLifecycle.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/unexplainedLocationWeeklyLifecycle.test.ts`, `src/test/advanceWeek.unexplainedLocation.integration.test.ts` |
+| Plan   | `planning/unexplained-location-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Case escalation from unexplained locations | SPE-1310 | Slice 3 cadence advance only |
+| Cover-story matcher / site board UI | Downstream UX owners | Explicitly out of slice |
+| `pending_reactivation` and `disputed` automation | Follow-up | Terminal / manual posture in slice 3 |
+
+## See also
+
+- `planning/unexplained-location-registry-slice-2.md`
+- `planning/extranormal-event-registry-slice-3.md`
+- `planning/minor-anomaly-item-registry-slice-3.md`

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -264,6 +264,7 @@ import {
 } from '../civicConsequenceNetwork'
 import { applyWeeklyExtranormalEventMonitoringTick } from '../extranormalEventWeeklyMonitoring'
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
+import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
 import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
@@ -4500,6 +4501,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   if (Object.keys(currentMinorAnomalyItems).length > 0) {
     outputWeeklyState.minorAnomalyItemRecords = applyWeeklyMinorAnomalyItemDispositionTick(
       currentMinorAnomalyItems,
+      result.week
+    )
+  }
+
+  // SPE-2106 slice 3: advance site lifecycle when monitoring cadence due week is reached.
+  const currentUnexplainedLocations = outputWeeklyState.unexplainedLocationRecords ?? {}
+  if (Object.keys(currentUnexplainedLocations).length > 0) {
+    outputWeeklyState.unexplainedLocationRecords = applyWeeklyUnexplainedLocationLifecycleTick(
+      currentUnexplainedLocations,
       result.week
     )
   }

--- a/src/domain/unexplainedLocationWeeklyLifecycle.ts
+++ b/src/domain/unexplainedLocationWeeklyLifecycle.ts
@@ -1,0 +1,224 @@
+/**
+ * SPE-2106 slice 3: weekly monitoring-cadence lifecycle advance for persisted unexplained locations.
+ *
+ * Pure deterministic tick: when the simulation week reaches the monitoring due week
+ * (anchor week + monitoringCadenceWeeks), advance one lifecycle step with append-only
+ * statusHistory. Does not add persistence fields or rewrite prior history entries.
+ */
+
+import {
+  validateUnexplainedLocationRecord,
+  isUnexplainedLocationLifecycleState,
+  type UnexplainedLocationLifecycleState,
+  type UnexplainedLocationRecord,
+  type UnexplainedLocationRecordsMap,
+  type UnexplainedLocationStatusHistoryEntry,
+} from './unexplainedLocationRegistry'
+
+const TERMINAL_LIFECYCLE_STATES: ReadonlySet<UnexplainedLocationLifecycleState> = new Set([
+  'archived',
+  'destroyed',
+  'neutralized',
+  'disputed',
+  'public_managed',
+  'pending_reactivation',
+])
+
+const DEFAULT_LIFECYCLE_ADVANCE: Partial<
+  Record<UnexplainedLocationLifecycleState, UnexplainedLocationLifecycleState>
+> = {
+  active: 'monitor_only',
+  monitor_only: 'archived',
+  utility_use: 'archived',
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function freezeRecord(record: UnexplainedLocationRecord): UnexplainedLocationRecord {
+  return Object.freeze({ ...record })
+}
+
+function resolveMonitoringAnchorWeek(record: UnexplainedLocationRecord): number | undefined {
+  let anchorWeek: number | undefined
+
+  if (record.discoveryWeek !== undefined && isFiniteWeek(record.discoveryWeek)) {
+    anchorWeek = record.discoveryWeek
+  }
+
+  if (record.containmentWeek !== undefined && isFiniteWeek(record.containmentWeek)) {
+    anchorWeek =
+      anchorWeek === undefined
+        ? record.containmentWeek
+        : Math.max(anchorWeek, record.containmentWeek)
+  }
+
+  const history = record.statusHistory ?? []
+  const last = history[history.length - 1]
+  if (last && isFiniteWeek(last.week)) {
+    anchorWeek = anchorWeek === undefined ? last.week : Math.max(anchorWeek, last.week)
+  }
+
+  return anchorWeek
+}
+
+/** Monitoring review due week from anchor + cadence; undefined when cadence is not declared. */
+export function resolveUnexplainedLocationMonitoringDueWeek(
+  record: UnexplainedLocationRecord
+): number | undefined {
+  const cadence = record.monitoringCadenceWeeks
+  if (cadence === undefined || !isFiniteWeek(cadence) || cadence === 0) {
+    return undefined
+  }
+
+  const anchorWeek = resolveMonitoringAnchorWeek(record)
+  if (anchorWeek === undefined) {
+    return undefined
+  }
+
+  return anchorWeek + cadence
+}
+
+function recordMatchesLastHistoryLifecycle(record: UnexplainedLocationRecord): boolean {
+  const history = record.statusHistory ?? []
+  if (history.length === 0) {
+    return true
+  }
+
+  const last = history[history.length - 1]
+  return last?.toState === record.lifecycleState
+}
+
+function alreadyAdvancedLifecycleThisWeek(
+  record: UnexplainedLocationRecord,
+  week: number
+): boolean {
+  const history = record.statusHistory ?? []
+  const last = history[history.length - 1]
+  return last?.week === week
+}
+
+function resolveScheduledTargetLifecycle(
+  record: UnexplainedLocationRecord
+): UnexplainedLocationLifecycleState | undefined {
+  if (TERMINAL_LIFECYCLE_STATES.has(record.lifecycleState)) {
+    return undefined
+  }
+
+  return DEFAULT_LIFECYCLE_ADVANCE[record.lifecycleState]
+}
+
+function appendStatusHistoryEntry(
+  record: UnexplainedLocationRecord,
+  fromState: UnexplainedLocationLifecycleState,
+  toState: UnexplainedLocationLifecycleState,
+  week: number
+): readonly UnexplainedLocationStatusHistoryEntry[] {
+  const prior = record.statusHistory ?? []
+  const entry: UnexplainedLocationStatusHistoryEntry = {
+    fromState,
+    toState,
+    week,
+    note: 'Weekly monitoring cadence lifecycle advance.',
+  }
+
+  return Object.freeze([...prior, entry])
+}
+
+/**
+ * Advances one record when the simulation week has reached its monitoring due week.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceUnexplainedLocationRecordLifecycleForWeek(
+  record: UnexplainedLocationRecord,
+  week: number
+): UnexplainedLocationRecord {
+  const normalizedWeek = normalizeWeek(week)
+  const dueWeek = resolveUnexplainedLocationMonitoringDueWeek(record)
+
+  if (dueWeek === undefined || normalizedWeek < dueWeek) {
+    return record
+  }
+
+  if (!recordMatchesLastHistoryLifecycle(record)) {
+    return record
+  }
+
+  if (alreadyAdvancedLifecycleThisWeek(record, normalizedWeek)) {
+    return record
+  }
+
+  const targetLifecycle = resolveScheduledTargetLifecycle(record)
+  if (!targetLifecycle || targetLifecycle === record.lifecycleState) {
+    return record
+  }
+
+  if (!isUnexplainedLocationLifecycleState(targetLifecycle)) {
+    return record
+  }
+
+  const nextHistory = appendStatusHistoryEntry(
+    record,
+    record.lifecycleState,
+    targetLifecycle,
+    normalizedWeek
+  )
+
+  const candidate: UnexplainedLocationRecord = {
+    ...record,
+    lifecycleState: targetLifecycle,
+    statusHistory: nextHistory,
+  }
+
+  const validationPolicy =
+    targetLifecycle === 'neutralized' ? { requireNeutralizationAuthorization: true } : {}
+
+  if (!validateUnexplainedLocationRecord(candidate, validationPolicy).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly monitoring-cadence lifecycle pass over persisted unexplained location records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklyUnexplainedLocationLifecycleTick(
+  records: UnexplainedLocationRecordsMap | null | undefined,
+  week: number
+): UnexplainedLocationRecordsMap {
+  const safeRecords = records ?? {}
+  const locationIds = Object.keys(safeRecords)
+  if (locationIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: UnexplainedLocationRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const locationId of locationIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[locationId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceUnexplainedLocationRecordLifecycleForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[locationId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/test/advanceWeek.unexplainedLocation.integration.test.ts
+++ b/src/test/advanceWeek.unexplainedLocation.integration.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+  REMOTE_MONITOR_SITE_FIXTURE,
+  type UnexplainedLocationRecord,
+} from '../domain/unexplainedLocationRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+function activeSiteRecord(overrides: Partial<UnexplainedLocationRecord> = {}): UnexplainedLocationRecord {
+  return {
+    id: 'location:advance-week-active',
+    label: 'Advance week active site',
+    effectGeometry: 'building',
+    effectDomainTags: ['spatial'],
+    populationSelectors: [{ kind: 'location', value: 'advance-week-building' }],
+    discoveryWeek: 8,
+    monitoringCadenceWeeks: 4,
+    lifecycleState: 'active',
+    latentSeverityScore: 20,
+    ...overrides,
+  }
+}
+
+describe('advanceWeek unexplained location lifecycle integration (SPE-2106 slice 3)', () => {
+  it('is a no-op for an empty unexplained location map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.unexplainedLocationRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.unexplainedLocationRecords).toEqual({})
+  })
+
+  it('retains active lifecycle before the monitoring due week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 10
+    const record = activeSiteRecord()
+    state.unexplainedLocationRecords = { [record.id]: record }
+
+    const nextState = advanceWeek(state)
+    const location = nextState.unexplainedLocationRecords?.[record.id]
+
+    expect(nextState.week).toBe(11)
+    expect(location?.lifecycleState).toBe('active')
+    expect(location?.statusHistory).toBeUndefined()
+  })
+
+  it('advances active to monitor_only when advanceWeek reaches the due week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 11
+    const record = activeSiteRecord()
+    state.unexplainedLocationRecords = { [record.id]: record }
+
+    const nextState = advanceWeek(state)
+    const location = nextState.unexplainedLocationRecords?.[record.id]
+
+    expect(nextState.week).toBe(12)
+    expect(location?.lifecycleState).toBe('monitor_only')
+    expect(location?.statusHistory?.[0]).toEqual(
+      expect.objectContaining({
+        fromState: 'active',
+        toState: 'monitor_only',
+        week: 12,
+      })
+    )
+  })
+
+  it('advances monitor_only to archived when advanceWeek reaches remote monitor due week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 13
+    state.unexplainedLocationRecords = {
+      [REMOTE_MONITOR_SITE_FIXTURE.id]: REMOTE_MONITOR_SITE_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const location = nextState.unexplainedLocationRecords?.[REMOTE_MONITOR_SITE_FIXTURE.id]
+
+    expect(nextState.week).toBe(14)
+    expect(location?.lifecycleState).toBe('archived')
+    expect(location?.coverStoryCode).toBe(REMOTE_MONITOR_SITE_FIXTURE.coverStoryCode)
+    expect(location?.mapLayerPolicy).toBe(REMOTE_MONITOR_SITE_FIXTURE.mapLayerPolicy)
+  })
+
+  it('preserves terminal fixture fields byte-stable through advanceWeek before cadence due', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 12
+    state.unexplainedLocationRecords = {
+      [LIFECYCLE_CHAIN_LOCATION_FIXTURE.id]: LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+      [REMOTE_MONITOR_SITE_FIXTURE.id]: REMOTE_MONITOR_SITE_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.unexplainedLocationRecords?.[LIFECYCLE_CHAIN_LOCATION_FIXTURE.id]).toEqual(
+      LIFECYCLE_CHAIN_LOCATION_FIXTURE
+    )
+    expect(nextState.unexplainedLocationRecords?.[REMOTE_MONITOR_SITE_FIXTURE.id]).toEqual(
+      REMOTE_MONITOR_SITE_FIXTURE
+    )
+  })
+})

--- a/src/test/unexplainedLocationWeeklyLifecycle.test.ts
+++ b/src/test/unexplainedLocationWeeklyLifecycle.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import {
+  LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+  REMOTE_MONITOR_SITE_FIXTURE,
+  type UnexplainedLocationRecord,
+} from '../domain/unexplainedLocationRegistry'
+import {
+  advanceUnexplainedLocationRecordLifecycleForWeek,
+  applyWeeklyUnexplainedLocationLifecycleTick,
+  resolveUnexplainedLocationMonitoringDueWeek,
+} from '../domain/unexplainedLocationWeeklyLifecycle'
+
+function activeSiteRecord(overrides: Partial<UnexplainedLocationRecord> = {}): UnexplainedLocationRecord {
+  return {
+    id: 'location:active-cadence-test',
+    label: 'Active cadence test site',
+    effectGeometry: 'building',
+    effectDomainTags: ['spatial'],
+    populationSelectors: [{ kind: 'location', value: 'test-building' }],
+    discoveryWeek: 8,
+    monitoringCadenceWeeks: 4,
+    lifecycleState: 'active',
+    latentSeverityScore: 20,
+    ...overrides,
+  }
+}
+
+describe('unexplainedLocationWeeklyLifecycle (SPE-2106 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklyUnexplainedLocationLifecycleTick({}, 12)).toEqual({})
+    expect(applyWeeklyUnexplainedLocationLifecycleTick(undefined, 12)).toEqual({})
+  })
+
+  it('resolves monitoring due week from anchor plus cadence', () => {
+    expect(resolveUnexplainedLocationMonitoringDueWeek(REMOTE_MONITOR_SITE_FIXTURE)).toBe(14)
+    expect(resolveUnexplainedLocationMonitoringDueWeek(activeSiteRecord())).toBe(12)
+  })
+
+  it('leaves lifecycle unchanged while week is before the due week', () => {
+    const record = activeSiteRecord()
+    const advanced = advanceUnexplainedLocationRecordLifecycleForWeek(record, 11)
+
+    expect(advanced).toBe(record)
+    expect(advanced.lifecycleState).toBe('active')
+    expect(advanced.statusHistory).toBeUndefined()
+  })
+
+  it('advances active to monitor_only when week reaches the due week', () => {
+    const record = activeSiteRecord()
+    const advanced = advanceUnexplainedLocationRecordLifecycleForWeek(record, 12)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.lifecycleState).toBe('monitor_only')
+    expect(advanced.statusHistory).toEqual([
+      expect.objectContaining({
+        fromState: 'active',
+        toState: 'monitor_only',
+        week: 12,
+      }),
+    ])
+  })
+
+  it('advances monitor_only to archived when monitoring cadence expires', () => {
+    const record = REMOTE_MONITOR_SITE_FIXTURE
+    const advanced = advanceUnexplainedLocationRecordLifecycleForWeek(record, 14)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.lifecycleState).toBe('archived')
+    expect(advanced.statusHistory).toEqual([
+      expect.objectContaining({
+        fromState: 'monitor_only',
+        toState: 'archived',
+        week: 14,
+      }),
+    ])
+    expect(advanced.monitoringCadenceWeeks).toBe(record.monitoringCadenceWeeks)
+    expect(advanced.locationTag).toBe(record.locationTag)
+  })
+
+  it('is idempotent when re-applied after lifecycle advance for the same week', () => {
+    const record = activeSiteRecord()
+    const once = advanceUnexplainedLocationRecordLifecycleForWeek(record, 12)
+    const twice = advanceUnexplainedLocationRecordLifecycleForWeek(once, 12)
+
+    expect(twice).toBe(once)
+  })
+
+  it('leaves neutralized records unchanged when due week is reached', () => {
+    const record = activeSiteRecord({
+      lifecycleState: 'neutralized',
+      discoveryWeek: 1,
+      monitoringCadenceWeeks: 1,
+    })
+    const advanced = advanceUnexplainedLocationRecordLifecycleForWeek(record, 5)
+
+    expect(advanced).toBe(record)
+    expect(advanced.lifecycleState).toBe('neutralized')
+  })
+
+  it('preserves terminal lifecycle chain fixture without mutation', () => {
+    const advanced = advanceUnexplainedLocationRecordLifecycleForWeek(
+      LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+      60
+    )
+
+    expect(advanced).toBe(LIFECYCLE_CHAIN_LOCATION_FIXTURE)
+    expect(advanced.statusHistory).toEqual(LIFECYCLE_CHAIN_LOCATION_FIXTURE.statusHistory)
+  })
+
+  it('applies tick in stable id order without mutating unrelated records', () => {
+    const activeRecord = activeSiteRecord()
+    const remoteRecord = REMOTE_MONITOR_SITE_FIXTURE
+    const map = {
+      [remoteRecord.id]: remoteRecord,
+      [activeRecord.id]: activeRecord,
+    }
+
+    const next = applyWeeklyUnexplainedLocationLifecycleTick(map, 12)
+
+    expect(next[remoteRecord.id]).toBe(remoteRecord)
+    expect(next[activeRecord.id]?.lifecycleState).toBe('monitor_only')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyUnexplainedLocationLifecycleTick` for persisted `unexplainedLocationRecords`: due week = max(discoveryWeek, containmentWeek, last statusHistory.week) + monitoringCadenceWeeks; default chain `active` → `monitor_only` → `archived` and `utility_use` → `archived` with append-only `statusHistory`.
- Wire tick in `advanceWeek` after week increment, reading `outputWeeklyState` (post–finalizeEvents block alongside sibling registry hooks).

## Linear

- **Slice:** [SPE-2317](https://linear.app/spectranoir/issue/SPE-2317)
- **Parent:** [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) — stays open (slice 3 only; not SPE-88 closure)

## Shipped

- Domain weekly lifecycle module + `advanceWeek` integration
- Domain and integration tests; persistence regression unchanged

## Validation

- `npm run lint`
- `npx vitest run src/test/unexplainedLocationWeeklyLifecycle.test.ts src/test/advanceWeek.unexplainedLocation.integration.test.ts src/test/unexplainedLocationRegistryPersistence.test.ts`

## Docs

- `planning/unexplained-location-registry-slice-3.md`
- `planning/backlog.md` handoff

## Parent status

SPE-2106 parent remains open — weekly hook only; no SPE-88 umbrella closure.