### PR TITLE
test(SPE-2378): near-catastrophe advanceWeek mirror integration (slice 9)

### DIFF
--- a/planning/post-incident-review-registry-slice-9.md
+++ b/planning/post-incident-review-registry-slice-9.md
@@ -1,0 +1,75 @@
+# SPE-868 — Near-catastrophe advanceWeek mirror integration (slice 9)
+
+One-page implementation plan. Linear: child [SPE-2378](https://linear.app/spectranoir/issue/SPE-2378) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 8 (`planning/post-incident-review-registry-slice-8.md`, PR #2622 / [SPE-2377](https://linear.app/spectranoir/issue/SPE-2377)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2378 — Near-catastrophe advanceWeek mirror integration (slice 9)](https://linear.app/spectranoir/issue/SPE-2378) |
+| **Status** | **In Progress** — pending PR merge                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-near-catastrophe-mirror-integration-slice-9`                                                      |
+| **Base `main` SHA** | `60d1f40f`                                                                                          |
+
+## Goal
+
+Extend `advanceWeek.postIncidentReview.integration.test.ts` to assert orchestration-created `review:near-catastrophe-*` records and mirror `qualifyingNearCatastropheCount` after qualifying escalation/raid conversion through the real weekly sim path.
+
+## Prerequisite (on `main` @ `60d1f40f`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Qualifying creation hook | `applyWeeklyPostIncidentReviewCreationTick` slice 7 (SPE-2376 / PR #2620) |
+| Mirror qualifying surfacing | `getPostIncidentReviewMirrorView` slice 8 (SPE-2377 / PR #2622)     |
+| Resolved-case integration | `advanceWeek.postIncidentReview.integration.test.ts` slice 7/8       |
+
+## Integration contract (this slice)
+
+| Rule | Detail |
+| --- | --- |
+| **Trigger path** | Open unassigned case with `deadlineRemaining: 1` crosses near-catastrophe band via deadline escalation (often raid conversion on starter templates) |
+| **Record ref** | `review:near-catastrophe-{caseId}` with `orchestration_week:<week>` |
+| **Mirror group** | `qualifying_near_catastrophe` source group; `qualifyingNearCatastropheCount` increments |
+| **Precedence** | Resolved closeout wins over near-catastrophe same week (slice 7 test asserts zero near-catastrophe when closeout exists) |
+| **Non-qualifying escalation** | Low stage-delta escalation must not materialize near-catastrophe review |
+| **Ordering** | Byte-stable `id` sort on qualifying incident mirror rows |
+| **Idempotency** | Re-advance same week does not duplicate near-catastrophe record |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| Near-catastrophe integration cases + mirror assertions           | Weekly orchestration qualification rules      |
+| Direct-tick parity test for escalation week                      | Domain schema expansion                       |
+| Slice 7 closeout test tightened (`qualifyingNearCatastropheCount === 0`) | Mirror UI changes unless test gaps found |
+| Slice doc (this file) + backlog handoff on ship                  | SPE-1310 lifecycle                            |
+|                                                                  | Full SPE-868 parent closure                   |
+|                                                                  | Catastrophe mirror page changes               |
+
+## Acceptance
+
+- [x] Deadline escalation crossing threshold materializes `review:near-catastrophe-*` via `advanceWeek`
+- [x] Mirror view reports `qualifyingNearCatastropheCount` and near-catastrophe source labels
+- [x] Non-qualifying escalation does not create review
+- [x] Re-advance idempotent; dual-case byte-stable ordering asserted
+- [x] Direct review tick parity for escalation week
+- [x] Slice 4/7/8 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Tests  | `src/test/advanceWeek.postIncidentReview.integration.test.ts`       |
+| Plan   | `planning/post-incident-review-registry-slice-9.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 | Out of integration-test boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Integration closure slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-8.md`

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
+import type { CaseInstance } from '../domain/models'
 import {
   RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
 } from '../domain/postIncidentReviewRegistry'
@@ -100,7 +101,12 @@ describe('advanceWeek post-incident review integration (SPE-868 slice 4)', () =>
     )
     const qualifyingDrafts = resolveQualifyingIncidentReviewDraftsFromEventDrafts(
       nextState.events
-        .filter((event) => event.week === state.week)
+        .filter(
+          (event) =>
+            'week' in event.payload &&
+            typeof event.payload.week === 'number' &&
+            event.payload.week === state.week
+        )
         .map((event) => ({
           type: event.type,
           sourceSystem: event.sourceSystem,
@@ -175,6 +181,7 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
 
     expect(mirrorView.hasQualifyingIncidentRecords).toBe(true)
     expect(mirrorView.summary.qualifyingCaseCloseoutCount).toBe(1)
+    expect(mirrorView.summary.qualifyingNearCatastropheCount).toBe(0)
     expect(mirrorView.qualifyingIncidentRecords[0]?.id).toBe('review:case-case-001-closeout')
     expect(mirrorView.qualifyingIncidentRecords[0]?.sourceLabel).toBe('Qualifying case closeout')
     expect(mirrorView.qualifyingIncidentRecords[0]?.linkedCaseIdLabel).toBe('case-001')
@@ -219,5 +226,195 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
 
     expect(created).toBeDefined()
     expect(twice.postIncidentReviewRecords?.['review:case-case-001-closeout']).toBe(created)
+  })
+})
+
+function suppressCaseSpawns(caseInstance: CaseInstance): CaseInstance {
+  return {
+    ...caseInstance,
+    onFail: {
+      ...caseInstance.onFail,
+      spawnCount: { min: 0, max: 0 },
+      spawnTemplateIds: [],
+    },
+    onUnresolved: {
+      ...caseInstance.onUnresolved,
+      spawnCount: { min: 0, max: 0 },
+      spawnTemplateIds: [],
+    },
+  }
+}
+
+function makeNearCatastropheDeadlineEscalationState() {
+  const state = createStartingState()
+  state.rngSeed = 313
+  state.rngState = 313
+  state.recurrentCatastropheRecords = {}
+  freezeCasesForQuietWeek(state)
+
+  state.cases['case-001'] = suppressCaseSpawns({
+    ...state.cases['case-001'],
+    status: 'open',
+    assignedTeamIds: [],
+    stage: 1,
+    deadlineRemaining: 1,
+  })
+
+  return state
+}
+
+function makeNonQualifyingDeadlineEscalationState() {
+  const state = createStartingState()
+  state.recurrentCatastropheRecords = {}
+  freezeCasesForQuietWeek(state)
+
+  state.cases['case-001'] = suppressCaseSpawns({
+    ...state.cases['case-001'],
+    status: 'open',
+    assignedTeamIds: [],
+    stage: 1,
+    deadlineRemaining: 1,
+    onUnresolved: {
+      ...state.cases['case-001'].onUnresolved,
+      stageDelta: 1,
+      deadlineResetWeeks: 4,
+      spawnCount: { min: 0, max: 0 },
+      spawnTemplateIds: [],
+    },
+  })
+
+  return state
+}
+
+function makeDualNearCatastropheDeadlineEscalationState() {
+  const state = createStartingState()
+  state.rngSeed = 314
+  state.rngState = 314
+  state.recurrentCatastropheRecords = {}
+  freezeCasesForQuietWeek(state)
+
+  for (const caseId of ['case-001', 'case-002'] as const) {
+    state.cases[caseId] = suppressCaseSpawns({
+      ...state.cases[caseId],
+      status: 'open',
+      assignedTeamIds: [],
+      stage: 1,
+      deadlineRemaining: 1,
+    })
+  }
+
+  return state
+}
+
+describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', () => {
+  it('creates a near-catastrophe review when deadline escalation crosses the threshold', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+    const created = nextState.postIncidentReviewRecords?.['review:near-catastrophe-case-001']
+
+    expect(nextState.cases['case-001'].kind).toBe('raid')
+    expect(nextState.cases['case-001'].stage).toBeGreaterThanOrEqual(3)
+    expect(
+      nextState.events.some(
+        (event) => event.type === 'case.escalated' && event.payload.caseId === 'case-001'
+      )
+    ).toBe(true)
+    expect(
+      nextState.events.some(
+        (event) => event.type === 'case.raid_converted' && event.payload.caseId === 'case-001'
+      )
+    ).toBe(true)
+    expect(created?.label).toBe(
+      'Near-catastrophe threshold review — ' + state.cases['case-001'].title
+    )
+    expect(created?.reviewRoute).toBe('external_audit')
+    expect(created?.closureOutcome).toBe('administratively_cleared')
+    expect(created?.milestoneTimings?.reportingWeek).toBe(nextState.week)
+    expect(created?.unknownFields).toEqual([`orchestration_week:${nextState.week}`])
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+
+    expect(mirrorView.hasQualifyingIncidentRecords).toBe(true)
+    expect(mirrorView.summary.qualifyingNearCatastropheCount).toBe(1)
+    expect(mirrorView.summary.qualifyingCaseCloseoutCount).toBe(0)
+    expect(mirrorView.qualifyingIncidentRecords[0]?.id).toBe('review:near-catastrophe-case-001')
+    expect(mirrorView.qualifyingIncidentRecords[0]?.sourceLabel).toBe('Near-catastrophe threshold')
+    expect(mirrorView.qualifyingIncidentRecords[0]?.linkedCaseIdLabel).toBe('case-001')
+    expect(mirrorView.qualifyingIncidentRecords[0]?.orchestrationWeekLabel).toBe(
+      `W${nextState.week}`
+    )
+  })
+
+  it('does not create a near-catastrophe review when escalation stays below the threshold', () => {
+    const state = makeNonQualifyingDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.cases['case-001'].stage).toBe(2)
+    expect(nextState.postIncidentReviewRecords?.['review:near-catastrophe-case-001']).toBeUndefined()
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+
+    expect(mirrorView.summary.qualifyingNearCatastropheCount).toBe(0)
+    expect(mirrorView.summary.qualifyingCaseCloseoutCount).toBe(0)
+  })
+
+  it('does not duplicate near-catastrophe reviews on re-advance', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const once = advanceWeek(state)
+    const twice = advanceWeek(once)
+    const created = once.postIncidentReviewRecords?.['review:near-catastrophe-case-001']
+
+    expect(created).toBeDefined()
+    expect(twice.postIncidentReviewRecords?.['review:near-catastrophe-case-001']).toBe(created)
+  })
+
+  it('orders qualifying near-catastrophe mirror rows by stable record id', () => {
+    const state = makeDualNearCatastropheDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const qualifyingIds = mirrorView.qualifyingIncidentRecords.map((record) => record.id)
+
+    expect(qualifyingIds).toEqual([
+      'review:near-catastrophe-case-001',
+      'review:near-catastrophe-case-002',
+    ])
+    expect(qualifyingIds).toEqual([...qualifyingIds].sort((left, right) => left.localeCompare(right)))
+    expect(mirrorView.summary.qualifyingNearCatastropheCount).toBe(2)
+  })
+
+  it('matches direct review creation for near-catastrophe escalation week', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+    const qualifyingDrafts = resolveQualifyingIncidentReviewDraftsFromEventDrafts(
+      nextState.events
+        .filter(
+          (event) =>
+            'week' in event.payload &&
+            typeof event.payload.week === 'number' &&
+            event.payload.week === state.week
+        )
+        .map((event) => ({
+          type: event.type,
+          sourceSystem: event.sourceSystem,
+          payload: event.payload,
+        })),
+      state.cases,
+      nextState.week
+    )
+    const directReviewTick = applyWeeklyPostIncidentReviewCreationTick(
+      state.postIncidentReviewRecords,
+      state.recurrentCatastropheRecords,
+      nextState.week,
+      qualifyingDrafts
+    )
+
+    expect(nextState.postIncidentReviewRecords?.['review:near-catastrophe-case-001']).toEqual(
+      directReviewTick['review:near-catastrophe-case-001']
+    )
   })
 })


### PR DESCRIPTION
## Linear

- **Slice:** [SPE-2378](https://linear.app/spectranoir/issue/SPE-2378) — Near-catastrophe advanceWeek mirror integration (slice 9)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — stays open

## Summary

- Extend `advanceWeek.postIncidentReview.integration.test.ts` with near-catastrophe escalation/raid-conversion cases asserting `review:near-catastrophe-*` creation and mirror `qualifyingNearCatastropheCount`
- Tighten slice 7 closeout test to assert zero near-catastrophe when resolved closeout wins
- Fix event-week filter in direct-tick parity helper to read `payload.week`
- Add `planning/post-incident-review-registry-slice-9.md`

## Validation

- `npm run test:run -- src/test/advanceWeek.postIncidentReview.integration.test.ts`
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-9.md`

## Parent status

SPE-868 remains open (integration-test slice only).
