### PR TITLE
feat(SPE-2403): branching reward logic on qualifying closeout paths (slice 28)

### DIFF
--- a/planning/post-incident-review-registry-slice-28.md
+++ b/planning/post-incident-review-registry-slice-28.md
@@ -1,0 +1,85 @@
+# SPE-868 — Branching reward logic on qualifying closeout paths (slice 28)
+
+One-page implementation plan. Linear: child [SPE-2403](https://linear.app/spectranoir/issue/SPE-2403) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 27 (`planning/post-incident-review-registry-slice-27.md`, PR #2661 / [SPE-2396](https://linear.app/spectranoir/issue/SPE-2396)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2403 — Branching reward logic on qualifying closeout paths (slice 28)](https://linear.app/spectranoir/issue/SPE-2403) |
+| **Status** | **Ready for ship**                                                                                         |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (**Done** on Linear; owner-choice deferred slice) |
+| **Branch** | `spe-868-branching-reward-slice-28`                                                                        |
+| **Base `main` SHA** | `2355dbc0`                                                                                          |
+
+## Goal
+
+Pure domain branching reward logic on qualifying post-incident review closeout paths — derive how objectives were completed and persist bounded `reward_branch:` tokens without expanding registry schema.
+
+## Prerequisite (on `main` @ `2355dbc0`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Qualifying closeout creation | slice 7 (SPE-2376)                                              |
+| Follow-on artifact tokens | slice 10 (SPE-2379)                                               |
+| Mirror label stack | slices 22–27 (SPE-2391–SPE-2396)                                       |
+| Milestone derivation | slice 20 (SPE-2389)                                                |
+
+## Reward branch contract (this slice)
+
+| Closeout path | Derivation inputs | Branch |
+| --- | --- | --- |
+| Qualifying case closeout (`review:case-*-closeout`) | `closureOutcome === contained` and `procedureAdherenceScore >= 0.65` | `containment_priority` |
+| Qualifying case closeout (else) | lower adherence or non-contained outcome on closeout path | `contested_containment` |
+| Near-catastrophe (`review:near-catastrophe-*`) | external-audit / administratively-cleared template | `threshold_mitigation` |
+| Cycle closeout (`review:cycle-*-closeout`) | `recurrenceObserved === true` | `recurrence_softening` |
+| Cycle closeout (else) | recurrence not observed | `containment_priority` |
+
+| Rule | Detail |
+| --- | --- |
+| **Persistence** | `reward_branch:<branch>` token in `unknownFields`; no new registry fields |
+| **Apply tick** | `applyWeeklyPostIncidentReviewCloseoutRewardBranchTick` after creation, before follow-on artifact |
+| **Eligibility** | Orchestration-created reviews only; stub fixtures unchanged |
+| **Idempotency** | Re-advance same week does not append duplicate tokens |
+| **Mirror** | `closeoutRewardBranchLabel` via `derivePostIncidentCloseoutRewardBranch` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| `postIncidentReviewCloseoutRewardBranch.ts` derivation + apply tick | Registry schema expansion                     |
+| `advanceWeek` wire after creation tick                           | Mission triage / funding payout hooks         |
+| Mirror `closeoutRewardBranchLabel`                               | SPE-1310 lifecycle                            |
+| Domain unit tests + one case-closeout integration assertion      | Compliance audit cycling (deferred slice 20)  |
+| Slice doc (this file) + backlog handoff on ship                  | Full SPE-868 parent re-close                  |
+
+## Acceptance
+
+- [x] Registry exports deterministic closeout reward branch derivation for case, near-catastrophe, and cycle closeout paths
+- [x] `advanceWeek` applies reward-branch tick after creation; tokens sorted in `unknownFields`
+- [x] Domain unit tests cover all four branches + idempotency + stub exclusion
+- [x] Qualifying case closeout integration asserts `reward_branch:containment_priority` + mirror label
+- [x] Slice 7–27 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/postIncidentReviewCloseoutRewardBranch.ts`, `src/domain/sim/advanceWeek.ts` |
+| Mirror | `src/features/operations/postIncidentReviewMirrorView.ts`             |
+| Tests  | `src/test/postIncidentReviewCloseoutRewardBranch.test.ts`, `src/test/advanceWeek.postIncidentReview.integration.test.ts` |
+| Plan   | `planning/post-incident-review-registry-slice-28.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Mission payout / funding hooks reading reward branch | SPE-868 follow-up | Domain token only; no payout integration in slice 28 |
+| Compliance audit cycling | SPE-868 | Deferred per slice 20; not conflated with reward branching |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+| Full SPE-868 retrospective engine | SPE-868 | Branching reward slice only; parent already **Done** on Linear |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-20.md` (branching reward deferral)
+- `planning/post-incident-review-registry-slice-21.md` (branching reward deferral)
+- `planning/post-incident-review-registry-slice-7.md`
+- `planning/post-incident-review-registry-slice-10.md`

--- a/src/domain/postIncidentReviewCloseoutRewardBranch.ts
+++ b/src/domain/postIncidentReviewCloseoutRewardBranch.ts
@@ -1,0 +1,193 @@
+/**
+ * SPE-868 slice 28: deterministic branching reward logic on qualifying closeout paths.
+ *
+ * Derives how objectives were completed (containment quality, threshold mitigation,
+ * recurrence softening) and persists bounded `reward_branch:` tokens in `unknownFields`.
+ * Does not mutate mission payouts or registry schema fields.
+ */
+
+import { isOrchestrationCreatedPostIncidentReviewRecord } from './postIncidentReviewFollowOnArtifact'
+import {
+  validatePostIncidentReviewRecord,
+  type PostIncidentReviewRecord,
+  type PostIncidentReviewRecordsMap,
+} from './postIncidentReviewRegistry'
+
+const CASE_CLOSEOUT_REVIEW_REF_PATTERN = /^review:case-([a-zA-Z0-9_-]+)-closeout$/
+const NEAR_CATASTROPHE_REVIEW_REF_PATTERN = /^review:near-catastrophe-([a-zA-Z0-9_-]+)$/
+const CYCLE_CLOSEOUT_REVIEW_REF_PATTERN = /^review:cycle-(\d+)-closeout$/
+
+export const CLOSEOUT_REWARD_BRANCH_TOKEN_PREFIX = 'reward_branch:'
+
+/** How qualifying closeout objectives were completed — drives follow-on reward posture. */
+export type PostIncidentCloseoutRewardBranch =
+  | 'containment_priority'
+  | 'contested_containment'
+  | 'threshold_mitigation'
+  | 'recurrence_softening'
+
+export const POST_INCIDENT_CLOSEOUT_REWARD_BRANCHES: readonly PostIncidentCloseoutRewardBranch[] =
+  ['containment_priority', 'contested_containment', 'threshold_mitigation', 'recurrence_softening'] as const
+
+const CONTAINMENT_PRIORITY_ADHERENCE_THRESHOLD = 0.65
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function freezeRecord(record: PostIncidentReviewRecord): PostIncidentReviewRecord {
+  return Object.freeze({ ...record })
+}
+
+function hasCloseoutRewardBranchToken(fields: readonly string[]): boolean {
+  return fields.some((field) => field.startsWith(CLOSEOUT_REWARD_BRANCH_TOKEN_PREFIX))
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+/**
+ * Derives the deterministic reward branch for an orchestration-created qualifying closeout record.
+ * Returns undefined for stub fixtures and non-closeout refs.
+ */
+export function derivePostIncidentCloseoutRewardBranch(
+  record: PostIncidentReviewRecord
+): PostIncidentCloseoutRewardBranch | undefined {
+  if (!isOrchestrationCreatedPostIncidentReviewRecord(record)) {
+    return undefined
+  }
+
+  const reviewId = normalizeToken(record.id)
+  if (!reviewId) {
+    return undefined
+  }
+
+  if (NEAR_CATASTROPHE_REVIEW_REF_PATTERN.test(reviewId)) {
+    return 'threshold_mitigation'
+  }
+
+  if (CYCLE_CLOSEOUT_REVIEW_REF_PATTERN.test(reviewId)) {
+    return record.recurrenceObserved === true ? 'recurrence_softening' : 'containment_priority'
+  }
+
+  if (CASE_CLOSEOUT_REVIEW_REF_PATTERN.test(reviewId)) {
+    const adherence = isValidUnitScore(record.procedureAdherenceScore)
+      ? record.procedureAdherenceScore
+      : 0
+
+    if (record.closureOutcome === 'contained' && adherence >= CONTAINMENT_PRIORITY_ADHERENCE_THRESHOLD) {
+      return 'containment_priority'
+    }
+
+    return 'contested_containment'
+  }
+
+  return undefined
+}
+
+export function buildCloseoutRewardBranchToken(
+  branch: PostIncidentCloseoutRewardBranch
+): string {
+  return `${CLOSEOUT_REWARD_BRANCH_TOKEN_PREFIX}${branch}`
+}
+
+export function parseCloseoutRewardBranchToken(
+  token: string
+): PostIncidentCloseoutRewardBranch | undefined {
+  const normalized = normalizeToken(token)
+  if (!normalized.startsWith(CLOSEOUT_REWARD_BRANCH_TOKEN_PREFIX)) {
+    return undefined
+  }
+
+  const branch = normalized.slice(CLOSEOUT_REWARD_BRANCH_TOKEN_PREFIX.length)
+  return POST_INCIDENT_CLOSEOUT_REWARD_BRANCHES.includes(branch as PostIncidentCloseoutRewardBranch)
+    ? (branch as PostIncidentCloseoutRewardBranch)
+    : undefined
+}
+
+function appendCloseoutRewardBranchToReview(
+  record: PostIncidentReviewRecord,
+  branch: PostIncidentCloseoutRewardBranch
+): PostIncidentReviewRecord | undefined {
+  const unknownFields = [...asStringArray(record.unknownFields), buildCloseoutRewardBranchToken(branch)].sort(
+    (left, right) => left.localeCompare(right)
+  )
+
+  const candidate: PostIncidentReviewRecord = {
+    ...record,
+    unknownFields,
+  }
+
+  if (!validatePostIncidentReviewRecord(candidate).valid) {
+    return undefined
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Appends reward-branch tokens for reviews materialized since the prior map snapshot.
+ * Re-applying for the same week is idempotent; stub registry entries are unchanged.
+ */
+export function applyWeeklyPostIncidentReviewCloseoutRewardBranchTick(
+  priorReviews: PostIncidentReviewRecordsMap | null | undefined,
+  reviews: PostIncidentReviewRecordsMap | null | undefined
+): PostIncidentReviewRecordsMap {
+  const safePrior = priorReviews ?? {}
+  const safeReviews = reviews ?? {}
+  const reviewRefs = Object.keys(safeReviews)
+
+  if (reviewRefs.length === 0) {
+    return safeReviews
+  }
+
+  const materializedRefs = reviewRefs
+    .filter((reviewRef) => {
+      const record = safeReviews[reviewRef]
+      return record && !safePrior[reviewRef] && isOrchestrationCreatedPostIncidentReviewRecord(record)
+    })
+    .sort((left, right) => left.localeCompare(right))
+
+  if (materializedRefs.length === 0) {
+    return safeReviews
+  }
+
+  const next: PostIncidentReviewRecordsMap = { ...safeReviews }
+  let changed = false
+
+  for (const reviewRef of materializedRefs) {
+    const record = next[reviewRef]
+    if (!record) {
+      continue
+    }
+
+    const unknownFields = asStringArray(record.unknownFields)
+    if (hasCloseoutRewardBranchToken(unknownFields)) {
+      continue
+    }
+
+    const branch = derivePostIncidentCloseoutRewardBranch(record)
+    if (!branch) {
+      continue
+    }
+
+    const updated = appendCloseoutRewardBranchToReview(record, branch)
+    if (!updated) {
+      continue
+    }
+
+    next[reviewRef] = updated
+    changed = true
+  }
+
+  return changed ? next : safeReviews
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -287,6 +287,7 @@ import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInforma
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
 import { applyWeeklyRecurrentCatastropheTick } from '../recurrentCatastropheWeeklyOrchestration'
+import { applyWeeklyPostIncidentReviewCloseoutRewardBranchTick } from '../postIncidentReviewCloseoutRewardBranch'
 import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../postIncidentReviewFollowOnArtifact'
 import { applyWeeklyPostIncidentReviewFollowOnRecommendationActionTick } from '../postIncidentReviewFollowOnRecommendationAction'
 import { applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick } from '../postIncidentReviewFollowOnRecommendationRegistry'
@@ -4724,6 +4725,11 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       result.week,
       qualifyingIncidentReviewDrafts
     )
+    outputWeeklyState.postIncidentReviewRecords =
+      applyWeeklyPostIncidentReviewCloseoutRewardBranchTick(
+        currentPostIncidentReviewRecords,
+        outputWeeklyState.postIncidentReviewRecords
+      )
     outputWeeklyState.postIncidentReviewRecords = applyWeeklyPostIncidentReviewFollowOnArtifactTick(
       currentPostIncidentReviewRecords,
       outputWeeklyState.postIncidentReviewRecords

--- a/src/features/operations/postIncidentReviewMirrorView.ts
+++ b/src/features/operations/postIncidentReviewMirrorView.ts
@@ -1,5 +1,9 @@
 import type { GameState } from '../../domain/models'
 import {
+  derivePostIncidentCloseoutRewardBranch,
+  type PostIncidentCloseoutRewardBranch,
+} from '../../domain/postIncidentReviewCloseoutRewardBranch'
+import {
   POST_INCIDENT_REVIEW_STUB_REGISTRY,
   projectPostIncidentReviewSummary,
   type PostIncidentReviewRecord,
@@ -35,6 +39,7 @@ export interface PostIncidentReviewMirrorRecordView {
   reportingWeekLabel: string
   procedureAdherenceScoreLabel: string
   recurrenceObservedLabel: string
+  closeoutRewardBranchLabel: string
   confidenceLabel: string
   unknownFieldLabels: readonly string[]
   redacted: boolean
@@ -193,6 +198,16 @@ function formatRecurrenceObserved(value: boolean | null | undefined): string {
   return value ? 'Yes' : 'No'
 }
 
+export function formatCloseoutRewardBranchLabel(
+  branch: PostIncidentCloseoutRewardBranch | undefined
+): string {
+  if (!branch) {
+    return '—'
+  }
+
+  return formatPostIncidentReviewEnumLabel(branch)
+}
+
 function formatMilestoneWeek(
   record: PostIncidentReviewRecord,
   field: keyof NonNullable<PostIncidentReviewRecord['milestoneTimings']>,
@@ -232,6 +247,9 @@ function toRecordView(record: PostIncidentReviewRecord): PostIncidentReviewMirro
     reportingWeekLabel: formatMilestoneWeek(record, 'reportingWeek', milestoneTimingsRedacted),
     procedureAdherenceScoreLabel: formatUnitScore(projection.procedureAdherenceScore),
     recurrenceObservedLabel: formatRecurrenceObserved(projection.recurrenceObserved),
+    closeoutRewardBranchLabel: formatCloseoutRewardBranchLabel(
+      derivePostIncidentCloseoutRewardBranch(record)
+    ),
     confidenceLabel: formatConfidence(projection.confidence),
     unknownFieldLabels: Object.freeze([...projection.unknownFields]),
     redacted: projection.redacted,

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -16,6 +16,7 @@ import {
   applyWeeklyPostIncidentReviewCreationTick,
   resolveQualifyingIncidentReviewDraftsFromEventDrafts,
 } from '../domain/postIncidentReviewWeeklyOrchestration'
+import { applyWeeklyPostIncidentReviewCloseoutRewardBranchTick } from '../domain/postIncidentReviewCloseoutRewardBranch'
 import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../domain/postIncidentReviewFollowOnArtifact'
 import {
   formatPostIncidentReviewEnumLabel,
@@ -25,6 +26,29 @@ import {
 import { getPostIncidentReviewRecommendationActionMirrorView } from '../features/operations/postIncidentReviewRecommendationActionMirrorView'
 import { getPostIncidentReviewRecommendationMirrorView } from '../features/operations/postIncidentReviewRecommendationMirrorView'
 import { applyWeeklyRecurrentCatastropheTick } from '../domain/recurrentCatastropheWeeklyOrchestration'
+import type { PostIncidentReviewRecordsMap } from '../domain/postIncidentReviewRegistry'
+import type { RecurrentCatastropheRecordsMap } from '../domain/recurrentCatastropheAmeliorationRegistry'
+import type { QualifyingIncidentReviewDraft } from '../domain/postIncidentReviewWeeklyOrchestration'
+
+function applyDirectPostIncidentReviewTicks(
+  priorReviews: PostIncidentReviewRecordsMap | undefined,
+  catastrophes: RecurrentCatastropheRecordsMap | undefined,
+  week: number,
+  qualifyingDrafts: readonly QualifyingIncidentReviewDraft[]
+): PostIncidentReviewRecordsMap {
+  const created = applyWeeklyPostIncidentReviewCreationTick(
+    priorReviews,
+    catastrophes,
+    week,
+    qualifyingDrafts
+  )
+  const withRewardBranch = applyWeeklyPostIncidentReviewCloseoutRewardBranchTick(
+    priorReviews,
+    created
+  )
+
+  return applyWeeklyPostIncidentReviewFollowOnArtifactTick(priorReviews, withRewardBranch)
+}
 
 function formatExpectedMilestoneWeekLabel(week: number | undefined): string {
   if (week === undefined) {
@@ -184,6 +208,7 @@ describe('advanceWeek post-incident review integration (SPE-868 slice 4)', () =>
     expect(created?.unknownFields).toEqual([
       'follow_on:training-ref:threat-assessment',
       'orchestration_week:53',
+      'reward_branch:recurrence_softening',
     ])
     expect(nextState.trainingQueue).toHaveLength(1)
     expect(nextState.trainingQueue[0]?.trainingId).toBe('threat-assessment')
@@ -287,14 +312,11 @@ describe('advanceWeek post-incident review integration (SPE-868 slice 4)', () =>
       state.cases,
       nextState.week
     )
-    const directReviewTick = applyWeeklyPostIncidentReviewFollowOnArtifactTick(
+    const directReviewTick = applyDirectPostIncidentReviewTicks(
       state.postIncidentReviewRecords,
-      applyWeeklyPostIncidentReviewCreationTick(
-        state.postIncidentReviewRecords,
-        directRecurrenceTick,
-        nextState.week,
-        qualifyingDrafts
-      )
+      directRecurrenceTick,
+      nextState.week,
+      qualifyingDrafts
     )
 
     expect(nextState.recurrentCatastropheRecords).toEqual(directRecurrenceTick)
@@ -355,6 +377,7 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
     expect(created?.unknownFields).toEqual([
       'follow_on:training-ref:threat-assessment',
       `orchestration_week:${nextState.week}`,
+      'reward_branch:containment_priority',
     ])
     expect(nextState.trainingQueue).toHaveLength(1)
     expect(nextState.trainingQueue[0]?.trainingId).toBe('threat-assessment')
@@ -374,6 +397,9 @@ describe('advanceWeek qualifying incident review integration (SPE-868 slice 7)',
     expect(mirrorView.summary.qualifyingCaseCloseoutCount).toBe(1)
     expect(mirrorView.summary.qualifyingNearCatastropheCount).toBe(0)
     expect(mirrorView.qualifyingIncidentRecords[0]?.id).toBe('review:case-case-001-closeout')
+    expect(mirrorView.qualifyingIncidentRecords[0]?.closeoutRewardBranchLabel).toBe(
+      'Containment Priority'
+    )
     expect(mirrorView.qualifyingIncidentRecords[0]?.sourceLabel).toBe('Qualifying case closeout')
     expect(mirrorView.qualifyingIncidentRecords[0]?.linkedCaseIdLabel).toBe('case-001')
     expect(mirrorView.qualifyingIncidentRecords[0]?.orchestrationWeekLabel).toBe(
@@ -668,6 +694,7 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
     expect(created?.unknownFields).toEqual([
       'follow_on:recommendation-stub:near-catastrophe-case-001',
       `orchestration_week:${nextState.week}`,
+      'reward_branch:threshold_mitigation',
     ])
 
     const weeklyReport = nextState.reports[nextState.reports.length - 1]
@@ -861,14 +888,11 @@ describe('advanceWeek near-catastrophe review integration (SPE-868 slice 9)', ()
       state.cases,
       nextState.week
     )
-    const directReviewTick = applyWeeklyPostIncidentReviewFollowOnArtifactTick(
+    const directReviewTick = applyDirectPostIncidentReviewTicks(
       state.postIncidentReviewRecords,
-      applyWeeklyPostIncidentReviewCreationTick(
-        state.postIncidentReviewRecords,
-        state.recurrentCatastropheRecords,
-        nextState.week,
-        qualifyingDrafts
-      )
+      state.recurrentCatastropheRecords,
+      nextState.week,
+      qualifyingDrafts
     )
 
     expect(nextState.postIncidentReviewRecords?.['review:near-catastrophe-case-001']).toEqual(

--- a/src/test/postIncidentReviewCloseoutRewardBranch.test.ts
+++ b/src/test/postIncidentReviewCloseoutRewardBranch.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyWeeklyPostIncidentReviewCloseoutRewardBranchTick,
+  buildCloseoutRewardBranchToken,
+  derivePostIncidentCloseoutRewardBranch,
+  parseCloseoutRewardBranchToken,
+} from '../domain/postIncidentReviewCloseoutRewardBranch'
+import { POST_INCIDENT_REVIEW_STUB_REGISTRY } from '../domain/postIncidentReviewRegistry'
+import type { RecurrentCatastropheRecord } from '../domain/recurrentCatastropheAmeliorationRegistry'
+import {
+  applyWeeklyPostIncidentReviewCreationTick,
+  buildQualifyingIncidentReviewRecordForDraft,
+  type QualifyingIncidentReviewDraft,
+} from '../domain/postIncidentReviewWeeklyOrchestration'
+
+function baseCatastrophe(
+  overrides: Partial<RecurrentCatastropheRecord> = {}
+): RecurrentCatastropheRecord {
+  return {
+    id: 'recurrent-catastrophe:test-review-creation',
+    label: 'Test review creation catastrophe',
+    recurrenceCadence: 'monthly',
+    failureMode: 'manifestation',
+    preventionCeiling: 'unknown',
+    ameliorationTactics: [{ tactic: 'shielding', active: true }],
+    recurrenceCount: 2,
+    lastOccurrenceWeek: 12,
+    postIncidentReviewRefs: ['review:cycle-2-closeout'],
+    ...overrides,
+  }
+}
+
+describe('postIncidentReviewCloseoutRewardBranch (SPE-868 slice 28)', () => {
+  const caseCloseoutDraft: QualifyingIncidentReviewDraft = {
+    reviewRef: 'review:case-case-major-closeout',
+    caseId: 'case-major',
+    caseTitle: 'District breach',
+    trigger: 'case_resolved',
+    stage: 4,
+    kind: 'standard',
+    anchorWeek: 12,
+  }
+
+  const nearCatastropheDraft: QualifyingIncidentReviewDraft = {
+    reviewRef: 'review:near-catastrophe-case-major',
+    caseId: 'case-major',
+    caseTitle: 'District breach',
+    trigger: 'near_catastrophe_threshold',
+    stage: 4,
+    kind: 'raid',
+    anchorWeek: 12,
+  }
+
+  it('derives containment_priority for high-adherence qualifying case closeout', () => {
+    const record = buildQualifyingIncidentReviewRecordForDraft(caseCloseoutDraft, 12)
+
+    expect(derivePostIncidentCloseoutRewardBranch(record!)).toBe('containment_priority')
+  })
+
+  it('derives contested_containment when procedure adherence is below threshold', () => {
+    const record = buildQualifyingIncidentReviewRecordForDraft(caseCloseoutDraft, 12)
+    const contested = {
+      ...record!,
+      procedureAdherenceScore: 0.5,
+    }
+
+    expect(derivePostIncidentCloseoutRewardBranch(contested)).toBe('contested_containment')
+  })
+
+  it('derives threshold_mitigation for near-catastrophe closeout path', () => {
+    const record = buildQualifyingIncidentReviewRecordForDraft(nearCatastropheDraft, 12)
+
+    expect(derivePostIncidentCloseoutRewardBranch(record!)).toBe('threshold_mitigation')
+  })
+
+  it('derives recurrence_softening for cycle closeout with recurrence observed', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const catastrophes = {
+      [baseCatastrophe().id]: baseCatastrophe({
+        recurrenceCount: 4,
+        lastOccurrenceWeek: 53,
+        postIncidentReviewRefs: ['review:cycle-4-closeout'],
+      }),
+    }
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, catastrophes, 53)
+    const record = created['review:cycle-4-closeout']
+
+    expect(derivePostIncidentCloseoutRewardBranch(record!)).toBe('recurrence_softening')
+  })
+
+  it('returns undefined for stub registry fixtures without orchestration week token', () => {
+    const stub = POST_INCIDENT_REVIEW_STUB_REGISTRY['review:cycle-3-closeout']
+
+    expect(derivePostIncidentCloseoutRewardBranch(stub)).toBeUndefined()
+  })
+
+  it('builds and parses reward branch tokens', () => {
+    const token = buildCloseoutRewardBranchToken('containment_priority')
+
+    expect(token).toBe('reward_branch:containment_priority')
+    expect(parseCloseoutRewardBranchToken(token)).toBe('containment_priority')
+    expect(parseCloseoutRewardBranchToken('follow_on:training-ref:threat-assessment')).toBeUndefined()
+  })
+
+  it('appends one reward branch token when a qualifying review materializes', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [caseCloseoutDraft])
+    const next = applyWeeklyPostIncidentReviewCloseoutRewardBranchTick(prior, created)
+    const record = next['review:case-case-major-closeout']
+
+    expect(record?.unknownFields).toEqual([
+      'orchestration_week:12',
+      'reward_branch:containment_priority',
+    ])
+  })
+
+  it('is idempotent when re-run for the same materialized review', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [caseCloseoutDraft])
+    const once = applyWeeklyPostIncidentReviewCloseoutRewardBranchTick(prior, created)
+    const twice = applyWeeklyPostIncidentReviewCloseoutRewardBranchTick(once, once)
+
+    expect(twice).toBe(once)
+    expect(twice['review:case-case-major-closeout']?.unknownFields).toEqual([
+      'orchestration_week:12',
+      'reward_branch:containment_priority',
+    ])
+  })
+
+  it('derives the same branch deterministically across repeated calls', () => {
+    const record = buildQualifyingIncidentReviewRecordForDraft(caseCloseoutDraft, 12)
+    const first = derivePostIncidentCloseoutRewardBranch(record!)
+    const second = derivePostIncidentCloseoutRewardBranch(record!)
+
+    expect(first).toBe(second)
+    expect(first).toBe('containment_priority')
+  })
+})


### PR DESCRIPTION
## Summary

- Add pure domain `derivePostIncidentCloseoutRewardBranch` + weekly apply tick that persists `reward_branch:` tokens in `unknownFields` on orchestration-created qualifying closeout paths (no registry schema expansion).
- Wire reward-branch tick in `advanceWeek` after creation, before follow-on artifact; expose `closeoutRewardBranchLabel` on post-incident review mirror view.
- Domain unit tests + qualifying case closeout integration assertion for `containment_priority` branch and mirror label.

## Linear

- **Slice:** [SPE-2403](https://linear.app/spectranoir/issue/SPE-2403) — Branching reward logic on qualifying closeout paths (slice 28)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — stays **Done** on Linear (owner-choice deferred slice)

## Docs

- `planning/post-incident-review-registry-slice-28.md`
- `planning/backlog.md` index row on merge

## Validation

- `npm run test:run -- src/test/postIncidentReviewCloseoutRewardBranch.test.ts src/test/advanceWeek.postIncidentReview.integration.test.ts src/features/operations/postIncidentReviewMirrorView.test.ts`
- `npm run lint`

## Parent status

SPE-868 parent remains **Done** — slice 28 satisfies deferred branching-reward AC only; compliance audit cycling and mission payout hooks remain deferred.