### PR TITLE
feat(SPE-2351): welfare-debt accounting planning mirror UI (slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -22,7 +22,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568); all derive/compose wire-ups complete. Parent [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889) **Done** on Linear — next: [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) slice 2 (registry persistence mirror UI or weekly orchestration) or intake registry follow-up per active queue below.
+Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). [SPE-2351](https://linear.app/spectranoir/issue/SPE-2351) **In progress** — welfare-debt accounting planning mirror UI; see `planning/welfare-debt-accounting-registry-slice-2.md`. Parent [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) stays open.
 
 ## Blocked / waiting
 

--- a/planning/welfare-debt-accounting-registry-slice-2.md
+++ b/planning/welfare-debt-accounting-registry-slice-2.md
@@ -1,0 +1,79 @@
+# SPE-1888 — Welfare-debt accounting registry planning mirror UI (slice 2)
+
+One-page implementation plan. Linear: [SPE-2351](https://linear.app/spectranoir/issue/SPE-2351) (child under [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888)). Follows shipped slice 1 via [SPE-2350](https://linear.app/spectranoir/issue/SPE-2350) / PR #2568 (`welfareDebtAccountingRegistry.ts` + wire-up).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2351 — Welfare-debt accounting registry planning mirror UI (slice 2)](https://linear.app/spectranoir/issue/SPE-2351) |
+| **Status** | **Shipped** — pending PR |
+| **Parent** | [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — welfare-debt accounting umbrella stays open |
+| **Branch** | `spe-1888-welfare-debt-accounting-mirror-ui-slice-2`                                                     |
+| **Base `main` SHA** | `67d7214e`                                                                                          |
+
+## Goal
+
+Read-only planning/operations mirror over persisted `welfareDebtAccountingRecords` with read-time `projectWelfareDebtAccounting` display for agent routing visibility, not player-facing canon.
+
+## Prerequisite (on `main` @ `67d7214e`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/welfareDebtAccountingRegistry.ts` (SPE-1888 slice 1 / SPE-2350 / PR #2568) |
+| Persistence          | `welfareDebtAccountingRecords` on `GameState` (SPE-1888 slice 1 / PR #2568) |
+| Wire-up              | `deriveWelfareDebtBundleFragmentsFromRecords` + `composeWelfareDebtIntoIntegratedHealthBundles` (SPE-2350) |
+| Sibling mirror template | `entityWelfareReclassificationMirrorView` (SPE-2341), `containedPersonIntegratedHealthBundleMirrorView` (SPE-2346) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `getWelfareDebtAccountingMirrorView` + `WelfareDebtAccountingMirrorPage` | New persistence fields                     |
+| Route `/welfare-debt-accounting` + Front Desk quick link           | Weekly tick / sanitize contract changes       |
+| View + component tests                                             | Integrated health bundle compose changes      |
+| Slice doc (this file) + backlog handoff                            | Re-validation of hidden/dropped records       |
+| Read-time `projectWelfareDebtAccounting` display from hydrated records | SPE-1888 parent Done                            |
+
+## Mirror contract
+
+- **Read-only** — no mutations to GameState from the mirror surface.
+- **Hydrated truth only** — display persisted records as hydrated; do not re-run validation to drop entries.
+- **Display guards** — `validateWelfareDebtAccountingRecord` surfaces warning-severity issues only; warning-only records remain visible.
+- **Read-time projections** — `projectWelfareDebtAccounting` at mirror build; not objective truth.
+- **Empty state** — when `welfareDebtAccountingRecords` map is empty after hydrate.
+- **Ordering** — byte-stable sort by record id.
+- **Copy** — CP-neutral labels; no franchise tokens in UI strings.
+
+## Acceptance
+
+- [x] Empty `welfareDebtAccountingRecords` map renders empty state without throw
+- [x] Records table shows severity band, mitigation state, source procedure, review owner, and containment benefit projection
+- [x] Summary counts distinguish unresolved, escalated, and mitigated welfare debt
+- [x] Warning-only records still shown with validation warning labels
+- [x] Redacted containment benefit scores show dash placeholders
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/welfareDebtAccountingMirrorView.ts` |
+| UI     | `src/features/operations/WelfareDebtAccountingMirrorPage.tsx` |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`, `src/app/appShellRoutePaths.ts` |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/welfareDebtAccountingMirrorView.test.ts`, `src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx` |
+| Plan   | `planning/welfare-debt-accounting-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Welfare-debt weekly orchestration hook | SPE-1888 slice 3+ | Wire-up consumes persisted records; tick deferred |
+| Ledger summary audit output | SPE-1888 | Out of mirror UI boundary |
+| SPE-1888 parent Done | SPE-1888 | Slice 2 is mirror UI only |
+
+## See also
+
+- `planning/contained-person-integrated-health-bundle-slice-10.md`
+- `planning/entity-welfare-reclassification-registry-slice-4.md` — mirror UI template (SPE-2341)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -102,6 +102,9 @@ const ContainedPersonTherapeuticCareMirrorRoute = createRouteComponent(
 const ContainedPersonIntegratedHealthBundleMirrorRoute = createRouteComponent(
   () => import('../features/operations/ContainedPersonIntegratedHealthBundleMirrorPage')
 )
+const WelfareDebtAccountingMirrorRoute = createRouteComponent(
+  () => import('../features/operations/WelfareDebtAccountingMirrorPage')
+)
 const NotFoundRoute = createRouteComponent(() =>
   import('../features/divisions/SystemBoundaryPage').then((module) => ({
     default: function NotFoundRoute() {
@@ -180,6 +183,10 @@ export default function App() {
         <Route
           path="contained-person-integrated-health-bundle"
           element={renderLazyRoute(ContainedPersonIntegratedHealthBundleMirrorRoute)}
+        />
+        <Route
+          path="welfare-debt-accounting"
+          element={renderLazyRoute(WelfareDebtAccountingMirrorRoute)}
         />
         <Route path="*" element={renderLazyRoute(NotFoundRoute)} />
       </Route>

--- a/src/app/appShellRoutePaths.ts
+++ b/src/app/appShellRoutePaths.ts
@@ -30,6 +30,7 @@ export const APP_SHELL_STATIC_ROUTE_PATHS = [
   'entity-welfare-reclassification',
   'contained-person-therapeutic-care',
   'contained-person-integrated-health-bundle',
+  'welfare-debt-accounting',
 ] as const
 
 export function navPathToShellSegment(path: string): string {

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -33,6 +33,7 @@ export const APP_ROUTES = {
   entityWelfareReclassification: '/entity-welfare-reclassification',
   containedPersonTherapeuticCare: '/contained-person-therapeutic-care',
   containedPersonIntegratedHealthBundle: '/contained-person-integrated-health-bundle',
+  welfareDebtAccounting: '/welfare-debt-accounting',
 } as const
 
 export const APP_ROUTE_PATTERNS = {

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1043,6 +1043,38 @@ export const CONTAINED_PERSON_THERAPEUTIC_CARE_MIRROR_UI_TEXT: Record<string, st
   redactedSuffix: 'Partial redaction',
 }
 
+export const WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Welfare debt accounting registry',
+  pageSubtitle:
+    'Read-only operations view over persisted welfare-debt accounting records and read-time containment benefit projections.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Persisted records',
+  unresolvedCountLabel: 'Unresolved debt',
+  escalatedCountLabel: 'Escalated debt',
+  mitigatedCountLabel: 'Mitigated debt',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Severity bands, mitigation states, and containment benefit scores mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
+  emptyTitle: 'No welfare debt accounting records',
+  emptyBody:
+    'Persisted welfare-debt accounting records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  recordsHeading: 'Persisted records',
+  recordsSubtitle:
+    'Containment benefit scores come from welfare-debt accounting projection at read time; unresolved and escalated states display as stored.',
+  labelColumn: 'Label',
+  debtColumn: 'Debt category / severity',
+  procedureColumn: 'Source procedure',
+  reviewColumn: 'Review / mitigation',
+  confidenceColumn: 'Confidence',
+  subjectRefPrefix: 'Subject:',
+  containmentBenefitPrefix: 'Containment benefit:',
+  reviewOwnerPrefix: 'Review owner:',
+  mitigationPathPrefix: 'Mitigation path:',
+  validationWarningPrefix: 'Validation warnings:',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const ENTITY_WELFARE_RECLASSIFICATION_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Entity welfare reclassification registry',

--- a/src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx
+++ b/src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+  FORCED_SEDATION_CYCLE_FIXTURE,
+} from '../../domain/welfareDebtAccountingRegistry'
+import { useGameStore } from '../../app/store/gameStore'
+import WelfareDebtAccountingMirrorPage from './WelfareDebtAccountingMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/welfare-debt-accounting']}>
+      <Routes>
+        <Route path="/welfare-debt-accounting" element={<WelfareDebtAccountingMirrorPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('WelfareDebtAccountingMirrorPage (SPE-1888 slice 2)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderMirrorPage()
+
+    expect(
+      screen.getByRole('region', { name: /welfare debt accounting registry mirror/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty registry state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no welfare debt accounting records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted records when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [FORCED_SEDATION_CYCLE_FIXTURE.id]: FORCED_SEDATION_CYCLE_FIXTURE,
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted welfare debt accounting records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(FORCED_SEDATION_CYCLE_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent(COERCIVE_RESTRAINT_LEDGER_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent('Escalated')
+    expect(recordsRegion).toHaveTextContent('Unresolved')
+    expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/features/operations/WelfareDebtAccountingMirrorPage.tsx
+++ b/src/features/operations/WelfareDebtAccountingMirrorPage.tsx
@@ -1,0 +1,169 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT } from '../../data/copy'
+import { getWelfareDebtAccountingMirrorView } from './welfareDebtAccountingMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function WelfareDebtAccountingMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getWelfareDebtAccountingMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Welfare debt accounting registry mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Registry summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">
+              {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.pageHeading}
+            </h2>
+            <p className="text-sm opacity-60">
+              {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.pageSubtitle}
+            </p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.unresolvedCountLabel}
+            value={String(view.summary.unresolvedCount)}
+          />
+          <StatCard
+            label={WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.escalatedCountLabel}
+            value={String(view.summary.escalatedCount)}
+          />
+          <StatCard
+            label={WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.mitigatedCountLabel}
+            value={String(view.summary.mitigatedCount)}
+          />
+          <StatCard
+            label={WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">
+          {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.readOnlyNote}
+        </p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty registry state">
+          <h3 className="text-lg font-semibold">
+            {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.emptyTitle}
+          </h3>
+          <p className="text-sm opacity-70">{WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted welfare debt accounting records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">
+              {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.recordsHeading}
+            </h3>
+            <p className="text-sm opacity-60">
+              {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.recordsSubtitle}
+            </p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">
+                    {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.labelColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.debtColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.procedureColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.reviewColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.confidenceColumn}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.subjectRefPrefix}{' '}
+                        {record.subjectRefLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.debtCategoryLabel}
+                      <p className="text-xs opacity-55">{record.severityBandLabel}</p>
+                      <p className="text-xs opacity-45">{record.mitigationStateLabel}</p>
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.sourceProcedureLabel}
+                      <p className="text-xs opacity-55">
+                        {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.containmentBenefitPrefix}{' '}
+                        {record.containmentBenefitScoreLabel}
+                      </p>
+                      {record.redacted ? (
+                        <p className="text-xs opacity-45">
+                          {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.redactedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <p className="text-xs opacity-55">
+                        {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.reviewOwnerPrefix}{' '}
+                        {record.reviewOwnerLabel}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.mitigationPathPrefix}{' '}
+                        {record.mitigationPathLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.confidenceLabel}
+                      {record.validationWarningLabels.length > 0 ? (
+                        <p className="text-xs text-amber-200/80">
+                          {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.validationWarningPrefix}{' '}
+                          {record.validationWarningLabels.length}
+                        </p>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -813,6 +813,12 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
       description:
         'Review mental-state bands, humane-care risk, and wired therapeutic care schedule links.',
     },
+    {
+      label: 'Open welfare debt accounting mirror',
+      href: APP_ROUTES.welfareDebtAccounting,
+      description:
+        'Review coercive-procedure welfare debt severity, mitigation state, and containment benefit projections.',
+    },
   ]
 }
 

--- a/src/features/operations/welfareDebtAccountingMirrorView.test.ts
+++ b/src/features/operations/welfareDebtAccountingMirrorView.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+  FORCED_SEDATION_CYCLE_FIXTURE,
+  projectWelfareDebtAccounting,
+  validateWelfareDebtAccountingRecord,
+  type WelfareDebtAccountingRecord,
+} from '../../domain/welfareDebtAccountingRegistry'
+import {
+  formatWelfareDebtAccountingEnumLabel,
+  getWelfareDebtAccountingMirrorView,
+} from './welfareDebtAccountingMirrorView'
+
+function warningOnlyRecord(): WelfareDebtAccountingRecord {
+  return {
+    id: 'welfare-debt:warning-only-escalated',
+    label: 'Escalated welfare debt without mitigation path',
+    subjectRef: 'subject:warning-only',
+    debtCategory: 'coerced_medication',
+    severityBand: 'critical',
+    mitigationState: 'escalated',
+    sourceProcedureLabel: 'forced sedation stabilization cycle',
+    reviewOwnerLabel: 'psychiatric review panel',
+    containmentBenefitScore: 0.64,
+  }
+}
+
+describe('welfareDebtAccountingMirrorView (SPE-1888 slice 2)', () => {
+  it('returns empty mirror when welfareDebtAccountingRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.welfareDebtAccountingRecords).toEqual({})
+
+    const view = getWelfareDebtAccountingMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('mirrors severity, mitigation state, and containment benefit from hydrated records', () => {
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+
+    const view = getWelfareDebtAccountingMirrorView(game)
+    const record = view.records[0]
+    const projection = projectWelfareDebtAccounting(COERCIVE_RESTRAINT_LEDGER_FIXTURE)
+
+    expect(view.isEmpty).toBe(false)
+    expect(view.summary.unresolvedCount).toBe(1)
+    expect(record?.severityBandLabel).toBe('High')
+    expect(record?.mitigationStateLabel).toBe('Unresolved')
+    expect(record?.sourceProcedureLabel).toBe('extended mechanical restraint cycle')
+    expect(record?.reviewOwnerLabel).toBe('ethics review board')
+    expect(record?.containmentBenefitScoreLabel).toBe(projection.containmentBenefitScore?.toFixed(2))
+  })
+
+  it('counts unresolved, escalated, and mitigated records in summary', () => {
+    const mitigatedRecord: WelfareDebtAccountingRecord = {
+      id: 'welfare-debt:mitigated-entry',
+      label: 'Mitigated welfare debt entry',
+      subjectRef: 'subject:mitigated',
+      debtCategory: 'privilege_deprivation',
+      severityBand: 'moderate',
+      mitigationState: 'mitigated',
+      sourceProcedureLabel: 'privilege suspension cycle',
+      reviewOwnerLabel: 'ethics review board',
+      mitigationPathLabel: 'restored visitation rights',
+      containmentBenefitScore: 0.42,
+    }
+
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      [FORCED_SEDATION_CYCLE_FIXTURE.id]: FORCED_SEDATION_CYCLE_FIXTURE,
+      [mitigatedRecord.id]: mitigatedRecord,
+    }
+
+    const view = getWelfareDebtAccountingMirrorView(game)
+
+    expect(view.summary.unresolvedCount).toBe(1)
+    expect(view.summary.escalatedCount).toBe(1)
+    expect(view.summary.mitigatedCount).toBe(1)
+  })
+
+  it('still mirrors warning-only records with validation warning labels', () => {
+    const warningRecord = warningOnlyRecord()
+    expect(validateWelfareDebtAccountingRecord(warningRecord).valid).toBe(true)
+
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [warningRecord.id]: warningRecord,
+    }
+
+    const view = getWelfareDebtAccountingMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.totalRecords).toBe(1)
+    expect(record?.validationWarningLabels.length).toBe(1)
+    expect(record?.mitigationPathLabel).toBe('—')
+    expect(record?.mitigationStateLabel).toBe('Escalated')
+  })
+
+  it('shows dash placeholders for redacted containment benefit scores', () => {
+    const redactedRecord: WelfareDebtAccountingRecord = {
+      ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      id: 'welfare-debt:redacted-benefit',
+      redactedFields: ['containmentBenefitScore'],
+    }
+
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [redactedRecord.id]: redactedRecord,
+    }
+
+    const view = getWelfareDebtAccountingMirrorView(game)
+    const record = view.records[0]
+
+    expect(record?.containmentBenefitScoreLabel).toBe('—')
+    expect(record?.redacted).toBe(true)
+  })
+
+  it('orders records by id and is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      [FORCED_SEDATION_CYCLE_FIXTURE.id]: FORCED_SEDATION_CYCLE_FIXTURE,
+    }
+
+    const view = getWelfareDebtAccountingMirrorView(game)
+
+    expect(view.records.map((record) => record.id)).toEqual([
+      COERCIVE_RESTRAINT_LEDGER_FIXTURE.id,
+      FORCED_SEDATION_CYCLE_FIXTURE.id,
+    ])
+
+    const first = JSON.stringify(getWelfareDebtAccountingMirrorView(game))
+    const second = JSON.stringify(getWelfareDebtAccountingMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatWelfareDebtAccountingEnumLabel('harmful_restraint')).toBe('Harmful Restraint')
+    expect(formatWelfareDebtAccountingEnumLabel('unresolved')).toBe('Unresolved')
+  })
+})

--- a/src/features/operations/welfareDebtAccountingMirrorView.ts
+++ b/src/features/operations/welfareDebtAccountingMirrorView.ts
@@ -1,0 +1,138 @@
+import type { GameState } from '../../domain/models'
+import {
+  projectWelfareDebtAccounting,
+  validateWelfareDebtAccountingRecord,
+  type WelfareDebtAccountingRecord,
+} from '../../domain/welfareDebtAccountingRegistry'
+
+export interface WelfareDebtAccountingMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  subjectRefLabel: string
+  debtCategoryLabel: string
+  severityBandLabel: string
+  mitigationStateLabel: string
+  sourceProcedureLabel: string
+  reviewOwnerLabel: string
+  mitigationPathLabel: string
+  containmentBenefitScoreLabel: string
+  validationWarningLabels: readonly string[]
+  confidenceLabel: string
+  redacted: boolean
+}
+
+export interface WelfareDebtAccountingMirrorSummaryView {
+  totalRecords: number
+  unresolvedCount: number
+  escalatedCount: number
+  mitigatedCount: number
+  week: number
+}
+
+export interface WelfareDebtAccountingMirrorView {
+  isEmpty: boolean
+  summary: WelfareDebtAccountingMirrorSummaryView
+  records: readonly WelfareDebtAccountingMirrorRecordView[]
+}
+
+export function formatWelfareDebtAccountingEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(game: GameState): WelfareDebtAccountingRecord[] {
+  const map = game.welfareDebtAccountingRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatConfidence(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatUnitScore(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function toRecordView(record: WelfareDebtAccountingRecord): WelfareDebtAccountingMirrorRecordView {
+  const projection = projectWelfareDebtAccounting(record)
+  const validation = validateWelfareDebtAccountingRecord(record)
+
+  const validationWarningLabels = Object.freeze(
+    validation.issues
+      .filter((issue) => issue.severity === 'warning')
+      .map((issue) => issue.detail)
+  )
+
+  const summaryLabel = record.summary?.trim() ? record.summary : '—'
+  const mitigationPathLabel = record.mitigationPathLabel?.trim()
+    ? record.mitigationPathLabel
+    : '—'
+
+  return Object.freeze({
+    id: record.id,
+    label: record.label,
+    summaryLabel,
+    subjectRefLabel: record.subjectRef,
+    debtCategoryLabel: formatWelfareDebtAccountingEnumLabel(record.debtCategory),
+    severityBandLabel: formatWelfareDebtAccountingEnumLabel(projection.severityBand),
+    mitigationStateLabel: formatWelfareDebtAccountingEnumLabel(projection.mitigationState),
+    sourceProcedureLabel: record.sourceProcedureLabel,
+    reviewOwnerLabel: record.reviewOwnerLabel,
+    mitigationPathLabel,
+    containmentBenefitScoreLabel: formatUnitScore(projection.containmentBenefitScore),
+    validationWarningLabels,
+    confidenceLabel: formatConfidence(projection.confidence),
+    redacted: projection.redacted,
+  })
+}
+
+/** Read-only mirror over hydrated `welfareDebtAccountingRecords`; does not re-validate dropped entries. */
+export function getWelfareDebtAccountingMirrorView(
+  game: GameState
+): WelfareDebtAccountingMirrorView {
+  const records = listPersistedRecords(game)
+  const week = game.week
+
+  let unresolvedCount = 0
+  let escalatedCount = 0
+  let mitigatedCount = 0
+
+  const recordViews = records.map((record) => {
+    if (record.mitigationState === 'unresolved') {
+      unresolvedCount += 1
+    }
+
+    if (record.mitigationState === 'escalated') {
+      escalatedCount += 1
+    }
+
+    if (record.mitigationState === 'mitigated') {
+      mitigatedCount += 1
+    }
+
+    return toRecordView(record)
+  })
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      totalRecords: records.length,
+      unresolvedCount,
+      escalatedCount,
+      mitigatedCount,
+      week,
+    }),
+    records: Object.freeze(recordViews),
+  })
+}


### PR DESCRIPTION
## Summary

- Add read-only planning mirror over persisted \welfareDebtAccountingRecords\ with \projectWelfareDebtAccounting\ display.
- Wire route \/welfare-debt-accounting\, Front Desk quick link, copy strings, and targeted view/component tests.

## Linear mapping

- **Slice issue:** [SPE-2351](https://linear.app/spectranoir/issue/SPE-2351)
- **Parent:** [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — stays open
- **Prerequisite:** SPE-1888 slice 1 registry shipped in SPE-2350 / PR #2568

## Validation

- \
pm run lint\
- \
pm run test:run -- src/features/operations/welfareDebtAccountingMirrorView.test.ts src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx\

## Docs updated

- \planning/welfare-debt-accounting-registry-slice-2.md\
- \planning/backlog.md\

Made with [Cursor](https://cursor.com)