### PR TITLE
SPE-2420: coercive contained-person protocol registry slice 1

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) full coercive contained-person protocol model (parent AC partial on ethics/accountability links defers [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) closure until [SPE-1047](https://linear.app/spectranoir/issue/SPE-1047) / [SPE-1131](https://linear.app/spectranoir/issue/SPE-1131) wire-up or explicit deferral). Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) slice 2 — GameState persistence + weekly orchestration for coercive protocol records (after [SPE-2420](https://linear.app/spectranoir/issue/SPE-2420) slice 1 merges). Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `d76b6885` (shipped: [SPE-2419](https://linear.app/spectranoir/issue/SPE-2419) grooming slice 2 @ `spe-1888-parent-acceptance-review-slice-2`)
+**Base `main` SHA:** `5e190cc9` (in flight: [SPE-2420](https://linear.app/spectranoir/issue/SPE-2420) coercive protocol registry slice 1 @ `jamesdyedbq/spe-1882-coercive-protocol-model-slice-1`)
 
 **Recently shipped:** [SPE-2418](https://linear.app/spectranoir/issue/SPE-2418) privilege-deprivation / personnel-sourcing welfare-debt creation (slice 6) @ PR #2705; [SPE-2417](https://linear.app/spectranoir/issue/SPE-2417) coercive procedure creation hook (slice 5) @ PR #2703; see `planning/welfare-debt-accounting-registry-slice-6.md`.
 
@@ -173,6 +173,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `contained-person-therapeutic-care-registry-slice-3.md`   | **Shipped**    | SPE-2343 / PR #2553; weekly missed-session streak + channel degradation hook in `advanceWeek` @ `6a7fc8b8`.                                          |
 | `contained-person-therapeutic-care-registry-slice-4.md`   | **Shipped**    | SPE-2344 / PR #2555; planning mirror UI over `containedPersonTherapeuticCareRecords` @ `8ca21f95`.                                                     |
 | `contained-person-therapeutic-care-registry-slice-5.md`   | **Shipped**    | SPE-2345 / PR #2557; therapeutic care → integrated health bundle wire-up @ `13789b0e`.                                                              |
+| `coercive-contained-person-protocol-model-slice-1.md`     | **In Progress** | SPE-2420; coercive protocol registry schema, validation, tradeoff + risk review projections.                                                          |
 | `contained-person-integrated-health-bundle-slice-6.md`  | **Shipped**    | SPE-2346 / PR #2559; planning mirror UI over `containedPersonIntegratedHealthBundles` @ `95d089e7`.                                                    |
 | `contained-person-integrated-health-bundle-slice-7.md`  | **Shipped**    | SPE-2347; medication/custody/welfare-debt mirror field groups on integrated health bundles @ `81d6a55e`.                                               |
 | `contained-person-integrated-health-bundle-slice-8.md`  | **Shipped**    | SPE-2348 / PR #2564; medication regimen derive/compose wire-up + SPE-1886 slice 1 registry @ `4ef9056d`.                                                |

--- a/planning/coercive-contained-person-protocol-model-slice-1.md
+++ b/planning/coercive-contained-person-protocol-model-slice-1.md
@@ -1,0 +1,80 @@
+# SPE-2420 — Coercive contained-person protocol registry slice 1
+
+One-page implementation plan. Linear: [SPE-2420](https://linear.app/spectranoir/issue/SPE-2420) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2420 — Coercive contained-person protocol registry (slice 1)](https://linear.app/spectranoir/issue/SPE-2420) |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model     |
+| **Branch** | `jamesdyedbq/spe-1882-coercive-protocol-model-slice-1`                                                     |
+| **Status** | **Ready for PR**                                                                                           |
+
+## Goal
+
+Add a pure deterministic **coercive contained-person protocol registry** so containment procedures expose authorization, consent, force policy, subject-fit state, containment-vs-care tradeoffs, and coercion-risk review without duplicating welfare-debt math, medication regimen details, or integrated health bundles.
+
+## Prerequisite (on `main` @ `5e190cc9`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Coercive procedure anchors | `src/domain/coerciveProcedureRegistry.ts` (SPE-1888 slices 5–6)   |
+| Welfare-debt creation hook | `src/domain/coerciveProcedureWelfareDebtCreation.ts`              |
+| Medication regimen registry | `src/domain/containedPersonMedicationRegimenRegistry.ts` (SPE-1886) |
+| Custody status registry | `src/domain/containedPersonCustodyStatusRegistry.ts` (SPE-1892)   |
+
+## Gap (pre-slice)
+
+- No bounded protocol record schema with full handling-mode taxonomy (`deceptive`, `abusive` missing from anchors).
+- No deterministic subject-fit, authorization, force-policy, or consent-confidence fields on protocol records.
+- No containment-stability-versus-care tradeoff or coercion-risk review projection.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `CoerciveProtocolRecord` + full handling-mode taxonomy in `coerciveContainedPersonProtocolRegistry.ts`                             | GameState persistence                         |
+| `validateCoerciveProtocolRecord` — franchise token scan, subject-fit / force-policy warnings                                       | Weekly orchestration wire-up                  |
+| `classifyCoerciveProtocolHandlingPosture` — legally authorized / emergency / compelled / abusive / voluntary                       | Contradiction-check siblings (SPE-1897+)      |
+| `projectContainmentCareTradeoff` + `projectCoerciveProtocolRiskReview` (non-blocking)                                              | Welfare-debt accounting math (SPE-1888)       |
+| Owner refs: `medicationRegimenRef`, `custodyStatusRef`, `procedureRef` — no regimen/custody field duplication                      | Medication regimen details (SPE-1886)         |
+| Extend `CoerciveHandlingMode` in `coerciveProcedureRegistry.ts` with `deceptive` + `abusive`                                        | Full SPE-1882 parent Done                     |
+| Focused tests in `src/test/coerciveContainedPersonProtocolRegistry.test.ts`                                                        | Faction ethics / accountability links (SPE-1047 / SPE-1131) |
+
+## Acceptance
+
+- [x] Fixture: emergency sedation with authorization, consent, force policy, subject-fit validation.
+- [x] Fixture: routine force + generalized subject fit flags contradiction risks without blocking.
+- [x] Fixture: abusive surveillance-isolation flags burden risk; handling posture `abusive`.
+- [x] Tradeoff projection: containment stability gain alongside personhood/trust/legitimacy harm.
+- [x] Owner refs link medication/custody/procedure without duplicating regimen fields.
+- [x] Negative: franchise token in label → validation error.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| GameState persistence + weekly orchestration | SPE-1882 slice 2 | Slice 1 is pure registry only |
+| Contradiction-check sibling implementations | SPE-1897 / SPE-1907 / SPE-1908 / SPE-1898 / SPE-1900 | Registry exposes flags; siblings own full checks |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of slice 1 boundary per SPE-1888 grooming |
+| Full SPE-1882 parent Done | SPE-1882 | Slice 1 satisfies partial parent AC only |
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolRegistry.ts`               |
+| Domain | `src/domain/coerciveProcedureRegistry.ts` (handling-mode taxonomy)    |
+| Tests  | `src/test/coerciveContainedPersonProtocolRegistry.test.ts`            |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-1.md`        |
+
+## Branch
+
+`jamesdyedbq/spe-1882-coercive-protocol-model-slice-1`
+
+## See also
+
+- `src/domain/coerciveProcedureRegistry.ts` — procedure anchors for welfare-debt wire-up
+- `src/domain/containedPersonCustodyStatusRegistry.ts` — custody owner refs (SPE-1892)
+- `src/domain/containedPersonMedicationRegimenRegistry.ts` — regimen owner refs (SPE-1886)

--- a/src/domain/coerciveContainedPersonProtocolRegistry.ts
+++ b/src/domain/coerciveContainedPersonProtocolRegistry.ts
@@ -1,0 +1,870 @@
+/**
+ * SPE-1882 slice 1: coercive contained-person protocol registry.
+ *
+ * Pure deterministic registry for contained-person procedure protocols —
+ * handling modes, authorization/consent/force posture, subject-fit state,
+ * containment-vs-care tradeoffs, and coercion-risk review output.
+ *
+ * Distinct from welfare-debt accounting math (SPE-1888), medication regimen
+ * details (SPE-1886), and integrated health bundles (SPE-1889).
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type CoerciveProtocolId = string
+
+export type CoerciveProtocolHandlingMode =
+  | 'voluntary'
+  | 'negotiated'
+  | 'compelled'
+  | 'emergency'
+  | 'punitive'
+  | 'deceptive'
+  | 'abusive'
+
+export const COERCIVE_PROTOCOL_HANDLING_MODES: readonly CoerciveProtocolHandlingMode[] = [
+  'voluntary',
+  'negotiated',
+  'compelled',
+  'emergency',
+  'punitive',
+  'deceptive',
+  'abusive',
+] as const
+
+export type CoerciveProtocolSubjectFitState = 'validated' | 'generalized' | 'pending' | 'mismatch'
+
+export const COERCIVE_PROTOCOL_SUBJECT_FIT_STATES: readonly CoerciveProtocolSubjectFitState[] = [
+  'validated',
+  'generalized',
+  'pending',
+  'mismatch',
+] as const
+
+export type CoerciveProtocolAuthorizationSource =
+  | 'court_order'
+  | 'emergency_directive'
+  | 'facility_policy'
+  | 'field_authority'
+  | 'undocumented'
+
+export const COERCIVE_PROTOCOL_AUTHORIZATION_SOURCES: readonly CoerciveProtocolAuthorizationSource[] =
+  [
+    'court_order',
+    'emergency_directive',
+    'facility_policy',
+    'field_authority',
+    'undocumented',
+  ] as const
+
+export type CoerciveProtocolForcePolicy = 'proportional' | 'routine_default' | 'escalated' | 'prohibited'
+
+export const COERCIVE_PROTOCOL_FORCE_POLICIES: readonly CoerciveProtocolForcePolicy[] = [
+  'proportional',
+  'routine_default',
+  'escalated',
+  'prohibited',
+] as const
+
+export type CoerciveProtocolRefusalHandling =
+  | 'documented_override'
+  | 'ignored'
+  | 'deferred_review'
+  | 'accommodated'
+
+export const COERCIVE_PROTOCOL_REFUSAL_HANDLING: readonly CoerciveProtocolRefusalHandling[] = [
+  'documented_override',
+  'ignored',
+  'deferred_review',
+  'accommodated',
+] as const
+
+export type CoerciveProtocolHandlingPosture =
+  | 'legally_authorized'
+  | 'emergency'
+  | 'compelled'
+  | 'abusive'
+  | 'voluntary'
+
+export const COERCIVE_PROTOCOL_HANDLING_POSTURES: readonly CoerciveProtocolHandlingPosture[] = [
+  'legally_authorized',
+  'emergency',
+  'compelled',
+  'abusive',
+  'voluntary',
+] as const
+
+export type CoerciveProtocolContradictionRiskFlag =
+  | 'routine_force_authorization'
+  | 'generalized_procedure_without_subject_fit'
+  | 'compliance_metric_masks_harm'
+  | 'surveillance_isolation_burden'
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface CoerciveProtocolRecord {
+  readonly id: CoerciveProtocolId
+  readonly label: string
+  readonly summary?: string
+  readonly subjectRef: string
+  readonly handlingMode: CoerciveProtocolHandlingMode
+  readonly subjectFitState: CoerciveProtocolSubjectFitState
+  readonly authorizationSource: CoerciveProtocolAuthorizationSource
+  readonly forcePolicy: CoerciveProtocolForcePolicy
+  readonly consentConfidence: number
+  readonly refusalHandling: CoerciveProtocolRefusalHandling
+  readonly dependencyLeverageScore?: number
+  readonly isolationBurdenScore: number
+  readonly surveillanceBurdenScore: number
+  /** Owner ref to SPE-1886 medication regimen — no regimen field duplication. */
+  readonly medicationRegimenRef?: string
+  /** Owner ref to SPE-1892 custody status — no custody field duplication. */
+  readonly custodyStatusRef?: string
+  /** Optional link to coercive procedure anchor for welfare-debt wire-up. */
+  readonly procedureRef?: string
+  readonly subjectFitValidationRef?: string
+  readonly containmentStabilityGain: number
+  readonly personhoodHarmRisk: number
+  readonly trustDamageRisk: number
+  readonly legitimacyRisk: number
+  readonly welfareDebtImpactLabel: string
+  readonly complianceMetricOnly?: boolean
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type CoerciveProtocolValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_subject_ref'
+  | 'invalid_handling_mode'
+  | 'invalid_subject_fit_state'
+  | 'invalid_authorization_source'
+  | 'invalid_force_policy'
+  | 'invalid_refusal_handling'
+  | 'invalid_consent_confidence'
+  | 'invalid_dependency_leverage_score'
+  | 'invalid_isolation_burden_score'
+  | 'invalid_surveillance_burden_score'
+  | 'invalid_containment_stability_gain'
+  | 'invalid_personhood_harm_risk'
+  | 'invalid_trust_damage_risk'
+  | 'invalid_legitimacy_risk'
+  | 'missing_welfare_debt_impact_label'
+  | 'invalid_confidence'
+  | 'compelled_without_authorization_source'
+  | 'emergency_without_authorization_source'
+  | 'abusive_without_review_path'
+  | 'deceptive_without_review_path'
+  | 'generalized_subject_fit_without_validation'
+  | 'routine_force_without_documented_override'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_field'
+
+export interface CoerciveProtocolValidationIssue {
+  readonly code: CoerciveProtocolValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface CoerciveProtocolValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly CoerciveProtocolValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Projections
+// ---------------------------------------------------------------------------
+
+export interface ContainmentCareTradeoffProjection {
+  readonly recordId: CoerciveProtocolId
+  readonly label: string
+  readonly handlingMode: CoerciveProtocolHandlingMode
+  readonly containmentStabilityGain: number
+  readonly personhoodHarmRisk: number
+  readonly trustDamageRisk: number
+  readonly legitimacyRisk: number
+  readonly stableContainmentDominatesCare: boolean
+  readonly welfareDebtImpactLabel: string
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+export interface CoerciveProtocolRiskReviewProjection {
+  readonly recordId: CoerciveProtocolId
+  readonly label: string
+  readonly handlingPosture: CoerciveProtocolHandlingPosture
+  readonly coercionRiskScore: number
+  readonly contradictionRiskFlags: readonly CoerciveProtocolContradictionRiskFlag[]
+  readonly blocksProcedure: boolean
+  readonly subjectFitState: CoerciveProtocolSubjectFitState
+  readonly forcePolicy: CoerciveProtocolForcePolicy
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const HANDLING_MODE_SET = new Set<string>(COERCIVE_PROTOCOL_HANDLING_MODES)
+const SUBJECT_FIT_STATE_SET = new Set<string>(COERCIVE_PROTOCOL_SUBJECT_FIT_STATES)
+const AUTHORIZATION_SOURCE_SET = new Set<string>(COERCIVE_PROTOCOL_AUTHORIZATION_SOURCES)
+const FORCE_POLICY_SET = new Set<string>(COERCIVE_PROTOCOL_FORCE_POLICIES)
+const REFUSAL_HANDLING_SET = new Set<string>(COERCIVE_PROTOCOL_REFUSAL_HANDLING)
+
+const LEGALLY_AUTHORIZED_SOURCES = new Set<CoerciveProtocolAuthorizationSource>(['court_order'])
+
+const COERCIVE_HANDLING_MODES = new Set<CoerciveProtocolHandlingMode>([
+  'compelled',
+  'emergency',
+  'punitive',
+  'deceptive',
+  'abusive',
+])
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /(?:\b(?:scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|group of interest|broken masquerade|masquerade breach)\b|goi-)/i
+
+export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
+
+const SURVEILLANCE_ISOLATION_BURDEN_THRESHOLD = 0.65
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((entry): entry is string => typeof entry === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return [...asStringArray(value).map((entry) => entry.trim()).filter((entry) => entry.length > 0)].sort(
+    (left, right) => left.localeCompare(right)
+  )
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function pushIssue(issues: CoerciveProtocolValidationIssue[], issue: CoerciveProtocolValidationIssue) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: CoerciveProtocolValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function freezeValidationResult(
+  issues: CoerciveProtocolValidationIssue[]
+): CoerciveProtocolValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function scanForbiddenTokens(
+  issues: CoerciveProtocolValidationIssue[],
+  id: string,
+  label: string,
+  record: CoerciveProtocolRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Coercive protocol record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Coercive protocol record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Coercive protocol record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Coercive protocol record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const subjectRef = normalizeToken(record.subjectRef)
+  if (subjectRef && (containsFranchiseToken(subjectRef) || containsBrandedObjectNumber(subjectRef))) {
+    pushIssue(issues, {
+      code: containsFranchiseToken(subjectRef)
+        ? 'franchise_token_in_field'
+        : 'branded_object_number_in_field',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} subjectRef contains a forbidden token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function resolveConfidence(record: CoerciveProtocolRecord): number | null {
+  const confidence = record.confidence
+  return isValidUnitScore(confidence) ? confidence : null
+}
+
+function resolveUnknownFields(record: CoerciveProtocolRecord): readonly string[] {
+  return sortedStringArray(record.unknownFields)
+}
+
+function isRedacted(record: CoerciveProtocolRecord): boolean {
+  return sortedStringArray(record.redactedFields).length > 0
+}
+
+function clampUnitScore(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+function roundUnitScore(value: number): number {
+  return Math.round(clampUnitScore(value) * 1000) / 1000
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function isCoerciveProtocolHandlingMode(value: unknown): value is CoerciveProtocolHandlingMode {
+  return typeof value === 'string' && HANDLING_MODE_SET.has(value)
+}
+
+export function isCoerciveProtocolSubjectFitState(
+  value: unknown
+): value is CoerciveProtocolSubjectFitState {
+  return typeof value === 'string' && SUBJECT_FIT_STATE_SET.has(value)
+}
+
+export function validateCoerciveProtocolRecord(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolValidationResult {
+  const issues: CoerciveProtocolValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const subjectRef = normalizeToken(record.subjectRef)
+  const welfareDebtImpactLabel = normalizeToken(record.welfareDebtImpactLabel)
+  const subjectFitValidationRef = normalizeToken(record.subjectFitValidationRef ?? '')
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Coercive protocol record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Coercive protocol record is missing label.',
+    })
+  }
+
+  if (!subjectRef) {
+    pushIssue(issues, {
+      code: 'missing_subject_ref',
+      severity: 'error',
+      detail: 'Coercive protocol record is missing subjectRef.',
+    })
+  }
+
+  if (!isCoerciveProtocolHandlingMode(record.handlingMode)) {
+    pushIssue(issues, {
+      code: 'invalid_handling_mode',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid handlingMode.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isCoerciveProtocolSubjectFitState(record.subjectFitState)) {
+    pushIssue(issues, {
+      code: 'invalid_subject_fit_state',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid subjectFitState.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    typeof record.authorizationSource !== 'string' ||
+    !AUTHORIZATION_SOURCE_SET.has(record.authorizationSource)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_authorization_source',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid authorizationSource.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (typeof record.forcePolicy !== 'string' || !FORCE_POLICY_SET.has(record.forcePolicy)) {
+    pushIssue(issues, {
+      code: 'invalid_force_policy',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid forcePolicy.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (typeof record.refusalHandling !== 'string' || !REFUSAL_HANDLING_SET.has(record.refusalHandling)) {
+    pushIssue(issues, {
+      code: 'invalid_refusal_handling',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid refusalHandling.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.consentConfidence)) {
+    pushIssue(issues, {
+      code: 'invalid_consent_confidence',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid consentConfidence.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.dependencyLeverageScore !== undefined &&
+    !isValidUnitScore(record.dependencyLeverageScore)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_dependency_leverage_score',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid dependencyLeverageScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.isolationBurdenScore)) {
+    pushIssue(issues, {
+      code: 'invalid_isolation_burden_score',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid isolationBurdenScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.surveillanceBurdenScore)) {
+    pushIssue(issues, {
+      code: 'invalid_surveillance_burden_score',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid surveillanceBurdenScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.containmentStabilityGain)) {
+    pushIssue(issues, {
+      code: 'invalid_containment_stability_gain',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid containmentStabilityGain.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.personhoodHarmRisk)) {
+    pushIssue(issues, {
+      code: 'invalid_personhood_harm_risk',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid personhoodHarmRisk.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.trustDamageRisk)) {
+    pushIssue(issues, {
+      code: 'invalid_trust_damage_risk',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid trustDamageRisk.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.legitimacyRisk)) {
+    pushIssue(issues, {
+      code: 'invalid_legitimacy_risk',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid legitimacyRisk.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!welfareDebtImpactLabel) {
+    pushIssue(issues, {
+      code: 'missing_welfare_debt_impact_label',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} is missing welfareDebtImpactLabel.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid confidence.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.handlingMode === 'compelled' &&
+    record.authorizationSource === 'undocumented'
+  ) {
+    pushIssue(issues, {
+      code: 'compelled_without_authorization_source',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is compelled without documented authorization.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.handlingMode === 'emergency' &&
+    record.authorizationSource === 'undocumented'
+  ) {
+    pushIssue(issues, {
+      code: 'emergency_without_authorization_source',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is emergency without documented authorization.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.handlingMode === 'abusive' && !subjectFitValidationRef) {
+    pushIssue(issues, {
+      code: 'abusive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is abusive without subject-fit validation or review ref.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.handlingMode === 'deceptive' && !subjectFitValidationRef) {
+    pushIssue(issues, {
+      code: 'deceptive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is deceptive without subject-fit validation or review ref.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.subjectFitState === 'generalized' && !subjectFitValidationRef) {
+    pushIssue(issues, {
+      code: 'generalized_subject_fit_without_validation',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} uses generalized subject fit without validation artifact.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.forcePolicy === 'routine_default' &&
+    record.refusalHandling !== 'documented_override'
+  ) {
+    pushIssue(issues, {
+      code: 'routine_force_without_documented_override',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} uses routine force without documented refusal override.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanForbiddenTokens(issues, id, label, record)
+
+  return freezeValidationResult(issues)
+}
+
+export function classifyCoerciveProtocolHandlingPosture(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolHandlingPosture {
+  if (record.handlingMode === 'abusive' || record.handlingMode === 'deceptive') {
+    return 'abusive'
+  }
+
+  if (record.handlingMode === 'voluntary' || record.handlingMode === 'negotiated') {
+    return 'voluntary'
+  }
+
+  if (record.handlingMode === 'emergency') {
+    return 'emergency'
+  }
+
+  if (
+    (record.handlingMode === 'compelled' || record.handlingMode === 'punitive') &&
+    LEGALLY_AUTHORIZED_SOURCES.has(record.authorizationSource)
+  ) {
+    return 'legally_authorized'
+  }
+
+  if (COERCIVE_HANDLING_MODES.has(record.handlingMode)) {
+    return 'compelled'
+  }
+
+  return 'compelled'
+}
+
+export function projectContainmentCareTradeoff(
+  record: CoerciveProtocolRecord
+): ContainmentCareTradeoffProjection {
+  const careHarmAggregate = roundUnitScore(
+    (record.personhoodHarmRisk + record.trustDamageRisk + record.legitimacyRisk) / 3
+  )
+  const stableContainmentDominatesCare =
+    record.containmentStabilityGain > careHarmAggregate
+
+  return Object.freeze({
+    recordId: record.id,
+    label: record.label,
+    handlingMode: record.handlingMode,
+    containmentStabilityGain: roundUnitScore(record.containmentStabilityGain),
+    personhoodHarmRisk: roundUnitScore(record.personhoodHarmRisk),
+    trustDamageRisk: roundUnitScore(record.trustDamageRisk),
+    legitimacyRisk: roundUnitScore(record.legitimacyRisk),
+    stableContainmentDominatesCare,
+    welfareDebtImpactLabel: normalizeToken(record.welfareDebtImpactLabel),
+    confidence: resolveConfidence(record),
+    redacted: isRedacted(record),
+    unknownFields: resolveUnknownFields(record),
+  })
+}
+
+function collectContradictionRiskFlags(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionRiskFlag[] {
+  const flags: CoerciveProtocolContradictionRiskFlag[] = []
+
+  if (record.forcePolicy === 'routine_default') {
+    flags.push('routine_force_authorization')
+  }
+
+  if (record.subjectFitState === 'generalized' && !normalizeToken(record.subjectFitValidationRef ?? '')) {
+    flags.push('generalized_procedure_without_subject_fit')
+  }
+
+  if (record.complianceMetricOnly === true) {
+    flags.push('compliance_metric_masks_harm')
+  }
+
+  if (
+    record.isolationBurdenScore >= SURVEILLANCE_ISOLATION_BURDEN_THRESHOLD &&
+    record.surveillanceBurdenScore >= SURVEILLANCE_ISOLATION_BURDEN_THRESHOLD
+  ) {
+    flags.push('surveillance_isolation_burden')
+  }
+
+  return flags.sort((left, right) => left.localeCompare(right))
+}
+
+function resolveCoercionRiskScore(
+  record: CoerciveProtocolRecord,
+  flags: readonly CoerciveProtocolContradictionRiskFlag[]
+): number {
+  let score = 0
+
+  if (record.handlingMode === 'abusive' || record.handlingMode === 'deceptive') {
+    score += 0.35
+  } else if (record.handlingMode === 'punitive' || record.handlingMode === 'compelled') {
+    score += 0.2
+  }
+
+  if (record.forcePolicy === 'routine_default') {
+    score += 0.2
+  } else if (record.forcePolicy === 'escalated') {
+    score += 0.15
+  }
+
+  if (record.subjectFitState === 'generalized' || record.subjectFitState === 'mismatch') {
+    score += 0.15
+  }
+
+  if (record.consentConfidence <= 0.35) {
+    score += 0.1
+  }
+
+  score += flags.length * 0.08
+
+  return roundUnitScore(score)
+}
+
+export function projectCoerciveProtocolRiskReview(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolRiskReviewProjection {
+  const contradictionRiskFlags = collectContradictionRiskFlags(record)
+
+  return Object.freeze({
+    recordId: record.id,
+    label: record.label,
+    handlingPosture: classifyCoerciveProtocolHandlingPosture(record),
+    coercionRiskScore: resolveCoercionRiskScore(record, contradictionRiskFlags),
+    contradictionRiskFlags: Object.freeze(contradictionRiskFlags),
+    blocksProcedure: false,
+    subjectFitState: record.subjectFitState,
+    forcePolicy: record.forcePolicy,
+    confidence: resolveConfidence(record),
+    redacted: isRedacted(record),
+    unknownFields: resolveUnknownFields(record),
+  })
+}
+
+function defineRecord(record: CoerciveProtocolRecord): CoerciveProtocolRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Emergency sedation protocol with documented authorization and owner refs. */
+export const EMERGENCY_SEDATION_PROTOCOL_FIXTURE: CoerciveProtocolRecord = defineRecord({
+  id: 'coercive-protocol:emergency-sedation-stabilization',
+  label: 'Emergency sedation stabilization protocol',
+  summary:
+    'Emergency compelled sedation improving containment stability while increasing coerced-medication welfare debt.',
+  subjectRef: 'subject:cooperative-field-asset-17',
+  handlingMode: 'emergency',
+  subjectFitState: 'validated',
+  authorizationSource: 'emergency_directive',
+  forcePolicy: 'proportional',
+  consentConfidence: 0.22,
+  refusalHandling: 'documented_override',
+  dependencyLeverageScore: 0.41,
+  isolationBurdenScore: 0.38,
+  surveillanceBurdenScore: 0.44,
+  medicationRegimenRef: 'medication-regimen:coercive-sedative-beta',
+  custodyStatusRef: 'custody-status:former-hostile-hold',
+  procedureRef: 'coercive-procedure:forced-sedation-stabilization',
+  subjectFitValidationRef: 'review-artifact:psych-fit-validation-17',
+  containmentStabilityGain: 0.78,
+  personhoodHarmRisk: 0.52,
+  trustDamageRisk: 0.47,
+  legitimacyRisk: 0.36,
+  welfareDebtImpactLabel: 'coerced medication welfare debt likely',
+  confidence: 0.84,
+})
+
+/** Routine force protocol generalized across subjects without fit validation. */
+export const ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE: CoerciveProtocolRecord = defineRecord({
+  id: 'coercive-protocol:routine-force-generalized',
+  label: 'Routine force generalized restraint protocol',
+  summary:
+    'Facility-default restraint protocol applied without subject-fit validation; compliance metrics mask harm.',
+  subjectRef: 'subject:cooperative-field-asset-31',
+  handlingMode: 'compelled',
+  subjectFitState: 'generalized',
+  authorizationSource: 'facility_policy',
+  forcePolicy: 'routine_default',
+  consentConfidence: 0.18,
+  refusalHandling: 'ignored',
+  isolationBurdenScore: 0.58,
+  surveillanceBurdenScore: 0.49,
+  custodyStatusRef: 'custody-status:privilege-suspended-hold',
+  procedureRef: 'coercive-procedure:extended-mechanical-restraint',
+  containmentStabilityGain: 0.71,
+  personhoodHarmRisk: 0.63,
+  trustDamageRisk: 0.58,
+  legitimacyRisk: 0.55,
+  welfareDebtImpactLabel: 'harmful restraint welfare debt likely',
+  complianceMetricOnly: true,
+  confidence: 0.69,
+})
+
+/** Abusive surveillance-isolation protocol with high burden scores. */
+export const ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE: CoerciveProtocolRecord = defineRecord({
+  id: 'coercive-protocol:abusive-surveillance-isolation',
+  label: 'Abusive surveillance isolation protocol',
+  summary:
+    'Abusive handling with elevated isolation and surveillance burden; review flags risk without blocking.',
+  subjectRef: 'subject:cooperative-field-asset-22',
+  handlingMode: 'abusive',
+  subjectFitState: 'mismatch',
+  authorizationSource: 'undocumented',
+  forcePolicy: 'escalated',
+  consentConfidence: 0.08,
+  refusalHandling: 'ignored',
+  dependencyLeverageScore: 0.72,
+  isolationBurdenScore: 0.82,
+  surveillanceBurdenScore: 0.79,
+  custodyStatusRef: 'custody-status:former-hostile-hold',
+  containmentStabilityGain: 0.66,
+  personhoodHarmRisk: 0.88,
+  trustDamageRisk: 0.84,
+  legitimacyRisk: 0.76,
+  welfareDebtImpactLabel: 'forced isolation welfare debt likely',
+  confidence: 0.73,
+})

--- a/src/domain/coerciveProcedureRegistry.ts
+++ b/src/domain/coerciveProcedureRegistry.ts
@@ -18,6 +18,8 @@ export type CoerciveHandlingMode =
   | 'compelled'
   | 'emergency'
   | 'punitive'
+  | 'deceptive'
+  | 'abusive'
 
 export const COERCIVE_HANDLING_MODES: readonly CoerciveHandlingMode[] = [
   'voluntary',
@@ -25,6 +27,8 @@ export const COERCIVE_HANDLING_MODES: readonly CoerciveHandlingMode[] = [
   'compelled',
   'emergency',
   'punitive',
+  'deceptive',
+  'abusive',
 ] as const
 
 export type CoerciveCoercionPressureTier = 'medium' | 'high'

--- a/src/test/coerciveContainedPersonProtocolRegistry.test.ts
+++ b/src/test/coerciveContainedPersonProtocolRegistry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+  classifyCoerciveProtocolHandlingPosture,
+  projectCoerciveProtocolRiskReview,
+  projectContainmentCareTradeoff,
+  validateCoerciveProtocolRecord,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+
+describe('coerciveContainedPersonProtocolRegistry (SPE-1882 slice 1)', () => {
+  it('validates emergency sedation protocol fixture without errors', () => {
+    const result = validateCoerciveProtocolRecord(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    expect(result.valid).toBe(true)
+    expect(result.issues.filter((issue) => issue.severity === 'error')).toHaveLength(0)
+  })
+
+  it('classifies handling posture for emergency, compelled, and abusive modes', () => {
+    expect(classifyCoerciveProtocolHandlingPosture(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)).toBe(
+      'emergency'
+    )
+
+    const compelled = {
+      ...EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:compelled-restraint',
+      handlingMode: 'compelled' as const,
+      authorizationSource: 'facility_policy' as const,
+    }
+    expect(classifyCoerciveProtocolHandlingPosture(compelled)).toBe('compelled')
+
+    expect(
+      classifyCoerciveProtocolHandlingPosture(ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE)
+    ).toBe('abusive')
+  })
+
+  it('projects containment stability gain alongside personhood and trust harm', () => {
+    const tradeoff = projectContainmentCareTradeoff(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+
+    expect(tradeoff.containmentStabilityGain).toBeGreaterThan(0.5)
+    expect(tradeoff.personhoodHarmRisk).toBeGreaterThan(0.4)
+    expect(tradeoff.trustDamageRisk).toBeGreaterThan(0.3)
+    expect(tradeoff.legitimacyRisk).toBeGreaterThan(0.2)
+    expect(tradeoff.stableContainmentDominatesCare).toBe(true)
+    expect(tradeoff.welfareDebtImpactLabel).toContain('coerced medication')
+  })
+
+  it('flags routine force and generalized subject fit as contradiction risks', () => {
+    const review = projectCoerciveProtocolRiskReview(ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE)
+
+    expect(review.coercionRiskScore).toBeGreaterThan(0.5)
+    expect(review.contradictionRiskFlags).toContain('routine_force_authorization')
+    expect(review.contradictionRiskFlags).toContain('generalized_procedure_without_subject_fit')
+    expect(review.blocksProcedure).toBe(false)
+  })
+
+  it('flags surveillance isolation burden without blocking abusive protocol review', () => {
+    const review = projectCoerciveProtocolRiskReview(ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE)
+
+    expect(review.contradictionRiskFlags).toContain('surveillance_isolation_burden')
+    expect(review.handlingPosture).toBe('abusive')
+    expect(review.blocksProcedure).toBe(false)
+  })
+
+  it('links medication and custody owner refs without duplicating regimen fields', () => {
+    const record = EMERGENCY_SEDATION_PROTOCOL_FIXTURE
+
+    expect(record.medicationRegimenRef).toBe('medication-regimen:coercive-sedative-beta')
+    expect(record.custodyStatusRef).toBe('custody-status:former-hostile-hold')
+    expect(record.procedureRef).toBe('coercive-procedure:forced-sedation-stabilization')
+    expect(record).not.toHaveProperty('deliveryVector')
+    expect(record).not.toHaveProperty('dosageCadenceLabel')
+  })
+
+  it('returns warning for generalized subject fit without validation artifact', () => {
+    const result = validateCoerciveProtocolRecord(ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(
+      result.issues.some((issue) => issue.code === 'generalized_subject_fit_without_validation')
+    ).toBe(true)
+  })
+
+  it('rejects franchise tokens in record label', () => {
+    const invalid = {
+      ...EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:franchise-label',
+      label: 'SCP division sedation protocol',
+    }
+
+    const result = validateCoerciveProtocolRecord(invalid)
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+
+  it('returns byte-stable validation on repeated calls', () => {
+    const first = validateCoerciveProtocolRecord(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    const second = validateCoerciveProtocolRecord(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `coerciveContainedPersonProtocolRegistry.ts` — deterministic protocol records with full handling-mode taxonomy, authorization/consent/force/subject-fit fields, containment-vs-care tradeoff projection, and non-blocking coercion-risk review output.
- Extends `CoerciveHandlingMode` in `coerciveProcedureRegistry.ts` with `deceptive` and `abusive` modes.
- Owner refs (`medicationRegimenRef`, `custodyStatusRef`, `procedureRef`) link to SPE-1886 / SPE-1892 / welfare-debt anchors without duplicating regimen or custody fields.

## Linear

- **Slice:** [SPE-2420](https://linear.app/spectranoir/issue/SPE-2420) — Coercive contained-person protocol registry (slice 1)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model (stays **In Progress**; partial parent AC only)

## What shipped

- `validateCoerciveProtocolRecord` with franchise-token scan and subject-fit / force-policy warnings
- `classifyCoerciveProtocolHandlingPosture` — legally authorized / emergency / compelled / abusive / voluntary
- `projectContainmentCareTradeoff` + `projectCoerciveProtocolRiskReview` (does not block procedures)
- Three fixtures: emergency sedation, routine-force generalized, abusive surveillance-isolation

## Validation

- `npm run lint`
- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts`
- `npm run test:run -- src/test/coerciveProcedureWelfareDebtCreation.test.ts src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts`

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-1.md`
- `planning/backlog.md` (handoff + planning slice index row)

## Parent remains open

SPE-1882 parent stays open — slice 2+ deferred: GameState persistence, weekly orchestration, contradiction-check siblings, faction ethics/accountability links.