### PR TITLE
feat(SPE-2363): recurrent catastrophe registry GameState persistence (slice 2)

### DIFF
--- a/planning/recurrent-catastrophe-amelioration-registry-slice-2.md
+++ b/planning/recurrent-catastrophe-amelioration-registry-slice-2.md
@@ -1,0 +1,66 @@
+# SPE-2117 — Recurrent catastrophe amelioration registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: child [SPE-2363](https://linear.app/spectranoir/issue/SPE-2363) under [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) / anchor [SPE-2117](https://linear.app/spectranoir/issue/SPE-2117). Follows shipped slice 1 (`planning/recurrent-catastrophe-amelioration-registry-slice-1.md`, PR #2436).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2363 — Recurrent catastrophe amelioration registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2363) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — Case / facility lifecycle (stays open)         |
+| **Anchor** | [SPE-2117](https://linear.app/spectranoir/issue/SPE-2117) — Recurrent catastrophe amelioration registry slice 1 |
+| **Branch** | `spe-2117-recurrent-catastrophe-persistence-slice-2`                                                     |
+| **Base `main` SHA** | `11d57c13`                                                                                          |
+
+## Goal
+
+Persist validated `RecurrentCatastropheRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Slice 1 deferred persistence; weekly recurrence orchestration is slice 3+.
+
+## Prerequisite (on `main` @ `11d57c13`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/recurrentCatastropheAmeliorationRegistry.ts` (SPE-2117 / PR #2436) |
+| Fixtures             | `IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE`, `RECURRENCE_DAMAGE_LEDGER_FIXTURE` |
+| Sibling persistence pattern | `planning/extranormal-event-registry-slice-2.md` (SPE-2312 / PR #2488), `planning/naming-hazard-descriptor-registry-slice-2.md` (SPE-2357) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `recurrentCatastropheRecords` on `GameState`                       | Weekly `advanceWeek` recurrence hook          |
+| `sanitizeRecurrentCatastropheRecords` + `runTransfer` hydrate wire | UI / dev overlay                              |
+| `validateRecurrentCatastropheRecord` on hydrate; drop invalid, no throw | SPE-1310 parent closure                  |
+| Default `{}` in `createStartingState`                              | SPE-868 post-incident review wire-up          |
+| Sanitize unit tests + save/import round-trip (byte-stable)         | Changes to slice-1 validation semantics       |
+| Warnings-only records persist (e.g. `recurrence_without_damage_ledger`) | Sibling registries (SPE-2123 persistence) |
+
+## Acceptance
+
+- [ ] Valid fixtures round-trip through serialize/import
+- [ ] Invalid/duplicate-id entries dropped safely on hydrate (including `active_prevention_when_ceiling_impossible`)
+- [ ] Warnings-only records persist through sanitize
+- [ ] `npm run lint` + targeted tests + slice-1 regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/recurrentCatastropheAmeliorationRegistry.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/recurrentCatastropheAmeliorationRegistryPersistence.test.ts` |
+| Plan   | `planning/recurrent-catastrophe-amelioration-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Weekly recurrence advance hook | SPE-2117 slice 3 | Persistence must land before orchestration |
+| SPE-868 post-incident review refs wire-up | SPE-868 follow-up | Out of persistence-only boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+
+## See also
+
+- `planning/recurrent-catastrophe-amelioration-registry-slice-1.md`
+- `planning/extranormal-event-registry-slice-2.md`
+- `src/test/namingHazardDescriptorRegistryPersistence.test.ts`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -194,6 +194,7 @@ import { sanitizeKnowledgeStateMap } from '../../domain/knowledge/sanitize'
 import { sanitizeInformationIntakeReports } from '../../domain/informationIntakeReport'
 import { sanitizeExtranormalEventRecords } from '../../domain/extranormalEventRegistry'
 import { sanitizeNamingHazardDescriptorRecords } from '../../domain/namingHazardDescriptorRegistry'
+import { sanitizeRecurrentCatastropheRecords } from '../../domain/recurrentCatastropheAmeliorationRegistry'
 import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLocationRegistry'
 import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
 import { sanitizeSelfCensoringInformationRecords } from '../../domain/selfCensoringInformationRegistry'
@@ -8418,6 +8419,10 @@ export function hydrateGame(
     game.namingHazardDescriptorRecords,
     fallback.namingHazardDescriptorRecords ?? {}
   )
+  const recurrentCatastropheRecords = sanitizeRecurrentCatastropheRecords(
+    game.recurrentCatastropheRecords,
+    fallback.recurrentCatastropheRecords ?? {}
+  )
   const selfCensoringInformationRecords = sanitizeSelfCensoringInformationRecords(
     game.selfCensoringInformationRecords,
     fallback.selfCensoringInformationRecords ?? {}
@@ -8584,6 +8589,7 @@ export function hydrateGame(
       unexplainedLocationRecords,
       minorAnomalyItemRecords,
       namingHazardDescriptorRecords,
+      recurrentCatastropheRecords,
       selfCensoringInformationRecords,
       publicDisclosureRecords,
       patternSourceSeriesRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -44,6 +44,7 @@ const startingStateTemplate: GameState = {
   unexplainedLocationRecords: {},
   minorAnomalyItemRecords: {},
   namingHazardDescriptorRecords: {},
+  recurrentCatastropheRecords: {},
   selfCensoringInformationRecords: {},
   publicDisclosureRecords: {},
   patternSourceSeriesRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -248,6 +248,7 @@ import type { ExtranormalEventRecord } from './extranormalEventRegistry'
 import type { UnexplainedLocationRecord } from './unexplainedLocationRegistry'
 import type { MinorAnomalyRecord } from './minorAnomalyItemRegistry'
 import type { NamingHazardDescriptorRecord } from './namingHazardDescriptorRegistry'
+import type { RecurrentCatastropheRecord } from './recurrentCatastropheAmeliorationRegistry'
 import type { SelfCensoringInformationRecord } from './selfCensoringInformationRegistry'
 import type { PublicDisclosureRecord } from './publicDisclosureStateRegistry'
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
@@ -2581,6 +2582,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   namingHazardDescriptorRecords?: Record<string, NamingHazardDescriptorRecord>
+
+  /**
+   * SPE-2117 slice 2: persisted recurrent catastrophe amelioration records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  recurrentCatastropheRecords?: Record<string, RecurrentCatastropheRecord>
 
   /**
    * SPE-2108 slice 2: persisted self-censoring information records (keyed by record id).

--- a/src/domain/recurrentCatastropheAmeliorationRegistry.ts
+++ b/src/domain/recurrentCatastropheAmeliorationRegistry.ts
@@ -732,6 +732,153 @@ export function projectNextRecurrenceRisk(
   })
 }
 
+// ---------------------------------------------------------------------------
+// Persistence / hydration (SPE-2117 slice 2)
+// ---------------------------------------------------------------------------
+
+export type RecurrentCatastropheRecordsMap = Record<
+  RecurrentCatastropheId,
+  RecurrentCatastropheRecord
+>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseStringRefList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function parseAmeliorationTacticEntries(value: unknown): readonly ActiveAmeliorationTactic[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const tactics: ActiveAmeliorationTactic[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const tactic = typeof entry.tactic === 'string' ? entry.tactic : ''
+    if (!isAmeliorationTactic(tactic) || seen.has(tactic)) {
+      continue
+    }
+
+    seen.add(tactic)
+    tactics.push({ tactic, active: entry.active === true })
+  }
+
+  return tactics
+}
+
+function parsePreventionTacticEntries(value: unknown): readonly ActivePreventionTactic[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const tactics: ActivePreventionTactic[] = []
+  const seen = new Set<string>()
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const tactic = typeof entry.tactic === 'string' ? entry.tactic : ''
+    if (!isPreventionTactic(tactic) || seen.has(tactic)) {
+      continue
+    }
+
+    seen.add(tactic)
+    tactics.push({ tactic, active: entry.active === true })
+  }
+
+  return tactics
+}
+
+function sanitizeRecurrentCatastropheRecordEntry(value: unknown): RecurrentCatastropheRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const recurrenceCadence =
+    typeof value.recurrenceCadence === 'string' ? value.recurrenceCadence : ''
+  const failureMode = typeof value.failureMode === 'string' ? value.failureMode : ''
+  const preventionCeiling =
+    typeof value.preventionCeiling === 'string' ? value.preventionCeiling : ''
+  const ameliorationTactics = parseAmeliorationTacticEntries(value.ameliorationTactics)
+  const preventionTactics = parsePreventionTacticEntries(value.preventionTactics)
+  const recurrenceCount = value.recurrenceCount
+  const lastOccurrenceWeek = value.lastOccurrenceWeek
+  const damageLedgerRefs = parseStringRefList(value.damageLedgerRefs)
+  const postIncidentReviewRefs = parseStringRefList(value.postIncidentReviewRefs)
+  const unknownFields = asStringArray(value.unknownFields)
+  const redactedFields = asStringArray(value.redactedFields)
+  const confidence = value.confidence
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+
+  const record: RecurrentCatastropheRecord = {
+    id,
+    label,
+    recurrenceCadence: recurrenceCadence as RecurrenceCadence,
+    failureMode: failureMode as CatastropheFailureMode,
+    preventionCeiling: preventionCeiling as PreventionCeiling,
+    ameliorationTactics,
+    recurrenceCount: typeof recurrenceCount === 'number' ? recurrenceCount : Number.NaN,
+    ...(summary ? { summary } : {}),
+    ...(preventionTactics.length > 0 ? { preventionTactics } : {}),
+    ...(isNonNegativeInteger(lastOccurrenceWeek) ? { lastOccurrenceWeek } : {}),
+    ...(damageLedgerRefs.length > 0 ? { damageLedgerRefs } : {}),
+    ...(postIncidentReviewRefs.length > 0 ? { postIncidentReviewRefs } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateRecurrentCatastropheRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical record map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeRecurrentCatastropheRecords(
+  value: unknown,
+  fallback: RecurrentCatastropheRecordsMap = {}
+): RecurrentCatastropheRecordsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: RecurrentCatastropheRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeRecurrentCatastropheRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 function defineRecord(record: RecurrentCatastropheRecord): RecurrentCatastropheRecord {
   return Object.freeze({ ...record })
 }

--- a/src/test/recurrentCatastropheAmeliorationRegistryPersistence.test.ts
+++ b/src/test/recurrentCatastropheAmeliorationRegistryPersistence.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+  RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+  sanitizeRecurrentCatastropheRecords,
+} from '../domain/recurrentCatastropheAmeliorationRegistry'
+
+describe('recurrentCatastropheAmeliorationRegistry persistence (SPE-2117 slice 2)', () => {
+  it('defaults starting state to an empty recurrent catastrophe map', () => {
+    expect(createStartingState().recurrentCatastropheRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeRecurrentCatastropheRecords(
+      {
+        valid: IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+        ledger: RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+        'wrong-key': {
+          ...RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+          id: 'recurrent-catastrophe:structural-breach-cycle',
+        },
+        duplicate: {
+          ...IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          recurrenceCadence: 'monthly',
+          failureMode: 'breach',
+          preventionCeiling: 'unknown',
+          ameliorationTactics: [{ tactic: 'shielding', active: true }],
+          recurrenceCount: 0,
+        },
+        activePreventionWhenImpossible: {
+          id: 'recurrent-catastrophe:invalid-prevention',
+          label: 'Invalid active prevention',
+          recurrenceCadence: 'monthly',
+          failureMode: 'breach',
+          preventionCeiling: 'impossible',
+          ameliorationTactics: [{ tactic: 'shielding', active: true }],
+          preventionTactics: [{ tactic: 'permanent_seal', active: true }],
+          recurrenceCount: 0,
+        },
+        franchiseToken: {
+          id: 'recurrent-catastrophe:franchise-label',
+          label: 'Foundation catastrophe record',
+          recurrenceCadence: 'weekly',
+          failureMode: 'manifestation',
+          preventionCeiling: 'unknown',
+          ameliorationTactics: [{ tactic: 'shielding', active: true }],
+          recurrenceCount: 0,
+        },
+        warningsOnly: {
+          id: 'recurrent-catastrophe:warning-only-recurrence',
+          label: 'Recurrence without ledger warning',
+          recurrenceCadence: 'weekly',
+          failureMode: 'manifestation',
+          preventionCeiling: 'unknown',
+          ameliorationTactics: [{ tactic: 'shielding', active: true }],
+          recurrenceCount: 2,
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['recurrent-catastrophe:structural-breach-cycle']).toEqual(
+      IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE
+    )
+    expect(sanitized['recurrent-catastrophe:manifestation-cascade-history']).toEqual(
+      RECURRENCE_DAMAGE_LEDGER_FIXTURE
+    )
+    expect(sanitized['recurrent-catastrophe:warning-only-recurrence']).toEqual({
+      id: 'recurrent-catastrophe:warning-only-recurrence',
+      label: 'Recurrence without ledger warning',
+      recurrenceCadence: 'weekly',
+      failureMode: 'manifestation',
+      preventionCeiling: 'unknown',
+      ameliorationTactics: [{ tactic: 'shielding', active: true }],
+      recurrenceCount: 2,
+    })
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.activePreventionWhenImpossible).toBeUndefined()
+    expect(sanitized.franchiseToken).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(Object.keys(sanitized)).toHaveLength(3)
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.recurrentCatastropheRecords = {
+      [IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE.id]: IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+      [RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]: RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.recurrentCatastropheRecords).toEqual(state.recurrentCatastropheRecords)
+    expect(
+      loaded.recurrentCatastropheRecords?.[RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]?.damageLedgerRefs
+    ).toEqual(RECURRENCE_DAMAGE_LEDGER_FIXTURE.damageLedgerRefs)
+    expect(
+      loaded.recurrentCatastropheRecords?.[RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]
+        ?.postIncidentReviewRefs
+    ).toEqual(RECURRENCE_DAMAGE_LEDGER_FIXTURE.postIncidentReviewRefs)
+  })
+
+  it('hydrates persisted recurrent catastrophe records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        recurrentCatastropheRecords: {
+          [IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE.id]: IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+          invalid: {
+            id: 'recurrent-catastrophe:invalid-prevention',
+            label: 'Invalid active prevention on hydrate',
+            recurrenceCadence: 'monthly',
+            failureMode: 'breach',
+            preventionCeiling: 'impossible',
+            ameliorationTactics: [{ tactic: 'shielding', active: true }],
+            preventionTactics: [{ tactic: 'neutralization', active: true }],
+            recurrenceCount: 0,
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.recurrentCatastropheRecords).toEqual({
+      [IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE.id]: IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `recurrentCatastropheRecords` to `GameState` with `sanitizeRecurrentCatastropheRecords` hydration wire in `runTransfer` and default `{}` in `createStartingState`.
- Mirror SPE-2312 / SPE-2357 / SPE-2116 slice-2 persistence pattern: invalid/duplicate-id entries dropped silently; warnings-only records persist.
- New persistence tests cover sanitize edge cases and byte-stable save/load round-trip for slice-1 fixtures.

## Linear mapping

- **Slice issue:** [SPE-2363](https://linear.app/spectranoir/issue/SPE-2363) — Recurrent catastrophe amelioration registry GameState persistence (slice 2)
- **Registry anchor:** [SPE-2117](https://linear.app/spectranoir/issue/SPE-2117) (slice 1 shipped PR #2436)
- **Parent:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — **stays open** (registry slice only)

## What shipped

- `RecurrentCatastropheRecordsMap`, `sanitizeRecurrentCatastropheRecordEntry`, `sanitizeRecurrentCatastropheRecords` in `recurrentCatastropheAmeliorationRegistry.ts`
- `recurrentCatastropheRecords` field on `GameState` (models.ts)
- Hydrate spread in `runTransfer.ts`
- `src/test/recurrentCatastropheAmeliorationRegistryPersistence.test.ts`
- `planning/recurrent-catastrophe-amelioration-registry-slice-2.md`

## Validation

- `npm run test:run -- src/test/recurrentCatastropheAmeliorationRegistryPersistence.test.ts src/test/recurrentCatastropheAmeliorationRegistry.test.ts` — 15 passed
- `npm run lint` — clean

## Docs updated

- `planning/recurrent-catastrophe-amelioration-registry-slice-2.md` (new)
- `planning/backlog.md` — update on merge

## Parent status

SPE-1310 remains open. Deferred: weekly recurrence advance hook (SPE-2117 slice 3), SPE-868 post-incident review wire-up.

Made with [Cursor](https://cursor.com)