### PR TITLE
feat(SPE-2377): post-incident review mirror qualifying incident surfacing (slice 8)

### DIFF
--- a/planning/post-incident-review-registry-slice-8.md
+++ b/planning/post-incident-review-registry-slice-8.md
@@ -1,0 +1,79 @@
+# SPE-868 — Post-incident review mirror qualifying incident surfacing (slice 8)
+
+One-page implementation plan. Linear: child [SPE-2377](https://linear.app/spectranoir/issue/SPE-2377) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 7 (`planning/post-incident-review-registry-slice-7.md`, PR #2620 / [SPE-2376](https://linear.app/spectranoir/issue/SPE-2376)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2377 — Post-incident review mirror qualifying incident surfacing (slice 8)](https://linear.app/spectranoir/issue/SPE-2377) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-qualifying-incident-mirror-slice-8`                                                               |
+| **Base `main` SHA** | `f7d21218`                                                                                          |
+
+## Goal
+
+Extend `getPostIncidentReviewMirrorView` and `PostIncidentReviewMirrorPage` to filter, group, and surface orchestration-created qualifying incident reviews (`review:case-*-closeout`, `review:near-catastrophe-*`) from persisted `game.postIncidentReviewRecords`.
+
+## Prerequisite (on `main` @ `f7d21218`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Qualifying creation hook | `applyWeeklyPostIncidentReviewCreationTick` slice 7 (SPE-2376 / PR #2620) |
+| Mirror UI base       | `getPostIncidentReviewMirrorView` (SPE-2372 / PR #2612)                |
+| Linked-review columns pattern | `RecurrentCatastropheMirrorPage` (SPE-2375 / PR #2618)           |
+| Compose projection   | `projectPostIncidentReviewSummary` (SPE-868 registry)                  |
+
+## Mirror UI contract
+
+| Rule | Detail |
+| --- | --- |
+| **Qualifying refs** | `review:case-*-closeout` and `review:near-catastrophe-*` with `orchestration_week:<week>` in `unknownFields` |
+| **Stub distinction** | Starting-state stub fixtures (`POST_INCIDENT_REVIEW_STUB_REGISTRY`) without orchestration token classify as stub, not qualifying |
+| **Recurrence orchestration** | `review:cycle-*-closeout` with orchestration token classifies separately; not grouped under qualifying incident section |
+| **Hydrated truth only** | Display persisted records as hydrated; do not re-sanitize dropped entries |
+| **Ordering** | Byte-stable `id` sort inherited for all record lists |
+| **Empty qualifying group** | No qualifying section when filter yields zero records |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Source classification + qualifying group in mirror view            | Weekly orchestration qualification rules      |
+| Summary stat cards + qualifying incident table section             | Domain schema expansion                       |
+| Source column on persisted records table                           | Domain link API changes                       |
+| View + component + integration tests                               | SPE-1310 lifecycle                            |
+| Slice doc (this file) + backlog handoff on ship                    | Full SPE-868 parent closure                   |
+| Copy strings in `POST_INCIDENT_REVIEW_MIRROR_UI_TEXT`              | Catastrophe mirror page changes               |
+
+## Acceptance
+
+- [ ] Empty map renders empty state without throw
+- [ ] Orchestration-created `review:case-*-closeout` appears in qualifying incident group with case closeout source label
+- [ ] Orchestration-created `review:near-catastrophe-*` appears in qualifying incident group with near-catastrophe source label
+- [ ] Stub fixtures classify as stub fixture, not qualifying orchestration
+- [ ] `advanceWeek` integration asserts mirror view after qualifying case resolution
+- [ ] Byte-stable mirror builds; slice 3/5/7 regressions green
+- [ ] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/postIncidentReviewMirrorView.ts`           |
+| UI     | `src/features/operations/PostIncidentReviewMirrorPage.tsx`        |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/postIncidentReviewMirrorView.test.ts`, `src/features/operations/PostIncidentReviewMirrorPage.test.tsx`, `src/test/advanceWeek.postIncidentReview.integration.test.ts` |
+| Plan   | `planning/post-incident-review-registry-slice-8.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 | Out of mirror UI boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Mirror surfacing slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-6.md`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -984,16 +984,26 @@ export const POST_INCIDENT_REVIEW_MIRROR_UI_TEXT: Record<string, string> = {
   totalRecordsLabel: 'Persisted records',
   externalAuditRouteLabel: 'External audit route',
   recurrenceObservedLabel: 'Recurrence observed',
+  qualifyingCaseCloseoutLabel: 'Qualifying case closeouts',
+  qualifyingNearCatastropheLabel: 'Near-catastrophe reviews',
+  orchestrationCreatedLabel: 'Orchestration-created',
+  stubFixtureLabel: 'Stub fixtures',
   weekLabel: 'Campaign week',
   readOnlyNote:
     'Review routes, closure outcomes, and milestone spans mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
   emptyTitle: 'No post-incident review records',
   emptyBody:
     'Persisted post-incident review records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  qualifyingRecordsHeading: 'Qualifying incident reviews',
+  qualifyingRecordsSubtitle:
+    'Orchestration-created case closeout and near-catastrophe threshold retrospectives from weekly advance.',
   recordsHeading: 'Persisted records',
   recordsSubtitle:
     'Milestone spans, adherence scores, and recurrence flags come from review summary projection.',
   labelColumn: 'Label',
+  sourceColumn: 'Source',
+  caseIdColumn: 'Linked case',
+  orchestrationWeekColumn: 'Orchestration week',
   routeColumn: 'Review route',
   closureColumn: 'Closure outcome',
   milestoneColumn: 'Milestone timings',

--- a/src/features/operations/PostIncidentReviewMirrorPage.test.tsx
+++ b/src/features/operations/PostIncidentReviewMirrorPage.test.tsx
@@ -8,6 +8,8 @@ import {
   EXTERNAL_AUDIT_CLEARED_REVIEW_FIXTURE,
   RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
 } from '../../domain/postIncidentReviewRegistry'
+import { buildQualifyingIncidentReviewRecordForDraft } from '../../domain/postIncidentReviewWeeklyOrchestration'
+import type { QualifyingIncidentReviewDraft } from '../../domain/postIncidentReviewWeeklyOrchestration'
 import { useGameStore } from '../../app/store/gameStore'
 import PostIncidentReviewMirrorPage from './PostIncidentReviewMirrorPage'
 
@@ -67,5 +69,35 @@ describe('PostIncidentReviewMirrorPage (SPE-868 slice 3)', () => {
       'href',
       '/'
     )
+  })
+
+  it('renders qualifying incident review section for orchestration-created records', () => {
+    const draft: QualifyingIncidentReviewDraft = {
+      reviewRef: 'review:case-case-major-closeout',
+      caseId: 'case-major',
+      caseTitle: 'District breach',
+      trigger: 'case_resolved',
+      stage: 4,
+      kind: 'standard',
+      anchorWeek: 12,
+    }
+    const created = buildQualifyingIncidentReviewRecordForDraft(draft, 12)
+    const game = createStartingState()
+    game.postIncidentReviewRecords = {
+      ...(created ? { [created.id]: created } : {}),
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const qualifyingRegion = screen.getByRole('region', {
+      name: /qualifying incident review records/i,
+    })
+
+    expect(qualifyingRegion).toBeInTheDocument()
+    expect(qualifyingRegion).toHaveTextContent('Qualifying case closeout')
+    expect(qualifyingRegion).toHaveTextContent('case-major')
+    expect(qualifyingRegion).toHaveTextContent('W12')
+    expect(qualifyingRegion).toHaveTextContent('Qualifying incident closeout review — District breach')
   })
 })

--- a/src/features/operations/PostIncidentReviewMirrorPage.tsx
+++ b/src/features/operations/PostIncidentReviewMirrorPage.tsx
@@ -40,18 +40,26 @@ export default function PostIncidentReviewMirrorPage() {
           </Link>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
           <StatCard
             label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.totalRecordsLabel}
             value={String(view.summary.totalRecords)}
           />
           <StatCard
-            label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.externalAuditRouteLabel}
-            value={String(view.summary.externalAuditRouteCount)}
+            label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.qualifyingCaseCloseoutLabel}
+            value={String(view.summary.qualifyingCaseCloseoutCount)}
           />
           <StatCard
