### PR TITLE
test(SPE-2393): redacted milestoneTimings mirror labels on qualifying paths (slice 24)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,7 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-[SPE-2362](https://linear.app/spectranoir/issue/SPE-2362) runtime validation hooks ships read-only dev-overlay surfacing for branch continuity audits ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) parent stays Done). Pick from `planning/scope-discipline-grooming-pass.md` §14 when a registry/slice owner exists, or backlog grooming for dedicated exploit-access content. Mission triage expansion remains **blocked**.
+**Groom then implement** the next [SPE-868](https://linear.app/spectranoir/issue/SPE-868) child (slice 24 — no Linear child yet). Likely boundary: extend redacted `milestoneTimings` mirror label integration tests to qualifying case-closeout (slice 7) and near-catastrophe (slice 9) `advanceWeek` paths, following shipped slice 23 pattern (`planning/post-incident-review-registry-slice-23.md`). Parent [SPE-868](https://linear.app/spectranoir/issue/SPE-868) stays open. Alternative: backlog grooming for dedicated exploit-access content ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) harvest deferral). Mission triage expansion remains **blocked**.
+
+**Base `main` SHA:** `c9c2355d`
 
 ## Blocked / waiting
 

--- a/planning/post-incident-review-registry-slice-24.md
+++ b/planning/post-incident-review-registry-slice-24.md
@@ -1,0 +1,76 @@
+# SPE-868 — Post-incident review redacted milestoneTimings mirror labels on qualifying advanceWeek paths (slice 24)
+
+One-page implementation plan. Linear: child [SPE-2393](https://linear.app/spectranoir/issue/SPE-2393) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 23 (`planning/post-incident-review-registry-slice-23.md`, PR #2653 / [SPE-2392](https://linear.app/spectranoir/issue/SPE-2392)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2393 — Post-incident review redacted milestoneTimings mirror labels on qualifying advanceWeek paths (slice 24)](https://linear.app/spectranoir/issue/SPE-2393) |
+| **Status** | **Ready for PR**                                                                                           |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-review-milestone-redaction-mirror-slice-24`                                                       |
+| **Base `main` SHA** | `c9c2355d`                                                                                          |
+
+## Goal
+
+Extend integration tests to assert em-dash milestone labels when `redactedFields` includes `milestoneTimings` on qualifying case-closeout (slice 7) and near-catastrophe (slice 9) advanceWeek paths.
+
+## Prerequisite (on `main` @ `c9c2355d`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Cycle-4 redaction integration | slice 23 (SPE-2392)                                            |
+| Qualifying case closeout integration | slice 7 (SPE-2376)                                       |
+| Near-catastrophe integration | slice 9 (SPE-2378)                                             |
+| Partial vs full redaction contrast | slice 23 unit fixture                                        |
+
+## Test contract (this slice)
+
+| Surface | Assertion |
+| --- | --- |
+| Qualifying case closeout path | Post-advance `review:case-case-001-closeout` with injected `redactedFields: ['milestoneTimings']` → all five milestone week labels + span `—` |
+| Near-catastrophe path | Post-advance `review:near-catastrophe-case-001` with injected redaction → all `—`; contrast partial profile (populated `W…` + missing `—`) before redaction |
+| Helper reuse | `expectRedactedMilestoneMirrorLabels` from slice 23 integration file |
+
+| Rule | Detail |
+| --- | --- |
+| **Redaction vs missing** | Redaction hides populated milestone weeks; near-catastrophe partial timings show `—` only for undefined fields without redaction |
+| **Span** | `milestoneSpanWeeksLabel` also `—` when projection redacts milestone span |
+| **No code changes** | Mirror and domain behavior already correct from slice 3/23 unless tests expose a bug |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| Integration redaction label assertions on slices 7 + 9 paths       | Domain derivation logic changes               |
+| Slice doc (this file) + backlog handoff on ship                  | Mirror or domain code changes                 |
+|                                                                  | Action/recommendation ticks                   |
+|                                                                  | SPE-1097 authority checks                     |
+|                                                                  | SPE-1310 parent closure                       |
+|                                                                  | Full SPE-868 parent closure                   |
+
+## Acceptance
+
+- [x] Redacted `milestoneTimings` mirror labels on qualifying case-closeout advanceWeek path
+- [x] Redacted `milestoneTimings` mirror labels on near-catastrophe advanceWeek path (hides populated partial weeks)
+- [x] Slice 22/23 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Tests  | `src/test/advanceWeek.postIncidentReview.integration.test.ts`         |
+| Plan   | `planning/post-incident-review-registry-slice-24.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1097 authority/legitimacy obedience checks | SPE-1097 | Out of milestone mirror boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Integration assertion slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-23.md`
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-9.md`

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -344,6 +344,32 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
     )
   })
 
