### PR TITLE
feat(SPE-2366): rule-document compliance weekly decay advance hook (slice 3)

### DIFF
--- a/planning/rule-document-compliance-containment-registry-slice-3.md
+++ b/planning/rule-document-compliance-containment-registry-slice-3.md
@@ -1,0 +1,81 @@
+# SPE-2123 — Rule-document compliance containment registry weekly compliance-decay advance hook (slice 3)
+
+One-page implementation plan. Linear: child [SPE-2366](https://linear.app/spectranoir/issue/SPE-2366) under [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) / anchor [SPE-2123](https://linear.app/spectranoir/issue/SPE-2123). Follows shipped slice 2 (`planning/rule-document-compliance-containment-registry-slice-2.md`, PR #2599).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2366 — Rule-document compliance containment registry weekly compliance-decay advance hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2366) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — Case / facility lifecycle (stays open)         |
+| **Anchor** | [SPE-2123](https://linear.app/spectranoir/issue/SPE-2123) — Rule-document compliance containment registry  |
+| **Branch** | `spe-2123-rule-document-compliance-weekly-hook-slice-3`                                                    |
+| **Base `main` SHA** | `f6423cf4`                                                                                          |
+
+## Goal
+
+Wire persisted `ruleDocumentComplianceRecords` into `advanceWeek` so weekly simulation ticks apply `projectComplianceDecay` forecast semantics and advance `complianceState` deterministically when drift bands warrant bounded transitions.
+
+## Prerequisite (on `main` @ `f6423cf4`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/ruleDocumentComplianceContainmentRegistry.ts` (SPE-2123 / PR #2442) |
+| Persistence          | `ruleDocumentComplianceRecords` on `GameState` (SPE-2365 / PR #2599)       |
+| Sibling weekly hooks | `recurrentCatastropheWeeklyOrchestration.ts` (SPE-2364), `unexplainedLocationWeeklyLifecycle.ts` (SPE-2317) |
+
+## Orchestration tick contract (slice 3)
+
+- **Projection input** = `projectComplianceDecay(record, { currentWeek: week })` at the post-increment simulation week.
+- **Redacted / null drift band** → record unchanged (no implicit state inference).
+- **`breach` state** → terminal; drift probability already 1; no further mutation.
+- **Decay band → state target** (one bounded step per tick; idempotent re-apply at same week):
+  - `stable` → no change
+  - `elevated` → `compliant` or `unknown` becomes `drifting`
+  - `critical` → `breach` when `breachConsequence` is declared (from any non-breach state); else `compliant` or `unknown` becomes `drifting`
+- `projectComplianceDecay` remains projection-only for reads; the tick does not consult other projection fields for mutation decisions.
+- `validateRuleDocumentComplianceRecord` gates any mutated record; invalid candidates return the prior record unchanged.
+- Warnings-only records (e.g. `compelled_binding_without_auditor`) still tick when band warrants.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyRuleDocumentComplianceTick` in domain module               | New persistence fields, UI, report notes      |
+| `resolveTargetComplianceStateFromDecayBand` / projection helper for tests | SPE-1310 parent closure                       |
+| Call from `advanceWeek` after week increment (`result.week`)       | SPE-1097 authority/legitimacy wire-up          |
+| Targeted domain + `advanceWeek` integration tests                    | Slice-1 validation semantic changes           |
+| Slice doc (this file) + backlog handoff on ship                      | Sanitize/hydration changes                    |
+
+## Acceptance
+
+- [ ] Empty `ruleDocumentComplianceRecords` map is a no-op without throw
+- [ ] Records unchanged while projected decay band is `stable`
+- [ ] `elevated` band advances `compliant` / `unknown` to `drifting`
+- [ ] `critical` band advances to `breach` when `breachConsequence` is declared
+- [ ] `breach` records and redacted projection inputs byte-stable through tick
+- [ ] Warnings-only records still tick when band warrants
+- [ ] Re-applying tick after advance is idempotent for the same week
+- [ ] Invalid post-mutation records revert to prior record
+- [ ] `npm run lint` + targeted tests + slice-1/2 regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/ruleDocumentComplianceWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/ruleDocumentComplianceWeeklyOrchestration.test.ts`, `src/test/advanceWeek.ruleDocumentCompliance.integration.test.ts` |
+| Plan   | `planning/rule-document-compliance-containment-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 follow-up | Out of weekly-hook boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Case lifecycle transitions on compliance breach | SPE-1310 | Decay-band advance only in slice 3 |
+
+## See also
+
+- `planning/rule-document-compliance-containment-registry-slice-2.md`
+- `planning/recurrent-catastrophe-amelioration-registry-slice-3.md`
+- `planning/unexplained-location-registry-slice-3.md`

--- a/src/domain/ruleDocumentComplianceWeeklyOrchestration.ts
+++ b/src/domain/ruleDocumentComplianceWeeklyOrchestration.ts
@@ -1,0 +1,166 @@
+/**
+ * SPE-2123 slice 3: weekly compliance-decay advance for persisted rule-document compliance records.
+ *
+ * Pure deterministic tick: project decay at the simulation week and advance complianceState
+ * when the forecast band warrants a bounded transition. Does not add persistence fields or
+ * mutate projection-only reads.
+ */
+
+import {
+  projectComplianceDecay,
+  validateRuleDocumentComplianceRecord,
+  type ComplianceDecayBand,
+  type ComplianceDecayProjection,
+  type ComplianceState,
+  type RuleDocumentComplianceRecord,
+  type RuleDocumentComplianceRecordsMap,
+} from './ruleDocumentComplianceContainmentRegistry'
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function freezeRecord(record: RuleDocumentComplianceRecord): RuleDocumentComplianceRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Target compliance state implied by a decay-band forecast; undefined when no transition applies. */
+export function resolveTargetComplianceStateFromDecayBand(
+  record: RuleDocumentComplianceRecord,
+  band: ComplianceDecayBand | null
+): ComplianceState | undefined {
+  if (record.complianceState === 'breach') {
+    return undefined
+  }
+
+  if (band === null || band === 'stable') {
+    return undefined
+  }
+
+  const current = record.complianceState
+
+  if (band === 'critical') {
+    if (record.breachConsequence !== undefined && current !== 'breach') {
+      return 'breach'
+    }
+
+    if (current === 'compliant' || current === 'unknown') {
+      return 'drifting'
+    }
+
+    return undefined
+  }
+
+  if (current === 'compliant' || current === 'unknown') {
+    return 'drifting'
+  }
+
+  return undefined
+}
+
+/** Target compliance state from a decay projection; undefined when projection is redacted or terminal. */
+export function resolveTargetComplianceStateFromProjection(
+  record: RuleDocumentComplianceRecord,
+  projection: ComplianceDecayProjection
+): ComplianceState | undefined {
+  if (projection.driftProbabilityPerWeek === null || projection.complianceDecayBand === null) {
+    return undefined
+  }
+
+  return resolveTargetComplianceStateFromDecayBand(record, projection.complianceDecayBand)
+}
+
+const DRIFT_PROJECTION_FIELDS = [
+  'bindingStrength',
+  'complianceState',
+  'physicalCopyRequired',
+  'revisionHistoryRefs',
+] as const
+
+function shouldRedactUnknownProjectionFields(record: RuleDocumentComplianceRecord): boolean {
+  const unknownFields = record.unknownFields ?? []
+  return DRIFT_PROJECTION_FIELDS.some((field) => unknownFields.includes(field))
+}
+
+function buildWeeklyAdvanceCandidate(
+  record: RuleDocumentComplianceRecord,
+  week: number
+): RuleDocumentComplianceRecord | undefined {
+  if (record.complianceState === 'breach') {
+    return undefined
+  }
+
+  const projection = projectComplianceDecay(record, {
+    currentWeek: week,
+    ...(shouldRedactUnknownProjectionFields(record) ? { redactUnknown: true } : {}),
+  })
+  const targetState = resolveTargetComplianceStateFromProjection(record, projection)
+
+  if (!targetState || targetState === record.complianceState) {
+    return undefined
+  }
+
+  return {
+    ...record,
+    complianceState: targetState,
+  }
+}
+
+/**
+ * Advances one record for the simulation week using projected compliance-decay band semantics.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceRuleDocumentComplianceRecordForWeek(
+  record: RuleDocumentComplianceRecord,
+  week: number
+): RuleDocumentComplianceRecord {
+  const normalizedWeek = normalizeWeek(week)
+  const candidate = buildWeeklyAdvanceCandidate(record, normalizedWeek)
+  if (!candidate) {
+    return record
+  }
+
+  if (!validateRuleDocumentComplianceRecord(candidate).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly compliance-decay pass over persisted rule-document compliance records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklyRuleDocumentComplianceTick(
+  records: RuleDocumentComplianceRecordsMap | null | undefined,
+  week: number
+): RuleDocumentComplianceRecordsMap {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: RuleDocumentComplianceRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceRuleDocumentComplianceRecordForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[recordId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -287,6 +287,7 @@ import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInforma
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
 import { applyWeeklyRecurrentCatastropheTick } from '../recurrentCatastropheWeeklyOrchestration'
+import { applyWeeklyRuleDocumentComplianceTick } from '../ruleDocumentComplianceWeeklyOrchestration'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
 import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
@@ -4691,6 +4692,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   if (Object.keys(currentRecurrentCatastropheRecords).length > 0) {
     outputWeeklyState.recurrentCatastropheRecords = applyWeeklyRecurrentCatastropheTick(
       currentRecurrentCatastropheRecords,
+      result.week
+    )
+  }
+
+  // SPE-2123 slice 3: compliance-decay band state transitions on rule-document compliance records.
+  const currentRuleDocumentComplianceRecords = outputWeeklyState.ruleDocumentComplianceRecords ?? {}
+  if (Object.keys(currentRuleDocumentComplianceRecords).length > 0) {
+    outputWeeklyState.ruleDocumentComplianceRecords = applyWeeklyRuleDocumentComplianceTick(
+      currentRuleDocumentComplianceRecords,
       result.week
     )
   }

--- a/src/test/advanceWeek.ruleDocumentCompliance.integration.test.ts
+++ b/src/test/advanceWeek.ruleDocumentCompliance.integration.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE } from '../domain/ruleDocumentComplianceContainmentRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyWeeklyRuleDocumentComplianceTick } from '../domain/ruleDocumentComplianceWeeklyOrchestration'
+import type { RuleDocumentComplianceRecord } from '../domain/ruleDocumentComplianceContainmentRegistry'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+function elevatedDriftRecord(
+  overrides: Partial<RuleDocumentComplianceRecord> = {}
+): RuleDocumentComplianceRecord {
+  return {
+    id: 'rule-document-compliance:integration-elevated-drift',
+    label: 'Integration elevated drift record',
+    documentRef: 'document:integration-conduct-code',
+    bindingStrength: 'contractual',
+    complianceState: 'compliant',
+    physicalCopyRequired: false,
+    ...overrides,
+  }
+}
+
+describe('advanceWeek rule document compliance integration (SPE-2123 slice 3)', () => {
+  it('is a no-op for an empty rule document compliance map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.ruleDocumentComplianceRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.ruleDocumentComplianceRecords).toEqual({})
+  })
+
+  it('retains compliance state while projected decay band is stable after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.ruleDocumentComplianceRecords = {
+      [VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE.id]: VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record =
+      nextState.ruleDocumentComplianceRecords?.[VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE.id]
+
+    expect(nextState.week).toBe(2)
+    expect(record?.complianceState).toBe('compliant')
+    expect(record?.physicalCopyRequired).toBe(true)
+  })
+
+  it('advances compliant records to drifting when advanceWeek reaches an elevated band week', () => {
+    const record = elevatedDriftRecord()
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 139
+    state.ruleDocumentComplianceRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state)
+    const advanced = nextState.ruleDocumentComplianceRecords?.[record.id]
+
+    expect(nextState.week).toBe(140)
+    expect(advanced?.complianceState).toBe('drifting')
+    expect(advanced?.documentRef).toBe(record.documentRef)
+  })
+
+  it('leaves breach records unchanged through advanceWeek', () => {
+    const record = elevatedDriftRecord({
+      id: 'rule-document-compliance:integration-breach-terminal',
+      complianceState: 'breach',
+      breachConsequence: 'escalate_review',
+    })
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 299
+    state.ruleDocumentComplianceRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state)
+    const advanced = nextState.ruleDocumentComplianceRecords?.[record.id]
+
+    expect(nextState.week).toBe(300)
+    expect(advanced).toEqual(record)
+  })
+
+  it('matches direct tick output for the post-advance week', () => {
+    const record = elevatedDriftRecord()
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 139
+    state.ruleDocumentComplianceRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state)
+    const directTick = applyWeeklyRuleDocumentComplianceTick(
+      state.ruleDocumentComplianceRecords,
+      nextState.week
+    )
+
+    expect(nextState.ruleDocumentComplianceRecords).toEqual(directTick)
+  })
+})

--- a/src/test/ruleDocumentComplianceWeeklyOrchestration.test.ts
+++ b/src/test/ruleDocumentComplianceWeeklyOrchestration.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import {
+  VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+  DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE,
+  projectComplianceDecay,
+  type RuleDocumentComplianceRecord,
+} from '../domain/ruleDocumentComplianceContainmentRegistry'
+import {
+  advanceRuleDocumentComplianceRecordForWeek,
+  applyWeeklyRuleDocumentComplianceTick,
+  resolveTargetComplianceStateFromDecayBand,
+  resolveTargetComplianceStateFromProjection,
+} from '../domain/ruleDocumentComplianceWeeklyOrchestration'
+
+function baseRecord(
+  overrides: Partial<RuleDocumentComplianceRecord> = {}
+): RuleDocumentComplianceRecord {
+  return {
+    id: 'rule-document-compliance:weekly-orchestration-test',
+    label: 'Weekly orchestration test record',
+    documentRef: 'document:test-conduct-code',
+    bindingStrength: 'contractual',
+    complianceState: 'compliant',
+    physicalCopyRequired: false,
+    ...overrides,
+  }
+}
+
+describe('ruleDocumentComplianceWeeklyOrchestration (SPE-2123 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklyRuleDocumentComplianceTick({}, 12)).toEqual({})
+    expect(applyWeeklyRuleDocumentComplianceTick(undefined, 12)).toEqual({})
+  })
+
+  it('resolves elevated-band target as drifting for compliant and unknown states', () => {
+    const compliant = baseRecord()
+    const unknown = baseRecord({ complianceState: 'unknown' })
+
+    expect(resolveTargetComplianceStateFromDecayBand(compliant, 'elevated')).toBe('drifting')
+    expect(resolveTargetComplianceStateFromDecayBand(unknown, 'elevated')).toBe('drifting')
+    expect(resolveTargetComplianceStateFromDecayBand(baseRecord({ complianceState: 'drifting' }), 'elevated')).toBeUndefined()
+  })
+
+  it('resolves critical-band target as breach when breachConsequence is declared', () => {
+    const record = baseRecord({
+      breachConsequence: 'escalate_review',
+    })
+
+    expect(resolveTargetComplianceStateFromDecayBand(record, 'critical')).toBe('breach')
+    expect(resolveTargetComplianceStateFromDecayBand(baseRecord({ complianceState: 'drifting', breachConsequence: 'recontain' }), 'critical')).toBe('breach')
+  })
+
+  it('resolves critical-band target as drifting when breachConsequence is absent', () => {
+    const record = baseRecord({ complianceState: 'compliant' })
+
+    expect(resolveTargetComplianceStateFromDecayBand(record, 'critical')).toBe('drifting')
+    expect(resolveTargetComplianceStateFromDecayBand(baseRecord({ complianceState: 'drifting' }), 'critical')).toBeUndefined()
+  })
+
+  it('leaves records unchanged while projected decay band is stable', () => {
+    const record = VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE
+    const projection = projectComplianceDecay(record, { currentWeek: 2 })
+
+    expect(projection.complianceDecayBand).toBe('stable')
+    expect(advanceRuleDocumentComplianceRecordForWeek(record, 2)).toBe(record)
+  })
+
+  it('advances compliant records to drifting when projected band is elevated', () => {
+    const record = baseRecord({ id: 'rule-document-compliance:elevated-drift' })
+    const week = 140
+    const projection = projectComplianceDecay(record, { currentWeek: week })
+
+    expect(projection.complianceDecayBand).toBe('elevated')
+    expect(resolveTargetComplianceStateFromProjection(record, projection)).toBe('drifting')
+
+    const advanced = advanceRuleDocumentComplianceRecordForWeek(record, week)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.complianceState).toBe('drifting')
+    expect(advanced.documentRef).toBe(record.documentRef)
+  })
+
+  it('advances to breach when projected band is critical and breachConsequence is declared', () => {
+    const record = baseRecord({
+      id: 'rule-document-compliance:critical-breach',
+      breachConsequence: 'escalate_review',
+    })
+    const week = 300
+    const projection = projectComplianceDecay(record, { currentWeek: week })
+
+    expect(projection.complianceDecayBand).toBe('critical')
+    expect(resolveTargetComplianceStateFromProjection(record, projection)).toBe('breach')
+
+    const advanced = advanceRuleDocumentComplianceRecordForWeek(record, week)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.complianceState).toBe('breach')
+    expect(advanced.breachConsequence).toBe('escalate_review')
+  })
+
+  it('leaves breach records unchanged at drift probability 1', () => {
+    const record = DRIFTING_TO_BREACH_ESCALATE_REVIEW_FIXTURE
+    const advanced = advanceRuleDocumentComplianceRecordForWeek(record, 52)
+
+    expect(advanced).toBe(record)
+    expect(advanced.complianceState).toBe('breach')
+  })
+
+  it('leaves records with redacted projection inputs unchanged', () => {
+    const redactedRecord = {
+      ...VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+      redactedFields: ['complianceState'],
+    }
+    const unknownRecord = {
+      ...VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE,
+      id: 'rule-document-compliance:unknown-compliance-state',
+      unknownFields: ['complianceState'],
+    }
+
+    expect(advanceRuleDocumentComplianceRecordForWeek(redactedRecord, 200)).toBe(redactedRecord)
+    expect(advanceRuleDocumentComplianceRecordForWeek(unknownRecord, 200)).toBe(unknownRecord)
+    expect(projectComplianceDecay(redactedRecord, { currentWeek: 200 }).complianceDecayBand).toBeNull()
+    expect(
+      projectComplianceDecay(unknownRecord, { currentWeek: 200, redactUnknown: true })
+        .complianceDecayBand
+    ).toBeNull()
+  })
+
+  it('is idempotent when re-applied after advance for the same week', () => {
+    const record = baseRecord({
+      id: 'rule-document-compliance:idempotent-elevated',
+      breachConsequence: 'terminate_protocol',
+    })
+    const week = 140
+    const once = advanceRuleDocumentComplianceRecordForWeek(record, week)
+    const twice = advanceRuleDocumentComplianceRecordForWeek(once, week)
+
+    expect(twice).toBe(once)
+    expect(twice.complianceState).toBe('drifting')
+  })
+
+  it('reverts invalid post-mutation records to the prior record', () => {
+    const record = baseRecord({
+      id: 'rule-document-compliance:invalid-breach-candidate',
+      complianceState: 'drifting',
+      breachConsequence: undefined,
+    })
+    const week = 300
+    const projection = projectComplianceDecay(record, { currentWeek: week })
+
+    expect(projection.complianceDecayBand).toBe('critical')
+    expect(resolveTargetComplianceStateFromDecayBand(record, 'critical')).toBeUndefined()
+
+    const advanced = advanceRuleDocumentComplianceRecordForWeek(record, week)
+
+    expect(advanced).toBe(record)
+  })
+
+  it('still advances warnings-only records when band warrants transition', () => {
+    const record = baseRecord({
+      id: 'rule-document-compliance:warning-only-compelled',
+      bindingStrength: 'compelled',
+      auditorAssigneeRefs: undefined,
+    })
+    const week = 200
+    const projection = projectComplianceDecay(record, { currentWeek: week })
+
+    expect(projection.complianceDecayBand).toBe('elevated')
+
+    const advanced = advanceRuleDocumentComplianceRecordForWeek(record, week)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.complianceState).toBe('drifting')
+  })
+
+  it('feeds updated compliance state into projection-only reads after band advance', () => {
+    const record = baseRecord({ id: 'rule-document-compliance:projection-read-after-tick' })
+    const week = 140
+    const before = projectComplianceDecay(record, { currentWeek: week })
+    const advanced = advanceRuleDocumentComplianceRecordForWeek(record, week)
+    const after = projectComplianceDecay(advanced, { currentWeek: week })
+
+    expect(before.complianceState).toBe('compliant')
+    expect(after.complianceState).toBe('drifting')
+    expect(after.driftProbabilityPerWeek).not.toBeNull()
+    expect(after.driftProbabilityPerWeek!).toBeGreaterThan(before.driftProbabilityPerWeek ?? 0)
+  })
+
+  it('applies map tick in stable id order without mutating unrelated records', () => {
+    const stableRecord = VOLUNTARY_COMPLIANT_PHYSICAL_COPY_FIXTURE
+    const elevatedRecord = baseRecord({ id: 'rule-document-compliance:z-elevated-drift' })
+    const week = 140
+
+    const next = applyWeeklyRuleDocumentComplianceTick(
+      {
+        [elevatedRecord.id]: elevatedRecord,
+        [stableRecord.id]: stableRecord,
+      },
+      week
+    )
+
+    expect(next[stableRecord.id]).toBe(stableRecord)
+    expect(next[elevatedRecord.id]?.complianceState).toBe('drifting')
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyRuleDocumentComplianceTick` to advance `complianceState` from `projectComplianceDecay` drift-band forecast semantics (`stable` no-op, `elevated` → drifting, `critical` → breach when consequence declared).
- Wire the tick into `advanceWeek` after week increment on `outputWeeklyState.ruleDocumentComplianceRecords`.
- Add domain unit tests and `advanceWeek` integration tests; slice doc `planning/rule-document-compliance-containment-registry-slice-3.md`.

## Linear mapping

- **Slice issue:** [SPE-2366](https://linear.app/spectranoir/issue/SPE-2366) — Rule-document compliance containment registry weekly compliance-decay advance hook (slice 3)
- **Parent:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — stays open
- **Anchor:** [SPE-2123](https://linear.app/spectranoir/issue/SPE-2123) — rule-document compliance containment registry

## What shipped

- `src/domain/ruleDocumentComplianceWeeklyOrchestration.ts`
- `advanceWeek` hook after recurrent catastrophe tick
- 14 domain tests + 5 integration tests

## Validation

- `npm run test:run -- src/test/ruleDocumentComplianceWeeklyOrchestration.test.ts src/test/advanceWeek.ruleDocumentCompliance.integration.test.ts src/test/ruleDocumentComplianceContainmentRegistry.test.ts src/test/ruleDocumentComplianceContainmentRegistryPersistence.test.ts` (38 passed)
- `npm run lint`

## Docs updated

- `planning/rule-document-compliance-containment-registry-slice-3.md` (in progress — ship hygiene on merge)

## Parent remains open

SPE-1310 parent closure and SPE-1097 authority wire-up remain deferred.