### PR TITLE
test(SPE-2395): audit-cycle recurrence compliance mirror integration (slice 26)

### DIFF
--- a/planning/post-incident-review-registry-slice-26.md
+++ b/planning/post-incident-review-registry-slice-26.md
@@ -1,0 +1,86 @@
+# SPE-868 — Audit-cycle recurrence / compliance adequacy mirror labels on qualifying advanceWeek paths (slice 26)
+
+One-page implementation plan. Linear: child [SPE-2395](https://linear.app/spectranoir/issue/SPE-2395) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 25 (`planning/post-incident-review-registry-slice-25.md`, PR #2657 / [SPE-2394](https://linear.app/spectranoir/issue/SPE-2394)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2395 — Audit-cycle recurrence / compliance adequacy mirror labels on qualifying advanceWeek paths (slice 26)](https://linear.app/spectranoir/issue/SPE-2395) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-audit-cycle-recurrence-slice-26`                                                                  |
+| **Base `main` SHA** | `3f05ac58`                                                                                          |
+
+## Goal
+
+Extend integration tests to assert `recurrenceObservedLabel`, `reviewRouteLabel`, and `closureOutcomeLabel` (plus summary recurrence/audit-route counts) on qualifying cycle-4 closeout (slice 4), case closeout (slice 7), near-catastrophe (slice 9), and dual-path advanceWeek fixtures.
+
+## Prerequisite (on `main` @ `3f05ac58`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Redacted score integration | slice 25 (SPE-2394)                                              |
+| Qualifying case closeout integration | slice 7 (SPE-2376)                                       |
+| Near-catastrophe integration | slice 9 (SPE-2378)                                             |
+| Cycle-4 closeout integration | slice 4 (SPE-2373)                                             |
+| Dual-path fixture | `makeDualPathCloseoutAndNearCatastropheState` (slices 14/17/19) |
+| Recurrence/compliance projection | `projectPostIncidentReviewSummary` resolve gates               |
+| Mirror label wiring | `formatRecurrenceObserved`, `formatPostIncidentReviewEnumLabel` |
+
+## Test contract (this slice)
+
+| Surface | Assertion |
+| --- | --- |
+| Cycle-4 closeout path | Post-advance `review:cycle-4-closeout` → `recurrenceObservedLabel` `Yes`; `reviewRouteLabel` `Internal Command`; `closureOutcomeLabel` `Contained`; summary `recurrenceObservedCount` includes stub + orchestration rows |
+| Qualifying case closeout path | Post-advance `review:case-case-001-closeout` → `No` / `Internal Command` / `Contained`; summary counts reflect no external-audit route |
+| Near-catastrophe path | Post-advance `review:near-catastrophe-case-001` → `No` / `External Audit` / `Administratively Cleared`; summary `externalAuditRouteCount` `1` |
+| Redaction | Inject `redactedFields: ['recurrenceObserved']` → label `—`; contrast populated `Yes`/`No` before injection |
+| Dual-path week | `makeDualPathCloseoutAndNearCatastropheState` → each qualifying row carries independent recurrence/compliance labels; re-advance does not duplicate rows |
+
+| Rule | Detail |
+| --- | --- |
+| **Recurrence vs missing** | Populated boolean renders `Yes`/`No`; redaction hides populated values as `—` |
+| **Compliance adequacy** | Near-catastrophe external-audit route + administratively cleared outcome mirror on advanceWeek path |
+| **Summary counts** | Include seeded `POST_INCIDENT_REVIEW_STUB_REGISTRY` baseline (`recurrenceObservedCount` 1, `externalAuditRouteCount` 1) before orchestration deltas |
+| **No code changes** | Mirror and domain behavior already correct from slices 3–7 unless tests expose a bug |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| Integration recurrence/compliance mirror label assertions on slices 4 + 7 + 9 | Domain derivation logic changes               |
+| Dual-path recurrence/compliance integration assertion              | Mirror or domain code changes                 |
+| Slice doc (this file) + backlog handoff on ship                  | Action/recommendation ticks                   |
+|                                                                  | SPE-1097 authority checks                     |
+|                                                                  | SPE-1310 parent closure                       |
+|                                                                  | Full SPE-868 parent closure                   |
+
+## Acceptance
+
+- [x] Cycle-4 closeout path asserts recurrence observed + compliance route/outcome mirror labels
+- [x] Qualifying case closeout path asserts recurrence/compliance mirror labels
+- [x] Near-catastrophe path asserts external-audit compliance adequacy mirror labels
+- [x] Redacted `recurrenceObserved` renders em-dash with contrast vs populated labels
+- [x] Dual-path week asserts independent recurrence/compliance labels per row
+- [x] Slice 22–25 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Tests  | `src/test/advanceWeek.postIncidentReview.integration.test.ts`         |
+| Plan   | `planning/post-incident-review-registry-slice-26.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Authority-route redaction (SPE-1097) | SPE-1097 | Out of recurrence/compliance mirror boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Integration assertion slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-25.md`
+- `planning/post-incident-review-registry-slice-4.md`
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-9.md`

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../domain/postIncidentReviewWeeklyOrchestration'
 import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../domain/postIncidentReviewFollowOnArtifact'
 import {
+  formatPostIncidentReviewEnumLabel,
   getPostIncidentReviewMirrorView,
   type PostIncidentReviewMirrorRecordView,
 } from '../features/operations/postIncidentReviewMirrorView'
@@ -74,6 +75,25 @@ function expectRedactedScoreMirrorLabels(
 ): void {
   expect(record?.procedureAdherenceScoreLabel).toBe('—')
   expect(record?.confidenceLabel).toBe('—')
+}
+
+function expectRecurrenceComplianceMirrorLabels(
+  record: PostIncidentReviewMirrorRecordView | undefined,
+  expected: {
+    reviewRouteLabel: string
+    closureOutcomeLabel: string
+    recurrenceObservedLabel: string
+  }
+): void {
+  expect(record?.reviewRouteLabel).toBe(expected.reviewRouteLabel)
+  expect(record?.closureOutcomeLabel).toBe(expected.closureOutcomeLabel)
+  expect(record?.recurrenceObservedLabel).toBe(expected.recurrenceObservedLabel)
+}
+
+function expectRedactedRecurrenceObservedMirrorLabel(
+  record: PostIncidentReviewMirrorRecordView | undefined
+): void {
+  expect(record?.recurrenceObservedLabel).toBe('—')
 }
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -182,6 +202,14 @@ describe('advanceWeek post-incident review integration (SPE-868 slice 4)', () =>
       created!.milestoneTimings!,
       projectPostIncidentReviewSummary(created!).milestoneSpanWeeks
     )
+    expectRecurrenceComplianceMirrorLabels(cycleMirrorRecord, {
+      reviewRouteLabel: 'Internal Command',
+      closureOutcomeLabel: 'Contained',
+      recurrenceObservedLabel: 'Yes',
+    })
+    expect(created?.recurrenceObserved).toBe(true)
+    expect(mirrorView.summary.recurrenceObservedCount).toBe(2)
+    expect(mirrorView.summary.externalAuditRouteCount).toBe(1)
   })
 
   it('renders redacted milestoneTimings mirror labels on cycle-4 closeout path (SPE-868 slice 23)', () => {
@@ -349,6 +377,14 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
       created!.milestoneTimings!,
       projectPostIncidentReviewSummary(created!).milestoneSpanWeeks
     )
+    expectRecurrenceComplianceMirrorLabels(mirrorView.qualifyingIncidentRecords[0], {
+      reviewRouteLabel: 'Internal Command',
+      closureOutcomeLabel: 'Contained',
+      recurrenceObservedLabel: 'No',
+    })
+    expect(created?.recurrenceObserved).toBe(false)
+    expect(mirrorView.summary.recurrenceObservedCount).toBe(1)
+    expect(mirrorView.summary.externalAuditRouteCount).toBe(1)
   })
 
   it('renders redacted milestoneTimings mirror labels on qualifying case closeout path (SPE-868 slice 24)', () => {
@@ -657,6 +693,14 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
       created!.milestoneTimings!,
       projectPostIncidentReviewSummary(created!).milestoneSpanWeeks
     )
+    expectRecurrenceComplianceMirrorLabels(mirrorView.qualifyingIncidentRecords[0], {
+      reviewRouteLabel: 'External Audit',
+      closureOutcomeLabel: 'Administratively Cleared',
+      recurrenceObservedLabel: 'No',
+    })
+    expect(created?.recurrenceObserved).toBe(false)
+    expect(mirrorView.summary.recurrenceObservedCount).toBe(1)
+    expect(mirrorView.summary.externalAuditRouteCount).toBe(2)
   })
 
   it('renders redacted milestoneTimings mirror labels on near-catastrophe path (SPE-868 slice 24)', () => {
@@ -1374,5 +1418,139 @@ describe('advanceWeek post-incident review redacted score mirror integration (SP
     expect(twiceMirror.qualifyingIncidentRecords).toHaveLength(2)
     expect(twiceMirror.summary.qualifyingCaseCloseoutCount).toBe(1)
     expect(twiceMirror.summary.qualifyingNearCatastropheCount).toBe(1)
+  })
+})
+
+describe('advanceWeek post-incident review recurrence compliance mirror integration (SPE-868 slice 26)', () => {
+  it('renders redacted recurrenceObserved mirror label on cycle-4 closeout path', () => {
+    const state = stateWithFollowOnTrainingEnqueueReady(createStartingState())
+    freezeCasesForQuietWeek(state)
+    state.week = 52
+    state.recurrentCatastropheRecords = {
+      [RECURRENCE_DAMAGE_LEDGER_FIXTURE.id]: {
+        ...RECURRENCE_DAMAGE_LEDGER_FIXTURE,
+        postIncidentReviewRefs: ['review:cycle-3-closeout', 'review:cycle-4-closeout'],
+      },
+    }
+
+    const nextState = advanceWeek(state)
+    const created = nextState.postIncidentReviewRecords?.['review:cycle-4-closeout']
+
+    expect(created?.recurrenceObserved).toBe(true)
+
+    const beforeMirror = getPostIncidentReviewMirrorView(nextState)
+    const beforeRecord = beforeMirror.records.find(
+      (record) => record.id === 'review:cycle-4-closeout'
+    )
+
+    expect(beforeRecord?.recurrenceObservedLabel).toBe('Yes')
+    expect(beforeRecord?.redacted).toBe(false)
+
+    nextState.postIncidentReviewRecords = {
+      ...nextState.postIncidentReviewRecords,
+      'review:cycle-4-closeout': {
+        ...created!,
+        redactedFields: ['recurrenceObserved'],
+      },
+    }
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const mirrorRecord = mirrorView.records.find((record) => record.id === 'review:cycle-4-closeout')
+
+    expectRedactedRecurrenceObservedMirrorLabel(mirrorRecord)
+    expect(mirrorRecord?.redacted).toBe(true)
+    expect(mirrorRecord?.recurrenceObservedLabel).not.toBe('Yes')
+    expect(mirrorRecord?.reviewRouteLabel).toBe('Internal Command')
+    expect(mirrorRecord?.closureOutcomeLabel).toBe('Contained')
+    expect(mirrorView.summary.recurrenceObservedCount).toBe(1)
+  })
+
+  it('renders redacted recurrenceObserved mirror label on near-catastrophe path', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+    const created = nextState.postIncidentReviewRecords?.['review:near-catastrophe-case-001']
+
+    expect(created?.recurrenceObserved).toBe(false)
+
+    const beforeMirror = getPostIncidentReviewMirrorView(nextState)
+    const beforeRecord = beforeMirror.qualifyingIncidentRecords[0]
+
+    expect(beforeRecord?.recurrenceObservedLabel).toBe('No')
+    expect(beforeRecord?.reviewRouteLabel).toBe('External Audit')
+    expect(beforeRecord?.closureOutcomeLabel).toBe('Administratively Cleared')
+    expect(beforeRecord?.redacted).toBe(false)
+
+    nextState.postIncidentReviewRecords = {
+      ...nextState.postIncidentReviewRecords,
+      'review:near-catastrophe-case-001': {
+        ...created!,
+        redactedFields: ['recurrenceObserved'],
+      },
+    }
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const mirrorRecord = mirrorView.qualifyingIncidentRecords[0]
+
+    expectRedactedRecurrenceObservedMirrorLabel(mirrorRecord)
+    expect(mirrorRecord?.redacted).toBe(true)
+    expect(mirrorRecord?.recurrenceObservedLabel).not.toBe('No')
+    expect(mirrorRecord?.reviewRouteLabel).toBe('External Audit')
+    expect(mirrorRecord?.closureOutcomeLabel).toBe('Administratively Cleared')
+    expect(mirrorView.summary.recurrenceObservedCount).toBe(1)
+    expect(mirrorView.summary.externalAuditRouteCount).toBe(2)
+  })
+
+  it('mirrors independent recurrence and compliance labels on dual-path week without duplicating on re-advance', () => {
+    const state = makeDualPathCloseoutAndNearCatastropheState()
+
+    const once = advanceWeek(state)
+    const closeout = once.postIncidentReviewRecords?.['review:case-case-001-closeout']
+    const nearCatastrophe = once.postIncidentReviewRecords?.['review:near-catastrophe-case-002']
+
+    expect(closeout?.recurrenceObserved).toBe(false)
+    expect(nearCatastrophe?.recurrenceObserved).toBe(false)
+
+    const beforeMirror = getPostIncidentReviewMirrorView(once)
+
+    expect(beforeMirror.summary.qualifyingCaseCloseoutCount).toBe(1)
+    expect(beforeMirror.summary.qualifyingNearCatastropheCount).toBe(1)
+    expect(beforeMirror.summary.recurrenceObservedCount).toBe(1)
+    expect(beforeMirror.summary.externalAuditRouteCount).toBe(2)
+    expect(beforeMirror.qualifyingIncidentRecords).toHaveLength(2)
+
+    const closeoutMirror = beforeMirror.qualifyingIncidentRecords.find(
+      (record) => record.id === 'review:case-case-001-closeout'
+    )
+    const nearMirror = beforeMirror.qualifyingIncidentRecords.find(
+      (record) => record.id === 'review:near-catastrophe-case-002'
+    )
+
+    expectRecurrenceComplianceMirrorLabels(closeoutMirror, {
+      reviewRouteLabel: 'Internal Command',
+      closureOutcomeLabel: 'Contained',
+      recurrenceObservedLabel: 'No',
+    })
+    expectRecurrenceComplianceMirrorLabels(nearMirror, {
+      reviewRouteLabel: 'External Audit',
+      closureOutcomeLabel: 'Administratively Cleared',
+      recurrenceObservedLabel: 'No',
+    })
+    expect(formatPostIncidentReviewEnumLabel('external_audit')).toBe('External Audit')
+
+    const twice = advanceWeek(once)
+
+    expect(twice.postIncidentReviewRecords?.['review:case-case-001-closeout']).toBe(closeout)
+    expect(twice.postIncidentReviewRecords?.['review:near-catastrophe-case-002']).toBe(
+      nearCatastrophe
+    )
+
+    const twiceMirror = getPostIncidentReviewMirrorView(twice)
+
+    expect(twiceMirror.qualifyingIncidentRecords).toHaveLength(2)
+    expect(twiceMirror.summary.qualifyingCaseCloseoutCount).toBe(1)
+    expect(twiceMirror.summary.qualifyingNearCatastropheCount).toBe(1)
+    expect(twiceMirror.summary.recurrenceObservedCount).toBe(1)
+    expect(twiceMirror.summary.externalAuditRouteCount).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary

- Extend `advanceWeek.postIncidentReview.integration.test.ts` with recurrence/compliance adequacy mirror label assertions on cycle-4 closeout, qualifying case closeout, near-catastrophe, and dual-path advanceWeek fixtures.
- Add helpers `expectRecurrenceComplianceMirrorLabels` and `expectRedactedRecurrenceObservedMirrorLabel`; redaction contrast tests for `recurrenceObserved`.
- Add `planning/post-incident-review-registry-slice-26.md`.

## Linear

- **Slice:** [SPE-2395](https://linear.app/spectranoir/issue/SPE-2395)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) (stays open / Backlog)

## Validation

- `npm run test:run -- src/test/advanceWeek.postIncidentReview.integration.test.ts`
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-26.md`
- `planning/backlog.md` (ship row — follow-up commit after merge if needed)

## Parent status

Parent SPE-868 remains open; this slice is integration assertions only.