### PR TITLE
feat(SPE-2356): intake ↔ unexplained location cross-link compose (slice 1)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,13 +16,13 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-1. **Intake registry follow-up (next)** — sibling registry cross-links (minor-item, unexplained-location) or sibling registry persistence (naming-hazard slice 2); SPE-1464 branch validation optional.
+1. **Naming-hazard descriptor registry persistence (slice 2)** — sibling registry persistence path; follow `planning/extranormal-event-registry-slice-2.md` pattern on `namingHazardDescriptorRegistry.ts`; SPE-1464 branch validation optional.
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
 ## Recommended next step (agent handoff)
 
-Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). Welfare-debt accounting slices 1–4 shipped (SPE-2350–SPE-2353 / PR #2568–#2574). [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354) **Done** — intake ↔ extranormal event cross-link compose shipped (PR #2576). [SPE-2355](https://linear.app/spectranoir/issue/SPE-2355) **Done** — intake ↔ minor anomaly item cross-link compose shipped (PR #2578); see `planning/information-intake-minor-anomaly-cross-link-slice-1.md`. **Next:** unexplained-location cross-link or naming-hazard registry persistence (slice 2).
+Integrated health bundle wire-up slices 5–10 shipped (SPE-2345–SPE-2350 / PR #2557–#2568). Welfare-debt accounting slices 1–4 shipped (SPE-2350–SPE-2353 / PR #2568–#2574). [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354) **Done** — intake ↔ extranormal event cross-link compose shipped (PR #2576). [SPE-2355](https://linear.app/spectranoir/issue/SPE-2355) **Done** — intake ↔ minor anomaly item cross-link compose shipped (PR #2578). [SPE-2356](https://linear.app/spectranoir/issue/SPE-2356) **In Progress** — intake ↔ unexplained location cross-link compose; see `planning/information-intake-unexplained-location-cross-link-slice-1.md`. **Next:** naming-hazard registry persistence (slice 2) or SPE-1464 branch validation.
 
 ## Blocked / waiting
 

--- a/planning/information-intake-unexplained-location-cross-link-slice-1.md
+++ b/planning/information-intake-unexplained-location-cross-link-slice-1.md
@@ -1,0 +1,71 @@
+# SPE-854 — Intake report ↔ unexplained location cross-link compose (slice 1)
+
+One-page implementation plan. Linear: [SPE-2356](https://linear.app/spectranoir/issue/SPE-2356) (child under [SPE-854](https://linear.app/spectranoir/issue/SPE-854)). Closes deferred item from [SPE-2355](https://linear.app/spectranoir/issue/SPE-2355) and [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) slice 3.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2356 — Intake report ↔ unexplained location cross-link compose (slice 1)](https://linear.app/spectranoir/issue/SPE-2356) |
+| **Status** | In Progress — PR pending                                                                                   |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — Information intake and verification engine (Done); registry anchor [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106) |
+| **Branch** | `spe-854-intake-unexplained-location-cross-link-slice-1`                                                   |
+| **Base `main` SHA** | `69502dc8`                                                                                          |
+
+## Goal
+
+Deterministic compose helper linking persisted `informationIntakeReports` to `unexplainedLocationRecords` via shared topic refs for agent routing and downstream verification synthesis.
+
+## Prerequisite (on `main` @ `69502dc8`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake report model  | `src/domain/informationIntakeReport.ts` (SPE-2292–2293)                |
+| Location registry    | `src/domain/unexplainedLocationRegistry.ts` (SPE-2106 slices 1–3)      |
+| Sibling cross-links  | `informationIntakeExtranormalCrossLink.ts` (SPE-2354), `informationIntakeMinorAnomalyCrossLink.ts` (SPE-2355) |
+
+## Cross-link contract (slice 1)
+
+- **Optional `intakeTopicRef`** on `UnexplainedLocationRecord` — sanitized on hydrate; backward compatible.
+- **Primary match** — `location.intakeTopicRef` overlaps `report.topicRef` via normalized topic keys (`resolveIntakeExtranormalTopicKeys`).
+- **Hydrated truth only** — compose over persisted maps; no re-sanitize or invalid-drop surfacing.
+- **Empty maps** — no-op summary with zero counts; no throw.
+- **Byte-stable ordering** — links sorted by topic, location id, report id; summaries deterministic on repeat.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `informationIntakeUnexplainedLocationCrossLink.ts` compose + list helpers | UI / report copy / triage chips               |
+| Optional `intakeTopicRef` on location sanitize/hydrate            | Intake report schema changes                  |
+| Canal-bridge fixture linkage on location fixture                    | `advanceWeek` hook changes                    |
+| Unit tests + location persistence regression                       | SPE-854 parent reopen                         |
+| Slice doc (this file) + backlog handoff                            | Bundle compose chain / triage surfacing       |
+
+## Acceptance
+
+- [x] Empty maps return zeroed summary without throw
+- [x] `intakeTopicRef` match links canal-bridge intake trio to linked location
+- [x] Warning-only hydrated locations included in linked summary
+- [x] Byte-stable ordering on repeated compose
+- [x] No re-surfacing of invalid hydrate drops
+- [x] `npm run lint` + targeted tests + unexplained-location persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/informationIntakeUnexplainedLocationCrossLink.ts`, `src/domain/unexplainedLocationRegistry.ts` |
+| Tests  | `src/test/informationIntakeUnexplainedLocationCrossLink.test.ts`, `src/test/unexplainedLocationRegistryPersistence.test.ts` |
+| Plan   | `planning/information-intake-unexplained-location-cross-link-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Cross-link surfacing in triage / report notes | SPE-854 or UX owner | Out of compose-only boundary |
+| SPE-1464 branch validation follow-up | SPE-1464 | Separate backlog option |
+| Naming-hazard descriptor registry persistence (slice 2) | SPE-2116 | Sibling registry persistence path |
+
+## See also
+
+- `planning/unexplained-location-registry-slice-3.md` — deferred cross-link row (out of slice 3 cadence scope)
+- `planning/information-intake-minor-anomaly-cross-link-slice-1.md` — sibling compose pattern

--- a/src/domain/informationIntakeUnexplainedLocationCrossLink.ts
+++ b/src/domain/informationIntakeUnexplainedLocationCrossLink.ts
@@ -1,0 +1,210 @@
+/**
+ * SPE-854 / SPE-2356 slice 1: intake report ↔ unexplained location cross-link compose.
+ *
+ * Pure deterministic linkage between persisted information intake reports and
+ * unexplained location registry records via shared topic refs — no new persistence
+ * fields on intake reports; optional `intakeTopicRef` on location records.
+ */
+
+import type {
+  InformationIntakeReportRecord,
+  InformationIntakeReportsMap,
+} from './informationIntakeReport'
+import { summarizeMixedSourceIntake } from './informationIntakeReport'
+import { resolveIntakeExtranormalTopicKeys } from './informationIntakeExtranormalCrossLink'
+import type {
+  UnexplainedLocationRecord,
+  UnexplainedLocationRecordsMap,
+} from './unexplainedLocationRegistry'
+
+function normalizeToken(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim().toLowerCase()
+}
+
+export type IntakeUnexplainedLocationMatchKind = 'intake_topic_ref'
+
+export interface IntakeUnexplainedLocationCrossLink {
+  readonly intakeReportId: string
+  readonly unexplainedLocationId: string
+  readonly topicRef: string
+  readonly matchKind: IntakeUnexplainedLocationMatchKind
+}
+
+export interface IntakeUnexplainedLocationCrossLinkSummary {
+  readonly topicRef: string
+  readonly links: readonly IntakeUnexplainedLocationCrossLink[]
+  readonly linkedReportCount: number
+  readonly linkedLocationCount: number
+  readonly intakeSummary: ReturnType<typeof summarizeMixedSourceIntake> | null
+  readonly structuredReasons: readonly string[]
+}
+
+function topicKeysOverlap(leftRef: string, rightRef: string): boolean {
+  const leftKeys = new Set(resolveIntakeExtranormalTopicKeys(leftRef))
+  if (leftKeys.size === 0) {
+    return false
+  }
+
+  for (const key of resolveIntakeExtranormalTopicKeys(rightRef)) {
+    if (leftKeys.has(key)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function resolveCrossLinkMatch(
+  report: InformationIntakeReportRecord,
+  location: UnexplainedLocationRecord
+): IntakeUnexplainedLocationCrossLink | null {
+  const reportTopicRef = normalizeToken(report.topicRef)
+  if (!reportTopicRef) {
+    return null
+  }
+
+  const intakeTopicRef = normalizeToken(location.intakeTopicRef ?? '')
+  if (intakeTopicRef && topicKeysOverlap(reportTopicRef, intakeTopicRef)) {
+    return {
+      intakeReportId: report.id,
+      unexplainedLocationId: location.id,
+      topicRef: intakeTopicRef,
+      matchKind: 'intake_topic_ref',
+    }
+  }
+
+  return null
+}
+
+export function listIntakeReportsForUnexplainedLocation(
+  reports: InformationIntakeReportsMap | undefined,
+  location: UnexplainedLocationRecord
+): InformationIntakeReportRecord[] {
+  if (!reports) {
+    return []
+  }
+
+  const linked: InformationIntakeReportRecord[] = []
+
+  for (const report of Object.values(reports)) {
+    if (resolveCrossLinkMatch(report, location)) {
+      linked.push(report)
+    }
+  }
+
+  return linked.sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export function listUnexplainedLocationsForIntakeTopic(
+  locations: UnexplainedLocationRecordsMap | undefined,
+  topicRef: string
+): UnexplainedLocationRecord[] {
+  if (!locations) {
+    return []
+  }
+
+  const normalizedTopicRef = normalizeToken(topicRef)
+  if (!normalizedTopicRef) {
+    return []
+  }
+
+  const linked: UnexplainedLocationRecord[] = []
+
+  for (const location of Object.values(locations)) {
+    const intakeTopicRef = normalizeToken(location.intakeTopicRef ?? '')
+
+    if (intakeTopicRef && topicKeysOverlap(normalizedTopicRef, intakeTopicRef)) {
+      linked.push(location)
+    }
+  }
+
+  return linked.sort((left, right) => left.id.localeCompare(right.id))
+}
+
+export function composeIntakeUnexplainedLocationCrossLinks(
+  reports: InformationIntakeReportsMap | undefined,
+  locations: UnexplainedLocationRecordsMap | undefined,
+  topicRef: string
+): IntakeUnexplainedLocationCrossLinkSummary {
+  const normalizedTopicRef = normalizeToken(topicRef)
+  const reportList = normalizedTopicRef
+    ? Object.values(reports ?? {}).filter((report) =>
+        topicKeysOverlap(normalizedTopicRef, report.topicRef)
+      )
+    : []
+  const locationList = listUnexplainedLocationsForIntakeTopic(locations, normalizedTopicRef)
+
+  reportList.sort((left, right) => left.id.localeCompare(right.id))
+
+  const links: IntakeUnexplainedLocationCrossLink[] = []
+
+  for (const report of reportList) {
+    for (const location of locationList) {
+      const match = resolveCrossLinkMatch(report, location)
+      if (match) {
+        links.push(match)
+      }
+    }
+  }
+
+  links.sort((left, right) => {
+    const byTopic = left.topicRef.localeCompare(right.topicRef)
+    if (byTopic !== 0) {
+      return byTopic
+    }
+
+    const byLocation = left.unexplainedLocationId.localeCompare(right.unexplainedLocationId)
+    if (byLocation !== 0) {
+      return byLocation
+    }
+
+    return left.intakeReportId.localeCompare(right.intakeReportId)
+  })
+
+  const linkedReportIds = new Set(links.map((link) => link.intakeReportId))
+  const linkedLocationIds = new Set(links.map((link) => link.unexplainedLocationId))
+  const linkedReports = reportList.filter((report) => linkedReportIds.has(report.id))
+
+  const structuredReasons = [
+    `topic:${normalizedTopicRef || '(unknown)'}`,
+    `link_count:${links.length}`,
+    `linked_report_count:${linkedReportIds.size}`,
+    `linked_location_count:${linkedLocationIds.size}`,
+    links.some((link) => link.matchKind === 'intake_topic_ref')
+      ? 'match:intake_topic_ref'
+      : 'match:none_intake_topic_ref',
+  ].sort((left, right) => left.localeCompare(right))
+
+  return {
+    topicRef: normalizedTopicRef || '(unknown)',
+    links,
+    linkedReportCount: linkedReportIds.size,
+    linkedLocationCount: linkedLocationIds.size,
+    intakeSummary: linkedReports.length > 0 ? summarizeMixedSourceIntake(linkedReports) : null,
+    structuredReasons,
+  }
+}
+
+/** Compose cross-link summaries for every topic ref present in linked intake reports. */
+export function composeAllIntakeUnexplainedLocationCrossLinks(
+  reports: InformationIntakeReportsMap | undefined,
+  locations: UnexplainedLocationRecordsMap | undefined
+): readonly IntakeUnexplainedLocationCrossLinkSummary[] {
+  const topicRefs = new Set<string>()
+
+  for (const report of Object.values(reports ?? {})) {
+    const topicRef = normalizeToken(report.topicRef)
+    if (topicRef) {
+      topicRefs.add(topicRef)
+    }
+  }
+
+  return [...topicRefs]
+    .sort((left, right) => left.localeCompare(right))
+    .map((topicRef) => composeIntakeUnexplainedLocationCrossLinks(reports, locations, topicRef))
+    .filter((summary) => summary.links.length > 0)
+}

--- a/src/domain/unexplainedLocationRegistry.ts
+++ b/src/domain/unexplainedLocationRegistry.ts
@@ -175,6 +175,7 @@ export interface UnexplainedLocationRecord {
   readonly neutralizationAuthorizationRef?: string
   readonly mapLayerPolicy?: string
   readonly locationTag?: string
+  readonly intakeTopicRef?: string
   readonly statusHistory?: readonly UnexplainedLocationStatusHistoryEntry[]
   readonly updateLedger?: readonly UnexplainedLocationUpdateLedgerEntry[]
 }
@@ -910,6 +911,7 @@ function sanitizeUnexplainedLocationRecordEntry(value: unknown): UnexplainedLoca
   const coverStoryCode = normalizeToken(value.coverStoryCode ?? '') || undefined
   const mapLayerPolicy = normalizeToken(value.mapLayerPolicy ?? '') || undefined
   const locationTag = normalizeToken(value.locationTag ?? '') || undefined
+  const intakeTopicRef = normalizeToken(value.intakeTopicRef ?? '') || undefined
   const neutralizationAuthorizationRef =
     normalizeToken(value.neutralizationAuthorizationRef ?? '') || undefined
 
@@ -946,6 +948,7 @@ function sanitizeUnexplainedLocationRecordEntry(value: unknown): UnexplainedLoca
     ...(neutralizationAuthorizationRef ? { neutralizationAuthorizationRef } : {}),
     ...(mapLayerPolicy ? { mapLayerPolicy } : {}),
     ...(locationTag ? { locationTag } : {}),
+    ...(intakeTopicRef ? { intakeTopicRef } : {}),
     ...(statusHistory.length > 0 ? { statusHistory } : {}),
     ...(updateLedger.length > 0 ? { updateLedger } : {}),
   }
@@ -1039,4 +1042,26 @@ export const LIFECYCLE_CHAIN_LOCATION_FIXTURE: UnexplainedLocationRecord = defin
     { fromState: 'active', toState: 'utility_use', week: 14, note: 'Repurposed under utility cover.' },
     { fromState: 'utility_use', toState: 'archived', week: 52, note: 'Monitoring cadence retired.' },
   ],
+})
+
+/** Canal-bridge intake grid linked to mixed-source intake via intakeTopicRef. */
+export const CANAL_BRIDGE_LOCATION_FIXTURE: UnexplainedLocationRecord = defineLocation({
+  id: 'location:canal-bridge-intake-grid',
+  label: 'East canal bridge intake grid',
+  descriptionStub: 'Low-threat spatial drift zone near east canal lock intake hardware.',
+  effectGeometry: 'building',
+  effectDomainTags: ['spatial', 'environmental'],
+  populationSelectors: [{ kind: 'location', value: 'east-canal-locker' }],
+  discoveryWeek: 11,
+  containmentWeek: 13,
+  securityControlTags: ['physical_exclusion', 'sensor_monitoring', 'public_cover'],
+  coverStoryCode: 'municipal-canal-maintenance',
+  monitoringCadenceWeeks: 8,
+  lifecycleState: 'active',
+  latentSeverityScore: 16,
+  accessProbability: 0.22,
+  lowPriority: true,
+  confidence: 0.49,
+  locationTag: 'site:east-canal-locker',
+  intakeTopicRef: 'topic:canal-bridge-incident',
 })

--- a/src/test/informationIntakeUnexplainedLocationCrossLink.test.ts
+++ b/src/test/informationIntakeUnexplainedLocationCrossLink.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  composeAllIntakeUnexplainedLocationCrossLinks,
+  composeIntakeUnexplainedLocationCrossLinks,
+  listIntakeReportsForUnexplainedLocation,
+  listUnexplainedLocationsForIntakeTopic,
+} from '../domain/informationIntakeUnexplainedLocationCrossLink'
+import { resolveIntakeExtranormalTopicKeys } from '../domain/informationIntakeExtranormalCrossLink'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import {
+  CANAL_BRIDGE_LOCATION_FIXTURE,
+  LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+  validateUnexplainedLocationRecord,
+} from '../domain/unexplainedLocationRegistry'
+
+const CANAL_BRIDGE_TOPIC = 'topic:canal-bridge-incident'
+
+const CANAL_BRIDGE_REPORTS = {
+  [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+}
+
+const WARNING_ONLY_LOCATION = {
+  ...CANAL_BRIDGE_LOCATION_FIXTURE,
+  id: 'location:canal-warning-only',
+  label: 'Canal warning-only annex',
+  lifecycleState: 'public_managed' as const,
+  latentSeverityScore: 0,
+  lowPriority: true,
+}
+
+describe('informationIntakeUnexplainedLocationCrossLink (SPE-2356 slice 1)', () => {
+  it('expands topic refs into stable match keys via shared resolver', () => {
+    expect(resolveIntakeExtranormalTopicKeys('topic:canal-bridge-incident')).toEqual([
+      'canal-bridge-incident',
+      'topic:canal-bridge-incident',
+    ])
+  })
+
+  it('links canal-bridge intake reports to locations via intakeTopicRef', () => {
+    const locations = {
+      [CANAL_BRIDGE_LOCATION_FIXTURE.id]: CANAL_BRIDGE_LOCATION_FIXTURE,
+    }
+
+    const summary = composeIntakeUnexplainedLocationCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      locations,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.linkedLocationCount).toBe(1)
+    expect(summary.linkedReportCount).toBe(3)
+    expect(summary.links).toHaveLength(3)
+    expect(summary.links.every((link) => link.matchKind === 'intake_topic_ref')).toBe(true)
+    expect(summary.intakeSummary?.hasConflictingVerification).toBe(true)
+    expect(summary.structuredReasons).toContain('match:intake_topic_ref')
+  })
+
+  it('includes warning-only hydrated locations in linked summary', () => {
+    expect(validateUnexplainedLocationRecord(WARNING_ONLY_LOCATION).valid).toBe(true)
+    expect(
+      validateUnexplainedLocationRecord(WARNING_ONLY_LOCATION).issues.some(
+        (issue) => issue.severity === 'warning'
+      )
+    ).toBe(true)
+
+    const locations = {
+      [WARNING_ONLY_LOCATION.id]: WARNING_ONLY_LOCATION,
+    }
+
+    const summary = composeIntakeUnexplainedLocationCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      locations,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.linkedLocationCount).toBe(1)
+    expect(summary.links).toHaveLength(3)
+  })
+
+  it('returns empty summary for empty maps without throw', () => {
+    const summary = composeIntakeUnexplainedLocationCrossLinks(
+      undefined,
+      undefined,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.links).toEqual([])
+    expect(summary.linkedReportCount).toBe(0)
+    expect(summary.linkedLocationCount).toBe(0)
+    expect(summary.intakeSummary).toBeNull()
+    expect(summary.structuredReasons).toContain('link_count:0')
+  })
+
+  it('lists locations for a topic in stable id order', () => {
+    const locations = {
+      [CANAL_BRIDGE_LOCATION_FIXTURE.id]: CANAL_BRIDGE_LOCATION_FIXTURE,
+    }
+
+    expect(listUnexplainedLocationsForIntakeTopic(locations, CANAL_BRIDGE_TOPIC)).toEqual([
+      CANAL_BRIDGE_LOCATION_FIXTURE,
+    ])
+  })
+
+  it('lists intake reports for a location in stable id order', () => {
+    const linkedReports = listIntakeReportsForUnexplainedLocation(
+      CANAL_BRIDGE_REPORTS,
+      CANAL_BRIDGE_LOCATION_FIXTURE
+    )
+
+    expect(linkedReports).toHaveLength(3)
+    expect(linkedReports.map((report) => report.id)).toEqual(
+      [
+        FORMAL_ALERT_PARTIAL_FIXTURE.id,
+        IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id,
+        PUBLIC_RUMOR_CONFLICT_FIXTURE.id,
+      ].sort((left, right) => left.localeCompare(right))
+    )
+  })
+
+  it('composeAllIntakeUnexplainedLocationCrossLinks returns byte-stable summaries', () => {
+    const locations = {
+      [CANAL_BRIDGE_LOCATION_FIXTURE.id]: CANAL_BRIDGE_LOCATION_FIXTURE,
+    }
+
+    const first = composeAllIntakeUnexplainedLocationCrossLinks(CANAL_BRIDGE_REPORTS, locations)
+    const second = composeAllIntakeUnexplainedLocationCrossLinks(CANAL_BRIDGE_REPORTS, locations)
+
+    expect(first).toEqual(second)
+    expect(first).toHaveLength(1)
+    expect(first[0]?.topicRef).toBe(CANAL_BRIDGE_TOPIC)
+  })
+
+  it('does not link locations without topic anchors', () => {
+    const locations = {
+      [LIFECYCLE_CHAIN_LOCATION_FIXTURE.id]: LIFECYCLE_CHAIN_LOCATION_FIXTURE,
+    }
+
+    const summary = composeIntakeUnexplainedLocationCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      locations,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(summary.links).toEqual([])
+  })
+
+  it('is idempotent on repeated compose calls', () => {
+    const locations = {
+      [CANAL_BRIDGE_LOCATION_FIXTURE.id]: CANAL_BRIDGE_LOCATION_FIXTURE,
+    }
+
+    const first = composeIntakeUnexplainedLocationCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      locations,
+      CANAL_BRIDGE_TOPIC
+    )
+    const second = composeIntakeUnexplainedLocationCrossLinks(
+      CANAL_BRIDGE_REPORTS,
+      locations,
+      CANAL_BRIDGE_TOPIC
+    )
+
+    expect(first).toEqual(second)
+  })
+})