-            label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.recurrenceObservedLabel}
-            value={String(view.summary.recurrenceObservedCount)}
+            label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.qualifyingNearCatastropheLabel}
+            value={String(view.summary.qualifyingNearCatastropheCount)}
+          />
+          <StatCard
+            label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.orchestrationCreatedLabel}
+            value={String(view.summary.orchestrationCreatedCount)}
+          />
+          <StatCard
+            label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.stubFixtureLabel}
+            value={String(view.summary.stubFixtureCount)}
           />
           <StatCard
             label={POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.weekLabel}
@@ -74,11 +82,87 @@ export default function PostIncidentReviewMirrorPage() {
           <p className="text-sm opacity-70">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.emptyBody}</p>
         </article>
       ) : (
-        <article
-          className="panel panel-support space-y-3"
-          role="region"
-          aria-label="Persisted post-incident review records"
-        >
+        <>
+          {view.hasQualifyingIncidentRecords ? (
+            <article
+              className="panel panel-support space-y-3"
+              role="region"
+              aria-label="Qualifying incident review records"
+            >
+              <div className="space-y-1">
+                <h3 className="text-lg font-semibold">
+                  {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.qualifyingRecordsHeading}
+                </h3>
+                <p className="text-sm opacity-60">
+                  {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.qualifyingRecordsSubtitle}
+                </p>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                      <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.labelColumn}</th>
+                      <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.sourceColumn}</th>
+                      <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.caseIdColumn}</th>
+                      <th className="px-2 py-2">
+                        {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.orchestrationWeekColumn}
+                      </th>
+                      <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.routeColumn}</th>
+                      <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.closureColumn}</th>
+                      <th className="px-2 py-2">
+                        {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.milestoneColumn}
+                      </th>
+                      <th className="px-2 py-2">
+                        {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.adherenceColumn}
+                      </th>
+                      <th className="px-2 py-2">
+                        {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.recurrenceColumn}
+                      </th>
+                      <th className="px-2 py-2">
+                        {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.confidenceColumn}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {view.qualifyingIncidentRecords.map((record) => (
+                      <tr key={record.id} className="border-b border-white/5 align-top">
+                        <td className="px-2 py-2">
+                          <p className="font-medium">{record.label}</p>
+                          <p className="text-xs opacity-55">{record.id}</p>
+                          <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                        </td>
+                        <td className="px-2 py-2">{record.sourceLabel}</td>
+                        <td className="px-2 py-2">{record.linkedCaseIdLabel}</td>
+                        <td className="px-2 py-2">{record.orchestrationWeekLabel}</td>
+                        <td className="px-2 py-2">{record.reviewRouteLabel}</td>
+                        <td className="px-2 py-2">{record.closureOutcomeLabel}</td>
+                        <td className="px-2 py-2">
+                          <p>
+                            {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.milestoneSpanPrefix}{' '}
+                            {record.milestoneSpanWeeksLabel}
+                          </p>
+                          <p className="text-xs opacity-55">
+                            {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.reportingPrefix}{' '}
+                            {record.reportingWeekLabel}
+                          </p>
+                        </td>
+                        <td className="px-2 py-2">{record.procedureAdherenceScoreLabel}</td>
+                        <td className="px-2 py-2">{record.recurrenceObservedLabel}</td>
+                        <td className="px-2 py-2">{record.confidenceLabel}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </article>
+          ) : null}
+
+          <article
+            className="panel panel-support space-y-3"
+            role="region"
+            aria-label="Persisted post-incident review records"
+          >
           <div className="space-y-1">
             <h3 className="text-lg font-semibold">
               {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.recordsHeading}
@@ -93,6 +177,7 @@ export default function PostIncidentReviewMirrorPage() {
               <thead>
                 <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
                   <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.labelColumn}</th>
+                  <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.sourceColumn}</th>
                   <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.routeColumn}</th>
                   <th className="px-2 py-2">{POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.closureColumn}</th>
                   <th className="px-2 py-2">
