### PR TITLE
feat(SPE-2354): intake ↔ extranormal event cross-link compose (slice 1)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,13 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Intake registry follow-up (next)** — pick next compendium/registry slice from `planning/backlog.md` (intake cross-link, sibling registry persistence, or SPE-1464 branch validation).
+1. **Intake registry follow-up (next)** — sibling registry cross-links (minor-item, unexplained-location) or sibling registry persistence (naming-hazard slice 2); SPE-1464 branch validation optional.
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
 ## Recommended next step (agent handoff)
 
-Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). [SPE-2351](https://linear.app/spectranoir/issue/SPE-2351) **Done** — welfare-debt accounting planning mirror UI shipped (PR #2570). [SPE-2352](https://linear.app/spectranoir/issue/SPE-2352) **Done** — welfare-debt accounting weekly orchestration hook shipped (PR #2572); see `planning/welfare-debt-accounting-registry-slice-3.md`. [SPE-2353](https://linear.app/spectranoir/issue/SPE-2353) **In Progress** — welfare-debt ledger summary audit output (slice 4); see `planning/welfare-debt-accounting-registry-slice-4.md`. Parent [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) stays open for coercive-protocol wire-up (SPE-1882) after slice 4 ships.
+Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). Welfare-debt accounting slices 1–4 shipped (SPE-2350–SPE-2353 / PR #2568–#2574). [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354) **In Progress** — intake ↔ extranormal event cross-link compose (slice 1); see `planning/information-intake-extranormal-cross-link-slice-1.md`. Parent [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) stays open for coercive-protocol wire-up (SPE-1882) after welfare-debt wave.
 
 ## Blocked / waiting
 
@@ -190,6 +190,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-weekly-hook-slice-9.md`                  | **Shipped**    | SPE-2300 / PR #2463; dynamic intake narrative templates from case outcome metadata under SPE-854.                                                    |
 | `information-intake-parent-integration-slice-1.md`           | **Shipped**    | SPE-2301 / PR #2465; mixed-source intake → mission triage/routing under SPE-854.                                                                    |
 | `information-intake-parent-integration-slice-2.md`           | **Shipped**    | SPE-2304 / PR #2471; mission routing hydrate intake-linked triage refresh under SPE-854.                                                            |
+| `information-intake-extranormal-cross-link-slice-1.md`       | **In progress** | SPE-2354; intake ↔ extranormal event cross-link compose @ `7ec285e8`.                                                                                |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-extranormal-cross-link-slice-1.md
+++ b/planning/information-intake-extranormal-cross-link-slice-1.md
@@ -1,0 +1,76 @@
+# SPE-854 — Intake report ↔ extranormal event cross-link compose (slice 1)
+
+One-page implementation plan. Linear: [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354) (child under [SPE-854](https://linear.app/spectranoir/issue/SPE-854)). Closes deferred item from [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) slices 2–3.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2354 — Intake report ↔ extranormal event cross-link compose (slice 1)](https://linear.app/spectranoir/issue/SPE-2354) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (Done); registry anchor [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105) |
+| **Branch** | `spe-854-intake-extranormal-cross-link-slice-1`                                                            |
+| **Base `main` SHA** | `7ec285e8`                                                                                          |
+
+## Goal
+
+Deterministic compose helper linking persisted `informationIntakeReports` to `extranormalEventRecords` via shared topic refs for agent routing and downstream verification synthesis.
+
+## Prerequisite (on `main` @ `7ec285e8`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake report model  | `src/domain/informationIntakeReport.ts` (SPE-2292–2293)                |
+| Intake weekly hook   | `src/domain/informationIntakeWeeklyCorroboration.ts` (SPE-2295)        |
+| Extranormal registry | `src/domain/extranormalEventRegistry.ts` (SPE-2105 slices 1–3)         |
+| Topic coverage compose | `evaluateTopicIntakeCoverage` in `publicSignalCoverage.ts` (SPE-2294) |
+
+## Cross-link contract (slice 1)
+
+- **Optional `intakeTopicRef`** on `ExtranormalEventRecord` — sanitized on hydrate; backward compatible.
+- **Primary match** — `event.intakeTopicRef` overlaps `report.topicRef` via normalized topic keys.
+- **Secondary match** — `event.escalatedCaseRef` overlaps report topic keys when `intakeTopicRef` absent.
+- **Hydrated truth only** — compose over persisted maps; no re-sanitize or invalid-drop surfacing.
+- **Empty maps** — no-op summary with zero counts; no throw.
+- **Byte-stable ordering** — links sorted by topic, event id, report id; summaries deterministic on repeat.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `informationIntakeExtranormalCrossLink.ts` compose + list helpers  | UI / report copy / triage chips               |
+| Optional `intakeTopicRef` on extranormal sanitize/hydrate          | Intake report schema changes                  |
+| Canal-bridge fixture linkage on `BRIEF_COVER_UP_EVENT_WITH_CLUSTER` | Minor-item / unexplained-location cross-links |
+| Unit tests                                                         | `advanceWeek` hook changes                    |
+| Slice doc (this file) + backlog handoff                            | SPE-854 parent reopen                         |
+
+## Acceptance
+
+- [x] Empty maps return zeroed summary without throw
+- [x] `intakeTopicRef` match links canal-bridge intake trio to linked extranormal event
+- [x] `escalatedCaseRef` fallback match when `intakeTopicRef` absent
+- [x] Warning-only / conflicting verification intake included in linked summary
+- [x] Byte-stable ordering on repeated compose
+- [x] No re-surfacing of invalid hydrate drops
+- [x] `npm run lint` + targeted tests + extranormal persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/informationIntakeExtranormalCrossLink.ts`, `src/domain/extranormalEventRegistry.ts` |
+| Tests  | `src/test/informationIntakeExtranormalCrossLink.test.ts`              |
+| Plan   | `planning/information-intake-extranormal-cross-link-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Intake ↔ minor anomaly item cross-link | SPE-854 follow-up | One sibling registry per slice |
+| Intake ↔ unexplained location cross-link | SPE-854 follow-up | One sibling registry per slice |
+| Cross-link surfacing in triage / report notes | SPE-854 or UX owner | Out of compose-only boundary |
+| SPE-1464 branch validation follow-up | SPE-1464 | Separate backlog option |
+
+## See also
+
+- `planning/extranormal-event-registry-slice-2.md` — deferred cross-link item
+- `planning/information-intake-coverage-compose-slice-3.md` — sibling compose pattern
+- `planning/welfare-debt-accounting-registry-slice-4.md` — audit compose pattern

--- a/src/domain/extranormalEventRegistry.ts
+++ b/src/domain/extranormalEventRegistry.ts
@@ -168,6 +168,8 @@ export interface ExtranormalEventRecord {
   readonly escalatedCaseRef?: string
   readonly observerClassTags?: readonly string[]
   readonly themeRef?: string
+  /** Shared intake topic anchor for cross-link compose with `informationIntakeReports`. */
+  readonly intakeTopicRef?: string
   readonly dangerProfileRef?: string
   readonly procedurePatternRefs?: readonly string[]
   readonly locationTag?: string
@@ -807,6 +809,7 @@ function sanitizeExtranormalEventRecordEntry(value: unknown): ExtranormalEventRe
   const closureState = typeof value.closureState === 'string' ? value.closureState : undefined
   const escalatedCaseRef = normalizeToken(value.escalatedCaseRef ?? '') || undefined
   const themeRef = normalizeToken(value.themeRef ?? '') || undefined
+  const intakeTopicRef = normalizeToken(value.intakeTopicRef ?? '') || undefined
   const dangerProfileRef = normalizeToken(value.dangerProfileRef ?? '') || undefined
   const locationTag = normalizeToken(value.locationTag ?? '') || undefined
   const summary = typeof value.summary === 'string' && value.summary.trim().length > 0 ? value.summary.trim() : undefined
@@ -838,6 +841,7 @@ function sanitizeExtranormalEventRecordEntry(value: unknown): ExtranormalEventRe
     ...(escalatedCaseRef ? { escalatedCaseRef } : {}),
     ...(observerClassTags.length > 0 ? { observerClassTags } : {}),
     ...(themeRef ? { themeRef } : {}),
+    ...(intakeTopicRef ? { intakeTopicRef } : {}),
     ...(dangerProfileRef ? { dangerProfileRef } : {}),
     ...(procedurePatternRefs.length > 0 ? { procedurePatternRefs } : {}),
     ...(locationTag ? { locationTag } : {}),
@@ -927,6 +931,7 @@ export const BRIEF_COVER_UP_EVENT_WITH_CLUSTER: ExtranormalEventRecord = defineE
   similarEventCluster: [{ eventId: 'event:brief-canal-shimmer', confidence: 0.39 }],
   observerClassTags: ['civilian-witness'],
   themeRef: 'theme:luminous-water-disturbance',
+  intakeTopicRef: 'topic:canal-bridge-incident',
   dangerProfileRef: 'danger:low-transient-glow',
   procedurePatternRefs: ['procedure:cover-story-monitoring'],
 })

--- a/src/domain/informationIntakeExtranormalCrossLink.ts
+++ b/src/domain/informationIntakeExtranormalCrossLink.ts
@@ -1,0 +1,246 @@
+/**
+ * SPE-854 / SPE-2354 slice 1: intake report ↔ extranormal event cross-link compose.
+ *
+ * Pure deterministic linkage between persisted information intake reports and
+ * extranormal event registry records via shared topic refs — no new persistence
+ * fields on intake reports; optional `intakeTopicRef` on extranormal events.
+ */
+
+import type {
+  InformationIntakeReportRecord,
+  InformationIntakeReportsMap,
+} from './informationIntakeReport'
+import { summarizeMixedSourceIntake } from './informationIntakeReport'
+import type {
+  ExtranormalEventRecord,
+  ExtranormalEventRecordsMap,
+} from './extranormalEventRegistry'
+
+function normalizeToken(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim().toLowerCase()
+}
+
+export type IntakeExtranormalMatchKind = 'intake_topic_ref' | 'escalated_case_topic'
+
+export interface IntakeExtranormalCrossLink {
+  readonly intakeReportId: string
+  readonly extranormalEventId: string
+  readonly topicRef: string
+  readonly matchKind: IntakeExtranormalMatchKind
+}
+
+export interface IntakeExtranormalCrossLinkSummary {
+  readonly topicRef: string
+  readonly links: readonly IntakeExtranormalCrossLink[]
+  readonly linkedReportCount: number
+  readonly linkedEventCount: number
+  readonly intakeSummary: ReturnType<typeof summarizeMixedSourceIntake> | null
+  readonly structuredReasons: readonly string[]
+}
+
+/** Expand a topic or case ref into normalized match keys (topic: prefix variants). */
+export function resolveIntakeExtranormalTopicKeys(topicRef: string): readonly string[] {
+  const normalized = normalizeToken(topicRef)
+  if (!normalized) {
+    return []
+  }
+
+  const keys = new Set<string>([normalized])
+  const stripped = normalized.startsWith('topic:')
+    ? normalized.slice('topic:'.length)
+    : normalized
+
+  if (stripped) {
+    keys.add(stripped)
+    keys.add(`topic:${stripped}`)
+  }
+
+  return [...keys].sort((left, right) => left.localeCompare(right))
+}
+
+function topicKeysOverlap(leftRef: string, rightRef: string): boolean {
+  const leftKeys = new Set(resolveIntakeExtranormalTopicKeys(leftRef))
+  if (leftKeys.size === 0) {
+    return false
+  }
+
+  for (const key of resolveIntakeExtranormalTopicKeys(rightRef)) {
+    if (leftKeys.has(key)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function resolveCrossLinkMatch(
+  report: InformationIntakeReportRecord,
+  event: ExtranormalEventRecord
+): IntakeExtranormalCrossLink | null {
+  const reportTopicRef = normalizeToken(report.topicRef)
+  if (!reportTopicRef) {
+    return null
+  }
+
+  const intakeTopicRef = normalizeToken(event.intakeTopicRef ?? '')
+  if (intakeTopicRef && topicKeysOverlap(reportTopicRef, intakeTopicRef)) {
+    return {
+      intakeReportId: report.id,
+      extranormalEventId: event.id,
+      topicRef: intakeTopicRef,
+      matchKind: 'intake_topic_ref',
+    }
+  }
+
+  const escalatedCaseRef = normalizeToken(event.escalatedCaseRef ?? '')
+  if (escalatedCaseRef && topicKeysOverlap(reportTopicRef, escalatedCaseRef)) {
+    return {
+      intakeReportId: report.id,
+      extranormalEventId: event.id,
+      topicRef: reportTopicRef,
+      matchKind: 'escalated_case_topic',
+    }
+  }
+
+  return null
+}
+
+export function listIntakeReportsForExtranormalEvent(
+  reports: InformationIntakeReportsMap | undefined,
+  event: ExtranormalEventRecord
+): InformationIntakeReportRecord[] {
+  if (!reports) {
+    return []
+  }
+
+  const linked: InformationIntakeReportRecord[] = []
+
+  for (const report of Object.values(reports)) {
+    if (resolveCrossLinkMatch(report, event)) {
+      linked.push(report)
+    }
+  }
+
+  return linked.sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export function listExtranormalEventsForIntakeTopic(
+  events: ExtranormalEventRecordsMap | undefined,
+  topicRef: string
+): ExtranormalEventRecord[] {
+  if (!events) {
+    return []
+  }
+
+  const normalizedTopicRef = normalizeToken(topicRef)
+  if (!normalizedTopicRef) {
+    return []
+  }
+
+  const linked: ExtranormalEventRecord[] = []
+
+  for (const event of Object.values(events)) {
+    const intakeTopicRef = normalizeToken(event.intakeTopicRef ?? '')
+    const escalatedCaseRef = normalizeToken(event.escalatedCaseRef ?? '')
+
+    if (
+      (intakeTopicRef && topicKeysOverlap(normalizedTopicRef, intakeTopicRef)) ||
+      (escalatedCaseRef && topicKeysOverlap(normalizedTopicRef, escalatedCaseRef))
+    ) {
+      linked.push(event)
+    }
+  }
+
+  return linked.sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export function composeIntakeExtranormalCrossLinks(
+  reports: InformationIntakeReportsMap | undefined,
+  events: ExtranormalEventRecordsMap | undefined,
+  topicRef: string
+): IntakeExtranormalCrossLinkSummary {
+  const normalizedTopicRef = normalizeToken(topicRef)
+  const reportList = normalizedTopicRef
+    ? Object.values(reports ?? {}).filter(
+        (report) => topicKeysOverlap(normalizedTopicRef, report.topicRef)
+      )
+    : []
+  const eventList = listExtranormalEventsForIntakeTopic(events, normalizedTopicRef)
+
+  reportList.sort((left, right) => left.id.localeCompare(right.id))
+
+  const links: IntakeExtranormalCrossLink[] = []
+
+  for (const report of reportList) {
+    for (const event of eventList) {
+      const match = resolveCrossLinkMatch(report, event)
+      if (match) {
+        links.push(match)
+      }
+    }
+  }
+
+  links.sort((left, right) => {
+    const byTopic = left.topicRef.localeCompare(right.topicRef)
+    if (byTopic !== 0) {
+      return byTopic
+    }
+
+    const byEvent = left.extranormalEventId.localeCompare(right.extranormalEventId)
+    if (byEvent !== 0) {
+      return byEvent
+    }
+
+    return left.intakeReportId.localeCompare(right.intakeReportId)
+  })
+
+  const linkedReportIds = new Set(links.map((link) => link.intakeReportId))
+  const linkedEventIds = new Set(links.map((link) => link.extranormalEventId))
+  const linkedReports = reportList.filter((report) => linkedReportIds.has(report.id))
+
+  const structuredReasons = [
+    `topic:${normalizedTopicRef || '(unknown)'}`,
+    `link_count:${links.length}`,
+    `linked_report_count:${linkedReportIds.size}`,
+    `linked_event_count:${linkedEventIds.size}`,
+    links.some((link) => link.matchKind === 'intake_topic_ref')
+      ? 'match:intake_topic_ref'
+      : 'match:none_intake_topic_ref',
+    links.some((link) => link.matchKind === 'escalated_case_topic')
+      ? 'match:escalated_case_topic'
+      : 'match:none_escalated_case_topic',
+  ].sort((left, right) => left.localeCompare(right))
+
+  return {
+    topicRef: normalizedTopicRef || '(unknown)',
+    links,
+    linkedReportCount: linkedReportIds.size,
+    linkedEventCount: linkedEventIds.size,
+    intakeSummary: linkedReports.length > 0 ? summarizeMixedSourceIntake(linkedReports) : null,
+    structuredReasons,
+  }
+}
+
+/** Compose cross-link summaries for every topic ref present in linked intake reports. */
+export function composeAllIntakeExtranormalCrossLinks(
+  reports: InformationIntakeReportsMap | undefined,
+  events: ExtranormalEventRecordsMap | undefined
+): readonly IntakeExtranormalCrossLinkSummary[] {
+  const topicRefs = new Set<string>()
+
+  for (const report of Object.values(reports ?? {})) {
+    const topicRef = normalizeToken(report.topicRef)
+    if (topicRef) {
+      topicRefs.add(topicRef)
+    }
+  }
+
+  return [...topicRefs]
+    .sort((left, right) => left.localeCompare(right))
+    .map((topicRef) => composeIntakeExtranormalCrossLinks(reports, events, topicRef))
+    .filter((summary) => summary.links.length > 0)
+}

--- a/src/test/informationIntakeExtranormalCrossLink.test.ts
+++ b/src/test/informationIntakeExtranormalCrossLink.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BRIEF_COVER_UP_EVENT_FIXTURE,
+  BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+} from '../domain/extranormalEventRegistry'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import {
+  composeAllIntakeExtranormalCrossLinks,
+  composeIntakeExtranormalCrossLinks,
+  listExtranormalEventsForIntakeTopic,
+  listIntakeReportsForExtranormalEvent,
+  resolveIntakeExtranormalTopicKeys,
+} from '../domain/informationIntakeExtranormalCrossLink'
+
+const CANAL_BRIDGE_TOPIC = 'topic:canal-bridge-incident'
+
+const CANAL_BRIDGE_REPORTS = {
+  [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+}
+
+describe('informationIntakeExtranormalCrossLink (SPE-2354 slice 1)', () => {
+  it('expands topic refs into stable match keys', () => {
+    expect(resolveIntakeExtranormalTopicKeys('topic:canal-bridge-incident')).toEqual([
+      'canal-bridge-incident',
+      'topic:canal-bridge-incident',
+    ])
+  })
+
+  it('links canal-bridge intake reports to extranormal events via intakeTopicRef', () => {
+    const events = {
+      [BRIEF_COVER_UP_EVENT_WITH_CLUSTER.id]: BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+    }
+
+    const summary = composeIntakeExtranormalCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      events,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.linkedEventCount).toBe(1)
+    expect(summary.linkedReportCount).toBe(3)
+    expect(summary.links).toHaveLength(3)
+    expect(summary.links.every((link) => link.matchKind === 'intake_topic_ref')).toBe(true)
+    expect(summary.intakeSummary?.hasConflictingVerification).toBe(true)
+    expect(summary.structuredReasons).toContain('match:intake_topic_ref')
+  })
+
+  it('links via escalatedCaseRef when intakeTopicRef is absent', () => {
+    const event = {
+      ...BRIEF_COVER_UP_EVENT_FIXTURE,
+      intakeTopicRef: undefined,
+      escalatedCaseRef: 'topic:canal-bridge-incident',
+    }
+    const events = { [event.id]: event }
+
+    const linkedReports = listIntakeReportsForExtranormalEvent(CANAL_BRIDGE_REPORTS, event)
+    expect(linkedReports).toHaveLength(3)
+
+    const summary = composeIntakeExtranormalCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      events,
+      CANAL_BRIDGE_TOPIC
+    )
+    expect(summary.links.every((link) => link.matchKind === 'escalated_case_topic')).toBe(true)
+    expect(summary.structuredReasons).toContain('match:escalated_case_topic')
+  })
+
+  it('returns empty summary for empty maps without throw', () => {
+    const summary = composeIntakeExtranormalCrossLinks(undefined, undefined, CANAL_BRIDGE_TOPIC)
+
+    expect(summary.links).toEqual([])
+    expect(summary.linkedReportCount).toBe(0)
+    expect(summary.linkedEventCount).toBe(0)
+    expect(summary.intakeSummary).toBeNull()
+    expect(summary.structuredReasons).toContain('link_count:0')
+  })
+
+  it('lists extranormal events for a topic in stable id order', () => {
+    const events = {
+      [BRIEF_COVER_UP_EVENT_WITH_CLUSTER.id]: BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+    }
+
+    expect(listExtranormalEventsForIntakeTopic(events, CANAL_BRIDGE_TOPIC)).toEqual([
+      BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+    ])
+  })
+
+  it('composeAllIntakeExtranormalCrossLinks returns byte-stable summaries', () => {
+    const events = {
+      [BRIEF_COVER_UP_EVENT_WITH_CLUSTER.id]: BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+    }
+
+    const first = composeAllIntakeExtranormalCrossLinks(CANAL_BRIDGE_REPORTS, events)
+    const second = composeAllIntakeExtranormalCrossLinks(CANAL_BRIDGE_REPORTS, events)
+
+    expect(first).toEqual(second)
+    expect(first).toHaveLength(1)
+    expect(first[0]?.topicRef).toBe(CANAL_BRIDGE_TOPIC)
+  })
+
+  it('does not link events without topic anchors', () => {
+    const events = {
+      [BRIEF_COVER_UP_EVENT_FIXTURE.id]: BRIEF_COVER_UP_EVENT_FIXTURE,
+    }
+
+    const summary = composeIntakeExtranormalCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      events,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.links).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

- Add \informationIntakeExtranormalCrossLink.ts\ compose/list helpers linking persisted \informationIntakeReports\ to \extranormalEventRecords\ via shared topic refs.
- Optional \intakeTopicRef\ on \ExtranormalEventRecord\ (sanitize/hydrate); \escalatedCaseRef\ fallback match.
- Canal-bridge fixture linkage on \BRIEF_COVER_UP_EVENT_WITH_CLUSTER\.

## Linear

- **Slice:** [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) (Done); registry anchor [SPE-2105](https://linear.app/spectranoir/issue/SPE-2105)

## What shipped

Deterministic cross-link compose for agent routing; closes deferred item from extranormal registry slices 2–3.

## Validation

- \
pm run lint\
- \
pm run test:run -- src/test/informationIntakeExtranormalCrossLink.test.ts src/test/extranormalEventRegistryPersistence.test.ts\

## Docs updated

- \planning/information-intake-extranormal-cross-link-slice-1.md\
- \planning/backlog.md\

## Parent status

SPE-854 remains Done. SPE-2105 parent unchanged.

Made with [Cursor](https://cursor.com)