### PR TITLE
feat(SPE-2357): naming-hazard descriptor registry GameState persistence (slice 2)

### DIFF
--- a/planning/naming-hazard-descriptor-registry-slice-2.md
+++ b/planning/naming-hazard-descriptor-registry-slice-2.md
@@ -1,0 +1,63 @@
+# SPE-2116 — Naming-hazard descriptor registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: child under [SPE-2116](https://linear.app/spectranoir/issue/SPE-2116) / parent anchor [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108). Follows shipped slice 1 (`planning/naming-hazard-descriptor-registry-slice-1.md`, PR #2435).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2357 — Naming-hazard descriptor registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2357) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108) — Self-censoring information registry; registry anchor [SPE-2116](https://linear.app/spectranoir/issue/SPE-2116) |
+| **Branch** | `spe-2116-naming-hazard-descriptor-registry-persistence-slice-2`                                           |
+| **Base `main` SHA** | `8bb2760f`                                                                                          |
+
+## Goal
+
+Persist validated `NamingHazardDescriptorRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Slice 1 deferred persistence; UI substitution and weekly orchestration are slice 3+.
+
+## Prerequisite (on `main` @ `8bb2760f`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/namingHazardDescriptorRegistry.ts` (SPE-2116 / PR #2435)   |
+| Fixtures             | `DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE`, `COMPULSIVE_PHRASE_BRIEFING_FIXTURE` |
+| Intake persistence pattern | `src/domain/unexplainedLocationRegistry.ts` + `planning/extranormal-event-registry-slice-2.md` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `namingHazardDescriptorRecords` map key on `GameState`               | Investigation UI substitution               |
+| `sanitizeNamingHazardDescriptorRecords` + `runTransfer` hydrate wire | Intake report cross-link compose              |
+| `validateNamingHazardDescriptorRecord` on hydrate; drop invalid, no throw | SPE-76 procedural naming integration     |
+| Default `{}` in `createStartingState`                              | SPE-2108 parent Done                          |
+| Sanitize unit tests + save/import round-trip (byte-stable pool order) | Shipped intake cross-link modules (SPE-2354–2356) |
+
+## Acceptance
+
+- [ ] Valid fixture round-trips through serialize/import with byte-stable `safeDescriptorPool` ordering
+- [ ] Invalid/duplicate-id/franchise-token entries dropped safely on hydrate
+- [ ] `npm run lint` + targeted tests + relevant save/hydration tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/namingHazardDescriptorRegistry.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/namingHazardDescriptorRegistryPersistence.test.ts`          |
+| Plan   | `planning/naming-hazard-descriptor-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Investigation UI substitution | SPE-2116 slice 3+ | Persistence must land before surfacing |
+| Intake report ↔ naming-hazard linkage | SPE-854 / SPE-2108 follow-up | Out of persistence-only boundary |
+| SPE-76 procedural naming integration | SPE-76 | Distinct from registry persistence |
+
+## See also
+
+- `planning/naming-hazard-descriptor-registry-slice-1.md`
+- `planning/extranormal-event-registry-slice-2.md`
+- `planning/unexplained-location-registry-slice-2.md` (if present)

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -193,6 +193,7 @@ import { getKnowledgeKey } from '../../domain/knowledge'
 import { sanitizeKnowledgeStateMap } from '../../domain/knowledge/sanitize'
 import { sanitizeInformationIntakeReports } from '../../domain/informationIntakeReport'
 import { sanitizeExtranormalEventRecords } from '../../domain/extranormalEventRegistry'
+import { sanitizeNamingHazardDescriptorRecords } from '../../domain/namingHazardDescriptorRegistry'
 import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLocationRegistry'
 import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
 import { sanitizeSelfCensoringInformationRecords } from '../../domain/selfCensoringInformationRegistry'
@@ -8413,6 +8414,10 @@ export function hydrateGame(
     game.minorAnomalyItemRecords,
     fallback.minorAnomalyItemRecords ?? {}
   )
+  const namingHazardDescriptorRecords = sanitizeNamingHazardDescriptorRecords(
+    game.namingHazardDescriptorRecords,
+    fallback.namingHazardDescriptorRecords ?? {}
+  )
   const selfCensoringInformationRecords = sanitizeSelfCensoringInformationRecords(
     game.selfCensoringInformationRecords,
     fallback.selfCensoringInformationRecords ?? {}
@@ -8578,6 +8583,7 @@ export function hydrateGame(
       extranormalEventRecords,
       unexplainedLocationRecords,
       minorAnomalyItemRecords,
+      namingHazardDescriptorRecords,
       selfCensoringInformationRecords,
       publicDisclosureRecords,
       patternSourceSeriesRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -43,6 +43,7 @@ const startingStateTemplate: GameState = {
   extranormalEventRecords: {},
   unexplainedLocationRecords: {},
   minorAnomalyItemRecords: {},
+  namingHazardDescriptorRecords: {},
   selfCensoringInformationRecords: {},
   publicDisclosureRecords: {},
   patternSourceSeriesRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -247,6 +247,7 @@ import type { InformationIntakeReportRecord } from './informationIntakeReport'
 import type { ExtranormalEventRecord } from './extranormalEventRegistry'
 import type { UnexplainedLocationRecord } from './unexplainedLocationRegistry'
 import type { MinorAnomalyRecord } from './minorAnomalyItemRegistry'
+import type { NamingHazardDescriptorRecord } from './namingHazardDescriptorRegistry'
 import type { SelfCensoringInformationRecord } from './selfCensoringInformationRegistry'
 import type { PublicDisclosureRecord } from './publicDisclosureStateRegistry'
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
@@ -2574,6 +2575,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   minorAnomalyItemRecords?: Record<string, MinorAnomalyRecord>
+
+  /**
+   * SPE-2116 slice 2: persisted naming-hazard descriptor records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  namingHazardDescriptorRecords?: Record<string, NamingHazardDescriptorRecord>
 
   /**
    * SPE-2108 slice 2: persisted self-censoring information records (keyed by record id).

--- a/src/domain/namingHazardDescriptorRegistry.ts
+++ b/src/domain/namingHazardDescriptorRegistry.ts
@@ -659,6 +659,194 @@ export function projectSafeLabel(
   })
 }
 
+// ---------------------------------------------------------------------------
+// Persistence / hydration (SPE-2116 slice 2)
+// ---------------------------------------------------------------------------
+
+export type NamingHazardDescriptorRecordsMap = Record<
+  NamingHazardDescriptorId,
+  NamingHazardDescriptorRecord
+>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function uniqueSorted(values: readonly string[]) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return uniqueSorted(
+    value.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry)
+  )
+}
+
+function parseReferenceConstraints(value: unknown): readonly ReferenceConstraint[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const constraints: ReferenceConstraint[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !isReferenceConstraint(entry) || seen.has(entry)) {
+      continue
+    }
+
+    seen.add(entry)
+    constraints.push(entry)
+  }
+
+  return constraints
+}
+
+/** Preserves source order for byte-stable descriptorIndex projection after round-trip. */
+function parseSafeDescriptorPool(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const pool: string[] = []
+
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue
+    }
+
+    pool.push(entry)
+  }
+
+  return pool
+}
+
+function parseCompulsivePhraseWatchlist(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const phrases: string[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue
+    }
+
+    const token = normalizeToken(entry)
+    if (!token) {
+      continue
+    }
+
+    const key = token.toLocaleLowerCase()
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    phrases.push(token)
+  }
+
+  return phrases
+}
+
+function isValidConfidence(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function sanitizeNamingHazardDescriptorRecordEntry(
+  value: unknown
+): NamingHazardDescriptorRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const uiSubstitutionPolicy =
+    typeof value.uiSubstitutionPolicy === 'string' ? value.uiSubstitutionPolicy : ''
+  const mapLabelMode = typeof value.mapLabelMode === 'string' ? value.mapLabelMode : ''
+  const safeDescriptorPool = parseSafeDescriptorPool(value.safeDescriptorPool)
+  const trueNameForbidden = value.trueNameForbidden === true
+
+  if (
+    !id ||
+    !label ||
+    !isUiSubstitutionPolicy(uiSubstitutionPolicy) ||
+    !isMapLabelMode(mapLabelMode)
+  ) {
+    return null
+  }
+
+  const referenceConstraints = parseReferenceConstraints(value.referenceConstraints)
+  const compulsivePhraseWatchlist = parseCompulsivePhraseWatchlist(value.compulsivePhraseWatchlist)
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const briefingTemplateSnippet =
+    typeof value.briefingTemplateSnippet === 'string' &&
+    value.briefingTemplateSnippet.trim().length > 0
+      ? value.briefingTemplateSnippet.trim()
+      : undefined
+  const confidence = value.confidence
+
+  const record: NamingHazardDescriptorRecord = {
+    id,
+    label,
+    trueNameForbidden,
+    safeDescriptorPool,
+    uiSubstitutionPolicy,
+    mapLabelMode,
+    ...(summary ? { summary } : {}),
+    ...(referenceConstraints.length > 0 ? { referenceConstraints } : {}),
+    ...(compulsivePhraseWatchlist.length > 0 ? { compulsivePhraseWatchlist } : {}),
+    ...(briefingTemplateSnippet ? { briefingTemplateSnippet } : {}),
+    ...(isValidConfidence(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateNamingHazardDescriptorRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical record map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeNamingHazardDescriptorRecords(
+  value: unknown,
+  fallback: NamingHazardDescriptorRecordsMap = {}
+): NamingHazardDescriptorRecordsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: NamingHazardDescriptorRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeNamingHazardDescriptorRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 function defineRecord(record: NamingHazardDescriptorRecord): NamingHazardDescriptorRecord {
   return Object.freeze({ ...record })
 }

--- a/src/test/namingHazardDescriptorRegistryPersistence.test.ts
+++ b/src/test/namingHazardDescriptorRegistryPersistence.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  COMPULSIVE_PHRASE_BRIEFING_FIXTURE,
+  DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+  sanitizeNamingHazardDescriptorRecords,
+} from '../domain/namingHazardDescriptorRegistry'
+
+describe('namingHazardDescriptorRegistry persistence (SPE-2116 slice 2)', () => {
+  it('defaults starting state to an empty naming-hazard descriptor map', () => {
+    expect(createStartingState().namingHazardDescriptorRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeNamingHazardDescriptorRecords(
+      {
+        valid: DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+        compulsive: COMPULSIVE_PHRASE_BRIEFING_FIXTURE,
+        'wrong-key': {
+          ...COMPULSIVE_PHRASE_BRIEFING_FIXTURE,
+          id: 'naming-hazard:coastal-approach-ward',
+        },
+        duplicate: {
+          ...DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          trueNameForbidden: true,
+          safeDescriptorPool: ['Approved surrogate'],
+          uiSubstitutionPolicy: 'pool_descriptor',
+          mapLabelMode: 'descriptor_only',
+        },
+        emptyPoolWhenForbidden: {
+          id: 'naming-hazard:empty-pool',
+          label: 'Empty pool when forbidden',
+          trueNameForbidden: true,
+          safeDescriptorPool: [],
+          uiSubstitutionPolicy: 'pool_descriptor',
+          mapLabelMode: 'descriptor_only',
+        },
+        invalidPolicy: {
+          id: 'naming-hazard:bad-policy',
+          label: 'Bad policy',
+          trueNameForbidden: false,
+          safeDescriptorPool: ['Approved surrogate'],
+          uiSubstitutionPolicy: 'not-a-policy',
+          mapLabelMode: 'descriptor_only',
+        },
+        franchiseToken: {
+          id: 'naming-hazard:franchise-label',
+          label: 'Foundation naming hazard record',
+          trueNameForbidden: true,
+          safeDescriptorPool: ['Approved surrogate'],
+          uiSubstitutionPolicy: 'pool_descriptor',
+          mapLabelMode: 'descriptor_only',
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['naming-hazard:coastal-approach-ward']).toEqual(
+      DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE
+    )
+    expect(sanitized['naming-hazard:archive-reading-room']).toEqual(
+      COMPULSIVE_PHRASE_BRIEFING_FIXTURE
+    )
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.emptyPoolWhenForbidden).toBeUndefined()
+    expect(sanitized.invalidPolicy).toBeUndefined()
+    expect(sanitized.franchiseToken).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(Object.keys(sanitized)).toHaveLength(2)
+  })
+
+  it('preserves safeDescriptorPool ordering byte-stable through sanitize and save/load', () => {
+    const poolOrder = ['North quarry overlook', 'Grid sector approach lane'] as const
+
+    expect(DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.safeDescriptorPool).toEqual([...poolOrder])
+
+    const sanitized = sanitizeNamingHazardDescriptorRecords({
+      coastal: DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+    })
+
+    expect(sanitized[DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.id]?.safeDescriptorPool).toEqual([
+      ...poolOrder,
+    ])
+
+    const state = createStartingState()
+    state.namingHazardDescriptorRecords = sanitized
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(
+      loaded.namingHazardDescriptorRecords?.[DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.id]
+        ?.safeDescriptorPool
+    ).toEqual([...poolOrder])
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.namingHazardDescriptorRecords = {
+      [DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.id]: DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+      [COMPULSIVE_PHRASE_BRIEFING_FIXTURE.id]: COMPULSIVE_PHRASE_BRIEFING_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.namingHazardDescriptorRecords).toEqual(state.namingHazardDescriptorRecords)
+    expect(
+      loaded.namingHazardDescriptorRecords?.[COMPULSIVE_PHRASE_BRIEFING_FIXTURE.id]
+        ?.compulsivePhraseWatchlist
+    ).toEqual(COMPULSIVE_PHRASE_BRIEFING_FIXTURE.compulsivePhraseWatchlist)
+  })
+
+  it('hydrates persisted naming-hazard descriptors through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        namingHazardDescriptorRecords: {
+          [DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.id]: DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+          invalid: {
+            id: 'naming-hazard:invalid',
+            label: 'Invalid empty pool',
+            trueNameForbidden: true,
+            safeDescriptorPool: [],
+            uiSubstitutionPolicy: 'pool_descriptor',
+            mapLabelMode: 'descriptor_only',
+          },
+          franchiseToken: {
+            id: 'naming-hazard:wiki-token',
+            label: 'See wiki.scpfoundation.net for details',
+            trueNameForbidden: true,
+            safeDescriptorPool: ['Approved surrogate'],
+            uiSubstitutionPolicy: 'pool_descriptor',
+            mapLabelMode: 'descriptor_only',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.namingHazardDescriptorRecords).toEqual({
+      [DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE.id]: DESCRIPTOR_ONLY_GRID_FALLBACK_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add \
amingHazardDescriptorRecords\ map to \GameState\ with default \{}\ in \createStartingState\
- Implement \sanitizeNamingHazardDescriptorRecords\ in \
amingHazardDescriptorRegistry.ts\ with \alidateNamingHazardDescriptorRecord\ hydrate gate (drops invalid/duplicate-id/franchise-token entries without throw)
- Wire hydrate in \unTransfer.ts\
- Add \
amingHazardDescriptorRegistryPersistence.test.ts\ covering byte-stable pool ordering and save/load round-trip

## Linear

- **Slice:** [SPE-2357](https://linear.app/spectranoir/issue/SPE-2357) — Naming-hazard descriptor registry GameState persistence (slice 2)
- **Parent registry:** [SPE-2116](https://linear.app/spectranoir/issue/SPE-2116) (slice 1 Done)
- **Umbrella:** [SPE-2108](https://linear.app/spectranoir/issue/SPE-2108) — remains open

## What shipped

GameState persistence for naming-hazard descriptor records only. No UI, weekly hooks, or cross-link compose.

## Validation

- \
pm run lint\
- \
pm run test:run -- src/test/namingHazardDescriptorRegistryPersistence.test.ts src/test/namingHazardDescriptorRegistry.test.ts\

## Docs updated

- \planning/naming-hazard-descriptor-registry-slice-2.md\

## Parent status

SPE-2108 parent remains open (persistence slice only).

Made with [Cursor](https://cursor.com)