### PR TITLE
feat(SPE-2365): rule-document compliance registry GameState persistence (slice 2)

### DIFF
--- a/planning/rule-document-compliance-containment-registry-slice-2.md
+++ b/planning/rule-document-compliance-containment-registry-slice-2.md
@@ -1,0 +1,66 @@
+# SPE-2123 — Rule-document compliance containment registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: child [SPE-2365](https://linear.app/spectranoir/issue/SPE-2365) under [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) / anchor [SPE-2123](https://linear.app/spectranoir/issue/SPE-2123). Follows shipped slice 1 (`planning/rule-document-compliance-containment-registry-slice-1.md`, PR #2442).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2365 — Rule-document compliance containment registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2365) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — Case / facility lifecycle (stays open)         |
+| **Anchor** | [SPE-2123](https://linear.app/spectranoir/issue/SPE-2123) — Rule-document compliance containment registry slice 1 |
+| **Branch** | `spe-2123-rule-document-compliance-persistence-slice-2`                                                    |
+| **Base `main` SHA** | `9582783b`                                                                                          |
+
+## Goal
+
+Persist validated `RuleDocumentComplianceRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Slice 1 deferred persistence; weekly compliance-decay orchestration is slice 3+.
+
+## Prerequisite (on `main` @ `9582783b`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/ruleDocumentComplianceContainmentRegistry.ts` (SPE-2123 / PR #2442) |
+| Fixtures             | `VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE`, `DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE` |
+| Sibling persistence pattern | `planning/recurrent-catastrophe-amelioration-registry-slice-2.md` (SPE-2363 / PR #2595) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `ruleDocumentComplianceRecords` on `GameState`                     | Weekly `advanceWeek` compliance-decay hook    |
+| `sanitizeRuleDocumentComplianceRecords` + `runTransfer` hydrate wire | UI / dev overlay                              |
+| `validateRuleDocumentComplianceRecord` on hydrate; drop invalid, no throw | SPE-1310 parent closure                  |
+| Default `{}` in `createStartingState`                              | SPE-1097 authority/legitimacy wire-up         |
+| Sanitize unit tests + save/import round-trip (byte-stable)         | Changes to slice-1 validation semantics       |
+| Warnings-only records persist (e.g. `compelled_binding_without_auditor`) | Sibling registry orchestration hooks     |
+
+## Acceptance
+
+- [ ] Valid fixtures round-trip through serialize/import
+- [ ] Invalid/duplicate-id entries dropped safely on hydrate (including `breach_without_breach_consequence`)
+- [ ] Warnings-only records persist through sanitize
+- [ ] `npm run lint` + targeted tests + slice-1 regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/ruleDocumentComplianceContainmentRegistry.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/ruleDocumentComplianceContainmentRegistryPersistence.test.ts` |
+| Plan   | `planning/rule-document-compliance-containment-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Weekly compliance-decay advance hook | SPE-2123 slice 3 | Persistence must land before orchestration |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 follow-up | Out of persistence-only boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+
+## See also
+
+- `planning/rule-document-compliance-containment-registry-slice-1.md`
+- `planning/recurrent-catastrophe-amelioration-registry-slice-2.md`
+- `src/test/recurrentCatastropheAmeliorationRegistryPersistence.test.ts`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -195,6 +195,7 @@ import { sanitizeInformationIntakeReports } from '../../domain/informationIntake
 import { sanitizeExtranormalEventRecords } from '../../domain/extranormalEventRegistry'
 import { sanitizeNamingHazardDescriptorRecords } from '../../domain/namingHazardDescriptorRegistry'
 import { sanitizeRecurrentCatastropheRecords } from '../../domain/recurrentCatastropheAmeliorationRegistry'
+import { sanitizeRuleDocumentComplianceRecords } from '../../domain/ruleDocumentComplianceContainmentRegistry'
 import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLocationRegistry'
 import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
 import { sanitizeSelfCensoringInformationRecords } from '../../domain/selfCensoringInformationRegistry'
@@ -8423,6 +8424,10 @@ export function hydrateGame(
     game.recurrentCatastropheRecords,
     fallback.recurrentCatastropheRecords ?? {}
   )
+  const ruleDocumentComplianceRecords = sanitizeRuleDocumentComplianceRecords(
+    game.ruleDocumentComplianceRecords,
+    fallback.ruleDocumentComplianceRecords ?? {}
+  )
   const selfCensoringInformationRecords = sanitizeSelfCensoringInformationRecords(
     game.selfCensoringInformationRecords,
     fallback.selfCensoringInformationRecords ?? {}
@@ -8590,6 +8595,7 @@ export function hydrateGame(
       minorAnomalyItemRecords,
       namingHazardDescriptorRecords,
       recurrentCatastropheRecords,
+      ruleDocumentComplianceRecords,
       selfCensoringInformationRecords,
       publicDisclosureRecords,
       patternSourceSeriesRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -45,6 +45,7 @@ const startingStateTemplate: GameState = {
   minorAnomalyItemRecords: {},
   namingHazardDescriptorRecords: {},
   recurrentCatastropheRecords: {},
+  ruleDocumentComplianceRecords: {},
   selfCensoringInformationRecords: {},
   publicDisclosureRecords: {},
   patternSourceSeriesRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -249,6 +249,7 @@ import type { UnexplainedLocationRecord } from './unexplainedLocationRegistry'
 import type { MinorAnomalyRecord } from './minorAnomalyItemRegistry'
 import type { NamingHazardDescriptorRecord } from './namingHazardDescriptorRegistry'
 import type { RecurrentCatastropheRecord } from './recurrentCatastropheAmeliorationRegistry'
+import type { RuleDocumentComplianceRecord } from './ruleDocumentComplianceContainmentRegistry'
 import type { SelfCensoringInformationRecord } from './selfCensoringInformationRegistry'
 import type { PublicDisclosureRecord } from './publicDisclosureStateRegistry'
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
@@ -2588,6 +2589,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   recurrentCatastropheRecords?: Record<string, RecurrentCatastropheRecord>
+
+  /**
+   * SPE-2123 slice 2: persisted rule-document compliance records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  ruleDocumentComplianceRecords?: Record<string, RuleDocumentComplianceRecord>
 
   /**
    * SPE-2108 slice 2: persisted self-censoring information records (keyed by record id).

--- a/src/domain/ruleDocumentComplianceContainmentRegistry.ts
+++ b/src/domain/ruleDocumentComplianceContainmentRegistry.ts
@@ -752,6 +752,114 @@ export function projectComplianceDecay(
   })
 }
 
+export type RuleDocumentComplianceRecordsMap = Record<
+  RuleDocumentComplianceId,
+  RuleDocumentComplianceRecord
+>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseNonEmptyStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+function sanitizeRuleDocumentComplianceRecordEntry(
+  value: unknown
+): RuleDocumentComplianceRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const documentRef = normalizeToken(value.documentRef)
+  const bindingStrength = value.bindingStrength
+  const complianceState = value.complianceState
+  const physicalCopyRequired = value.physicalCopyRequired
+
+  if (
+    !id ||
+    !label ||
+    !documentRef ||
+    typeof bindingStrength !== 'string' ||
+    !isBindingStrength(bindingStrength) ||
+    typeof complianceState !== 'string' ||
+    !isComplianceState(complianceState) ||
+    typeof physicalCopyRequired !== 'boolean'
+  ) {
+    return null
+  }
+
+  const breachConsequence = value.breachConsequence
+  const revisionHistoryRefs = parseNonEmptyStringList(value.revisionHistoryRefs)
+  const auditorAssigneeRefs = parseNonEmptyStringList(value.auditorAssigneeRefs)
+  const unknownFields = asStringArray(value.unknownFields)
+  const redactedFields = asStringArray(value.redactedFields)
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const confidence = value.confidence
+
+  const record: RuleDocumentComplianceRecord = {
+    id,
+    label,
+    documentRef,
+    bindingStrength,
+    complianceState,
+    physicalCopyRequired,
+    ...(summary ? { summary } : {}),
+    ...(revisionHistoryRefs.length > 0 ? { revisionHistoryRefs } : {}),
+    ...(typeof breachConsequence === 'string' && isBreachConsequence(breachConsequence)
+      ? { breachConsequence }
+      : {}),
+    ...(auditorAssigneeRefs.length > 0 ? { auditorAssigneeRefs } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateRuleDocumentComplianceRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical record map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeRuleDocumentComplianceRecords(
+  value: unknown,
+  fallback: RuleDocumentComplianceRecordsMap = {}
+): RuleDocumentComplianceRecordsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: RuleDocumentComplianceRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeRuleDocumentComplianceRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 function defineRecord(record: RuleDocumentComplianceRecord): RuleDocumentComplianceRecord {
   return Object.freeze({ ...record })
 }

--- a/src/test/ruleDocumentComplianceContainmentRegistryPersistence.test.ts
+++ b/src/test/ruleDocumentComplianceContainmentRegistryPersistence.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE,
+  VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+  sanitizeRuleDocumentComplianceRecords,
+} from '../domain/ruleDocumentComplianceContainmentRegistry'
+
+describe('ruleDocumentComplianceContainmentRegistry persistence (SPE-2123 slice 2)', () => {
+  it('defaults starting state to an empty rule document compliance map', () => {
+    expect(createStartingState().ruleDocumentComplianceRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeRuleDocumentComplianceRecords(
+      {
+        valid: VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+        breach: DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE,
+        'wrong-key': {
+          ...DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE,
+          id: 'rule-document-compliance:voluntary-cooperative-subject-a',
+        },
+        duplicate: {
+          ...VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          documentRef: 'document:bad',
+          bindingStrength: 'voluntary',
+          complianceState: 'compliant',
+          physicalCopyRequired: true,
+        },
+        breachWithoutConsequence: {
+          id: 'rule-document-compliance:breach-without-consequence',
+          label: 'Breach without consequence',
+          documentRef: 'document:breach-missing-consequence',
+          bindingStrength: 'contractual',
+          complianceState: 'breach',
+          physicalCopyRequired: true,
+        },
+        franchiseToken: {
+          id: 'rule-document-compliance:foundation-binding',
+          label: 'Franchise token binding',
+          documentRef: 'document:conduct-agreement',
+          bindingStrength: 'voluntary',
+          complianceState: 'compliant',
+          physicalCopyRequired: false,
+        },
+        warningsOnly: {
+          id: 'rule-document-compliance:compelled-without-auditor',
+          label: 'Compelled binding without auditor warning',
+          documentRef: 'document:compelled-conduct-code',
+          bindingStrength: 'compelled',
+          complianceState: 'drifting',
+          physicalCopyRequired: false,
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['rule-document-compliance:voluntary-cooperative-subject-a']).toEqual(
+      VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE
+    )
+    expect(sanitized['rule-document-compliance:drift-to-breach-review']).toEqual(
+      DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE
+    )
+    expect(sanitized['rule-document-compliance:compelled-without-auditor']).toEqual({
+      id: 'rule-document-compliance:compelled-without-auditor',
+      label: 'Compelled binding without auditor warning',
+      documentRef: 'document:compelled-conduct-code',
+      bindingStrength: 'compelled',
+      complianceState: 'drifting',
+      physicalCopyRequired: false,
+    })
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.breachWithoutConsequence).toBeUndefined()
+    expect(sanitized.franchiseToken).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(Object.keys(sanitized)).toHaveLength(3)
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.ruleDocumentComplianceRecords = {
+      [VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE.id]: VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+      [DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE.id]: DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.ruleDocumentComplianceRecords).toEqual(state.ruleDocumentComplianceRecords)
+    expect(
+      loaded.ruleDocumentComplianceRecords?.[DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE.id]
+        ?.revisionHistoryRefs
+    ).toEqual(DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE.revisionHistoryRefs)
+    expect(
+      loaded.ruleDocumentComplianceRecords?.[DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE.id]
+        ?.breachConsequence
+    ).toBe('escalate_review')
+  })
+
+  it('hydrates persisted rule document compliance records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        ruleDocumentComplianceRecords: {
+          [VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE.id]: VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+          invalid: {
+            id: 'rule-document-compliance:breach-without-consequence',
+            label: 'Invalid breach on hydrate',
+            documentRef: 'document:breach-missing-consequence',
+            bindingStrength: 'contractual',
+            complianceState: 'breach',
+            physicalCopyRequired: true,
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.ruleDocumentComplianceRecords).toEqual({
+      [VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE.id]: VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add uleDocumentComplianceRecords to GameState with sanitizeRuleDocumentComplianceRecords and unTransfer hydrate wire
- Default empty map in createStartingState; drop invalid/duplicate-id entries on hydrate without throwing
- Persistence tests cover warnings-only records, breach-without-consequence drop, and save round-trip

## Linear

- **Slice:** [SPE-2365](https://linear.app/spectranoir/issue/SPE-2365) — Rule-document compliance containment registry GameState persistence (slice 2)
- **Parent:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — stays open
- **Anchor:** [SPE-2123](https://linear.app/spectranoir/issue/SPE-2123)

## What shipped

- sanitizeRuleDocumentComplianceRecords + entry sanitizer gated by slice-1 alidateRuleDocumentComplianceRecord
- GameState.ruleDocumentComplianceRecords, starting state default {}, hydrate in unTransfer
- src/test/ruleDocumentComplianceContainmentRegistryPersistence.test.ts

## Validation

- 
pm run test:run -- src/test/ruleDocumentComplianceContainmentRegistryPersistence.test.ts src/test/ruleDocumentComplianceContainmentRegistry.test.ts (19 passed)
- 
pm run lint

## Docs updated

- planning/rule-document-compliance-containment-registry-slice-2.md (created)

## Parent status

SPE-1310 remains open — registry persistence slice only.

Made with [Cursor](https://cursor.com)