### PR TITLE
feat(SPE-2353): welfare-debt ledger summary audit output (slice 4)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -22,7 +22,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). [SPE-2351](https://linear.app/spectranoir/issue/SPE-2351) **Done** — welfare-debt accounting planning mirror UI shipped (PR #2570). [SPE-2352](https://linear.app/spectranoir/issue/SPE-2352) **Done** — welfare-debt accounting weekly orchestration hook shipped (PR #2572); see `planning/welfare-debt-accounting-registry-slice-3.md`. Parent [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) stays open — next: ledger summary audit or intake registry follow-up per active queue below.
+Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). [SPE-2351](https://linear.app/spectranoir/issue/SPE-2351) **Done** — welfare-debt accounting planning mirror UI shipped (PR #2570). [SPE-2352](https://linear.app/spectranoir/issue/SPE-2352) **Done** — welfare-debt accounting weekly orchestration hook shipped (PR #2572); see `planning/welfare-debt-accounting-registry-slice-3.md`. [SPE-2353](https://linear.app/spectranoir/issue/SPE-2353) **In Progress** — welfare-debt ledger summary audit output (slice 4); see `planning/welfare-debt-accounting-registry-slice-4.md`. Parent [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) stays open for coercive-protocol wire-up (SPE-1882) after slice 4 ships.
 
 ## Blocked / waiting
 

--- a/planning/welfare-debt-accounting-registry-slice-4.md
+++ b/planning/welfare-debt-accounting-registry-slice-4.md
@@ -1,0 +1,74 @@
+# SPE-1888 — Welfare-debt accounting registry ledger summary audit output (slice 4)
+
+One-page implementation plan. Linear: [SPE-2353](https://linear.app/spectranoir/issue/SPE-2353) (child under [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888)). Follows shipped slice 3 (`planning/welfare-debt-accounting-registry-slice-3.md`, PR #2572).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2353 — Welfare-debt accounting registry ledger summary audit output (slice 4)](https://linear.app/spectranoir/issue/SPE-2353) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — ledger summary audit closes deferred slice 2/3 item |
+| **Branch** | `spe-1888-welfare-debt-ledger-summary-audit-slice-4`                                                       |
+| **Base `main` SHA** | `1ec3ca12`                                                                                          |
+
+## Goal
+
+Deterministic audit/summary projection over persisted `welfareDebtAccountingRecords` for agent routing — unresolved / escalated / mitigated counts plus canonical category breakdown.
+
+## Prerequisite (on `main` @ `1ec3ca12`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/welfareDebtAccountingRegistry.ts` (SPE-1888 slice 1 / SPE-2350 / PR #2568) |
+| Persistence          | `welfareDebtAccountingRecords` on `GameState` (SPE-1888 slice 1 / PR #2568) |
+| Mirror UI            | `welfareDebtAccountingMirrorView` (SPE-2351 / PR #2570)                |
+| Weekly orchestration | `applyWeeklyWelfareDebtAccountingTick` (SPE-2352 / PR #2572)             |
+
+## Audit contract (slice 4)
+
+- **Hydrated truth only** — summarize persisted records as hydrated; do not re-sanitize or surface invalid hydrate drops.
+- **Mitigation buckets** — count `unresolved`, `escalated`, `mitigated`, `acknowledged`, `waived`, and `denied` separately.
+- **Warning-only inclusion** — valid records with warning-severity validation issues contribute to `warningOnlyCount`.
+- **Category breakdown** — all `WELFARE_DEBT_CATEGORIES` in canonical order with zero counts preserved for byte stability.
+- **Export surface** — `buildWelfareDebtAccountingLedgerAuditReport` emits deterministic `lines` for agent routing; no new UI in this slice.
+- **Mirror integration** — `summarizeWelfareDebtAccountingRecords` shared with mirror summary counts (read-time only).
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `summarizeWelfareDebtAccountingRecords` + `buildWelfareDebtAccountingLedgerAuditReport` | New persistence fields                     |
+| Mirror summary counts via shared summarize helper                  | UI page/route changes                         |
+| Unit tests for summary/audit helper                                | Weekly tick contract changes                  |
+| Slice doc (this file) + backlog handoff                            | Coercive-protocol wire-up (SPE-1882)          |
+|                                                                    | Bundle compose chain changes                  |
+
+## Acceptance
+
+- [ ] Empty `welfareDebtAccountingRecords` map returns zeroed summary without throw
+- [ ] Warning-only hydrated records included in counts
+- [ ] Terminal states (`mitigated`, `waived`, `denied`) bucketed correctly; `acknowledged` counted separately
+- [ ] Category breakdown covers all canonical categories in stable order
+- [ ] Byte-stable ordering on repeated audit builds
+- [ ] No re-surfacing of invalid hydrate drops
+- [ ] `npm run lint` + targeted tests + slice 1–3 regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/welfareDebtAccountingRegistry.ts`                         |
+| Mirror | `src/features/operations/welfareDebtAccountingMirrorView.ts` (summary reuse) |
+| Tests  | `src/test/welfareDebtAccountingLedgerAudit.test.ts`                   |
+| Plan   | `planning/welfare-debt-accounting-registry-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Coercive protocol wire-up | SPE-1882 | Parent umbrella; out of audit boundary |
+| SPE-1888 parent Done | SPE-1888 | Slice 4 closes ledger-summary deferral; coercive wire-up remains |
+
+## See also
+
+- `planning/welfare-debt-accounting-registry-slice-3.md`
+- `src/domain/branchContinuityAudit.ts` — sibling audit report pattern

--- a/src/domain/welfareDebtAccountingRegistry.ts
+++ b/src/domain/welfareDebtAccountingRegistry.ts
@@ -901,3 +901,225 @@ export function applyWeeklyWelfareDebtAccountingTick(
 
   return changed ? next : safeRecords
 }
+
+// ---------------------------------------------------------------------------
+// Ledger summary audit (SPE-1888 slice 4)
+// ---------------------------------------------------------------------------
+
+export interface WelfareDebtCategorySummary {
+  readonly category: WelfareDebtCategory
+  readonly count: number
+}
+
+export interface WelfareDebtAccountingLedgerSummary {
+  readonly totalRecords: number
+  readonly unresolvedCount: number
+  readonly escalatedCount: number
+  readonly mitigatedCount: number
+  readonly acknowledgedCount: number
+  readonly waivedCount: number
+  readonly deniedCount: number
+  readonly warningOnlyCount: number
+  readonly categoryBreakdown: readonly WelfareDebtCategorySummary[]
+}
+
+export interface WelfareDebtAccountingLedgerAuditInput {
+  readonly records: WelfareDebtAccountingRecordsMap | null | undefined
+  readonly week?: number
+  readonly auditId?: string
+}
+
+export interface WelfareDebtAccountingLedgerAuditReport {
+  readonly auditId: string
+  readonly week: number | null
+  readonly isEmpty: boolean
+  readonly summary: WelfareDebtAccountingLedgerSummary
+  readonly lines: readonly string[]
+}
+
+function listPersistedWelfareDebtAccountingRecords(
+  records: WelfareDebtAccountingRecordsMap | null | undefined
+): readonly WelfareDebtAccountingRecord[] {
+  const safeRecords = records ?? {}
+
+  return Object.freeze(
+    Object.values(safeRecords).sort((left, right) => left.id.localeCompare(right.id))
+  )
+}
+
+function emptyCategoryBreakdown(): readonly WelfareDebtCategorySummary[] {
+  return Object.freeze(
+    WELFARE_DEBT_CATEGORIES.map((category) => Object.freeze({ category, count: 0 }))
+  )
+}
+
+function emptyLedgerSummary(): WelfareDebtAccountingLedgerSummary {
+  return Object.freeze({
+    totalRecords: 0,
+    unresolvedCount: 0,
+    escalatedCount: 0,
+    mitigatedCount: 0,
+    acknowledgedCount: 0,
+    waivedCount: 0,
+    deniedCount: 0,
+    warningOnlyCount: 0,
+    categoryBreakdown: emptyCategoryBreakdown(),
+  })
+}
+
+function isWarningOnlyRecord(record: WelfareDebtAccountingRecord): boolean {
+  const validation = validateWelfareDebtAccountingRecord(record)
+  if (!validation.valid) {
+    return false
+  }
+
+  return validation.issues.some((issue) => issue.severity === 'warning')
+}
+
+/**
+ * Deterministic summary projection over hydrated `welfareDebtAccountingRecords`.
+ * Does not re-sanitize or surface invalid hydrate drops.
+ */
+export function summarizeWelfareDebtAccountingRecords(
+  records: WelfareDebtAccountingRecordsMap | null | undefined
+): WelfareDebtAccountingLedgerSummary {
+  const persisted = listPersistedWelfareDebtAccountingRecords(records)
+  if (persisted.length === 0) {
+    return emptyLedgerSummary()
+  }
+
+  const categoryCounts = new Map<WelfareDebtCategory, number>(
+    WELFARE_DEBT_CATEGORIES.map((category) => [category, 0])
+  )
+
+  let unresolvedCount = 0
+  let escalatedCount = 0
+  let mitigatedCount = 0
+  let acknowledgedCount = 0
+  let waivedCount = 0
+  let deniedCount = 0
+  let warningOnlyCount = 0
+
+  for (const record of persisted) {
+    categoryCounts.set(
+      record.debtCategory,
+      (categoryCounts.get(record.debtCategory) ?? 0) + 1
+    )
+
+    switch (record.mitigationState) {
+      case 'unresolved':
+        unresolvedCount += 1
+        break
+      case 'escalated':
+        escalatedCount += 1
+        break
+      case 'mitigated':
+        mitigatedCount += 1
+        break
+      case 'acknowledged':
+        acknowledgedCount += 1
+        break
+      case 'waived':
+        waivedCount += 1
+        break
+      case 'denied':
+        deniedCount += 1
+        break
+      default:
+        break
+    }
+
+    if (isWarningOnlyRecord(record)) {
+      warningOnlyCount += 1
+    }
+  }
+
+  const categoryBreakdown = Object.freeze(
+    WELFARE_DEBT_CATEGORIES.map((category) =>
+      Object.freeze({
+        category,
+        count: categoryCounts.get(category) ?? 0,
+      })
+    )
+  )
+
+  return Object.freeze({
+    totalRecords: persisted.length,
+    unresolvedCount,
+    escalatedCount,
+    mitigatedCount,
+    acknowledgedCount,
+    waivedCount,
+    deniedCount,
+    warningOnlyCount,
+    categoryBreakdown,
+  })
+}
+
+function resolveLedgerAuditId(auditId: string | undefined): string {
+  const normalized = typeof auditId === 'string' ? auditId.trim() : ''
+  return normalized.length > 0 ? normalized : 'welfare-debt-ledger'
+}
+
+function resolveLedgerAuditWeek(week: number | undefined): number | null {
+  if (week === undefined || !Number.isFinite(week)) {
+    return null
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function formatCategoryBreakdownLine(
+  breakdown: readonly WelfareDebtCategorySummary[]
+): string {
+  const parts = breakdown
+    .filter((entry) => entry.count > 0)
+    .map((entry) => `${entry.category}=${entry.count}`)
+
+  return parts.length > 0 ? parts.join(', ') : 'none'
+}
+
+function formatWelfareDebtAccountingLedgerAuditLines(
+  auditId: string,
+  week: number | null,
+  summary: WelfareDebtAccountingLedgerSummary
+): readonly string[] {
+  const weekLine = week !== null ? `Week: ${week}` : 'Week: —'
+  const totals = [
+    `Records: ${summary.totalRecords}`,
+    `unresolved=${summary.unresolvedCount}`,
+    `escalated=${summary.escalatedCount}`,
+    `mitigated=${summary.mitigatedCount}`,
+    `acknowledged=${summary.acknowledgedCount}`,
+    `waived=${summary.waivedCount}`,
+    `denied=${summary.deniedCount}`,
+    `warningOnly=${summary.warningOnlyCount}`,
+  ].join('; ')
+
+  return Object.freeze([
+    `Welfare-debt ledger audit: ${auditId}`,
+    weekLine,
+    totals,
+    `Categories: ${formatCategoryBreakdownLine(summary.categoryBreakdown)}`,
+  ])
+}
+
+/**
+ * Export-only ledger audit report for agent routing over persisted welfare-debt records.
+ * Hydrated truth only — does not re-validate or surface dropped invalid entries.
+ */
+export function buildWelfareDebtAccountingLedgerAuditReport(
+  input: WelfareDebtAccountingLedgerAuditInput
+): WelfareDebtAccountingLedgerAuditReport {
+  const auditId = resolveLedgerAuditId(input.auditId)
+  const week = resolveLedgerAuditWeek(input.week)
+  const summary = summarizeWelfareDebtAccountingRecords(input.records)
+
+  return Object.freeze({
+    auditId,
+    week,
+    isEmpty: summary.totalRecords === 0,
+    summary,
+    lines: formatWelfareDebtAccountingLedgerAuditLines(auditId, week, summary),
+  })
+}

--- a/src/features/operations/welfareDebtAccountingMirrorView.ts
+++ b/src/features/operations/welfareDebtAccountingMirrorView.ts
@@ -1,6 +1,7 @@
 import type { GameState } from '../../domain/models'
 import {
   projectWelfareDebtAccounting,
+  summarizeWelfareDebtAccountingRecords,
   validateWelfareDebtAccountingRecord,
   type WelfareDebtAccountingRecord,
 } from '../../domain/welfareDebtAccountingRegistry'
@@ -103,34 +104,17 @@ export function getWelfareDebtAccountingMirrorView(
 ): WelfareDebtAccountingMirrorView {
   const records = listPersistedRecords(game)
   const week = game.week
+  const ledgerSummary = summarizeWelfareDebtAccountingRecords(game.welfareDebtAccountingRecords)
 
-  let unresolvedCount = 0
-  let escalatedCount = 0
-  let mitigatedCount = 0
-
-  const recordViews = records.map((record) => {
-    if (record.mitigationState === 'unresolved') {
-      unresolvedCount += 1
-    }
-
-    if (record.mitigationState === 'escalated') {
-      escalatedCount += 1
-    }
-
-    if (record.mitigationState === 'mitigated') {
-      mitigatedCount += 1
-    }
-
-    return toRecordView(record)
-  })
+  const recordViews = records.map((record) => toRecordView(record))
 
   return Object.freeze({
     isEmpty: records.length === 0,
     summary: Object.freeze({
-      totalRecords: records.length,
-      unresolvedCount,
-      escalatedCount,
-      mitigatedCount,
+      totalRecords: ledgerSummary.totalRecords,
+      unresolvedCount: ledgerSummary.unresolvedCount,
+      escalatedCount: ledgerSummary.escalatedCount,
+      mitigatedCount: ledgerSummary.mitigatedCount,
       week,
     }),
     records: Object.freeze(recordViews),

--- a/src/test/welfareDebtAccountingLedgerAudit.test.ts
+++ b/src/test/welfareDebtAccountingLedgerAudit.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildWelfareDebtAccountingLedgerAuditReport,
+  COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+  FORCED_SEDATION_CYCLE_FIXTURE,
+  sanitizeWelfareDebtAccountingRecords,
+  summarizeWelfareDebtAccountingRecords,
+  validateWelfareDebtAccountingRecord,
+  WELFARE_DEBT_CATEGORIES,
+  type WelfareDebtAccountingRecord,
+} from '../domain/welfareDebtAccountingRegistry'
+
+function warningOnlyRecord(): WelfareDebtAccountingRecord {
+  return {
+    id: 'welfare-debt:warning-only-escalated',
+    label: 'Escalated welfare debt without mitigation path',
+    subjectRef: 'subject:warning-only',
+    debtCategory: 'coerced_medication',
+    severityBand: 'critical',
+    mitigationState: 'escalated',
+    sourceProcedureLabel: 'forced sedation stabilization cycle',
+    reviewOwnerLabel: 'psychiatric review panel',
+    containmentBenefitScore: 0.64,
+  }
+}
+
+describe('welfareDebtAccountingLedgerAudit (SPE-1888 slice 4)', () => {
+  it('returns zeroed summary for empty map without throw', () => {
+    const summary = summarizeWelfareDebtAccountingRecords({})
+    const report = buildWelfareDebtAccountingLedgerAuditReport({ records: {} })
+
+    expect(summary.totalRecords).toBe(0)
+    expect(summary.unresolvedCount).toBe(0)
+    expect(summary.escalatedCount).toBe(0)
+    expect(summary.mitigatedCount).toBe(0)
+    expect(summary.categoryBreakdown).toHaveLength(WELFARE_DEBT_CATEGORIES.length)
+    expect(summary.categoryBreakdown.every((entry) => entry.count === 0)).toBe(true)
+
+    expect(report.isEmpty).toBe(true)
+    expect(report.lines[0]).toBe('Welfare-debt ledger audit: welfare-debt-ledger')
+    expect(report.lines[2]).toContain('Records: 0')
+  })
+
+  it('counts unresolved, escalated, mitigated, and terminal states from hydrated records', () => {
+    const mitigatedRecord: WelfareDebtAccountingRecord = {
+      id: 'welfare-debt:mitigated-entry',
+      label: 'Mitigated welfare debt entry',
+      subjectRef: 'subject:mitigated',
+      debtCategory: 'privilege_deprivation',
+      severityBand: 'moderate',
+      mitigationState: 'mitigated',
+      sourceProcedureLabel: 'privilege suspension cycle',
+      reviewOwnerLabel: 'ethics review board',
+      mitigationPathLabel: 'restored visitation rights',
+      containmentBenefitScore: 0.42,
+    }
+
+    const waivedRecord: WelfareDebtAccountingRecord = {
+      id: 'welfare-debt:waived-entry',
+      label: 'Waived welfare debt entry',
+      subjectRef: 'subject:waived',
+      debtCategory: 'coerced_participation',
+      severityBand: 'low',
+      mitigationState: 'waived',
+      sourceProcedureLabel: 'coerced interview participation',
+      reviewOwnerLabel: 'ethics review board',
+      mitigationPathLabel: 'institutional waiver',
+      containmentBenefitScore: 0.88,
+    }
+
+    const deniedRecord: WelfareDebtAccountingRecord = {
+      id: 'welfare-debt:denied-entry',
+      label: 'Denied welfare debt entry',
+      subjectRef: 'subject:denied',
+      debtCategory: 'coercive_interview',
+      severityBand: 'moderate',
+      mitigationState: 'denied',
+      sourceProcedureLabel: 'coercive interview cycle',
+      reviewOwnerLabel: 'ethics review board',
+      mitigationPathLabel: 'institutional denial',
+      containmentBenefitScore: 0.91,
+    }
+
+    const acknowledgedRecord: WelfareDebtAccountingRecord = {
+      ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      id: 'welfare-debt:acknowledged-entry',
+      mitigationState: 'acknowledged',
+    }
+
+    const records = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      [FORCED_SEDATION_CYCLE_FIXTURE.id]: FORCED_SEDATION_CYCLE_FIXTURE,
+      [mitigatedRecord.id]: mitigatedRecord,
+      [waivedRecord.id]: waivedRecord,
+      [deniedRecord.id]: deniedRecord,
+      [acknowledgedRecord.id]: acknowledgedRecord,
+    }
+
+    const summary = summarizeWelfareDebtAccountingRecords(records)
+
+    expect(summary.totalRecords).toBe(6)
+    expect(summary.unresolvedCount).toBe(1)
+    expect(summary.escalatedCount).toBe(1)
+    expect(summary.mitigatedCount).toBe(1)
+    expect(summary.acknowledgedCount).toBe(1)
+    expect(summary.waivedCount).toBe(1)
+    expect(summary.deniedCount).toBe(1)
+  })
+
+  it('includes warning-only hydrated records in warningOnlyCount', () => {
+    const warningRecord = warningOnlyRecord()
+    expect(validateWelfareDebtAccountingRecord(warningRecord).valid).toBe(true)
+
+    const summary = summarizeWelfareDebtAccountingRecords({
+      [warningRecord.id]: warningRecord,
+    })
+
+    expect(summary.totalRecords).toBe(1)
+    expect(summary.escalatedCount).toBe(1)
+    expect(summary.warningOnlyCount).toBe(1)
+  })
+
+  it('emits category breakdown in canonical category order', () => {
+    const records = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      [FORCED_SEDATION_CYCLE_FIXTURE.id]: FORCED_SEDATION_CYCLE_FIXTURE,
+    }
+
+    const summary = summarizeWelfareDebtAccountingRecords(records)
+
+    expect(summary.categoryBreakdown.map((entry) => entry.category)).toEqual([
+      ...WELFARE_DEBT_CATEGORIES,
+    ])
+    expect(
+      summary.categoryBreakdown.find((entry) => entry.category === 'harmful_restraint')?.count
+    ).toBe(1)
+    expect(
+      summary.categoryBreakdown.find((entry) => entry.category === 'coerced_medication')?.count
+    ).toBe(1)
+  })
+
+  it('does not re-surface invalid hydrate drops in audit summary', () => {
+    const hydrated = sanitizeWelfareDebtAccountingRecords({
+      valid: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      invalid: {
+        id: '',
+        label: 'Dropped invalid entry',
+        subjectRef: 'subject:invalid',
+        debtCategory: 'not_a_category',
+        severityBand: 'high',
+        mitigationState: 'unresolved',
+        sourceProcedureLabel: 'invalid',
+        reviewOwnerLabel: 'invalid',
+      },
+    })
+
+    const summary = summarizeWelfareDebtAccountingRecords(hydrated)
+
+    expect(Object.keys(hydrated)).toEqual([COERCIVE_RESTRAINT_LEDGER_FIXTURE.id])
+    expect(summary.totalRecords).toBe(1)
+    expect(summary.unresolvedCount).toBe(1)
+  })
+
+  it('builds byte-stable audit report lines on repeated calls', () => {
+    const records = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      [FORCED_SEDATION_CYCLE_FIXTURE.id]: FORCED_SEDATION_CYCLE_FIXTURE,
+    }
+
+    const first = buildWelfareDebtAccountingLedgerAuditReport({
+      records,
+      week: 4,
+      auditId: 'weekly-routing',
+    })
+    const second = buildWelfareDebtAccountingLedgerAuditReport({
+      records,
+      week: 4,
+      auditId: 'weekly-routing',
+    })
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+    expect(first.lines[1]).toBe('Week: 4')
+    expect(first.lines[3]).toContain('harmful_restraint=1')
+    expect(first.lines[3]).toContain('coerced_medication=1')
+  })
+})


### PR DESCRIPTION
## Linear mapping

- **Slice issue:** [SPE-2353](https://linear.app/spectranoir/issue/SPE-2353) — Welfare-debt accounting registry ledger summary audit output (slice 4)
- **Parent:** [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — Welfare-debt accounting for coercive procedures (stays open for SPE-1882 wire-up)

## Summary

- Add `summarizeWelfareDebtAccountingRecords` and `buildWelfareDebtAccountingLedgerAuditReport` in the welfare-debt registry for deterministic agent-routing audit output (mitigation counts + canonical category breakdown).
- Reuse the summarize helper for mirror summary counts so mirror and audit stay aligned.
- Add slice 4 plan doc and backlog handoff.

## What shipped

- Export-only ledger audit report with byte-stable `lines` over hydrated persisted records.
- Mitigation buckets: unresolved, escalated, mitigated, acknowledged, waived, denied, plus warning-only count.
- Category breakdown across all `WELFARE_DEBT_CATEGORIES` in canonical order.
- No persistence, UI route, weekly tick, or bundle compose changes.

## Validation

- `npm run lint`
- `npm run test:run -- src/test/welfareDebtAccountingLedgerAudit.test.ts src/features/operations/welfareDebtAccountingMirrorView.test.ts src/test/welfareDebtAccountingRegistry.test.ts src/test/welfareDebtAccountingWeeklyOrchestration.test.ts`

## Docs updated

- `planning/welfare-debt-accounting-registry-slice-4.md`
- `planning/backlog.md`

## Parent status

SPE-1888 remains open — coercive-protocol wire-up (SPE-1882) is still deferred.