### PR TITLE
SPE-2404: closeout reward-branch payout wire-up (slice 29)

### DIFF
--- a/planning/post-incident-review-registry-slice-29.md
+++ b/planning/post-incident-review-registry-slice-29.md
@@ -1,0 +1,80 @@
+# SPE-868 — Reward-branch payout wire-up on qualifying closeout week (slice 29)
+
+One-page implementation plan. Linear: child [SPE-2404](https://linear.app/spectranoir/issue/SPE-2404) under [SPE-868](https://linear.app/spectranoir/issue/SPE-868). Follows shipped slice 28 (`planning/post-incident-review-registry-slice-28.md`, PR #2675 / [SPE-2403](https://linear.app/spectranoir/issue/SPE-2403)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2404 — Reward-branch payout wire-up on qualifying closeout week (slice 29)](https://linear.app/spectranoir/issue/SPE-2404) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — Post-incident review and response metrics (**Done** on Linear; owner-choice deferred slice) |
+| **Branch** | `spe-868-reward-branch-payout-slice-29`                                                                    |
+| **Base `main` SHA** | `da694b31`                                                                                          |
+
+## Goal
+
+Read `reward_branch:` tokens from orchestration-created reviews and apply bounded funding/training credit deltas on the qualifying closeout week only — no registry schema change.
+
+## Prerequisite (on `main` @ `da694b31`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Reward branch tokens | slice 28 (SPE-2403) — `applyWeeklyPostIncidentReviewCloseoutRewardBranchTick` |
+| Follow-on training enqueue | slice 13 (SPE-2382) — `applyWeeklyPostIncidentReviewFollowOnTrainingEnqueueTick` |
+| Mission reward breakdown | `src/domain/missionResults.ts` (reference scale only)              |
+
+## Payout contract (this slice)
+
+| Branch | Funding delta | Training credit (when `follow_on:training-ref:` present) |
+| --- | --- | --- |
+| `containment_priority` | +6 | +3 |
+| `contested_containment` | +2 | 0 |
+| `threshold_mitigation` | +4 | +2 |
+| `recurrence_softening` | +3 | +2 |
+
+| Rule | Detail |
+| --- | --- |
+| **Trigger** | Review ref absent from prior map, present after reward-branch tick with parsed `reward_branch:` token |
+| **Apply tick** | `applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick` after follow-on training enqueue |
+| **Funding path** | `applyFundingIncome` on `agency.fundingState` + top-level `funding` sync |
+| **Idempotency** | `post-incident-closeout-reward:<reviewRef>` sourceId in `fundingHistory` |
+| **Stub exclusion** | Orchestration-created reviews only |
+| **Training credit** | Skipped when review carries recommendation-stub token only |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ---------------------------------------------------------------- | --------------------------------------------- |
+| `postIncidentReviewCloseoutRewardBranchPayout.ts` payout tick    | Registry schema expansion                     |
+| `advanceWeek` wire after follow-on training enqueue              | Branch derivation rules (slice 28)            |
+| Domain unit tests per branch + advanceWeek integration           | Mission triage UI                             |
+| Slice doc (this file) + backlog handoff on ship                  | SPE-1310 lifecycle                            |
+|                                                                  | Full SPE-868 parent re-close                  |
+
+## Acceptance
+
+- [ ] Orchestration-created reviews with `reward_branch:` token trigger bounded funding delta on materialization week
+- [ ] Training credit delta differs by branch when follow-on training-ref present
+- [ ] `containment_priority` funding delta > `contested_containment` (deterministic)
+- [ ] Re-advance idempotent; stub fixtures excluded
+- [ ] Slice 28 regressions green; `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/postIncidentReviewCloseoutRewardBranchPayout.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/postIncidentReviewCloseoutRewardBranchPayout.test.ts`, `src/test/advanceWeek.postIncidentReview.integration.test.ts` |
+| Plan   | `planning/post-incident-review-registry-slice-29.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Mission triage / payout UI surfacing | SPE-868 follow-up | Domain funding history only this slice |
+| Compliance audit cycling | SPE-868 | Deferred per slice 20 |
+| SPE-1310 parent closure | SPE-1310 | Registry slices do not satisfy full parent acceptance |
+
+## See also
+
+- `planning/post-incident-review-registry-slice-28.md`
+- `planning/post-incident-review-registry-slice-13.md`

--- a/src/domain/funding.ts
+++ b/src/domain/funding.ts
@@ -666,6 +666,15 @@ export function cancelProcurementOrder(
   }
 }
 
+export const POST_INCIDENT_CLOSEOUT_REWARD_REASON = 'post_incident_closeout_reward'
+export const POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON =
+  'post_incident_closeout_training_credit'
+
+const BUDGET_PRESSURE_HISTORY_EXCLUDED_REASONS = new Set<string>([
+  POST_INCIDENT_CLOSEOUT_REWARD_REASON,
+  POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON,
+])
+
 // --- Budget Pressure Logic ---
 
 export function recomputeBudgetPressure(state: FundingState, currentWeek?: number): FundingState {
@@ -691,8 +700,11 @@ export function recomputeBudgetPressure(state: FundingState, currentWeek?: numbe
   ) {
     pressure += 1
   }
+  const penaltyRelevantHistory = state.fundingHistory.filter(
+    (entry) => !BUDGET_PRESSURE_HISTORY_EXCLUDED_REASONS.has(entry.reason)
+  )
   if (
-    state.fundingHistory
+    penaltyRelevantHistory
       .slice(-FUNDING_CALIBRATION.budgetPressure.recentPenaltyWindow)
       .filter(
         (h) =>

--- a/src/domain/postIncidentReviewCloseoutRewardBranchPayout.ts
+++ b/src/domain/postIncidentReviewCloseoutRewardBranchPayout.ts
@@ -9,6 +9,8 @@
 import {
   applyFundingIncome,
   createInitialFundingState,
+  POST_INCIDENT_CLOSEOUT_REWARD_REASON,
+  POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON,
   type FundingState,
 } from './funding'
 import type { GameState } from './models'
@@ -26,9 +28,7 @@ export const CLOSEOUT_REWARD_BRANCH_PAYOUT_SOURCE_PREFIX = 'post-incident-closeo
 export const CLOSEOUT_REWARD_BRANCH_TRAINING_CREDIT_SOURCE_PREFIX =
   'post-incident-closeout-training-credit:'
 
-export const POST_INCIDENT_CLOSEOUT_REWARD_REASON = 'post_incident_closeout_reward'
-export const POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON =
-  'post_incident_closeout_training_credit'
+export { POST_INCIDENT_CLOSEOUT_REWARD_REASON, POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON }
 
 export interface CloseoutRewardBranchPayoutDeltas {
   readonly fundingDelta: number

--- a/src/domain/postIncidentReviewCloseoutRewardBranchPayout.ts
+++ b/src/domain/postIncidentReviewCloseoutRewardBranchPayout.ts
@@ -1,0 +1,252 @@
+/**
+ * SPE-868 slice 29: bounded funding/training credit payouts from closeout reward branches.
+ *
+ * Reads `reward_branch:` tokens on orchestration-created reviews materialized this tick and
+ * applies deterministic funding deltas plus optional training credits when a follow-on
+ * training-ref is present. Does not change branch derivation (slice 28).
+ */
+
+import {
+  applyFundingIncome,
+  createInitialFundingState,
+  type FundingState,
+} from './funding'
+import type { GameState } from './models'
+import {
+  FOLLOW_ON_TRAINING_REF_PREFIX,
+  isOrchestrationCreatedPostIncidentReviewRecord,
+} from './postIncidentReviewFollowOnArtifact'
+import {
+  parseCloseoutRewardBranchToken,
+  type PostIncidentCloseoutRewardBranch,
+} from './postIncidentReviewCloseoutRewardBranch'
+import type { PostIncidentReviewRecordsMap } from './postIncidentReviewRegistry'
+
+export const CLOSEOUT_REWARD_BRANCH_PAYOUT_SOURCE_PREFIX = 'post-incident-closeout-reward:'
+export const CLOSEOUT_REWARD_BRANCH_TRAINING_CREDIT_SOURCE_PREFIX =
+  'post-incident-closeout-training-credit:'
+
+export const POST_INCIDENT_CLOSEOUT_REWARD_REASON = 'post_incident_closeout_reward'
+export const POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON =
+  'post_incident_closeout_training_credit'
+
+export interface CloseoutRewardBranchPayoutDeltas {
+  readonly fundingDelta: number
+  readonly trainingCreditDelta: number
+}
+
+export const CLOSEOUT_REWARD_BRANCH_PAYOUT_BY_BRANCH: Readonly<
+  Record<PostIncidentCloseoutRewardBranch, CloseoutRewardBranchPayoutDeltas>
+> = {
+  containment_priority: { fundingDelta: 6, trainingCreditDelta: 3 },
+  contested_containment: { fundingDelta: 2, trainingCreditDelta: 0 },
+  threshold_mitigation: { fundingDelta: 4, trainingCreditDelta: 2 },
+  recurrence_softening: { fundingDelta: 3, trainingCreditDelta: 2 },
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function buildPayoutSourceId(reviewRef: string): string {
+  return `${CLOSEOUT_REWARD_BRANCH_PAYOUT_SOURCE_PREFIX}${reviewRef}`
+}
+
+function buildTrainingCreditSourceId(reviewRef: string): string {
+  return `${CLOSEOUT_REWARD_BRANCH_TRAINING_CREDIT_SOURCE_PREFIX}${reviewRef}`
+}
+
+export function getCloseoutRewardBranchPayoutDeltas(
+  branch: PostIncidentCloseoutRewardBranch
+): CloseoutRewardBranchPayoutDeltas {
+  return CLOSEOUT_REWARD_BRANCH_PAYOUT_BY_BRANCH[branch]
+}
+
+export function extractCloseoutRewardBranchFromUnknownFields(
+  unknownFields: readonly string[] | undefined
+): PostIncidentCloseoutRewardBranch | undefined {
+  for (const field of asStringArray(unknownFields)) {
+    const branch = parseCloseoutRewardBranchToken(field)
+    if (branch) {
+      return branch
+    }
+  }
+
+  return undefined
+}
+
+function hasFollowOnTrainingRefToken(fields: readonly string[]): boolean {
+  return fields.some((field) => field.startsWith(FOLLOW_ON_TRAINING_REF_PREFIX))
+}
+
+export function hasCloseoutRewardBranchPayoutForReview(
+  fundingState: FundingState | undefined,
+  reviewRef: string
+): boolean {
+  if (!fundingState) {
+    return false
+  }
+
+  const sourceId = buildPayoutSourceId(reviewRef)
+  return fundingState.fundingHistory.some((entry) => entry.sourceId === sourceId)
+}
+
+function collectMaterializedRewardBranchReviewRefs(input: {
+  priorReviews: PostIncidentReviewRecordsMap
+  nextReviews: PostIncidentReviewRecordsMap
+}): readonly string[] {
+  return Object.keys(input.nextReviews)
+    .filter((reviewRef) => {
+      const nextRecord = input.nextReviews[reviewRef]
+      if (!nextRecord || input.priorReviews[reviewRef]) {
+        return false
+      }
+
+      if (!isOrchestrationCreatedPostIncidentReviewRecord(nextRecord)) {
+        return false
+      }
+
+      return extractCloseoutRewardBranchFromUnknownFields(nextRecord.unknownFields) !== undefined
+    })
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function resolveFundingState(state: GameState): FundingState {
+  if (state.agency?.fundingState) {
+    return state.agency.fundingState
+  }
+
+  return createInitialFundingState(
+    state.config.fundingBasePerWeek,
+    state.config.fundingPerResolution,
+    state.config.fundingPenaltyPerFail,
+    state.config.fundingPenaltyPerUnresolved,
+    state.funding
+  )
+}
+
+function applyPayoutToFundingState(
+  fundingState: FundingState,
+  input: {
+    week: number
+    reviewRef: string
+    fundingDelta: number
+    trainingCreditDelta: number
+  }
+): { fundingState: FundingState; totalDelta: number } {
+  const week = Math.max(1, Math.trunc(input.week))
+  let current = fundingState
+  let totalDelta = 0
+
+  if (input.fundingDelta > 0) {
+    current = applyFundingIncome(
+      current,
+      input.fundingDelta,
+      POST_INCIDENT_CLOSEOUT_REWARD_REASON,
+      week,
+      buildPayoutSourceId(input.reviewRef)
+    )
+    totalDelta += input.fundingDelta
+  }
+
+  if (input.trainingCreditDelta > 0) {
+    current = applyFundingIncome(
+      current,
+      input.trainingCreditDelta,
+      POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON,
+      week,
+      buildTrainingCreditSourceId(input.reviewRef)
+    )
+    totalDelta += input.trainingCreditDelta
+  }
+
+  return { fundingState: current, totalDelta }
+}
+
+/**
+ * Applies bounded closeout reward-branch payouts for reviews materialized this tick.
+ * Re-applying for the same week is idempotent; stub registry entries are unchanged.
+ */
+export function applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+  state: GameState,
+  priorReviews: PostIncidentReviewRecordsMap | null | undefined,
+  nextReviews: PostIncidentReviewRecordsMap | null | undefined,
+  week: number
+): GameState {
+  const prior = priorReviews ?? {}
+  const next = nextReviews ?? {}
+  const materializedRefs = collectMaterializedRewardBranchReviewRefs({
+    priorReviews: prior,
+    nextReviews: next,
+  })
+
+  if (materializedRefs.length === 0) {
+    return state
+  }
+
+  let fundingState = resolveFundingState(state)
+  let funding = state.funding
+  let changed = false
+
+  for (const reviewRef of materializedRefs) {
+    if (hasCloseoutRewardBranchPayoutForReview(fundingState, reviewRef)) {
+      continue
+    }
+
+    const record = next[reviewRef]
+    if (!record) {
+      continue
+    }
+
+    const branch = extractCloseoutRewardBranchFromUnknownFields(record.unknownFields)
+    if (!branch) {
+      continue
+    }
+
+    const deltas = getCloseoutRewardBranchPayoutDeltas(branch)
+    const unknownFields = asStringArray(record.unknownFields)
+    const trainingCreditDelta = hasFollowOnTrainingRefToken(unknownFields)
+      ? deltas.trainingCreditDelta
+      : 0
+
+    const applied = applyPayoutToFundingState(fundingState, {
+      week,
+      reviewRef,
+      fundingDelta: deltas.fundingDelta,
+      trainingCreditDelta,
+    })
+
+    if (applied.totalDelta === 0) {
+      continue
+    }
+
+    fundingState = applied.fundingState
+    funding += applied.totalDelta
+    changed = true
+  }
+
+  if (!changed) {
+    return state
+  }
+
+  const agency = state.agency ?? {
+    containmentRating: state.containmentRating,
+    clearanceLevel: state.clearanceLevel,
+    funding: state.funding,
+    supportAvailable: 0,
+  }
+
+  return {
+    ...state,
+    funding,
+    agency: {
+      ...agency,
+      funding,
+      fundingState,
+    },
+  }
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -288,6 +288,7 @@ import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemW
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
 import { applyWeeklyRecurrentCatastropheTick } from '../recurrentCatastropheWeeklyOrchestration'
 import { applyWeeklyPostIncidentReviewCloseoutRewardBranchTick } from '../postIncidentReviewCloseoutRewardBranch'
+import { applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick } from '../postIncidentReviewCloseoutRewardBranchPayout'
 import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../postIncidentReviewFollowOnArtifact'
 import { applyWeeklyPostIncidentReviewFollowOnRecommendationActionTick } from '../postIncidentReviewFollowOnRecommendationAction'
 import { applyWeeklyPostIncidentReviewFollowOnRecommendationRegistryTick } from '../postIncidentReviewFollowOnRecommendationRegistry'
@@ -4757,6 +4758,18 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.agents = stateAfterFollowOnTrainingEnqueue.agents
     outputWeeklyState.funding = stateAfterFollowOnTrainingEnqueue.funding
     outputWeeklyState.events = stateAfterFollowOnTrainingEnqueue.events
+
+    const stateAfterCloseoutRewardBranchPayout =
+      applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+        stateAfterFollowOnTrainingEnqueue,
+        currentPostIncidentReviewRecords,
+        outputWeeklyState.postIncidentReviewRecords,
+        result.week
+      )
+    outputWeeklyState.funding = stateAfterCloseoutRewardBranchPayout.funding
+    if (stateAfterCloseoutRewardBranchPayout.agency) {
+      outputWeeklyState.agency = stateAfterCloseoutRewardBranchPayout.agency
+    }
 
     // SPE-868 slice 11: project follow-on artifact narratives into weekly report notes.
     const lastWeeklyReportForFollowOn = result.reports[result.reports.length - 1]

--- a/src/test/advanceWeek.postIncidentReview.integration.test.ts
+++ b/src/test/advanceWeek.postIncidentReview.integration.test.ts
@@ -16,7 +16,16 @@ import {
   applyWeeklyPostIncidentReviewCreationTick,
   resolveQualifyingIncidentReviewDraftsFromEventDrafts,
 } from '../domain/postIncidentReviewWeeklyOrchestration'
-import { applyWeeklyPostIncidentReviewCloseoutRewardBranchTick } from '../domain/postIncidentReviewCloseoutRewardBranch'
+import {
+  applyWeeklyPostIncidentReviewCloseoutRewardBranchTick,
+  buildCloseoutRewardBranchToken,
+} from '../domain/postIncidentReviewCloseoutRewardBranch'
+import {
+  applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick,
+  getCloseoutRewardBranchPayoutDeltas,
+  POST_INCIDENT_CLOSEOUT_REWARD_REASON,
+  POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON,
+} from '../domain/postIncidentReviewCloseoutRewardBranchPayout'
 import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../domain/postIncidentReviewFollowOnArtifact'
 import {
   formatPostIncidentReviewEnumLabel,
@@ -1724,5 +1733,63 @@ describe('advanceWeek post-incident review reviewRoute closureOutcome redaction 
     expect(twiceMirror.summary.qualifyingCaseCloseoutCount).toBe(1)
     expect(twiceMirror.summary.qualifyingNearCatastropheCount).toBe(1)
     expect(twiceMirror.summary.externalAuditRouteCount).toBe(1)
+  })
+})
+
+describe('advanceWeek post-incident closeout reward-branch payout integration (SPE-868 slice 29)', () => {
+  it('applies branch-specific funding and training credit deltas on qualifying closeout week', () => {
+    const state = stateWithFollowOnTrainingEnqueueReady(makeQualifyingResolvedCaseState())
+    const nextState = advanceWeek(state)
+    const reviewRef = 'review:case-case-001-closeout'
+    const history = nextState.agency?.fundingState?.fundingHistory ?? []
+
+    const rewardEntry = history.find(
+      (entry) =>
+        entry.reason === POST_INCIDENT_CLOSEOUT_REWARD_REASON && entry.sourceId === `post-incident-closeout-reward:${reviewRef}`
+    )
+    const trainingEntry = history.find(
+      (entry) =>
+        entry.reason === POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON &&
+        entry.sourceId === `post-incident-closeout-training-credit:${reviewRef}`
+    )
+
+    const containmentDeltas = getCloseoutRewardBranchPayoutDeltas('containment_priority')
+    const contestedDeltas = getCloseoutRewardBranchPayoutDeltas('contested_containment')
+
+    expect(rewardEntry?.delta).toBe(containmentDeltas.fundingDelta)
+    expect(trainingEntry?.delta).toBe(containmentDeltas.trainingCreditDelta)
+    expect(containmentDeltas.fundingDelta).toBeGreaterThan(contestedDeltas.fundingDelta)
+    expect(containmentDeltas.trainingCreditDelta).toBeGreaterThan(contestedDeltas.trainingCreditDelta)
+
+    const prior = state.postIncidentReviewRecords ?? {}
+    const contestedRecord = {
+      ...nextState.postIncidentReviewRecords![reviewRef],
+      unknownFields: [
+        'follow_on:training-ref:threat-assessment',
+        `orchestration_week:${nextState.week}`,
+        buildCloseoutRewardBranchToken('contested_containment'),
+      ],
+    }
+    const contestedNext = {
+      ...nextState.postIncidentReviewRecords,
+      'review:case-case-contested-closeout': {
+        ...contestedRecord,
+        id: 'review:case-case-contested-closeout',
+      },
+    }
+    const contestedPayout = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+      stateWithFollowOnTrainingEnqueueReady(createStartingState()),
+      prior,
+      contestedNext,
+      nextState.week
+    )
+    const contestedReward = contestedPayout.agency?.fundingState?.fundingHistory.find(
+      (entry) =>
+        entry.reason === POST_INCIDENT_CLOSEOUT_REWARD_REASON &&
+        entry.sourceId === 'post-incident-closeout-reward:review:case-case-contested-closeout'
+    )
+
+    expect(contestedReward?.delta).toBe(contestedDeltas.fundingDelta)
+    expect(contestedReward!.delta).toBeLessThan(rewardEntry!.delta!)
   })
 })

--- a/src/test/postIncidentReviewCloseoutRewardBranchPayout.test.ts
+++ b/src/test/postIncidentReviewCloseoutRewardBranchPayout.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick,
+  CLOSEOUT_REWARD_BRANCH_PAYOUT_BY_BRANCH,
+  extractCloseoutRewardBranchFromUnknownFields,
+  getCloseoutRewardBranchPayoutDeltas,
+  hasCloseoutRewardBranchPayoutForReview,
+  POST_INCIDENT_CLOSEOUT_REWARD_REASON,
+  POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON,
+} from '../domain/postIncidentReviewCloseoutRewardBranchPayout'
+import {
+  applyWeeklyPostIncidentReviewCloseoutRewardBranchTick,
+  buildCloseoutRewardBranchToken,
+  type PostIncidentCloseoutRewardBranch,
+} from '../domain/postIncidentReviewCloseoutRewardBranch'
+import { applyWeeklyPostIncidentReviewFollowOnArtifactTick } from '../domain/postIncidentReviewFollowOnArtifact'
+import { POST_INCIDENT_REVIEW_STUB_REGISTRY } from '../domain/postIncidentReviewRegistry'
+import {
+  applyWeeklyPostIncidentReviewCreationTick,
+  buildQualifyingIncidentReviewRecordForDraft,
+  type QualifyingIncidentReviewDraft,
+} from '../domain/postIncidentReviewWeeklyOrchestration'
+
+function stateReadyForPayout() {
+  return {
+    ...createStartingState(),
+    academyTier: 1,
+    funding: 200,
+  }
+}
+
+function reviewsWithRewardBranchForDraft(
+  draft: QualifyingIncidentReviewDraft,
+  branch?: PostIncidentCloseoutRewardBranch
+) {
+  const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+  const created = applyWeeklyPostIncidentReviewCreationTick(prior, {}, 12, [draft])
+  const withRewardBranch = applyWeeklyPostIncidentReviewCloseoutRewardBranchTick(prior, created)
+  const withArtifact = applyWeeklyPostIncidentReviewFollowOnArtifactTick(prior, withRewardBranch)
+
+  if (!branch) {
+    return { prior, next: withArtifact }
+  }
+
+  const record = withArtifact[draft.reviewRef]
+  if (!record) {
+    return { prior, next: withArtifact }
+  }
+
+  const unknownFields = [
+    ...((record.unknownFields ?? []) as string[]).filter(
+      (field) => !field.startsWith('reward_branch:')
+    ),
+    buildCloseoutRewardBranchToken(branch),
+  ].sort((left, right) => left.localeCompare(right))
+
+  return {
+    prior,
+    next: {
+      ...withArtifact,
+      [draft.reviewRef]: {
+        ...record,
+        unknownFields,
+      },
+    },
+  }
+}
+
+describe('postIncidentReviewCloseoutRewardBranchPayout (SPE-868 slice 29)', () => {
+  const caseCloseoutDraft: QualifyingIncidentReviewDraft = {
+    reviewRef: 'review:case-case-major-closeout',
+    caseId: 'case-major',
+    caseTitle: 'District breach',
+    trigger: 'case_resolved',
+    stage: 4,
+    kind: 'standard',
+    anchorWeek: 12,
+  }
+
+  it('exports deterministic bounded deltas for every reward branch', () => {
+    const branches = Object.keys(
+      CLOSEOUT_REWARD_BRANCH_PAYOUT_BY_BRANCH
+    ) as PostIncidentCloseoutRewardBranch[]
+
+    for (const branch of branches) {
+      const deltas = getCloseoutRewardBranchPayoutDeltas(branch)
+      expect(deltas.fundingDelta).toBeGreaterThan(0)
+      expect(deltas.trainingCreditDelta).toBeGreaterThanOrEqual(0)
+    }
+
+    expect(getCloseoutRewardBranchPayoutDeltas('containment_priority').fundingDelta).toBeGreaterThan(
+      getCloseoutRewardBranchPayoutDeltas('contested_containment').fundingDelta
+    )
+  })
+
+  it('extracts reward branch tokens from unknownFields', () => {
+    expect(
+      extractCloseoutRewardBranchFromUnknownFields([
+        'orchestration_week:12',
+        'reward_branch:threshold_mitigation',
+      ])
+    ).toBe('threshold_mitigation')
+    expect(extractCloseoutRewardBranchFromUnknownFields(['follow_on:training-ref:threat-assessment'])).toBeUndefined()
+  })
+
+  it('applies containment_priority funding and training credit when a qualifying review materializes', () => {
+    const { prior, next } = reviewsWithRewardBranchForDraft(caseCloseoutDraft)
+    const result = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+      stateReadyForPayout(),
+      prior,
+      next,
+      12
+    )
+
+    expect(result.funding).toBe(200 + 6 + 3)
+    const history = result.agency?.fundingState?.fundingHistory ?? []
+    expect(history).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          week: 12,
+          delta: 6,
+          reason: POST_INCIDENT_CLOSEOUT_REWARD_REASON,
+          sourceId: 'post-incident-closeout-reward:review:case-case-major-closeout',
+        }),
+        expect.objectContaining({
+          week: 12,
+          delta: 3,
+          reason: POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON,
+          sourceId: 'post-incident-closeout-training-credit:review:case-case-major-closeout',
+        }),
+      ])
+    )
+  })
+
+  it('applies contested_containment funding without training credit', () => {
+    const { prior, next } = reviewsWithRewardBranchForDraft(
+      caseCloseoutDraft,
+      'contested_containment'
+    )
+    const result = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+      stateReadyForPayout(),
+      prior,
+      next,
+      12
+    )
+
+    expect(result.funding).toBe(202)
+    const history = result.agency?.fundingState?.fundingHistory ?? []
+    expect(history.some((entry) => entry.reason === POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON)).toBe(
+      false
+    )
+  })
+
+  it('applies threshold_mitigation deltas for near-catastrophe reviews without training-ref', () => {
+    const nearCatastropheDraft: QualifyingIncidentReviewDraft = {
+      reviewRef: 'review:near-catastrophe-case-major',
+      caseId: 'case-major',
+      caseTitle: 'District breach',
+      trigger: 'near_catastrophe_threshold',
+      stage: 4,
+      kind: 'raid',
+      anchorWeek: 12,
+    }
+    const { prior, next } = reviewsWithRewardBranchForDraft(nearCatastropheDraft)
+    const result = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+      stateReadyForPayout(),
+      prior,
+      next,
+      12
+    )
+
+    expect(result.funding).toBe(204)
+    expect(
+      result.agency?.fundingState?.fundingHistory.some(
+        (entry) => entry.reason === POST_INCIDENT_CLOSEOUT_TRAINING_CREDIT_REASON
+      )
+    ).toBe(false)
+  })
+
+  it('applies recurrence_softening deltas on cycle closeout reviews', () => {
+    const record = buildQualifyingIncidentReviewRecordForDraft(caseCloseoutDraft, 12)
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const next = {
+      'review:cycle-4-closeout': {
+        ...record!,
+        id: 'review:cycle-4-closeout',
+        unknownFields: [
+          'orchestration_week:12',
+          'reward_branch:recurrence_softening',
+          'follow_on:training-ref:threat-assessment',
+        ],
+      },
+    }
+
+    const result = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+      stateReadyForPayout(),
+      prior,
+      next,
+      12
+    )
+
+    expect(result.funding).toBe(205)
+  })
+
+  it('is idempotent when re-run for the same materialized review', () => {
+    const { prior, next } = reviewsWithRewardBranchForDraft(caseCloseoutDraft)
+    const baseState = stateReadyForPayout()
+    const once = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(baseState, prior, next, 12)
+    const twice = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(once, prior, next, 12)
+
+    expect(twice).toBe(once)
+    expect(hasCloseoutRewardBranchPayoutForReview(once.agency?.fundingState, caseCloseoutDraft.reviewRef)).toBe(
+      true
+    )
+  })
+
+  it('skips stub registry fixtures without orchestration week token', () => {
+    const prior = { ...POST_INCIDENT_REVIEW_STUB_REGISTRY }
+    const next = {
+      ...prior,
+      'review:cycle-3-closeout': {
+        ...prior['review:cycle-3-closeout'],
+        unknownFields: ['reward_branch:containment_priority'],
+      },
+    }
+    const result = applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick(
+      stateReadyForPayout(),
+      prior,
+      next,
+      12
+    )
+
+    expect(result.funding).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyPostIncidentReviewCloseoutRewardBranchPayoutTick` to read `reward_branch:` tokens on orchestration-created reviews and apply bounded funding/training credit deltas on the qualifying closeout week.
- Wire payout tick in `advanceWeek` after follow-on training enqueue; idempotent via `fundingHistory` sourceIds.
- `containment_priority` pays more than `contested_containment`; training credit applies only when a follow-on training-ref is present.

## Linear

- **Slice:** [SPE-2404](https://linear.app/spectranoir/issue/SPE-2404) — Reward-branch payout wire-up on qualifying closeout week (slice 29)
- **Parent:** [SPE-868](https://linear.app/spectranoir/issue/SPE-868) — stays **Done** (deferred follow-up slice only)

## What shipped

- `src/domain/postIncidentReviewCloseoutRewardBranchPayout.ts`
- `advanceWeek` post-review tick ordering extension
- Domain unit tests per branch + advanceWeek integration asserting branch-specific deltas
- `planning/post-incident-review-registry-slice-29.md`

## Validation

- `npm run test:run -- src/test/postIncidentReviewCloseoutRewardBranchPayout.test.ts src/test/postIncidentReviewCloseoutRewardBranch.test.ts src/test/advanceWeek.postIncidentReview.integration.test.ts` (67 passed)
- `npm run lint` (green)

## Docs updated

- `planning/post-incident-review-registry-slice-29.md` (this slice)
- `planning/backlog.md` — updated on merge

## Parent status

SPE-868 remains **Done** on Linear; this is an owner-choice deferred payout slice, not parent re-close.

Made with [Cursor](https://cursor.com)