### PR TITLE
feat(SPE-2324): self-censoring registry weekly retention/rediscovery hook (slice 3)

### DIFF
--- a/.cursor/rules/implementation-lite.mdc
+++ b/.cursor/rules/implementation-lite.mdc
@@ -100,10 +100,12 @@ Run the ship loop only **after** pre-ship audit completion criteria are met:
 2. **Push** the branch to `origin` (`git push -u origin HEAD` when the remote branch is new).
 3. **Open a PR** against `main` with the PR mapping body below.
 4. **Linear:** comment the PR URL on the **slice** issue; keep the slice **In Progress** until merge (then **Done** + merge comment per `linear-always-update.mdc`).
+5. **Babysit → merge (same session, mandatory):** after the PR opens, babysit until CI is clean and the PR is mergeable — triage review comments, fix in-boundary failures, push, re-watch `gh pr checks` until green. Then **merge** the PR (`gh pr merge`). Do **not** end the session or write a next-issue plan while the PR is still open.
+6. **Sync `main`:** `git checkout main` && `git pull origin main`. Confirm the merge commit is on local `main`.
 
-Do **not** end an implementation session with only local files, uncommitted work, or "say if you want a PR."
+Do **not** end an implementation session with only local files, uncommitted work, an open unmerged PR, or "say if you want a PR."
 
-**Exceptions** (honor explicit user words only): "no commit," "no PR," "local only," "plan only," or "do not push."
+**Exceptions** (honor explicit user words only): "no commit," "no PR," "local only," "plan only," "do not push," or "do not merge."
 
 Repo ship loop overrides a generic "commit only when asked" preference for Containment Protocol **implementation** sessions on a named slice branch.
 
@@ -135,19 +137,19 @@ If Linear tooling is unavailable, report the exact status/comment update that sh
 
 ## Session closeout (mandatory)
 
-Two phases — **do not** produce the next-issue plan when the PR is only open.
+**Order:** ship loop → babysit CI → merge → `checkout main` && pull → **then** closeout. **Do not** produce a next-issue plan until merge and local `main` sync are complete.
 
-### Phase A — PR opened (end of implementation session)
+### Phase A — PR open, babysit blocked (interim only)
 
-After **commit**, **push**, **PR opened**, and **Linear** updated (PR URL on slice issue; slice **In Progress**):
+Use only when babysit cannot finish in-session (external blocker, merge policy, or explicit user **do not merge**):
 
-1. **Do not** implement the next issue in this session.
-2. **Do not** prepare a next-issue implementation plan yet.
-3. Return the **phase A** final response in `docs/agent-session-closeout.md` (no `Next issue implementation plan` content except the deferral line).
+1. Report blocker, PR URL, and CI status.
+2. **Do not** prepare a next-issue implementation plan.
+3. Return the **phase A** structure in `docs/agent-session-closeout.md`.
 
-### Phase B — After merge
+### Phase B — After merge (normal session end)
 
-After the PR is **merged**, slice issue **Done**, and merge comment on Linear:
+After **PR merged**, slice issue **Done**, merge comment on Linear, and **`git checkout main` && `git pull`**:
 
 1. **Do not** implement the next issue unless the user explicitly asks in that session.
 2. **Do** prepare a **next-issue implementation plan** only (see `docs/agent-session-closeout.md`).
@@ -157,4 +159,4 @@ Next-issue plan must cover: issue ID/title; smallest boundary; files to inspect;
 
 Closeout rules: do not expand the current issue; do not mark Done until merge when the full child boundary is satisfied; keep parent open for child-only slices; prefer small deterministic testable changes; preserve mistaken records and later corrections (no silent overwrite).
 
-After **merge** (phase B): remind the human: `git checkout main` && `git pull`, then **new agent chat** with Linear URL, slice doc, branch name, and `main` SHA.
+After **merge** (phase B): remind the human to **start a new agent chat** with Linear URL, slice doc, branch name, and current `main` SHA (agent already synced `main` in-session).

--- a/.cursor/rules/linear-always-update.mdc
+++ b/.cursor/rules/linear-always-update.mdc
@@ -17,6 +17,7 @@ Linear is the **system of record** for issue state, scope, and closure. GitHub P
 | **During work** | Harvest triage: **`docs/harvest-candidate-triage-agent.md`**; owner comments with full mechanic + boundary + fold-in vs child reasoning (**`docs/harvest-fold-in-linear-comments.md`**, not one-liners); owner map QA **`docs/harvest-mirror-owner-map-qa.md`**; SPE-2110 intake same session; comment on slice issue when scope or blockers change materially. |
 | **Slice ready** | **Commit**, **push**, and **open PR** on the named branch before claiming the slice complete locally (`implementation-lite.mdc` ship loop). |
 | **PR opened** | Link the **slice** issue in the PR body (not only the parent epic); comment PR URL on the slice issue. |
