### PR TITLE
feat(SPE-2364): recurrent catastrophe weekly recurrence advance hook (slice 3)

### DIFF
--- a/planning/recurrent-catastrophe-amelioration-registry-slice-3.md
+++ b/planning/recurrent-catastrophe-amelioration-registry-slice-3.md
@@ -1,0 +1,76 @@
+# SPE-2117 — Recurrent catastrophe amelioration registry weekly recurrence advance hook (slice 3)
+
+One-page implementation plan. Linear: child [SPE-2364](https://linear.app/spectranoir/issue/SPE-2364) under [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) / anchor [SPE-2117](https://linear.app/spectranoir/issue/SPE-2117). Follows shipped slice 2 (`planning/recurrent-catastrophe-amelioration-registry-slice-2.md`, PR #2595).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2364 — Recurrent catastrophe amelioration registry weekly recurrence advance hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2364) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — Case / facility lifecycle (stays open)         |
+| **Anchor** | [SPE-2117](https://linear.app/spectranoir/issue/SPE-2117) — Recurrent catastrophe amelioration registry    |
+| **Branch** | `spe-2117-recurrent-catastrophe-weekly-hook-slice-3`                                                     |
+| **Base `main` SHA** | `833c3006`                                                                                          |
+
+## Goal
+
+Wire persisted `recurrentCatastropheRecords` into `advanceWeek` so cadence-due recurrence cycles advance `recurrenceCount` and `lastOccurrenceWeek` deterministically when the simulation week crosses the cadence interval.
+
+## Prerequisite (on `main` @ `833c3006`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/recurrentCatastropheAmeliorationRegistry.ts` (SPE-2117 / PR #2436) |
+| Persistence          | `recurrentCatastropheRecords` on `GameState` (SPE-2363 / PR #2595)       |
+| Sibling weekly hooks | `extranormalEventWeeklyMonitoring.ts` (SPE-2315), `unexplainedLocationWeeklyLifecycle.ts` (SPE-2317) |
+
+## Orchestration tick contract (slice 3)
+
+- **Due week** = `lastOccurrenceWeek` + cadence interval (`weekly` 1, `monthly` 4, `seasonal` 13, `annual` 52, `irregular` 8).
+- When `week >= dueWeek`: increment `recurrenceCount` by 1 and set `lastOccurrenceWeek` to the current simulation week.
+- Records without `lastOccurrenceWeek` are unchanged (no implicit seed).
+- One recurrence step per record per tick when due; re-applying for the same week is idempotent.
+- `projectNextRecurrenceRisk` is projection-only; the tick does not consult it for mutation decisions.
+- `validateRecurrentCatastropheRecord` gates any mutated record; invalid candidates return the prior record unchanged.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyRecurrentCatastropheTick` in domain module               | New persistence fields, UI, report notes      |
+| `resolveRecurrenceDueWeek` helper for tests and due-week reads       | SPE-1310 parent closure                       |
+| Call from `advanceWeek` after week increment (`result.week`)       | SPE-868 post-incident review wire-up          |
+| Targeted domain + `advanceWeek` integration tests                    | Slice-1 validation semantic changes           |
+| Slice doc (this file) + backlog handoff on ship                      | Sanitize/hydration changes                    |
+
+## Acceptance
+
+- [ ] Empty `recurrentCatastropheRecords` map is a no-op without throw
+- [ ] Records unchanged while `week < recurrenceDueWeek`
+- [ ] Cadence-due records advance `recurrenceCount` and `lastOccurrenceWeek` when `week >= dueWeek`
+- [ ] `preventionCeiling: impossible` records do not gain active prevention tactics on tick
+- [ ] Warnings-only records still tick when cadence due
+- [ ] `irregular` cadence interval (8 weeks) handled deterministically
+- [ ] Re-applying tick after advance is idempotent for the same week
+- [ ] `npm run lint` + targeted tests + persistence regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/recurrentCatastropheWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/recurrentCatastropheWeeklyOrchestration.test.ts`, `src/test/advanceWeek.recurrentCatastrophe.integration.test.ts` |
+| Plan   | `planning/recurrent-catastrophe-amelioration-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-868 post-incident review refs wire-up | SPE-868 follow-up | Out of weekly-hook boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Case lifecycle transitions on recurrence | SPE-1310 | Cadence advance only in slice 3 |
+
+## See also
+
+- `planning/recurrent-catastrophe-amelioration-registry-slice-2.md`
+- `planning/unexplained-location-registry-slice-3.md`
+- `planning/extranormal-event-registry-slice-3.md`

--- a/src/app/App.trainingDivision.route.test.tsx
+++ b/src/app/App.trainingDivision.route.test.tsx
@@ -20,7 +20,7 @@ describe('App training division route', () => {
     )
 
     expect(
-      await screen.findByRole('heading', { level: 2, name: /training division/i })
+      await screen.findByRole('heading', { level: 2, name: /training division/i }, { timeout: 5000 })
     ).toBeInTheDocument()
     expect(
       screen.queryByRole('heading', { level: 2, name: /route not found/i })

--- a/src/domain/recurrentCatastropheWeeklyOrchestration.ts
+++ b/src/domain/recurrentCatastropheWeeklyOrchestration.ts
@@ -1,0 +1,130 @@
+/**
+ * SPE-2117 slice 3: weekly recurrence advance for persisted recurrent catastrophe records.
+ *
+ * Pure deterministic tick: when the simulation week reaches the cadence due week
+ * (lastOccurrenceWeek + cadence interval), increment recurrenceCount and advance
+ * lastOccurrenceWeek. Does not add persistence fields or activate prevention tactics.
+ */
+
+import {
+  isRecurrenceCadence,
+  validateRecurrentCatastropheRecord,
+  type RecurrenceCadence,
+  type RecurrentCatastropheRecord,
+  type RecurrentCatastropheRecordsMap,
+} from './recurrentCatastropheAmeliorationRegistry'
+
+const CADENCE_WEEK_INTERVAL: Readonly<Record<RecurrenceCadence, number>> = {
+  weekly: 1,
+  monthly: 4,
+  seasonal: 13,
+  annual: 52,
+  irregular: 8,
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function freezeRecord(record: RecurrentCatastropheRecord): RecurrentCatastropheRecord {
+  return Object.freeze({ ...record })
+}
+
+function resolveCadenceInterval(record: RecurrentCatastropheRecord): number {
+  const cadence = isRecurrenceCadence(record.recurrenceCadence)
+    ? record.recurrenceCadence
+    : 'irregular'
+
+  return CADENCE_WEEK_INTERVAL[cadence]
+}
+
+/** Recurrence due week from last occurrence + cadence interval; undefined when anchor is not declared. */
+export function resolveRecurrenceDueWeek(record: RecurrentCatastropheRecord): number | undefined {
+  const lastOccurrenceWeek = record.lastOccurrenceWeek
+  if (!isFiniteWeek(lastOccurrenceWeek)) {
+    return undefined
+  }
+
+  return lastOccurrenceWeek + resolveCadenceInterval(record)
+}
+
+function alreadyAdvancedRecurrenceThisWeek(
+  record: RecurrentCatastropheRecord,
+  week: number
+): boolean {
+  return record.lastOccurrenceWeek === week
+}
+
+/**
+ * Advances one record when the simulation week has reached its recurrence due week.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceRecurrentCatastropheRecordForWeek(
+  record: RecurrentCatastropheRecord,
+  week: number
+): RecurrentCatastropheRecord {
+  const normalizedWeek = normalizeWeek(week)
+  const dueWeek = resolveRecurrenceDueWeek(record)
+
+  if (dueWeek === undefined || normalizedWeek < dueWeek) {
+    return record
+  }
+
+  if (alreadyAdvancedRecurrenceThisWeek(record, normalizedWeek)) {
+    return record
+  }
+
+  const candidate: RecurrentCatastropheRecord = {
+    ...record,
+    recurrenceCount: record.recurrenceCount + 1,
+    lastOccurrenceWeek: normalizedWeek,
+  }
+
+  if (!validateRecurrentCatastropheRecord(candidate).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly recurrence pass over persisted recurrent catastrophe records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklyRecurrentCatastropheTick(
+  records: RecurrentCatastropheRecordsMap | null | undefined,
+  week: number
+): RecurrentCatastropheRecordsMap {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: RecurrentCatastropheRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceRecurrentCatastropheRecordForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[recordId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -286,6 +286,7 @@ import { applyWeeklyPublicDisclosureProgressionTick } from '../publicDisclosureW
 import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInformationWeeklyRetention'
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
+import { applyWeeklyRecurrentCatastropheTick } from '../recurrentCatastropheWeeklyOrchestration'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
 import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
@@ -4681,6 +4682,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   if (Object.keys(currentWelfareDebtAccountingRecords).length > 0) {
     outputWeeklyState.welfareDebtAccountingRecords = applyWeeklyWelfareDebtAccountingTick(
       currentWelfareDebtAccountingRecords,
+      result.week
+    )
+  }
+
+  // SPE-2117 slice 3: cadence-due recurrenceCount and lastOccurrenceWeek advance on recurrent catastrophes.
+  const currentRecurrentCatastropheRecords = outputWeeklyState.recurrentCatastropheRecords ?? {}
+  if (Object.keys(currentRecurrentCatastropheRecords).length > 0) {
+    outputWeeklyState.recurrentCatastropheRecords = applyWeeklyRecurrentCatastropheTick(
+      currentRecurrentCatastropheRecords,
       result.week
     )
   }

--- a/src/test/advanceWeek.recurrentCatastrophe.integration.test.ts
+++ b/src/test/advanceWeek.recurrentCatastrophe.integration.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+  RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+} from '../domain/recurrentCatastropheAmeliorationRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyWeeklyRecurrentCatastropheTick } from '../domain/recurrentCatastropheWeeklyOrchestration'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek recurrent catastrophe integration (SPE-2117 slice 3)', () => {
+  it('is a no-op for an empty recurrent catastrophe map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.recurrentCatastropheRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.recurrentCatastropheRecords).toEqual({})
+  })
+
+  it('retains recurrence fields before the due week after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 51
+    state.recurrentCatastropheRecords = {
+      [RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]: RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record = nextState.recurrentCatastropheRecords?.[RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]
+
+    expect(nextState.week).toBe(52)
+    expect(record?.recurrenceCount).toBe(3)
+    expect(record?.lastOccurrenceWeek).toBe(40)
+    expect(record?.damageLedgerRefs).toEqual(RECURRENCE_DAMAGE_LEDGER_FIXTURE.damageLedgerRefs)
+  })
+
+  it('advances recurrenceCount and lastOccurrenceWeek when advanceWeek reaches the due week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 52
+    state.recurrentCatastropheRecords = {
+      [RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]: RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record = nextState.recurrentCatastropheRecords?.[RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]
+
+    expect(nextState.week).toBe(53)
+    expect(record?.recurrenceCount).toBe(4)
+    expect(record?.lastOccurrenceWeek).toBe(53)
+    expect(record?.postIncidentReviewRefs).toEqual(
+      RECURRENCE_DAMAGE_LEDGER_FIXTURE.postIncidentReviewRefs
+    )
+  })
+
+  it('does not activate prevention tactics on impossible-ceiling records through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 10
+    state.recurrentCatastropheRecords = {
+      [IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE.id]: {
+        ...IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+        recurrenceCadence: 'weekly',
+        recurrenceCount: 1,
+        lastOccurrenceWeek: 10,
+      },
+    }
+
+    const nextState = advanceWeek(state)
+    const record =
+      nextState.recurrentCatastropheRecords?.[IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE.id]
+
+    expect(nextState.week).toBe(11)
+    expect(record?.recurrenceCount).toBe(2)
+    expect(record?.lastOccurrenceWeek).toBe(11)
+    expect(record?.preventionTactics?.every((entry) => entry.active === false)).toBe(true)
+  })
+
+  it('matches direct tick output for the post-advance week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 52
+    state.recurrentCatastropheRecords = {
+      [RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]: RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const directTick = applyWeeklyRecurrentCatastropheTick(
+      state.recurrentCatastropheRecords,
+      nextState.week
+    )
+
+    expect(nextState.recurrentCatastropheRecords).toEqual(directTick)
+  })
+})

--- a/src/test/recurrentCatastropheWeeklyOrchestration.test.ts
+++ b/src/test/recurrentCatastropheWeeklyOrchestration.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+  RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+  projectNextRecurrenceRisk,
+  type RecurrentCatastropheRecord,
+} from '../domain/recurrentCatastropheAmeliorationRegistry'
+import {
+  advanceRecurrentCatastropheRecordForWeek,
+  applyWeeklyRecurrentCatastropheTick,
+  resolveRecurrenceDueWeek,
+} from '../domain/recurrentCatastropheWeeklyOrchestration'
+
+function baseRecord(
+  overrides: Partial<RecurrentCatastropheRecord> = {}
+): RecurrentCatastropheRecord {
+  return {
+    id: 'recurrent-catastrophe:test-cadence',
+    label: 'Test cadence recurrence record',
+    recurrenceCadence: 'monthly',
+    failureMode: 'manifestation',
+    preventionCeiling: 'unknown',
+    ameliorationTactics: [{ tactic: 'shielding', active: true }],
+    recurrenceCount: 1,
+    lastOccurrenceWeek: 8,
+    ...overrides,
+  }
+}
+
+describe('recurrentCatastropheWeeklyOrchestration (SPE-2117 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklyRecurrentCatastropheTick({}, 12)).toEqual({})
+    expect(applyWeeklyRecurrentCatastropheTick(undefined, 12)).toEqual({})
+  })
+
+  it('resolves recurrence due week from last occurrence plus cadence interval', () => {
+    expect(resolveRecurrenceDueWeek(RECURRENCE_DAMAGE_LEDGER_FIXTURE)).toBe(53)
+    expect(resolveRecurrenceDueWeek(baseRecord())).toBe(12)
+    expect(resolveRecurrenceDueWeek(baseRecord({ recurrenceCadence: 'irregular' }))).toBe(16)
+    expect(resolveRecurrenceDueWeek(IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE)).toBeUndefined()
+  })
+
+  it('leaves records unchanged while week is before the due week', () => {
+    const record = baseRecord()
+    const advanced = advanceRecurrentCatastropheRecordForWeek(record, 11)
+
+    expect(advanced).toBe(record)
+    expect(advanced.recurrenceCount).toBe(1)
+    expect(advanced.lastOccurrenceWeek).toBe(8)
+  })
+
+  it('advances recurrenceCount and lastOccurrenceWeek when week reaches the due week', () => {
+    const record = baseRecord()
+    const advanced = advanceRecurrentCatastropheRecordForWeek(record, 12)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.recurrenceCount).toBe(2)
+    expect(advanced.lastOccurrenceWeek).toBe(12)
+    expect(advanced.ameliorationTactics).toEqual(record.ameliorationTactics)
+  })
+
+  it('advances seasonal cadence fixture when due week is reached', () => {
+    const record = RECURRENCE_DAMAGE_LEDGER_FIXTURE
+    const advanced = advanceRecurrentCatastropheRecordForWeek(record, 53)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.recurrenceCount).toBe(4)
+    expect(advanced.lastOccurrenceWeek).toBe(53)
+    expect(advanced.damageLedgerRefs).toEqual(record.damageLedgerRefs)
+  })
+
+  it('is idempotent when re-applied after recurrence advance for the same week', () => {
+    const record = baseRecord()
+    const once = advanceRecurrentCatastropheRecordForWeek(record, 12)
+    const twice = advanceRecurrentCatastropheRecordForWeek(once, 12)
+
+    expect(twice).toBe(once)
+  })
+
+  it('leaves records without lastOccurrenceWeek unchanged', () => {
+    const record = IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE
+    const advanced = advanceRecurrentCatastropheRecordForWeek(record, 52)
+
+    expect(advanced).toBe(record)
+    expect(advanced.recurrenceCount).toBe(0)
+    expect(advanced.lastOccurrenceWeek).toBeUndefined()
+  })
+
+  it('does not activate prevention tactics on impossible-ceiling records when due', () => {
+    const record = {
+      ...IMPOSSIBLE_PREVENTION_DAMPENING_FIXTURE,
+      lastOccurrenceWeek: 10,
+      recurrenceCadence: 'weekly' as const,
+      recurrenceCount: 2,
+    }
+    const advanced = advanceRecurrentCatastropheRecordForWeek(record, 11)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.recurrenceCount).toBe(3)
+    expect(advanced.lastOccurrenceWeek).toBe(11)
+    expect(advanced.preventionTactics).toEqual(record.preventionTactics)
+    expect(advanced.preventionTactics?.every((entry) => entry.active === false)).toBe(true)
+  })
+
+  it('still advances warnings-only records when cadence is due', () => {
+    const record = baseRecord({
+      id: 'recurrent-catastrophe:warning-only-recurrence',
+      label: 'Recurrence without ledger warning',
+      recurrenceCadence: 'weekly',
+      recurrenceCount: 2,
+      lastOccurrenceWeek: 5,
+      damageLedgerRefs: undefined,
+    })
+    const advanced = advanceRecurrentCatastropheRecordForWeek(record, 6)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.recurrenceCount).toBe(3)
+    expect(advanced.lastOccurrenceWeek).toBe(6)
+  })
+
+  it('feeds updated recurrence fields into projection-only reads after cadence advance', () => {
+    const before = projectNextRecurrenceRisk(RECURRENCE_DAMAGE_LEDGER_FIXTURE, { currentWeek: 53 })
+    const advanced = advanceRecurrentCatastropheRecordForWeek(RECURRENCE_DAMAGE_LEDGER_FIXTURE, 53)
+    const after = projectNextRecurrenceRisk(advanced, { currentWeek: 53 })
+
+    expect(before.recurrenceCount).toBe(3)
+    expect(before.lastOccurrenceWeek).toBe(40)
+    expect(after.recurrenceCount).toBe(4)
+    expect(after.lastOccurrenceWeek).toBe(53)
+    expect(after.recurrenceRiskScore).not.toBeNull()
+  })
+
+  it('applies map tick in stable id order without mutating unrelated records', () => {
+    const dueRecord = baseRecord({ id: 'recurrent-catastrophe:z-due' })
+    const notDueRecord = baseRecord({
+      id: 'recurrent-catastrophe:a-not-due',
+      lastOccurrenceWeek: 20,
+    })
+    const next = applyWeeklyRecurrentCatastropheTick(
+      {
+        [dueRecord.id]: dueRecord,
+        [notDueRecord.id]: notDueRecord,
+      },
+      12
+    )
+
+    expect(next[dueRecord.id]?.recurrenceCount).toBe(2)
+    expect(next[notDueRecord.id]).toBe(notDueRecord)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyRecurrentCatastropheTick` for cadence-due `recurrenceCount` / `lastOccurrenceWeek` advancement on persisted recurrent catastrophe records.
- Wire the tick into `advanceWeek` after week increment on `outputWeeklyState.recurrentCatastropheRecords`.
- Add domain unit tests and `advanceWeek` integration tests; slice doc `planning/recurrent-catastrophe-amelioration-registry-slice-3.md`.

## Linear mapping

- **Slice issue:** [SPE-2364](https://linear.app/spectranoir/issue/SPE-2364) — Recurrent catastrophe amelioration registry weekly recurrence advance hook (slice 3)
- **Parent:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — stays open
- **Anchor:** [SPE-2117](https://linear.app/spectranoir/issue/SPE-2117) — recurrent catastrophe registry slice 1

## What shipped

- `src/domain/recurrentCatastropheWeeklyOrchestration.ts` — due week = lastOccurrenceWeek + cadence interval; one recurrence step per record per tick when due; idempotent re-apply
- `src/domain/sim/advanceWeek.ts` — post-week-increment hook
- Tests: `recurrentCatastropheWeeklyOrchestration.test.ts`, `advanceWeek.recurrentCatastrophe.integration.test.ts`

## Validation

- `npm run test:run -- src/test/recurrentCatastropheWeeklyOrchestration.test.ts src/test/advanceWeek.recurrentCatastrophe.integration.test.ts src/test/recurrentCatastropheAmeliorationRegistryPersistence.test.ts src/test/recurrentCatastropheAmeliorationRegistry.test.ts`
- `npm run lint`

## Docs updated

- `planning/recurrent-catastrophe-amelioration-registry-slice-3.md` (created)

## Parent remains open

SPE-1310 parent not closed — registry slice only; SPE-868 wire-up deferred.