### PR TITLE
feat(SPE-2381): dedicated post-incident follow-on report note type (slice 12)

### DIFF
--- a/planning/post-incident-review-registry-slice-12.md
+++ b/planning/post-incident-review-registry-slice-12.md
@@ -1,0 +1,65 @@
+# SPE-868 — Dedicated post-incident follow-on report note type (slice 12)
+
+One-page implementation plan. Linear: child [SPE-2381](https://linear.app/spectranoir/issue/SPE-2381) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 11 (`planning/post-incident-review-registry-slice-11.md`, PR #2628 / [SPE-2380](https://linear.app/spectranoir/issue/SPE-2380)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2381 — Dedicated post-incident follow-on report note type (slice 12)](https://linear.app/spectranoir/issue/SPE-2381) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-review-follow-on-report-note-type-slice-12`                                                       |
+| **Base `main` SHA** | `f8fab0bd`                                                                                          |
+
+## Goal
+
+Add dedicated `post_incident_review.follow_on` report note type with UI categorization bucket; switch weekly follow-on note builder from `system.week_delta`. Mirrors [SPE-2299](https://linear.app/spectranoir/issue/SPE-2299) / information-intake slice 8.
+
+## Prerequisite (on `main` @ `f8fab0bd`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Follow-on report notes | `src/domain/postIncidentReviewFollowOnWeeklyReportNotes.ts` (SPE-2380 slice 11) |
+| Follow-on artifact hook | `applyWeeklyPostIncidentReviewFollowOnArtifactTick` slice 10 (SPE-2379) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| `ReportNoteType` union + audit registry                          | `PostIncidentReviewRecord` schema changes     |
+| `runTransfer` hydration allowlist + metadata keys                | Follow-on qualification rules (slice 7)       |
+| `reportNoteView` `post_incident_review` category bucket          | Mirror UI changes                             |
+| Switch follow-on note builder from `system.week_delta`           | Orchestration tick order changes              |
+| Unit + audit/view/integration note type expectations             | Actual training queue enqueue                 |
+| Slice doc (this file) + backlog handoff on ship                  | SPE-1310 lifecycle                            |
+|                                                                  | Full SPE-868 parent closure                   |
+
+## Acceptance
+
+- [ ] Follow-on notes use `post_incident_review.follow_on` with bounded metadata
+- [ ] Audit registry, `REPORT_NOTE_TYPES`, and `reportNoteView` stay aligned (40 types)
+- [ ] `npm run test:run -- src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts src/test/postIncidentReviewFollowOnWeeklyReportNotes.test.ts src/test/advanceWeek.postIncidentReview.integration.test.ts` and `npm run lint` pass
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/models.ts`, `src/domain/postIncidentReviewFollowOnWeeklyReportNotes.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| UI     | `src/features/report/reportNoteView.ts`                               |
+| Tests  | `src/test/reportNoteTypeAudit.test.ts`, `src/features/report/reportNoteView.test.ts`, `src/test/postIncidentReviewFollowOnWeeklyReportNotes.test.ts`, `src/test/advanceWeek.postIncidentReview.integration.test.ts` |
+| Plan   | `planning/post-incident-review-registry-slice-12.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Actual training queue enqueue from follow-on refs | SPE-868 follow-up | Reference stub only slice 10 |
+| Recommendation record registry persistence | SPE-868 follow-up | Bounded token in review `unknownFields` only |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 | Out of report-note boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Follow-on type slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-11.md`
+- `planning/information-intake-weekly-hook-slice-8.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -340,6 +340,7 @@ export const REPORT_NOTE_TYPES = [
   'hub.rumor',
   'system.equipment_recovered',
   'information_intake.verification',
+  'post_incident_review.follow_on',
 ] as const satisfies readonly ReportNoteType[]
 
 const REPORT_NOTE_METADATA_MAX_KEYS = 32
@@ -602,6 +603,13 @@ const REPORT_NOTE_METADATA_ALLOWLIST: Partial<Record<ReportNoteType, readonly st
     'reportLabel',
     'eventKind',
     'verificationStatus',
+    'week',
+  ],
+  'post_incident_review.follow_on': [
+    'reviewRef',
+    'reviewLabel',
+    'followOnKind',
+    'followOnToken',
     'week',
   ],
 }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1509,6 +1509,7 @@ export type ReportNoteType =
   | 'hub.rumor'
   | 'system.equipment_recovered'
   | 'information_intake.verification'
+  | 'post_incident_review.follow_on'
 
 export type ReportNoteMetadataValue =
   | string

--- a/src/domain/postIncidentReviewFollowOnWeeklyReportNotes.ts
+++ b/src/domain/postIncidentReviewFollowOnWeeklyReportNotes.ts
@@ -109,7 +109,7 @@ export function buildWeeklyPostIncidentReviewFollowOnReportNotes(input: {
         input.week,
         sequence,
         input.baseTimestamp,
-        'system.week_delta',
+        'post_incident_review.follow_on',
         {
           reviewRef,
           reviewLabel: record.label,

--- a/src/features/report/reportNoteView.test.ts
+++ b/src/features/report/reportNoteView.test.ts
@@ -57,6 +57,7 @@ const EXPECTED_CATEGORY_BY_TYPE = {
   'hub.opportunity': 'system',
   'hub.rumor': 'system',
   'information_intake.verification': 'information_intake',
+  'post_incident_review.follow_on': 'post_incident_review',
 } satisfies Record<ReportNoteType, ReportNoteCategory>
 
 describe('reportNoteView', () => {
@@ -108,6 +109,7 @@ describe('reportNoteView', () => {
   it('exposes stable category labels', () => {
     expect(REPORT_NOTE_CATEGORY_LABELS.incident_response).toBe('Incident response')
     expect(REPORT_NOTE_CATEGORY_LABELS.information_intake).toBe('Information intake')
+    expect(REPORT_NOTE_CATEGORY_LABELS.post_incident_review).toBe('Post-incident review')
     expect(REPORT_NOTE_CATEGORY_LABELS.system).toBe('System')
   })
 })

--- a/src/features/report/reportNoteView.ts
+++ b/src/features/report/reportNoteView.ts
@@ -4,6 +4,7 @@ export type ReportNoteCategory =
   | 'incident_response'
   | 'recruitment'
   | 'information_intake'
+  | 'post_incident_review'
   | 'system'
   | 'uncategorized'
 
@@ -11,11 +12,14 @@ export const REPORT_NOTE_CATEGORY_LABELS: Record<ReportNoteCategory, string> = {
   incident_response: 'Incident response',
   recruitment: 'Recruitment',
   information_intake: 'Information intake',
+  post_incident_review: 'Post-incident review',
   system: 'System',
   uncategorized: 'Uncategorized',
 }
 
 const INFORMATION_INTAKE_NOTE_TYPES: ReportNoteType[] = ['information_intake.verification']
+
+const POST_INCIDENT_REVIEW_NOTE_TYPES: ReportNoteType[] = ['post_incident_review.follow_on']
 
 const INCIDENT_NOTE_TYPES: ReportNoteType[] = [
   'case.resolved',
@@ -71,6 +75,10 @@ export function getReportNoteCategory(note: ReportNote): ReportNoteCategory {
 
   if (note.type !== undefined && INFORMATION_INTAKE_NOTE_TYPES.includes(note.type)) {
     return 'information_intake'
+  }
+
+  if (note.type !== undefined && POST_INCIDENT_REVIEW_NOTE_TYPES.includes(note.type)) {
+    return 'post_incident_review'
   }
 
   if (note.type !== undefined && SYSTEM_NOTE_TYPES.includes(note.type)) {

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -86,6 +86,7 @@ describe('advanceWeek post-incident review integration (SPE-868 slice 4)', () =>
     const followOnNotes =
       weeklyReport?.notes.filter((note) => note.content.startsWith('Post-incident follow-on —')) ?? []
     expect(followOnNotes).toHaveLength(1)
+    expect(followOnNotes[0]?.type).toBe('post_incident_review.follow_on')
     expect(followOnNotes[0]?.content).toContain('training reference (threat assessment)')
     expect(nextState.postIncidentReviewRecords?.[RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE.id]).toEqual(
       RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE
@@ -196,6 +197,7 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
     const followOnNotes =
       weeklyReport?.notes.filter((note) => note.content.startsWith('Post-incident follow-on —')) ?? []
     expect(followOnNotes).toHaveLength(1)
+    expect(followOnNotes[0]?.type).toBe('post_incident_review.follow_on')
     expect(followOnNotes[0]?.content).toContain(created?.label ?? '')
     expect(followOnNotes[0]?.content).toContain('training reference (threat assessment)')
 
@@ -371,6 +373,7 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
     const followOnNotes =
       weeklyReport?.notes.filter((note) => note.content.startsWith('Post-incident follow-on —')) ?? []
     expect(followOnNotes).toHaveLength(1)
+    expect(followOnNotes[0]?.type).toBe('post_incident_review.follow_on')
     expect(followOnNotes[0]?.content).toContain('recommendation stub (near catastrophe case 001)')
 
     const mirrorView = getPostIncidentReviewMirrorView(nextState)

--- a/src/test/postIncidentReviewFollowOnWeeklyReportNotes.test.ts
+++ b/src/test/postIncidentReviewFollowOnWeeklyReportNotes.test.ts
@@ -61,7 +61,7 @@ describe('postIncidentReviewFollowOnWeeklyReportNotes (SPE-868 slice 11)', () =>
     })
 
     expect(notes).toHaveLength(1)
-    expect(notes[0]?.type).toBe('system.week_delta')
+    expect(notes[0]?.type).toBe('post_incident_review.follow_on')
     expect(notes[0]?.content).toBe(
       'Post-incident follow-on — Qualifying incident closeout review — District breach: training reference (threat assessment).'
     )

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -53,6 +53,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
     producer: 'informationIntakeWeeklyReportNotes',
     category: 'information_intake',
   },
+  'post_incident_review.follow_on': {
+    status: 'active',
+    producer: 'postIncidentReviewFollowOnWeeklyReportNotes',
+    category: 'post_incident_review',
+  },
 } as const satisfies Record<
   ReportNoteType,
   { status: 'active' | 'future-reserved' | 'stale'; producer: string; category: string }
@@ -64,7 +69,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(39)
+    expect(entries).toHaveLength(40)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Add `post_incident_review.follow_on` to `ReportNoteType` union (40 types total)
- Switch `buildWeeklyPostIncidentReviewFollowOnReportNotes` from `system.week_delta` to the dedicated type
- Wire audit registry, `runTransfer` hydration allowlist + metadata keys, and new `post_incident_review` UI category bucket in `reportNoteView`

## Linear

- **Slice:** [SPE-2381](https://linear.app/spectranoir/issue/SPE-2381) — Dedicated post-incident follow-on report note type (slice 12)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — stays open

## What shipped

Dedicated report note type + UI categorization for weekly post-incident follow-on notes (mirrors SPE-2299 / intake slice 8). No orchestration, schema, or training-queue changes.

## Validation

- `npm run test:run -- src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts src/test/postIncidentReviewFollowOnWeeklyReportNotes.test.ts src/test/advanceWeek.postIncidentReview.integration.test.ts`
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-12.md` (new)

## Parent status

SPE-868 remains open — slice 12 satisfies dedicated type/UI bucket only.