### PR TITLE
SPE-2322: compromised authority distorts procurement routing

### DIFF
--- a/planning/spe-28-corruption-routing-slice.md
+++ b/planning/spe-28-corruption-routing-slice.md
@@ -1,0 +1,65 @@
+# SPE-28 — compromised authority procurement routing (child slice)
+
+**Linear:** [SPE-2322](https://linear.app/spectranoir/issue/SPE-2322/spe-28-compromised-authority-distorts-procurement-routing)  
+**Parent:** [SPE-28](https://linear.app/spectranoir/issue/SPE-28/funding-pressure-and-procurement-availability) (stays **Backlog**)  
+**Branch:** `spe-28-corruption-routing`  
+**Base:** `main` @ `f11320e4`
+
+## Goal
+
+One deterministic procurement outcome change routed through office-mediated diversion / `compromisedAuthority` signals — not price, shortage bundles, or week-close cash. Read-time derivation only (listings derived at read per SPE-448).
+
+Satisfies parent acceptance: *at least one procurement outcome changes because of corruption routing rather than price alone.*
+
+## Acceptance (this slice)
+
+- [x] Only `material:electronic_parts` receives corruption routing penalty
+- [x] Penalty fires on office-mediated diversion (magistrate/watchCommander + evidence distortion)
+- [x] Procurement outcome changes: buy blocked by diverted availability while funding sufficient
+- [x] Deterministic, no new persistence fields
+- [x] Market copy distinguishes corruption routing from shortage and holding-cost budget tightening
+- [x] Sibling slices (shortage SPE-2321, holding cost SPE-2320, delayed SPE-2319, favor) regression-clean
+- [x] Tests + lint clean
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Calibration | `FUNDING_CALIBRATION.procurementCorruptionRouting` in `src/domain/sim/calibration.ts` |
+| Domain signal | `assessCompromisedAuthorityProcurementDiversion` in `src/domain/sim/compromisedAuthority.ts` |
+| Domain hook | `assessProcurementCorruptionRouting`, `applyCorruptionRoutingToBundleAvailability` in `src/domain/market.ts`; wired in `getBaseAvailability` after shortage delta |
+| Pressure / UX | `assessFundingPressure` reason `compromised-authority-procurement-diversion`; `src/features/market/marketView.ts` budget summary + listing detail |
+| Tests | `src/test/market.corruptionRouting.test.ts`, `src/features/market/marketView.test.ts` |
+
+Office-mediated diversion requires `magistrate` or `watchCommander` role with `evidence` in `distortedCategories`. Penalty stacks after shortage on the same read path but targets a different listing id.
+
+## Out of scope
+
+- Week-close holding cost (`applyWeeklyInventoryHoldingCostToFundingState`, SPE-2320)
+- Vendor shortage pressure hook (`assessProcurementShortagePressure`, SPE-2321)
+- Delayed fulfillment / favor exchange / merchant sim
+- New persisted market state or price multipliers
+- `ProcurementPage.tsx` legacy surface
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Service-boon / callable-obligation rewards | SPE-28 child | Obligation semantics + UI are larger |
+| Barter / recovery channel variants | SPE-28 child | Multi-system |
+| Full merchant / cashflow simulator | — | Explicit non-goal |
+
+## Sibling slices (do not regress)
+
+| Slice | Issue | Notes |
+| --- | --- | --- |
+| Vendor shortage pressure | [SPE-2321](https://linear.app/spectranoir/issue/SPE-2321) | `material:medical_supplies`; orthogonal listing |
+| Weekly inventory holding cost | [SPE-2320](https://linear.app/spectranoir/issue/SPE-2320) | Cash at week-close |
+| Delayed fulfillment | [SPE-2319](https://linear.app/spectranoir/issue/SPE-2319) | `placeDelayedMarketOrder` unchanged |
+| Favor exchange | SPE-28 (merged) | Access vs budget separation |
+| Weekly operating cost | SPE-28 (merged) | Budget blocker path unchanged |
+
+## Validation
+
+- `npm run test:run -- src/test/market.corruptionRouting.test.ts src/features/market/marketView.test.ts src/test/market.shortagePressure.test.ts src/domain/funding.test.ts`
+- `npm run lint`

--- a/planning/spe-28-shortage-pressure-slice.md
+++ b/planning/spe-28-shortage-pressure-slice.md
@@ -44,7 +44,7 @@ High stock uses `stockThreshold: 60` (holding cost bills above 50). Penalty stac
 
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
-| Corruption routing on procurement outcomes | SPE-28 child | `compromisedAuthority.ts` is patrol/custody-focused |
+| Corruption routing on procurement outcomes | [SPE-2322](https://linear.app/spectranoir/issue/SPE-2322) | Shipped as read-time roster diversion on `material:electronic_parts` |
 | Service-boon / callable-obligation rewards | SPE-28 child | Obligation semantics + UI are larger |
 | Barter / recovery channel variants | SPE-28 child | Multi-system |
 | Full merchant / cashflow simulator | — | Explicit non-goal |

--- a/src/domain/funding.ts
+++ b/src/domain/funding.ts
@@ -17,6 +17,7 @@ import type {
   ProcurementBacklogEntry,
   SupportStaffSummary,
 } from './models'
+import { hasCompromisedAuthorityProcurementDiversionSignals } from './sim/compromisedAuthority'
 import { FUNDING_CALIBRATION } from './sim/calibration'
 
 const PROCUREMENT_SOURCE_REASONS = new Set<string>(['market_transaction'])
@@ -787,7 +788,10 @@ export function getCanonicalFundingState(
 }
 
 export function assessFundingPressure(
-  game: Pick<GameState, 'agency' | 'config' | 'funding' | 'supportStaff' | 'week' | 'inventory'>
+  game: Pick<
+    GameState,
+    'agency' | 'config' | 'funding' | 'supportStaff' | 'week' | 'inventory' | 'compromisedAuthority'
+  >
 ): FundingPressureAssessment {
   const fundingState = getCanonicalFundingState(game)
   const pendingProcurementRequestIds = fundingState.procurementBacklog
@@ -878,6 +882,9 @@ export function assessFundingPressure(
       holdingCostSignalsProcurementTiming ? 'weekly-inventory-holding-cost' : '',
       hasVendorShortagePressureSignals(game, fundingState, staleProcurementRequestIds)
         ? 'vendor-shortage-pressure'
+        : '',
+      hasCompromisedAuthorityProcurementDiversionSignals(game)
+        ? 'compromised-authority-procurement-diversion'
         : '',
     ]),
   }

--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -18,6 +18,10 @@ import {
 import type { MarketTransactionListingResourceStatus } from './events/types'
 import type { GameState, MarketPressure, MarketState, OperationEvent } from './models'
 import { getCanonicalFundingState, sumInventoryStock } from './funding'
+import {
+  assessCompromisedAuthorityProcurementDiversion,
+  type ProcurementCorruptionRoutingReason,
+} from './sim/compromisedAuthority'
 import { FUNDING_CALIBRATION } from './sim/calibration'
 
 export type ProcurementTransactionAction = 'buy' | 'sell' | 'favor_exchange' | 'order' | 'fulfill'
@@ -133,6 +137,15 @@ export interface ProcurementListing {
   availableBundles: number
   inventoryStock: number
   shortagePressureDetail?: ProcurementShortagePressureDetail
+  corruptionRoutingDetail?: ProcurementCorruptionRoutingDetail
+}
+
+export interface ProcurementCorruptionRoutingDetail {
+  active: boolean
+  reasons: ProcurementCorruptionRoutingReason[]
+  availabilityPenaltyBundles: number
+  officialRole?: string
+  benefittingFactionId?: string
 }
 
 export type ProcurementShortagePressureReason = 'high-agency-stock' | 'funding-strain'
@@ -1035,6 +1048,34 @@ export function applyShortagePressureToBundleAvailability(
   )
 }
 
+export function assessProcurementCorruptionRouting(
+  game: Pick<GameState, 'compromisedAuthority'>
+) {
+  return assessCompromisedAuthorityProcurementDiversion(game)
+}
+
+export function applyCorruptionRoutingToBundleAvailability(
+  definition: Pick<ProcurementListingDefinition, 'id'>,
+  game: Pick<GameState, 'compromisedAuthority'>,
+  bundleAvailability: number
+): number {
+  const cal = FUNDING_CALIBRATION.procurementCorruptionRouting
+
+  if (definition.id !== cal.listingId) {
+    return bundleAvailability
+  }
+
+  const assessment = assessProcurementCorruptionRouting(game)
+  if (!assessment.active) {
+    return bundleAvailability
+  }
+
+  return Math.max(
+    cal.minBundles,
+    bundleAvailability - cal.availabilityPenaltyBundles
+  )
+}
+
 function getBaseAvailability(
   definition: ProcurementListingDefinition,
   game: GameState,
@@ -1057,10 +1098,15 @@ function getBaseAvailability(
   const packetAdjustedBundleAvailability = marketPacket.available
     ? Math.max(0, Math.floor(bundleAvailability * marketPacket.availabilityMultiplier))
     : 0
-  const adjustedBundleAvailability = applyShortagePressureToBundleAvailability(
+  const shortageAdjustedBundleAvailability = applyShortagePressureToBundleAvailability(
     definition,
     game,
     packetAdjustedBundleAvailability
+  )
+  const adjustedBundleAvailability = applyCorruptionRoutingToBundleAvailability(
+    definition,
+    game,
+    shortageAdjustedBundleAvailability
   )
 
   return adjustedBundleAvailability * definition.bundleQuantity
@@ -1133,6 +1179,8 @@ function buildListing(
   const featured = definition.recipeId === game.market.featuredRecipeId
   const shortageAssessment = assessProcurementShortagePressure(game)
   const shortageCalibration = FUNDING_CALIBRATION.procurementShortagePressure
+  const corruptionAssessment = assessProcurementCorruptionRouting(game)
+  const corruptionCalibration = FUNDING_CALIBRATION.procurementCorruptionRouting
   const totalAvailability = getBaseAvailability(definition, game, marketPacket)
   const bought = transactionTotals.boughtByListingId[definition.id] ?? 0
   const sold = transactionTotals.soldByListingId[definition.id] ?? 0
@@ -1168,6 +1216,21 @@ function buildListing(
             active: true,
             reasons: shortageAssessment.reasons,
             availabilityPenaltyBundles: shortageCalibration.availabilityPenaltyBundles,
+          },
+        }
+      : {}),
+    ...(definition.id === corruptionCalibration.listingId && corruptionAssessment.active
+      ? {
+          corruptionRoutingDetail: {
+            active: true,
+            reasons: corruptionAssessment.reasons,
+            availabilityPenaltyBundles: corruptionCalibration.availabilityPenaltyBundles,
+            ...(corruptionAssessment.officialRole
+              ? { officialRole: corruptionAssessment.officialRole }
+              : {}),
+            ...(corruptionAssessment.benefittingFactionId
+              ? { benefittingFactionId: corruptionAssessment.benefittingFactionId }
+              : {}),
           },
         }
       : {}),

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -207,6 +207,13 @@ export const FUNDING_CALIBRATION = {
     availabilityPenaltyBundles: 12,
     minBundles: 0,
   },
+  /** SPE-2322: read-time office-mediated diversion on one canonical roster listing. */
+  procurementCorruptionRouting: {
+    listingId: 'material:electronic_parts',
+    /** Subtracted from derived bundle availability when compromised-authority diversion is active. */
+    availabilityPenaltyBundles: 12,
+    minBundles: 0,
+  },
 } as const
 
 export const ATTRITION_CALIBRATION = {

--- a/src/domain/sim/compromisedAuthority.ts
+++ b/src/domain/sim/compromisedAuthority.ts
@@ -17,6 +17,7 @@ import type {
   CompromisedResponseOverride,
   CorruptionDepth,
   FactionRuntimeState,
+  GameState,
 } from '../models'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -118,6 +119,63 @@ const TIER_ORDER: BeliefTier[] = ['clear', 'uncertain', 'suspected', 'condemned'
 function escalateTier(tier: BeliefTier): BeliefTier {
   const idx = TIER_ORDER.indexOf(tier)
   return TIER_ORDER[Math.min(idx + 1, TIER_ORDER.length - 1)]
+}
+
+// ---------------------------------------------------------------------------
+// Procurement diversion (SPE-2322)
+// ---------------------------------------------------------------------------
+
+const OFFICE_MEDIATED_DIVERSION_ROLES = new Set<CompromisedOfficialRole>([
+  'magistrate',
+  'watchCommander',
+])
+
+export type ProcurementCorruptionRoutingReason = 'office-mediated-diversion'
+
+export interface ProcurementCorruptionRoutingAssessment {
+  active: boolean
+  reasons: ProcurementCorruptionRoutingReason[]
+  officialRole?: CompromisedOfficialRole
+  benefittingFactionId?: string
+}
+
+/**
+ * Office-mediated diversion: compromised office holder distorts evidence routing,
+ * which diverts supplier roster attention away from one calibrated listing.
+ */
+export function assessCompromisedAuthorityProcurementDiversion(
+  game: Pick<GameState, 'compromisedAuthority'>
+): ProcurementCorruptionRoutingAssessment {
+  const authority = game.compromisedAuthority
+  if (!authority) {
+    return { active: false, reasons: [] }
+  }
+
+  const reasons: ProcurementCorruptionRoutingReason[] = []
+  if (
+    OFFICE_MEDIATED_DIVERSION_ROLES.has(authority.officialRole) &&
+    authority.distortedCategories.includes('evidence')
+  ) {
+    reasons.push('office-mediated-diversion')
+  }
+
+  return {
+    active: reasons.length > 0,
+    reasons,
+    ...(reasons.length > 0
+      ? {
+          officialRole: authority.officialRole,
+          benefittingFactionId: authority.benefittingFactionId,
+        }
+      : {}),
+  }
+}
+
+/** Lightweight signal for funding.ts (avoid importing market). */
+export function hasCompromisedAuthorityProcurementDiversionSignals(
+  game: Pick<GameState, 'compromisedAuthority'>
+): boolean {
+  return assessCompromisedAuthorityProcurementDiversion(game).active
 }
 
 // ---------------------------------------------------------------------------

--- a/src/features/market/marketView.test.ts
+++ b/src/features/market/marketView.test.ts
@@ -293,6 +293,45 @@ describe('marketView', () => {
     expect(view.selectedDetail?.blockerDetails.join(' ')).toMatch(/Vendor shortage pressure/i)
   })
 
+  it('surfaces compromised-authority procurement diversion in budget summary and listing blockers', () => {
+    const game = {
+      ...createStartingState(),
+      compromisedAuthority: {
+        officialRole: 'watchCommander' as const,
+        benefittingFactionId: 'corporate_supply',
+        distortedCategories: ['evidence' as const],
+        corruptionDepth: 'embedded_control' as const,
+        patrolAnomalyCount: 0,
+      },
+    }
+    const listing = getProcurementListings(game).find(
+      (entry) => entry.id === 'material:electronic_parts'
+    )
+
+    expect(listing).toBeDefined()
+    expect(assessFundingPressure(game).reasonCodes).toContain(
+      'compromised-authority-procurement-diversion'
+    )
+
+    const view = getProcurementScreenView(
+      game,
+      {
+        q: '',
+        category: 'all',
+        sort: 'recommended',
+      },
+      listing!.id
+    )
+
+    expect(view.budgetSummary.details.join(' ')).toMatch(/Compromised authority is diverting/i)
+
+    const listingView = getMarketListings(game).find((entry) => entry.id === listing!.id)
+    expect(listingView?.canAffordOne).toBe(true)
+    expect(listingView?.canBuyOne).toBe(false)
+    expect(view.selectedDetail?.canBuyOne).toBe(false)
+    expect(view.selectedDetail?.blockerDetails.join(' ')).toMatch(/Compromised authority diverted/i)
+  })
+
   it('surfaces inventory holding cost in procurement budget summary when stock tightens headroom', () => {
     const game = createStartingState()
     const fundingState = normalizeFundingState(

--- a/src/features/market/marketView.ts
+++ b/src/features/market/marketView.ts
@@ -560,6 +560,9 @@ function buildProcurementDetailView(
         listing.shortagePressureDetail?.active
           ? `Vendor shortage: supplier trimmed ${listing.shortagePressureDetail.availabilityPenaltyBundles} bundle${listing.shortagePressureDetail.availabilityPenaltyBundles === 1 ? '' : 's'} (${listing.shortagePressureDetail.reasons.join(', ')}).`
           : '',
+        listing.corruptionRoutingDetail?.active
+          ? `Office-mediated diversion: ${listing.corruptionRoutingDetail.officialRole ?? 'compromised office'} rerouted ${listing.corruptionRoutingDetail.availabilityPenaltyBundles} roster bundle${listing.corruptionRoutingDetail.availabilityPenaltyBundles === 1 ? '' : 's'} (${listing.corruptionRoutingDetail.reasons.join(', ')}${listing.corruptionRoutingDetail.benefittingFactionId ? `; favors ${listing.corruptionRoutingDetail.benefittingFactionId}` : ''}).`
+          : '',
         `Market pressure: ${listing.pressureLabel}.`,
         selectedTransactions.length > 0
           ? `This week: ${selectedTransactions
@@ -583,9 +586,11 @@ function buildProcurementDetailView(
         listing.buyBlockedReason ?? '',
         listing.sellBlockedReason ?? '',
         listing.availableBundles < 1
-          ? listing.shortagePressureDetail?.active
-            ? 'Vendor shortage pressure exhausted supplier bundles while funding still covers the line.'
-            : 'Current-week supplier availability is exhausted for this listing.'
+          ? listing.corruptionRoutingDetail?.active
+            ? 'Compromised authority diverted roster bundles while funding still covers the line.'
+            : listing.shortagePressureDetail?.active
+              ? 'Vendor shortage pressure exhausted supplier bundles while funding still covers the line.'
+              : 'Current-week supplier availability is exhausted for this listing.'
           : '',
         typeof listing.fabricationCost === 'number'
           ? 'Fabrication remains the slower but stable fallback if supplier stock collapses.'
@@ -648,6 +653,9 @@ function buildProcurementBudgetSummary(
           : '',
         fundingPressure.reasonCodes.includes('vendor-shortage-pressure')
           ? 'Vendor shortage pressure is rationing agency-roster supplier bundles (availability, not quoted price or carrying fees).'
+          : '',
+        fundingPressure.reasonCodes.includes('compromised-authority-procurement-diversion')
+          ? 'Compromised authority is diverting office-mediated supplier roster attention (availability, not quoted price, carrying fees, or vendor shortage).'
           : '',
         game.factions?.corporate_supply?.availableFavors?.some(
           (favor) => favor.id === 'corporate-supply-salvage-credit'

--- a/src/test/market.corruptionRouting.test.ts
+++ b/src/test/market.corruptionRouting.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  assessProcurementCorruptionRouting,
+  getProcurementListings,
+} from '../domain/market'
+import { purchaseMarketInventory } from '../domain/sim/market'
+import { FUNDING_CALIBRATION } from '../domain/sim/calibration'
+
+const TARGET_LISTING_ID = FUNDING_CALIBRATION.procurementCorruptionRouting.listingId
+const SHORTAGE_LISTING_ID = FUNDING_CALIBRATION.procurementShortagePressure.listingId
+
+function getTargetListing(game: ReturnType<typeof createStartingState>) {
+  return getProcurementListings(game).find((entry) => entry.id === TARGET_LISTING_ID)
+}
+
+function withOfficeMediatedDiversion(game: ReturnType<typeof createStartingState>) {
+  return {
+    ...game,
+    compromisedAuthority: {
+      officialRole: 'magistrate' as const,
+      benefittingFactionId: 'corporate_supply',
+      distortedCategories: ['evidence' as const],
+      corruptionDepth: 'embedded_control' as const,
+      patrolAnomalyCount: 0,
+    },
+  }
+}
+
+describe('procurement corruption routing (SPE-2322)', () => {
+  it('leaves starting-state listings unchanged when diversion signals are inactive', () => {
+    const game = createStartingState()
+    const listing = getTargetListing(game)
+
+    expect(listing).toBeDefined()
+    expect(assessProcurementCorruptionRouting(game).active).toBe(false)
+    expect(listing!.corruptionRoutingDetail).toBeUndefined()
+    expect(listing!.availableBundles).toBeGreaterThan(0)
+  })
+
+  it('reduces electronic parts bundles under office-mediated diversion without changing price', () => {
+    const baseline = createStartingState()
+    const diverted = withOfficeMediatedDiversion(baseline)
+    const baselineListing = getTargetListing(baseline)!
+    const divertedListing = getTargetListing(diverted)!
+
+    expect(assessProcurementCorruptionRouting(diverted).reasons).toContain(
+      'office-mediated-diversion'
+    )
+    expect(divertedListing.availableBundles).toBeLessThan(baselineListing.availableBundles)
+    expect(divertedListing.buyPrice).toBe(baselineListing.buyPrice)
+  })
+
+  it('blocks purchase when funding is sufficient but roster bundles are diverted', () => {
+    const game = withOfficeMediatedDiversion(createStartingState())
+    const listing = getTargetListing(game)!
+
+    expect(game.funding).toBeGreaterThanOrEqual(listing.buyPrice)
+    expect(listing.availableBundles).toBe(0)
+
+    const result = purchaseMarketInventory(game, listing.id, 1)
+    expect(result).toBe(game)
+  })
+
+  it('tightens only the calibrated listing when diversion is active', () => {
+    const game = withOfficeMediatedDiversion(createStartingState())
+    const target = getTargetListing(game)!
+    const otherMaterial = getProcurementListings(game).find(
+      (entry) => entry.source === 'material' && entry.id !== TARGET_LISTING_ID
+    )
+
+    expect(target.availableBundles).toBe(0)
+    expect(otherMaterial).toBeDefined()
+    expect(otherMaterial!.availableBundles).toBeGreaterThan(0)
+  })
+
+  it('stays orthogonal to vendor shortage pressure on a different listing', () => {
+    const game = {
+      ...withOfficeMediatedDiversion(createStartingState()),
+      inventory: {
+        ...createStartingState().inventory,
+        medkits: 25,
+      },
+    }
+    const corruptionTarget = getTargetListing(game)!
+    const shortageTarget = getProcurementListings(game).find(
+      (entry) => entry.id === SHORTAGE_LISTING_ID
+    )!
+
+    expect(corruptionTarget.corruptionRoutingDetail?.active).toBe(true)
+    expect(corruptionTarget.shortagePressureDetail).toBeUndefined()
+    expect(shortageTarget?.shortagePressureDetail?.active).toBe(true)
+    expect(shortageTarget?.corruptionRoutingDetail).toBeUndefined()
+  })
+
+  it('ignores compromised authority without evidence distortion', () => {
+    const game = {
+      ...createStartingState(),
+      compromisedAuthority: {
+        officialRole: 'magistrate' as const,
+        benefittingFactionId: 'corporate_supply',
+        distortedCategories: ['patrol' as const],
+        corruptionDepth: 'shallow_cover' as const,
+        patrolAnomalyCount: 0,
+      },
+    }
+
+    expect(assessProcurementCorruptionRouting(game).active).toBe(false)
+    expect(getTargetListing(game)!.corruptionRoutingDetail).toBeUndefined()
+  })
+
+  it('derives listings deterministically for the same state', () => {
+    const game = withOfficeMediatedDiversion(createStartingState())
+
+    expect(getProcurementListings(game)).toEqual(getProcurementListings(game))
+  })
+})


### PR DESCRIPTION
## Summary

- Bridge `compromisedAuthority` office-mediated diversion (magistrate/watchCommander + evidence distortion) to read-time bundle availability on `material:electronic_parts`.
- Add `compromised-authority-procurement-diversion` funding pressure reason code and distinct market budget/listing copy.
- Domain + marketView tests; shortage (SPE-2321), holding cost, and favor paths unchanged.

## Linear mapping

- **Slice:** [SPE-2322](https://linear.app/spectranoir/issue/SPE-2322/spe-28-compromised-authority-distorts-procurement-routing)
- **Parent:** [SPE-28](https://linear.app/spectranoir/issue/SPE-28/funding-pressure-and-procurement-availability) — remains open in backlog (child-only slice)
- **Slice doc:** `planning/spe-28-corruption-routing-slice.md`

## What shipped

- `assessCompromisedAuthorityProcurementDiversion` in `src/domain/sim/compromisedAuthority.ts`
- `applyCorruptionRoutingToBundleAvailability` wired in `getBaseAvailability` / `buildListing`
- `FUNDING_CALIBRATION.procurementCorruptionRouting` calibration
- Market UI copy in `marketView.ts`

## Validation

- `npm run test:run -- src/test/market.corruptionRouting.test.ts src/features/market/marketView.test.ts src/test/market.shortagePressure.test.ts src/domain/funding.test.ts` (45 passed)
- `npm run lint` (clean)

## Docs updated

- `planning/spe-28-corruption-routing-slice.md` (new)
- `planning/spe-28-shortage-pressure-slice.md` (deferred pointer → SPE-2322)

## Parent status

SPE-28 parent stays **Backlog** — this child satisfies one corruption-routing acceptance path only.