+| **Babysit → merge** | Same session: babysit CI until green, merge PR, then `git checkout main` && `git pull origin main` (`implementation-lite.mdc`). |
 | **PR merged** | Set slice issue **Done**; parent **Done** only if full parent scope shipped, else return parent to **Backlog**. |
 | **After merge** | Short comment on the slice issue: PR URL + what shipped. |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 2. **Start a new agent chat** before the next slice—not the thread that opened or babysat the merged PR.
 3. First message: Linear issue, `planning/…-slice.md`, new branch name, confirm current `main` commit.
 
-Agents: when merge is complete, remind the user to sync `main` and **start a new agent** for the next task.
+Agents: when merge is complete, sync `main` in-session, then remind the user to **start a new agent** for the next task.
 
 ### Linear — mandatory (every session, every agent)
 
@@ -30,6 +30,7 @@ Linear is the system of record for issue state and closure. **Do not** skip Line
 | **Harvest / triage closure** | Follow **`docs/harvest-candidate-triage-agent.md`**. Post **rich** owner comments (mechanic, repo anchor, ownership, boundary, fold-in vs child reasoning) per **`docs/harvest-fold-in-linear-comments.md`** — not one-line notes; mirror table must match. Owner-map QA: **`docs/harvest-mirror-owner-map-qa.md`**; SPE-2110 intake same session — not "table only." |
 | **Slice ready** | **Commit**, **push**, and **open PR** on the named branch before claiming the slice complete (`docs/cursor-implementation-lite-user-rules-snippet.md` ship loop; tracked rule `.cursor/rules/implementation-lite.mdc`). |
 | **PR opened** | Link the **slice** issue in the PR body (not only the parent epic); comment PR URL on the slice issue. |
+| **Babysit → merge** | Same session: watch CI until green, fix in-boundary failures, merge PR; then `git checkout main` && `git pull origin main`. |
 | **On merge** | Slice issue **Done**; parent **Done** only if full parent scope shipped, else parent **Backlog**. |
 | **After merge** | Short Linear comment: PR URL + what shipped. |
 

--- a/docs/agent-session-closeout.md
+++ b/docs/agent-session-closeout.md
@@ -6,18 +6,24 @@ Tracked rule: `.cursor/rules/implementation-lite.mdc` (`Session closeout`). Past
 
 ---
 
-## Two phases (order matters)
+## Session order (mandatory)
+
+1. Pre-ship audit → commit → push → open PR → Linear PR comment (slice **In Progress**).
+2. **Babysit → merge (same session):** watch CI (`gh pr checks`), triage comments, fix in-boundary failures, push until green; merge when mergeable.
+3. **`git checkout main` && `git pull origin main`** — agent syncs local `main` before closeout.
+4. Linear slice **Done** + merge comment.
+5. **Phase B closeout** — next-issue plan only; **do not** code the next issue.
+
+**Next-issue plan is phase B only** — after merge and local `main` sync, not while the PR is open.
+
+## Two phases (closeout format)
 
 | Phase | When | Agent does | Agent does **not** |
 | ----- | ---- | ---------- | ------------------- |
-| **A — PR opened** | Commit + push + PR + Linear PR comment; slice **In Progress** | Pre-ship closeout (status, changes, audit, validation, deferred, PR URL) | Next-issue plan; mark slice **Done** |
-| **B — After merge** | PR merged; slice **Done** + merge comment on Linear | Next-issue implementation plan only (research) | Code the next issue in the merge/babysit thread |
+| **A — Babysit blocked** | PR open; merge cannot complete in-session | Interim status, PR URL, CI/blocker | Next-issue plan; mark slice **Done** |
+| **B — After merge** | PR merged; slice **Done**; local `main` synced | Next-issue implementation plan only (research) | Code the next issue in this thread |
 
-**Next-issue plan is phase B only** — after merge on `main`, not when the PR is first opened.
-
-Phase A reminder for the human: merge the PR, then `git checkout main` && `git pull`, then **new agent chat** for phase B (or the next slice).
-
-Phase B reminder: new chat with Linear URL, slice doc, branch name, and current `main` SHA.
+Phase B reminder: **new agent chat** for the next slice (Linear URL, slice doc, branch name, `main` SHA) — even though this session already ran `checkout main`.
 
 ---
 
@@ -79,9 +85,9 @@ Tracked rule: `.cursor/rules/implementation-lite.mdc` § Deferred work recording
 
 Return **only** the structure for the current phase (no extra sections, no preamble).
 
-### Phase A — PR opened (implementation session end)
+### Phase A — PR open, babysit blocked (interim only)
 
-Use when the slice is committed, pushed, PR is open, and Linear has the PR link (slice stays **In Progress** until merge).
+Use when the slice is committed, pushed, PR is open, and babysit/merge cannot finish in-session (external blocker or explicit **do not merge**).
 
 ```text
 Current issue status:
@@ -114,7 +120,7 @@ Next issue implementation plan:
 
 ### Phase B — After merge
 
-Use when the PR is **merged**, the slice issue is **Done**, and the merge comment is on Linear.
+Use when the PR is **merged**, the slice issue is **Done**, the merge comment is on Linear, and the agent has run **`git checkout main` && `git pull origin main`**.
 
 ```text
 Merge closeout:
