### PR TITLE
feat(SPE-34): wire legacy procurement view to canonical listings

### DIFF
--- a/src/features/procurement/ProcurementPage.tsx
+++ b/src/features/procurement/ProcurementPage.tsx
@@ -2,10 +2,7 @@ import React, { useState } from 'react'
 import { getProcurementScreenView } from './procurementView'
 import './ProcurementPage.css'
 
-// TODO: Wire to canonical state/store
-
 export const ProcurementPage: React.FC = () => {
-  // Placeholder: Replace with canonical state
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null)
   const view = getProcurementScreenView()
 
@@ -65,6 +62,10 @@ export const ProcurementPage: React.FC = () => {
             <div>Category: {selected.category}</div>
             <div>Source: {selected.source}</div>
             <div>Availability: {selected.availability}</div>
+            {selected.accessLabel && <div>Access: {selected.accessLabel}</div>}
+            {selected.accessDetails && selected.accessDetails.length > 0 && (
+              <div>Access details: {selected.accessDetails.join('; ')}</div>
+            )}
             <div>Budget Impact: {selected.budgetImpact}</div>
             <div>After Purchase: ${selected.afterFunding}</div>
             <div>Pressure Consequences: {selected.pressureConsequences}</div>

--- a/src/features/procurement/procurementView.test.ts
+++ b/src/features/procurement/procurementView.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useGameStore } from '../../app/store/gameStore'
+import { createStartingState } from '../../data/startingState'
+import { getProcurementListings } from '../../domain/market'
+import { getProcurementScreenView } from './procurementView'
+
+describe('procurementView', () => {
+  beforeEach(() => {
+    useGameStore.persist.clearStorage()
+    useGameStore.setState({ game: createStartingState() })
+  })
+
+  it('builds market options from canonical procurement listings with buyPrice as cost', () => {
+    const game = createStartingState()
+    useGameStore.setState({ game })
+
+    const listings = getProcurementListings(game)
+    const view = getProcurementScreenView()
+
+    expect(view.options.length).toBeGreaterThan(listings.length)
+    expect(view.options.some((option) => option.category === 'Fabrication')).toBe(true)
+
+    for (const listing of listings) {
+      const option = view.options.find((candidate) => candidate.id === listing.id)
+      expect(option).toBeDefined()
+      expect(option!.cost).toBe(listing.buyPrice)
+      expect(option!.name).toBe(listing.itemName)
+      expect(option!.source).toBe(listing.marketPacket.label)
+    }
+  })
+
+  it('keeps insufficient funds out of blockers while still marking the option unaffordable', () => {
+    const game = {
+      ...createStartingState(),
+      funding: 0,
+    }
+    useGameStore.setState({ game })
+
+    const listing = getProcurementListings(game).find(
+      (candidate) => candidate.accessAvailable && candidate.buyPrice > 0
+    )
+
+    expect(listing).toBeDefined()
+
+    const option = getProcurementScreenView().options.find(
+      (candidate) => candidate.id === listing!.id
+    )
+
+    expect(option).toBeDefined()
+    expect(option!.affordable).toBe(false)
+    expect(option!.blockers).not.toContain('Insufficient funds')
+    expect(option!.blockers.every((blocker) => !/need \+\$/i.test(blocker))).toBe(true)
+  })
+
+  it('surfaces canonical access blockers when funding can cover a restricted listing', () => {
+    const game = createStartingState()
+    useGameStore.setState({ game })
+
+    const listing = getProcurementListings(game).find(
+      (candidate) => candidate.itemId === 'advanced_recon_suite'
+    )
+
+    expect(listing).toBeDefined()
+    expect(game.funding).toBeGreaterThanOrEqual(listing!.buyPrice)
+
+    const option = getProcurementScreenView().options.find(
+      (candidate) => candidate.id === listing!.id
+    )
+
+    expect(option).toBeDefined()
+    expect(option!.affordable).toBe(true)
+    expect(option!.blockers.length).toBeGreaterThan(0)
+    expect(option!.blockers.join(' ')).toMatch(/directorate special channel locked/i)
+    expect(option!.accessLabel).toBe(listing!.accessLabel)
+    expect(option!.availability).toMatch(/directorate special channel locked/i)
+  })
+
+  it('preserves fabrication queue options with canonical fabricationCost', () => {
+    const game = createStartingState()
+    useGameStore.setState({ game })
+
+    const recipeListing = getProcurementListings(game).find(
+      (candidate) => candidate.source === 'recipe' && candidate.fabricationCost !== undefined
+    )
+
+    expect(recipeListing).toBeDefined()
+
+    const fabricationOption = getProcurementScreenView().options.find(
+      (candidate) =>
+        candidate.category === 'Fabrication' && candidate.id === recipeListing!.recipeId
+    )
+
+    expect(fabricationOption).toBeDefined()
+    expect(fabricationOption!.cost).toBe(recipeListing!.fabricationCost)
+    expect(fabricationOption!.source).toBe('Workshop')
+  })
+})