+  it('renders redacted milestoneTimings mirror labels on qualifying case closeout path (SPE-868 slice 24)', () => {
+    const state = makeQualifyingResolvedCaseState()
+
+    const nextState = advanceWeek(state)
+    const created = nextState.postIncidentReviewRecords?.['review:case-case-001-closeout']
+
+    expect(created?.milestoneTimings).toBeDefined()
+
+    nextState.postIncidentReviewRecords = {
+      ...nextState.postIncidentReviewRecords,
+      'review:case-case-001-closeout': {
+        ...created!,
+        redactedFields: ['milestoneTimings'],
+      },
+    }
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const mirrorRecord = mirrorView.qualifyingIncidentRecords[0]
+
+    expectRedactedMilestoneMirrorLabels(mirrorRecord)
+    expect(mirrorRecord?.redacted).toBe(true)
+    expect(mirrorRecord?.discoveryWeekLabel).not.toBe(
+      formatExpectedMilestoneWeekLabel(created!.milestoneTimings!.discoveryWeek)
+    )
+  })
+
   it('does not create a review when a non-qualifying case resolves', () => {
     const state = createStartingState()
     freezeCasesForQuietWeek(state)
@@ -585,6 +611,48 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
       mirrorView.qualifyingIncidentRecords[0],
       created!.milestoneTimings!,
       projectPostIncidentReviewSummary(created!).milestoneSpanWeeks
+    )
+  })
+
+  it('renders redacted milestoneTimings mirror labels on near-catastrophe path (SPE-868 slice 24)', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+    const created = nextState.postIncidentReviewRecords?.['review:near-catastrophe-case-001']
+
+    expect(created?.milestoneTimings).toBeDefined()
+
+    const beforeMirror = getPostIncidentReviewMirrorView(nextState)
+    const beforeRecord = beforeMirror.qualifyingIncidentRecords[0]
+
+    expect(beforeRecord?.discoveryWeekLabel).toBe(
+      formatExpectedMilestoneWeekLabel(created!.milestoneTimings!.discoveryWeek)
+    )
+    expect(beforeRecord?.responseWeekLabel).toBe(
+      formatExpectedMilestoneWeekLabel(created!.milestoneTimings!.responseWeek)
+    )
+    expect(beforeRecord?.containmentWeekLabel).toBe('—')
+    expect(beforeRecord?.recoveryWeekLabel).toBe('—')
+    expect(beforeRecord?.reportingWeekLabel).toBe(
+      formatExpectedMilestoneWeekLabel(created!.milestoneTimings!.reportingWeek)
+    )
+    expect(beforeRecord?.redacted).toBe(false)
+
+    nextState.postIncidentReviewRecords = {
+      ...nextState.postIncidentReviewRecords,
+      'review:near-catastrophe-case-001': {
+        ...created!,
+        redactedFields: ['milestoneTimings'],
+      },
+    }
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const mirrorRecord = mirrorView.qualifyingIncidentRecords[0]
+
+    expectRedactedMilestoneMirrorLabels(mirrorRecord)
+    expect(mirrorRecord?.redacted).toBe(true)
+    expect(mirrorRecord?.discoveryWeekLabel).not.toBe(
+      formatExpectedMilestoneWeekLabel(created!.milestoneTimings!.discoveryWeek)
     )
   })
 


### PR DESCRIPTION
## Summary

- Extend slice 23 redacted `milestoneTimings` mirror label integration pattern to qualifying case-closeout (slice 7) and near-catastrophe (slice 9) `advanceWeek` paths
- Inject `redactedFields: ['milestoneTimings']` on post-advance records and assert all five milestone week labels + span render `—` via `getPostIncidentReviewMirrorView`
- Near-catastrophe test contrasts partial profile (populated `W…` + missing `—`) before redaction vs full em-dash after redaction

## Linear mapping

- **Slice:** [SPE-2393](https://linear.app/spectranoir/issue/SPE-2393) — Post-incident review redacted milestoneTimings mirror labels on qualifying advanceWeek paths (slice 24)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (**stays open**)

## What shipped

Tests-only integration assertions; no mirror or domain code changes.

## Validation

- `npm run test:run -- src/test/advanceWeek.postIncidentReview.integration.test.ts src/features/operations/postIncidentReviewMirrorView.test.ts` (49 passed)
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-24.md` (new)
- `planning/backlog.md` (handoff base SHA)