### PR TITLE
feat(SPE-2383): post-incident recommendation record registry persistence (slice 14)

### DIFF
--- a/planning/post-incident-review-registry-slice-14.md
+++ b/planning/post-incident-review-registry-slice-14.md
@@ -1,0 +1,76 @@
+# SPE-868 — Post-incident recommendation record registry persistence (slice 14)
+
+One-page implementation plan. Linear: child [SPE-2383](https://linear.app/spectranoir/issue/SPE-2383) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 13 (`planning/post-incident-review-registry-slice-13.md`, PR #2632 / [SPE-2382](https://linear.app/spectranoir/issue/SPE-2382)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2383 — Post-incident recommendation record registry persistence (slice 14)](https://linear.app/spectranoir/issue/SPE-2383) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (do not re-close) |
+| **Branch** | `spe-868-review-follow-on-recommendation-registry-slice-14`                                                |
+| **Base `main` SHA** | `1d6066fd`                                                                                          |
+
+## Goal
+
+When orchestration-created reviews materialize with `follow_on:recommendation-stub:` tokens, persist one bounded recommendation record per review ref into `postIncidentReviewRecommendationRecords` on `GameState` — domain-only; mirrors slice 10 artifact hook + slice 13 materialization/idempotency pattern.
+
+## Prerequisite (on `main` @ `1d6066fd`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Follow-on artifact hook | `applyWeeklyPostIncidentReviewFollowOnArtifactTick` slice 10 (SPE-2379) |
+| Training enqueue     | `applyWeeklyPostIncidentReviewFollowOnTrainingEnqueueTick` slice 13 (SPE-2382) |
+| Review persistence   | `postIncidentReviewRecords` slice 2 (SPE-2371)                         |
+
+## Recommendation registry contract (this slice)
+
+| Rule | Detail |
+| --- | --- |
+| **Trigger** | Review ref absent from prior map, present after follow-on tick with recommendation-stub token |
+| **Record id** | `recommendation:<stub-suffix>` derived from token |
+| **Training exclusion** | `follow_on:training-ref:` tokens skip registry append |
+| **Stub exclusion** | Starting-state stub registry entries without orchestration token are untouched |
+| **Idempotency** | Re-advance is a no-op when review ref already in prior map or recommendation id already persisted |
+| **Dual path** | Closeout (training-ref) + near-catastrophe (recommendation-stub) same tick → only stub path appends |
+| **Forbidden tokens** | Franchise/source-literal and branded object numbers in id, label, or stub suffix drop the record |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| `postIncidentReviewRecommendationRecords` on `GameState`         | Training enqueue path changes                 |
+| `applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick` | Follow-on qualification rules (slice 7)      |
+| `sanitizePostIncidentReviewRecommendationRecords` + `runTransfer` | Mirror UI changes                             |
+| Wire in `advanceWeek` after follow-on artifact tick              | New report note types                         |
+| Domain unit + integration tests                                  | SPE-1310 lifecycle                            |
+| Slice doc (this file) + backlog handoff on ship                  | SPE-868 parent closure                        |
+
+## Acceptance
+
+- [ ] Near-catastrophe review → one `recommendation:<suffix>` registry entry
+- [ ] Re-advance idempotent; stub registry unchanged; training-ref path skips recommendation append
+- [ ] `advanceWeek` near-catastrophe + recurrence closeout integration expectations
+- [ ] Slice 10/11/12/13 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/postIncidentReviewRecommendationRegistry.ts`, `src/domain/postIncidentReviewFollowOnRecommendationRegistry.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Tests  | `src/test/postIncidentReviewFollowOnRecommendationRegistry.test.ts`, `src/test/advanceWeek.postIncidentReview.integration.test.ts` |
+| Plan   | `planning/post-incident-review-registry-slice-14.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Recommendation registry planning mirror UI | SPE-868 follow-up | Persistence + advance hook only this slice |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 | Out of recommendation-registry boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Recommendation persistence slice only |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-13.md`
+- `planning/post-incident-review-registry-slice-10.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -196,6 +196,7 @@ import { sanitizeExtranormalEventRecords } from '../../domain/extranormalEventRe
 import { sanitizeNamingHazardDescriptorRecords } from '../../domain/namingHazardDescriptorRegistry'
 import { sanitizeRecurrentCatastropheRecords } from '../../domain/recurrentCatastropheAmeliorationRegistry'
 import { sanitizePostIncidentReviewRecords } from '../../domain/postIncidentReviewRegistry'
+import { sanitizePostIncidentReviewRecommendationRecords } from '../../domain/postIncidentReviewRecommendationRegistry'
 import { sanitizeRuleDocumentComplianceRecords } from '../../domain/ruleDocumentComplianceContainmentRegistry'
 import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLocationRegistry'
 import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
@@ -8437,6 +8438,10 @@ export function hydrateGame(
     game.postIncidentReviewRecords,
     fallback.postIncidentReviewRecords ?? {}
   )
+  const postIncidentReviewRecommendationRecords = sanitizePostIncidentReviewRecommendationRecords(
+    game.postIncidentReviewRecommendationRecords,
+    fallback.postIncidentReviewRecommendationRecords ?? {}
+  )
   const ruleDocumentComplianceRecords = sanitizeRuleDocumentComplianceRecords(
     game.ruleDocumentComplianceRecords,
     fallback.ruleDocumentComplianceRecords ?? {}
@@ -8609,6 +8614,7 @@ export function hydrateGame(
       namingHazardDescriptorRecords,
       recurrentCatastropheRecords,
       postIncidentReviewRecords,
+      postIncidentReviewRecommendationRecords,
       ruleDocumentComplianceRecords,
       selfCensoringInformationRecords,
       publicDisclosureRecords,

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -250,6 +250,7 @@ import type { MinorAnomalyRecord } from './minorAnomalyItemRegistry'
 import type { NamingHazardDescriptorRecord } from './namingHazardDescriptorRegistry'
 import type { RecurrentCatastropheRecord } from './recurrentCatastropheAmeliorationRegistry'
 import type { PostIncidentReviewRecord } from './postIncidentReviewRegistry'
+import type { PostIncidentReviewRecommendationRecord } from './postIncidentReviewRecommendationRegistry'
 import type { RuleDocumentComplianceRecord } from './ruleDocumentComplianceContainmentRegistry'
 import type { SelfCensoringInformationRecord } from './selfCensoringInformationRegistry'
 import type { PublicDisclosureRecord } from './publicDisclosureStateRegistry'
@@ -2597,6 +2598,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   postIncidentReviewRecords?: Record<string, PostIncidentReviewRecord>
+
+  /**
+   * SPE-868 slice 14: persisted follow-on recommendation-stub records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  postIncidentReviewRecommendationRecords?: Record<string, PostIncidentReviewRecommendationRecord>
 
   /**
    * SPE-2123 slice 2: persisted rule-document compliance records (keyed by record id).

--- a/src/domain/postIncidentReviewFollowOnRecommendationRegistry.ts
+++ b/src/domain/postIncidentReviewFollowOnRecommendationRegistry.ts
@@ -1,0 +1,172 @@
+/**
+ * SPE-868 slice 14: persist recommendation-stub follow-on tokens into GameState registry.
+ *
+ * When orchestration-created reviews materialize with recommendation-stub tokens, append one
+ * bounded recommendation record per review ref. Training-ref tokens are ignored.
+ */
+
+import {
+  FOLLOW_ON_RECOMMENDATION_STUB_PREFIX,
+  isOrchestrationCreatedPostIncidentReviewRecord,
+} from './postIncidentReviewFollowOnArtifact'
+import { extractFollowOnArtifactTokenFromUnknownFields } from './postIncidentReviewFollowOnWeeklyReportNotes'
+import type { PostIncidentReviewRecord, PostIncidentReviewRecordsMap } from './postIncidentReviewRegistry'
+import {
+  validatePostIncidentReviewRecommendationRecord,
+  type PostIncidentReviewRecommendationRecord,
+  type PostIncidentReviewRecommendationRecordsMap,
+} from './postIncidentReviewRecommendationRegistry'
+
+const ORCHESTRATION_WEEK_TOKEN_PREFIX = 'orchestration_week:'
+const RECOMMENDATION_ID_PREFIX = 'recommendation:'
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function freezeRecord(
+  record: PostIncidentReviewRecommendationRecord
+): PostIncidentReviewRecommendationRecord {
+  return Object.freeze({ ...record })
+}
+
+function parseOrchestrationWeek(unknownFields: readonly string[] | undefined): number | undefined {
+  const token = asStringArray(unknownFields).find((field) =>
+    field.startsWith(ORCHESTRATION_WEEK_TOKEN_PREFIX)
+  )
+  if (!token) {
+    return undefined
+  }
+
+  const week = Number.parseInt(token.slice(ORCHESTRATION_WEEK_TOKEN_PREFIX.length), 10)
+  return Number.isFinite(week) && week >= 0 && week === Math.trunc(week) ? week : undefined
+}
+
+/** Returns a bounded stub suffix from a follow-on recommendation-stub token, or undefined. */
+export function parseFollowOnRecommendationStubToken(token: string): string | undefined {
+  if (!token.startsWith(FOLLOW_ON_RECOMMENDATION_STUB_PREFIX)) {
+    return undefined
+  }
+
+  const stubSuffix = token.slice(FOLLOW_ON_RECOMMENDATION_STUB_PREFIX.length).trim()
+  return stubSuffix.length > 0 ? stubSuffix : undefined
+}
+
+function buildRecommendationId(stubSuffix: string): string {
+  return `${RECOMMENDATION_ID_PREFIX}${stubSuffix}`
+}
+
+/**
+ * Builds one recommendation registry record from an orchestration-created review carrying a stub token.
+ * Returns undefined when the record is ineligible or the token fails validation.
+ */
+export function buildRecommendationRecordFromReview(
+  record: PostIncidentReviewRecord,
+  followOnToken: string
+): PostIncidentReviewRecommendationRecord | undefined {
+  if (!isOrchestrationCreatedPostIncidentReviewRecord(record)) {
+    return undefined
+  }
+
+  const stubSuffix = parseFollowOnRecommendationStubToken(followOnToken)
+  if (!stubSuffix) {
+    return undefined
+  }
+
+  const reviewRef = normalizeToken(record.id)
+  if (!reviewRef) {
+    return undefined
+  }
+
+  const orchestrationWeek = parseOrchestrationWeek(record.unknownFields)
+  const candidate: PostIncidentReviewRecommendationRecord = {
+    id: buildRecommendationId(stubSuffix),
+    label: `Follow-on recommendation — ${normalizeToken(record.label) || reviewRef}`,
+    reviewRef,
+    stubSuffix,
+    followOnToken,
+    ...(orchestrationWeek !== undefined ? { orchestrationWeek } : {}),
+  }
+
+  if (!validatePostIncidentReviewRecommendationRecord(candidate).valid) {
+    return undefined
+  }
+
+  return freezeRecord(candidate)
+}
+
+function collectMaterializedFollowOnRecommendationStubReviewRefs(input: {
+  priorReviews: PostIncidentReviewRecordsMap
+  nextReviews: PostIncidentReviewRecordsMap
+}): readonly string[] {
+  return Object.keys(input.nextReviews)
+    .filter((reviewRef) => {
+      const nextRecord = input.nextReviews[reviewRef]
+      if (!nextRecord || input.priorReviews[reviewRef]) {
+        return false
+      }
+
+      if (!isOrchestrationCreatedPostIncidentReviewRecord(nextRecord)) {
+        return false
+      }
+
+      const token = extractFollowOnArtifactTokenFromUnknownFields(nextRecord.unknownFields)
+      return token !== undefined && parseFollowOnRecommendationStubToken(token) !== undefined
+    })
+    .sort((left, right) => left.localeCompare(right))
+}
+
+/**
+ * Appends recommendation registry records for stub artifacts on reviews materialized this tick.
+ * Re-applying for the same week is idempotent; training-ref tokens and stub registry reviews are skipped.
+ */
+export function applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick(
+  priorRecommendations: PostIncidentReviewRecommendationRecordsMap | null | undefined,
+  priorReviews: PostIncidentReviewRecordsMap | null | undefined,
+  nextReviews: PostIncidentReviewRecordsMap | null | undefined
+): PostIncidentReviewRecommendationRecordsMap {
+  const prior = priorRecommendations ?? {}
+  const priorReviewMap = priorReviews ?? {}
+  const next = nextReviews ?? {}
+  const materializedRefs = collectMaterializedFollowOnRecommendationStubReviewRefs({
+    priorReviews: priorReviewMap,
+    nextReviews: next,
+  })
+
+  if (materializedRefs.length === 0) {
+    return prior
+  }
+
+  const nextRecommendations: PostIncidentReviewRecommendationRecordsMap = { ...prior }
+  let changed = false
+
+  for (const reviewRef of materializedRefs) {
+    const record = next[reviewRef]
+    if (!record) {
+      continue
+    }
+
+    const token = extractFollowOnArtifactTokenFromUnknownFields(record.unknownFields)
+    if (!token) {
+      continue
+    }
+
+    const recommendation = buildRecommendationRecordFromReview(record, token)
+    if (!recommendation || nextRecommendations[recommendation.id]) {
+      continue
+    }
+
+    nextRecommendations[recommendation.id] = recommendation
+    changed = true
+  }
+
+  return changed ? nextRecommendations : prior
+}

--- a/src/domain/postIncidentReviewRecommendationRegistry.ts
+++ b/src/domain/postIncidentReviewRecommendationRegistry.ts
@@ -1,0 +1,337 @@
+/**
+ * SPE-868 slice 14: lightweight recommendation-stub registry for orchestration follow-ons.
+ *
+ * Persists bounded `follow_on:recommendation-stub:` tokens from review `unknownFields`
+ * into a separate GameState map — distinct from full retrospective engine (SPE-868).
+ */
+
+import {
+  BRANDED_OBJECT_NUMBER_PATTERN,
+  FRANCHISE_TOKEN_PATTERN,
+} from './postIncidentReviewRegistry'
+
+// ---------------------------------------------------------------------------
+// Identifiers and records
+// ---------------------------------------------------------------------------
+
+export type PostIncidentReviewRecommendationId = string
+
+export interface PostIncidentReviewRecommendationRecord {
+  readonly id: PostIncidentReviewRecommendationId
+  readonly label: string
+  readonly reviewRef: string
+  readonly stubSuffix: string
+  readonly followOnToken: string
+  readonly orchestrationWeek?: number
+}
+
+export type PostIncidentReviewRecommendationRecordsMap = Record<
+  PostIncidentReviewRecommendationId,
+  PostIncidentReviewRecommendationRecord
+>
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type PostIncidentReviewRecommendationValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_review_ref'
+  | 'missing_stub_suffix'
+  | 'missing_follow_on_token'
+  | 'invalid_orchestration_week'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_stub_suffix'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_stub_suffix'
+
+export interface PostIncidentReviewRecommendationValidationIssue {
+  readonly code: PostIncidentReviewRecommendationValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface PostIncidentReviewRecommendationValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly PostIncidentReviewRecommendationValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function pushIssue(
+  issues: PostIncidentReviewRecommendationValidationIssue[],
+  issue: PostIncidentReviewRecommendationValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: PostIncidentReviewRecommendationValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function freezeValidationResult(
+  issues: PostIncidentReviewRecommendationValidationIssue[]
+): PostIncidentReviewRecommendationValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function scanForbiddenTokens(
+  issues: PostIncidentReviewRecommendationValidationIssue[],
+  id: string,
+  label: string,
+  stubSuffix: string
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Post-incident recommendation record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Post-incident recommendation record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Post-incident recommendation record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Post-incident recommendation record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(stubSuffix)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_stub_suffix',
+      severity: 'error',
+      detail: `Post-incident recommendation record ${id || '(unknown)'} stubSuffix contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(stubSuffix)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_stub_suffix',
+      severity: 'error',
+      detail: `Post-incident recommendation record ${id || '(unknown)'} stubSuffix contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function freezeRecord(
+  record: PostIncidentReviewRecommendationRecord
+): PostIncidentReviewRecommendationRecord {
+  return Object.freeze({ ...record })
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validatePostIncidentReviewRecommendationRecord(
+  record: PostIncidentReviewRecommendationRecord
+): PostIncidentReviewRecommendationValidationResult {
+  const issues: PostIncidentReviewRecommendationValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const reviewRef = normalizeToken(record.reviewRef)
+  const stubSuffix = normalizeToken(record.stubSuffix)
+  const followOnToken = normalizeToken(record.followOnToken)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Post-incident recommendation record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Post-incident recommendation record is missing label.',
+    })
+  }
+
+  if (!reviewRef) {
+    pushIssue(issues, {
+      code: 'missing_review_ref',
+      severity: 'error',
+      detail: `Post-incident recommendation record ${id || '(unknown)'} is missing reviewRef.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!stubSuffix) {
+    pushIssue(issues, {
+      code: 'missing_stub_suffix',
+      severity: 'error',
+      detail: `Post-incident recommendation record ${id || '(unknown)'} is missing stubSuffix.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!followOnToken) {
+    pushIssue(issues, {
+      code: 'missing_follow_on_token',
+      severity: 'error',
+      detail: `Post-incident recommendation record ${id || '(unknown)'} is missing followOnToken.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.orchestrationWeek !== undefined &&
+    !isNonNegativeInteger(record.orchestrationWeek)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_orchestration_week',
+      severity: 'error',
+      detail: `Post-incident recommendation record ${id || '(unknown)'} orchestrationWeek must be a non-negative integer.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanForbiddenTokens(issues, id, label, stubSuffix)
+
+  return freezeValidationResult(issues)
+}
+
+function sanitizePostIncidentReviewRecommendationRecordEntry(
+  value: unknown
+): PostIncidentReviewRecommendationRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const reviewRef = normalizeToken(value.reviewRef)
+  const stubSuffix = normalizeToken(value.stubSuffix)
+  const followOnToken = normalizeToken(value.followOnToken)
+  const orchestrationWeek = value.orchestrationWeek
+
+  const record: PostIncidentReviewRecommendationRecord = {
+    id,
+    label,
+    reviewRef,
+    stubSuffix,
+    followOnToken,
+    ...(isNonNegativeInteger(orchestrationWeek) ? { orchestrationWeek } : {}),
+  }
+
+  if (!validatePostIncidentReviewRecommendationRecord(record).valid) {
+    return null
+  }
+
+  return freezeRecord(record)
+}
+
+/** Hydration: canonical recommendation map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizePostIncidentReviewRecommendationRecords(
+  value: unknown,
+  fallback: PostIncidentReviewRecommendationRecordsMap = {}
+): PostIncidentReviewRecommendationRecordsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: PostIncidentReviewRecommendationRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizePostIncidentReviewRecommendationRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
+export function getPostIncidentReviewRecommendationById(
+  registry: PostIncidentReviewRecommendationRecordsMap | undefined,
+  recommendationId: string
+): PostIncidentReviewRecommendationRecord | undefined {
+  const normalized = normalizeToken(recommendationId)
+  if (!normalized || !registry) {
+    return undefined
+  }
+
+  return registry[normalized]
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -288,6 +288,7 @@ import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemW
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
 import { applyWeeklyRecurrentCatastropheTick } from '../recurrentCatastropheWeeklyOrchestration'
 import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../postIncidentReviewFollowOnArtifact'
+import { applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick } from '../postIncidentReviewFollowOnRecommendationRegistry'
 import { applyWeeklyPostIncidentReviewFollowOnTrainingEnqueueTick } from '../postIncidentReviewFollowOnTrainingEnqueue'
 import { buildWeeklyPostIncidentReviewFollowOnReportNotes } from '../postIncidentReviewFollowOnWeeklyReportNotes'
 import { applyWeeklyPostIncidentReviewCreationTick, resolveQualifyingIncidentReviewDraftsFromEventDrafts } from '../postIncidentReviewWeeklyOrchestration'
@@ -4702,6 +4703,8 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
 
   // SPE-868 slice 4/7: retrospective creation for recurrence closeout refs and qualifying incidents.
   const currentPostIncidentReviewRecords = outputWeeklyState.postIncidentReviewRecords ?? {}
+  const currentPostIncidentReviewRecommendationRecords =
+    outputWeeklyState.postIncidentReviewRecommendationRecords ?? {}
   const recurrentCatastrophesForReviewCreation = outputWeeklyState.recurrentCatastropheRecords ?? {}
   const qualifyingIncidentReviewDrafts = resolveQualifyingIncidentReviewDraftsFromEventDrafts(
     context.eventDrafts,
@@ -4722,6 +4725,12 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       currentPostIncidentReviewRecords,
       outputWeeklyState.postIncidentReviewRecords
     )
+    outputWeeklyState.postIncidentReviewRecommendationRecords =
+      applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick(
+        currentPostIncidentReviewRecommendationRecords,
+        currentPostIncidentReviewRecords,
+        outputWeeklyState.postIncidentReviewRecords
+      )
 
     const stateAfterFollowOnTrainingEnqueue = applyWeeklyPostIncidentReviewFollowOnTrainingEnqueueTick(
       outputWeeklyState,

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -93,6 +93,7 @@ describe('advanceWeek post-incident review integration (SPE-868 slice 4)', () =>
     expect(nextState.trainingQueue).toHaveLength(1)
     expect(nextState.trainingQueue[0]?.trainingId).toBe('threat-assessment')
     expect(nextState.trainingQueue[0]?.agentId).toBe('a_ava')
+    expect(nextState.postIncidentReviewRecommendationRecords).toEqual({})
     const weeklyReport = nextState.reports[nextState.reports.length - 1]
     const followOnNotes =
       weeklyReport?.notes.filter((note) => note.content.startsWith('Post-incident follow-on —')) ?? []
@@ -393,6 +394,12 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
     expect(followOnNotes[0]?.type).toBe('post_incident_review.follow_on')
     expect(followOnNotes[0]?.content).toContain('recommendation stub (near catastrophe case 001)')
     expect(nextState.trainingQueue).toHaveLength(0)
+    expect(nextState.postIncidentReviewRecommendationRecords?.['recommendation:near-catastrophe-case-001']).toMatchObject({
+      reviewRef: 'review:near-catastrophe-case-001',
+      stubSuffix: 'near-catastrophe-case-001',
+      followOnToken: 'follow_on:recommendation-stub:near-catastrophe-case-001',
+      orchestrationWeek: nextState.week,
+    })
 
     const mirrorView = getPostIncidentReviewMirrorView(nextState)
 
@@ -430,6 +437,9 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
 
     expect(created).toBeDefined()
     expect(twice.postIncidentReviewRecords?.['review:near-catastrophe-case-001']).toBe(created)
+    expect(twice.postIncidentReviewRecommendationRecords).toEqual(
+      once.postIncidentReviewRecommendationRecords
+    )
   })
 
   it('orders qualifying near-catastrophe mirror rows by stable record id', () => {
@@ -554,5 +564,41 @@ describe('advanceWeek post-incident follow-on training enqueue integration (SPE-
 
     expect(nextState.postIncidentReviewRecords?.['review:case-case-001-closeout']).toBeDefined()
     expect(nextState.trainingQueue).toHaveLength(0)
+    expect(nextState.postIncidentReviewRecommendationRecords).toEqual({})
+  })
+})
+
+describe('advanceWeek post-incident recommendation registry integration (SPE-868 slice 14)', () => {
+  it('leaves recommendation registry empty on a quiet week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.recurrentCatastropheRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.postIncidentReviewRecommendationRecords ?? {}).toEqual({})
+  })
+
+  it('persists recommendation stub for near-catastrophe without enqueueing training', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.trainingQueue).toHaveLength(0)
+    expect(nextState.postIncidentReviewRecommendationRecords?.['recommendation:near-catastrophe-case-001']).toMatchObject({
+      reviewRef: 'review:near-catastrophe-case-001',
+      followOnToken: 'follow_on:recommendation-stub:near-catastrophe-case-001',
+    })
+  })
+
+  it('does not duplicate recommendation records on re-advance', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const once = advanceWeek(state)
+    const twice = advanceWeek(once)
+
+    expect(twice.postIncidentReviewRecommendationRecords).toEqual(
+      once.postIncidentReviewRecommendationRecords
+    )
   })
 })

--- a/src/test/postIncidentReviewFollowOnRecommendationRegistry.test.ts
+++ b/src/test/postIncidentReviewFollowOnRecommendationRegistry.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  POST_INCIDENT_REVIEW_STUB_REGISTRY,
+  RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
+} from '../domain/postIncidentReviewRegistry'
+import {
+  applyWeeklyPostIncidentReviewFollowOnArtifactTick,
+  FOLLOW_ON_RECOMMENDATION_STUB_PREFIX,
+} from '../domain/postIncidentReviewFollowOnArtifact'
+import {
+  applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick,
+  buildRecommendationRecordFromReview,
+  parseFollowOnRecommendationStubToken,
+} from '../domain/postIncidentReviewFollowOnRecommendationRegistry'
+import {
+  applyWeeklyPostIncidentReviewCreationTick,
+  type QualifyingIncidentReviewDraft,
+} from '../domain/postIncidentReviewWeeklyOrchestration'
+
+describe('postIncidentReviewFollowOnRecommendationRegistry (SPE-868 slice 14)', () => {
+  const nearCatastropheDraft: QualifyingIncidentReviewDraft = {
+    reviewRef: 'review:near-catastrophe-case-major',
+    caseId: 'case-major',
+    caseTitle: 'District breach',
+    trigger: 'near_catastrophe_threshold',
+    stage: 4,
+    kind: 'raid',
+    anchorWeek: 12,
+  }
+
+  const caseCloseoutDraft: QualifyingIncidentReviewDraft = {
+    reviewRef: 'review:case-case-major-closeout',
+    caseId: 'case-major',
+    caseTitle: 'District breach',
+    trigger: 'case_resolved',
+    stage: 4,
+    kind: 'standard',
+    anchorWeek: 12,
+  }
+
+  it('parses recommendation-stub tokens and rejects training refs', () => {
+    expect(
+      parseFollowOnRecommendationStubToken(
+        `${FOLLOW_ON_RECOMMENDATION_STUB_PREFIX}near-catastrophe-case-major`
+      )
+    ).toBe('near-catastrophe-case-major')
+    expect(parseFollowOnRecommendationStubToken('follow_on:training-ref:threat-assessment')).toBeUndefined()
+    expect(parseFollowOnRecommendationStubToken(`${FOLLOW_ON_RECOMMENDATION_STUB_PREFIX}`)).toBeUndefined()
+  })
+
+  it('builds a recommendation record from an orchestration-created near-catastrophe review', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [nearCatastropheDraft])
+    const withArtifact = applyWeeklyPostIncidentReviewFollowOnArtifactTick(prior, created)
+    const review = withArtifact['review:near-catastrophe-case-major']
+    const token = review?.unknownFields?.find((field) =>
+      field.startsWith(FOLLOW_ON_RECOMMENDATION_STUB_PREFIX)
+    )
+    expect(review).toBeDefined()
+    expect(token).toBeDefined()
+
+    const recommendation = buildRecommendationRecordFromReview(review!, token!)
+
+    expect(recommendation).toEqual({
+      id: 'recommendation:near-catastrophe-case-major',
+      label: 'Follow-on recommendation — Near-catastrophe threshold review — District breach',
+      reviewRef: 'review:near-catastrophe-case-major',
+      stubSuffix: 'near-catastrophe-case-major',
+      followOnToken: 'follow_on:recommendation-stub:near-catastrophe-case-major',
+      orchestrationWeek: 12,
+    })
+  })
+
+  it('rejects recommendation records when stub suffix contains forbidden tokens', () => {
+    const review = {
+      id: 'review:franchise-stub',
+      label: 'External audit review',
+      reviewRoute: 'external_audit' as const,
+      closureOutcome: 'administratively_cleared' as const,
+      unknownFields: [
+        'follow_on:recommendation-stub:foundation-audit',
+        'orchestration_week:12',
+      ],
+    }
+
+    expect(
+      buildRecommendationRecordFromReview(
+        review,
+        'follow_on:recommendation-stub:foundation-audit'
+      )
+    ).toBeUndefined()
+  })
+
+  it('appends one recommendation record when a near-catastrophe review materializes', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [nearCatastropheDraft])
+    const withArtifact = applyWeeklyPostIncidentReviewFollowOnArtifactTick(prior, created)
+    const next = applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick({}, prior, withArtifact)
+
+    expect(next['recommendation:near-catastrophe-case-major']).toMatchObject({
+      reviewRef: 'review:near-catastrophe-case-major',
+      stubSuffix: 'near-catastrophe-case-major',
+      followOnToken: 'follow_on:recommendation-stub:near-catastrophe-case-major',
+      orchestrationWeek: 12,
+    })
+  })
+
+  it('is idempotent when re-run for the same materialized review', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [nearCatastropheDraft])
+    const withArtifact = applyWeeklyPostIncidentReviewFollowOnArtifactTick(prior, created)
+    const once = applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick({}, prior, withArtifact)
+    const twice = applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick(
+      once,
+      withArtifact,
+      withArtifact
+    )
+
+    expect(twice).toBe(once)
+    expect(Object.keys(twice)).toHaveLength(1)
+  })
+
+  it('does not append for stub registry reviews or training-ref closeouts', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const stubOnly = applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick({}, prior, prior)
+
+    expect(stubOnly).toEqual({})
+    expect(
+      stubOnly[RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE.id as keyof typeof stubOnly]
+    ).toBeUndefined()
+
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [caseCloseoutDraft])
+    const withArtifact = applyWeeklyPostIncidentReviewFollowOnArtifactTick(prior, created)
+    const closeoutPath = applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick(
+      {},
+      prior,
+      withArtifact
+    )
+
+    expect(closeoutPath).toEqual({})
+    expect(withArtifact['review:case-case-major-closeout']?.unknownFields).toContain(
+      'follow_on:training-ref:threat-assessment'
+    )
+  })
+
+  it('persists distinct recommendation records when closeout and near-catastrophe materialize same tick', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [
+      caseCloseoutDraft,
+      nearCatastropheDraft,
+    ])
+    const withArtifact = applyWeeklyPostIncidentReviewFollowOnArtifactTick(prior, created)
+    const next = applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick({}, prior, withArtifact)
+
+    expect(Object.keys(next)).toEqual(['recommendation:near-catastrophe-case-major'])
+    expect(next['recommendation:near-catastrophe-case-major']?.reviewRef).toBe(
+      'review:near-catastrophe-case-major'
+    )
+  })
+
+  it('does not append recommendations on a quiet tick', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const next = applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick(
+      {},
+      prior,
+      prior
+    )
+
+    expect(next).toEqual({})
+    expect(createStartingState().postIncidentReviewRecommendationRecords).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Add `postIncidentReviewRecommendationRecords` on GameState with sanitize/hydrate in `runTransfer`
- Wire `applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick` in `advanceWeek` after the follow-on artifact tick
- Persist bounded `follow_on:recommendation-stub:` tokens when orchestration-created reviews materialize; training-ref tokens are skipped

## Linear mapping

- **Slice:** [SPE-2383](https://linear.app/spectranoir/issue/SPE-2383) — Post-incident recommendation record registry persistence (slice 14)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — stays open (do not re-close)

## What shipped

- Domain registry schema + weekly append helper
- `advanceWeek` integration after follow-on artifact tick
- Domain unit + integration tests for near-catastrophe, idempotency, dual-path, and forbidden-token rejection

## Validation

- `npm run test:run -- src/test/postIncidentReviewFollowOnRecommendationRegistry.test.ts src/test/advanceWeek.postIncidentReview.integration.test.ts src/test/postIncidentReviewFollowOnTrainingEnqueue.test.ts src/test/postIncidentReviewFollowOnArtifact.test.ts src/test/postIncidentReviewFollowOnWeeklyReportNotes.test.ts`
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-14.md` (new)

## Parent remains open

SPE-868 parent closure and SPE-1310 lifecycle are out of slice boundary.

Made with [Cursor](https://cursor.com)