### PR TITLE
SPE-2417: coercive procedure welfare-debt creation hook (slice 5)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) coercive-procedure → welfare-debt creation follow-up (primary open AC per [SPE-2400](https://linear.app/spectranoir/issue/SPE-2400) grooming). Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** After [SPE-2417](https://linear.app/spectranoir/issue/SPE-2417) merges — [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) privilege-deprivation / personnel-sourcing procedural cases or [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) full protocol model. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `e7943029`
+**Base `main` SHA:** `6e9ffb3d` (in progress: [SPE-2417](https://linear.app/spectranoir/issue/SPE-2417) slice 5 @ `spe-1888-coercive-procedure-welfare-debt-creation-slice-5`)
 
 **Recently shipped:** [SPE-2414](https://linear.app/spectranoir/issue/SPE-2414) anomaly case lifecycle slice 6 — `lifecycleInstitutionalLabel` @ PR #2697; see `planning/anomaly-case-lifecycle-state-machine-slice-6.md`.
 

--- a/planning/welfare-debt-accounting-registry-slice-5.md
+++ b/planning/welfare-debt-accounting-registry-slice-5.md
@@ -1,0 +1,77 @@
+# SPE-1888 — Coercive procedure welfare-debt creation hook (slice 5)
+
+One-page implementation plan. Linear: [SPE-2417](https://linear.app/spectranoir/issue/SPE-2417) (child under [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888)). Follows shipped slice 4 (`planning/welfare-debt-accounting-registry-slice-4.md`, PR #2574) and grooming [SPE-2400](https://linear.app/spectranoir/issue/SPE-2400).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2417 — Coercive procedure welfare-debt creation hook (slice 5)](https://linear.app/spectranoir/issue/SPE-2417) |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — procedural debt-creation AC; parent stays **Backlog** until remaining AC gaps close |
+| **Branch** | `spe-1888-coercive-procedure-welfare-debt-creation-slice-5`                                                |
+| **Base `main` SHA** | `6e9ffb3d`                                                                                          |
+
+## Goal
+
+Deterministic hook that creates `WelfareDebtAccountingRecord` entries when a coercive procedure executes and containment or security improves — reuse registry schema + weekly tick; no new parallel ledger.
+
+## Prerequisite (on `main` @ `6e9ffb3d`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/welfareDebtAccountingRegistry.ts` (SPE-1888 slice 1 / SPE-2350 / PR #2568) |
+| Persistence          | `welfareDebtAccountingRecords` on `GameState` (SPE-1888 slice 1 / PR #2568) |
+| Mirror UI            | `welfareDebtAccountingMirrorView` (SPE-2351 / PR #2570)                |
+| Weekly orchestration | `applyWeeklyWelfareDebtAccountingTick` (SPE-2352 / PR #2572)             |
+| Ledger summary audit | `summarizeWelfareDebtAccountingRecords` (SPE-2353 / PR #2574)           |
+| Medication / custody regimens | `containedPersonMedicationRegimenRegistry.ts`, `containedPersonCustodyStatusRegistry.ts` |
+
+## Creation hook contract (slice 5)
+
+- **Procedure anchors** — minimal [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) refs in `coerciveProcedureRegistry.ts` (forced sedation stabilization, extended mechanical restraint).
+- **Execution draft** — derive from compelled medication regimens with `containmentPurposeLabel` and elevated custody holds; require `postContainmentScore > priorContainmentScore`.
+- **Legitimacy cost separate from operational success** — `containmentBenefitScore` records operational benefit; high benefit does **not** suppress debt creation.
+- **Severity classification** — category base band + coercion pressure + adverse-reaction escalation; independent of benefit magnitude.
+- **Idempotent creation** — stable `executionKey` per procedure instance; re-tick with same drafts is a no-op; authored fixtures preserved when ids do not collide.
+- **Weekly ordering** — creation tick runs before `applyWeeklyWelfareDebtAccountingTick` in `advanceWeek`.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coerciveProcedureRegistry.ts` + `coerciveProcedureWelfareDebtCreation.ts` | Full SPE-1882 protocol model |
+| `advanceWeek` wire-up before weekly welfare-debt tick              | Mission triage UI                             |
+| Unit + integration tests                                           | Registry decay semantic changes               |
+| Slice doc (this file) + backlog handoff                            | SPE-1888 parent Done                            |
+|                                                                    | SPE-1889 parent closure                       |
+|                                                                    | Privilege-deprivation / personnel-sourcing procedural cases (follow-up) |
+
+## Acceptance
+
+- [ ] Coercive procedure execution with containment improvement creates validated `WelfareDebtAccountingRecord`
+- [ ] Severity classification deterministic from category + coercion signals
+- [ ] High containment benefit still creates unresolved debt (no benefit-as-erasure)
+- [ ] Re-applying creation tick is idempotent; authored fixtures preserved
+- [ ] `advanceWeek` integration creates debt from medication/custody anchors
+- [ ] `npm run lint` + targeted tests + slice 1–4 audit summary regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProcedureRegistry.ts`, `src/domain/coerciveProcedureWelfareDebtCreation.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/coerciveProcedureWelfareDebtCreation.test.ts`, `src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts` |
+| Plan   | `planning/welfare-debt-accounting-registry-slice-5.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full SPE-1882 coercive protocol model | SPE-1882 | Slice 5 uses minimal anchors only |
+| Privilege-deprivation / coerced-risk sourcing cases | SPE-1888 follow-up | Out of smallest hook boundary |
+| Ethics / accountability matrix links | SPE-1047, SPE-1131 | Parent scope links; not registry slice |
+| SPE-1888 parent Done | SPE-1888 | Slice 5 closes primary open AC from SPE-2400; remaining parent links deferred |
+
+## See also
+
+- `planning/welfare-debt-accounting-registry-slice-4.md`
+- `planning/spe-1888-parent-acceptance-review-slice-1.md`

--- a/src/domain/coerciveProcedureRegistry.ts
+++ b/src/domain/coerciveProcedureRegistry.ts
@@ -1,0 +1,91 @@
+/**
+ * SPE-1882 / SPE-1888 slice 5: minimal coercive contained-person procedure anchors.
+ *
+ * Bounded procedure refs for welfare-debt creation wire-up — not the full
+ * coercive protocol model (SPE-1882 parent remains open).
+ */
+
+import type { WelfareDebtCategory } from './welfareDebtAccountingRegistry'
+
+// ---------------------------------------------------------------------------
+// Handling modes (subset of SPE-1882 taxonomy)
+// ---------------------------------------------------------------------------
+
+export type CoerciveHandlingMode =
+  | 'voluntary'
+  | 'negotiated'
+  | 'compelled'
+  | 'emergency'
+  | 'punitive'
+
+export const COERCIVE_HANDLING_MODES: readonly CoerciveHandlingMode[] = [
+  'voluntary',
+  'negotiated',
+  'compelled',
+  'emergency',
+  'punitive',
+] as const
+
+export type CoerciveCoercionPressureTier = 'medium' | 'high'
+
+// ---------------------------------------------------------------------------
+// Procedure anchors
+// ---------------------------------------------------------------------------
+
+export interface CoerciveProcedureAnchor {
+  readonly procedureRef: string
+  readonly sourceProcedureLabel: string
+  readonly debtCategory: WelfareDebtCategory
+  readonly handlingMode: CoerciveHandlingMode
+  readonly reviewOwnerLabel: string
+  readonly mitigationPathLabel: string
+  readonly coercionPressureTier: CoerciveCoercionPressureTier
+  /** Optional medication-regimen id that authorizes this coercive procedure. */
+  readonly regimenRef?: string
+  /** Optional custody-status id that authorizes restraint-style coercion. */
+  readonly custodyStatusRef?: string
+}
+
+function defineAnchor(anchor: CoerciveProcedureAnchor): CoerciveProcedureAnchor {
+  return Object.freeze({ ...anchor })
+}
+
+/** Forced sedation stabilization with compelled medication and containment purpose. */
+export const FORCED_SEDATION_STABILIZATION_ANCHOR: CoerciveProcedureAnchor = defineAnchor({
+  procedureRef: 'coercive-procedure:forced-sedation-stabilization',
+  sourceProcedureLabel: 'forced sedation stabilization cycle',
+  debtCategory: 'coerced_medication',
+  handlingMode: 'compelled',
+  reviewOwnerLabel: 'psychiatric review panel',
+  mitigationPathLabel: 'independent welfare audit',
+  coercionPressureTier: 'high',
+  regimenRef: 'medication-regimen:coercive-sedative-beta',
+})
+
+/** Extended mechanical restraint with elevated custody restrictions. */
+export const EXTENDED_MECHANICAL_RESTRAINT_ANCHOR: CoerciveProcedureAnchor = defineAnchor({
+  procedureRef: 'coercive-procedure:extended-mechanical-restraint',
+  sourceProcedureLabel: 'extended mechanical restraint cycle',
+  debtCategory: 'harmful_restraint',
+  handlingMode: 'compelled',
+  reviewOwnerLabel: 'ethics review board',
+  mitigationPathLabel: 'independent welfare audit',
+  coercionPressureTier: 'high',
+  custodyStatusRef: 'custody-status:former-hostile-hold',
+})
+
+export const COERCIVE_PROCEDURE_ANCHORS: readonly CoerciveProcedureAnchor[] = Object.freeze([
+  FORCED_SEDATION_STABILIZATION_ANCHOR,
+  EXTENDED_MECHANICAL_RESTRAINT_ANCHOR,
+])
+
+const COERCIVE_PROCEDURE_ANCHOR_BY_REF = new Map<string, CoerciveProcedureAnchor>(
+  COERCIVE_PROCEDURE_ANCHORS.map((anchor) => [anchor.procedureRef, anchor])
+)
+
+export function resolveCoerciveProcedureAnchor(
+  procedureRef: string
+): CoerciveProcedureAnchor | undefined {
+  const normalized = procedureRef.trim()
+  return normalized.length > 0 ? COERCIVE_PROCEDURE_ANCHOR_BY_REF.get(normalized) : undefined
+}

--- a/src/domain/coerciveProcedureWelfareDebtCreation.ts
+++ b/src/domain/coerciveProcedureWelfareDebtCreation.ts
@@ -1,0 +1,397 @@
+/**
+ * SPE-1888 slice 5: welfare-debt creation on coercive procedure execution.
+ *
+ * Creates persisted `WelfareDebtAccountingRecord` entries when a coercive procedure
+ * executes and containment or security improves. Legitimacy cost is recorded
+ * separately from operational containment benefit — high benefit does not erase debt.
+ */
+
+import type { CustodyStatusRecordsMap, CustodyStatusRecord } from './containedPersonCustodyStatusRegistry'
+import type { MedicationRegimenRecordsMap, MedicationRegimenRecord } from './containedPersonMedicationRegimenRegistry'
+import {
+  COERCIVE_PROCEDURE_ANCHORS,
+  resolveCoerciveProcedureAnchor,
+  type CoerciveProcedureAnchor,
+} from './coerciveProcedureRegistry'
+import {
+  resolveNextWelfareDebtSeverityBand,
+  validateWelfareDebtAccountingRecord,
+  type WelfareDebtAccountingRecord,
+  type WelfareDebtAccountingRecordsMap,
+  type WelfareDebtCategory,
+  type WelfareDebtSeverityBand,
+} from './welfareDebtAccountingRegistry'
+
+// ---------------------------------------------------------------------------
+// Execution draft
+// ---------------------------------------------------------------------------
+
+export interface CoerciveProcedureExecutionDraft {
+  /** Stable idempotency key — one debt ledger entry per procedure execution instance. */
+  readonly executionKey: string
+  readonly subjectRef: string
+  readonly procedureRef: string
+  readonly priorContainmentScore: number
+  readonly postContainmentScore: number
+  readonly week: number
+  readonly adverseReactionFlag?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const CATEGORY_BASE_SEVERITY: Readonly<Record<WelfareDebtCategory, WelfareDebtSeverityBand>> = {
+  harmful_restraint: 'high',
+  coerced_medication: 'high',
+  punitive_handling: 'high',
+  high_risk_personnel_sourcing: 'high',
+  forced_isolation: 'moderate',
+  coercive_interview: 'moderate',
+  privilege_deprivation: 'moderate',
+  coerced_participation: 'low',
+}
+
+const BASELINE_INSECURITY_SCORE = 0.38
+const ELEVATED_CUSTODY_IMPROVEMENT_SCORE = 0.71
+const ADVERSE_REACTION_CONTAINMENT_PENALTY = 0.1
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function clampUnitScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.min(1, Math.max(0, value))
+}
+
+function freezeRecord(record: WelfareDebtAccountingRecord): WelfareDebtAccountingRecord {
+  return Object.freeze({ ...record })
+}
+
+function buildExecutionKey(procedureRef: string, subjectRef: string): string {
+  return `${procedureRef}:${subjectRef}`
+}
+
+function buildWelfareDebtRecordId(executionKey: string): string {
+  return `welfare-debt:${executionKey}`
+}
+
+// ---------------------------------------------------------------------------
+// Public classification helpers
+// ---------------------------------------------------------------------------
+
+/** Whether containment or security improved between prior and post scores. */
+export function hasContainmentOrSecurityImprovement(
+  draft: CoerciveProcedureExecutionDraft
+): boolean {
+  return draft.postContainmentScore > draft.priorContainmentScore
+}
+
+/**
+ * Operational containment benefit for the ledger entry.
+ * Recorded alongside welfare debt — does not gate or erase debt creation.
+ */
+export function resolveContainmentBenefitScoreFromExecution(
+  draft: CoerciveProcedureExecutionDraft
+): number {
+  return clampUnitScore(draft.postContainmentScore)
+}
+
+/**
+ * Deterministic severity classification from debt category, coercion pressure,
+ * and adverse-reaction signals. Independent of containment benefit magnitude.
+ */
+export function resolveWelfareDebtSeverityBandForCoerciveProcedure(
+  anchor: CoerciveProcedureAnchor,
+  draft: CoerciveProcedureExecutionDraft
+): WelfareDebtSeverityBand {
+  let severityBand = CATEGORY_BASE_SEVERITY[anchor.debtCategory]
+
+  if (anchor.coercionPressureTier === 'high' && severityBand === 'moderate') {
+    severityBand = 'high'
+  }
+
+  if (draft.adverseReactionFlag === true) {
+    const escalated = resolveNextWelfareDebtSeverityBand(severityBand)
+    if (escalated) {
+      severityBand = escalated
+    }
+  }
+
+  return severityBand
+}
+
+// ---------------------------------------------------------------------------
+// Record builder
+// ---------------------------------------------------------------------------
+
+export function buildWelfareDebtAccountingRecordForCoerciveProcedureExecution(
+  draft: CoerciveProcedureExecutionDraft,
+  anchor: CoerciveProcedureAnchor
+): WelfareDebtAccountingRecord | undefined {
+  if (!hasContainmentOrSecurityImprovement(draft)) {
+    return undefined
+  }
+
+  const containmentBenefitScore = resolveContainmentBenefitScoreFromExecution(draft)
+  const recordId = buildWelfareDebtRecordId(draft.executionKey)
+
+  const candidate: WelfareDebtAccountingRecord = {
+    id: recordId,
+    label: `${anchor.sourceProcedureLabel} welfare debt`,
+    summary:
+      'Coercive procedure with documented containment benefit and unresolved welfare debt.',
+    subjectRef: draft.subjectRef,
+    debtCategory: anchor.debtCategory,
+    severityBand: resolveWelfareDebtSeverityBandForCoerciveProcedure(anchor, draft),
+    mitigationState: 'unresolved',
+    sourceProcedureLabel: anchor.sourceProcedureLabel,
+    reviewOwnerLabel: anchor.reviewOwnerLabel,
+    mitigationPathLabel: anchor.mitigationPathLabel,
+    containmentBenefitScore,
+    confidence: containmentBenefitScore,
+  }
+
+  if (!validateWelfareDebtAccountingRecord(candidate).valid) {
+    return undefined
+  }
+
+  return freezeRecord(candidate)
+}
+
+// ---------------------------------------------------------------------------
+// Draft derivation
+// ---------------------------------------------------------------------------
+
+function resolvePostContainmentScoreFromMedicationRegimen(
+  regimen: MedicationRegimenRecord
+): number | undefined {
+  if (regimen.consentStatus !== 'compelled') {
+    return undefined
+  }
+
+  if (!normalizeToken(regimen.containmentPurposeLabel)) {
+    return undefined
+  }
+
+  const confidence = isValidUnitScore(regimen.confidence) ? regimen.confidence : 0.5
+  const penalty = regimen.adverseReactionFlag ? ADVERSE_REACTION_CONTAINMENT_PENALTY : 0
+
+  return clampUnitScore(confidence - penalty)
+}
+
+function resolvePostContainmentScoreFromCustodyStatus(
+  custody: CustodyStatusRecord
+): number | undefined {
+  if (custody.custodyStage !== 'contained_person') {
+    return undefined
+  }
+
+  if (normalizeToken(custody.restrictionLevel) !== 'elevated') {
+    return undefined
+  }
+
+  const confidence = isValidUnitScore(custody.confidence) ? custody.confidence : 0.5
+  return clampUnitScore(Math.max(confidence, ELEVATED_CUSTODY_IMPROVEMENT_SCORE))
+}
+
+function pushMedicationRegimenDraft(
+  drafts: CoerciveProcedureExecutionDraft[],
+  anchor: CoerciveProcedureAnchor,
+  regimen: MedicationRegimenRecord,
+  week: number
+) {
+  const postContainmentScore = resolvePostContainmentScoreFromMedicationRegimen(regimen)
+  if (postContainmentScore === undefined) {
+    return
+  }
+
+  const priorContainmentScore = BASELINE_INSECURITY_SCORE
+  if (postContainmentScore <= priorContainmentScore) {
+    return
+  }
+
+  const subjectRef = normalizeToken(regimen.subjectRef)
+  if (!subjectRef) {
+    return
+  }
+
+  drafts.push({
+    executionKey: buildExecutionKey(anchor.procedureRef, subjectRef),
+    subjectRef,
+    procedureRef: anchor.procedureRef,
+    priorContainmentScore,
+    postContainmentScore,
+    week,
+    adverseReactionFlag: regimen.adverseReactionFlag,
+  })
+}
+
+function pushCustodyStatusDraft(
+  drafts: CoerciveProcedureExecutionDraft[],
+  anchor: CoerciveProcedureAnchor,
+  custody: CustodyStatusRecord,
+  week: number
+) {
+  const postContainmentScore = resolvePostContainmentScoreFromCustodyStatus(custody)
+  if (postContainmentScore === undefined) {
+    return
+  }
+
+  const priorContainmentScore = BASELINE_INSECURITY_SCORE
+  if (postContainmentScore <= priorContainmentScore) {
+    return
+  }
+
+  const subjectRef = normalizeToken(custody.subjectRef)
+  if (!subjectRef) {
+    return
+  }
+
+  drafts.push({
+    executionKey: buildExecutionKey(anchor.procedureRef, subjectRef),
+    subjectRef,
+    procedureRef: anchor.procedureRef,
+    priorContainmentScore,
+    postContainmentScore,
+    week,
+  })
+}
+
+/** Derive coercive procedure execution drafts from persisted medication regimen records. */
+export function resolveCoerciveProcedureExecutionDraftsFromMedicationRegimens(
+  regimens: MedicationRegimenRecordsMap | null | undefined,
+  week: number
+): readonly CoerciveProcedureExecutionDraft[] {
+  const safeRegimens = regimens ?? {}
+  const normalizedWeek = normalizeWeek(week)
+  const drafts: CoerciveProcedureExecutionDraft[] = []
+
+  for (const anchor of COERCIVE_PROCEDURE_ANCHORS) {
+    const regimenRef = anchor.regimenRef
+    if (!regimenRef) {
+      continue
+    }
+
+    const regimen = safeRegimens[regimenRef]
+    if (!regimen) {
+      continue
+    }
+
+    pushMedicationRegimenDraft(drafts, anchor, regimen, normalizedWeek)
+  }
+
+  return Object.freeze(
+    drafts.sort((left, right) => left.executionKey.localeCompare(right.executionKey))
+  )
+}
+
+/** Derive coercive procedure execution drafts from persisted custody status records. */
+export function resolveCoerciveProcedureExecutionDraftsFromCustodyStatus(
+  custodyRecords: CustodyStatusRecordsMap | null | undefined,
+  week: number
+): readonly CoerciveProcedureExecutionDraft[] {
+  const safeRecords = custodyRecords ?? {}
+  const normalizedWeek = normalizeWeek(week)
+  const drafts: CoerciveProcedureExecutionDraft[] = []
+
+  for (const anchor of COERCIVE_PROCEDURE_ANCHORS) {
+    const custodyStatusRef = anchor.custodyStatusRef
+    if (!custodyStatusRef) {
+      continue
+    }
+
+    const custody = safeRecords[custodyStatusRef]
+    if (!custody) {
+      continue
+    }
+
+    pushCustodyStatusDraft(drafts, anchor, custody, normalizedWeek)
+  }
+
+  return Object.freeze(
+    drafts.sort((left, right) => left.executionKey.localeCompare(right.executionKey))
+  )
+}
+
+/** Merge medication-regimen and custody-status derived execution drafts. */
+export function resolveCoerciveProcedureExecutionDrafts(
+  regimens: MedicationRegimenRecordsMap | null | undefined,
+  custodyRecords: CustodyStatusRecordsMap | null | undefined,
+  week: number
+): readonly CoerciveProcedureExecutionDraft[] {
+  const merged = new Map<string, CoerciveProcedureExecutionDraft>()
+
+  for (const draft of resolveCoerciveProcedureExecutionDraftsFromMedicationRegimens(regimens, week)) {
+    merged.set(draft.executionKey, draft)
+  }
+
+  for (const draft of resolveCoerciveProcedureExecutionDraftsFromCustodyStatus(custodyRecords, week)) {
+    merged.set(draft.executionKey, draft)
+  }
+
+  return Object.freeze(
+    [...merged.values()].sort((left, right) => left.executionKey.localeCompare(right.executionKey))
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Creation tick
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies one coercive-procedure welfare-debt creation pass over persisted records.
+ * Empty drafts is a no-op. Re-applying with the same execution keys is idempotent.
+ */
+export function applyCoerciveProcedureWelfareDebtCreationTick(
+  records: WelfareDebtAccountingRecordsMap | null | undefined,
+  drafts: readonly CoerciveProcedureExecutionDraft[]
+): WelfareDebtAccountingRecordsMap {
+  const safeRecords = records ?? {}
+  if (drafts.length === 0) {
+    return safeRecords
+  }
+
+  const next: WelfareDebtAccountingRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const draft of [...drafts].sort((left, right) =>
+    left.executionKey.localeCompare(right.executionKey)
+  )) {
+    const recordId = buildWelfareDebtRecordId(draft.executionKey)
+    if (next[recordId]) {
+      continue
+    }
+
+    const anchor = resolveCoerciveProcedureAnchor(draft.procedureRef)
+    if (!anchor) {
+      continue
+    }
+
+    const created = buildWelfareDebtAccountingRecordForCoerciveProcedureExecution(draft, anchor)
+    if (!created) {
+      continue
+    }
+
+    next[recordId] = created
+    changed = true
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -269,6 +269,10 @@ import { applyWeeklyEntityWelfareReclassificationTick } from '../entityWelfareRe
 import { applyWeeklyVisualTriggerHazardTick } from '../visualTriggerHazardWeeklyOrchestration'
 import { applyWeeklyNamingHazardDescriptorTick } from '../namingHazardDescriptorWeeklyOrchestration'
 import { applyWeeklyTherapeuticCareTick } from '../containedPersonTherapeuticCareWeeklyOrchestration'
+import {
+  applyCoerciveProcedureWelfareDebtCreationTick,
+  resolveCoerciveProcedureExecutionDrafts,
+} from '../coerciveProcedureWelfareDebtCreation'
 import { applyWeeklyWelfareDebtAccountingTick } from '../welfareDebtAccountingRegistry'
 import { deriveTherapeuticCareBundleFragmentsFromRecords } from '../containedPersonTherapeuticCareHealthBundleLinks'
 import { deriveCustodyStatusBundleFragmentsFromRecords } from '../containedPersonCustodyStatusHealthBundleLinks'
@@ -4716,6 +4720,19 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.containedPersonTherapeuticCareRecords = applyWeeklyTherapeuticCareTick(
       currentTherapeuticCareRecords,
       result.week
+    )
+  }
+
+  // SPE-1888 slice 5: welfare-debt creation when coercive procedures execute with containment improvement.
+  const coerciveProcedureExecutionDrafts = resolveCoerciveProcedureExecutionDrafts(
+    outputWeeklyState.containedPersonMedicationRegimenRecords,
+    outputWeeklyState.containedPersonCustodyStatusRecords,
+    result.week
+  )
+  if (coerciveProcedureExecutionDrafts.length > 0) {
+    outputWeeklyState.welfareDebtAccountingRecords = applyCoerciveProcedureWelfareDebtCreationTick(
+      outputWeeklyState.welfareDebtAccountingRecords ?? {},
+      coerciveProcedureExecutionDrafts
     )
   }
 

--- a/src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE } from '../domain/containedPersonCustodyStatusRegistry'
+import { COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE } from '../domain/containedPersonMedicationRegimenRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import {
+  applyCoerciveProcedureWelfareDebtCreationTick,
+  resolveCoerciveProcedureExecutionDrafts,
+} from '../domain/coerciveProcedureWelfareDebtCreation'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek coercive procedure welfare-debt integration (SPE-1888 slice 5)', () => {
+  it('is a no-op when no coercive procedure anchors are present', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.welfareDebtAccountingRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.welfareDebtAccountingRecords).toEqual({})
+  })
+
+  it('creates welfare-debt records from compelled medication regimen through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 3
+    state.containedPersonMedicationRegimenRecords = {
+      [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record =
+      nextState.welfareDebtAccountingRecords?.[
+        'welfare-debt:coercive-procedure:forced-sedation-stabilization:subject:cooperative-field-asset-22'
+      ]
+
+    expect(nextState.week).toBe(4)
+    expect(record?.debtCategory).toBe('coerced_medication')
+    expect(record?.severityBand).toBe('critical')
+    expect(record?.mitigationState).toBe('acknowledged')
+    expect(record?.containmentBenefitScore).toBe(0.64)
+  })
+
+  it('creates restraint welfare debt from elevated custody status through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 1
+    state.containedPersonCustodyStatusRecords = {
+      [HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE.id]: HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record =
+      nextState.welfareDebtAccountingRecords?.[
+        'welfare-debt:coercive-procedure:extended-mechanical-restraint:subject:cooperative-field-asset-17'
+      ]
+
+    expect(record?.debtCategory).toBe('harmful_restraint')
+    expect(record?.severityBand).toBe('high')
+    expect(record?.mitigationState).toBe('acknowledged')
+    expect(record?.containmentBenefitScore).toBe(0.81)
+  })
+
+  it('does not duplicate debt entries when advanceWeek runs again with the same anchors', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 2
+    state.containedPersonMedicationRegimenRecords = {
+      [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+    }
+
+    const once = advanceWeek(state)
+    const twice = advanceWeek(once)
+
+    expect(Object.keys(once.welfareDebtAccountingRecords ?? {})).toHaveLength(1)
+    expect(twice.welfareDebtAccountingRecords).toEqual(once.welfareDebtAccountingRecords)
+  })
+
+  it('matches standalone creation tick output for the same derived drafts', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 5
+    state.containedPersonMedicationRegimenRecords = {
+      [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+    }
+    state.containedPersonCustodyStatusRecords = {
+      [HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE.id]: HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE,
+    }
+
+    const nextWeek = state.week + 1
+    const drafts = resolveCoerciveProcedureExecutionDrafts(
+      state.containedPersonMedicationRegimenRecords,
+      state.containedPersonCustodyStatusRecords,
+      nextWeek
+    )
+    const createdOnly = applyCoerciveProcedureWelfareDebtCreationTick({}, drafts)
+    const viaAdvanceWeek = advanceWeek(state).welfareDebtAccountingRecords ?? {}
+
+    for (const recordId of Object.keys(createdOnly)) {
+      expect(viaAdvanceWeek[recordId]?.id).toBe(createdOnly[recordId]?.id)
+      expect(viaAdvanceWeek[recordId]?.debtCategory).toBe(createdOnly[recordId]?.debtCategory)
+      expect(viaAdvanceWeek[recordId]?.severityBand).toBe(createdOnly[recordId]?.severityBand)
+      expect(viaAdvanceWeek[recordId]?.containmentBenefitScore).toBe(
+        createdOnly[recordId]?.containmentBenefitScore
+      )
+    }
+  })
+})

--- a/src/test/coerciveProcedureWelfareDebtCreation.test.ts
+++ b/src/test/coerciveProcedureWelfareDebtCreation.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import { HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE } from '../domain/containedPersonCustodyStatusRegistry'
+import { COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE } from '../domain/containedPersonMedicationRegimenRegistry'
+import {
+  EXTENDED_MECHANICAL_RESTRAINT_ANCHOR,
+  FORCED_SEDATION_STABILIZATION_ANCHOR,
+} from '../domain/coerciveProcedureRegistry'
+import {
+  applyCoerciveProcedureWelfareDebtCreationTick,
+  buildWelfareDebtAccountingRecordForCoerciveProcedureExecution,
+  hasContainmentOrSecurityImprovement,
+  resolveCoerciveProcedureExecutionDrafts,
+  resolveCoerciveProcedureExecutionDraftsFromCustodyStatus,
+  resolveCoerciveProcedureExecutionDraftsFromMedicationRegimens,
+  resolveContainmentBenefitScoreFromExecution,
+  resolveWelfareDebtSeverityBandForCoerciveProcedure,
+  type CoerciveProcedureExecutionDraft,
+} from '../domain/coerciveProcedureWelfareDebtCreation'
+import {
+  COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+  validateWelfareDebtAccountingRecord,
+} from '../domain/welfareDebtAccountingRegistry'
+
+function sedationDraft(
+  overrides: Partial<CoerciveProcedureExecutionDraft> = {}
+): CoerciveProcedureExecutionDraft {
+  return {
+    executionKey:
+      'coercive-procedure:forced-sedation-stabilization:subject:cooperative-field-asset-22',
+    subjectRef: 'subject:cooperative-field-asset-22',
+    procedureRef: 'coercive-procedure:forced-sedation-stabilization',
+    priorContainmentScore: 0.38,
+    postContainmentScore: 0.64,
+    week: 4,
+    adverseReactionFlag: true,
+    ...overrides,
+  }
+}
+
+describe('coerciveProcedureWelfareDebtCreation (SPE-1888 slice 5)', () => {
+  it('requires containment or security improvement before creating debt', () => {
+    const draft = sedationDraft({ postContainmentScore: 0.3 })
+
+    expect(hasContainmentOrSecurityImprovement(draft)).toBe(false)
+    expect(
+      buildWelfareDebtAccountingRecordForCoerciveProcedureExecution(
+        draft,
+        FORCED_SEDATION_STABILIZATION_ANCHOR
+      )
+    ).toBeUndefined()
+  })
+
+  it('classifies severity from category pressure and adverse reaction without erasing debt at high benefit', () => {
+    const draft = sedationDraft({ postContainmentScore: 0.91 })
+
+    expect(resolveWelfareDebtSeverityBandForCoerciveProcedure(
+      FORCED_SEDATION_STABILIZATION_ANCHOR,
+      draft
+    )).toBe('critical')
+    expect(resolveContainmentBenefitScoreFromExecution(draft)).toBe(0.91)
+
+    const created = buildWelfareDebtAccountingRecordForCoerciveProcedureExecution(
+      draft,
+      FORCED_SEDATION_STABILIZATION_ANCHOR
+    )
+
+    expect(created).toBeDefined()
+    expect(created?.containmentBenefitScore).toBe(0.91)
+    expect(created?.severityBand).toBe('critical')
+    expect(created?.mitigationState).toBe('unresolved')
+    expect(validateWelfareDebtAccountingRecord(created!).valid).toBe(true)
+  })
+
+  it('builds restraint debt with high severity and containment benefit from custody anchor', () => {
+    const draft: CoerciveProcedureExecutionDraft = {
+      executionKey:
+        'coercive-procedure:extended-mechanical-restraint:subject:cooperative-field-asset-17',
+      subjectRef: 'subject:cooperative-field-asset-17',
+      procedureRef: 'coercive-procedure:extended-mechanical-restraint',
+      priorContainmentScore: 0.38,
+      postContainmentScore: 0.71,
+      week: 3,
+    }
+
+    const created = buildWelfareDebtAccountingRecordForCoerciveProcedureExecution(
+      draft,
+      EXTENDED_MECHANICAL_RESTRAINT_ANCHOR
+    )
+
+    expect(created?.debtCategory).toBe('harmful_restraint')
+    expect(created?.severityBand).toBe('high')
+    expect(created?.containmentBenefitScore).toBe(0.71)
+    expect(created?.sourceProcedureLabel).toBe('extended mechanical restraint cycle')
+  })
+
+  it('derives deterministic execution drafts from compelled medication regimen fixture', () => {
+    const drafts = resolveCoerciveProcedureExecutionDraftsFromMedicationRegimens(
+      {
+        [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+      },
+      6
+    )
+
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]?.postContainmentScore).toBe(0.64)
+    expect(drafts[0]?.adverseReactionFlag).toBe(true)
+  })
+
+  it('derives deterministic execution drafts from elevated custody status fixture', () => {
+    const drafts = resolveCoerciveProcedureExecutionDraftsFromCustodyStatus(
+      {
+        [HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE.id]: HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE,
+      },
+      6
+    )
+
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]?.postContainmentScore).toBe(0.81)
+    expect(drafts[0]?.procedureRef).toBe('coercive-procedure:extended-mechanical-restraint')
+  })
+
+  it('merges medication and custody drafts without duplicate execution keys', () => {
+    const drafts = resolveCoerciveProcedureExecutionDrafts(
+      {
+        [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+      },
+      {
+        [HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE.id]: HOSTILE_ACTOR_CONTAINED_HOLD_FIXTURE,
+      },
+      2
+    )
+
+    expect(drafts).toHaveLength(2)
+    expect(drafts.map((draft) => draft.executionKey)).toEqual([
+      'coercive-procedure:extended-mechanical-restraint:subject:cooperative-field-asset-17',
+      'coercive-procedure:forced-sedation-stabilization:subject:cooperative-field-asset-22',
+    ])
+  })
+
+  it('is idempotent when re-applying creation tick with the same drafts', () => {
+    const drafts = resolveCoerciveProcedureExecutionDraftsFromMedicationRegimens(
+      {
+        [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+      },
+      1
+    )
+
+    const once = applyCoerciveProcedureWelfareDebtCreationTick({}, drafts)
+    const twice = applyCoerciveProcedureWelfareDebtCreationTick(once, drafts)
+
+    expect(Object.keys(once)).toHaveLength(1)
+    expect(twice).toBe(once)
+  })
+
+  it('preserves authored fixtures when ids do not collide', () => {
+    const drafts = resolveCoerciveProcedureExecutionDraftsFromMedicationRegimens(
+      {
+        [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+      },
+      1
+    )
+
+    const next = applyCoerciveProcedureWelfareDebtCreationTick(
+      {
+        [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      },
+      drafts
+    )
+
+    expect(next[COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]).toEqual(COERCIVE_RESTRAINT_LEDGER_FIXTURE)
+    expect(Object.keys(next)).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Summary

- Add minimal SPE-1882 coercive procedure anchors and a deterministic welfare-debt creation hook when coercive procedures execute with containment/security improvement.
- Wire `applyCoerciveProcedureWelfareDebtCreationTick` into `advanceWeek` before the existing weekly welfare-debt orchestration pass.
- High containment benefit records operational success separately — it does not suppress debt creation.

## Linear mapping

- **Slice:** [SPE-2417](https://linear.app/spectranoir/issue/SPE-2417) — Coercive procedure welfare-debt creation hook (slice 5)
- **Parent:** [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — stays **Backlog** (privilege-deprivation / personnel-sourcing and ethics links remain deferred)

## What shipped

- `src/domain/coerciveProcedureRegistry.ts` — forced sedation + mechanical restraint anchors
- `src/domain/coerciveProcedureWelfareDebtCreation.ts` — draft derive, severity classification, idempotent creation tick
- `advanceWeek` integration from medication regimen + custody status anchors
- Tests: `coerciveProcedureWelfareDebtCreation.test.ts`, `advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts`
- Plan: `planning/welfare-debt-accounting-registry-slice-5.md`, `planning/backlog.md` handoff

## Validation

- `npm run test:run -- src/test/coerciveProcedureWelfareDebtCreation.test.ts src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts src/test/welfareDebtAccountingRegistry.test.ts src/test/welfareDebtAccountingLedgerAudit.test.ts src/test/welfareDebtAccountingWeeklyOrchestration.test.ts src/test/advanceWeek.welfareDebtAccounting.integration.test.ts` (41 passed)
- `npm run lint`

## Docs updated

- `planning/welfare-debt-accounting-registry-slice-5.md`
- `planning/backlog.md`

## Parent remains open

SPE-1888 parent is not closed — privilege-deprivation / personnel-sourcing procedural cases and SPE-1047 / SPE-1131 link surfaces remain deferred per slice doc.