### PR TITLE
feat(SPE-2389): milestone timing capture on review creation tick (slice 20)

### DIFF
--- a/planning/post-incident-review-registry-slice-20.md
+++ b/planning/post-incident-review-registry-slice-20.md
@@ -1,0 +1,81 @@
+# SPE-868 — Milestone timing capture beyond reportingWeek (slice 20)
+
+One-page implementation plan. Linear: child [SPE-2389](https://linear.app/spectranoir/issue/SPE-2389) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 19 (`planning/post-incident-review-registry-slice-19.md`, PR #2644 / [SPE-2388](https://linear.app/spectranoir/issue/SPE-2388)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2389 — Milestone timing capture beyond reportingWeek (slice 20)](https://linear.app/spectranoir/issue/SPE-2389) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-review-milestone-timing-capture-slice-20`                                                         |
+| **Base `main` SHA** | `bb40af3c`                                                                                          |
+
+## Goal
+
+Extend qualifying review records with distinct milestone intervals (discovery / response / containment / recovery / reporting) on the deterministic creation-tick path — domain schema + creation tick only.
+
+## Prerequisite (on `main` @ `bb40af3c`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Qualifying incident creation tick | `applyWeeklyPostIncidentReviewCreationTick` slice 7 (SPE-2376) |
+| Near-catastrophe fixture | `advanceWeek.postIncidentReview.integration.test.ts` slice 9 (SPE-2378) |
+| `milestoneTimings` schema | `PostIncidentMilestoneTimings` on `postIncidentReviewRegistry` slice 5 |
+| `reportingWeek` on creation | Private builders in orchestration (pre-slice-20) |
+
+## Milestone derivation contract (this slice)
+
+| Profile | Milestones captured | Use |
+| --- | --- | --- |
+| `cycle_closeout` | discovery, response, containment, recovery, reporting | Recurrence cycle closeout refs |
+| `case_closeout` | discovery, response, containment, reporting | Qualifying case resolved |
+| `near_catastrophe` | discovery, response, reporting | Near-catastrophe threshold |
+| `reporting_only` | reporting | Generic closeout stub when lifecycle unknown |
+
+| Rule | Detail |
+| --- | --- |
+| **Anchor week** | `anchorWeek` from draft or `lastOccurrenceWeek`; normalized to `max(1, trunc(week))`. |
+| **Partial data** | Profiles omit milestones when incident lifecycle lacks full events (no recovery on case closeout; no containment/recovery on near-catastrophe). |
+| **Registry API** | `derivePostIncidentMilestoneTimings(profile, anchorWeek)` exported from `postIncidentReviewRegistry.ts`. |
+| **Creation tick** | Orchestration imports registry derivation; no duplicate private builders. |
+| **Idempotency** | Re-advance same week does not mutate milestone timings on existing records. |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| `derivePostIncidentMilestoneTimings` + profile union on registry | Mirror UI changes                             |
+| Orchestration uses registry derivation                           | Action engine / recommendation tick           |
+| Domain unit tests for milestone profiles                         | SPE-1097 authority checks                     |
+| One `advanceWeek` integration case (qualifying case closeout)    | SPE-1310 parent closure                       |
+| Slice doc (this file) + backlog handoff on ship                  | Full SPE-868 parent closure                   |
+
+## Acceptance
+
+- [ ] Registry exports deterministic milestone derivation for cycle closeout, case closeout, and near-catastrophe profiles
+- [ ] Creation tick uses registry derivation (no duplicate private builders)
+- [ ] Domain unit tests cover all three profiles + partial-milestone edge cases
+- [ ] `advanceWeek` integration asserts full milestone intervals on qualifying case closeout path
+- [ ] Re-advance idempotent; slice 7/9 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/postIncidentReviewRegistry.ts`, `src/domain/postIncidentReviewWeeklyOrchestration.ts` |
+| Tests  | `src/test/postIncidentReviewRegistry.test.ts`, `src/test/advanceWeek.postIncidentReview.integration.test.ts` |
+| Plan   | `planning/post-incident-review-registry-slice-20.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 | Out of milestone boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine, compliance audit cycling, branching reward logic | SPE-868 | Milestone capture slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-9.md`
+- `planning/post-incident-review-registry-slice-19.md`

--- a/src/domain/postIncidentReviewRegistry.ts
+++ b/src/domain/postIncidentReviewRegistry.ts
@@ -49,6 +49,16 @@ export interface PostIncidentMilestoneTimings {
   readonly reportingWeek?: number
 }
 
+/** Deterministic milestone span profile for retrospective creation ticks. */
+export type PostIncidentMilestoneTimingProfile =
+  | 'cycle_closeout'
+  | 'case_closeout'
+  | 'near_catastrophe'
+  | 'reporting_only'
+
+export const POST_INCIDENT_MILESTONE_TIMING_PROFILES: readonly PostIncidentMilestoneTimingProfile[] =
+  ['cycle_closeout', 'case_closeout', 'near_catastrophe', 'reporting_only'] as const
+
 // ---------------------------------------------------------------------------
 // Records
 // ---------------------------------------------------------------------------
@@ -191,6 +201,55 @@ function isValidUnitScore(value: unknown): value is number {
 
 function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function normalizeMilestoneAnchorWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+/**
+ * Derives deterministic milestone week intervals from an anchor reporting week.
+ * Partial profiles omit milestones when the incident lifecycle lacks full events.
+ */
+export function derivePostIncidentMilestoneTimings(
+  profile: PostIncidentMilestoneTimingProfile,
+  anchorWeek: number
+): PostIncidentMilestoneTimings {
+  const week = normalizeMilestoneAnchorWeek(anchorWeek)
+
+  switch (profile) {
+    case 'cycle_closeout':
+      return {
+        discoveryWeek: Math.max(0, week - 4),
+        responseWeek: Math.max(0, week - 3),
+        containmentWeek: Math.max(0, week - 2),
+        recoveryWeek: Math.max(0, week - 1),
+        reportingWeek: week,
+      }
+    case 'case_closeout':
+      return {
+        discoveryWeek: Math.max(0, week - 3),
+        responseWeek: Math.max(0, week - 2),
+        containmentWeek: Math.max(0, week - 1),
+        reportingWeek: week,
+      }
+    case 'near_catastrophe':
+      return {
+        discoveryWeek: Math.max(0, week - 2),
+        responseWeek: Math.max(0, week - 1),
+        reportingWeek: week,
+      }
+    case 'reporting_only':
+      return { reportingWeek: week }
+    default: {
+      const exhaustive: never = profile
+      return exhaustive
+    }
+  }
 }
 
 function freezeValidationResult(

--- a/src/domain/postIncidentReviewWeeklyOrchestration.ts
+++ b/src/domain/postIncidentReviewWeeklyOrchestration.ts
@@ -16,6 +16,7 @@ import {
 } from './recurrentCatastropheAmeliorationRegistry'
 import {
   BRANDED_OBJECT_NUMBER_PATTERN,
+  derivePostIncidentMilestoneTimings,
   FRANCHISE_TOKEN_PATTERN,
   validatePostIncidentReviewRecord,
   type PostIncidentReviewRecord,
@@ -89,39 +90,6 @@ function parseCycleCloseoutNumber(reviewRef: string): number | undefined {
   }
 
   return cycleNumber
-}
-
-function buildCycleCloseoutMilestoneTimings(anchorWeek: number) {
-  const week = normalizeWeek(anchorWeek)
-
-  return {
-    discoveryWeek: Math.max(0, week - 4),
-    responseWeek: Math.max(0, week - 3),
-    containmentWeek: Math.max(0, week - 2),
-    recoveryWeek: Math.max(0, week - 1),
-    reportingWeek: week,
-  }
-}
-
-function buildCaseCloseoutMilestoneTimings(anchorWeek: number) {
-  const week = normalizeWeek(anchorWeek)
-
-  return {
-    discoveryWeek: Math.max(0, week - 3),
-    responseWeek: Math.max(0, week - 2),
-    containmentWeek: Math.max(0, week - 1),
-    reportingWeek: week,
-  }
-}
-
-function buildNearCatastropheMilestoneTimings(anchorWeek: number) {
-  const week = normalizeWeek(anchorWeek)
-
-  return {
-    discoveryWeek: Math.max(0, week - 2),
-    responseWeek: Math.max(0, week - 1),
-    reportingWeek: week,
-  }
 }
 
 function isNearCatastropheQualifyingSnapshot(snapshot: NearCatastropheQualifyingSnapshot): boolean {
@@ -299,7 +267,7 @@ export function buildQualifyingIncidentReviewRecordForDraft(
           summary: 'Structured retrospective after qualifying incident resolution.',
           reviewRoute: 'internal_command',
           closureOutcome: 'contained',
-          milestoneTimings: buildCaseCloseoutMilestoneTimings(anchorWeek),
+          milestoneTimings: derivePostIncidentMilestoneTimings('case_closeout', anchorWeek),
           procedureAdherenceScore: 0.68,
           recurrenceObserved: false,
           confidence: 0.72,
@@ -311,7 +279,7 @@ export function buildQualifyingIncidentReviewRecordForDraft(
           summary: 'Structured retrospective triggered by near-catastrophe escalation threshold.',
           reviewRoute: 'external_audit',
           closureOutcome: 'administratively_cleared',
-          milestoneTimings: buildNearCatastropheMilestoneTimings(anchorWeek),
+          milestoneTimings: derivePostIncidentMilestoneTimings('near_catastrophe', anchorWeek),
           procedureAdherenceScore: 0.55,
           recurrenceObserved: false,
           confidence: 0.61,
@@ -407,7 +375,7 @@ export function buildPostIncidentReviewRecordForRef(
           summary: 'Structured retrospective after seasonal cascade recurrence recovery.',
           reviewRoute: 'internal_command',
           closureOutcome: 'contained',
-          milestoneTimings: buildCycleCloseoutMilestoneTimings(anchorWeek),
+          milestoneTimings: derivePostIncidentMilestoneTimings('cycle_closeout', anchorWeek),
           procedureAdherenceScore: 0.71,
           recurrenceObserved: true,
           confidence: 0.74,
@@ -419,7 +387,7 @@ export function buildPostIncidentReviewRecordForRef(
           summary: 'Structured retrospective pending formal milestone capture.',
           reviewRoute: 'internal_command',
           closureOutcome: 'contained',
-          milestoneTimings: { reportingWeek: anchorWeek },
+          milestoneTimings: derivePostIncidentMilestoneTimings('reporting_only', anchorWeek),
           procedureAdherenceScore: 0.5,
           recurrenceObserved: true,
           confidence: 0.5,

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import type { CaseInstance } from '../domain/models'
 import {
+  derivePostIncidentMilestoneTimings,
   RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
 } from '../domain/postIncidentReviewRegistry'
 import {
@@ -208,7 +209,9 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
     expect(created?.label).toBe(
       'Qualifying incident closeout review — ' + state.cases['case-001'].title
     )
-    expect(created?.milestoneTimings?.reportingWeek).toBe(nextState.week)
+    expect(created?.milestoneTimings).toEqual(
+      derivePostIncidentMilestoneTimings('case_closeout', nextState.week)
+    )
     expect(created?.unknownFields).toEqual([
       'follow_on:training-ref:threat-assessment',
       `orchestration_week:${nextState.week}`,

--- a/src/test/postIncidentReviewRegistry.test.ts
+++ b/src/test/postIncidentReviewRegistry.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  derivePostIncidentMilestoneTimings,
   EXTERNAL_AUDIT_CLEARED_REVIEW_FIXTURE,
+  POST_INCIDENT_MILESTONE_TIMING_PROFILES,
   POST_INCIDENT_REVIEW_ROUTES,
   POST_INCIDENT_CLOSURE_OUTCOMES,
   POST_INCIDENT_REVIEW_STUB_REGISTRY,
@@ -98,6 +100,70 @@ describe('postIncidentReviewRegistry (SPE-868 slice 5)', () => {
   it('returns byte-stable validation results on repeated calls', () => {
     const first = validatePostIncidentReviewRecord(RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE)
     const second = validatePostIncidentReviewRecord(RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE)
+
+    expect(first).toEqual(second)
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+})
+
+describe('derivePostIncidentMilestoneTimings (SPE-868 slice 20)', () => {
+  it('exports stable milestone timing profile catalog', () => {
+    expect(POST_INCIDENT_MILESTONE_TIMING_PROFILES).toEqual([
+      'cycle_closeout',
+      'case_closeout',
+      'near_catastrophe',
+      'reporting_only',
+    ])
+  })
+
+  it('derives full five-milestone cycle closeout intervals from anchor week', () => {
+    expect(derivePostIncidentMilestoneTimings('cycle_closeout', 53)).toEqual({
+      discoveryWeek: 49,
+      responseWeek: 50,
+      containmentWeek: 51,
+      recoveryWeek: 52,
+      reportingWeek: 53,
+    })
+  })
+
+  it('derives four-milestone case closeout intervals without recovery', () => {
+    expect(derivePostIncidentMilestoneTimings('case_closeout', 12)).toEqual({
+      discoveryWeek: 9,
+      responseWeek: 10,
+      containmentWeek: 11,
+      reportingWeek: 12,
+    })
+  })
+
+  it('derives three-milestone near-catastrophe intervals without containment or recovery', () => {
+    expect(derivePostIncidentMilestoneTimings('near_catastrophe', 12)).toEqual({
+      discoveryWeek: 10,
+      responseWeek: 11,
+      reportingWeek: 12,
+    })
+  })
+
+  it('derives reporting-only stub when lifecycle events are unknown', () => {
+    expect(derivePostIncidentMilestoneTimings('reporting_only', 12)).toEqual({
+      reportingWeek: 12,
+    })
+  })
+
+  it('clamps sub-one anchor weeks and non-finite inputs to week 1', () => {
+    expect(derivePostIncidentMilestoneTimings('case_closeout', 0)).toEqual({
+      discoveryWeek: 0,
+      responseWeek: 0,
+      containmentWeek: 0,
+      reportingWeek: 1,
+    })
+    expect(derivePostIncidentMilestoneTimings('reporting_only', Number.NaN)).toEqual({
+      reportingWeek: 1,
+    })
+  })
+
+  it('returns byte-stable milestone timings on repeated calls', () => {
+    const first = derivePostIncidentMilestoneTimings('cycle_closeout', 42)
+    const second = derivePostIncidentMilestoneTimings('cycle_closeout', 42)
 
     expect(first).toEqual(second)
     expect(JSON.stringify(first)).toBe(JSON.stringify(second))


### PR DESCRIPTION
## Summary

- Export `derivePostIncidentMilestoneTimings` and `PostIncidentMilestoneTimingProfile` on `postIncidentReviewRegistry` for deterministic milestone interval derivation (cycle closeout, case closeout, near-catastrophe, reporting-only).
- Wire `postIncidentReviewWeeklyOrchestration` creation tick to registry derivation; remove duplicate private builders.
- Add domain unit tests for all milestone profiles and extend qualifying case closeout `advanceWeek` integration to assert full milestone intervals.

## Linear mapping

| Issue | Role |
| --- | --- |
| [SPE-2389](https://linear.app/spectranoir/issue/SPE-2389) | **Slice** — milestone timing capture (slice 20) |
| [SPE-868](https://linear.app/spectranoir/issue/SPE-868) | **Parent** — stays open |

## What shipped

Domain schema + creation tick milestone capture beyond `reportingWeek` only. No mirror UI, action engine, or SPE-1097 authority changes.

## Validation

- `npm run test:run -- src/test/postIncidentReviewRegistry.test.ts src/test/postIncidentReviewWeeklyOrchestration.test.ts src/test/advanceWeek.postIncidentReview.integration.test.ts`
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-20.md` (new)
- `planning/backlog.md` — on merge

## Parent status

SPE-868 remains open (registry slice only; full retrospective engine deferred).