### PR TITLE
feat(SPE-2276): retire legacy team.assignedCaseId alias

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -237,12 +237,18 @@ function createCasesCoverageGame() {
 
   game.teams['t_nightwatch'] = {
     ...game.teams['t_nightwatch'],
-    assignedCaseId: 'case-002',
+    status: {
+      ...(game.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'case-002',
+    },
   }
 
   game.teams['t_greentape'] = {
     ...game.teams['t_greentape'],
-    assignedCaseId: 'case-001',
+    status: {
+      ...(game.teams['t_greentape'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'case-001',
+    },
   }
 
   return game

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -13,6 +13,7 @@ import { buildWeeklyReportTutorialChoices } from '../../features/operations/fron
 import type { AgentData, Candidate } from '../../domain/models'
 import { advanceWeek as advanceWeekDomain } from '../../domain/sim/advanceWeek'
 import { assignTeam, unassignTeam } from '../../domain/sim/assign'
+import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
 import { hireCandidate as hireCandidateDomain } from '../../domain/sim/hire'
 import { scoutCandidate as scoutCandidateDomain } from '../../domain/sim/recruitmentScouting'
 import {
@@ -246,12 +247,12 @@ describe('gameStore', () => {
     useGameStore.getState().assign('case-001', 't_nightwatch')
 
     expect(useGameStore.getState().game.cases['case-001'].assignedTeamIds).toEqual(['t_nightwatch'])
-    expect(useGameStore.getState().game.teams['t_nightwatch'].assignedCaseId).toBe('case-001')
+    expect(getTeamAssignedCaseId(useGameStore.getState().game.teams['t_nightwatch'])).toBe('case-001')
 
     useGameStore.getState().unassign('case-001', 't_nightwatch')
 
     expect(useGameStore.getState().game.cases['case-001'].assignedTeamIds).toEqual([])
-    expect(useGameStore.getState().game.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(useGameStore.getState().game.teams['t_nightwatch'])).toBeNull()
   })
 
   it('advances the simulation and appends a report', () => {

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -1639,7 +1639,6 @@ describe('runTransfer helpers', () => {
     )
 
     expect(teams[teamId]?.status?.assignedCaseId).toBe(caseCanonical)
-    expect(teams[teamId]?.assignedCaseId).toBe(caseCanonical)
   })
 
   it('sanitizeTeamsMap recomposes compositionState from live roster (315)', () => {
@@ -5331,7 +5330,6 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
 
       expect(hydrated.teams[teamId]?.status?.assignedCaseId).toBe(caseCanonical)
-      expect(hydrated.teams[teamId]?.assignedCaseId).toBe(caseCanonical)
 
       const danglingTeamId = 't_dangling_assignment'
       const danglingHydrated = hydrateGame({
@@ -5348,7 +5346,6 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
 
       expect(danglingHydrated.teams[danglingTeamId]?.status?.assignedCaseId).toBeNull()
-      expect(danglingHydrated.teams[danglingTeamId]?.assignedCaseId).toBeUndefined()
     })
 
     it('413 recomputes team status state via resolveTeamStatus for invalid persisted states', () => {
@@ -12572,7 +12569,6 @@ describe('runTransfer import sanitization (326-332)', () => {
 
       expect(aligned.cases[caseId]?.assignedTeamIds).toEqual([teamId])
       expect(aligned.teams[teamId]?.status?.assignedCaseId).toBe(caseId)
-      expect(aligned.teams[teamId]?.assignedCaseId).toBe(caseId)
 
       const danglingTeam = hydrateGame(
         {
@@ -12601,7 +12597,6 @@ describe('runTransfer import sanitization (326-332)', () => {
       )
 
       expect(danglingTeam.teams[teamId]?.status?.assignedCaseId).toBeNull()
-      expect(danglingTeam.teams[teamId]?.assignedCaseId).toBeUndefined()
       expect(danglingTeam.teams[teamId]?.status?.state).toBe('ready')
     })
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -94,7 +94,6 @@ import { sanitizePersistedFieldBasePacket } from '../../domain/fieldBaseStaging'
 import { FACTION_DEFINITIONS, getFactionDefinition, getFactionReputationTier } from '../../domain/factions'
 import { buildTeamCompositionState } from '../../domain/teamComposition'
 import {
-  getTeamAssignedCaseId,
   getTeamMemberIds,
   syncTeamSimulationTeam,
 } from '../../domain/teamSimulation'
@@ -3327,6 +3326,23 @@ function sanitizeTeamRecoveryPressure(value: unknown): number | undefined {
   return clamped > 0 ? clamped : undefined
 }
 
+/** Hydration: prefer status.assignedCaseId; fall back to legacy top-level save field. */
+function resolveHydratedTeamAssignedCaseId(
+  statusRecord: Record<string, unknown> | undefined,
+  legacyAssignedCaseId: unknown
+): Id | null {
+  if (statusRecord) {
+    if (typeof statusRecord.assignedCaseId === 'string') {
+      return statusRecord.assignedCaseId
+    }
+    if (statusRecord.assignedCaseId === null) {
+      return null
+    }
+  }
+
+  return typeof legacyAssignedCaseId === 'string' ? legacyAssignedCaseId : null
+}
+
 /** Hydration 412: team assignment must exist on the case roster mirror. */
 function reconcileTeamAssignedCaseId(
   teamId: string,
@@ -3379,23 +3395,10 @@ export function sanitizeTeamsMap(
     const category = sanitizeTeamCategoryField(reconciledEntry.category)
 
     const statusRecord = isRecord(reconciledEntry.status) ? reconciledEntry.status : undefined
-    const rawAssignedCaseId = getTeamAssignedCaseId({
-      status: statusRecord
-        ? {
-            state: sanitizeTeamStateKind(statusRecord.state, 'ready'),
-            assignedCaseId:
-              typeof statusRecord.assignedCaseId === 'string'
-                ? statusRecord.assignedCaseId
-                : statusRecord.assignedCaseId === null
-                  ? null
-                  : null,
-          }
-        : undefined,
-      assignedCaseId:
-        typeof reconciledEntry.assignedCaseId === 'string'
-          ? reconciledEntry.assignedCaseId
-          : undefined,
-    })
+    const rawAssignedCaseId = resolveHydratedTeamAssignedCaseId(
+      statusRecord,
+      reconciledEntry.assignedCaseId
+    )
     const assignedCaseId = reconcileTeamAssignedCaseId(teamId, rawAssignedCaseId, cases)
     const recoveryPressure = sanitizeTeamRecoveryPressure(reconciledEntry.recoveryPressure)
 
@@ -3411,7 +3414,6 @@ export function sanitizeTeamsMap(
       leaderId,
       tags: sanitizeTagList(reconciledEntry.tags),
       ...(category !== undefined ? { category } : {}),
-      assignedCaseId,
       status: resolveTeamStatus({
         currentState: sanitizeTeamStateKind(
           statusRecord?.state,
@@ -3437,6 +3439,8 @@ export function sanitizeTeamsMap(
     if (recoveryPressure === undefined) {
       delete teamWithoutComposition.recoveryPressure
     }
+
+    delete (teamWithoutComposition as Record<string, unknown>).assignedCaseId
 
     const synced = syncTeamSimulationTeam(teamWithoutComposition, agents, cases)
     const teamsForComposition = {

--- a/src/domain/deploymentReadiness.ts
+++ b/src/domain/deploymentReadiness.ts
@@ -15,7 +15,7 @@ import {
   buildTeamWeakestLinkSummary,
   validateTeamComposition,
 } from './teamComposition'
-import { getTeamMemberIds } from './teamSimulation'
+import { getTeamAssignedCaseId, getTeamMemberIds } from './teamSimulation'
 import type {
   Agent,
   AgentAvailabilityState,
@@ -338,8 +338,8 @@ export function evaluateDeploymentEligibility(
     missionRoutingState === 'blocked' || missionRoutingState === 'deferred'
       ? 'routing-state-blocked'
       : '',
-    (team.status?.assignedCaseId ?? team.assignedCaseId) &&
-    (team.status?.assignedCaseId ?? team.assignedCaseId) !== missionId
+    getTeamAssignedCaseId(team) &&
+    getTeamAssignedCaseId(team) !== missionId
       ? 'capacity-locked'
       : '',
   ]) as DeploymentHardBlockerCode[]
@@ -400,8 +400,7 @@ export function buildTeamDeploymentReadinessState(
   const team = state.teams[teamId]
   const members = team ? getTeamMembers(team, state.agents) : []
   const effectiveMissionId =
-    missionId ??
-    (team?.status?.assignedCaseId ?? team?.assignedCaseId ?? Object.keys(state.cases)[0] ?? '')
+    missionId ?? (team ? getTeamAssignedCaseId(team) : null) ?? Object.keys(state.cases)[0] ?? ''
   const effectiveMission = state.cases[effectiveMissionId]
   const missionValidation =
     team && effectiveMission

--- a/src/domain/missionIntakeRouting.ts
+++ b/src/domain/missionIntakeRouting.ts
@@ -30,6 +30,7 @@ import type {
   MissionTriageDisposition,
   Team,
 } from './models'
+import { getTeamAssignedCaseId } from './teamSimulation'
 
 const MISSION_TRIAGE_THRESHOLDS = {
   critical: 80,
@@ -348,7 +349,7 @@ function buildMissionRoutingCandidate(
   const avgFatigue = members.length > 0
     ? Math.round(members.reduce((sum, member) => sum + member.fatigue, 0) / members.length)
     : 100
-  const assignedCaseId = team.status?.assignedCaseId ?? team.assignedCaseId ?? null
+  const assignedCaseId = getTeamAssignedCaseId(team)
 
   const blockerCodes = uniqueSortedStrings([
     ...eligibility.hardBlockers,

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -661,7 +661,7 @@ export interface TeamSynergyProfile {
 export interface TeamStatus {
   /** Current FSM state for the squad. */
   state: TeamState
-  /** Canonical assignment pointer mirrored to the legacy team field. */
+  /** Canonical assignment pointer for the team's active case. */
   assignedCaseId?: Id | null
 }
 
@@ -1157,9 +1157,6 @@ export interface Team {
    * Runtime state mirrors this from `memberIds`.
    */
   agentIds: Id[]
-
-  /** Legacy compatibility alias mirrored from `status.assignedCaseId`. */
-  assignedCaseId?: Id
 
   /** Optional equipment tags (e.g., "van", "lab-kit"). */
   tags: string[]

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -726,7 +726,6 @@ function releaseTeams(teams: GameState['teams'], releasedTeamIds: string[]): Gam
       releasedTeamIds.includes(id)
         ? {
             ...team,
-            assignedCaseId: undefined,
             status: team.status ? { ...team.status, assignedCaseId: null } : team.status,
           }
         : team,

--- a/src/domain/sim/assign.ts
+++ b/src/domain/sim/assign.ts
@@ -152,7 +152,6 @@ export function assignTeam(state: GameState, caseId: Id, teamId: Id): GameState 
     ...teams,
     [teamId]: {
       ...teams[teamId],
-      assignedCaseId: caseId,
       status: teams[teamId]?.status
         ? { ...teams[teamId].status, assignedCaseId: caseId }
         : teams[teamId]?.status,
@@ -274,7 +273,6 @@ export function launchMajorIncident(
   for (const teamId of selectedTeamIds) {
     nextTeams[teamId] = {
       ...nextTeams[teamId]!,
-      assignedCaseId: caseId,
       status: nextTeams[teamId]?.status
         ? { ...nextTeams[teamId]!.status, assignedCaseId: caseId }
         : nextTeams[teamId]?.status,

--- a/src/domain/sim/teamRelease.ts
+++ b/src/domain/sim/teamRelease.ts
@@ -16,7 +16,6 @@ export function releaseTeamsFromCases(
       releasedTeamIdSet.has(id)
         ? {
             ...team,
-            assignedCaseId: undefined,
             status: team.status ? { ...team.status, assignedCaseId: null } : team.status,
           }
         : team,

--- a/src/domain/sim/validation.ts
+++ b/src/domain/sim/validation.ts
@@ -8,7 +8,7 @@ import {
   type MissionPriorityBand,
   type WeeklyDirectiveId,
 } from '../models'
-import { normalizeGameState } from '../teamSimulation'
+import { getTeamAssignedCaseId, normalizeGameState } from '../teamSimulation'
 import { advanceWeek } from './advanceWeek'
 import { assignTeam } from './assign'
 
@@ -504,7 +504,7 @@ function compareMissionIds(state: GameState, leftId: string, rightId: string) {
 
 function isTeamAssignable(state: GameState, teamId: string, missionId: string) {
   const team = state.teams[teamId]
-  const assignedCaseId = team?.status?.assignedCaseId ?? team?.assignedCaseId ?? null
+  const assignedCaseId = team ? getTeamAssignedCaseId(team) : null
 
   return Boolean(team) && (!assignedCaseId || assignedCaseId === missionId)
 }

--- a/src/domain/stabilityLayer.ts
+++ b/src/domain/stabilityLayer.ts
@@ -20,6 +20,7 @@ import { getTrainingProgram } from '../data/training'
 import { getCertificationDefinitions } from './sim/training-compat'
 import { buildTeamCompositionState } from './teamComposition'
 import { buildTeamDeploymentReadinessState } from './deploymentReadiness'
+import { getTeamAssignedCaseId } from './teamSimulation'
 import { normalizeMissionRoutingState, routeMission, triageMission } from './missionIntakeRouting'
 import { getCandidateFunnelStage, normalizeCandidateHireStatus } from './recruitment'
 import { assessResearchRequirements } from './research'
@@ -1267,9 +1268,10 @@ export function analyzeRuntimeStability(state: GameState): StabilityReport {
       recoveryIds.add('review-frontdesk-fallback-routing')
     }
 
+    const teamAssignedCaseId = getTeamAssignedCaseId(team)
     if (
-      (team.status?.state === 'recovering' && (team.status?.assignedCaseId ?? team.assignedCaseId)) ||
-      (team.status?.state === 'ready' && (team.status?.assignedCaseId ?? team.assignedCaseId) && recomputedReadiness.hardBlockers.includes('capacity-locked'))
+      (team.status?.state === 'recovering' && teamAssignedCaseId) ||
+      (team.status?.state === 'ready' && teamAssignedCaseId && recomputedReadiness.hardBlockers.includes('capacity-locked'))
     ) {
       pushIssue(issues, {
         id: `deployment.impossible-team-status.${team.id}`,

--- a/src/domain/teamComposition.ts
+++ b/src/domain/teamComposition.ts
@@ -15,6 +15,7 @@ import {
   type ValidationIssue,
 } from './models'
 import { getAgentCoverageRoles } from './validateTeam'
+import { getTeamAssignedCaseId } from './teamSimulation'
 
 export interface TeamCompositionValidationResult {
   valid: boolean
@@ -77,20 +78,6 @@ function getTeamMembers(team: Pick<Team, 'memberIds' | 'agentIds'>, agentsById: 
   return getTeamMemberIds(team)
     .map((agentId) => agentsById[agentId])
     .filter((agent): agent is Agent => Boolean(agent))
-}
-
-function getTeamAssignedCaseId(team: Pick<Team, 'status' | 'assignedCaseId'>): Id | null {
-  const statusAssignedCaseId = team.status?.assignedCaseId ?? null
-
-  if (statusAssignedCaseId !== null) {
-    return statusAssignedCaseId
-  }
-
-  if (Object.prototype.hasOwnProperty.call(team, 'assignedCaseId')) {
-    return team.assignedCaseId ?? null
-  }
-
-  return null
 }
 
 function average(values: number[]) {

--- a/src/domain/teamSimulation.ts
+++ b/src/domain/teamSimulation.ts
@@ -645,18 +645,8 @@ export function getUniqueTeamMembers(
     .filter((agent): agent is Agent => Boolean(agent))
 }
 
-export function getTeamAssignedCaseId(team: Pick<Team, 'status' | 'assignedCaseId'>): Id | null {
-  const statusAssignedCaseId = team.status?.assignedCaseId ?? null
-
-  if (statusAssignedCaseId !== null) {
-    return statusAssignedCaseId
-  }
-
-  if (Object.prototype.hasOwnProperty.call(team, 'assignedCaseId')) {
-    return team.assignedCaseId ?? null
-  }
-
-  return null
+export function getTeamAssignedCaseId(team: Pick<Team, 'status'>): Id | null {
+  return team.status?.assignedCaseId ?? null
 }
 
 export function getTeamLeaderId(
@@ -907,7 +897,6 @@ export function syncTeamSimulationTeam(
       memberCount: memberIds.length,
     }),
     agentIds: memberIds,
-    assignedCaseId: assignedCaseId ?? undefined,
   }
 }
 
@@ -957,13 +946,10 @@ function normalizeCaseQueueMirror(state: GameState): NonNullable<GameState['case
 
 function hasTeamMirrorParity(team: Team) {
   const memberIds = getTeamMemberIds(team)
-  const statusAssignedCaseId = team.status?.assignedCaseId ?? null
-  const assignedCaseMirror = team.assignedCaseId ?? null
 
   return (
     areIdListsEqual(team.memberIds, memberIds) &&
-    areIdListsEqual(team.agentIds, memberIds) &&
-    statusAssignedCaseId === assignedCaseMirror
+    areIdListsEqual(team.agentIds, memberIds)
   )
 }
 
@@ -1019,7 +1005,6 @@ function clearDanglingTeamCasePointers(
         teamId,
         {
           ...team,
-          assignedCaseId: undefined,
           status: team.status ? { ...team.status, assignedCaseId: null } : team.status,
         },
       ]

--- a/src/domain/visibility.ts
+++ b/src/domain/visibility.ts
@@ -14,6 +14,7 @@ import {
   type ValidationPressureSource,
 } from './sim/validation'
 import { WEAKEST_LINK_CALIBRATION } from './sim/calibration'
+import { getTeamAssignedCaseId } from './teamSimulation'
 import type {
   WeakestLinkMissionResolutionResult,
   WeakestLinkPenaltyBucket,
@@ -434,7 +435,7 @@ export function explainDeploymentReadiness(
   const team = state.teams[teamId]
   const effectiveMissionId =
     missionId ??
-    (team?.status?.assignedCaseId ?? team?.assignedCaseId ?? Object.keys(state.cases)[0] ?? '')
+    (team ? getTeamAssignedCaseId(team) : null) ?? Object.keys(state.cases)[0] ?? ''
   const mission = state.cases[effectiveMissionId]
 
   if (!team || !mission) {

--- a/src/features/agents/AgentTabsContainer.test.tsx
+++ b/src/features/agents/AgentTabsContainer.test.tsx
@@ -77,7 +77,10 @@ function buildDetailedAgentGame() {
   const seededXp = getXpThresholdForLevel(4) + 20
 
   game.teams.t_nightwatch.agentIds = [agent.id]
-  game.teams.t_nightwatch.assignedCaseId = 'case-001'
+  game.teams.t_nightwatch.status = {
+    ...(game.teams.t_nightwatch.status ?? { state: 'deployed', assignedCaseId: null }),
+    assignedCaseId: 'case-001',
+  }
   game.agents[agent.id] = {
     ...agent,
     status: 'active',

--- a/src/features/agents/AgentsPage.test.tsx
+++ b/src/features/agents/AgentsPage.test.tsx
@@ -60,7 +60,10 @@ it('filters the roster and links into agent detail', async () => {
   ]
 
   game.teams.t_nightwatch.agentIds = [primaryAgent.id]
-  game.teams.t_nightwatch.assignedCaseId = 'case-001'
+  game.teams.t_nightwatch.status = {
+    ...(game.teams.t_nightwatch.status ?? { state: 'deployed', assignedCaseId: null }),
+    assignedCaseId: 'case-001',
+  }
 
   primaryAgent.status = 'active'
   primaryAgent.fatigue = 10

--- a/src/features/agents/agentView.ts
+++ b/src/features/agents/agentView.ts
@@ -318,7 +318,8 @@ export function getAgentView(game: GameState, agentId: string): AgentView | unde
     getTeamMemberIds(team).includes(agentId)
   )
   const team = getAgentTeamContext(game, agentId)
-  const assignedCase = team?.assignedCaseId ? game.cases[team.assignedCaseId] : undefined
+  const assignedCaseId = team?.assignedCaseId
+  const assignedCase = assignedCaseId ? game.cases[assignedCaseId] : undefined
   const trainingEntry = game.trainingQueue.find((entry) => entry.agentId === agentId)
   const materialized = buildMaterializedAgentState(
     game,

--- a/src/features/developer/developerOverlayView.ts
+++ b/src/features/developer/developerOverlayView.ts
@@ -19,6 +19,7 @@ import {
 } from '../../domain/teamComposition'
 import { normalizeMissionRoutingState } from '../../domain/missionIntakeRouting'
 import { analyzeRuntimeStability } from '../../domain/stabilityLayer'
+import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
 import {
   explainDeploymentReadiness,
   explainMissionRouting,
@@ -313,7 +314,7 @@ export function buildDeveloperOverlaySnapshot(game: GameState): DeveloperOverlay
     .sort((left, right) => left.teamId.localeCompare(right.teamId))
   const deploymentSummaries = Object.values(game.teams)
     .map((team) => {
-      const assignedCaseId = team.status?.assignedCaseId ?? team.assignedCaseId
+      const assignedCaseId = getTeamAssignedCaseId(team)
       const caseDeploymentCarryInByAgentId =
         assignedCaseId && game.cases[assignedCaseId]
           ? (game.cases[assignedCaseId].deploymentCarryInByAgentId ?? null)

--- a/src/test/agentModel.integration.test.ts
+++ b/src/test/agentModel.integration.test.ts
@@ -529,8 +529,7 @@ describe('core agent model integration', () => {
     state.clearanceLevel = 1
     state.funding = 100
     state.recruitmentPool = []
-    team.status!.assignedCaseId = null
-    team.assignedCaseId = 'case-001'
+    team.agentIds = [...team.memberIds!, 'a_missing']
 
     expect(hasGameStateMirrorParity(state)).toBe(false)
 
@@ -541,7 +540,6 @@ describe('core agent model integration', () => {
     expect(normalized.clearanceLevel).toBe(1)
     expect(normalized.funding).toBe(100)
     expect(normalized.recruitmentPool).toEqual([candidate])
-    expect(normalized.teams.t_nightwatch.status!.assignedCaseId).toBe(null)
-    expect(normalized.teams.t_nightwatch.assignedCaseId).toBeUndefined()
+    expect(normalized.teams.t_nightwatch.agentIds).toEqual(normalized.teams.t_nightwatch.memberIds)
   })
 })

--- a/src/test/caseInsights.test.ts
+++ b/src/test/caseInsights.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { getCaseAssignmentInsights } from '../features/cases/caseInsights'
 
+function assignTeamToCase(
+  game: ReturnType<typeof createStartingState>,
+  teamId: string,
+  caseId: string
+) {
+  game.teams[teamId] = {
+    ...game.teams[teamId],
+    status: {
+      ...(game.teams[teamId].status ?? { state: 'deployed', assignedCaseId: null }),
+      state: 'deployed',
+      assignedCaseId: caseId,
+    },
+  }
+}
+
 describe('getCaseAssignmentInsights', () => {
   it('blocks teams when case is resolved', () => {
     const game = createStartingState()
@@ -23,10 +38,7 @@ describe('getCaseAssignmentInsights', () => {
     const currentCase = game.cases['case-001']
 
     // Assign t_nightwatch to a different case
-    game.teams['t_nightwatch'] = {
-      ...game.teams['t_nightwatch'],
-      assignedCaseId: 'case-002',
-    }
+    assignTeamToCase(game, 't_nightwatch', 'case-002')
 
     const insights = getCaseAssignmentInsights(currentCase, game)
     const blockedNightwatch = insights.blockedTeams.find((view) => view.team.id === 't_nightwatch')
@@ -190,10 +202,7 @@ describe('getCaseAssignmentInsights', () => {
       raid: { minTeams: 1, maxTeams: 3 },
       assignedTeamIds: ['t_nightwatch'],
     }
-    game.teams['t_nightwatch'] = {
-      ...game.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(game, 't_nightwatch', 'case-001')
 
     const insights = getCaseAssignmentInsights(game.cases['case-001'], game)
 

--- a/src/test/caseResolution.abstraction.test.ts
+++ b/src/test/caseResolution.abstraction.test.ts
@@ -4,6 +4,7 @@ import { createStartingState } from '../data/startingState'
 import { assignTeam } from '../domain/sim/assign'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { resolveCase } from '../domain/sim/resolve'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 
 const FORBIDDEN_PLAYBACK_FIELDS = [
   'animationQueue',
@@ -48,14 +49,17 @@ describe('case resolution abstraction', () => {
     }
     state.teams['t_nightwatch'] = {
       ...state.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
+      status: {
+        ...(state.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+        assignedCaseId: 'case-001',
+      },
     }
 
     const next = advanceWeek(state)
     const report = next.reports.at(-1)
 
     expect(next.cases['case-001'].status).toBe('resolved')
-    expect(next.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBeNull()
     expect(report).toMatchObject({
       resolvedCases: ['case-001'],
       notes: expect.any(Array),

--- a/src/test/contracts.test.ts
+++ b/src/test/contracts.test.ts
@@ -12,7 +12,7 @@ import {
   sanitizeContractSystemState,
 } from '../domain/contracts'
 import { advanceWeek } from '../domain/sim/advanceWeek'
-import { syncTeamSimulationState } from '../domain/teamSimulation'
+import { getTeamAssignedCaseId, syncTeamSimulationState } from '../domain/teamSimulation'
 import type { AgentRole, ContractOffer } from '../domain/models'
 
 const RECON_FAVORABLE_ROLES = ['hunter', 'tech', 'investigator'] satisfies AgentRole[]
@@ -108,13 +108,13 @@ describe('contract system', () => {
     expect(activeCase).toBeDefined()
     expect(activeCase?.status).toBe('in_progress')
     expect(activeCase?.weeksRemaining).toBe(offer.durationWeeks)
-    expect(launched.teams['t_nightwatch'].assignedCaseId).toBe(activeCase?.id)
+    expect(getTeamAssignedCaseId(launched.teams['t_nightwatch'])).toBe(activeCase?.id)
 
     const afterOneWeek = advanceWeek(launched)
 
     expect(afterOneWeek.cases[activeCase!.id]?.status).toBe('in_progress')
     expect(afterOneWeek.cases[activeCase!.id]?.weeksRemaining).toBe(offer.durationWeeks - 1)
-    expect(afterOneWeek.teams['t_nightwatch'].assignedCaseId).toBe(activeCase!.id)
+    expect(getTeamAssignedCaseId(afterOneWeek.teams['t_nightwatch'])).toBe(activeCase!.id)
   })
 
   it('multi-stage contract chains unlock after successful completion', () => {

--- a/src/test/dashboardView.test.ts
+++ b/src/test/dashboardView.test.ts
@@ -7,6 +7,21 @@ import {
   getLatestReportSummary,
 } from '../features/dashboard/dashboardView'
 
+function assignTeamToCase(
+  game: ReturnType<typeof createStartingState>,
+  teamId: string,
+  caseId: string
+) {
+  game.teams[teamId] = {
+    ...game.teams[teamId],
+    status: {
+      ...(game.teams[teamId].status ?? { state: 'deployed', assignedCaseId: null }),
+      state: 'deployed',
+      assignedCaseId: caseId,
+    },
+  }
+}
+
 function setTeamFatigue(
   game: ReturnType<typeof createStartingState>,
   teamId: string,
@@ -47,10 +62,7 @@ describe('getFieldStatusViews', () => {
       assignedTeamIds: ['t_nightwatch'],
       weeksRemaining: expectedRemaining,
     }
-    assigned.teams['t_nightwatch'] = {
-      ...assigned.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(assigned, 't_nightwatch', 'case-001')
     setTeamFatigue(assigned, 't_nightwatch', 12)
 
     const views = getFieldStatusViews(assigned)
@@ -69,10 +81,7 @@ describe('getFieldStatusViews', () => {
       assignedTeamIds: ['t_nightwatch'],
       weeksRemaining: 1,
     }
-    assigned.teams['t_nightwatch'] = {
-      ...assigned.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(assigned, 't_nightwatch', 'case-001')
     setTeamFatigue(assigned, 't_nightwatch', 45)
 
     const views = getFieldStatusViews(assigned)
@@ -118,14 +127,8 @@ describe('getFieldStatusViews', () => {
       assignedTeamIds: ['t_greentape'],
     }
 
-    game.teams['t_nightwatch'] = {
-      ...game.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
-    }
-    game.teams['t_greentape'] = {
-      ...game.teams['t_greentape'],
-      assignedCaseId: 'case-002',
-    }
+    assignTeamToCase(game, 't_nightwatch', 'case-001')
+    assignTeamToCase(game, 't_greentape', 'case-002')
 
     const views = getFieldStatusViews(game)
     const ids = views.map((view) => view.team.id)
@@ -145,10 +148,7 @@ describe('getFieldStatusViews', () => {
       deadlineRemaining: 1,
       stage: 4,
     }
-    assigned.teams['t_nightwatch'] = {
-      ...assigned.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(assigned, 't_nightwatch', 'case-001')
 
     const views = getFieldStatusViews(assigned)
     const nightWatch = views.find((view) => view.team.id === 't_nightwatch')
@@ -169,10 +169,7 @@ describe('getFieldStatusViews', () => {
       assignedTeamIds: ['t_nightwatch'],
       weeksRemaining: 2,
     }
-    game.teams['t_nightwatch'] = {
-      ...game.teams['t_nightwatch'],
-      assignedCaseId: 'case-003',
-    }
+    assignTeamToCase(game, 't_nightwatch', 'case-003')
 
     const views = getFieldStatusViews(game)
     const nightWatch = views.find((view) => view.team.id === 't_nightwatch')
@@ -196,10 +193,7 @@ describe('getDashboardMetrics', () => {
       stage: 4,
       weeksRemaining: 1,
     }
-    game.teams['t_nightwatch'] = {
-      ...game.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(game, 't_nightwatch', 'case-001')
     setTeamFatigue(game, 't_nightwatch', 60)
 
     const metrics = getDashboardMetrics(game)

--- a/src/test/expeditionRecoveryNode.test.ts
+++ b/src/test/expeditionRecoveryNode.test.ts
@@ -245,7 +245,7 @@ describe('expeditionRecoveryNode (SPE-99)', () => {
         name: 'T',
         agentIds: ['a1', 'a2'],
         tags: [],
-        assignedCaseId: 'case-s',
+        status: { state: 'deployed', assignedCaseId: 'case-s' },
       },
     }
     const cases: GameState['cases'] = { 'case-s': caseWithSanctuary }

--- a/src/test/fieldBaseStaging.test.ts
+++ b/src/test/fieldBaseStaging.test.ts
@@ -144,7 +144,10 @@ describe('field base staging (SPE-1654)', () => {
         },
         [deployedTeamId]: {
           ...shell.teams[deployedTeamId]!,
-          assignedCaseId: 'case_exp',
+          status: {
+            ...(shell.teams[deployedTeamId]!.status ?? { state: 'deployed', assignedCaseId: null }),
+            assignedCaseId: 'case_exp',
+          },
         },
       },
       agents: {
@@ -231,7 +234,10 @@ describe('field base staging (SPE-1654)', () => {
         },
         [deployedTeamId]: {
           ...shell.teams[deployedTeamId]!,
-          assignedCaseId: 'case_exp',
+          status: {
+            ...(shell.teams[deployedTeamId]!.status ?? { state: 'deployed', assignedCaseId: null }),
+            assignedCaseId: 'case_exp',
+          },
         },
       },
       agents: {

--- a/src/test/helpers/weeklyMvpLoopProof.ts
+++ b/src/test/helpers/weeklyMvpLoopProof.ts
@@ -52,7 +52,6 @@ export function createWeeklyMvpLoopProofFixture(): WeeklyMvpLoopProofFixture {
   }
 
   for (const team of Object.values(state.teams)) {
-    team.assignedCaseId = undefined
     if (team.status) {
       team.status = { ...team.status, assignedCaseId: null }
     }

--- a/src/test/reportTeamStatus.test.ts
+++ b/src/test/reportTeamStatus.test.ts
@@ -46,11 +46,16 @@ describe('reportTeamStatus (SPE-99)', () => {
     }
     const sourceTeam: Team = {
       ...shell.teams.t_nightwatch,
-      assignedCaseId: 'case_exp',
+      status: {
+        ...(shell.teams.t_nightwatch.status ?? { state: 'deployed', assignedCaseId: null }),
+        assignedCaseId: 'case_exp',
+      },
     }
     const releasedTeam: Team = {
       ...shell.teams.t_nightwatch,
-      assignedCaseId: undefined,
+      status: shell.teams.t_nightwatch.status
+        ? { ...shell.teams.t_nightwatch.status, assignedCaseId: null }
+        : { state: 'ready', assignedCaseId: null },
     }
 
     const entry = buildReportTeamStatusEntry(

--- a/src/test/selectorParityFixtures.ts
+++ b/src/test/selectorParityFixtures.ts
@@ -195,7 +195,7 @@ export function makeAlreadyAssignedFixture(): GameState {
 
   state.teams['team-good'] = {
     ...state.teams['team-good'],
-    assignedCaseId: 'case-good',
+    status: { state: 'deployed', assignedCaseId: 'case-good' },
   }
 
   return normalizeGameState(state)
@@ -214,11 +214,11 @@ export function makeRaidAtCapacityFixture(): GameState {
 
   state.teams['team-good'] = {
     ...state.teams['team-good'],
-    assignedCaseId: 'raid-capacity',
+    status: { state: 'deployed', assignedCaseId: 'raid-capacity' },
   }
   state.teams['team-bad'] = {
     ...state.teams['team-bad'],
-    assignedCaseId: 'raid-capacity',
+    status: { state: 'deployed', assignedCaseId: 'raid-capacity' },
   }
 
   return normalizeGameState(state)
@@ -384,7 +384,7 @@ export function makeDeployedTeamFixture(): GameState {
 
   state.teams['team-good'] = {
     ...state.teams['team-good'],
-    assignedCaseId: 'case-good',
+    status: { state: 'deployed', assignedCaseId: 'case-good' },
   }
 
   return normalizeGameState(state)
@@ -416,7 +416,7 @@ export function makeTeamBuilderParityFixture(): GameState {
       ['agent-deployed'],
       'agent-deployed',
       ['combat'],
-      { assignedCaseId: 'case-active' }
+      { status: { state: 'deployed', assignedCaseId: 'case-active' } }
     ),
     'team-idle': makeTeam(
       'team-idle',
@@ -461,7 +461,7 @@ export function makeRaidUnderCapacityFixture(): GameState {
       ['agent-anchor'],
       'agent-anchor',
       ['combat'],
-      { assignedCaseId: 'raid-under-capacity' }
+      { status: { state: 'deployed', assignedCaseId: 'raid-under-capacity' } }
     ),
     'team-beta': makeTeam('team-beta', 'Beta Team', ['agent-beta'], 'agent-beta', ['tech']),
     'team-gamma': makeTeam('team-gamma', 'Gamma Team', ['agent-gamma'], 'agent-gamma', ['occult']),
@@ -530,7 +530,7 @@ export function makeTrainingSelectorParityFixture(): GameState {
       ['agent-deployed-a', 'agent-deployed-b'],
       'agent-deployed-a',
       ['investigation'],
-      { assignedCaseId: 'case-deployed' }
+      { status: { state: 'deployed', assignedCaseId: 'case-deployed' } }
     ),
     'team-inactive': makeTeam(
       'team-inactive',

--- a/src/test/sim.advanceWeek.test.ts
+++ b/src/test/sim.advanceWeek.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../domain/sim/advanceWeek'
 import { refreshContractBoard, getContractOffers, launchContract } from '../domain/contracts'
 import { assignTeam, launchMajorIncident } from '../domain/sim/assign'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 import { queueFabrication } from '../domain/sim/production'
 import { computeTeamScore } from '../domain/sim/scoring'
 import { buildAgencyProtocolState } from '../domain/protocols'
@@ -132,9 +133,9 @@ it('keeps launched major incident teams locked while weeks remain', () => {
 
   expect(next.cases['major-incident'].status).toBe('in_progress')
   expect(next.cases['major-incident'].weeksRemaining).toBeGreaterThan(0)
-  expect(next.teams['team-alpha'].assignedCaseId).toBe('major-incident')
-  expect(next.teams['team-bravo'].assignedCaseId).toBe('major-incident')
-  expect(next.teams['team-charlie'].assignedCaseId).toBe('major-incident')
+  expect(getTeamAssignedCaseId(next.teams['team-alpha'])).toBe('major-incident')
+  expect(getTeamAssignedCaseId(next.teams['team-bravo'])).toBe('major-incident')
+  expect(getTeamAssignedCaseId(next.teams['team-charlie'])).toBe('major-incident')
 })
 
 function getPressureThresholdSpawnEvent(events: OperationEvent[]) {
@@ -315,11 +316,17 @@ function makeAggregateBattleIntegrationState() {
   }
   state.teams['t_nightwatch'] = {
     ...state.teams['t_nightwatch'],
-    assignedCaseId: 'case-raid-battle',
+    status: {
+      ...(state.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'case-raid-battle',
+    },
   }
   state.teams['t_greentape'] = {
     ...state.teams['t_greentape'],
-    assignedCaseId: 'case-raid-battle',
+    status: {
+      ...(state.teams['t_greentape'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'case-raid-battle',
+    },
   }
 
   for (const agentId of state.teams['t_nightwatch'].agentIds) {
@@ -395,11 +402,17 @@ function makeParallelObjectiveAggregateBattleState() {
   }
   state.teams['t_nightwatch'] = {
     ...state.teams['t_nightwatch'],
-    assignedCaseId: 'case-ritual-battle',
+    status: {
+      ...(state.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'case-ritual-battle',
+    },
   }
   state.teams['t_greentape'] = {
     ...state.teams['t_greentape'],
-    assignedCaseId: 'case-ritual-battle',
+    status: {
+      ...(state.teams['t_greentape'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'case-ritual-battle',
+    },
   }
 
   for (const agentId of state.teams['t_nightwatch'].agentIds) {
@@ -1429,17 +1442,23 @@ describe('advanceWeek', () => {
     }
     state.teams['t_nightwatch'] = {
       ...state.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
+      status: {
+        ...(state.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+        assignedCaseId: 'case-001',
+      },
     }
     state.teams['t_greentape'] = {
       ...state.teams['t_greentape'],
-      assignedCaseId: 'case-001',
+      status: {
+        ...(state.teams['t_greentape'].status ?? { state: 'deployed', assignedCaseId: null }),
+        assignedCaseId: 'case-001',
+      },
     }
 
     const next = advanceWeek(state)
 
-    expect(next.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
-    expect(next.teams['t_greentape'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBeNull()
+    expect(getTeamAssignedCaseId(next.teams['t_greentape'])).toBeNull()
     expect(next.teams['t_greentape'].status?.assignedCaseId ?? null).toBeNull()
   })
 
@@ -1772,7 +1791,7 @@ describe('advanceWeek', () => {
     const next = advanceWeek(state)
 
     expect(next.cases['case-001'].deadlineRemaining).toBe(2)
-    expect(next.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBeNull()
     expect(next.teams['t_nightwatch'].status?.assignedCaseId ?? null).toBeNull()
   })
 
@@ -2627,8 +2646,20 @@ describe('advanceWeek', () => {
       preferredTags: [],
       raid: { minTeams: 2, maxTeams: 2 },
     }
-    base.teams['t_nightwatch'] = { ...base.teams['t_nightwatch'], assignedCaseId: raidCaseId }
-    base.teams['team-x'] = { ...base.teams['team-x'], assignedCaseId: raidCaseId }
+    base.teams['t_nightwatch'] = {
+      ...base.teams['t_nightwatch'],
+      status: {
+        ...(base.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+        assignedCaseId: raidCaseId,
+      },
+    }
+    base.teams['team-x'] = {
+      ...base.teams['team-x'],
+      status: {
+        ...(base.teams['team-x'].status ?? { state: 'deployed', assignedCaseId: null }),
+        assignedCaseId: raidCaseId,
+      },
+    }
 
     const nextA = advanceWeek(structuredClone(base))
     const nextB = advanceWeek(structuredClone(base))
@@ -2636,8 +2667,8 @@ describe('advanceWeek', () => {
     // Deterministic across runs
     expect(nextA.cases[raidCaseId]).toEqual(nextB.cases[raidCaseId])
     expect(nextA.reports[0].resolvedCases).toEqual(['raid-test'])
-    expect(nextA.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
-    expect(nextA.teams['team-x'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(nextA.teams['t_nightwatch'])).toBeNull()
+    expect(getTeamAssignedCaseId(nextA.teams['team-x'])).toBeNull()
     expect(nextA.agents['a_ava'].assignment?.state).toBe('idle')
     expect(nextA.agents['agent-x'].assignment?.state).toBe('idle')
     expect(

--- a/src/test/sim.assign.test.ts
+++ b/src/test/sim.assign.test.ts
@@ -2,7 +2,19 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { assignTeam, launchMajorIncident, unassignTeam } from '../domain/sim/assign'
-import type { OperationEvent } from '../domain/models'
+import type { OperationEvent, Team } from '../domain/models'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
+
+function assignTeamCaseFixture(team: Team, caseId: string): Team {
+  return {
+    ...team,
+    status: {
+      ...(team.status ?? { state: 'deployed', assignedCaseId: null }),
+      state: 'deployed',
+      assignedCaseId: caseId,
+    },
+  }
+}
 
 describe('assignTeam', () => {
   it('returns the same state when the target case does not exist', () => {
@@ -32,8 +44,8 @@ describe('assignTeam', () => {
     const withBravo = assignTeam(withAlpha, 'case-001', 't_greentape')
 
     expect(withBravo.cases['case-001'].assignedTeamIds).toEqual(['t_greentape'])
-    expect(withBravo.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
-    expect(withBravo.teams['t_greentape'].assignedCaseId).toBe('case-001')
+    expect(getTeamAssignedCaseId(withBravo.teams['t_nightwatch'])).toBeNull()
+    expect(getTeamAssignedCaseId(withBravo.teams['t_greentape'])).toBe('case-001')
   })
 
   it('emits assignment events for new and replaced team assignments', () => {
@@ -85,30 +97,26 @@ describe('assignTeam', () => {
       assignedTeamIds: ['t_nightwatch', 't_greentape'],
       weeksRemaining: 1,
     }
-    state.teams['t_nightwatch'] = { ...state.teams['t_nightwatch'], assignedCaseId: 'case-001' }
-    state.teams['t_greentape'] = { ...state.teams['t_greentape'], assignedCaseId: 'case-001' }
+    state.teams['t_nightwatch'] = assignTeamCaseFixture(state.teams['t_nightwatch'], 'case-001')
+    state.teams['t_greentape'] = assignTeamCaseFixture(state.teams['t_greentape'], 'case-001')
 
     const next = assignTeam(state, 'case-001', 'team-charlie')
 
     expect(next).not.toBe(state)
     expect(next.cases['case-001'].assignedTeamIds).toEqual(['t_nightwatch', 't_greentape'])
-    expect(next.teams['team-charlie'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['team-charlie'])).toBeNull()
     expect(next.teams['t_nightwatch'].status?.assignedCaseId).toBe('case-001')
     expect(next.teams['t_greentape'].status?.assignedCaseId).toBe('case-001')
   })
 
   it('returns the same state when the team is already assigned to another case', () => {
     const state = createStartingState()
-    state.teams['t_nightwatch'] = {
-      ...state.teams['t_nightwatch'],
-      assignedCaseId: 'case-002',
-    }
+    state.teams['t_nightwatch'] = assignTeamCaseFixture(state.teams['t_nightwatch'], 'case-002')
 
     const next = assignTeam(state, 'case-001', 't_nightwatch')
 
-    expect(next).not.toBe(state)
     expect(next.cases['case-001'].assignedTeamIds).toEqual([])
-    expect(next.teams['t_nightwatch'].status?.assignedCaseId).toBe(null)
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBe('case-002')
   })
 
   it('rejects assignments that do not satisfy required tags', () => {
@@ -122,7 +130,7 @@ describe('assignTeam', () => {
 
     expect(next).toBe(state)
     expect(next.cases['case-003'].assignedTeamIds).toEqual([])
-    expect(next.teams['t_greentape'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_greentape'])).toBeNull()
   })
 
   it('rejects assignments that do not satisfy required role coverage', () => {
@@ -137,7 +145,7 @@ describe('assignTeam', () => {
 
     expect(next).toBe(state)
     expect(next.cases['case-003'].assignedTeamIds).toEqual([])
-    expect(next.teams['t_greentape'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_greentape'])).toBeNull()
   })
 
   it('rejects assignments when the only matching capability comes from a dead agent', () => {
@@ -156,7 +164,7 @@ describe('assignTeam', () => {
 
     expect(next).not.toBe(state)
     expect(next.cases['case-003'].assignedTeamIds).toEqual([])
-    expect(next.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBeNull()
     expect(next.teams['t_nightwatch'].derivedStats?.overall).toBeGreaterThan(0)
   })
 
@@ -174,7 +182,7 @@ describe('assignTeam', () => {
 
     expect(next).not.toBe(state)
     expect(next.cases['case-001'].assignedTeamIds).toEqual(['t_nightwatch'])
-    expect(next.teams['t_nightwatch'].assignedCaseId).toBe('case-001')
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBe('case-001')
   })
 
   it('rejects raid additions from squads with no deployable members even when other teams satisfy the case', () => {
@@ -187,7 +195,7 @@ describe('assignTeam', () => {
       requiredRoles: ['technical'],
       assignedTeamIds: ['t_nightwatch'],
     }
-    state.teams['t_nightwatch'] = { ...state.teams['t_nightwatch'], assignedCaseId: 'case-001' }
+    state.teams['t_nightwatch'] = assignTeamCaseFixture(state.teams['t_nightwatch'], 'case-001')
     state.teams['team-empty'] = {
       id: 'team-empty',
       name: 'Empty Frame',
@@ -207,7 +215,7 @@ describe('assignTeam', () => {
 
     expect(next).not.toBe(state)
     expect(next.cases['case-001'].assignedTeamIds).toEqual(['t_nightwatch'])
-    expect(next.teams['team-empty'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['team-empty'])).toBeNull()
     expect(next.teams['team-empty'].status).toBeDefined()
   })
 })
@@ -221,19 +229,19 @@ describe('unassignTeam', () => {
       kind: 'raid',
       raid: { minTeams: 2, maxTeams: 2 },
       status: 'in_progress',
-      assignedTeamIds: ['team-alpha', 'team-bravo'],
+      assignedTeamIds: ['t_nightwatch', 't_greentape'],
       weeksRemaining: 2,
     }
-    state.teams['team-alpha'] = { ...state.teams['team-alpha'], assignedCaseId: 'case-001' }
-    state.teams['team-bravo'] = { ...state.teams['team-bravo'], assignedCaseId: 'case-001' }
+    state.teams['t_nightwatch'] = assignTeamCaseFixture(state.teams['t_nightwatch'], 'case-001')
+    state.teams['t_greentape'] = assignTeamCaseFixture(state.teams['t_greentape'], 'case-001')
 
     const next = unassignTeam(state, 'case-001')
 
     expect(next.cases['case-001'].assignedTeamIds).toEqual([])
     expect(next.cases['case-001'].status).toBe('open')
     expect(next.cases['case-001'].weeksRemaining).toBeUndefined()
-    expect(next.teams['team-alpha'].assignedCaseId).toBeUndefined()
-    expect(next.teams['team-bravo'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBeNull()
+    expect(getTeamAssignedCaseId(next.teams['t_greentape'])).toBeNull()
   })
 
   it('returns the same state when the case does not exist', () => {
@@ -273,8 +281,8 @@ describe('unassignTeam', () => {
       weeksRemaining: 1,
       assignedTeamIds: ['t_nightwatch', 't_greentape'],
     }
-    state.teams['t_nightwatch'] = { ...state.teams['t_nightwatch'], assignedCaseId: 'case-001' }
-    state.teams['t_greentape'] = { ...state.teams['t_greentape'], assignedCaseId: 'case-001' }
+    state.teams['t_nightwatch'] = assignTeamCaseFixture(state.teams['t_nightwatch'], 'case-001')
+    state.teams['t_greentape'] = assignTeamCaseFixture(state.teams['t_greentape'], 'case-001')
 
     const cleared = unassignTeam(state, 'case-001')
     const reassigned = assignTeam(cleared, 'case-001', 't_nightwatch')
@@ -312,8 +320,8 @@ describe('unassignTeam', () => {
     ])
 
     expect(assignedBackNightWatch.cases['case-001'].assignedTeamIds).toEqual(['t_nightwatch'])
-    expect(assignedBackNightWatch.teams['t_nightwatch'].assignedCaseId).toBe('case-001')
-    expect(assignedBackNightWatch.teams['t_greentape'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(assignedBackNightWatch.teams['t_nightwatch'])).toBe('case-001')
+    expect(getTeamAssignedCaseId(assignedBackNightWatch.teams['t_greentape'])).toBeNull()
   })
 })
 
@@ -345,9 +353,9 @@ describe('launchMajorIncident', () => {
       'team-charlie',
     ])
     expect(next.cases['major-incident'].majorIncident?.requiredTeams).toBe(3)
-    expect(next.teams['team-alpha'].assignedCaseId).toBe('major-incident')
-    expect(next.teams['team-bravo'].assignedCaseId).toBe('major-incident')
-    expect(next.teams['team-charlie'].assignedCaseId).toBe('major-incident')
+    expect(getTeamAssignedCaseId(next.teams['team-alpha'])).toBe('major-incident')
+    expect(getTeamAssignedCaseId(next.teams['team-bravo'])).toBe('major-incident')
+    expect(getTeamAssignedCaseId(next.teams['team-charlie'])).toBe('major-incident')
     expect(next.inventory['medical_supplies']).toBe(state.inventory['medical_supplies'] - 2)
   })
 
@@ -366,7 +374,7 @@ describe('launchMajorIncident', () => {
       'team-bravo',
       'team-charlie',
     ])
-    expect(next.teams['team-alpha'].assignedCaseId).toBe('major-incident')
+    expect(getTeamAssignedCaseId(next.teams['team-alpha'])).toBe('major-incident')
   })
 })
 

--- a/src/test/sim.immutability-fix-validation.test.ts
+++ b/src/test/sim.immutability-fix-validation.test.ts
@@ -3,6 +3,7 @@ import { createStartingState } from '../data/startingState'
 import { type CaseInstance } from '../domain/models'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { assignTeam } from '../domain/sim/assign'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 
 function createControlledState() {
   const state = createStartingState()
@@ -78,7 +79,7 @@ describe('Immutability Fix Validation', () => {
     const next = advanceWeek(assigned)
 
     // Verify team was released
-    expect(next.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(next.teams['t_nightwatch'])).toBeNull()
     expect(next.cases['short-success'].status).toBe('resolved')
 
     // The team is released for the following week, but the agent still worked this week,
@@ -113,7 +114,7 @@ describe('Immutability Fix Validation', () => {
     // This prevents double-counting active time
 
     expect(state.agents['a_ava'].fatigue).toBeDefined()
-    expect(state.teams['t_nightwatch'].assignedCaseId).toBe('case-beta')
+    expect(getTeamAssignedCaseId(state.teams['t_nightwatch'])).toBe('case-beta')
     expect(state.cases['case-beta'].status).toBe('in_progress')
   })
 

--- a/src/test/sim.pipeline.invariants.test.ts
+++ b/src/test/sim.pipeline.invariants.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import type { Agent, CaseInstance, Team } from '../domain/models'
 import { createSeededRng } from '../domain/math'
-import { normalizeGameState } from '../domain/teamSimulation'
+import { getTeamAssignedCaseId, normalizeGameState } from '../domain/teamSimulation'
 import { getCaseAssignmentInsights } from '../features/cases/caseInsights'
 import { getTeamAssignableCaseViews } from '../features/teams/teamInsights'
 import {
@@ -200,7 +200,6 @@ function makeDirtyTeamState() {
       state: 'ready',
       assignedCaseId: null,
     },
-    assignedCaseId: undefined,
   }
 
   return state
@@ -331,7 +330,7 @@ function makeMixedEventStateForOrdering(seed: number) {
       agentIds: ['agent-strong'],
       leaderId: 'agent-strong',
       tags: [],
-      assignedCaseId: 'case-success',
+      status: { state: 'deployed', assignedCaseId: 'case-success' },
     },
     'team-weak': {
       id: 'team-weak',
@@ -340,7 +339,7 @@ function makeMixedEventStateForOrdering(seed: number) {
       agentIds: ['agent-weak'],
       leaderId: 'agent-weak',
       tags: [],
-      assignedCaseId: 'case-fail',
+      status: { state: 'deployed', assignedCaseId: 'case-fail' },
     },
   }
 
@@ -1013,14 +1012,16 @@ describe('stale derived fields', () => {
     }
     state.teams['t_greentape'] = {
       ...state.teams['t_greentape'],
-      assignedCaseId: 'missing-case',
+      status: {
+        ...(state.teams['t_greentape'].status ?? { state: 'deployed', assignedCaseId: null }),
+        assignedCaseId: 'missing-case',
+      },
     }
 
     const next = normalizeGameState(state)
 
     expect(next.cases['case-001'].assignedTeamIds).toEqual(['t_nightwatch'])
-    expect(next.teams['t_greentape'].assignedCaseId).toBeUndefined()
-    expect(next.teams['t_greentape'].status?.assignedCaseId ?? null).toBeNull()
+    expect(getTeamAssignedCaseId(next.teams['t_greentape'])).toBeNull()
   })
 
   it('every team-mutating domain mutator emits already-normalized team state', () => {

--- a/src/test/sim.raid.hardening.test.ts
+++ b/src/test/sim.raid.hardening.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { type CaseInstance } from '../domain/models'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 
 function createControlledRaidState() {
   const state = createStartingState()
@@ -62,8 +63,14 @@ describe('Raid Coordination Hardening', () => {
     const state = createControlledRaidState()
     state.cases['raid-test'] = createRaidCase('raid-test', { title: 'Test Raid' })
 
-    state.teams['t_nightwatch'].assignedCaseId = 'raid-test'
-    state.teams['t_greentape'].assignedCaseId = 'raid-test'
+    state.teams['t_nightwatch'].status = {
+      ...(state.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'raid-test',
+    }
+    state.teams['t_greentape'].status = {
+      ...(state.teams['t_greentape'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'raid-test',
+    }
 
     const before = structuredClone(state)
     const next = advanceWeek(state)
@@ -94,8 +101,14 @@ describe('Raid Coordination Hardening', () => {
       weeksRemaining: 5,
     })
 
-    state.teams['t_nightwatch'].assignedCaseId = 'long-raid'
-    state.teams['t_greentape'].assignedCaseId = 'long-raid'
+    state.teams['t_nightwatch'].status = {
+      ...(state.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'long-raid',
+    }
+    state.teams['t_greentape'].status = {
+      ...(state.teams['t_greentape'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'long-raid',
+    }
 
     // Advance 3 weeks and verify no crashes
     for (let i = 0; i < 3; i++) {

--- a/src/test/sim.raid.hardening.test.ts
+++ b/src/test/sim.raid.hardening.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { type CaseInstance } from '../domain/models'
 import { advanceWeek } from '../domain/sim/advanceWeek'
-import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 
 function createControlledRaidState() {
   const state = createStartingState()

--- a/src/test/sim.selectorParity.test.ts
+++ b/src/test/sim.selectorParity.test.ts
@@ -32,6 +32,7 @@ import {
   resolveCase,
 } from '../domain/sim/resolve'
 import { assignTeam } from '../domain/sim/assign'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 import { getTeamEditability, getTeamMoveEligibility } from '../domain/sim/teamManagement'
 import { validateTeamIds } from '../domain/validateTeam'
 import type { CaseInstance, GameState, Id, Team } from '../domain/models'
@@ -258,7 +259,7 @@ describe('Selector Parity: Mutation vs Preview Blocking', () => {
 
     const next = assignTeam(game, caseEntry.id, team.id)
     expect(next.cases[caseEntry.id].assignedTeamIds).not.toContain(team.id)
-    expect(next.teams[team.id].assignedCaseId).not.toBe(caseEntry.id)
+    expect(getTeamAssignedCaseId(next.teams[team.id])).not.toBe(caseEntry.id)
   })
 
   it('blocked preview → assignTeam rejects (already-committed)', () => {
@@ -311,7 +312,7 @@ describe('Selector Parity: Mutation vs Preview Blocking', () => {
 
     const next = assignTeam(game, caseEntry.id, team.id)
     expect(next.cases[caseEntry.id].assignedTeamIds).toContain(team.id)
-    expect(next.teams[team.id].assignedCaseId).toBe(caseEntry.id)
+    expect(getTeamAssignedCaseId(next.teams[team.id])).toBe(caseEntry.id)
   })
 
   it('blocked by role requirement → assignTeam rejects', () => {

--- a/src/test/sim.teamManagement.test.ts
+++ b/src/test/sim.teamManagement.test.ts
@@ -1,6 +1,21 @@
 // cspell:words editability greentape sato
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
+
+function assignTeamToCase(
+  state: ReturnType<typeof createStartingState>,
+  teamId: string,
+  caseId: string
+) {
+  state.teams[teamId] = {
+    ...state.teams[teamId],
+    status: {
+      ...(state.teams[teamId].status ?? { state: 'deployed', assignedCaseId: null }),
+      state: 'deployed',
+      assignedCaseId: caseId,
+    },
+  }
+}
 import { assignTeam } from '../domain/sim/assign'
 import {
   createTeam,
@@ -102,10 +117,7 @@ describe('renameTeam', () => {
   it('returns unchanged state when the team is deployed to a case', () => {
     const state = createStartingState()
     // mark the team as deployed
-    state.teams[ALPHA_TEAM] = {
-      ...state.teams[ALPHA_TEAM],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(state, ALPHA_TEAM, 'case-001')
     const next = renameTeam(state, ALPHA_TEAM, 'Deployed Rename')
 
     expect(next.teams[ALPHA_TEAM].name).toBe(state.teams[ALPHA_TEAM].name)
@@ -266,10 +278,7 @@ describe('getTeamEditability', () => {
 
   it('returns non-editable with case title when deployed', () => {
     const state = createStartingState()
-    state.teams[ALPHA_TEAM] = {
-      ...state.teams[ALPHA_TEAM],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(state, ALPHA_TEAM, 'case-001')
     const result = getTeamEditability(state.teams[ALPHA_TEAM], state.cases)
     expect(result.editable).toBe(false)
     expect(result.reason).toMatch(/deployed/i)
@@ -277,10 +286,7 @@ describe('getTeamEditability', () => {
 
   it('returns editable when assigned case pointer is orphaned', () => {
     const state = createStartingState()
-    state.teams[ALPHA_TEAM] = {
-      ...state.teams[ALPHA_TEAM],
-      assignedCaseId: 'missing-case',
-    }
+    assignTeamToCase(state, ALPHA_TEAM, 'missing-case')
 
     const result = getTeamEditability(state.teams[ALPHA_TEAM], state.cases)
     expect(result.editable).toBe(true)
@@ -305,10 +311,7 @@ describe('getTeamMoveEligibility', () => {
 
   it('blocks move when the target team is deployed', () => {
     const state = createStartingState()
-    state.teams[ALPHA_TEAM] = {
-      ...state.teams[ALPHA_TEAM],
-      assignedCaseId: 'case-001',
-    }
+    assignTeamToCase(state, ALPHA_TEAM, 'case-001')
     const result = getTeamMoveEligibility(state, BRAVO_AGENT, ALPHA_TEAM)
     expect(result.allowed).toBe(false)
     expect(result.reasons.some((r) => /target team/i.test(r))).toBe(true)

--- a/src/test/sim.teamRelease.test.ts
+++ b/src/test/sim.teamRelease.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { releaseTeamsFromCases } from '../domain/sim/teamRelease'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 
 describe('releaseTeamsFromCases', () => {
   it('returns the same teams object when no team ids are provided', () => {
@@ -14,7 +15,6 @@ describe('releaseTeamsFromCases', () => {
     const state = createStartingState()
     state.teams['t_nightwatch'] = {
       ...state.teams['t_nightwatch'],
-      assignedCaseId: 'case-001',
       status: {
         ...(state.teams['t_nightwatch'].status ?? { state: 'ready', assignedCaseId: null }),
         assignedCaseId: 'case-001',
@@ -22,7 +22,6 @@ describe('releaseTeamsFromCases', () => {
     }
     state.teams['t_greentape'] = {
       ...state.teams['t_greentape'],
-      assignedCaseId: 'case-002',
       status: {
         ...(state.teams['t_greentape'].status ?? { state: 'ready', assignedCaseId: null }),
         assignedCaseId: 'case-002',
@@ -31,9 +30,7 @@ describe('releaseTeamsFromCases', () => {
 
     const nextTeams = releaseTeamsFromCases(state.teams, ['t_nightwatch'])
 
-    expect(nextTeams['t_nightwatch'].assignedCaseId).toBeUndefined()
-    expect(nextTeams['t_nightwatch'].status?.assignedCaseId ?? null).toBeNull()
-    expect(nextTeams['t_greentape'].assignedCaseId).toBe('case-002')
-    expect(nextTeams['t_greentape'].status?.assignedCaseId).toBe('case-002')
+    expect(getTeamAssignedCaseId(nextTeams['t_nightwatch'])).toBeNull()
+    expect(getTeamAssignedCaseId(nextTeams['t_greentape'])).toBe('case-002')
   })
 })

--- a/src/test/starterContent.test.ts
+++ b/src/test/starterContent.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { caseTemplateMap } from '../data/caseTemplates'
 import { CASE_LORE_STUBS } from '../data/copy'
 import { createStartingState } from '../data/startingState'
+import { getTeamAssignedCaseId } from '../domain/teamSimulation'
 import {
   assertKnownAuthoredAbilities,
   getAuthoredAbilityValidationIssues,
@@ -342,11 +343,14 @@ describe('starter content contracts', () => {
     const stateA = createStartingState()
     const stateB = createStartingState()
 
-    stateA.teams['t_nightwatch'].assignedCaseId = 'case-001'
+    stateA.teams['t_nightwatch'].status = {
+      ...(stateA.teams['t_nightwatch'].status ?? { state: 'deployed', assignedCaseId: null }),
+      assignedCaseId: 'case-001',
+    }
     stateA.cases['case-001'].assignedTeamIds.push('t_nightwatch')
     stateA.cases['case-001'].onFail.spawnTemplateIds!.push('combat_vampire_nest')
 
-    expect(stateB.teams['t_nightwatch'].assignedCaseId).toBeUndefined()
+    expect(getTeamAssignedCaseId(stateB.teams['t_nightwatch'])).toBeNull()
     expect(stateB.cases['case-001'].assignedTeamIds).toEqual([])
     expect(stateB.cases['case-001'].onFail.spawnTemplateIds ?? []).toEqual([
       'followup_missing_persons',

--- a/src/test/teamSimulation.test.ts
+++ b/src/test/teamSimulation.test.ts
@@ -86,31 +86,29 @@ describe('teamSimulation', () => {
     })
   })
 
-  it('keeps canonical status mirrored with legacy assignment fields', () => {
+  it('stores assignment on team status after assignTeam sync', () => {
     const state = syncTeamSimulationState(
       assignTeam(createStartingState(), 'case-001', 't_nightwatch')
     )
     const team = state.teams['t_nightwatch']
 
     expect(getTeamAssignedCaseId(team)).toBe('case-001')
-    expect(team.assignedCaseId).toBe('case-001')
     expect(team.status?.assignedCaseId).toBe('case-001')
     expect(team.status?.state).toMatch(/deployed|resolving/)
   })
 
-  it('prefers canonical status assignment over legacy alias when both are present', () => {
+  it('reads assignment from team status only', () => {
     const state = createStartingState()
-    const conflictingTeam = {
+    const teamWithStatus = {
       ...state.teams['t_nightwatch'],
       status: {
         ...state.teams['t_nightwatch'].status,
         state: state.teams['t_nightwatch'].status?.state ?? 'ready',
         assignedCaseId: 'case-001',
       },
-      assignedCaseId: 'case-003',
     }
 
-    expect(getTeamAssignedCaseId(conflictingTeam)).toBe('case-001')
+    expect(getTeamAssignedCaseId(teamWithStatus)).toBe('case-001')
   })
 
   it('builds a squad composition profile with readiness and chemistry outputs', () => {


### PR DESCRIPTION
## Summary

- Remove legacy \	eam.assignedCaseId\ from the \Team\ interface; canonical assignment lives on \	eam.status.assignedCaseId\ and is read via \getTeamAssignedCaseId\.
- Migrate production readers (\deploymentReadiness\, \missionIntakeRouting\, \alidation\, \isibility\, \stabilityLayer\, \	eamComposition\, \developerOverlayView\, \gentView\) and writers (\ssign\, \	eamRelease\, \dvanceWeek\, \syncTeamSimulationTeam\).
- Add bounded save hydration in \unTransfer.ts\ (\esolveHydratedTeamAssignedCaseId\) so old saves with only the top-level field migrate into status on load.
- Update or remove assignment mirror-parity tests and migrate fixtures to status-only assignment pointers.

## Linear

- **Slice:** [SPE-2276](https://linear.app/spectranoir/issue/SPE-2276/retire-legacy-teamassignedcaseid-alias-after-ui-migration)
- **Parent:** none (standalone slice)

## What shipped

Assignment-pointer cleanup only — no changes to assignment rules, fatigue rules, team availability, or case resolution behavior.

## Validation

- \
pm run lint\
- \
pm run test:run\ (5072 tests)

## Docs

- \SCHEMA_REGISTRY.md\ — not updated (no legacy alias documented there)

## Parent status

N/A — slice issue only.

Made with [Cursor](https://cursor.com)