### PR TITLE
SPE-2321: vendor shortage pressure tightens supplier availability

### DIFF
--- a/planning/spe-28-inventory-holding-cost-slice.md
+++ b/planning/spe-28-inventory-holding-cost-slice.md
@@ -45,7 +45,7 @@ Add a deterministic weekly inventory holding fee at week-close so stocked units 
 
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
-| Shortage pressure (vendor-managed stock distortion) | SPE-28 child after holding cost | Separate mechanic; needs vendor stock model |
+| Shortage pressure (vendor-managed stock distortion) | [SPE-2321](https://linear.app/spectranoir/issue/SPE-2321) | Shipped as read-time roster listing penalty (sibling slice) |
 | Corruption routing on procurement outcomes | SPE-28 child | `compromisedAuthority.ts` is patrol/custody-focused; needs procurement bridge |
 | Service-boon / callable-obligation rewards | SPE-28 child | `availableFavors` exists but obligation semantics + UI are larger |
 | Barter / recovery channel variants | SPE-28 child | Multi-system: missions → inventory → market |

--- a/planning/spe-28-shortage-pressure-slice.md
+++ b/planning/spe-28-shortage-pressure-slice.md
@@ -1,0 +1,64 @@
+# SPE-28 — vendor shortage pressure (child slice)
+
+**Linear:** [SPE-2321](https://linear.app/spectranoir/issue/SPE-2321/spe-28-vendor-shortage-pressure-tightens-supplier-availability)  
+**Parent:** [SPE-28](https://linear.app/spectranoir/issue/SPE-28/funding-pressure-and-procurement-availability) (stays **Backlog**)  
+**Branch:** `spe-28-shortage-pressure`  
+**Base:** `main` @ `2a2d2f47`
+
+## Goal
+
+One vendor-managed availability distortion on canonical listing `material:medical_supplies`: supplier bundles tighten when agency inventory is high or funding is strained, without changing price or deducting cash. Read-time derivation only (listings derived at read per SPE-448).
+
+Satisfies parent acceptance: *at least one procurement outcome changes because of shortage pressure rather than price alone.*
+
+## Acceptance (this slice)
+
+- [x] Only `material:medical_supplies` receives shortage penalty
+- [x] Penalty fires on high agency stock or funding strain (either signal sufficient)
+- [x] Procurement outcome changes: buy blocked by availability while funding sufficient
+- [x] Deterministic, no new persistence fields
+- [x] Market copy distinguishes shortage from holding-cost budget tightening
+- [x] Sibling slices (holding cost SPE-2320, delayed SPE-2319, favor) regression-clean
+- [x] Tests + lint clean
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Calibration | `FUNDING_CALIBRATION.procurementShortagePressure` in `src/domain/sim/calibration.ts` |
+| Domain | `assessProcurementShortagePressure`, `applyShortagePressureToBundleAvailability` in `src/domain/market.ts`; wired in `getBaseAvailability` after RNG/pressure delta |
+| Pressure / UX | `assessFundingPressure` reason `vendor-shortage-pressure`; `src/features/market/marketView.ts` budget summary + listing detail |
+| Stock sum | `sumInventoryStock` exported from `src/domain/funding.ts` |
+| Tests | `src/test/market.shortagePressure.test.ts`, `src/features/market/marketView.test.ts` |
+
+High stock uses `stockThreshold: 60` (holding cost bills above 50). Penalty stacks with `market.pressure === 'tight'` availability delta on the same listing.
+
+## Out of scope
+
+- Week-close holding cost (`applyWeeklyInventoryHoldingCostToFundingState`, SPE-2320)
+- Delayed fulfillment / favor exchange / merchant sim
+- New persisted market state or price multipliers
+- `ProcurementPage.tsx` legacy surface
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Corruption routing on procurement outcomes | SPE-28 child | `compromisedAuthority.ts` is patrol/custody-focused |
+| Service-boon / callable-obligation rewards | SPE-28 child | Obligation semantics + UI are larger |
+| Barter / recovery channel variants | SPE-28 child | Multi-system |
+| Full merchant / cashflow simulator | — | Explicit non-goal |
+
+## Sibling slices (do not regress)
+
+| Slice | Issue | Notes |
+| --- | --- | --- |
+| Weekly inventory holding cost | [SPE-2320](https://linear.app/spectranoir/issue/SPE-2320) | Cash at week-close; shortage is bundle penalty at listing build |
+| Delayed fulfillment | [SPE-2319](https://linear.app/spectranoir/issue/SPE-2319) | `placeDelayedMarketOrder` unchanged |
+| Favor exchange | SPE-28 (merged) | Access vs budget separation |
+| Weekly operating cost | SPE-28 (merged) | Budget blocker path unchanged |
+
+## Validation
+
+- `npm run test:run -- src/test/market.shortagePressure.test.ts src/features/market/marketView.test.ts src/domain/funding.test.ts src/test/sim.advanceWeek.test.ts`
+- `npm run lint`

--- a/src/domain/funding.ts
+++ b/src/domain/funding.ts
@@ -492,7 +492,11 @@ export function applyWeeklyOperatingCostToFundingState(
   }
 }
 
-export function sumInventoryStock(inventory: GameState['inventory']): number {
+export function sumInventoryStock(inventory: GameState['inventory'] | undefined): number {
+  if (!inventory) {
+    return 0
+  }
+
   return Object.values(inventory).reduce(
     (sum, quantity) =>
       sum + Math.max(0, Math.trunc(typeof quantity === 'number' && Number.isFinite(quantity) ? quantity : 0)),

--- a/src/domain/funding.ts
+++ b/src/domain/funding.ts
@@ -492,11 +492,32 @@ export function applyWeeklyOperatingCostToFundingState(
   }
 }
 
-function sumInventoryStock(inventory: GameState['inventory']): number {
+export function sumInventoryStock(inventory: GameState['inventory']): number {
   return Object.values(inventory).reduce(
     (sum, quantity) =>
       sum + Math.max(0, Math.trunc(typeof quantity === 'number' && Number.isFinite(quantity) ? quantity : 0)),
     0
+  )
+}
+
+/** SPE-2321: mirrors assessProcurementShortagePressure in market.ts (avoid circular import). */
+function hasVendorShortagePressureSignals(
+  game: Pick<GameState, 'agency' | 'config' | 'funding' | 'week' | 'inventory'>
+): boolean {
+  const cal = FUNDING_CALIBRATION.procurementShortagePressure
+  if (sumInventoryStock(game.inventory) > cal.stockThreshold) {
+    return true
+  }
+
+  const fundingState = getCanonicalFundingState(game)
+  const staleProcurementBacklog = fundingState.procurementBacklog.some(
+    (entry) =>
+      entry.status === 'pending' &&
+      game.week - entry.requestedWeek > FUNDING_CALIBRATION.budgetPressure.staleBacklogWeeks
+  )
+
+  return (
+    fundingState.budgetPressure >= cal.budgetPressureThreshold || staleProcurementBacklog
   )
 }
 
@@ -857,6 +878,7 @@ export function assessFundingPressure(
       staleProcurementRequestIds.length > 0 ? 'stale-procurement-backlog' : '',
       operatingCostSignalsProcurementTiming ? 'weekly-operating-cost' : '',
       holdingCostSignalsProcurementTiming ? 'weekly-inventory-holding-cost' : '',
+      hasVendorShortagePressureSignals(game) ? 'vendor-shortage-pressure' : '',
     ]),
   }
 }

--- a/src/domain/funding.ts
+++ b/src/domain/funding.ts
@@ -506,22 +506,16 @@ export function sumInventoryStock(inventory: GameState['inventory'] | undefined)
 
 /** SPE-2321: mirrors assessProcurementShortagePressure in market.ts (avoid circular import). */
 function hasVendorShortagePressureSignals(
-  game: Pick<GameState, 'agency' | 'config' | 'funding' | 'week' | 'inventory'>
+  game: Pick<GameState, 'inventory'>,
+  fundingState: FundingState,
+  staleProcurementRequestIds: readonly string[]
 ): boolean {
   const cal = FUNDING_CALIBRATION.procurementShortagePressure
-  if (sumInventoryStock(game.inventory) > cal.stockThreshold) {
-    return true
-  }
-
-  const fundingState = getCanonicalFundingState(game)
-  const staleProcurementBacklog = fundingState.procurementBacklog.some(
-    (entry) =>
-      entry.status === 'pending' &&
-      game.week - entry.requestedWeek > FUNDING_CALIBRATION.budgetPressure.staleBacklogWeeks
-  )
 
   return (
-    fundingState.budgetPressure >= cal.budgetPressureThreshold || staleProcurementBacklog
+    sumInventoryStock(game.inventory) > cal.stockThreshold ||
+    fundingState.budgetPressure >= cal.budgetPressureThreshold ||
+    staleProcurementRequestIds.length > 0
   )
 }
 
@@ -793,7 +787,7 @@ export function getCanonicalFundingState(
 }
 
 export function assessFundingPressure(
-  game: Pick<GameState, 'agency' | 'config' | 'funding' | 'supportStaff' | 'week'>
+  game: Pick<GameState, 'agency' | 'config' | 'funding' | 'supportStaff' | 'week' | 'inventory'>
 ): FundingPressureAssessment {
   const fundingState = getCanonicalFundingState(game)
   const pendingProcurementRequestIds = fundingState.procurementBacklog
@@ -882,7 +876,9 @@ export function assessFundingPressure(
       staleProcurementRequestIds.length > 0 ? 'stale-procurement-backlog' : '',
       operatingCostSignalsProcurementTiming ? 'weekly-operating-cost' : '',
       holdingCostSignalsProcurementTiming ? 'weekly-inventory-holding-cost' : '',
-      hasVendorShortagePressureSignals(game) ? 'vendor-shortage-pressure' : '',
+      hasVendorShortagePressureSignals(game, fundingState, staleProcurementRequestIds)
+        ? 'vendor-shortage-pressure'
+        : '',
     ]),
   }
 }

--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -17,6 +17,7 @@ import {
 } from './equipment'
 import type { MarketTransactionListingResourceStatus } from './events/types'
 import type { GameState, MarketPressure, MarketState, OperationEvent } from './models'
+import { getCanonicalFundingState, sumInventoryStock } from './funding'
 import { FUNDING_CALIBRATION } from './sim/calibration'
 
 export type ProcurementTransactionAction = 'buy' | 'sell' | 'favor_exchange' | 'order' | 'fulfill'
@@ -131,6 +132,20 @@ export interface ProcurementListing {
   remainingAvailability: number
   availableBundles: number
   inventoryStock: number
+  shortagePressureDetail?: ProcurementShortagePressureDetail
+}
+
+export type ProcurementShortagePressureReason = 'high-agency-stock' | 'funding-strain'
+
+export interface ProcurementShortagePressureAssessment {
+  active: boolean
+  reasons: ProcurementShortagePressureReason[]
+}
+
+export interface ProcurementShortagePressureDetail {
+  active: boolean
+  reasons: ProcurementShortagePressureReason[]
+  availabilityPenaltyBundles: number
 }
 
 export interface ProcurementTransactionView {
@@ -969,6 +984,57 @@ function buildAllocationStatus(
   }
 }
 
+export function assessProcurementShortagePressure(
+  game: Pick<GameState, 'agency' | 'config' | 'funding' | 'week' | 'inventory'>
+): ProcurementShortagePressureAssessment {
+  const cal = FUNDING_CALIBRATION.procurementShortagePressure
+  const reasons: ProcurementShortagePressureReason[] = []
+
+  if (sumInventoryStock(game.inventory) > cal.stockThreshold) {
+    reasons.push('high-agency-stock')
+  }
+
+  const fundingState = getCanonicalFundingState(game)
+  const staleProcurementBacklog = fundingState.procurementBacklog.some(
+    (entry) =>
+      entry.status === 'pending' &&
+      game.week - entry.requestedWeek > FUNDING_CALIBRATION.budgetPressure.staleBacklogWeeks
+  )
+  if (
+    fundingState.budgetPressure >= cal.budgetPressureThreshold ||
+    staleProcurementBacklog
+  ) {
+    reasons.push('funding-strain')
+  }
+
+  return {
+    active: reasons.length > 0,
+    reasons,
+  }
+}
+
+export function applyShortagePressureToBundleAvailability(
+  definition: Pick<ProcurementListingDefinition, 'id'>,
+  game: Pick<GameState, 'agency' | 'config' | 'funding' | 'week' | 'inventory'>,
+  bundleAvailability: number
+): number {
+  const cal = FUNDING_CALIBRATION.procurementShortagePressure
+
+  if (definition.id !== cal.listingId) {
+    return bundleAvailability
+  }
+
+  const assessment = assessProcurementShortagePressure(game)
+  if (!assessment.active) {
+    return bundleAvailability
+  }
+
+  return Math.max(
+    cal.minBundles,
+    bundleAvailability - cal.availabilityPenaltyBundles
+  )
+}
+
 function getBaseAvailability(
   definition: ProcurementListingDefinition,
   game: GameState,
@@ -988,9 +1054,14 @@ function getBaseAvailability(
       featuredBonus
   )
 
-  const adjustedBundleAvailability = marketPacket.available
+  const packetAdjustedBundleAvailability = marketPacket.available
     ? Math.max(0, Math.floor(bundleAvailability * marketPacket.availabilityMultiplier))
     : 0
+  const adjustedBundleAvailability = applyShortagePressureToBundleAvailability(
+    definition,
+    game,
+    packetAdjustedBundleAvailability
+  )
 
   return adjustedBundleAvailability * definition.bundleQuantity
 }
@@ -1060,6 +1131,8 @@ function buildListing(
         : undefined
       : undefined
   const featured = definition.recipeId === game.market.featuredRecipeId
+  const shortageAssessment = assessProcurementShortagePressure(game)
+  const shortageCalibration = FUNDING_CALIBRATION.procurementShortagePressure
   const totalAvailability = getBaseAvailability(definition, game, marketPacket)
   const bought = transactionTotals.boughtByListingId[definition.id] ?? 0
   const sold = transactionTotals.soldByListingId[definition.id] ?? 0
@@ -1089,6 +1162,15 @@ function buildListing(
     remainingAvailability,
     availableBundles: Math.floor(remainingAvailability / definition.bundleQuantity),
     inventoryStock: game.inventory[definition.itemId] ?? 0,
+    ...(definition.id === shortageCalibration.listingId && shortageAssessment.active
+      ? {
+          shortagePressureDetail: {
+            active: true,
+            reasons: shortageAssessment.reasons,
+            availabilityPenaltyBundles: shortageCalibration.availabilityPenaltyBundles,
+          },
+        }
+      : {}),
   }
 }
 

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -197,6 +197,16 @@ export const FUNDING_CALIBRATION = {
     billableStockThreshold: 50,
     costPerStockUnit: 1,
   },
+  /** SPE-2321: read-time vendor shortage on one canonical roster listing (no week-close cash). */
+  procurementShortagePressure: {
+    listingId: 'material:medical_supplies',
+    /** Agency stock above this level signals vendor rationing on the target listing. */
+    stockThreshold: 60,
+    budgetPressureThreshold: 2,
+    /** Subtracted from derived bundle availability when shortage signals are active. */
+    availabilityPenaltyBundles: 12,
+    minBundles: 0,
+  },
 } as const
 
 export const ATTRITION_CALIBRATION = {

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -7,6 +7,7 @@ import {
   createInitialFundingState,
   normalizeFundingState,
 } from '../../domain/funding'
+import { getProcurementListings } from '../../domain/market'
 import {
   getCurrentWeekMarketTransactions,
   getFilteredMarketListings,
@@ -256,6 +257,40 @@ describe('marketView', () => {
     )
     expect(combatStims!.canBuyOne).toBe(false)
     expect(combatStims!.buyBlockedReason).toMatch(/doctrine attestation is stale/i)
+  })
+
+  it('surfaces vendor shortage pressure in procurement budget summary and listing blockers', () => {
+    const game = {
+      ...createStartingState(),
+      inventory: {
+        ...createStartingState().inventory,
+        medkits: 25,
+      },
+    }
+    const listing = getProcurementListings(game).find(
+      (entry) => entry.id === 'material:medical_supplies'
+    )
+
+    expect(listing).toBeDefined()
+    expect(assessFundingPressure(game).reasonCodes).toContain('vendor-shortage-pressure')
+
+    const view = getProcurementScreenView(
+      game,
+      {
+        q: '',
+        category: 'all',
+        sort: 'recommended',
+      },
+      listing!.id
+    )
+
+    expect(view.budgetSummary.details.join(' ')).toMatch(/Vendor shortage pressure/i)
+
+    const listingView = getMarketListings(game).find((entry) => entry.id === listing!.id)
+    expect(listingView?.canAffordOne).toBe(true)
+    expect(listingView?.canBuyOne).toBe(false)
+    expect(view.selectedDetail?.canBuyOne).toBe(false)
+    expect(view.selectedDetail?.blockerDetails.join(' ')).toMatch(/Vendor shortage pressure/i)
   })
 
   it('surfaces inventory holding cost in procurement budget summary when stock tightens headroom', () => {

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -557,6 +557,9 @@ function buildProcurementDetailView(
           status.substitution ? `Substitution: ${status.substitution.summary}` : ''
         ),
         `Current stock on hand: ${listing.inventoryStock}.`,
+        listing.shortagePressureDetail?.active
+          ? `Vendor shortage: supplier trimmed ${listing.shortagePressureDetail.availabilityPenaltyBundles} bundle${listing.shortagePressureDetail.availabilityPenaltyBundles === 1 ? '' : 's'} (${listing.shortagePressureDetail.reasons.join(', ')}).`
+          : '',
         `Market pressure: ${listing.pressureLabel}.`,
         selectedTransactions.length > 0
           ? `This week: ${selectedTransactions
@@ -580,7 +583,9 @@ function buildProcurementDetailView(
         listing.buyBlockedReason ?? '',
         listing.sellBlockedReason ?? '',
         listing.availableBundles < 1
-          ? 'Current-week supplier availability is exhausted for this listing.'
+          ? listing.shortagePressureDetail?.active
+            ? 'Vendor shortage pressure exhausted supplier bundles while funding still covers the line.'
+            : 'Current-week supplier availability is exhausted for this listing.'
           : '',
         typeof listing.fabricationCost === 'number'
           ? 'Fabrication remains the slower but stable fallback if supplier stock collapses.'
@@ -640,6 +645,9 @@ function buildProcurementBudgetSummary(
           : '',
         fundingPressure.reasonCodes.includes('weekly-inventory-holding-cost')
           ? 'Inventory carrying costs were charged at week close, tightening procurement headroom.'
+          : '',
+        fundingPressure.reasonCodes.includes('vendor-shortage-pressure')
+          ? 'Vendor shortage pressure is rationing agency-roster supplier bundles (availability, not quoted price or carrying fees).'
           : '',
         game.factions?.corporate_supply?.availableFavors?.some(
           (favor) => favor.id === 'corporate-supply-salvage-credit'

--- a/src/test/market.shortagePressure.test.ts
+++ b/src/test/market.shortagePressure.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { createInitialFundingState, normalizeFundingState } from '../domain/funding'
+import {
+  assessProcurementShortagePressure,
+  getProcurementListings,
+} from '../domain/market'
+import { purchaseMarketInventory } from '../domain/sim/market'
+import { FUNDING_CALIBRATION } from '../domain/sim/calibration'
+
+const TARGET_LISTING_ID = FUNDING_CALIBRATION.procurementShortagePressure.listingId
+
+function getTargetListing(game: ReturnType<typeof createStartingState>) {
+  return getProcurementListings(game).find((entry) => entry.id === TARGET_LISTING_ID)
+}
+
+function withHighAgencyStock(game: ReturnType<typeof createStartingState>) {
+  return {
+    ...game,
+    inventory: {
+      ...game.inventory,
+      medkits: 25,
+    },
+  }
+}
+
+function withFundingStrain(game: ReturnType<typeof createStartingState>) {
+  const pendingBacklog = Array.from({ length: 8 }, (_, index) => ({
+    requestId: `shortage-test-${index}`,
+    status: 'pending' as const,
+    requestedWeek: game.week,
+    itemId: 'medkits',
+    quantity: 1,
+    cost: 10,
+  }))
+  const fundingState = normalizeFundingState(
+    -1,
+    game.config,
+    {
+      ...createInitialFundingState(
+        game.config.fundingBasePerWeek,
+        game.config.fundingPerResolution,
+        game.config.fundingPenaltyPerFail,
+        game.config.fundingPenaltyPerUnresolved,
+        -1
+      ),
+      procurementBacklog: pendingBacklog,
+    },
+    game.week
+  )
+
+  return {
+    ...game,
+    funding: -1,
+    agency: {
+      ...game.agency!,
+      funding: -1,
+      fundingState,
+    },
+  }
+}
+
+describe('procurement shortage pressure (SPE-2321)', () => {
+  it('leaves starting-state listings unchanged when shortage signals are inactive', () => {
+    const game = createStartingState()
+    const listing = getTargetListing(game)
+
+    expect(listing).toBeDefined()
+    expect(assessProcurementShortagePressure(game).active).toBe(false)
+    expect(listing!.shortagePressureDetail).toBeUndefined()
+    expect(listing!.availableBundles).toBeGreaterThan(0)
+  })
+
+  it('reduces medical supplies bundles on high agency stock without changing price', () => {
+    const baseline = createStartingState()
+    const pressured = withHighAgencyStock(baseline)
+    const baselineListing = getTargetListing(baseline)!
+    const pressuredListing = getTargetListing(pressured)!
+
+    expect(assessProcurementShortagePressure(pressured).reasons).toContain('high-agency-stock')
+    expect(pressuredListing.availableBundles).toBeLessThan(baselineListing.availableBundles)
+    expect(pressuredListing.buyPrice).toBe(baselineListing.buyPrice)
+  })
+
+  it('blocks purchase when funding is sufficient but vendor bundles are exhausted', () => {
+    const game = withHighAgencyStock(createStartingState())
+    const listing = getTargetListing(game)!
+
+    expect(game.funding).toBeGreaterThanOrEqual(listing.buyPrice)
+    expect(listing.availableBundles).toBe(0)
+
+    const result = purchaseMarketInventory(game, listing.id, 1)
+    expect(result).toBe(game)
+  })
+
+  it('tightens only the calibrated listing when funding is strained', () => {
+    const game = withFundingStrain(createStartingState())
+    const target = getTargetListing(game)!
+    const otherMaterial = getProcurementListings(game).find(
+      (entry) => entry.source === 'material' && entry.id !== TARGET_LISTING_ID
+    )
+
+    expect(assessProcurementShortagePressure(game).reasons).toContain('funding-strain')
+    expect(target.availableBundles).toBe(0)
+    expect(otherMaterial).toBeDefined()
+    expect(otherMaterial!.availableBundles).toBeGreaterThan(0)
+  })
+
+  it('stacks with neutral market pressure while still zeroing target bundles', () => {
+    const game = {
+      ...withHighAgencyStock(createStartingState()),
+      market: {
+        ...createStartingState().market,
+        pressure: 'stable' as const,
+      },
+    }
+    const listing = getTargetListing(game)!
+
+    expect(listing!.availableBundles).toBe(0)
+  })
+
+  it('derives listings deterministically for the same state', () => {
+    const game = withHighAgencyStock(createStartingState())
+
+    expect(getProcurementListings(game)).toEqual(getProcurementListings(game))
+  })
+})

--- a/src/test/sim.validation.test.ts
+++ b/src/test/sim.validation.test.ts
@@ -69,11 +69,11 @@ describe('simulation validation pass', () => {
     ])
   })
 
-  it('reproduces deterministic long-run validation runs', () => {
+  it('reproduces deterministic long-run validation runs', { timeout: 30_000 }, () => {
     expect(toStableRunSnapshot('mixed-pressure')).toEqual(toStableRunSnapshot('mixed-pressure'))
   })
 
-  it('keeps scenario summaries stable across repeated suite runs', () => {
+  it('keeps scenario summaries stable across repeated suite runs', { timeout: 30_000 }, () => {
     expect(toSummarySnapshot()).toEqual(toSummarySnapshot())
   })
 


### PR DESCRIPTION
## Summary
- Add read-time vendor shortage penalty on `material:medical_supplies` when agency stock exceeds calibration threshold or budget strain signals are active.
- Export `sumInventoryStock`; wire `assessProcurementShortagePressure` into listing availability; surface `vendor-shortage-pressure` in funding pressure and market UI copy (distinct from holding-cost headroom).
- Domain + marketView tests; sibling holding-cost / delayed / favor paths unchanged.

## Linear
- **Slice:** [SPE-2321](https://linear.app/spectranoir/issue/SPE-2321/spe-28-vendor-shortage-pressure-tightens-supplier-availability)
- **Parent:** [SPE-28](https://linear.app/spectranoir/issue/SPE-28/funding-pressure-and-procurement-availability) (remains **Backlog**)

## Validation
- `npm run test:run -- src/test/market.shortagePressure.test.ts src/features/market/marketView.test.ts src/domain/funding.test.ts src/test/sim.advanceWeek.test.ts src/test/sim.market.test.ts`
- `npm run lint`

## Docs
- `planning/spe-28-shortage-pressure-slice.md`
- Deferred pointer in `planning/spe-28-inventory-holding-cost-slice.md`

## Parent status
Parent stays open — shortage slice only; corruption routing and other deferred SPE-28 children remain.

Made with [Cursor](https://cursor.com)