### PR TITLE
feat(SPE-2335): mass anomalous population emergence normalization wire-up (slice 5)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -22,7 +22,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-On `main` @ `b74226ae` (post–SPE-2330 merge, PR #2527). [SPE-2330](https://linear.app/spectranoir/issue/SPE-2330) **Done** — self-censoring information planning mirror UI shipped. Pick next compendium/registry slice from active queue.
+On `main` @ `60da9665`. [SPE-2334](https://linear.app/spectranoir/issue/SPE-2334) **Done** — mass anomalous population emergence planning mirror UI shipped (PR #2535). Next: [SPE-2335](https://linear.app/spectranoir/issue/SPE-2335) normalization inputs wire-up (`planning/mass-anomalous-population-emergence-registry-slice-5.md`).
 
 ## Blocked / waiting
 

--- a/planning/mass-anomalous-population-emergence-registry-slice-5.md
+++ b/planning/mass-anomalous-population-emergence-registry-slice-5.md
@@ -1,0 +1,80 @@
+# SPE-2122 — Mass anomalous population emergence normalization inputs wire-up (slice 5)
+
+One-page implementation plan. Linear: [SPE-2335](https://linear.app/spectranoir/issue/SPE-2335) (child under [SPE-2122](https://linear.app/spectranoir/issue/SPE-2122)). Follows shipped slice 4 (`planning/mass-anomalous-population-emergence-registry-slice-4.md`, PR #2535).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2335 — Mass anomalous population emergence normalization inputs wire-up (slice 5)](https://linear.app/spectranoir/issue/SPE-2335) |
+| **Status** | In Progress                                                                                                |
+| **Parent** | [SPE-2122](https://linear.app/spectranoir/issue/SPE-2122) — registry anchor (slice 1–4 shipped); umbrella [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) stays open |
+| **Branch** | `spe-2122-mass-anomalous-population-emergence-normalization-wire-slice-5`                                  |
+| **Base `main` SHA** | `60da9665`                                                                                          |
+
+## Goal
+
+Pure domain derive + compose wire-up: derive `NormalizationInput[]` from persisted `massAnomalousPopulationEmergenceRecords` and merge into `publicDisclosureRecords.normalizationInputs` for consumption by public-disclosure normalization paths.
+
+## Prerequisite (on `main` @ `60da9665`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/massAnomalousPopulationEmergenceRegistry.ts` (SPE-2122 / PR #2441) |
+| Persistence          | `massAnomalousPopulationEmergenceRecords` on `GameState` (SPE-2332 / PR #2531) |
+| Weekly governance hook | `applyWeeklyPopulationEmergenceGovernanceTick` (SPE-2333 / PR #2533) |
+| Disclosure schema    | `NormalizationInput` + `mass_anomalous_population_emergence` kind (SPE-2109 / PR #2430) |
+| Disclosure persistence | `publicDisclosureRecords` on `GameState` (SPE-2325 / PR #2517)       |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `deriveNormalizationInputsFromPopulationEmergenceRecords`          | New persistence fields                     |
+| `composePopulationEmergenceNormalizationIntoDisclosureRecords`     | Mirror UI (slice 4)                           |
+| Call compose from `advanceWeek` after emergence + disclosure ticks | Weekly tick / sanitize contract changes       |
+| Unit + integration tests                                           | SPE-2109 parent Done                            |
+| Slice doc (this file) + backlog handoff                            | SPE-861 / SPE-1343 player UI                    |
+
+## Derive contract
+
+- **Hydrated truth only** — derive from persisted map entries; skip invalid records without re-surfacing dropped payloads.
+- **Governance-mode kinds** — `secrecy_restore` → `cleanup_front`; `managed_disclosure` → `mass_anomalous_population_emergence`; `collapsed_masquerade` → `community_integration_program`.
+- **Week drift** — descriptor includes `resolvePopulationEmergenceGovernanceSurgeForWeek` surge band when projection is available.
+- **Ordering** — sorted by population-emergence record id.
+- **Copy** — CP-neutral descriptors; no franchise tokens.
+
+## Compose contract
+
+- **Qualifying disclosure records** — `official_disclosure` and `normalization` awareness levels only.
+- **Merge** — preserve authored normalization inputs; replace prior wired inputs identified by `population-emergence:` ref prefix.
+- **Strip** — remove wired inputs from pre-disclosure awareness records.
+- **Validation** — invalid post-compose candidate preserves source record.
+
+## Acceptance
+
+- [x] Empty population emergence map is a no-op without throw
+- [x] Derived inputs use governance-mode-specific kinds with deterministic ordering
+- [x] Wired inputs appear on disclosure records when fixtures coexist through `advanceWeek`
+- [x] Authored normalization inputs preserved; invalid/dropped emergence records not re-surfaced
+- [x] Persistence regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/massAnomalousPopulationEmergenceNormalizationInputs.ts`, `src/domain/publicDisclosureNormalizationCompose.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/massAnomalousPopulationEmergenceNormalizationInputs.test.ts`, `src/test/publicDisclosureNormalizationCompose.test.ts`, `src/test/advanceWeek.populationEmergenceNormalization.integration.test.ts` |
+| Plan   | `planning/mass-anomalous-population-emergence-registry-slice-5.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Default ladder auto-progression without pre-scheduled history | SPE-2109 follow-up | Deferred per public-disclosure slice 3 doc |
+| Public-trust engine wire-up | SPE-861 | Parent umbrella; out of normalization compose boundary |
+| Disclosure campaign player UI | SPE-1343 | Out of domain wire-up boundary |
+
+## See also
+
+- `planning/mass-anomalous-population-emergence-registry-slice-4.md`
+- `planning/public-disclosure-state-registry-slice-4.md` — deferred normalization wire-up source

--- a/src/domain/massAnomalousPopulationEmergenceNormalizationInputs.ts
+++ b/src/domain/massAnomalousPopulationEmergenceNormalizationInputs.ts
@@ -1,0 +1,134 @@
+/**
+ * SPE-2122 slice 5: derive public-disclosure normalization inputs from persisted
+ * mass anomalous population emergence records.
+ *
+ * Pure deterministic projection — consumes hydrated records only; does not re-surface
+ * invalid or dropped entries. Governance-mode-specific input kinds with week-drift
+ * surge context via resolvePopulationEmergenceGovernanceSurgeForWeek.
+ */
+
+import {
+  FRANCHISE_TOKEN_PATTERN,
+  BRANDED_OBJECT_NUMBER_PATTERN,
+  validatePopulationEmergenceRecord,
+  type GovernanceMode,
+  type MassAnomalousPopulationEmergenceRecordsMap,
+  type PopulationEmergenceRecord,
+} from './massAnomalousPopulationEmergenceRegistry'
+import { resolvePopulationEmergenceGovernanceSurgeForWeek } from './massAnomalousPopulationEmergenceWeeklyGovernance'
+import type { NormalizationInput, NormalizationInputKind } from './publicDisclosureStateRegistry'
+
+export interface DerivePopulationEmergenceNormalizationInputsPolicy {
+  readonly week?: number
+}
+
+const GOVERNANCE_MODE_NORMALIZATION_KIND: Readonly<Record<GovernanceMode, NormalizationInputKind>> =
+  {
+    secrecy_restore: 'cleanup_front',
+    managed_disclosure: 'mass_anomalous_population_emergence',
+    collapsed_masquerade: 'community_integration_program',
+  }
+
+function normalizeWeek(week: number | undefined): number {
+  if (typeof week !== 'number' || !Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function containsForbiddenToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return (
+    token.length > 0 &&
+    (FRANCHISE_TOKEN_PATTERN.test(token) || BRANDED_OBJECT_NUMBER_PATTERN.test(token))
+  )
+}
+
+function buildDescriptor(
+  record: PopulationEmergenceRecord,
+  week: number
+): string | null {
+  const label = normalizeToken(record.label)
+  if (!label || containsForbiddenToken(label)) {
+    return null
+  }
+
+  const projection = resolvePopulationEmergenceGovernanceSurgeForWeek(record, week)
+  const backlogWeeks = record.registrationBacklogWeeks
+  const surgeFragment =
+    projection.governanceSurgeBand !== null
+      ? `, governance surge ${projection.governanceSurgeBand}`
+      : ''
+
+  const descriptor = `${record.emergenceMagnitudeBand} ${record.governanceMode} population emergence normalization driver: ${label} (backlog ${backlogWeeks}w${surgeFragment})`
+
+  if (!descriptor || containsForbiddenToken(descriptor)) {
+    return null
+  }
+
+  return descriptor
+}
+
+function deriveInputForRecord(
+  record: PopulationEmergenceRecord,
+  week: number
+): NormalizationInput | null {
+  const recordId = normalizeToken(record.id)
+  if (!recordId || containsForbiddenToken(recordId)) {
+    return null
+  }
+
+  if (!validatePopulationEmergenceRecord(record).valid) {
+    return null
+  }
+
+  const descriptor = buildDescriptor(record, week)
+  if (!descriptor) {
+    return null
+  }
+
+  const kind = GOVERNANCE_MODE_NORMALIZATION_KIND[record.governanceMode]
+
+  return Object.freeze({
+    kind,
+    descriptor,
+    ref: recordId,
+  })
+}
+
+/**
+ * Derives disclosure normalization inputs from hydrated population emergence records.
+ * Empty map returns an empty frozen array without throw.
+ */
+export function deriveNormalizationInputsFromPopulationEmergenceRecords(
+  records: MassAnomalousPopulationEmergenceRecordsMap | null | undefined,
+  policy: DerivePopulationEmergenceNormalizationInputsPolicy = {}
+): readonly NormalizationInput[] {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return Object.freeze([])
+  }
+
+  const week = normalizeWeek(policy.week)
+  const inputs: NormalizationInput[] = []
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const input = deriveInputForRecord(record, week)
+    if (input) {
+      inputs.push(input)
+    }
+  }
+
+  return Object.freeze(inputs)
+}

--- a/src/domain/publicDisclosureNormalizationCompose.ts
+++ b/src/domain/publicDisclosureNormalizationCompose.ts
@@ -1,0 +1,142 @@
+/**
+ * SPE-2122 slice 5 / SPE-2109: compose population-emergence-derived normalization
+ * inputs into persisted public disclosure records.
+ *
+ * Pure deterministic merge — strips prior wired inputs by population-emergence ref prefix,
+ * preserves authored normalization inputs, and appends fresh derived inputs on qualifying
+ * disclosure records only.
+ */
+
+import {
+  validatePublicDisclosureRecord,
+  type AwarenessLevel,
+  type NormalizationInput,
+  type PublicDisclosureRecord,
+  type PublicDisclosureRecordsMap,
+} from './publicDisclosureStateRegistry'
+
+const POPULATION_EMERGENCE_REF_PREFIX = 'population-emergence:'
+
+const DISCLOSURE_AWARENESS_LEVELS_FOR_EMERGENCE_WIRE = new Set<AwarenessLevel>([
+  'official_disclosure',
+  'normalization',
+])
+
+function isWiredPopulationEmergenceInput(input: NormalizationInput): boolean {
+  const ref = typeof input.ref === 'string' ? input.ref.trim() : ''
+  return ref.startsWith(POPULATION_EMERGENCE_REF_PREFIX)
+}
+
+function sortNormalizationInputs(inputs: readonly NormalizationInput[]): readonly NormalizationInput[] {
+  return Object.freeze(
+    [...inputs].sort((left, right) => {
+      const refCompare = (left.ref ?? '').localeCompare(right.ref ?? '')
+      if (refCompare !== 0) {
+        return refCompare
+      }
+
+      const kindCompare = left.kind.localeCompare(right.kind)
+      if (kindCompare !== 0) {
+        return kindCompare
+      }
+
+      return left.descriptor.localeCompare(right.descriptor)
+    })
+  )
+}
+
+function mergeNormalizationInputs(
+  existing: readonly NormalizationInput[] | undefined,
+  derived: readonly NormalizationInput[]
+): readonly NormalizationInput[] {
+  const preserved = (existing ?? []).filter((input) => !isWiredPopulationEmergenceInput(input))
+  return sortNormalizationInputs([...preserved, ...derived])
+}
+
+function qualifiesForEmergenceWire(record: PublicDisclosureRecord): boolean {
+  return DISCLOSURE_AWARENESS_LEVELS_FOR_EMERGENCE_WIRE.has(record.awarenessLevel)
+}
+
+function composeRecordNormalizationInputs(
+  record: PublicDisclosureRecord,
+  derivedInputs: readonly NormalizationInput[]
+): PublicDisclosureRecord {
+  const merged = mergeNormalizationInputs(record.normalizationInputs, derivedInputs)
+  const existing = record.normalizationInputs ?? []
+
+  if (
+    merged.length === existing.length &&
+    merged.every((input, index) => {
+      const prior = existing[index]
+      return (
+        prior &&
+        prior.kind === input.kind &&
+        prior.descriptor === input.descriptor &&
+        prior.ref === input.ref
+      )
+    })
+  ) {
+    return record
+  }
+
+  const candidate: PublicDisclosureRecord =
+    merged.length > 0
+      ? {
+          ...record,
+          normalizationInputs: merged,
+        }
+      : {
+          ...record,
+          normalizationInputs: undefined,
+        }
+
+  if (!validatePublicDisclosureRecord(candidate).valid) {
+    return record
+  }
+
+  return Object.freeze(candidate)
+}
+
+/**
+ * Merges population-emergence-derived normalization inputs into qualifying disclosure records.
+ * Empty disclosure map or empty derived inputs with no prior wired inputs is a no-op.
+ */
+export function composePopulationEmergenceNormalizationIntoDisclosureRecords(
+  disclosureRecords: PublicDisclosureRecordsMap | null | undefined,
+  derivedInputs: readonly NormalizationInput[]
+): PublicDisclosureRecordsMap {
+  const safeRecords = disclosureRecords ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const next: PublicDisclosureRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    if (!qualifiesForEmergenceWire(record)) {
+      if ((record.normalizationInputs ?? []).some(isWiredPopulationEmergenceInput)) {
+        const stripped = composeRecordNormalizationInputs(record, [])
+        if (stripped !== record) {
+          next[recordId] = stripped
+          changed = true
+        }
+      }
+      continue
+    }
+
+    const composed = composeRecordNormalizationInputs(record, derivedInputs)
+    if (composed !== record) {
+      next[recordId] = composed
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -263,8 +263,10 @@ import {
   type CompactCivicAuthorityConsequencePacket,
 } from '../civicConsequenceNetwork'
 import { applyWeeklyExtranormalEventMonitoringTick } from '../extranormalEventWeeklyMonitoring'
+import { deriveNormalizationInputsFromPopulationEmergenceRecords } from '../massAnomalousPopulationEmergenceNormalizationInputs'
 import { applyWeeklyPopulationEmergenceGovernanceTick } from '../massAnomalousPopulationEmergenceWeeklyGovernance'
 import { applyWeeklyPatternSourceSeriesIntakeTick } from '../patternSourceSeriesWeeklyIntake'
+import { composePopulationEmergenceNormalizationIntoDisclosureRecords } from '../publicDisclosureNormalizationCompose'
 import { applyWeeklyPublicDisclosureProgressionTick } from '../publicDisclosureWeeklyProgression'
 import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInformationWeeklyRetention'
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
@@ -4619,6 +4621,22 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       applyWeeklyPopulationEmergenceGovernanceTick(
         currentMassAnomalousPopulationEmergenceRecords,
         result.week
+      )
+  }
+
+  // SPE-2122 slice 5: wire population-emergence-derived normalization inputs into disclosure records.
+  const currentDisclosureRecordsForCompose = outputWeeklyState.publicDisclosureRecords ?? {}
+  if (Object.keys(currentDisclosureRecordsForCompose).length > 0) {
+    const derivedPopulationEmergenceNormalizationInputs =
+      deriveNormalizationInputsFromPopulationEmergenceRecords(
+        outputWeeklyState.massAnomalousPopulationEmergenceRecords,
+        { week: result.week }
+      )
+
+    outputWeeklyState.publicDisclosureRecords =
+      composePopulationEmergenceNormalizationIntoDisclosureRecords(
+        currentDisclosureRecordsForCompose,
+        derivedPopulationEmergenceNormalizationInputs
       )
   }
 

--- a/src/test/advanceWeek.populationEmergenceNormalization.integration.test.ts
+++ b/src/test/advanceWeek.populationEmergenceNormalization.integration.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  COLLAPSED_MASQUERADE_EDUCATION_FIXTURE,
+  MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+} from '../domain/massAnomalousPopulationEmergenceRegistry'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  NORMALIZATION_INPUT_FIXTURE,
+} from '../domain/publicDisclosureStateRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek population emergence normalization wire-up (SPE-2122 slice 5)', () => {
+  it('wires derived normalization inputs onto disclosure records when fixtures coexist', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 12
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    }
+    state.massAnomalousPopulationEmergenceRecords = {
+      [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+      [COLLAPSED_MASQUERADE_EDUCATION_FIXTURE.id]: COLLAPSED_MASQUERADE_EDUCATION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const officialRecord = nextState.publicDisclosureRecords?.[DISCLOSURE_PROGRESSION_FIXTURE.id]
+    const normalizationRecord =
+      nextState.publicDisclosureRecords?.[NORMALIZATION_INPUT_FIXTURE.id]
+
+    expect(
+      officialRecord?.normalizationInputs?.some(
+        (input) => input.ref === MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id
+      )
+    ).toBe(true)
+    expect(
+      normalizationRecord?.normalizationInputs?.some(
+        (input) => input.ref === COLLAPSED_MASQUERADE_EDUCATION_FIXTURE.id
+      )
+    ).toBe(true)
+    expect(
+      normalizationRecord?.normalizationInputs?.some(
+        (input) => input.kind === 'anomaly_tourism' && input.ref === 'program:public-tour-pilot-7'
+      )
+    ).toBe(true)
+  })
+
+  it('does not mutate disclosure records when population emergence map is empty', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    }
+    state.massAnomalousPopulationEmergenceRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.publicDisclosureRecords?.[NORMALIZATION_INPUT_FIXTURE.id]).toEqual(
+      NORMALIZATION_INPUT_FIXTURE
+    )
+  })
+})

--- a/src/test/massAnomalousPopulationEmergenceNormalizationInputs.test.ts
+++ b/src/test/massAnomalousPopulationEmergenceNormalizationInputs.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COLLAPSED_MASQUERADE_EDUCATION_FIXTURE,
+  MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+  type PopulationEmergenceRecord,
+} from '../domain/massAnomalousPopulationEmergenceRegistry'
+import { deriveNormalizationInputsFromPopulationEmergenceRecords } from '../domain/massAnomalousPopulationEmergenceNormalizationInputs'
+import { FRANCHISE_TOKEN_PATTERN } from '../domain/publicDisclosureStateRegistry'
+
+describe('massAnomalousPopulationEmergenceNormalizationInputs (SPE-2122 slice 5)', () => {
+  it('returns an empty frozen array for an empty map without throw', () => {
+    expect(deriveNormalizationInputsFromPopulationEmergenceRecords({})).toEqual([])
+    expect(deriveNormalizationInputsFromPopulationEmergenceRecords(null)).toEqual([])
+    expect(deriveNormalizationInputsFromPopulationEmergenceRecords(undefined)).toEqual([])
+  })
+
+  it('derives governance-mode-specific normalization input kinds in deterministic record-id order', () => {
+    const inputs = deriveNormalizationInputsFromPopulationEmergenceRecords(
+      {
+        [COLLAPSED_MASQUERADE_EDUCATION_FIXTURE.id]: COLLAPSED_MASQUERADE_EDUCATION_FIXTURE,
+        [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+      },
+      { week: 12 }
+    )
+
+    expect(inputs).toHaveLength(2)
+    expect(inputs.map((input) => input.ref)).toEqual([
+      COLLAPSED_MASQUERADE_EDUCATION_FIXTURE.id,
+      MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id,
+    ])
+    expect(inputs[0]?.kind).toBe('community_integration_program')
+    expect(inputs[1]?.kind).toBe('mass_anomalous_population_emergence')
+  })
+
+  it('maps secrecy_restore governance mode to cleanup_front normalization kind', () => {
+    const record: PopulationEmergenceRecord = {
+      ...MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+      id: 'population-emergence:secrecy-restore-local',
+      governanceMode: 'secrecy_restore',
+      emergenceMagnitudeBand: 'local',
+    }
+
+    const [input] = deriveNormalizationInputsFromPopulationEmergenceRecords(
+      { [record.id]: record },
+      { week: 3 }
+    )
+
+    expect(input?.kind).toBe('cleanup_front')
+    expect(input?.ref).toBe(record.id)
+  })
+
+  it('includes week-drift governance surge band in descriptor when projection is available', () => {
+    const [input] = deriveNormalizationInputsFromPopulationEmergenceRecords(
+      {
+        [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+      },
+      { week: 20 }
+    )
+
+    expect(input?.descriptor).toContain('managed_disclosure')
+    expect(input?.descriptor).toContain('backlog 6w')
+    expect(input?.descriptor).toMatch(/governance surge (low|elevated|critical)/)
+  })
+
+  it('does not re-surface invalid records from the persisted map', () => {
+    const invalidRecord = {
+      ...MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+      id: 'population-emergence:invalid-empty-triage',
+      triageLanes: [],
+    }
+
+    const inputs = deriveNormalizationInputsFromPopulationEmergenceRecords({
+      [invalidRecord.id]: invalidRecord,
+      [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+    })
+
+    expect(inputs).toHaveLength(1)
+    expect(inputs[0]?.ref).toBe(MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id)
+  })
+
+  it('skips descriptors that would contain franchise tokens', () => {
+    const record: PopulationEmergenceRecord = {
+      ...MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+      id: 'population-emergence:token-label',
+      label: 'Foundation registration surge',
+    }
+
+    expect(FRANCHISE_TOKEN_PATTERN.test(record.label)).toBe(true)
+    expect(deriveNormalizationInputsFromPopulationEmergenceRecords({ [record.id]: record })).toEqual(
+      []
+    )
+  })
+
+  it('returns byte-stable results on repeated calls', () => {
+    const records = {
+      [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+    }
+    const first = deriveNormalizationInputsFromPopulationEmergenceRecords(records, { week: 8 })
+    const second = deriveNormalizationInputsFromPopulationEmergenceRecords(records, { week: 8 })
+
+    expect(first).toEqual(second)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+})

--- a/src/test/publicDisclosureNormalizationCompose.test.ts
+++ b/src/test/publicDisclosureNormalizationCompose.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COLLAPSED_MASQUERADE_EDUCATION_FIXTURE,
+  MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+} from '../domain/massAnomalousPopulationEmergenceRegistry'
+import { deriveNormalizationInputsFromPopulationEmergenceRecords } from '../domain/massAnomalousPopulationEmergenceNormalizationInputs'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  NORMALIZATION_INPUT_FIXTURE,
+  type PublicDisclosureRecord,
+} from '../domain/publicDisclosureStateRegistry'
+import { composePopulationEmergenceNormalizationIntoDisclosureRecords } from '../domain/publicDisclosureNormalizationCompose'
+
+describe('publicDisclosureNormalizationCompose (SPE-2122 slice 5)', () => {
+  it('is a no-op for an empty disclosure map without throw', () => {
+    const derived = deriveNormalizationInputsFromPopulationEmergenceRecords({
+      [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+    })
+
+    expect(composePopulationEmergenceNormalizationIntoDisclosureRecords({}, derived)).toEqual({})
+  })
+
+  it('merges derived inputs onto qualifying official_disclosure and normalization records', () => {
+    const derived = deriveNormalizationInputsFromPopulationEmergenceRecords(
+      {
+        [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+        [COLLAPSED_MASQUERADE_EDUCATION_FIXTURE.id]: COLLAPSED_MASQUERADE_EDUCATION_FIXTURE,
+      },
+      { week: 10 }
+    )
+
+    const composed = composePopulationEmergenceNormalizationIntoDisclosureRecords(
+      {
+        [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+        [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+      },
+      derived
+    )
+
+    const officialRecord = composed[DISCLOSURE_PROGRESSION_FIXTURE.id]
+    const normalizationRecord = composed[NORMALIZATION_INPUT_FIXTURE.id]
+
+    expect(officialRecord?.normalizationInputs?.length).toBeGreaterThan(
+      DISCLOSURE_PROGRESSION_FIXTURE.normalizationInputs?.length ?? 0
+    )
+    expect(normalizationRecord?.normalizationInputs?.length).toBeGreaterThan(
+      NORMALIZATION_INPUT_FIXTURE.normalizationInputs?.length ?? 0
+    )
+    expect(
+      officialRecord?.normalizationInputs?.some(
+        (input) => input.ref === MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id
+      )
+    ).toBe(true)
+    expect(
+      normalizationRecord?.normalizationInputs?.some(
+        (input) => input.ref === COLLAPSED_MASQUERADE_EDUCATION_FIXTURE.id
+      )
+    ).toBe(true)
+    expect(
+      normalizationRecord?.normalizationInputs?.some(
+        (input) => input.kind === 'anomaly_tourism' && input.ref === 'program:public-tour-pilot-7'
+      )
+    ).toBe(true)
+  })
+
+  it('preserves authored normalization inputs while replacing prior wired inputs by ref prefix', () => {
+    const derived = deriveNormalizationInputsFromPopulationEmergenceRecords({
+      [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+    })
+
+    const seeded: PublicDisclosureRecord = {
+      ...DISCLOSURE_PROGRESSION_FIXTURE,
+      normalizationInputs: [
+        {
+          kind: 'product_line',
+          descriptor: 'Authored product normalization line',
+          ref: 'program:authored-product-1',
+        },
+        {
+          kind: 'mass_anomalous_population_emergence',
+          descriptor: 'Stale wired descriptor',
+          ref: MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id,
+        },
+      ],
+    }
+
+    const composed = composePopulationEmergenceNormalizationIntoDisclosureRecords(
+      { [seeded.id]: seeded },
+      derived
+    )
+    const record = composed[seeded.id]
+
+    expect(record?.normalizationInputs).toHaveLength(2)
+    expect(
+      record?.normalizationInputs?.find((input) => input.ref === 'program:authored-product-1')?.kind
+    ).toBe('product_line')
+    expect(
+      record?.normalizationInputs?.find(
+        (input) => input.ref === MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id
+      )?.descriptor
+    ).not.toBe('Stale wired descriptor')
+  })
+
+  it('strips wired inputs from pre-disclosure awareness records', () => {
+    const preDisclosure: PublicDisclosureRecord = {
+      id: 'disclosure:pre-disclosure',
+      label: 'Pre-disclosure record',
+      awarenessLevel: 'credible_leak',
+      falloutPhase: 'leak',
+      normalizationInputs: [
+        {
+          kind: 'mass_anomalous_population_emergence',
+          descriptor: 'Stale wired descriptor',
+          ref: MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id,
+        },
+      ],
+    }
+
+    const composed = composePopulationEmergenceNormalizationIntoDisclosureRecords(
+      { [preDisclosure.id]: preDisclosure },
+      deriveNormalizationInputsFromPopulationEmergenceRecords({
+        [MANAGED_DISCLOSURE_BACKLOG_FIXTURE.id]: MANAGED_DISCLOSURE_BACKLOG_FIXTURE,
+      })
+    )
+
+    expect(composed[preDisclosure.id]?.normalizationInputs).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Add pure derive function mapping persisted population emergence records to governance-mode-specific NormalizationInput[] with week-drift surge descriptors.
- Add compose helper merging wired inputs into official_disclosure and normalization public disclosure records; wire into advanceWeek after emergence and disclosure ticks.
- Unit + integration tests; slice doc and backlog handoff.

## Linear
- Slice: [SPE-2335](https://linear.app/spectranoir/issue/SPE-2335)
- Parent: [SPE-2122](https://linear.app/spectranoir/issue/SPE-2122)
- Umbrella: [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) (stays open)

## Validation
- npm run lint
- npm run test:run -- src/test/massAnomalousPopulationEmergenceNormalizationInputs.test.ts src/test/publicDisclosureNormalizationCompose.test.ts src/test/advanceWeek.populationEmergenceNormalization.integration.test.ts src/test/massAnomalousPopulationEmergenceRegistryPersistence.test.ts

## Docs
- planning/mass-anomalous-population-emergence-registry-slice-5.md
- planning/backlog.md

## Parent status
SPE-2109 and SPE-2122 remain open (normalization wire-up only; no parent closure).

Made with [Cursor](https://cursor.com)