@@ -121,6 +206,12 @@ export default function PostIncidentReviewMirrorPage() {
                           {POST_INCIDENT_REVIEW_MIRROR_UI_TEXT.unknownFieldsPrefix}{' '}
                           {record.unknownFieldLabels.join('; ')}
                         </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <p>{record.sourceLabel}</p>
+                      {record.orchestrationWeekLabel !== '—' ? (
+                        <p className="text-xs opacity-55">{record.orchestrationWeekLabel}</p>
                       ) : null}
                     </td>
                     <td className="px-2 py-2">{record.reviewRouteLabel}</td>
@@ -167,6 +258,7 @@ export default function PostIncidentReviewMirrorPage() {
             </table>
           </div>
         </article>
+        </>
       )}
     </section>
   )

--- a/src/features/operations/postIncidentReviewMirrorView.test.ts
+++ b/src/features/operations/postIncidentReviewMirrorView.test.ts
@@ -5,6 +5,8 @@ import {
   RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
   sanitizePostIncidentReviewRecords,
 } from '../../domain/postIncidentReviewRegistry'
+import { buildQualifyingIncidentReviewRecordForDraft } from '../../domain/postIncidentReviewWeeklyOrchestration'
+import type { QualifyingIncidentReviewDraft } from '../../domain/postIncidentReviewWeeklyOrchestration'
 import {
   formatPostIncidentReviewEnumLabel,
   getPostIncidentReviewMirrorView,
@@ -18,7 +20,11 @@ describe('postIncidentReviewMirrorView (SPE-868 slice 3)', () => {
     const view = getPostIncidentReviewMirrorView(game)
 
     expect(view.isEmpty).toBe(true)
+    expect(view.hasQualifyingIncidentRecords).toBe(false)
     expect(view.summary.totalRecords).toBe(0)
+    expect(view.summary.qualifyingCaseCloseoutCount).toBe(0)
+    expect(view.summary.stubFixtureCount).toBe(0)
+    expect(view.qualifyingIncidentRecords).toEqual([])
     expect(view.records).toEqual([])
   })
 
@@ -42,7 +48,13 @@ describe('postIncidentReviewMirrorView (SPE-868 slice 3)', () => {
     expect(view.summary.totalRecords).toBe(2)
     expect(view.summary.externalAuditRouteCount).toBe(1)
     expect(view.summary.recurrenceObservedCount).toBe(1)
+    expect(view.summary.qualifyingCaseCloseoutCount).toBe(0)
+    expect(view.summary.stubFixtureCount).toBe(2)
     expect(view.summary.week).toBe(42)
+    expect(view.hasQualifyingIncidentRecords).toBe(false)
+    expect(closeout?.sourceGroup).toBe('stub_fixture')
+    expect(closeout?.sourceLabel).toBe('Stub fixture')
+    expect(audit?.sourceGroup).toBe('stub_fixture')
     expect(closeout?.reviewRouteLabel).toBe('Internal Command')
     expect(closeout?.closureOutcomeLabel).toBe('Contained')
     expect(closeout?.milestoneSpanWeeksLabel).toBe('4')
@@ -98,6 +110,74 @@ describe('postIncidentReviewMirrorView (SPE-868 slice 3)', () => {
     expect(formatPostIncidentReviewEnumLabel('administratively_cleared')).toBe(
       'Administratively Cleared'
     )
+  })
+
+  it('groups orchestration-created qualifying incident reviews separately from stub fixtures', () => {
+    const resolvedDraft: QualifyingIncidentReviewDraft = {
+      reviewRef: 'review:case-case-major-closeout',
+      caseId: 'case-major',
+      caseTitle: 'District breach',
+      trigger: 'case_resolved',
+      stage: 4,
+      kind: 'standard',
+      anchorWeek: 12,
+    }
+    const nearCatastropheDraft: QualifyingIncidentReviewDraft = {
+      reviewRef: 'review:near-catastrophe-case-raid',
+      caseId: 'case-raid',
+      caseTitle: 'Raid conversion',
+      trigger: 'near_catastrophe_threshold',
+      stage: 4,
+      kind: 'raid',
+      anchorWeek: 12,
+    }
+    const caseCloseout = buildQualifyingIncidentReviewRecordForDraft(resolvedDraft, 12)
+    const nearCatastrophe = buildQualifyingIncidentReviewRecordForDraft(nearCatastropheDraft, 12)
+
+    const game = createStartingState()
+    game.week = 12
+    game.postIncidentReviewRecords = {
+      [RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE.id]: RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
+      ...(caseCloseout ? { [caseCloseout.id]: caseCloseout } : {}),
+      ...(nearCatastrophe ? { [nearCatastrophe.id]: nearCatastrophe } : {}),
+    }
+
+    const view = getPostIncidentReviewMirrorView(game)
+    const qualifyingIds = view.qualifyingIncidentRecords.map((record) => record.id)
+
+    expect(view.hasQualifyingIncidentRecords).toBe(true)
+    expect(view.summary.qualifyingCaseCloseoutCount).toBe(1)
+    expect(view.summary.qualifyingNearCatastropheCount).toBe(1)
+    expect(view.summary.orchestrationCreatedCount).toBe(2)
+    expect(view.summary.stubFixtureCount).toBe(1)
+    expect(qualifyingIds).toEqual([
+      'review:case-case-major-closeout',
+      'review:near-catastrophe-case-raid',
+    ])
+    expect(view.qualifyingIncidentRecords[0]?.sourceLabel).toBe('Qualifying case closeout')
+    expect(view.qualifyingIncidentRecords[0]?.linkedCaseIdLabel).toBe('case-major')
+    expect(view.qualifyingIncidentRecords[0]?.orchestrationWeekLabel).toBe('W12')
+    expect(view.qualifyingIncidentRecords[1]?.sourceLabel).toBe('Near-catastrophe threshold')
+    expect(view.qualifyingIncidentRecords[1]?.linkedCaseIdLabel).toBe('case-raid')
+  })
+
+  it('does not classify qualifying ref patterns without orchestration week token', () => {
+    const game = createStartingState()
+    game.postIncidentReviewRecords = {
+      'review:case-manual-closeout': {
+        id: 'review:case-manual-closeout',
+        label: 'Manual case closeout review',
+        reviewRoute: 'internal_command',
+        closureOutcome: 'contained',
+      },
+    }
+
+    const view = getPostIncidentReviewMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.hasQualifyingIncidentRecords).toBe(false)
+    expect(record?.sourceGroup).toBe('other_persisted')
+    expect(record?.orchestrationWeekLabel).toBe('—')
   })
 
   it('is byte-stable for repeated mirror builds', () => {

--- a/src/features/operations/postIncidentReviewMirrorView.ts
+++ b/src/features/operations/postIncidentReviewMirrorView.ts
@@ -1,13 +1,30 @@
 import type { GameState } from '../../domain/models'
 import {
+  POST_INCIDENT_REVIEW_STUB_REGISTRY,
   projectPostIncidentReviewSummary,
   type PostIncidentReviewRecord,
 } from '../../domain/postIncidentReviewRegistry'
+
+const CASE_CLOSEOUT_REVIEW_REF_PATTERN = /^review:case-([a-zA-Z0-9_-]+)-closeout$/
+const NEAR_CATASTROPHE_REVIEW_REF_PATTERN = /^review:near-catastrophe-([a-zA-Z0-9_-]+)$/
+const CYCLE_CLOSEOUT_REVIEW_REF_PATTERN = /^review:cycle-(\d+)-closeout$/
+const ORCHESTRATION_WEEK_TOKEN_PREFIX = 'orchestration_week:'
+
+export type PostIncidentReviewMirrorRecordSourceGroup =
+  | 'qualifying_case_closeout'
+  | 'qualifying_near_catastrophe'
+  | 'recurrence_cycle_orchestration'
+  | 'stub_fixture'
+  | 'other_persisted'
 
 export interface PostIncidentReviewMirrorRecordView {
   id: string
   label: string
   summaryLabel: string
+  sourceGroup: PostIncidentReviewMirrorRecordSourceGroup
+  sourceLabel: string
+  linkedCaseIdLabel: string
+  orchestrationWeekLabel: string
   reviewRouteLabel: string
   closureOutcomeLabel: string
   milestoneSpanWeeksLabel: string
@@ -27,12 +44,18 @@ export interface PostIncidentReviewMirrorSummaryView {
   totalRecords: number
   externalAuditRouteCount: number
   recurrenceObservedCount: number
+  qualifyingCaseCloseoutCount: number
+  qualifyingNearCatastropheCount: number
+  orchestrationCreatedCount: number
+  stubFixtureCount: number
   week: number
 }
 
 export interface PostIncidentReviewMirrorView {
   isEmpty: boolean
+  hasQualifyingIncidentRecords: boolean
   summary: PostIncidentReviewMirrorSummaryView
+  qualifyingIncidentRecords: readonly PostIncidentReviewMirrorRecordView[]
   records: readonly PostIncidentReviewMirrorRecordView[]
 }
 
@@ -46,6 +69,80 @@ export function formatPostIncidentReviewEnumLabel(value: string): string {
 function listPersistedRecords(game: GameState): PostIncidentReviewRecord[] {
   const map = game.postIncidentReviewRecords ?? {}
   return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function extractOrchestrationWeek(record: PostIncidentReviewRecord): number | undefined {
+  for (const field of record.unknownFields ?? []) {
+    if (!field.startsWith(ORCHESTRATION_WEEK_TOKEN_PREFIX)) {
+      continue
+    }
+
+    const week = Number.parseInt(field.slice(ORCHESTRATION_WEEK_TOKEN_PREFIX.length), 10)
+    if (Number.isFinite(week) && week >= 1 && week === Math.trunc(week)) {
+      return week
+    }
+  }
+
+  return undefined
+}
+
+function isOrchestrationCreated(record: PostIncidentReviewRecord): boolean {
+  return extractOrchestrationWeek(record) !== undefined
+}
+
+function extractLinkedCaseId(recordId: string): string {
+  const caseCloseoutMatch = CASE_CLOSEOUT_REVIEW_REF_PATTERN.exec(recordId)
+  if (caseCloseoutMatch?.[1]) {
+    return caseCloseoutMatch[1]
+  }
+
+  const nearCatastropheMatch = NEAR_CATASTROPHE_REVIEW_REF_PATTERN.exec(recordId)
+  if (nearCatastropheMatch?.[1]) {
+    return nearCatastropheMatch[1]
+  }
+
+  return ''
+}
+
+function classifySourceGroup(record: PostIncidentReviewRecord): PostIncidentReviewMirrorRecordSourceGroup {
+  if (CASE_CLOSEOUT_REVIEW_REF_PATTERN.test(record.id)) {
+    return isOrchestrationCreated(record) ? 'qualifying_case_closeout' : 'other_persisted'
+  }
+
+  if (NEAR_CATASTROPHE_REVIEW_REF_PATTERN.test(record.id)) {
+    return isOrchestrationCreated(record) ? 'qualifying_near_catastrophe' : 'other_persisted'
+  }
+
+  if (CYCLE_CLOSEOUT_REVIEW_REF_PATTERN.test(record.id) && isOrchestrationCreated(record)) {
+    return 'recurrence_cycle_orchestration'
+  }
+
+  if (POST_INCIDENT_REVIEW_STUB_REGISTRY[record.id] && !isOrchestrationCreated(record)) {
+    return 'stub_fixture'
+  }
+
+  return 'other_persisted'
+}
+
+function sourceGroupLabel(group: PostIncidentReviewMirrorRecordSourceGroup): string {
+  switch (group) {
+    case 'qualifying_case_closeout':
+      return 'Qualifying case closeout'
+    case 'qualifying_near_catastrophe':
+      return 'Near-catastrophe threshold'
+    case 'recurrence_cycle_orchestration':
+      return 'Recurrence cycle closeout'
+    case 'stub_fixture':
+      return 'Stub fixture'
+    case 'other_persisted':
+      return 'Other persisted'
+  }
+}
+
+function isQualifyingIncidentSourceGroup(
+  group: PostIncidentReviewMirrorRecordSourceGroup
+): boolean {
+  return group === 'qualifying_case_closeout' || group === 'qualifying_near_catastrophe'
 }
 
 function formatConfidence(value: number | null | undefined): string {
@@ -103,6 +200,9 @@ function formatMilestoneWeek(
 function toRecordView(record: PostIncidentReviewRecord): PostIncidentReviewMirrorRecordView {
   const projection = projectPostIncidentReviewSummary(record)
   const milestoneTimingsRedacted = (record.redactedFields ?? []).includes('milestoneTimings')
+  const sourceGroup = classifySourceGroup(record)
+  const orchestrationWeek = extractOrchestrationWeek(record)
+  const linkedCaseId = extractLinkedCaseId(record.id)
 
   const summaryLabel = record.summary?.trim() ? record.summary : '—'
 
@@ -110,6 +210,10 @@ function toRecordView(record: PostIncidentReviewRecord): PostIncidentReviewMirro
     id: record.id,
     label: record.label,
     summaryLabel,
+    sourceGroup,
+    sourceLabel: sourceGroupLabel(sourceGroup),
+    linkedCaseIdLabel: linkedCaseId || '—',
+    orchestrationWeekLabel: orchestrationWeek === undefined ? '—' : `W${orchestrationWeek}`,
     reviewRouteLabel: formatPostIncidentReviewEnumLabel(projection.reviewRoute),
     closureOutcomeLabel: formatPostIncidentReviewEnumLabel(projection.closureOutcome),
     milestoneSpanWeeksLabel: formatMilestoneSpanWeeks(projection.milestoneSpanWeeks),
@@ -133,9 +237,14 @@ export function getPostIncidentReviewMirrorView(game: GameState): PostIncidentRe
 
   let externalAuditRouteCount = 0
   let recurrenceObservedCount = 0
+  let qualifyingCaseCloseoutCount = 0
+  let qualifyingNearCatastropheCount = 0
+  let orchestrationCreatedCount = 0
+  let stubFixtureCount = 0
 
   const recordViews = records.map((record) => {
     const projection = projectPostIncidentReviewSummary(record)
+    const recordView = toRecordView(record)
 
     if (projection.reviewRoute === 'external_audit') {
       externalAuditRouteCount += 1
@@ -145,17 +254,43 @@ export function getPostIncidentReviewMirrorView(game: GameState): PostIncidentRe
       recurrenceObservedCount += 1
     }
 
-    return toRecordView(record)
+    if (recordView.sourceGroup === 'qualifying_case_closeout') {
+      qualifyingCaseCloseoutCount += 1
+    }
+
+    if (recordView.sourceGroup === 'qualifying_near_catastrophe') {
+      qualifyingNearCatastropheCount += 1
+    }
+
+    if (isOrchestrationCreated(record)) {
+      orchestrationCreatedCount += 1
+    }
+
+    if (recordView.sourceGroup === 'stub_fixture') {
+      stubFixtureCount += 1
+    }
+
+    return recordView
   })
+
+  const qualifyingIncidentRecords = Object.freeze(
+    recordViews.filter((record) => isQualifyingIncidentSourceGroup(record.sourceGroup))
+  )
 
   return Object.freeze({
     isEmpty: records.length === 0,
+    hasQualifyingIncidentRecords: qualifyingIncidentRecords.length > 0,
     summary: Object.freeze({
       totalRecords: records.length,
       externalAuditRouteCount,
       recurrenceObservedCount,
+      qualifyingCaseCloseoutCount,
+      qualifyingNearCatastropheCount,
+      orchestrationCreatedCount,
+      stubFixtureCount,
       week,
     }),
+    qualifyingIncidentRecords,
     records: Object.freeze(recordViews),
   })
 }

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -12,6 +12,7 @@ import {
   applyWeeklyPostIncidentReviewCreationTick,
   resolveQualifyingIncidentReviewDraftsFromEventDrafts,
 } from '../domain/postIncidentReviewWeeklyOrchestration'
+import { getPostIncidentReviewMirrorView } from '../features/operations/postIncidentReviewMirrorView'
 import { applyWeeklyRecurrentCatastropheTick } from '../domain/recurrentCatastropheWeeklyOrchestration'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -169,6 +170,17 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
     )
     expect(created?.milestoneTimings?.reportingWeek).toBe(nextState.week)
     expect(created?.unknownFields).toEqual([`orchestration_week:${nextState.week}`])
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+
+    expect(mirrorView.hasQualifyingIncidentRecords).toBe(true)
+    expect(mirrorView.summary.qualifyingCaseCloseoutCount).toBe(1)
+    expect(mirrorView.qualifyingIncidentRecords[0]?.id).toBe('review:case-case-001-closeout')
+    expect(mirrorView.qualifyingIncidentRecords[0]?.sourceLabel).toBe('Qualifying case closeout')
+    expect(mirrorView.qualifyingIncidentRecords[0]?.linkedCaseIdLabel).toBe('case-001')
+    expect(mirrorView.qualifyingIncidentRecords[0]?.orchestrationWeekLabel).toBe(
+      `W${nextState.week}`
+    )
   })
 
   it('does not create a review when a non-qualifying case resolves', () => {


### PR DESCRIPTION
## Summary

- Extend `getPostIncidentReviewMirrorView` to classify orchestration-created qualifying incident reviews (`review:case-*-closeout`, `review:near-catastrophe-*`) separately from stub fixtures and other persisted records.
- Add qualifying incident summary stats, dedicated table section, and source column on `PostIncidentReviewMirrorPage`.
- Add view/component/integration tests asserting mirror surfacing after `advanceWeek` qualifying case resolution.

## Linear

- **Slice:** [SPE-2377](https://linear.app/spectranoir/issue/SPE-2377) — Post-incident review mirror qualifying incident surfacing (slice 8)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — stays open (mirror UI slice only)

## What shipped

- Source classification by review ref pattern + `orchestration_week` token in `unknownFields`
- `qualifyingIncidentRecords` group + summary counts on mirror view
- Qualifying incident table section + source column on persisted records table
- Copy strings in `POST_INCIDENT_REVIEW_MIRROR_UI_TEXT`
- Slice doc `planning/post-incident-review-registry-slice-8.md`

## Validation

- `npm run test:run -- src/features/operations/postIncidentReviewMirrorView.test.ts src/features/operations/PostIncidentReviewMirrorPage.test.tsx src/test/advanceWeek.postIncidentReview.integration.test.ts` (18 passed)
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-8.md` (new)
- `planning/backlog.md` (on merge)

## Parent remains open

SPE-868 full retrospective engine acceptance not satisfied by this mirror-only slice.

Made with [Cursor](https://cursor.com)