@@ -134,7 +140,7 @@ Next issue implementation plan:
 - Implementation sequence:
 
 Handoff:
-- Remind: git checkout main && git pull; new agent chat with Linear URL, slice doc, branch name, main SHA.
+- Agent already synced main in-session; remind human: new agent chat with Linear URL, slice doc, branch name, main SHA.
 ```
 
 Fill every subsection for the active phase. Use `none` only when truly empty. **Phase A:** **Audit passes** summarize the six pre-ship passes from `docs/agent-pre-ship-audit.md`. **Phase B:** skip audit/validation unless re-run for merge fixes — focus on the next-issue plan.

--- a/docs/cursor-implementation-lite-user-rules-snippet.md
+++ b/docs/cursor-implementation-lite-user-rules-snippet.md
@@ -63,10 +63,12 @@ Run only **after** pre-ship audit passes:
 2. **Push** the branch to `origin` (`git push -u origin HEAD` when the remote branch is new).
 3. **Open a PR** against `main` with the PR mapping body below.
 4. **Linear:** comment the PR URL on the **slice** issue; keep the slice **In Progress** until merge (then **Done** + merge comment).
+5. **Babysit → merge (same session):** watch CI (`gh pr checks`), triage comments, fix in-boundary failures, push until green; merge when mergeable. Do **not** end the session or write a next-issue plan while the PR is still open.
+6. **Sync `main`:** `git checkout main` && `git pull origin main`.
 
-Do **not** end an implementation session with only local files, uncommitted work, or "say if you want a PR."
+Do **not** end an implementation session with only local files, uncommitted work, an open unmerged PR, or "say if you want a PR."
 
-**Exceptions** (explicit user words only): "no commit," "no PR," "local only," "plan only," or "do not push."
+**Exceptions** (explicit user words only): "no commit," "no PR," "local only," "plan only," "do not push," or "do not merge."
 
 Repo ship loop overrides a generic "commit only when asked" preference for Containment Protocol **implementation** sessions on a named slice branch.
 
@@ -98,4 +100,4 @@ If Linear tooling is unavailable, report the exact status/comment update that sh
 
 ### Session closeout (mandatory)
 
-**Phase A (PR open):** after commit, push, PR, and Linear PR comment — closeout only; **no** next-issue plan. **Phase B (after merge):** slice Done + merge comment — next-issue plan only. Formats: `docs/agent-session-closeout.md`. Paste: `docs/cursor-session-closeout-user-rules-snippet.md`.
+**Order:** ship loop → babysit CI → merge → `checkout main` && pull → closeout. **Phase B (after merge):** slice Done + merge comment — next-issue plan only. **Phase A (interim):** only when babysit/merge is blocked in-session. Formats: `docs/agent-session-closeout.md`. Paste: `docs/cursor-session-closeout-user-rules-snippet.md`.

--- a/docs/cursor-session-closeout-user-rules-snippet.md
+++ b/docs/cursor-session-closeout-user-rules-snippet.md
@@ -4,17 +4,17 @@ Paste into **Cursor → Settings → Rules → User Rules** (or merge into your 
 
 ---
 
-## Phase A — PR opened (implementation session end)
+## Phase A — PR open, babysit blocked (interim only)
 
-After commit, push, PR opened, and Linear updated (PR URL on slice; slice **In Progress**):
+When commit, push, and PR are done but babysit/merge **cannot** finish in-session (blocker or explicit **do not merge**):
 
 Do not implement the next issue. **Do not** write a next-issue plan yet.
 
-End the session using **only** the **phase A** structure in `docs/agent-session-closeout.md` (status → changes → audit passes → validation → deferred → PR URL). Under **Next issue implementation plan**, write only: deferred until after merge.
+End using the **phase A** structure in `docs/agent-session-closeout.md`.
 
-## Phase B — After merge
+## Phase B — After merge (normal session end)
 
-After the PR is **merged**, slice **Done**, and merge comment on Linear:
+After babysit → merge, slice **Done**, merge comment on Linear, and **`git checkout main` && `git pull origin main`**:
 
 Do not implement the next issue unless the user explicitly asks. Prepare a **next-issue implementation plan** only.
 
@@ -22,7 +22,7 @@ Next-issue plan must include: (1) issue ID and title, (2) smallest correct bound
 
 End with the **phase B** structure in `docs/agent-session-closeout.md` (merge closeout → next-issue plan → handoff).
 
-Remind: `git checkout main` && `git pull`, then **new agent chat** with Linear URL, slice doc, branch name, and `main` SHA.
+Remind: agent already synced `main` in-session; **new agent chat** for the next slice with Linear URL, slice doc, branch name, and `main` SHA.
 
 ---
 

--- a/docs/cursor-user-rules-snippet.md
+++ b/docs/cursor-user-rules-snippet.md
@@ -12,7 +12,7 @@ Copy the standing-workflow block below into **Cursor → Settings → Rules → 
 
 ## Containment Protocol — standing workflow
 
-- **Git exception:** For Containment Protocol **implementation slices**, follow repo **`implementation-lite` ship loop** (commit → push → open PR on the named branch) even when another rule says "only commit when requested." Tracked repo rules apply automatically: `.cursor/rules/implementation-lite.mdc` and `.cursor/rules/linear-always-update.mdc` (`alwaysApply: true`). Honor explicit **no commit** / **no PR** / **local only** only when the user says so in that session.
+- **Git exception:** For Containment Protocol **implementation slices**, follow repo **`implementation-lite` ship loop** (commit → push → open PR → **babysit CI until green → merge** → `checkout main` && pull) even when another rule says "only commit when requested." Do **not** plan the next slice until merge and local `main` sync complete. Tracked repo rules: `.cursor/rules/implementation-lite.mdc` and `.cursor/rules/linear-always-update.mdc` (`alwaysApply: true`). Honor explicit **no commit** / **no PR** / **local only** / **do not merge** only when the user says so in that session.
 - **Linear is mandatory on every agent session** (implementation, harvest, PR babysit, review): In Progress before work, **commit + push + open PR** before claiming an implementation slice complete, slice issue linked in PR, Done + comment on merge. Never skip because GitHub has a bot linkback. Repo rules: `.cursor/rules/linear-always-update.mdc`, `.cursor/rules/implementation-lite.mdc`; detail in **`AGENTS.md`**. Harvest triage: post **rich** owner comments (mechanic + boundary + fold-in vs child) per **`docs/harvest-fold-in-linear-comments.md`** — not one-line notes.
 - After a PR **merges**: run `git checkout main` and `git pull origin main`, then **start a new agent chat** for the next slice. Do not continue the old thread—it keeps stale branches, CI context, and failed "Move to local" branch names.
 - During an **open PR** on one branch: one agent session is fine until merge.
@@ -22,7 +22,7 @@ Copy the standing-workflow block below into **Cursor → Settings → Rules → 
 - When I merge, remind me to sync `main` and **switch to a new agent** before the next issue.
 - **Implementation lite:** `docs/cursor-implementation-lite-user-rules-snippet.md` (scope, **pre-ship audit**, **ship loop**, PR mapping, Linear).
 - **Pre-ship audit:** before commit/merge — six passes until clean; `docs/agent-pre-ship-audit.md`.
-- **Session closeout:** phase A after PR open (closeout only, **no** next-issue plan); phase B after merge (next-issue plan only). Final reply **only** per `docs/agent-session-closeout.md`.
+- **Session closeout:** babysit → merge → sync `main`, then phase B (next-issue plan only). Phase A only if babysit blocked. Final reply per `docs/agent-session-closeout.md`.
 - **Backlog hygiene:** remind me to use the block from `docs/cursor-backlog-hygiene-user-rules-snippet.md` when running hygiene or grooming passes (not implementation).
 
 ---

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -22,7 +22,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `9cd48aeb` (post–SPE-2318 merge, PR #2500). [SPE-2318](https://linear.app/spectranoir/issue/SPE-2318) **Done** — `selfCensoringInformationRecords` persistence shipped. Pick next compendium/registry slice from active queue.
+On `main` @ `61a23c04` (post–SPE-2323 merge). [SPE-2324](https://linear.app/spectranoir/issue/SPE-2324) **In Progress** — self-censoring information registry weekly retention/rediscovery hook (slice 3); see `planning/self-censoring-information-registry-slice-3.md`.
 
 ## Blocked / waiting
 

--- a/planning/self-censoring-information-registry-slice-3.md
+++ b/planning/self-censoring-information-registry-slice-3.md
@@ -1,0 +1,63 @@
+# SPE-2108 — Self-censoring information registry weekly retention/rediscovery hook (slice 3)
+
+One-page implementation plan. Linear: [SPE-2324](https://linear.app/spectranoir/issue/SPE-2324) (child under [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108)). Follows shipped slice 2 (`planning/self-censoring-information-registry-slice-2.md`, PR #2500).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2324 — Self-censoring registry weekly retention/rediscovery hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2324) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108) — registry anchor (slice 1–2 shipped); umbrella [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays open |
+| **Branch** | `spe-2108-self-censoring-weekly-hook-slice-3`                                                              |
+| **Base `main` SHA** | `61a23c04`                                                                                          |
+
+## Goal
+
+Wire persisted `selfCensoringInformationRecords` into `advanceWeek` so `retentionDecayTimer` countdown expires deterministically and `rediscoveryLoop` advances when `lastAlarmWeek` due week is reached.
+
+## Prerequisite (on `main` @ `61a23c04`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/selfCensoringInformationRegistry.ts` (SPE-2108 / PR #2429) |
+| Persistence          | `selfCensoringInformationRecords` on `GameState` (SPE-2318 / PR #2500) |
+| Sibling weekly hook  | `src/domain/extranormalEventWeeklyMonitoring.ts` (SPE-2315 pattern)  |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklySelfCensoringInformationTick` in domain module           | New persistence fields, UI, dossier surfacing |
+| Call from `advanceWeek` after week increment (`result.week`)       | SPE-1309 cognitive hazard engine wire-up      |
+| Targeted domain + `advanceWeek` integration tests                    | Extranormal / minor-anomaly / unexplained-location hooks |
+| Slice doc (this file) + backlog handoff                              | SPE-2108 parent Done / SPE-1309 parent closure |
+
+## Acceptance
+
+- [ ] Empty `selfCensoringInformationRecords` map is a no-op without throw
+- [ ] `retentionDecayTimer` decrements each week; cleared when countdown reaches expiry
+- [ ] `rediscoveryLoop` unchanged while `week < lastAlarmWeek`
+- [ ] When `week >= lastAlarmWeek`, `loopCount` decrements and `lastAlarmWeek` clears; alarm refs clear when loop completes
+- [ ] Re-applying tick for same post-advance week is idempotent
+- [ ] Invalid post-tick record must not mutate source record
+- [ ] `npm run lint` + targeted tests + persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/selfCensoringInformationWeeklyRetention.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/selfCensoringInformationWeeklyRetention.test.ts`, `src/test/advanceWeek.selfCensoringInformation.integration.test.ts` |
+| Plan   | `planning/self-censoring-information-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Investigation exposure dossier surfacing | SPE-2159 / E54 | Out of weekly-hook boundary |
+| Unified cognitive hazard engine wire-up | SPE-1309 | Parent umbrella; out of slice |
+| SPE-854 unusable-archive routing | SPE-854 follow-up | Intake cross-link deferred |
+
+## See also
+
+- `planning/self-censoring-information-registry-slice-2.md`
+- `planning/extranormal-event-registry-slice-3.md`

--- a/src/domain/selfCensoringInformationWeeklyRetention.ts
+++ b/src/domain/selfCensoringInformationWeeklyRetention.ts
@@ -1,0 +1,185 @@
+/**
+ * SPE-2108 slice 3: weekly retention-decay expiry and rediscovery-loop advance for persisted
+ * self-censoring information records.
+ *
+ * Pure deterministic tick: each week decrements retentionDecayTimer until expiry (field cleared);
+ * when the simulation week reaches rediscoveryLoop.lastAlarmWeek, decrement loopCount and clear
+ * alarm refs when the loop completes. Does not add persistence fields or mutate unrelated record data.
+ */
+
+import {
+  validateSelfCensoringInformationRecord,
+  type RediscoveryLoop,
+  type SelfCensoringInformationRecord,
+  type SelfCensoringInformationRecordsMap,
+} from './selfCensoringInformationRegistry'
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function isValidLoopCount(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function freezeRecord(record: SelfCensoringInformationRecord): SelfCensoringInformationRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Rediscovery alarm due week from lastAlarmWeek; undefined when no alarm is scheduled. */
+export function resolveSelfCensoringRediscoveryAlarmDueWeek(
+  record: SelfCensoringInformationRecord
+): number | undefined {
+  const loop = record.rediscoveryLoop
+  if (!loop || !isValidLoopCount(loop.loopCount) || loop.loopCount === 0) {
+    return undefined
+  }
+
+  const lastAlarmWeek = loop.lastAlarmWeek
+  return isFiniteWeek(lastAlarmWeek) ? lastAlarmWeek : undefined
+}
+
+function resolveNextRetentionDecayTimer(
+  timer: number | undefined
+): number | undefined {
+  if (!isFiniteWeek(timer)) {
+    return undefined
+  }
+
+  if (timer <= 1) {
+    return undefined
+  }
+
+  return timer - 1
+}
+
+function resolveNextRediscoveryLoop(
+  loop: RediscoveryLoop | undefined,
+  week: number
+): RediscoveryLoop | undefined {
+  if (!loop || !isValidLoopCount(loop.loopCount) || loop.loopCount === 0) {
+    return loop
+  }
+
+  const lastAlarmWeek = loop.lastAlarmWeek
+  if (!isFiniteWeek(lastAlarmWeek) || week < lastAlarmWeek) {
+    return loop
+  }
+
+  const nextLoopCount = loop.loopCount - 1
+  if (nextLoopCount === 0) {
+    return { loopCount: 0 }
+  }
+
+  const forgottenWarningRefs = loop.forgottenWarningRefs
+  return {
+    loopCount: nextLoopCount,
+    ...(forgottenWarningRefs && forgottenWarningRefs.length > 0
+      ? { forgottenWarningRefs }
+      : {}),
+  }
+}
+
+function buildCandidateRecord(
+  record: SelfCensoringInformationRecord,
+  week: number
+): SelfCensoringInformationRecord {
+  const nextRetentionDecayTimer = resolveNextRetentionDecayTimer(record.retentionDecayTimer)
+  const nextRediscoveryLoop = resolveNextRediscoveryLoop(record.rediscoveryLoop, week)
+
+  const retentionChanged = nextRetentionDecayTimer !== record.retentionDecayTimer
+  const rediscoveryChanged = nextRediscoveryLoop !== record.rediscoveryLoop
+
+  if (!retentionChanged && !rediscoveryChanged) {
+    return record
+  }
+
+  const withRetention: SelfCensoringInformationRecord = retentionChanged
+    ? nextRetentionDecayTimer === undefined
+      ? (() => {
+          const { retentionDecayTimer: _retentionDecayTimer, ...withoutTimer } = record
+          void _retentionDecayTimer
+          return withoutTimer
+        })()
+      : { ...record, retentionDecayTimer: nextRetentionDecayTimer }
+    : record
+
+  if (!rediscoveryChanged) {
+    return withRetention
+  }
+
+  if (nextRediscoveryLoop === undefined) {
+    const { rediscoveryLoop: _rediscoveryLoop, ...withoutLoop } = withRetention
+    void _rediscoveryLoop
+    return withoutLoop
+  }
+
+  return {
+    ...withRetention,
+    rediscoveryLoop: nextRediscoveryLoop,
+  }
+}
+
+/**
+ * Advances one record for the simulation week: retention timer countdown and rediscovery due-week.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceSelfCensoringInformationRecordForWeek(
+  record: SelfCensoringInformationRecord,
+  week: number
+): SelfCensoringInformationRecord {
+  const normalizedWeek = normalizeWeek(week)
+  const candidate = buildCandidateRecord(record, normalizedWeek)
+
+  if (candidate === record) {
+    return record
+  }
+
+  if (!validateSelfCensoringInformationRecord(candidate).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly retention/rediscovery pass over persisted self-censoring information records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklySelfCensoringInformationTick(
+  records: SelfCensoringInformationRecordsMap | null | undefined,
+  week: number
+): SelfCensoringInformationRecordsMap {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: SelfCensoringInformationRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceSelfCensoringInformationRecordForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[recordId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -263,6 +263,7 @@ import {
   type CompactCivicAuthorityConsequencePacket,
 } from '../civicConsequenceNetwork'
 import { applyWeeklyExtranormalEventMonitoringTick } from '../extranormalEventWeeklyMonitoring'
+import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInformationWeeklyRetention'
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
@@ -4576,6 +4577,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   if (Object.keys(currentUnexplainedLocations).length > 0) {
     outputWeeklyState.unexplainedLocationRecords = applyWeeklyUnexplainedLocationLifecycleTick(
       currentUnexplainedLocations,
+      result.week
+    )
+  }
+
+  // SPE-2108 slice 3: expire retention decay timers and advance rediscovery due-week loops.
+  const currentSelfCensoringInformation = outputWeeklyState.selfCensoringInformationRecords ?? {}
+  if (Object.keys(currentSelfCensoringInformation).length > 0) {
+    outputWeeklyState.selfCensoringInformationRecords = applyWeeklySelfCensoringInformationTick(
+      currentSelfCensoringInformation,
       result.week
     )
   }

--- a/src/test/advanceWeek.selfCensoringInformation.integration.test.ts
+++ b/src/test/advanceWeek.selfCensoringInformation.integration.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  REDISCOVERY_LOOP_RECORD_FIXTURE,
+  STUDY_BLOCKED_ARCHIVE_FIXTURE,
+} from '../domain/selfCensoringInformationRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek self-censoring information integration (SPE-2108 slice 3)', () => {
+  it('is a no-op for an empty self-censoring information map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.selfCensoringInformationRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.selfCensoringInformationRecords).toEqual({})
+  })
+
+  it('decrements retentionDecayTimer after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 40
+    state.selfCensoringInformationRecords = {
+      [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: {
+        ...REDISCOVERY_LOOP_RECORD_FIXTURE,
+        retentionDecayTimer: 3,
+      },
+    }
+
+    const nextState = advanceWeek(state)
+    const record = nextState.selfCensoringInformationRecords?.[REDISCOVERY_LOOP_RECORD_FIXTURE.id]
+
+    expect(nextState.week).toBe(41)
+    expect(record?.retentionDecayTimer).toBe(2)
+    expect(record?.rediscoveryLoop).toEqual({
+      loopCount: 1,
+      forgottenWarningRefs: ['warning:wing-c-roster-gap-38', 'warning:wing-c-roster-gap-40'],
+    })
+  })
+
+  it('leaves rediscoveryLoop unchanged before the due week after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 39
+    state.selfCensoringInformationRecords = {
+      [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record = nextState.selfCensoringInformationRecords?.[REDISCOVERY_LOOP_RECORD_FIXTURE.id]
+
+    expect(nextState.week).toBe(40)
+    expect(record?.rediscoveryLoop).toEqual(REDISCOVERY_LOOP_RECORD_FIXTURE.rediscoveryLoop)
+    expect(record?.retentionDecayTimer).toBe(7)
+  })
+
+  it('preserves unrelated record fields byte-stable through advanceWeek tick', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 40
+    state.selfCensoringInformationRecords = {
+      [STUDY_BLOCKED_ARCHIVE_FIXTURE.id]: STUDY_BLOCKED_ARCHIVE_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record = nextState.selfCensoringInformationRecords?.[STUDY_BLOCKED_ARCHIVE_FIXTURE.id]
+
+    expect(record).toEqual(STUDY_BLOCKED_ARCHIVE_FIXTURE)
+  })
+})

--- a/src/test/selfCensoringInformationWeeklyRetention.test.ts
+++ b/src/test/selfCensoringInformationWeeklyRetention.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REDISCOVERY_LOOP_RECORD_FIXTURE,
+  STUDY_BLOCKED_ARCHIVE_FIXTURE,
+  type SelfCensoringInformationRecord,
+} from '../domain/selfCensoringInformationRegistry'
+import {
+  advanceSelfCensoringInformationRecordForWeek,
+  applyWeeklySelfCensoringInformationTick,
+  resolveSelfCensoringRediscoveryAlarmDueWeek,
+} from '../domain/selfCensoringInformationWeeklyRetention'
+
+function retentionRecord(
+  overrides: Partial<SelfCensoringInformationRecord> = {}
+): SelfCensoringInformationRecord {
+  return {
+    id: 'info:retention-timer-test',
+    label: 'Retention timer test record',
+    retentionDecayTimer: 4,
+    ...overrides,
+  }
+}
+
+function rediscoveryRecord(
+  overrides: Partial<SelfCensoringInformationRecord> = {}
+): SelfCensoringInformationRecord {
+  return {
+    id: 'info:rediscovery-loop-test',
+    label: 'Rediscovery loop test record',
+    rediscoveryLoop: {
+      loopCount: 2,
+      lastAlarmWeek: 10,
+      forgottenWarningRefs: ['warning:gap-8', 'warning:gap-9'],
+    },
+    ...overrides,
+  }
+}
+
+describe('selfCensoringInformationWeeklyRetention (SPE-2108 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklySelfCensoringInformationTick({}, 12)).toEqual({})
+    expect(applyWeeklySelfCensoringInformationTick(undefined, 12)).toEqual({})
+  })
+
+  it('resolves rediscovery alarm due week from lastAlarmWeek', () => {
+    expect(resolveSelfCensoringRediscoveryAlarmDueWeek(rediscoveryRecord())).toBe(10)
+    expect(resolveSelfCensoringRediscoveryAlarmDueWeek(REDISCOVERY_LOOP_RECORD_FIXTURE)).toBe(41)
+    expect(
+      resolveSelfCensoringRediscoveryAlarmDueWeek(
+        rediscoveryRecord({ rediscoveryLoop: { loopCount: 1 } })
+      )
+    ).toBeUndefined()
+  })
+
+  it('decrements retentionDecayTimer each week until expiry', () => {
+    const record = retentionRecord({ retentionDecayTimer: 3 })
+    const weekTwo = advanceSelfCensoringInformationRecordForWeek(record, 2)
+
+    expect(weekTwo).not.toBe(record)
+    expect(weekTwo.retentionDecayTimer).toBe(2)
+
+    const weekThree = advanceSelfCensoringInformationRecordForWeek(weekTwo, 3)
+    expect(weekThree.retentionDecayTimer).toBe(1)
+
+    const expired = advanceSelfCensoringInformationRecordForWeek(weekThree, 4)
+    expect(expired.retentionDecayTimer).toBeUndefined()
+  })
+
+  it('leaves retentionDecayTimer unchanged when already absent', () => {
+    const record = STUDY_BLOCKED_ARCHIVE_FIXTURE
+    const advanced = advanceSelfCensoringInformationRecordForWeek(record, 5)
+
+    expect(advanced).toBe(record)
+  })
+
+  it('leaves rediscoveryLoop unchanged while week is before the due week', () => {
+    const record = rediscoveryRecord()
+    const advanced = advanceSelfCensoringInformationRecordForWeek(record, 9)
+
+    expect(advanced).toBe(record)
+    expect(advanced.rediscoveryLoop).toEqual(record.rediscoveryLoop)
+  })
+
+  it('advances rediscoveryLoop when week reaches the due week', () => {
+    const record = rediscoveryRecord()
+    const advanced = advanceSelfCensoringInformationRecordForWeek(record, 10)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.rediscoveryLoop).toEqual({
+      loopCount: 1,
+      forgottenWarningRefs: ['warning:gap-8', 'warning:gap-9'],
+    })
+    expect(advanced.rediscoveryLoop?.lastAlarmWeek).toBeUndefined()
+  })
+
+  it('clears alarm refs when rediscovery loop completes', () => {
+    const record = rediscoveryRecord({
+      rediscoveryLoop: {
+        loopCount: 1,
+        lastAlarmWeek: 12,
+        forgottenWarningRefs: ['warning:final-gap'],
+      },
+    })
+    const advanced = advanceSelfCensoringInformationRecordForWeek(record, 12)
+
+    expect(advanced.rediscoveryLoop).toEqual({ loopCount: 0 })
+  })
+
+  it('is idempotent when re-applied after retention expiry for the same week', () => {
+    const record = retentionRecord({ retentionDecayTimer: 1 })
+    const once = advanceSelfCensoringInformationRecordForWeek(record, 5)
+    const twice = advanceSelfCensoringInformationRecordForWeek(once, 5)
+
+    expect(twice).toBe(once)
+    expect(twice.retentionDecayTimer).toBeUndefined()
+  })
+
+  it('is idempotent when re-applied after rediscovery advance for the same week', () => {
+    const record = rediscoveryRecord()
+    const once = advanceSelfCensoringInformationRecordForWeek(record, 10)
+    const twice = advanceSelfCensoringInformationRecordForWeek(once, 10)
+
+    expect(twice).toBe(once)
+  })
+
+  it('does not mutate invalid post-tick records', () => {
+    const record = {
+      id: 'info:invalid-loop',
+      label: 'Invalid loop record',
+      rediscoveryLoop: {
+        loopCount: 0,
+        lastAlarmWeek: 5,
+        forgottenWarningRefs: ['warning:stale'],
+      },
+    } as SelfCensoringInformationRecord
+
+    const advanced = advanceSelfCensoringInformationRecordForWeek(record, 6)
+
+    expect(advanced).toBe(record)
+  })
+
+  it('applies tick in stable id order without mutating unrelated records', () => {
+    const retention = retentionRecord({ retentionDecayTimer: 1 })
+    const rediscovery = rediscoveryRecord()
+    const studyBlocked = STUDY_BLOCKED_ARCHIVE_FIXTURE
+    const map = {
+      [studyBlocked.id]: studyBlocked,
+      [retention.id]: retention,
+      [rediscovery.id]: rediscovery,
+    }
+
+    const next = applyWeeklySelfCensoringInformationTick(map, 10)
+
+    expect(next[studyBlocked.id]).toBe(studyBlocked)
+    expect(next[retention.id]?.retentionDecayTimer).toBeUndefined()
+    expect(next[rediscovery.id]?.rediscoveryLoop).toEqual({
+      loopCount: 1,
+      forgottenWarningRefs: ['warning:gap-8', 'warning:gap-9'],
+    })
+  })
+
+  it('applies both retention decay and rediscovery advance on the same record', () => {
+    const record = {
+      ...REDISCOVERY_LOOP_RECORD_FIXTURE,
+      retentionDecayTimer: 2,
+    }
+    const advanced = advanceSelfCensoringInformationRecordForWeek(record, 41)
+
+    expect(advanced.retentionDecayTimer).toBe(1)
+    expect(advanced.rediscoveryLoop).toEqual({
+      loopCount: 1,
+      forgottenWarningRefs: ['warning:wing-c-roster-gap-38', 'warning:wing-c-roster-gap-40'],
+    })
+    expect(advanced.label).toBe(record.label)
+    expect(advanced.negativeFacts).toEqual(record.negativeFacts)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds pplyWeeklySelfCensoringInformationTick in src/domain/selfCensoringInformationWeeklyRetention.ts — decrements etentionDecayTimer until expiry and advances ediscoveryLoop when lastAlarmWeek due week is reached.
- Wires the tick into dvanceWeek after week increment (post–unexplained-location hook), mirroring the SPE-2315 extranormal pattern.
- Domain unit tests + dvanceWeek integration test; persistence regression unchanged.

## Linear

- **Slice:** [SPE-2324](https://linear.app/spectranoir/issue/SPE-2324)
- **Parent:** [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108) (slice 1–2 shipped; parent stays open)
- **Umbrella:** [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays open

## What shipped

- Weekly retention decay countdown + rediscovery due-week advance only; no new persistence fields, no UI.
- Invalid post-tick records are rejected without mutating source records.

## Validation

- 
pm run test:run -- src/test/selfCensoringInformationWeeklyRetention.test.ts src/test/advanceWeek.selfCensoringInformation.integration.test.ts src/test/selfCensoringInformationRegistryPersistence.test.ts
- 
pm run lint

## Docs

- planning/self-censoring-information-registry-slice-3.md
- planning/backlog.md handoff SHA updated

## Parent status

SPE-2108 remains open (weekly hook is slice 3 only; SPE-1309 engine wire-up deferred).

Made with [Cursor](https://cursor.com)