### PR TITLE
test(SPE-2391): post-incident review mirror milestone label integration (slice 22)

### DIFF
--- a/planning/post-incident-review-registry-slice-22.md
+++ b/planning/post-incident-review-registry-slice-22.md
@@ -1,0 +1,79 @@
+# SPE-868 — Post-incident review mirror milestone label integration (slice 22)
+
+One-page implementation plan. Linear: child [SPE-2391](https://linear.app/spectranoir/issue/SPE-2391) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 21 (`planning/post-incident-review-registry-slice-21.md`, PR #2648 / [SPE-2390](https://linear.app/spectranoir/issue/SPE-2390)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2391 — Post-incident review mirror milestone label integration (slice 22)](https://linear.app/spectranoir/issue/SPE-2391) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-review-milestone-mirror-slice-22`                                                                 |
+| **Base `main` SHA** | `3d01d429`                                                                                          |
+
+## Goal
+
+Extend `advanceWeek.postIncidentReview.integration.test.ts` to assert mirror milestone week labels and span on case closeout (slice 7), cycle-4 closeout (slice 4), and near-catastrophe (slice 9) paths via `getPostIncidentReviewMirrorView`.
+
+## Prerequisite (on `main` @ `3d01d429`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Full milestoneTimings on records | slice 21 (SPE-2390)                                              |
+| Qualifying mirror surfacing | slice 8 (SPE-2377)                                                |
+| Milestone span derivation | `projectPostIncidentReviewSummary` in registry                    |
+| Mirror label wiring | `formatMilestoneWeek`, `formatMilestoneSpanWeeks` in mirror view |
+
+## Integration contract (this slice)
+
+| Path | Mirror row | Labels asserted |
+| --- | --- | --- |
+| Case closeout (slice 7 fixture) | `qualifyingIncidentRecords[0]` | discovery, response, containment, reporting; recovery `—`; span |
+| Cycle-4 closeout (slice 4 fixture) | `records` find `review:cycle-4-closeout` | all five milestones + span |
+| Near-catastrophe (slice 9 fixture) | `qualifyingIncidentRecords[0]` | discovery, response, reporting; containment/recovery `—`; span |
+
+| Rule | Detail |
+| --- | --- |
+| **Assertion shape** | `expect(record?.discoveryWeekLabel).toBe('W…')` etc. aligned with `derivePostIncidentMilestoneTimings` + `projectPostIncidentReviewSummary` |
+| **Partial profiles** | Near-catastrophe omits containment/recovery labels (`—`); case closeout omits recovery |
+| **Idempotency** | Existing re-advance tests unchanged |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| Three integration assertion blocks in existing slice 4/7/9 tests | Domain derivation logic changes               |
+| Slice doc (this file) + backlog handoff on ship                  | Mirror or domain code changes                 |
+|                                                                  | Action/recommendation ticks                   |
+|                                                                  | SPE-1097 authority checks                     |
+|                                                                  | SPE-1310 parent closure                       |
+|                                                                  | Full SPE-868 parent closure                   |
+
+## Acceptance
+
+- [ ] Case closeout path asserts milestone mirror labels via `getPostIncidentReviewMirrorView`
+- [ ] Cycle-4 closeout path asserts milestone mirror labels via `getPostIncidentReviewMirrorView`
+- [ ] Near-catastrophe path asserts partial milestone mirror labels (containment/recovery `—`)
+- [ ] Slice 21 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Tests  | `src/test/advanceWeek.postIncidentReview.integration.test.ts`         |
+| Plan   | `planning/post-incident-review-registry-slice-22.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Redacted milestoneTimings em-dash label integration | follow-up slice | Out of slice 22 boundary (no redaction fixtures in 4/7/9 paths) |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 | Out of milestone mirror boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Integration assertion slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-4.md`
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-9.md`
+- `planning/post-incident-review-registry-slice-21.md`

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -3,7 +3,9 @@ import { createStartingState } from '../data/startingState'
 import type { CaseInstance } from '../domain/models'
 import {
   derivePostIncidentMilestoneTimings,
+  projectPostIncidentReviewSummary,
   RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
+  type PostIncidentMilestoneTimings,
 } from '../domain/postIncidentReviewRegistry'
 import {
   RECURRENCE_DAMAGE_LEDGER_FIXTURE,
@@ -15,10 +17,46 @@ import {
   resolveQualifyingIncidentReviewDraftsFromEventDrafts,
 } from '../domain/postIncidentReviewWeeklyOrchestration'
 import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../domain/postIncidentReviewFollowOnArtifact'
-import { getPostIncidentReviewMirrorView } from '../features/operations/postIncidentReviewMirrorView'
+import {
+  getPostIncidentReviewMirrorView,
+  type PostIncidentReviewMirrorRecordView,
+} from '../features/operations/postIncidentReviewMirrorView'
 import { getPostIncidentReviewRecommendationActionMirrorView } from '../features/operations/postIncidentReviewRecommendationActionMirrorView'
 import { getPostIncidentReviewRecommendationMirrorView } from '../features/operations/postIncidentReviewRecommendationMirrorView'
 import { applyWeeklyRecurrentCatastropheTick } from '../domain/recurrentCatastropheWeeklyOrchestration'
+
+function formatExpectedMilestoneWeekLabel(week: number | undefined): string {
+  if (week === undefined) {
+    return '—'
+  }
+
+  return `W${week}`
+}
+
+function expectMilestoneMirrorLabels(
+  record: PostIncidentReviewMirrorRecordView | undefined,
+  milestoneTimings: PostIncidentMilestoneTimings,
+  milestoneSpanWeeks: number | null
+): void {
+  expect(record?.discoveryWeekLabel).toBe(
+    formatExpectedMilestoneWeekLabel(milestoneTimings.discoveryWeek)
+  )
+  expect(record?.responseWeekLabel).toBe(
+    formatExpectedMilestoneWeekLabel(milestoneTimings.responseWeek)
+  )
+  expect(record?.containmentWeekLabel).toBe(
+    formatExpectedMilestoneWeekLabel(milestoneTimings.containmentWeek)
+  )
+  expect(record?.recoveryWeekLabel).toBe(
+    formatExpectedMilestoneWeekLabel(milestoneTimings.recoveryWeek)
+  )
+  expect(record?.reportingWeekLabel).toBe(
+    formatExpectedMilestoneWeekLabel(milestoneTimings.reportingWeek)
+  )
+  expect(record?.milestoneSpanWeeksLabel).toBe(
+    milestoneSpanWeeks === null ? '—' : String(milestoneSpanWeeks)
+  )
+}
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
   for (const currentCase of Object.values(state.cases)) {
@@ -114,6 +152,17 @@ describe('advanceWeek post-incident review integration (SPE-868 slice 4)', () =>
     expect(followOnNotes[0]?.content).toContain('training reference (threat assessment)')
     expect(nextState.postIncidentReviewRecords?.[RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE.id]).toEqual(
       RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE
+    )
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const cycleMirrorRecord = mirrorView.records.find(
+      (record) => record.id === 'review:cycle-4-closeout'
+    )
+
+    expectMilestoneMirrorLabels(
+      cycleMirrorRecord,
+      created!.milestoneTimings!,
+      projectPostIncidentReviewSummary(created!).milestoneSpanWeeks
     )
   })
 
@@ -240,6 +289,11 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
     expect(mirrorView.qualifyingIncidentRecords[0]?.linkedCaseIdLabel).toBe('case-001')
     expect(mirrorView.qualifyingIncidentRecords[0]?.orchestrationWeekLabel).toBe(
       `W${nextState.week}`
+    )
+    expectMilestoneMirrorLabels(
+      mirrorView.qualifyingIncidentRecords[0],
+      created!.milestoneTimings!,
+      projectPostIncidentReviewSummary(created!).milestoneSpanWeeks
     )
   })
 
@@ -479,6 +533,11 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
     expect(mirrorView.qualifyingIncidentRecords[0]?.linkedCaseIdLabel).toBe('case-001')
     expect(mirrorView.qualifyingIncidentRecords[0]?.orchestrationWeekLabel).toBe(
       `W${nextState.week}`
+    )
+    expectMilestoneMirrorLabels(
+      mirrorView.qualifyingIncidentRecords[0],
+      created!.milestoneTimings!,
+      projectPostIncidentReviewSummary(created!).milestoneSpanWeeks
     )
   })
 


### PR DESCRIPTION
## Summary

- Extend `advanceWeek.postIncidentReview.integration.test.ts` with milestone mirror label assertions on case closeout (slice 7), cycle-4 closeout (slice 4), and near-catastrophe (slice 9) paths via `getPostIncidentReviewMirrorView`.
- Assert `discoveryWeekLabel`, `responseWeekLabel`, `containmentWeekLabel`, `recoveryWeekLabel`, `reportingWeekLabel`, and `milestoneSpanWeeksLabel` aligned with persisted `milestoneTimings` and `projectPostIncidentReviewSummary` span derivation.
- Add slice doc `planning/post-incident-review-registry-slice-22.md`.

## Linear

- **Slice:** [SPE-2391](https://linear.app/spectranoir/issue/SPE-2391) — Post-incident review mirror milestone label integration (slice 22)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — stays open

## What shipped

Integration-test-only milestone mirror label coverage for three qualifying advanceWeek paths; no mirror or domain changes.

## Validation

- `npm run test:run -- src/test/advanceWeek.postIncidentReview.integration.test.ts` — 37 passed
- `npm run lint` — green

## Docs updated

- `planning/post-incident-review-registry-slice-22.md` (new)
- `planning/backlog.md` — pending merge closeout

## Parent remains open

SPE-868 parent scope not satisfied by this slice alone.