### PR TITLE
SPE-2412: research_invalidation / procedure_revised weekly lifecycle hooks (slice 4)

### DIFF
--- a/planning/anomaly-case-lifecycle-state-machine-slice-4.md
+++ b/planning/anomaly-case-lifecycle-state-machine-slice-4.md
@@ -1,0 +1,81 @@
+# SPE-1310 — Anomaly case lifecycle state machine slice 4
+
+One-page implementation plan. Linear: [SPE-2412](https://linear.app/spectranoir/issue/SPE-2412) (child under [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310)). Follows shipped slice 3 (`planning/anomaly-case-lifecycle-state-machine-slice-3.md`, PR #2690).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2412 — research_invalidation / procedure_revised weekly hooks (slice 4)](https://linear.app/spectranoir/issue/SPE-2412) |
+| **Parent** | [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — Anomaly case lifecycle state machine; stays **Backlog** until remaining AC gaps close |
+| **Branch** | `spe-1310-anomaly-case-lifecycle-state-machine-slice-4`                                                    |
+| **Status** | **Ready for PR**                                                                                           |
+| **Base `main` SHA** | `2950fd5a`                                                                                          |
+
+## Goal
+
+Map `research_invalidation` from rule-document compliance breach/drift signals and `procedure_revised` from a deterministic registry recovery hook; wire through `applyWeeklyCaseLifecycleTick`; persist containment ↔ revision transitions during `advanceWeek`.
+
+## Prerequisite (on `main` @ `2950fd5a`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Lifecycle graph      | `src/domain/caseLifecycleStateMachine.ts` (SPE-2409 / PR #2687)        |
+| Stage persistence    | `CaseInstance.lifecycleStage` hydrate (SPE-2410 / PR #2689)            |
+| Slice 3 tick         | `applyWeeklyCaseLifecycleTick` intake + extranormal mappings (SPE-2411 / PR #2690) |
+| Compliance weekly tick | `applyWeeklyRuleDocumentComplianceTick` (SPE-2366 / PR #2601)        |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `research_invalidation` from compliance drift/breach crossing        | UI surfacing                                  |
+| `procedure_revised` from revision ref + compliance recovery hook     | `presumed_neutralized` disposition            |
+| Explicit `documentRef` ↔ case id/templateId linkage only             | Policy-tier upgrade on adaptation             |
+| `advanceWeek` lifecycle tick after compliance-decay tick           | Legacy `CaseStatus` remapping                 |
+| Unit + integration tests for containment ↔ revision loop             | Slice 3 credibility/anomaly mapping changes   |
+| Cases without `lifecycleStage` unchanged                             | Full SPE-1310 parent Done                     |
+
+## Event mapping
+
+| Lifecycle event | Weekly source | Transition |
+| --- | --- | --- |
+| `research_invalidation` | Linked compliance record first crosses into `drifting`/`breach` (or `drifting` → `breach`) via `applyWeeklyRuleDocumentComplianceTick` output | `containment` → `revision` |
+| `procedure_revised` | Linked compliance record gains new `revision:` ref and compliance state improves | `revision` → `containment` |
+
+Explicit linkage: `documentRef` must equal case `id` or `templateId` (no fuzzy topic overlap). Invalid events preserve the current stage.
+
+## Acceptance
+
+- [x] Containment case advances to `revision` when linked compliance drifts through `advanceWeek`
+- [x] Revision case returns to `containment` on registry procedure-recovery hook
+- [x] Cases without `lifecycleStage` remain unchanged after `advanceWeek`
+- [x] Re-tick with unchanged compliance maps is idempotent
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/caseLifecycleWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/caseLifecycleWeeklyOrchestration.test.ts`, `src/test/advanceWeek.caseLifecycle.integration.test.ts` |
+| Plan   | `planning/anomaly-case-lifecycle-state-machine-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| UI surfacing on mission triage / cases board | Mission triage refresh | Blocked per `ux/mission-triage.md` |
+| `presumed_neutralized` disposition with surveillance clocks | SPE-1310 / SPE-921 | Parent AC; not in slice-4 graph |
+| Policy-revision-on-adaptation tier upgrade transition | SPE-1310 | Adaptation trigger deferred |
+| Legacy `CaseStatus` mapping / migration | SPE-1310 follow-up | Preserve mistaken records; map in dedicated slice |
+| Automated compliance recovery tick (without manual state seed) | SPE-2123 follow-up | Slice 4 detects recovery when prior/next maps differ |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/caseLifecycleWeeklyOrchestration.test.ts src/test/advanceWeek.caseLifecycle.integration.test.ts`
+
+## See also
+
+- `planning/anomaly-case-lifecycle-state-machine-slice-3.md`
+- `planning/rule-document-compliance-containment-registry-slice-3.md`
+- `src/domain/caseLifecycleStateMachine.ts`

--- a/src/domain/caseLifecycleWeeklyOrchestration.ts
+++ b/src/domain/caseLifecycleWeeklyOrchestration.ts
@@ -1,9 +1,10 @@
 /**
- * SPE-1310 slice 3: weekly lifecycle transition tick for persisted case lifecycleStage.
+ * SPE-1310 slice 3–4: weekly lifecycle transition tick for persisted case lifecycleStage.
  *
  * Maps deterministic weekly event sources (intake credibility review pass, extranormal
- * anomaly confirmation) onto the slice-1 transition graph. Cases without lifecycleStage
- * are not auto-initialized; invalid transitions preserve the current stage.
+ * anomaly confirmation, rule-document compliance breach/drift, procedure revision recovery)
+ * onto the slice-1 transition graph. Cases without lifecycleStage are not auto-initialized;
+ * invalid transitions preserve the current stage.
  */
 
 import type { CaseLifecycleEvent } from './caseLifecycleStateMachine'
@@ -19,6 +20,11 @@ import type {
 } from './informationIntakeReport'
 import type { ExtranormalEventRecordsMap } from './extranormalEventRegistry'
 import type { CaseInstance } from './models'
+import type {
+  ComplianceState,
+  RuleDocumentComplianceRecord,
+  RuleDocumentComplianceRecordsMap,
+} from './ruleDocumentComplianceContainmentRegistry'
 
 const CREDIBILITY_REVIEW_PASSED_STATUSES: ReadonlySet<InformationVerificationStatus> = new Set([
   'verified',
@@ -35,6 +41,8 @@ export interface WeeklyCaseLifecycleTickInput {
   readonly priorIntakeReports?: InformationIntakeReportsMap | null
   readonly nextIntakeReports?: InformationIntakeReportsMap | null
   readonly extranormalEventRecords?: ExtranormalEventRecordsMap | null
+  readonly priorRuleDocumentComplianceRecords?: RuleDocumentComplianceRecordsMap | null
+  readonly nextRuleDocumentComplianceRecords?: RuleDocumentComplianceRecordsMap | null
 }
 
 export interface WeeklyCaseLifecycleTickResult {
@@ -229,6 +237,149 @@ export function resolveAnomalyConfirmedCaseIds(
   return [...matched].sort((left, right) => left.localeCompare(right))
 }
 
+const REVISION_HISTORY_REF_PREFIX = 'revision:'
+
+const COMPLIANCE_STATE_RECOVERY_RANK: Readonly<Record<ComplianceState, number>> = {
+  compliant: 3,
+  unknown: 2,
+  drifting: 1,
+  breach: 0,
+}
+
+function complianceRecordExplicitlyLinksToCase(
+  record: RuleDocumentComplianceRecord,
+  currentCase: WeeklyCaseLifecycleCaseContext
+): boolean {
+  const documentRef = normalizeToken(record.documentRef)
+  if (!documentRef) {
+    return false
+  }
+
+  return (
+    normalizeToken(currentCase.id) === documentRef ||
+    normalizeToken(currentCase.templateId) === documentRef
+  )
+}
+
+/** First weekly crossing into drifting/breach, or drifting → breach escalation. */
+export function didComplianceResearchInvalidationSignal(
+  priorState: ComplianceState | undefined,
+  nextState: ComplianceState
+): boolean {
+  const priorSignal = priorState === 'drifting' || priorState === 'breach'
+  const nextSignal = nextState === 'drifting' || nextState === 'breach'
+
+  if (!nextSignal) {
+    return false
+  }
+
+  if (!priorSignal) {
+    return true
+  }
+
+  return priorState === 'drifting' && nextState === 'breach'
+}
+
+export function resolveResearchInvalidationCaseIds(
+  priorRecords: RuleDocumentComplianceRecordsMap | null | undefined,
+  nextRecords: RuleDocumentComplianceRecordsMap | null | undefined,
+  cases: Record<string, CaseInstance>
+): readonly string[] {
+  const safePrior = priorRecords ?? {}
+  const safeNext = nextRecords ?? {}
+  const matched = new Set<string>()
+
+  for (const recordId of Object.keys(safeNext).sort((left, right) => left.localeCompare(right))) {
+    const priorRecord = safePrior[recordId]
+    const nextRecord = safeNext[recordId]
+    if (!nextRecord) {
+      continue
+    }
+
+    if (
+      !didComplianceResearchInvalidationSignal(
+        priorRecord?.complianceState,
+        nextRecord.complianceState
+      )
+    ) {
+      continue
+    }
+
+    for (const currentCase of Object.values(cases)) {
+      if (currentCase.status === 'resolved') {
+        continue
+      }
+
+      if (complianceRecordExplicitlyLinksToCase(nextRecord, currentCase)) {
+        matched.add(currentCase.id)
+      }
+    }
+  }
+
+  return [...matched].sort((left, right) => left.localeCompare(right))
+}
+
+function complianceStateImproved(priorState: ComplianceState, nextState: ComplianceState): boolean {
+  return COMPLIANCE_STATE_RECOVERY_RANK[nextState] > COMPLIANCE_STATE_RECOVERY_RANK[priorState]
+}
+
+function hasNewRevisionHistoryRef(
+  priorRecord: RuleDocumentComplianceRecord,
+  nextRecord: RuleDocumentComplianceRecord
+): boolean {
+  const priorRefs = new Set(priorRecord.revisionHistoryRefs ?? [])
+
+  return (nextRecord.revisionHistoryRefs ?? []).some(
+    (ref) => ref.startsWith(REVISION_HISTORY_REF_PREFIX) && !priorRefs.has(ref)
+  )
+}
+
+/** Registry recovery: new revision ref logged while compliance state improves. */
+export function didProcedureRevisionRecover(
+  priorRecord: RuleDocumentComplianceRecord,
+  nextRecord: RuleDocumentComplianceRecord
+): boolean {
+  if (!hasNewRevisionHistoryRef(priorRecord, nextRecord)) {
+    return false
+  }
+
+  return complianceStateImproved(priorRecord.complianceState, nextRecord.complianceState)
+}
+
+export function resolveProcedureRevisedCaseIds(
+  priorRecords: RuleDocumentComplianceRecordsMap | null | undefined,
+  nextRecords: RuleDocumentComplianceRecordsMap | null | undefined,
+  cases: Record<string, CaseInstance>
+): readonly string[] {
+  const safePrior = priorRecords ?? {}
+  const safeNext = nextRecords ?? {}
+  const matched = new Set<string>()
+
+  for (const recordId of Object.keys(safeNext).sort((left, right) => left.localeCompare(right))) {
+    const priorRecord = safePrior[recordId]
+    const nextRecord = safeNext[recordId]
+    if (!priorRecord || !nextRecord) {
+      continue
+    }
+
+    if (!didProcedureRevisionRecover(priorRecord, nextRecord)) {
+      continue
+    }
+
+    for (const currentCase of Object.values(cases)) {
+      if (currentCase.status === 'resolved') {
+        continue
+      }
+
+      if (complianceRecordExplicitlyLinksToCase(nextRecord, currentCase)) {
+        matched.add(currentCase.id)
+      }
+    }
+  }
+
+  return [...matched].sort((left, right) => left.localeCompare(right))
+}
+
 export function applyCaseLifecycleEventToCase(
   caseData: CaseInstance,
   event: CaseLifecycleEvent
@@ -276,6 +427,22 @@ function resolveWeeklyCaseLifecycleEvents(
 
   for (const caseId of resolveAnomalyConfirmedCaseIds(input.extranormalEventRecords, cases)) {
     appendEvent(caseId, 'anomaly_confirmed')
+  }
+
+  for (const caseId of resolveResearchInvalidationCaseIds(
+    input.priorRuleDocumentComplianceRecords,
+    input.nextRuleDocumentComplianceRecords,
+    cases
+  )) {
+    appendEvent(caseId, 'research_invalidation')
+  }
+
+  for (const caseId of resolveProcedureRevisedCaseIds(
+    input.priorRuleDocumentComplianceRecords,
+    input.nextRuleDocumentComplianceRecords,
+    cases
+  )) {
+    appendEvent(caseId, 'procedure_revised')
   }
 
   return eventsByCase

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4586,20 +4586,6 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     }
   }
 
-  // SPE-1310 slice 3: apply case lifecycle transitions from weekly intake/registry event sources.
-  const priorCasesForLifecycle = outputWeeklyState.cases ?? {}
-  if (Object.keys(priorCasesForLifecycle).length > 0) {
-    const lifecycleTick = applyWeeklyCaseLifecycleTick(priorCasesForLifecycle, {
-      week: result.week,
-      priorIntakeReports,
-      nextIntakeReports: outputWeeklyState.informationIntakeReports ?? priorIntakeReports,
-      extranormalEventRecords: outputWeeklyState.extranormalEventRecords,
-    })
-    if (lifecycleTick.changed) {
-      outputWeeklyState.cases = lifecycleTick.cases
-    }
-  }
-
   // SPE-2105 slice 3: expire extranormal monitoring windows and advance monitor_only closure.
   const currentExtranormalEvents = outputWeeklyState.extranormalEventRecords ?? {}
   if (Object.keys(currentExtranormalEvents).length > 0) {
@@ -4862,12 +4848,28 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   }
 
   // SPE-2123 slice 3: compliance-decay band state transitions on rule-document compliance records.
-  const currentRuleDocumentComplianceRecords = outputWeeklyState.ruleDocumentComplianceRecords ?? {}
-  if (Object.keys(currentRuleDocumentComplianceRecords).length > 0) {
+  const priorRuleDocumentComplianceRecords = outputWeeklyState.ruleDocumentComplianceRecords ?? {}
+  if (Object.keys(priorRuleDocumentComplianceRecords).length > 0) {
     outputWeeklyState.ruleDocumentComplianceRecords = applyWeeklyRuleDocumentComplianceTick(
-      currentRuleDocumentComplianceRecords,
+      priorRuleDocumentComplianceRecords,
       result.week
     )
+  }
+
+  // SPE-1310 slice 3–4: apply case lifecycle transitions from weekly intake/registry/compliance sources.
+  const priorCasesForLifecycle = outputWeeklyState.cases ?? {}
+  if (Object.keys(priorCasesForLifecycle).length > 0) {
+    const lifecycleTick = applyWeeklyCaseLifecycleTick(priorCasesForLifecycle, {
+      week: result.week,
+      priorIntakeReports,
+      nextIntakeReports: outputWeeklyState.informationIntakeReports ?? priorIntakeReports,
+      extranormalEventRecords: outputWeeklyState.extranormalEventRecords,
+      priorRuleDocumentComplianceRecords,
+      nextRuleDocumentComplianceRecords: outputWeeklyState.ruleDocumentComplianceRecords,
+    })
+    if (lifecycleTick.changed) {
+      outputWeeklyState.cases = lifecycleTick.cases
+    }
   }
 
   // SPE-1889 slice 5: wire therapeutic-care records into integrated health bundles.

--- a/src/test/advanceWeek.caseLifecycle.integration.test.ts
+++ b/src/test/advanceWeek.caseLifecycle.integration.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { createInformationIntakeReport } from '../domain/informationIntakeReport'
 import type { ExtranormalEventRecord } from '../domain/extranormalEventRegistry'
+import { applyWeeklyCaseLifecycleTick } from '../domain/caseLifecycleWeeklyOrchestration'
+import type { RuleDocumentComplianceRecord } from '../domain/ruleDocumentComplianceContainmentRegistry'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -11,6 +13,21 @@ function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) 
     currentCase.requiredTags = []
     currentCase.preferredTags = []
     currentCase.weeksRemaining = undefined
+  }
+}
+
+function elevatedDriftComplianceRecord(
+  caseId: string,
+  overrides: Partial<RuleDocumentComplianceRecord> = {}
+): RuleDocumentComplianceRecord {
+  return {
+    id: 'rule-document-compliance:advance-week-lifecycle-drift',
+    label: 'Advance week lifecycle drift record',
+    documentRef: caseId,
+    bindingStrength: 'contractual',
+    complianceState: 'compliant',
+    physicalCopyRequired: false,
+    ...overrides,
   }
 }
 
@@ -112,5 +129,72 @@ describe('advanceWeek case lifecycle integration (SPE-1310 slice 3)', () => {
     const nextState = advanceWeek(state)
 
     expect(nextState.cases[targetCase.id]?.lifecycleStage).toBe('containment')
+  })
+})
+
+describe('advanceWeek case lifecycle integration (SPE-1310 slice 4)', () => {
+  it('advances containment to revision when linked compliance drifts through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+
+    const targetCase = Object.values(state.cases)[0]
+    targetCase.lifecycleStage = 'containment'
+
+    const record = elevatedDriftComplianceRecord(targetCase.id)
+    state.week = 139
+    state.ruleDocumentComplianceRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.week).toBe(140)
+    expect(nextState.cases[targetCase.id]?.lifecycleStage).toBe('revision')
+    expect(nextState.ruleDocumentComplianceRecords?.[record.id]?.complianceState).toBe('drifting')
+  })
+
+  it('runs containment to revision via advanceWeek then back to containment on registry recovery', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+
+    const targetCase = Object.values(state.cases)[0]
+    targetCase.lifecycleStage = 'containment'
+
+    const record = elevatedDriftComplianceRecord(targetCase.id)
+    state.week = 139
+    state.ruleDocumentComplianceRecords = {
+      [record.id]: record,
+    }
+
+    const afterDriftState = advanceWeek(state)
+    expect(afterDriftState.cases[targetCase.id]?.lifecycleStage).toBe('revision')
+
+    const driftingRecord = afterDriftState.ruleDocumentComplianceRecords?.[record.id]
+    if (!driftingRecord) {
+      throw new Error('expected drifting compliance record after first advanceWeek')
+    }
+
+    const priorRecoveryRecords = {
+      [record.id]: {
+        ...driftingRecord,
+        revisionHistoryRefs: ['revision:containment-loop-v1'],
+      },
+    }
+    const nextRecoveryRecords = {
+      [record.id]: {
+        ...driftingRecord,
+        complianceState: 'compliant' as const,
+        revisionHistoryRefs: ['revision:containment-loop-v1', 'revision:containment-loop-v2'],
+      },
+    }
+
+    const recoveryTick = applyWeeklyCaseLifecycleTick(afterDriftState.cases, {
+      week: afterDriftState.week,
+      priorRuleDocumentComplianceRecords: priorRecoveryRecords,
+      nextRuleDocumentComplianceRecords: nextRecoveryRecords,
+    })
+
+    expect(recoveryTick.changed).toBe(true)
+    expect(recoveryTick.cases[targetCase.id]?.lifecycleStage).toBe('containment')
   })
 })

--- a/src/test/caseLifecycleWeeklyOrchestration.test.ts
+++ b/src/test/caseLifecycleWeeklyOrchestration.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, it } from 'vitest'
 import {
   applyCaseLifecycleEventToCase,
   applyWeeklyCaseLifecycleTick,
+  didComplianceResearchInvalidationSignal,
   didIntakeCredibilityReviewPass,
+  didProcedureRevisionRecover,
   resolveAnomalyConfirmedCaseIds,
   resolveCredibilityReviewPassedCaseIds,
+  resolveProcedureRevisedCaseIds,
+  resolveResearchInvalidationCaseIds,
 } from '../domain/caseLifecycleWeeklyOrchestration'
+import type { RuleDocumentComplianceRecord } from '../domain/ruleDocumentComplianceContainmentRegistry'
 import { createInformationIntakeReport } from '../domain/informationIntakeReport'
 import type { CaseInstance } from '../domain/models'
 import type { ExtranormalEventRecord } from '../domain/extranormalEventRegistry'
@@ -29,6 +34,20 @@ function makeCase(overrides: Partial<CaseInstance> = {}): CaseInstance {
     deadlineWeeks: 8,
     deadlineRemaining: 8,
     assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+function complianceRecord(
+  overrides: Partial<RuleDocumentComplianceRecord> = {}
+): RuleDocumentComplianceRecord {
+  return {
+    id: 'rule-document-compliance:lifecycle-test',
+    label: 'Lifecycle compliance test record',
+    documentRef: 'case:lifecycle-target',
+    bindingStrength: 'contractual',
+    complianceState: 'compliant',
+    physicalCopyRequired: false,
     ...overrides,
   }
 }
@@ -194,5 +213,181 @@ describe('caseLifecycleWeeklyOrchestration (SPE-1310 slice 3)', () => {
 
     expect(result.changed).toBe(false)
     expect(result.cases[uninitializedCase.id]?.lifecycleStage).toBeUndefined()
+  })
+})
+
+describe('caseLifecycleWeeklyOrchestration (SPE-1310 slice 4)', () => {
+  it('applyCaseLifecycleEventToCase advances containment to revision on research invalidation', () => {
+    const currentCase = makeCase({ lifecycleStage: 'containment' })
+    const nextCase = applyCaseLifecycleEventToCase(currentCase, 'research_invalidation')
+
+    expect(nextCase.lifecycleStage).toBe('revision')
+  })
+
+  it('applyCaseLifecycleEventToCase advances revision to containment on procedure revised', () => {
+    const currentCase = makeCase({ lifecycleStage: 'revision' })
+    const nextCase = applyCaseLifecycleEventToCase(currentCase, 'procedure_revised')
+
+    expect(nextCase.lifecycleStage).toBe('containment')
+  })
+
+  it('didComplianceResearchInvalidationSignal detects first drift and breach escalation', () => {
+    expect(didComplianceResearchInvalidationSignal('compliant', 'drifting')).toBe(true)
+    expect(didComplianceResearchInvalidationSignal('drifting', 'breach')).toBe(true)
+    expect(didComplianceResearchInvalidationSignal('drifting', 'drifting')).toBe(false)
+    expect(didComplianceResearchInvalidationSignal('breach', 'breach')).toBe(false)
+  })
+
+  it('resolveResearchInvalidationCaseIds requires explicit documentRef case linkage', () => {
+    const currentCase = makeCase({ lifecycleStage: 'containment' })
+    const linkedRecord = complianceRecord({
+      id: 'rule-document-compliance:linked-drift',
+      documentRef: currentCase.id,
+    })
+    const unlinkedRecord = complianceRecord({
+      id: 'rule-document-compliance:unlinked-drift',
+      documentRef: 'document:unrelated-procedure',
+    })
+
+    const priorRecords = {
+      [linkedRecord.id]: { ...linkedRecord, complianceState: 'compliant' as const },
+      [unlinkedRecord.id]: { ...unlinkedRecord, complianceState: 'compliant' as const },
+    }
+    const nextRecords = {
+      [linkedRecord.id]: { ...linkedRecord, complianceState: 'drifting' as const },
+      [unlinkedRecord.id]: { ...unlinkedRecord, complianceState: 'drifting' as const },
+    }
+
+    expect(
+      resolveResearchInvalidationCaseIds(priorRecords, nextRecords, {
+        [currentCase.id]: currentCase,
+      })
+    ).toEqual([currentCase.id])
+  })
+
+  it('didProcedureRevisionRecover detects new revision ref with compliance recovery', () => {
+    const priorRecord = complianceRecord({
+      complianceState: 'drifting',
+      revisionHistoryRefs: ['revision:procedure-v1'],
+    })
+    const nextRecord = complianceRecord({
+      complianceState: 'compliant',
+      revisionHistoryRefs: ['revision:procedure-v1', 'revision:procedure-v2'],
+    })
+
+    expect(didProcedureRevisionRecover(priorRecord, nextRecord)).toBe(true)
+    expect(
+      didProcedureRevisionRecover(nextRecord, {
+        ...nextRecord,
+        revisionHistoryRefs: ['revision:procedure-v1', 'revision:procedure-v2'],
+      })
+    ).toBe(false)
+  })
+
+  it('resolveProcedureRevisedCaseIds links recovery to explicitly referenced cases', () => {
+    const currentCase = makeCase({ lifecycleStage: 'revision' })
+    const record = complianceRecord({
+      id: 'rule-document-compliance:procedure-recovery',
+      documentRef: currentCase.templateId,
+      revisionHistoryRefs: ['revision:procedure-v1'],
+    })
+
+    const priorRecords = {
+      [record.id]: { ...record, complianceState: 'drifting' as const },
+    }
+    const nextRecords = {
+      [record.id]: {
+        ...record,
+        complianceState: 'compliant' as const,
+        revisionHistoryRefs: ['revision:procedure-v1', 'revision:procedure-v2'],
+      },
+    }
+
+    expect(
+      resolveProcedureRevisedCaseIds(priorRecords, nextRecords, {
+        [currentCase.id]: currentCase,
+      })
+    ).toEqual([currentCase.id])
+  })
+
+  it('applyWeeklyCaseLifecycleTick applies containment revision loop events', () => {
+    const containmentCase = makeCase({
+      id: 'case:containment-loop',
+      lifecycleStage: 'containment',
+    })
+    const revisionCase = makeCase({
+      id: 'case:revision-loop',
+      lifecycleStage: 'revision',
+    })
+    const driftRecord = complianceRecord({
+      id: 'rule-document-compliance:containment-drift',
+      documentRef: containmentCase.id,
+    })
+    const recoveryRecord = complianceRecord({
+      id: 'rule-document-compliance:revision-recovery',
+      documentRef: revisionCase.id,
+      revisionHistoryRefs: ['revision:loop-v1'],
+    })
+
+    const result = applyWeeklyCaseLifecycleTick(
+      {
+        [containmentCase.id]: containmentCase,
+        [revisionCase.id]: revisionCase,
+      },
+      {
+        week: 8,
+        priorRuleDocumentComplianceRecords: {
+          [driftRecord.id]: { ...driftRecord, complianceState: 'compliant' },
+          [recoveryRecord.id]: { ...recoveryRecord, complianceState: 'drifting' },
+        },
+        nextRuleDocumentComplianceRecords: {
+          [driftRecord.id]: { ...driftRecord, complianceState: 'drifting' },
+          [recoveryRecord.id]: {
+            ...recoveryRecord,
+            complianceState: 'compliant',
+            revisionHistoryRefs: ['revision:loop-v1', 'revision:loop-v2'],
+          },
+        },
+      }
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.cases[containmentCase.id]?.lifecycleStage).toBe('revision')
+    expect(result.cases[revisionCase.id]?.lifecycleStage).toBe('containment')
+    expect(result.appliedEvents).toEqual([
+      {
+        caseId: containmentCase.id,
+        event: 'research_invalidation',
+        fromStage: 'containment',
+        toStage: 'revision',
+      },
+      {
+        caseId: revisionCase.id,
+        event: 'procedure_revised',
+        fromStage: 'revision',
+        toStage: 'containment',
+      },
+    ])
+  })
+
+  it('applyWeeklyCaseLifecycleTick is idempotent when compliance maps are unchanged', () => {
+    const currentCase = makeCase({ lifecycleStage: 'containment' })
+    const record = complianceRecord({
+      documentRef: currentCase.id,
+      complianceState: 'drifting',
+    })
+    const records = { [record.id]: record }
+
+    const result = applyWeeklyCaseLifecycleTick(
+      { [currentCase.id]: currentCase },
+      {
+        week: 3,
+        priorRuleDocumentComplianceRecords: records,
+        nextRuleDocumentComplianceRecords: records,
+      }
+    )
+
+    expect(result.changed).toBe(false)
+    expect(result.cases[currentCase.id]?.lifecycleStage).toBe('containment')
   })
 })


### PR DESCRIPTION
## Summary

- Map esearch_invalidation from rule-document compliance drift/breach crossings (pplyWeeklyRuleDocumentComplianceTick prior/next output) with explicit documentRef ↔ case id/templateId linkage.
- Map procedure_revised from registry recovery (new evision: ref + improved compliance state).
- Move dvanceWeek lifecycle tick to run after the compliance-decay tick and pass prior/next compliance maps.

## Linear

- **Slice:** [SPE-2412](https://linear.app/spectranoir/issue/SPE-2412)
- **Parent:** [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) — remains open (disposition / policy-tier / institutional-vs-operational AC gaps)

## What shipped

- Extended pplyWeeklyCaseLifecycleTick with compliance breach/drift and procedure-recovery resolvers.
- dvanceWeek wires prior/next uleDocumentComplianceRecords into the lifecycle tick after SPE-2123 compliance-decay advance.
- Unit + integration tests for containment ↔ revision transitions and uninitialized-case regression.

## Validation

- 
pm run lint
- 
pm run test:run src/test/caseLifecycleWeeklyOrchestration.test.ts src/test/advanceWeek.caseLifecycle.integration.test.ts

## Docs

- planning/anomaly-case-lifecycle-state-machine-slice-4.md (backlog update deferred to merge closeout)

Made with [Cursor](https://cursor.com)