### PR TITLE
SPE-2410: CaseInstance.lifecycleStage persistence (SPE-1310 slice 2)

### DIFF
--- a/planning/anomaly-case-lifecycle-state-machine-slice-2.md
+++ b/planning/anomaly-case-lifecycle-state-machine-slice-2.md
@@ -1,0 +1,71 @@
+# SPE-1310 — Anomaly case lifecycle state machine slice 2
+
+One-page implementation plan. Linear: [SPE-2410](https://linear.app/spectranoir/issue/SPE-2410) (child under [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310)). Follows shipped slice 1 (`planning/anomaly-case-lifecycle-state-machine-slice-1.md`, PR #2687).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2410 — CaseInstance.lifecycleStage persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2410) |
+| **Parent** | [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — Anomaly case lifecycle state machine; stays **Backlog** until remaining AC gaps close |
+| **Branch** | `spe-1310-anomaly-case-lifecycle-state-machine-slice-2`                                                    |
+| **Status** | **In progress** — SPE-2410                                                                                 |
+| **Base `main` SHA** | `9ca9ca68`                                                                                          |
+
+## Goal
+
+Persist optional `lifecycleStage?: CaseLifecycleStage` on `CaseInstance` with sanitize/hydrate wire-up and save round-trip tests. Slice 1 shipped the pure domain graph only.
+
+## Prerequisite (on `main` @ `9ca9ca68`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Lifecycle graph      | `src/domain/caseLifecycleStateMachine.ts` (SPE-2409 / PR #2687)        |
+| Registry persistence pattern | `planning/minor-anomaly-item-registry-slice-2.md` (SPE-2314)   |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `lifecycleStage?: CaseLifecycleStage` on `CaseInstance`            | `advanceWeek` integration                     |
+| `sanitizeCaseLifecycleStage` + `normalizeCaseInstance` hydrate     | UI surfacing                                  |
+| `sanitizeCasesMap` wire-up (via normalizeCase)                     | `presumed_neutralized` disposition            |
+| Default `lead` on `createStarterCase` only                         | Policy-tier upgrade on adaptation             |
+| Drop invalid persisted stages without throw (no silent coerce)     | Legacy `CaseStatus` remapping                 |
+| No backfill when field absent on persisted cases                   | Full SPE-1310 parent Done                     |
+| Sanitize + save/import round-trip tests                            |                                               |
+
+## Acceptance
+
+- [x] Valid `lifecycleStage` round-trips through serialize/import
+- [x] Invalid/unknown stage strings dropped safely on hydrate
+- [x] Cases without `lifecycleStage` remain byte-stable after round-trip
+- [x] New starter cases get `lifecycleStage: 'lead'`
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/models.ts`, `src/domain/case/normalizeCase.ts`, `src/domain/templates/startingCases.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Tests  | `src/test/caseLifecycleStagePersistence.test.ts`                      |
+| Plan   | `planning/anomaly-case-lifecycle-state-machine-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| `advanceWeek` lifecycle tick / intake registry wire-up | SPE-1310 slice 3+ | Requires trigger sources beyond persistence |
+| UI surfacing on mission triage / cases board | Mission triage refresh | Blocked per `ux/mission-triage.md` |
+| `presumed_neutralized` disposition with surveillance clocks | SPE-1310 / SPE-921 | Parent AC; not in slice-2 graph |
+| Policy-revision-on-adaptation tier upgrade transition | SPE-1310 | Adaptation trigger deferred |
+| Legacy `CaseStatus` mapping / migration | SPE-1310 follow-up | Preserve mistaken records; map in dedicated slice |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/caseLifecycleStagePersistence.test.ts`
+
+## See also
+
+- `planning/anomaly-case-lifecycle-state-machine-slice-1.md`
+- `src/domain/caseLifecycleStateMachine.ts`

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,13 +20,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) slice 2 — `CaseInstance.lifecycleStage` persistence + hydrate wire-up (follows shipped slice 1 @ PR #2687). Parent stays **Backlog** until remaining AC gaps close.
+**Next step:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) slice 3+ — `advanceWeek` lifecycle tick / intake registry wire-up (follows shipped slice 2). Parent stays **Backlog** until remaining AC gaps close.
 
 Mission triage expansion remains **blocked**.
 
-**Base `main` SHA:** `d400338b`
+**Base `main` SHA:** `9ca9ca68`
 
-**Recently shipped:** [SPE-2409](https://linear.app/spectranoir/issue/SPE-2409) anomaly case lifecycle state machine slice 1 — pure domain transition graph (`lead`→`confirmation`→`containment`↔`revision`) @ PR #2687 / `c10168c3`; see `planning/anomaly-case-lifecycle-state-machine-slice-1.md`.
+**Recently shipped:** [SPE-2410](https://linear.app/spectranoir/issue/SPE-2410) anomaly case lifecycle state machine slice 2 — `CaseInstance.lifecycleStage` persistence + hydrate wire-up @ PR (pending) / branch `spe-1310-anomaly-case-lifecycle-state-machine-slice-2`; see `planning/anomaly-case-lifecycle-state-machine-slice-2.md`.
 
 ## Blocked / waiting
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -3581,6 +3581,7 @@ export function resolveKnownCaseTemplateIds(
   return new Set(Object.keys(templates))
 }
 
+/** SPE-1310 slice 2: case lifecycleStage hydrates via normalizeCaseInstance (no fallback backfill). */
 export function sanitizeCasesMap(
   value: unknown,
   teams: GameState['teams'],

--- a/src/domain/case/normalizeCase.ts
+++ b/src/domain/case/normalizeCase.ts
@@ -1,4 +1,5 @@
 import type { BeliefTier, BeliefTrackState } from '../beliefTracks'
+import { CASE_LIFECYCLE_STAGES } from '../caseLifecycleStateMachine'
 import { sanitizePersistedFieldBasePacket, sanitizeFieldBaseQualityBands } from '../fieldBaseStaging'
 import { buildConcealmentActivationTriggersFromAuthored } from '../hiddenStateActivationAuthoring'
 import { buildInfiltrationCoverProfileFromAuthoredRecord } from '../infiltrationCoverAuthoring'
@@ -1272,6 +1273,18 @@ function sanitizeOptionalCaseId(value: unknown, fallback: string | undefined): s
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
+/** SPE-1310 slice 2: accept known lifecycle stages; drop unknown strings without throw. */
+export function sanitizeCaseLifecycleStage(
+  value: unknown,
+  fallback: CaseInstance['lifecycleStage']
+): CaseInstance['lifecycleStage'] | undefined {
+  if (value === undefined) {
+    return fallback
+  }
+
+  return isOneOf(value, CASE_LIFECYCLE_STAGES) ? value : undefined
+}
+
 function sanitizeDeploymentCarryInByAgentId(
   value: unknown,
   context: {
@@ -1521,6 +1534,10 @@ export function normalizeCaseInstance(
     fallback.counterExplanation,
     MAX_CASE_COUNTER_EXPLANATION_LENGTH
   )
+  const lifecycleStage =
+    entry.lifecycleStage !== undefined
+      ? sanitizeCaseLifecycleStage(entry.lifecycleStage, undefined)
+      : undefined
 
   const baseCase: CaseInstance = {
     ...fallback,
@@ -1641,6 +1658,7 @@ export function normalizeCaseInstance(
     ...(stealthLeaveBehindId !== undefined ? { stealthLeaveBehindId } : {}),
     ...(factionId !== undefined ? { factionId } : {}),
     ...(contactId !== undefined ? { contactId } : {}),
+    ...(lifecycleStage !== undefined ? { lifecycleStage } : {}),
     deploymentCarryInByAgentId:
       context.agents === undefined
         ? undefined
@@ -1800,6 +1818,10 @@ export function normalizeCaseInstance(
 
   if (entry.counterDetection !== undefined && sanitizeCounterDetectionField(entry.counterDetection) === undefined) {
     delete (baseCase as { counterDetection?: CaseInstance['counterDetection'] }).counterDetection
+  }
+
+  if (lifecycleStage === undefined) {
+    delete (baseCase as { lifecycleStage?: CaseInstance['lifecycleStage'] }).lifecycleStage
   }
 
   if (!catalogKnown) {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1406,6 +1406,9 @@ export interface CaseInstance {
   mapLayer?: import('./siteGeneration/mapMetadata').MapLayerResult
   /** Runtime weird-room state packets attached to this site. Populated by applySiteGenerationToCase. */
   weirdRoomPackets?: WeirdRoomPacket[]
+
+  /** SPE-1310 slice 2: anomaly case lifecycle stage (distinct from operational CaseStatus). */
+  lifecycleStage?: import('./caseLifecycleStateMachine').CaseLifecycleStage
 }
 
 export interface ResolutionOutcome {

--- a/src/domain/templates/startingCases.ts
+++ b/src/domain/templates/startingCases.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CASE_LIFECYCLE_STAGE } from '../caseLifecycleStateMachine'
 import { type CaseInstance } from '../models'
 import { inferFactionIdFromCaseTags } from '../factions'
 import { createMissionIntelState } from '../intel'
@@ -111,6 +112,7 @@ export function createStarterCase(seed: StarterCaseSeed): CaseInstance {
         : undefined,
     infiltrationProbePlan: copyInfiltrationProbePlan(template.infiltrationProbePlan),
     infiltrationCoverProfile: copyInfiltrationCoverProfile(template.infiltrationCoverProfile),
+    lifecycleStage: DEFAULT_CASE_LIFECYCLE_STAGE,
   }
 
   return applySiteGenerationToCase({

--- a/src/test/caseLifecycleStagePersistence.test.ts
+++ b/src/test/caseLifecycleStagePersistence.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import { hydrateGame, sanitizeCasesMap } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  normalizeCaseInstance,
+  sanitizeCaseLifecycleStage,
+} from '../domain/case/normalizeCase'
+import { createStartingState } from '../data/startingState'
+import { starterCases } from '../domain/templates/startingCases'
+
+describe('caseLifecycleStage persistence (SPE-1310 slice 2)', () => {
+  it('sanitizeCaseLifecycleStage accepts valid stages and drops unknown strings', () => {
+    expect(sanitizeCaseLifecycleStage('lead', undefined)).toBe('lead')
+    expect(sanitizeCaseLifecycleStage('confirmation', undefined)).toBe('confirmation')
+    expect(sanitizeCaseLifecycleStage('containment', undefined)).toBe('containment')
+    expect(sanitizeCaseLifecycleStage('revision', undefined)).toBe('revision')
+    expect(sanitizeCaseLifecycleStage('presumed_neutralized', undefined)).toBeUndefined()
+    expect(sanitizeCaseLifecycleStage('bogus', undefined)).toBeUndefined()
+    expect(sanitizeCaseLifecycleStage(42, undefined)).toBeUndefined()
+    expect(sanitizeCaseLifecycleStage(undefined, 'lead')).toBe('lead')
+  })
+
+  it('normalizeCaseInstance drops invalid lifecycleStage without coercing to lead', () => {
+    const fallback = createStartingState()
+    const caseId = 'case-lifecycle-invalid'
+    const seed = fallback.cases['case-001']!
+
+    const normalized = normalizeCaseInstance(
+      caseId,
+      {
+        ...seed,
+        id: caseId,
+        lifecycleStage: 'bogus',
+      },
+      seed,
+      { week: 1, teams: fallback.teams }
+    )
+
+    expect(normalized.lifecycleStage).toBeUndefined()
+  })
+
+  it('normalizeCaseInstance omits lifecycleStage when absent from persisted entry (no fallback backfill)', () => {
+    const fallback = createStartingState()
+    const caseId = 'case-lifecycle-absent'
+    const seed = fallback.cases['case-001']!
+
+    expect(seed.lifecycleStage).toBe('lead')
+
+    const normalized = normalizeCaseInstance(
+      caseId,
+      {
+        ...seed,
+        id: caseId,
+        lifecycleStage: undefined,
+      },
+      seed,
+      { week: 1, teams: fallback.teams }
+    )
+
+    expect('lifecycleStage' in normalized).toBe(false)
+  })
+
+  it('starter cases default lifecycleStage to lead', () => {
+    for (const starterCase of Object.values(starterCases)) {
+      expect(starterCase.lifecycleStage).toBe('lead')
+    }
+  })
+
+  it('round-trips lifecycleStage byte-stable through save/load when present', () => {
+    const state = createStartingState()
+    const caseId = 'case-001'
+
+    state.cases[caseId] = {
+      ...state.cases[caseId]!,
+      lifecycleStage: 'confirmation',
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.cases[caseId]?.lifecycleStage).toBe('confirmation')
+  })
+
+  it('preserves cases without lifecycleStage byte-stable through save/load', () => {
+    const state = createStartingState()
+    const caseId = 'case-legacy-no-stage'
+    const seed = state.cases['case-001']!
+
+    for (const existingCase of Object.values(state.cases)) {
+      delete existingCase.lifecycleStage
+    }
+
+    state.cases[caseId] = {
+      ...seed,
+      id: caseId,
+      title: caseId,
+      assignedTeamIds: [],
+    }
+    delete state.cases[caseId]!.lifecycleStage
+
+    const serialized = serializeGameSave(state)
+    const loaded = loadGameSave(serialized)
+
+    expect(loaded.cases[caseId]?.lifecycleStage).toBeUndefined()
+    expect(serialized).not.toContain('"lifecycleStage"')
+    for (const hydratedCase of Object.values(loaded.cases)) {
+      expect(hydratedCase.lifecycleStage).toBeUndefined()
+    }
+  })
+
+  it('sanitizeCasesMap drops invalid lifecycleStage during hydrate', () => {
+    const fallback = createStartingState()
+    const caseId = 'case-hydrate-invalid-stage'
+    const seed = fallback.cases['case-001']!
+
+    const sanitized = sanitizeCasesMap(
+      {
+        [caseId]: {
+          ...seed,
+          id: caseId,
+          lifecycleStage: 'open',
+        },
+      },
+      fallback.teams,
+      1,
+      fallback.cases
+    )
+
+    expect(sanitized[caseId]?.lifecycleStage).toBeUndefined()
+  })
+
+  it('hydrates valid lifecycleStage through import parsing', () => {
+    const fallback = createStartingState()
+    const caseId = 'case-hydrate-valid-stage'
+    const seed = fallback.cases['case-001']!
+
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        cases: {
+          [caseId]: {
+            ...seed,
+            id: caseId,
+            lifecycleStage: 'containment',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.cases[caseId]?.lifecycleStage).toBe('containment')
+  })
+})


### PR DESCRIPTION
## Summary

- Add optional `lifecycleStage?: CaseLifecycleStage` to `CaseInstance`
- Sanitize/hydrate via `sanitizeCaseLifecycleStage` + `normalizeCaseInstance`; wire through `sanitizeCasesMap`
- Default `lead` on `createStarterCase` only; no backfill when field absent on persisted cases
- Invalid stage strings dropped without throw (not coerced to lead)

## Linear

- **Slice:** [SPE-2410](https://linear.app/spectranoir/issue/SPE-2410)
- **Parent:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — remains open (AC gaps)

## What shipped

- Model field + normalizeCase validation
- Starter case default
- Persistence tests + slice doc

## Validation

- `npm run lint`
- `npm run test:run src/test/caseLifecycleStagePersistence.test.ts`
- `npm run test:run src/test/starterContent.test.ts src/test/sim.validation.test.ts src/test/caseLifecycleStateMachine.test.ts`

## Docs

- `planning/anomaly-case-lifecycle-state-machine-slice-2.md`
- `planning/backlog.md` handoff updated

## Parent status

Parent SPE-1310 stays **Backlog** — slice 2 is persistence only; advanceWeek/UI/deferred AC out of scope.

Made with [Cursor](https://cursor.com)