--- a/src/features/procurement/procurementView.ts
+++ b/src/features/procurement/procurementView.ts
@@ -1,8 +1,11 @@
 // View-model for Procurement / Market Screen (SPE-34)
 
+import { MARKET_SOURCE_LABELS, MARKET_UI_TEXT } from '../../data/copy'
 import { assessFundingPressure, getCanonicalFundingState, getProcurementBacklog } from '../../domain/funding'
-import { getEquipmentCatalogEntries } from '../../domain/equipment'
-import { productionCatalog } from '../../data/production'
+import {
+  getProcurementListings,
+  type ProcurementListing,
+} from '../../domain/market'
 import { useGameStore } from '../../app/store/gameStore'
 
 // Types for the procurement screen
@@ -14,6 +17,8 @@ export interface ProcurementOptionView {
   category?: string
   source?: string
   availability?: string
+  accessLabel?: string
+  accessDetails?: string[]
   affordable: boolean
   blockers: string[]
   budgetImpact?: string
@@ -43,96 +48,170 @@ export interface ProcurementScreenView {
   onRequest: (optionId: string) => void
 }
 
+function formatCurrency(value: number) {
+  return `$${value}`
+}
+
+function mapListingCategory(listing: ProcurementListing): string {
+  if (listing.source === 'direct_equipment') {
+    return 'Equipment'
+  }
+
+  if (listing.source === 'recipe') {
+    return 'Market'
+  }
+
+  return MARKET_SOURCE_LABELS[listing.source]
+}
+
+function buildAvailabilityLabel(listing: ProcurementListing): string {
+  if (!listing.accessAvailable) {
+    return listing.accessBlockedReason ?? 'Access blocked'
+  }
+
+  if (listing.availableBundles <= 0) {
+    return MARKET_UI_TEXT.exhaustedListing
+  }
+
+  const bundleLabel =
+    listing.availableBundles === 1
+      ? '1 bundle open'
+      : `${listing.availableBundles} bundles open`
+
+  return `${bundleLabel} (${listing.remainingAvailability} units remaining)`
+}
+
+function collectNonBudgetBlockers(listing: ProcurementListing): string[] {
+  const blockers: string[] = []
+
+  if (!listing.accessAvailable && listing.accessBlockedReason) {
+    blockers.push(listing.accessBlockedReason)
+  }
+
+  if (listing.marketPacket.blockedReason) {
+    blockers.push(listing.marketPacket.blockedReason)
+  }
+
+  for (const status of listing.resourceStatuses) {
+    if (!status.purchaseAvailable && status.blockerReason) {
+      blockers.push(status.blockerReason)
+    }
+  }
+
+  if (listing.accessAvailable && listing.availableBundles < 1) {
+    blockers.push(MARKET_UI_TEXT.exhaustedListing)
+  }
+
+  return [...new Set(blockers)]
+}
+
+function buildListingOption(
+  listing: ProcurementListing,
+  funding: number,
+  budgetPressure: number
+): ProcurementOptionView {
+  const cost = listing.buyPrice
+  const affordable = funding >= cost
+  const afterFunding = funding - cost
+  const blockers = collectNonBudgetBlockers(listing)
+  const isCritical = budgetPressure >= 3 && affordable && blockers.length === 0
+  const isRecommended = budgetPressure < 2 && affordable && blockers.length === 0
+
+  return {
+    id: listing.id,
+    name: listing.itemName,
+    description: listing.description,
+    cost,
+    category: mapListingCategory(listing),
+    source: listing.marketPacket.label,
+    availability: buildAvailabilityLabel(listing),
+    accessLabel: listing.accessLabel,
+    accessDetails: listing.accessDetails,
+    affordable,
+    blockers,
+    budgetImpact: `-${formatCurrency(cost)}`,
+    pressureConsequences: listing.pressureLabel,
+    afterFunding,
+    isCritical,
+    isRecommended,
+  }
+}
+
+function buildFabricationOption(
+  listing: ProcurementListing,
+  funding: number,
+  budgetPressure: number
+): ProcurementOptionView | null {
+  if (listing.source !== 'recipe' || listing.fabricationCost === undefined || !listing.recipeId) {
+    return null
+  }
+
+  const cost = listing.fabricationCost
+  const affordable = funding >= cost
+  const afterFunding = funding - cost
+  const blockers: string[] = []
+  const isCritical = budgetPressure >= 3 && affordable
+  const isRecommended = budgetPressure < 2 && affordable
+
+  return {
+    id: listing.recipeId,
+    name: listing.itemName,
+    description: listing.description,
+    cost,
+    category: 'Fabrication',
+    source: 'Workshop',
+    availability: 'Queue when funded',
+    affordable,
+    blockers,
+    budgetImpact: `-${formatCurrency(cost)}`,
+    pressureConsequences: undefined,
+    afterFunding,
+    isCritical,
+    isRecommended,
+  }
+}
+
 // Main view-model function
 export function getProcurementScreenView(): ProcurementScreenView {
-  // Use canonical game state from the store
   const game = useGameStore.getState().game
   const fundingState = getCanonicalFundingState(game)
   const fundingPressure = assessFundingPressure(game)
   const backlog = getProcurementBacklog(fundingState)
+  const listings = getProcurementListings(game)
 
-  // Aggregate all procurement options (equipment + fabrication/production)
-  const equipmentOptions = getEquipmentCatalogEntries().map((def) => {
-    // Affordability and blockers
-    const cost = 100 // Placeholder, replace with real cost
-    const affordable = fundingState.funding >= cost
-    const afterFunding = fundingState.funding - cost
-    const blockers: string[] = []
-    if (!affordable) blockers.push('Insufficient funds')
-    // Priority: recommend if budget pressure is low and affordable, critical if pressure is high and affordable
-    const isCritical = fundingPressure.budgetPressure >= 3 && affordable
-    const isRecommended = fundingPressure.budgetPressure < 2 && affordable
-    return {
-      id: def.id,
-      name: def.name,
-      description: undefined, // Could add from definition
-      cost,
-      category: 'Equipment',
-      source: 'Quartermaster',
-      availability: 'Available',
-      affordable,
-      blockers,
-      budgetImpact: `-$${cost}`,
-      pressureConsequences: undefined,
-      afterFunding,
-      isCritical,
-      isRecommended,
-    }
-  })
+  const listingOptions = listings.map((listing) =>
+    buildListingOption(listing, fundingState.funding, fundingPressure.budgetPressure)
+  )
 
-  const fabricationOptions = productionCatalog.map((recipe) => {
-    const cost = recipe.baseFundingCost
-    const affordable = fundingState.funding >= cost
-    const afterFunding = fundingState.funding - cost
-    const blockers: string[] = []
-    if (!affordable) blockers.push('Insufficient funds')
-    // Priority: recommend if backlog is low, critical if pressure is high
-    const isCritical = fundingPressure.budgetPressure >= 3 && affordable
-    const isRecommended = fundingPressure.budgetPressure < 2 && affordable
-    return {
-      id: recipe.recipeId,
-      name: recipe.name,
-      description: recipe.description,
-      cost,
-      category: 'Fabrication',
-      source: 'Workshop',
-      availability: 'Available',
-      affordable,
-      blockers,
-      budgetImpact: `-$${cost}`,
-      pressureConsequences: undefined,
-      afterFunding,
-      isCritical,
-      isRecommended,
-    }
-  })
+  const fabricationOptions = listings
+    .map((listing) =>
+      buildFabricationOption(listing, fundingState.funding, fundingPressure.budgetPressure)
+    )
+    .filter((option): option is ProcurementOptionView => option !== null)
 
-  // Combine all options
-  const options = [...equipmentOptions, ...fabricationOptions]
+  const options = [...listingOptions, ...fabricationOptions]
 
-  // Map backlog entries
   const backlogView: ProcurementBacklogEntryView[] = backlog.map((entry) => {
-    // Try to resolve name from equipment or production
-    const eq = getEquipmentCatalogEntries().find((e) => e.id === entry.itemId)
-    const prod = productionCatalog.find((r) => r.outputItemId === entry.itemId)
+    const listing = listings.find((candidate) => candidate.itemId === entry.itemId)
+
     return {
       requestId: entry.requestId,
-      name: eq?.name || prod?.outputItemName || entry.itemId,
+      name: listing?.itemName ?? entry.itemId,
       cost: entry.cost,
       status: entry.status,
     }
   })
 
-  // Backlog pressure signal
-  const backlogPending = backlog.filter((e) => e.status === 'pending').length
+  const backlogPending = backlog.filter((entry) => entry.status === 'pending').length
   const backlogStale = backlog.filter(
-    (e) => e.status === 'pending' && fundingPressure.staleProcurementRequestIds.includes(e.requestId)
+    (entry) =>
+      entry.status === 'pending' &&
+      fundingPressure.staleProcurementRequestIds.includes(entry.requestId)
   ).length
   let backlogSignal = ''
   if (backlogPending >= 5) backlogSignal = 'Backlog congestion'
   else if (backlogStale > 0) backlogSignal = 'Delay risk'
 
-  // Budget/pressure summary
   const budget = {
     funding: fundingPressure.funding,
     budgetPressure: fundingPressure.budgetPressure,
@@ -141,18 +220,16 @@ export function getProcurementScreenView(): ProcurementScreenView {
     backlogSignal,
   }
 
-  // Canonical purchase/request action
   function onRequest(optionId: string) {
-    const opt = options.find((o) => o.id === optionId)
-    if (!opt || !opt.affordable) return
-    // Canonical action: dispatch to store
-    // For equipment: treat as market inventory purchase
-    // For fabrication: treat as production/fabrication request
-    if (opt.category === 'Equipment') {
-      useGameStore.getState().purchaseMarketInventory(optionId)
-    } else if (opt.category === 'Fabrication') {
+    const opt = options.find((candidate) => candidate.id === optionId)
+    if (!opt || !opt.affordable || opt.blockers.length > 0) return
+
+    if (opt.category === 'Fabrication') {
       useGameStore.getState().queueFabrication(optionId)
+      return
     }
+
+    useGameStore.getState().purchaseMarketInventory(optionId)
   }
 
   return {


### PR DESCRIPTION
## Summary

- Refactor getProcurementScreenView to build market options from getProcurementListings(game) instead of hardcoded equipment catalog placeholders.
- Use canonical uyPrice, availability, access, market packet, resource status, and pressure fields; keep affordability separate from access/availability blockers.
- Preserve fabrication queue behavior for recipe listings via queueFabrication.
- Add procurementView.test.ts with access-blocker coverage (dvanced_recon_suite affordable but channel-locked).

## Linear

- **Slice / child:** [SPE-34 — Procurement / Market Screen](https://linear.app/spectranoir/issue/SPE-34/procurement-market-screen)
- **Parent:** [SPE-28 — Funding pressure and procurement availability](https://linear.app/spectranoir/issue/SPE-28/funding-pressure-and-procurement-availability) (remains open)

## What shipped

- src/features/procurement/procurementView.ts — canonical listing pipeline
- src/features/procurement/ProcurementPage.tsx — access label/details in detail panel
- src/features/procurement/procurementView.test.ts — new targeted tests

## Validation

- [x] 
pm run lint
- [x] 
pm run test:run -- src/features/procurement/ (10 passed)

## Docs updated

None (in-boundary code + tests only).

## Parent status

SPE-28 stays **Backlog / In Progress** — broader umbrella acceptance not satisfied by this slice alone.

Made with [Cursor](https://cursor.com)