### PR TITLE
test(SPE-2396): reviewRoute/closureOutcome redaction mirror integration (slice 27)

### DIFF
--- a/planning/post-incident-review-registry-slice-27.md
+++ b/planning/post-incident-review-registry-slice-27.md
@@ -1,0 +1,79 @@
+# SPE-868 — Post-incident review redacted reviewRoute/closureOutcome mirror labels on qualifying advanceWeek paths (slice 27)
+
+One-page implementation plan. Linear: child [SPE-2396](https://linear.app/spectranoir/issue/SPE-2396) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 26 (`planning/post-incident-review-registry-slice-26.md`, PR #2659 / [SPE-2395](https://linear.app/spectranoir/issue/SPE-2395)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2396 — Post-incident review redacted reviewRoute/closureOutcome mirror labels on qualifying advanceWeek paths (slice 27)](https://linear.app/spectranoir/issue/SPE-2396) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (stays open) |
+| **Branch** | `spe-868-review-route-redaction-slice-27`                                                                  |
+| **Base `main` SHA** | `829ce083`                                                                                          |
+
+## Goal
+
+Extend integration tests to assert em-dash `reviewRouteLabel` and `closureOutcomeLabel` when `redactedFields` includes `reviewRoute` and/or `closureOutcome` on qualifying case closeout (slice 7), near-catastrophe (slice 9), and dual-path advanceWeek fixtures.
+
+## Prerequisite (on `main` @ `829ce083`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Recurrence/compliance integration | slice 26 (SPE-2395)                                              |
+| Qualifying case closeout integration | slice 7 (SPE-2376)                                       |
+| Near-catastrophe integration | slice 9 (SPE-2378)                                             |
+| Dual-path fixture | `makeDualPathCloseoutAndNearCatastropheState` (slices 14/17/19) |
+| Redaction contrast patterns | slices 23–26 helpers                                               |
+
+## Test contract (this slice)
+
+| Surface | Assertion |
+| --- | --- |
+| Qualifying case closeout path | Post-advance `review:case-case-001-closeout` with injected `redactedFields: ['reviewRoute', 'closureOutcome']` → both labels `—`; contrast populated `Internal Command` / `Contained` before injection |
+| Near-catastrophe path | Post-advance `review:near-catastrophe-case-001` with injected redaction → route/outcome labels `—`; recurrence/score labels remain visible under partial profile |
+| Dual-path week | `makeDualPathCloseoutAndNearCatastropheState` → inject redaction on both qualifying rows → each row route/outcome `—` independently; re-advance does not duplicate rows |
+| Summary counts | Redacted `reviewRoute` excludes row from `externalAuditRouteCount`; stub baseline awareness unchanged |
+
+| Rule | Detail |
+| --- | --- |
+| **Redaction vs missing** | Redaction hides populated route/outcome as `—`; invalid enum fallbacks remain out of slice unless tests expose a bug |
+| **Partial redaction** | Redacting route/outcome leaves recurrence/score/milestone labels visible when not in `redactedFields` |
+| **No scope creep** | Domain/mirror changes only if integration tests expose missing projection gates |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| Integration reviewRoute/closureOutcome redaction mirror assertions on slices 7 + 9 | Action/recommendation ticks                   |
+| Dual-path route/outcome redaction integration assertion            | SPE-1097 authority checks                     |
+| Projection/mirror redaction gates if tests expose gap             | SPE-1310 parent closure                       |
+| Slice doc (this file) + backlog handoff on ship                  | Full SPE-868 parent closure                   |
+
+## Acceptance
+
+- [x] Qualifying case closeout path asserts redacted reviewRoute/closureOutcome mirror labels with contrast
+- [x] Near-catastrophe path asserts redacted route/outcome labels; partial profile leaves other labels legible
+- [x] Dual-path week asserts independent route/outcome redaction per row without row duplication on re-advance
+- [x] Slice 22–26 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/postIncidentReviewRegistry.ts` (if tests expose gap)    |
+| Mirror | `src/features/operations/postIncidentReviewMirrorView.ts`, `recurrentCatastrophePostIncidentReviewLinksView.ts` (if needed) |
+| Tests  | `src/test/advanceWeek.postIncidentReview.integration.test.ts`         |
+| Plan   | `planning/post-incident-review-registry-slice-27.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Authority-route redaction (SPE-1097) | SPE-1097 | Out of route/outcome mirror boundary |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Integration assertion slice only; parent stays open |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-26.md`
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-9.md`

--- a/src/domain/postIncidentReviewRegistry.ts
+++ b/src/domain/postIncidentReviewRegistry.ts
@@ -120,8 +120,8 @@ export interface PostIncidentReviewSummaryProjectionPolicy {
 export interface PostIncidentReviewSummaryProjection {
   readonly reviewId: PostIncidentReviewId
   readonly label: string
-  readonly reviewRoute: PostIncidentReviewRoute
-  readonly closureOutcome: PostIncidentClosureOutcome
+  readonly reviewRoute: PostIncidentReviewRoute | null
+  readonly closureOutcome: PostIncidentClosureOutcome | null
   readonly milestoneSpanWeeks: number | null
   readonly procedureAdherenceScore: number | null
   readonly recurrenceObserved: boolean | null
@@ -436,6 +436,42 @@ function resolveRecurrenceObserved(
   return typeof record.recurrenceObserved === 'boolean' ? record.recurrenceObserved : null
 }
 
+function resolveReviewRoute(
+  record: PostIncidentReviewRecord,
+  policy: PostIncidentReviewSummaryProjectionPolicy
+): PostIncidentReviewRoute | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (
+    redactedFields.has('reviewRoute') ||
+    (policy.redactUnknown === true && unknownFields.includes('reviewRoute'))
+  ) {
+    return null
+  }
+
+  return isPostIncidentReviewRoute(record.reviewRoute) ? record.reviewRoute : 'internal_command'
+}
+
+function resolveClosureOutcome(
+  record: PostIncidentReviewRecord,
+  policy: PostIncidentReviewSummaryProjectionPolicy
+): PostIncidentClosureOutcome | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (
+    redactedFields.has('closureOutcome') ||
+    (policy.redactUnknown === true && unknownFields.includes('closureOutcome'))
+  ) {
+    return null
+  }
+
+  return isPostIncidentClosureOutcome(record.closureOutcome)
+    ? record.closureOutcome
+    : 'contained'
+}
+
 // ---------------------------------------------------------------------------
 // Type guards
 // ---------------------------------------------------------------------------
@@ -546,28 +582,30 @@ export function projectPostIncidentReviewSummary(
   const milestoneSpanWeeks = resolveMilestoneSpanWeeks(record, policy)
   const procedureAdherenceScore = resolveProcedureAdherenceScore(record, policy)
   const recurrenceObserved = resolveRecurrenceObserved(record, policy)
+  const reviewRoute = resolveReviewRoute(record, policy)
+  const closureOutcome = resolveClosureOutcome(record, policy)
 
   const redacted =
     redactedFields.has('milestoneTimings') ||
     redactedFields.has('procedureAdherenceScore') ||
     redactedFields.has('recurrenceObserved') ||
+    redactedFields.has('reviewRoute') ||
+    redactedFields.has('closureOutcome') ||
     redactedFields.has('confidence') ||
     (policy.redactUnknown === true &&
       (unknownFields.includes('milestoneTimings') ||
         unknownFields.includes('procedureAdherenceScore') ||
         unknownFields.includes('recurrenceObserved') ||
+        unknownFields.includes('reviewRoute') ||
+        unknownFields.includes('closureOutcome') ||
         unknownFields.includes('confidence'))) ||
     (confidence === null && record.confidence !== undefined && policy.minimumConfidence !== undefined)
 
   return Object.freeze({
     reviewId,
     label: normalizeToken(record.label) || '(unknown)',
-    reviewRoute: isPostIncidentReviewRoute(record.reviewRoute)
-      ? record.reviewRoute
-      : 'internal_command',
-    closureOutcome: isPostIncidentClosureOutcome(record.closureOutcome)
-      ? record.closureOutcome
-      : 'contained',
+    reviewRoute,
+    closureOutcome,
     milestoneSpanWeeks,
     procedureAdherenceScore,
     recurrenceObserved,

--- a/src/features/operations/postIncidentReviewMirrorView.ts
+++ b/src/features/operations/postIncidentReviewMirrorView.ts
@@ -66,6 +66,14 @@ export function formatPostIncidentReviewEnumLabel(value: string): string {
     .join(' ')
 }
 
+export function formatOptionalPostIncidentReviewEnumLabel(value: string | null): string {
+  if (value === null) {
+    return '—'
+  }
+
+  return formatPostIncidentReviewEnumLabel(value)
+}
+
 function listPersistedRecords(game: GameState): PostIncidentReviewRecord[] {
   const map = game.postIncidentReviewRecords ?? {}
   return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
@@ -214,8 +222,8 @@ function toRecordView(record: PostIncidentReviewRecord): PostIncidentReviewMirro
     sourceLabel: sourceGroupLabel(sourceGroup),
     linkedCaseIdLabel: linkedCaseId || '—',
     orchestrationWeekLabel: orchestrationWeek === undefined ? '—' : `W${orchestrationWeek}`,
-    reviewRouteLabel: formatPostIncidentReviewEnumLabel(projection.reviewRoute),
-    closureOutcomeLabel: formatPostIncidentReviewEnumLabel(projection.closureOutcome),
+    reviewRouteLabel: formatOptionalPostIncidentReviewEnumLabel(projection.reviewRoute),
+    closureOutcomeLabel: formatOptionalPostIncidentReviewEnumLabel(projection.closureOutcome),
     milestoneSpanWeeksLabel: formatMilestoneSpanWeeks(projection.milestoneSpanWeeks),
     discoveryWeekLabel: formatMilestoneWeek(record, 'discoveryWeek', milestoneTimingsRedacted),
     responseWeekLabel: formatMilestoneWeek(record, 'responseWeek', milestoneTimingsRedacted),

--- a/src/features/operations/recurrentCatastrophePostIncidentReviewLinksView.ts
+++ b/src/features/operations/recurrentCatastrophePostIncidentReviewLinksView.ts
@@ -4,7 +4,7 @@ import {
   validateRecurrentCatastrophePostIncidentReviewRefs,
   type RecurrentCatastrophePostIncidentReviewLinkSummary,
 } from '../../domain/recurrentCatastrophePostIncidentReviewLinks'
-import { formatPostIncidentReviewEnumLabel } from './postIncidentReviewMirrorView'
+import { formatOptionalPostIncidentReviewEnumLabel } from './postIncidentReviewMirrorView'
 
 export interface RecurrentCatastrophePostIncidentReviewLinkRecordView {
   recordId: string
@@ -79,8 +79,8 @@ function toLinkItemView(
   return Object.freeze({
     reviewRefLabel: link.reviewRef,
     reviewIdLabel: link.reviewId,
-    reviewRouteLabel: formatPostIncidentReviewEnumLabel(summary.reviewRoute),
-    closureOutcomeLabel: formatPostIncidentReviewEnumLabel(summary.closureOutcome),
+    reviewRouteLabel: formatOptionalPostIncidentReviewEnumLabel(summary.reviewRoute),
+    closureOutcomeLabel: formatOptionalPostIncidentReviewEnumLabel(summary.closureOutcome),
     milestoneSpanWeeksLabel: formatMilestoneSpanWeeks(summary.milestoneSpanWeeks),
     recurrenceObservedLabel: formatRecurrenceObserved(summary.recurrenceObserved),
     procedureAdherenceScoreLabel: formatUnitScore(summary.procedureAdherenceScore),

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -96,6 +96,13 @@ function expectRedactedRecurrenceObservedMirrorLabel(
   expect(record?.recurrenceObservedLabel).toBe('—')
 }
 
+function expectRedactedReviewRouteClosureOutcomeMirrorLabels(
+  record: PostIncidentReviewMirrorRecordView | undefined
+): void {
+  expect(record?.reviewRouteLabel).toBe('—')
+  expect(record?.closureOutcomeLabel).toBe('—')
+}
+
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
   for (const currentCase of Object.values(state.cases)) {
     currentCase.status = 'open'
@@ -1552,5 +1559,146 @@ describe('advanceWeek post-incident review recurrence compliance mirror integrat
     expect(twiceMirror.summary.qualifyingNearCatastropheCount).toBe(1)
     expect(twiceMirror.summary.recurrenceObservedCount).toBe(1)
     expect(twiceMirror.summary.externalAuditRouteCount).toBe(2)
+  })
+})
+
+describe('advanceWeek post-incident review reviewRoute closureOutcome redaction mirror integration (SPE-868 slice 27)', () => {
+  it('renders redacted reviewRoute and closureOutcome mirror labels on qualifying case closeout path', () => {
+    const state = makeQualifyingResolvedCaseState()
+
+    const nextState = advanceWeek(state)
+    const created = nextState.postIncidentReviewRecords?.['review:case-case-001-closeout']
+
+    expect(created?.reviewRoute).toBe('internal_command')
+    expect(created?.closureOutcome).toBe('contained')
+
+    const beforeMirror = getPostIncidentReviewMirrorView(nextState)
+    const beforeRecord = beforeMirror.qualifyingIncidentRecords[0]
+
+    expect(beforeRecord?.reviewRouteLabel).toBe('Internal Command')
+    expect(beforeRecord?.closureOutcomeLabel).toBe('Contained')
+    expect(beforeRecord?.redacted).toBe(false)
+
+    nextState.postIncidentReviewRecords = {
+      ...nextState.postIncidentReviewRecords,
+      'review:case-case-001-closeout': {
+        ...created!,
+        redactedFields: ['reviewRoute', 'closureOutcome'],
+      },
+    }
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const mirrorRecord = mirrorView.qualifyingIncidentRecords[0]
+
+    expectRedactedReviewRouteClosureOutcomeMirrorLabels(mirrorRecord)
+    expect(mirrorRecord?.redacted).toBe(true)
+    expect(mirrorRecord?.reviewRouteLabel).not.toBe('Internal Command')
+    expect(mirrorRecord?.closureOutcomeLabel).not.toBe('Contained')
+    expect(mirrorRecord?.recurrenceObservedLabel).toBe('No')
+    expect(mirrorRecord?.procedureAdherenceScoreLabel).toBe('0.68')
+    expect(mirrorRecord?.confidenceLabel).toBe('0.72')
+    expect(mirrorView.summary.externalAuditRouteCount).toBe(1)
+  })
+
+  it('renders redacted reviewRoute and closureOutcome mirror labels on near-catastrophe path', () => {
+    const state = makeNearCatastropheDeadlineEscalationState()
+
+    const nextState = advanceWeek(state)
+    const created = nextState.postIncidentReviewRecords?.['review:near-catastrophe-case-001']
+
+    expect(created?.reviewRoute).toBe('external_audit')
+    expect(created?.closureOutcome).toBe('administratively_cleared')
+
+    const beforeMirror = getPostIncidentReviewMirrorView(nextState)
+    const beforeRecord = beforeMirror.qualifyingIncidentRecords[0]
+
+    expect(beforeRecord?.reviewRouteLabel).toBe('External Audit')
+    expect(beforeRecord?.closureOutcomeLabel).toBe('Administratively Cleared')
+    expect(beforeRecord?.redacted).toBe(false)
+    expect(beforeMirror.summary.externalAuditRouteCount).toBe(2)
+
+    nextState.postIncidentReviewRecords = {
+      ...nextState.postIncidentReviewRecords,
+      'review:near-catastrophe-case-001': {
+        ...created!,
+        redactedFields: ['reviewRoute', 'closureOutcome'],
+      },
+    }
+
+    const mirrorView = getPostIncidentReviewMirrorView(nextState)
+    const mirrorRecord = mirrorView.qualifyingIncidentRecords[0]
+
+    expectRedactedReviewRouteClosureOutcomeMirrorLabels(mirrorRecord)
+    expect(mirrorRecord?.redacted).toBe(true)
+    expect(mirrorRecord?.reviewRouteLabel).not.toBe('External Audit')
+    expect(mirrorRecord?.closureOutcomeLabel).not.toBe('Administratively Cleared')
+    expect(mirrorRecord?.recurrenceObservedLabel).toBe('No')
+    expect(mirrorRecord?.procedureAdherenceScoreLabel).toBe('0.55')
+    expect(mirrorRecord?.confidenceLabel).toBe('0.61')
+    expect(mirrorView.summary.externalAuditRouteCount).toBe(1)
+    expect(mirrorView.summary.recurrenceObservedCount).toBe(1)
+  })
+
+  it('mirrors independent reviewRoute and closureOutcome redaction on dual-path week without duplicating on re-advance', () => {
+    const state = makeDualPathCloseoutAndNearCatastropheState()
+
+    const once = advanceWeek(state)
+    const closeout = once.postIncidentReviewRecords?.['review:case-case-001-closeout']
+    const nearCatastrophe = once.postIncidentReviewRecords?.['review:near-catastrophe-case-002']
+
+    expect(closeout?.reviewRoute).toBe('internal_command')
+    expect(nearCatastrophe?.reviewRoute).toBe('external_audit')
+
+    const beforeMirror = getPostIncidentReviewMirrorView(once)
+
+    expect(beforeMirror.summary.externalAuditRouteCount).toBe(2)
+    expect(beforeMirror.qualifyingIncidentRecords).toHaveLength(2)
+
+    once.postIncidentReviewRecords = {
+      ...once.postIncidentReviewRecords,
+      'review:case-case-001-closeout': {
+        ...closeout!,
+        redactedFields: ['reviewRoute', 'closureOutcome'],
+      },
+      'review:near-catastrophe-case-002': {
+        ...nearCatastrophe!,
+        redactedFields: ['reviewRoute', 'closureOutcome'],
+      },
+    }
+
+    const redactedMirror = getPostIncidentReviewMirrorView(once)
+    const redactedCloseout = redactedMirror.qualifyingIncidentRecords.find(
+      (record) => record.id === 'review:case-case-001-closeout'
+    )
+    const redactedNear = redactedMirror.qualifyingIncidentRecords.find(
+      (record) => record.id === 'review:near-catastrophe-case-002'
+    )
+
+    expectRedactedReviewRouteClosureOutcomeMirrorLabels(redactedCloseout)
+    expectRedactedReviewRouteClosureOutcomeMirrorLabels(redactedNear)
+    expect(redactedCloseout?.recurrenceObservedLabel).toBe('No')
+    expect(redactedNear?.recurrenceObservedLabel).toBe('No')
+    expect(redactedMirror.summary.externalAuditRouteCount).toBe(1)
+
+    const redactedCloseoutRecord =
+      once.postIncidentReviewRecords?.['review:case-case-001-closeout']
+    const redactedNearRecord =
+      once.postIncidentReviewRecords?.['review:near-catastrophe-case-002']
+
+    const twice = advanceWeek(once)
+
+    expect(twice.postIncidentReviewRecords?.['review:case-case-001-closeout']).toBe(
+      redactedCloseoutRecord
+    )
+    expect(twice.postIncidentReviewRecords?.['review:near-catastrophe-case-002']).toBe(
+      redactedNearRecord
+    )
+
+    const twiceMirror = getPostIncidentReviewMirrorView(twice)
+
+    expect(twiceMirror.qualifyingIncidentRecords).toHaveLength(2)
+    expect(twiceMirror.summary.qualifyingCaseCloseoutCount).toBe(1)
+    expect(twiceMirror.summary.qualifyingNearCatastropheCount).toBe(1)
+    expect(twiceMirror.summary.externalAuditRouteCount).toBe(1)
   })
 })

--- a/src/test/postIncidentReviewRegistry.test.ts
+++ b/src/test/postIncidentReviewRegistry.test.ts
@@ -60,6 +60,18 @@ describe('postIncidentReviewRegistry (SPE-868 slice 5)', () => {
     expect(projection.redacted).toBe(true)
   })
 
+  it('redacts reviewRoute and closureOutcome when redactedFields includes them', () => {
+    const projection = projectPostIncidentReviewSummary({
+      ...RECURRENCE_CYCLE_CLOSEOUT_REVIEW_FIXTURE,
+      redactedFields: ['reviewRoute', 'closureOutcome'],
+    })
+
+    expect(projection.reviewRoute).toBeNull()
+    expect(projection.closureOutcome).toBeNull()
+    expect(projection.redacted).toBe(true)
+    expect(projection.recurrenceObserved).toBe(true)
+  })
+
   it('errors on franchise token in review label', () => {
     const result = validatePostIncidentReviewRecord(
       baseRecord({


### PR DESCRIPTION
## Summary

- Add projection gates for redacted `reviewRoute` / `closureOutcome` and mirror em-dash formatting when projection returns null.
- Add integration tests on qualifying case closeout, near-catastrophe, and dual-path advanceWeek fixtures asserting route/outcome label redaction contrast, partial profile legibility, and summary `externalAuditRouteCount` behavior.

## Linear

- **Slice:** [SPE-2396](https://linear.app/spectranoir/issue/SPE-2396)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) (stays open)

## What shipped

- `resolveReviewRoute` / `resolveClosureOutcome` in `postIncidentReviewRegistry.ts`
- `formatOptionalPostIncidentReviewEnumLabel` in mirror + links views
- Slice 27 integration describe block + `expectRedactedReviewRouteClosureOutcomeMirrorLabels` helper
- `planning/post-incident-review-registry-slice-27.md`

## Validation

- `npm run test:run -- src/test/advanceWeek.postIncidentReview.integration.test.ts src/test/postIncidentReviewRegistry.test.ts src/features/operations/postIncidentReviewMirrorView.test.ts src/features/operations/recurrentCatastrophePostIncidentReviewLinksView.test.ts`
- `npm run lint`

## Docs updated

- `planning/post-incident-review-registry-slice-27.md` (new)
- `planning/backlog.md` handoff deferred to merge commit

## Parent status

SPE-868 parent remains open (mirror integration slice only).