--- a/src/test/unexplainedLocationRegistryPersistence.test.ts
+++ b/src/test/unexplainedLocationRegistryPersistence.test.ts
@@ -4,6 +4,7 @@ import { createStartingState } from '../data/startingState'
 import { hydrateGame } from '../app/store/runTransfer'
 import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
 import {
+  CANAL_BRIDGE_LOCATION_FIXTURE,
   LIFECYCLE_CHAIN_LOCATION_FIXTURE,
   REMOTE_MONITOR_SITE_FIXTURE,
   sanitizeUnexplainedLocationRecords,
@@ -66,6 +67,24 @@ describe('unexplainedLocationRegistry persistence (SPE-2106 slice 2)', () => {
     expect(sanitized.invalidLifecycle).toBeUndefined()
     expect(sanitized.duplicate).toBeUndefined()
     expect(Object.keys(sanitized)).toHaveLength(2)
+  })
+
+  it('preserves optional intakeTopicRef through sanitize and save/load round-trip', () => {
+    const sanitized = sanitizeUnexplainedLocationRecords({
+      canalBridge: CANAL_BRIDGE_LOCATION_FIXTURE,
+    })
+
+    expect(sanitized[CANAL_BRIDGE_LOCATION_FIXTURE.id]?.intakeTopicRef).toBe(
+      'topic:canal-bridge-incident'
+    )
+
+    const state = createStartingState()
+    state.unexplainedLocationRecords = sanitized
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(
+      loaded.unexplainedLocationRecords?.[CANAL_BRIDGE_LOCATION_FIXTURE.id]?.intakeTopicRef
+    ).toBe('topic:canal-bridge-incident')
   })
 
   it('round-trips fixture locations with statusHistory byte-stable through save/load', () => {


### PR DESCRIPTION
## Summary

- Add \informationIntakeUnexplainedLocationCrossLink.ts\ compose + list helpers mirroring SPE-2354/SPE-2355
- Optional \intakeTopicRef\ on \UnexplainedLocationRecord\ (sanitize/hydrate) + \CANAL_BRIDGE_LOCATION_FIXTURE\
- Unit tests and unexplained-location persistence regression for \intakeTopicRef\ round-trip

## Linear

- **Slice:** [SPE-2356](https://linear.app/spectranoir/issue/SPE-2356) — Intake report ↔ unexplained location cross-link compose (slice 1)
- **Parent:** [SPE-854](https://linear.app/spectranoir/issue/SPE-854) (Done — follow-up slice; parent stays Done)
- **Registry anchor:** [SPE-2106](https://linear.app/spectranoir/issue/SPE-2106)

## What shipped

Pure deterministic compose linking \informationIntakeReports\ to \unexplainedLocationRecords\ via shared topic refs. No UI, advanceWeek, or intake schema changes.

## Validation

- \
pm run lint\
- \
pm run test:run -- src/test/informationIntakeUnexplainedLocationCrossLink.test.ts src/test/unexplainedLocationRegistryPersistence.test.ts\

## Docs updated

- \planning/information-intake-unexplained-location-cross-link-slice-1.md\
- \planning/backlog.md\

## Parent status

SPE-854 remains **Done** — compose-only follow-up; triage/report surfacing deferred.

Made with [Cursor](https://cursor.com)