### PR TITLE
feat(SPE-2355): intake ↔ minor anomaly item cross-link compose (slice 1)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -22,7 +22,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). Welfare-debt accounting slices 1–4 shipped (SPE-2350–SPE-2353 / PR #2568–#2574). [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354) **Done** — intake ↔ extranormal event cross-link compose shipped (PR #2576); see `planning/information-intake-extranormal-cross-link-slice-1.md`. **Next:** sibling cross-link (minor-item or unexplained-location) or naming-hazard registry persistence (slice 2).
+Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). Welfare-debt accounting slices 1–4 shipped (SPE-2350–SPE-2353 / PR #2568–#2574). [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354) **Done** — intake ↔ extranormal event cross-link compose shipped (PR #2576). [SPE-2355](https://linear.app/spectranoir/issue/SPE-2355) **In Progress** — intake ↔ minor anomaly item cross-link compose; see `planning/information-intake-minor-anomaly-cross-link-slice-1.md`. **Next:** unexplained-location cross-link or naming-hazard registry persistence (slice 2).
 
 ## Blocked / waiting
 
@@ -191,6 +191,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-parent-integration-slice-1.md`           | **Shipped**    | SPE-2301 / PR #2465; mixed-source intake → mission triage/routing under SPE-854.                                                                    |
 | `information-intake-parent-integration-slice-2.md`           | **Shipped**    | SPE-2304 / PR #2471; mission routing hydrate intake-linked triage refresh under SPE-854.                                                            |
 | `information-intake-extranormal-cross-link-slice-1.md`       | **Shipped**    | SPE-2354 / PR #2576; intake ↔ extranormal event cross-link compose @ `bd38d2ee`.                                                                     |
+| `information-intake-minor-anomaly-cross-link-slice-1.md`     | **In Progress**| SPE-2355; intake ↔ minor anomaly item cross-link compose @ `72eef839`.                                                                               |
 | `reveal-payload-slice-1.md` … `reveal-payload-slice-5.md` | **Shipped**    | SPE-781 slices 1–5; sequential stack.                                                                                                               |
 | `stealth-leave-behind-tradeoff-selection-slice-5.md`      | **Shipped**    | SPE-2247 / PR #2323.                                                                                                                                |
 

--- a/planning/information-intake-minor-anomaly-cross-link-slice-1.md
+++ b/planning/information-intake-minor-anomaly-cross-link-slice-1.md
@@ -1,0 +1,71 @@
+# SPE-854 — Intake report ↔ minor anomaly item cross-link compose (slice 1)
+
+One-page implementation plan. Linear: [SPE-2355](https://linear.app/spectranoir/issue/SPE-2355) (child under [SPE-854](https://linear.app/spectranoir/issue/SPE-854)). Closes deferred item from [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) slice 3 and [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2355 — Intake report ↔ minor anomaly item cross-link compose (slice 1)](https://linear.app/spectranoir/issue/SPE-2355) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (Done); registry anchor [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104) |
+| **Branch** | `spe-854-intake-minor-anomaly-cross-link-slice-1`                                                          |
+| **Base `main` SHA** | `72eef839`                                                                                          |
+
+## Goal
+
+Deterministic compose helper linking persisted `informationIntakeReports` to `minorAnomalyItemRecords` via shared topic refs for agent routing and downstream verification synthesis.
+
+## Prerequisite (on `main` @ `72eef839`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake report model  | `src/domain/informationIntakeReport.ts` (SPE-2292–2293)                |
+| Minor-item registry  | `src/domain/minorAnomalyItemRegistry.ts` (SPE-2104 slices 1–3)         |
+| Extranormal cross-link pattern | `src/domain/informationIntakeExtranormalCrossLink.ts` (SPE-2354) |
+
+## Cross-link contract (slice 1)
+
+- **Optional `intakeTopicRef`** on `MinorAnomalyRecord` — sanitized on hydrate; backward compatible.
+- **Primary match** — `item.intakeTopicRef` overlaps `report.topicRef` via normalized topic keys (`resolveIntakeExtranormalTopicKeys`).
+- **Hydrated truth only** — compose over persisted maps; no re-sanitize or invalid-drop surfacing.
+- **Empty maps** — no-op summary with zero counts; no throw.
+- **Byte-stable ordering** — links sorted by topic, item id, report id; summaries deterministic on repeat.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `informationIntakeMinorAnomalyCrossLink.ts` compose + list helpers  | UI / report copy / triage chips               |
+| Optional `intakeTopicRef` on minor-item sanitize/hydrate          | Intake report schema changes                  |
+| Canal-bridge fixture linkage on minor-item fixture                  | Unexplained-location cross-link               |
+| Unit tests                                                         | `advanceWeek` hook changes                    |
+| Slice doc (this file) + backlog handoff                            | SPE-854 parent reopen                         |
+
+## Acceptance
+
+- [x] Empty maps return zeroed summary without throw
+- [x] `intakeTopicRef` match links canal-bridge intake trio to linked minor item
+- [x] Warning-only hydrated minor items included in linked summary
+- [x] Byte-stable ordering on repeated compose
+- [x] No re-surfacing of invalid hydrate drops
+- [x] `npm run lint` + targeted tests + minor-item persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/informationIntakeMinorAnomalyCrossLink.ts`, `src/domain/minorAnomalyItemRegistry.ts` |
+| Tests  | `src/test/informationIntakeMinorAnomalyCrossLink.test.ts`              |
+| Plan   | `planning/information-intake-minor-anomaly-cross-link-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Intake ↔ unexplained location cross-link | SPE-854 follow-up | One sibling registry per slice |
+| Cross-link surfacing in triage / report notes | SPE-854 or UX owner | Out of compose-only boundary |
+| SPE-1464 branch validation follow-up | SPE-1464 | Separate backlog option |
+
+## See also
+
+- `planning/minor-anomaly-item-registry-slice-3.md` — deferred cross-link row
+- `planning/information-intake-extranormal-cross-link-slice-1.md` — sibling compose pattern

--- a/src/domain/informationIntakeMinorAnomalyCrossLink.ts
+++ b/src/domain/informationIntakeMinorAnomalyCrossLink.ts
@@ -1,0 +1,210 @@
+/**
+ * SPE-854 / SPE-2355 slice 1: intake report ↔ minor anomaly item cross-link compose.
+ *
+ * Pure deterministic linkage between persisted information intake reports and
+ * minor anomaly item registry records via shared topic refs — no new persistence
+ * fields on intake reports; optional `intakeTopicRef` on minor items.
+ */
+
+import type {
+  InformationIntakeReportRecord,
+  InformationIntakeReportsMap,
+} from './informationIntakeReport'
+import { summarizeMixedSourceIntake } from './informationIntakeReport'
+import { resolveIntakeExtranormalTopicKeys } from './informationIntakeExtranormalCrossLink'
+import type {
+  MinorAnomalyRecord,
+  MinorAnomalyItemRecordsMap,
+} from './minorAnomalyItemRegistry'
+
+function normalizeToken(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim().toLowerCase()
+}
+
+export type IntakeMinorAnomalyMatchKind = 'intake_topic_ref'
+
+export interface IntakeMinorAnomalyCrossLink {
+  readonly intakeReportId: string
+  readonly minorAnomalyItemId: string
+  readonly topicRef: string
+  readonly matchKind: IntakeMinorAnomalyMatchKind
+}
+
+export interface IntakeMinorAnomalyCrossLinkSummary {
+  readonly topicRef: string
+  readonly links: readonly IntakeMinorAnomalyCrossLink[]
+  readonly linkedReportCount: number
+  readonly linkedItemCount: number
+  readonly intakeSummary: ReturnType<typeof summarizeMixedSourceIntake> | null
+  readonly structuredReasons: readonly string[]
+}
+
+function topicKeysOverlap(leftRef: string, rightRef: string): boolean {
+  const leftKeys = new Set(resolveIntakeExtranormalTopicKeys(leftRef))
+  if (leftKeys.size === 0) {
+    return false
+  }
+
+  for (const key of resolveIntakeExtranormalTopicKeys(rightRef)) {
+    if (leftKeys.has(key)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function resolveCrossLinkMatch(
+  report: InformationIntakeReportRecord,
+  item: MinorAnomalyRecord
+): IntakeMinorAnomalyCrossLink | null {
+  const reportTopicRef = normalizeToken(report.topicRef)
+  if (!reportTopicRef) {
+    return null
+  }
+
+  const intakeTopicRef = normalizeToken(item.intakeTopicRef ?? '')
+  if (intakeTopicRef && topicKeysOverlap(reportTopicRef, intakeTopicRef)) {
+    return {
+      intakeReportId: report.id,
+      minorAnomalyItemId: item.id,
+      topicRef: intakeTopicRef,
+      matchKind: 'intake_topic_ref',
+    }
+  }
+
+  return null
+}
+
+export function listIntakeReportsForMinorAnomalyItem(
+  reports: InformationIntakeReportsMap | undefined,
+  item: MinorAnomalyRecord
+): InformationIntakeReportRecord[] {
+  if (!reports) {
+    return []
+  }
+
+  const linked: InformationIntakeReportRecord[] = []
+
+  for (const report of Object.values(reports)) {
+    if (resolveCrossLinkMatch(report, item)) {
+      linked.push(report)
+    }
+  }
+
+  return linked.sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export function listMinorAnomalyItemsForIntakeTopic(
+  items: MinorAnomalyItemRecordsMap | undefined,
+  topicRef: string
+): MinorAnomalyRecord[] {
+  if (!items) {
+    return []
+  }
+
+  const normalizedTopicRef = normalizeToken(topicRef)
+  if (!normalizedTopicRef) {
+    return []
+  }
+
+  const linked: MinorAnomalyRecord[] = []
+
+  for (const item of Object.values(items)) {
+    const intakeTopicRef = normalizeToken(item.intakeTopicRef ?? '')
+
+    if (intakeTopicRef && topicKeysOverlap(normalizedTopicRef, intakeTopicRef)) {
+      linked.push(item)
+    }
+  }
+
+  return linked.sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export function composeIntakeMinorAnomalyCrossLinks(
+  reports: InformationIntakeReportsMap | undefined,
+  items: MinorAnomalyItemRecordsMap | undefined,
+  topicRef: string
+): IntakeMinorAnomalyCrossLinkSummary {
+  const normalizedTopicRef = normalizeToken(topicRef)
+  const reportList = normalizedTopicRef
+    ? Object.values(reports ?? {}).filter((report) =>
+        topicKeysOverlap(normalizedTopicRef, report.topicRef)
+      )
+    : []
+  const itemList = listMinorAnomalyItemsForIntakeTopic(items, normalizedTopicRef)
+
+  reportList.sort((left, right) => left.id.localeCompare(right.id))
+
+  const links: IntakeMinorAnomalyCrossLink[] = []
+
+  for (const report of reportList) {
+    for (const item of itemList) {
+      const match = resolveCrossLinkMatch(report, item)
+      if (match) {
+        links.push(match)
+      }
+    }
+  }
+
+  links.sort((left, right) => {
+    const byTopic = left.topicRef.localeCompare(right.topicRef)
+    if (byTopic !== 0) {
+      return byTopic
+    }
+
+    const byItem = left.minorAnomalyItemId.localeCompare(right.minorAnomalyItemId)
+    if (byItem !== 0) {
+      return byItem
+    }
+
+    return left.intakeReportId.localeCompare(right.intakeReportId)
+  })
+
+  const linkedReportIds = new Set(links.map((link) => link.intakeReportId))
+  const linkedItemIds = new Set(links.map((link) => link.minorAnomalyItemId))
+  const linkedReports = reportList.filter((report) => linkedReportIds.has(report.id))
+
+  const structuredReasons = [
+    `topic:${normalizedTopicRef || '(unknown)'}`,
+    `link_count:${links.length}`,
+    `linked_report_count:${linkedReportIds.size}`,
+    `linked_item_count:${linkedItemIds.size}`,
+    links.some((link) => link.matchKind === 'intake_topic_ref')
+      ? 'match:intake_topic_ref'
+      : 'match:none_intake_topic_ref',
+  ].sort((left, right) => left.localeCompare(right))
+
+  return {
+    topicRef: normalizedTopicRef || '(unknown)',
+    links,
+    linkedReportCount: linkedReportIds.size,
+    linkedItemCount: linkedItemIds.size,
+    intakeSummary: linkedReports.length > 0 ? summarizeMixedSourceIntake(linkedReports) : null,
+    structuredReasons,
+  }
+}
+
+/** Compose cross-link summaries for every topic ref present in linked intake reports. */
+export function composeAllIntakeMinorAnomalyCrossLinks(
+  reports: InformationIntakeReportsMap | undefined,
+  items: MinorAnomalyItemRecordsMap | undefined
+): readonly IntakeMinorAnomalyCrossLinkSummary[] {
+  const topicRefs = new Set<string>()
+
+  for (const report of Object.values(reports ?? {})) {
+    const topicRef = normalizeToken(report.topicRef)
+    if (topicRef) {
+      topicRefs.add(topicRef)
+    }
+  }
+
+  return [...topicRefs]
+    .sort((left, right) => left.localeCompare(right))
+    .map((topicRef) => composeIntakeMinorAnomalyCrossLinks(reports, items, topicRef))
+    .filter((summary) => summary.links.length > 0)
+}

--- a/src/domain/minorAnomalyItemRegistry.ts
+++ b/src/domain/minorAnomalyItemRegistry.ts
@@ -89,6 +89,8 @@ export interface MinorAnomalyRecord {
   readonly investigationRef?: string
   readonly publicDisruptionRef?: string
   readonly staffNoteProvenance?: readonly StaffNoteProvenanceHook[]
+  /** Shared intake topic anchor for cross-link compose with `informationIntakeReports`. */
+  readonly intakeTopicRef?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -656,6 +658,7 @@ function sanitizeMinorAnomalyItemRecordEntry(value: unknown): MinorAnomalyRecord
     normalizeToken(value.destructionAuthorizationRef ?? '') || undefined
   const investigationRef = normalizeToken(value.investigationRef ?? '') || undefined
   const publicDisruptionRef = normalizeToken(value.publicDisruptionRef ?? '') || undefined
+  const intakeTopicRef = normalizeToken(value.intakeTopicRef ?? '') || undefined
   const lowValue = value.lowValue === true ? true : undefined
   const confidence = value.confidence
 
@@ -677,6 +680,7 @@ function sanitizeMinorAnomalyItemRecordEntry(value: unknown): MinorAnomalyRecord
     ...(destructionAuthorizationRef ? { destructionAuthorizationRef } : {}),
     ...(investigationRef ? { investigationRef } : {}),
     ...(publicDisruptionRef ? { publicDisruptionRef } : {}),
+    ...(intakeTopicRef ? { intakeTopicRef } : {}),
     ...(staffNoteProvenance.length > 0 ? { staffNoteProvenance } : {}),
   }
 
@@ -733,6 +737,20 @@ export const DISPOSITION_CHAIN_ITEM_FIXTURE: MinorAnomalyRecord = defineItem({
     { fromDisposition: 'recovered', toDisposition: 'stored', week: 9, note: 'Logged in low-priority vault.' },
     { fromDisposition: 'stored', toDisposition: 'staff_use', week: 22, note: 'Issued for calibration drills.' },
   ],
+})
+
+/** Canal-bridge residue vial linked to mixed-source intake via intakeTopicRef. */
+export const CANAL_BRIDGE_MINOR_ITEM_FIXTURE: MinorAnomalyRecord = defineItem({
+  id: 'item:canal-residue-vial',
+  label: 'Canal residue vial',
+  descriptionStub: 'Low-priority residue sample recovered near east canal intake grid.',
+  recoverySiteRef: 'site:east-canal-locker',
+  currentCustodyRef: 'custody:field-locker-7',
+  disposition: 'recovered',
+  latentRiskScore: 9,
+  lowValue: true,
+  confidence: 0.44,
+  intakeTopicRef: 'topic:canal-bridge-incident',
 })
 
 /** False-positive return closed with investigation ref. */

--- a/src/test/informationIntakeMinorAnomalyCrossLink.test.ts
+++ b/src/test/informationIntakeMinorAnomalyCrossLink.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  composeAllIntakeMinorAnomalyCrossLinks,
+  composeIntakeMinorAnomalyCrossLinks,
+  listIntakeReportsForMinorAnomalyItem,
+  listMinorAnomalyItemsForIntakeTopic,
+} from '../domain/informationIntakeMinorAnomalyCrossLink'
+import { resolveIntakeExtranormalTopicKeys } from '../domain/informationIntakeExtranormalCrossLink'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import {
+  CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+  DISPOSITION_CHAIN_ITEM_FIXTURE,
+  validateMinorAnomalyRecord,
+} from '../domain/minorAnomalyItemRegistry'
+
+const CANAL_BRIDGE_TOPIC = 'topic:canal-bridge-incident'
+
+const CANAL_BRIDGE_REPORTS = {
+  [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+}
+
+const WARNING_ONLY_MINOR_ITEM = {
+  ...CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+  id: 'item:canal-warning-only',
+  label: 'Canal warning-only shard',
+  disposition: 'recovered' as const,
+  status: 'stored',
+}
+
+describe('informationIntakeMinorAnomalyCrossLink (SPE-2355 slice 1)', () => {
+  it('expands topic refs into stable match keys via shared resolver', () => {
+    expect(resolveIntakeExtranormalTopicKeys('topic:canal-bridge-incident')).toEqual([
+      'canal-bridge-incident',
+      'topic:canal-bridge-incident',
+    ])
+  })
+
+  it('links canal-bridge intake reports to minor items via intakeTopicRef', () => {
+    const items = {
+      [CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]: CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+    }
+
+    const summary = composeIntakeMinorAnomalyCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      items,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.linkedItemCount).toBe(1)
+    expect(summary.linkedReportCount).toBe(3)
+    expect(summary.links).toHaveLength(3)
+    expect(summary.links.every((link) => link.matchKind === 'intake_topic_ref')).toBe(true)
+    expect(summary.intakeSummary?.hasConflictingVerification).toBe(true)
+    expect(summary.structuredReasons).toContain('match:intake_topic_ref')
+  })
+
+  it('includes warning-only hydrated minor items in linked summary', () => {
+    expect(validateMinorAnomalyRecord(WARNING_ONLY_MINOR_ITEM).valid).toBe(true)
+    expect(
+      validateMinorAnomalyRecord(WARNING_ONLY_MINOR_ITEM).issues.some(
+        (issue) => issue.severity === 'warning'
+      )
+    ).toBe(true)
+
+    const items = {
+      [WARNING_ONLY_MINOR_ITEM.id]: WARNING_ONLY_MINOR_ITEM,
+    }
+
+    const summary = composeIntakeMinorAnomalyCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      items,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.linkedItemCount).toBe(1)
+    expect(summary.links).toHaveLength(3)
+  })
+
+  it('returns empty summary for empty maps without throw', () => {
+    const summary = composeIntakeMinorAnomalyCrossLinks(undefined, undefined, CANAL_BRIDGE_TOPIC)
+
+    expect(summary.links).toEqual([])
+    expect(summary.linkedReportCount).toBe(0)
+    expect(summary.linkedItemCount).toBe(0)
+    expect(summary.intakeSummary).toBeNull()
+    expect(summary.structuredReasons).toContain('link_count:0')
+  })
+
+  it('lists minor items for a topic in stable id order', () => {
+    const items = {
+      [CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]: CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+    }
+
+    expect(listMinorAnomalyItemsForIntakeTopic(items, CANAL_BRIDGE_TOPIC)).toEqual([
+      CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+    ])
+  })
+
+  it('lists intake reports for a minor item in stable id order', () => {
+    const linkedReports = listIntakeReportsForMinorAnomalyItem(
+      CANAL_BRIDGE_REPORTS,
+      CANAL_BRIDGE_MINOR_ITEM_FIXTURE
+    )
+
+    expect(linkedReports).toHaveLength(3)
+    expect(linkedReports.map((report) => report.id)).toEqual(
+      [
+        FORMAL_ALERT_PARTIAL_FIXTURE.id,
+        IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id,
+        PUBLIC_RUMOR_CONFLICT_FIXTURE.id,
+      ].sort((left, right) => left.localeCompare(right))
+    )
+  })
+
+  it('composeAllIntakeMinorAnomalyCrossLinks returns byte-stable summaries', () => {
+    const items = {
+      [CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]: CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+    }
+
+    const first = composeAllIntakeMinorAnomalyCrossLinks(CANAL_BRIDGE_REPORTS, items)
+    const second = composeAllIntakeMinorAnomalyCrossLinks(CANAL_BRIDGE_REPORTS, items)
+
+    expect(first).toEqual(second)
+    expect(first).toHaveLength(1)
+    expect(first[0]?.topicRef).toBe(CANAL_BRIDGE_TOPIC)
+  })
+
+  it('does not link items without topic anchors', () => {
+    const items = {
+      [DISPOSITION_CHAIN_ITEM_FIXTURE.id]: DISPOSITION_CHAIN_ITEM_FIXTURE,
+    }
+
+    const summary = composeIntakeMinorAnomalyCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      items,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.links).toEqual([])
+  })
+
+  it('is idempotent on repeated compose calls', () => {
+    const items = {
+      [CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]: CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+    }
+
+    const first = composeIntakeMinorAnomalyCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      items,
+      CANAL_BRIDGE_TOPIC
+    )
+    const second = composeIntakeMinorAnomalyCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      items,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(first).toEqual(second)
+  })
+})

--- a/src/test/minorAnomalyItemRegistryPersistence.test.ts
+++ b/src/test/minorAnomalyItemRegistryPersistence.test.ts
@@ -4,6 +4,7 @@ import { createStartingState } from '../data/startingState'
 import { hydrateGame } from '../app/store/runTransfer'
 import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
 import {
+  CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
   DISPOSITION_CHAIN_ITEM_FIXTURE,
   FALSE_POSITIVE_ITEM_FIXTURE,
   sanitizeMinorAnomalyItemRecords,
@@ -103,6 +104,24 @@ describe('minorAnomalyItemRegistry persistence (SPE-2104 slice 2)', () => {
       statusHistory: [{ fromDisposition: 'recovered', toDisposition: 'stored', week: 4 }],
     })
     expect(Object.keys(sanitized)).toHaveLength(3)
+  })
+
+  it('preserves optional intakeTopicRef through sanitize and save/load round-trip', () => {
+    const sanitized = sanitizeMinorAnomalyItemRecords({
+      canalBridge: CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+    })
+
+    expect(sanitized[CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]?.intakeTopicRef).toBe(
+      'topic:canal-bridge-incident'
+    )
+
+    const state = createStartingState()
+    state.minorAnomalyItemRecords = sanitized
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.minorAnomalyItemRecords?.[CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]?.intakeTopicRef).toBe(
+      'topic:canal-bridge-incident'
+    )
   })
 
   it('round-trips fixture items with statusHistory and investigationRef byte-stable through save/load', () => {


### PR DESCRIPTION
## Summary

- Add pure compose helper `informationIntakeMinorAnomalyCrossLink.ts` linking `informationIntakeReports` to `minorAnomalyItemRecords` via shared topic refs (mirrors SPE-2354 extranormal pattern).
- Add optional `intakeTopicRef` on `MinorAnomalyRecord` sanitize/hydrate plus `CANAL_BRIDGE_MINOR_ITEM_FIXTURE` for canal-bridge linkage tests.
- Unit tests + minor-item persistence regression for `intakeTopicRef` round-trip.

## Linear mapping

- **Slice:** [SPE-2355](https://linear.app/spectranoir/issue/SPE-2355) — Intake report ↔ minor anomaly item cross-link compose (slice 1)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — stays Done (follow-up slice only)
- **Registry anchor:** [SPE-2104](https://linear.app/spectranoir/issue/SPE-2104)
- **Sibling reference:** [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354) — shipped extranormal cross-link

## What shipped

- `composeIntakeMinorAnomalyCrossLinks` / `composeAllIntakeMinorAnomalyCrossLinks` + list helpers
- Optional `intakeTopicRef` on minor-item records (backward compatible)
- Canal-bridge fixture linkage; warning-only hydrated items included; byte-stable ordering

## Validation

- `npm run test:run -- src/test/informationIntakeMinorAnomalyCrossLink.test.ts src/test/minorAnomalyItemRegistryPersistence.test.ts`
- `npm run lint`

## Docs updated

- `planning/information-intake-minor-anomaly-cross-link-slice-1.md`
- `planning/backlog.md`

## Parent remains open?

No — SPE-854 stays Done; this is a follow-up compose slice only.

Made with [Cursor](https://cursor.com)