### PR TITLE
SPE-2421: coercive protocol GameState persistence (slice 2)

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-2.md
+++ b/planning/coercive-contained-person-protocol-model-slice-2.md
@@ -1,0 +1,67 @@
+# SPE-2421 — Coercive contained-person protocol GameState persistence (slice 2)
+
+One-page implementation plan. Linear: [SPE-2421](https://linear.app/spectranoir/issue/SPE-2421) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Follows shipped slice 1 (`planning/coercive-contained-person-protocol-model-slice-1.md`, PR #2709 / [SPE-2420](https://linear.app/spectranoir/issue/SPE-2420)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2421 — Coercive contained-person protocol GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2421) |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model     |
+| **Branch** | `jamesdyedbq/spe-1882-coercive-protocol-model-slice-2`                                                     |
+| **Status** | Ready for PR                                                                                               |
+| **Base `main` SHA** | `52b1f406`                                                                                          |
+
+## Goal
+
+Persist validated `CoerciveProtocolRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Mirror SPE-1892 / SPE-1886 slice 2 persistence pattern. Weekly orchestration hook deferred to slice 3.
+
+## Prerequisite (on `main` @ `52b1f406`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Fixtures             | `EMERGENCY_SEDATION_PROTOCOL_FIXTURE`, `ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE`, `ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE` |
+| Custody persistence pattern | `sanitizeCustodyStatusRecords` in `containedPersonCustodyStatusRegistry.ts` |
+| Welfare-debt hook    | `coerciveProcedureWelfareDebtCreation.ts` (SPE-1888 slice 5)           |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coerciveContainedPersonProtocolRecords` on `GameState`            | Weekly `advanceWeek` orchestration hook       |
+| `sanitizeCoerciveProtocolRecords` + `runTransfer` hydrate wire     | Contradiction-check siblings (SPE-1897+)      |
+| `validateCoerciveProtocolRecord` on hydrate; drop invalid, no throw | Faction ethics links (SPE-1047 / SPE-1131) |
+| Default `{}` in `createStartingState`                              | Welfare-debt accounting math (SPE-1888)       |
+| Persistence + advanceWeek preservation regression tests            | Full SPE-1882 parent Done                     |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] Owner refs (`medicationRegimenRef`, `custodyStatusRef`, `procedureRef`) byte-stable after round-trip
+- [x] `advanceWeek` preserves protocol records; welfare-debt hook regression green
+- [x] Slice 1 registry tests unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolRegistry.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts`, `src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Weekly orchestration hook in `advanceWeek` | SPE-1882 slice 3 | Persistence must land before orchestration |
+| Contradiction-check sibling implementations | SPE-1897 / SPE-1907 / SPE-1908 / SPE-1898 / SPE-1900 | Registry exposes flags only |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Per SPE-1888 grooming |
+| Full SPE-1882 parent Done | SPE-1882 | Multiple slices remain |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-1.md`
+- `planning/extranormal-event-registry-slice-2.md` — persistence-only slice pattern

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -209,6 +209,7 @@ import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entit
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
 import { sanitizeCustodyStatusRecords } from '../../domain/containedPersonCustodyStatusRegistry'
 import { sanitizeWelfareDebtAccountingRecords } from '../../domain/welfareDebtAccountingRegistry'
+import { sanitizeCoerciveProtocolRecords } from '../../domain/coerciveContainedPersonProtocolRegistry'
 import { sanitizeMedicationRegimenRecords } from '../../domain/containedPersonMedicationRegimenRegistry'
 import { sanitizeContainedPersonIntegratedHealthBundles } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
 import { sanitizeVisualTriggerHazardRecords } from '../../domain/visualTriggerHazardRegistry'
@@ -8506,6 +8507,10 @@ export function hydrateGame(
     game.containedPersonCustodyStatusRecords,
     fallback.containedPersonCustodyStatusRecords ?? {}
   )
+  const coerciveContainedPersonProtocolRecords = sanitizeCoerciveProtocolRecords(
+    game.coerciveContainedPersonProtocolRecords,
+    fallback.coerciveContainedPersonProtocolRecords ?? {}
+  )
   const welfareDebtAccountingRecords = sanitizeWelfareDebtAccountingRecords(
     game.welfareDebtAccountingRecords,
     fallback.welfareDebtAccountingRecords ?? {}
@@ -8649,6 +8654,7 @@ export function hydrateGame(
       containedPersonTherapeuticCareRecords,
       containedPersonMedicationRegimenRecords,
       containedPersonCustodyStatusRecords,
+      coerciveContainedPersonProtocolRecords,
       welfareDebtAccountingRecords,
       containedPersonIntegratedHealthBundles,
       candidates,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -57,6 +57,7 @@ const startingStateTemplate: GameState = {
   containedPersonTherapeuticCareRecords: {},
   containedPersonMedicationRegimenRecords: {},
   containedPersonCustodyStatusRecords: {},
+  coerciveContainedPersonProtocolRecords: {},
   welfareDebtAccountingRecords: {},
   containedPersonIntegratedHealthBundles: {},
   factions: createInitialFactionState(),

--- a/src/domain/coerciveContainedPersonProtocolRegistry.ts
+++ b/src/domain/coerciveContainedPersonProtocolRegistry.ts
@@ -868,3 +868,146 @@ export const ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE: CoerciveProtocolRe
   welfareDebtImpactLabel: 'forced isolation welfare debt likely',
   confidence: 0.73,
 })
+
+// ---------------------------------------------------------------------------
+// Persistence / hydration
+// ---------------------------------------------------------------------------
+
+export type CoerciveProtocolRecordsMap = Record<CoerciveProtocolId, CoerciveProtocolRecord>
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+function sanitizeCoerciveProtocolRecordEntry(value: unknown): CoerciveProtocolRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const subjectRef = normalizeToken(value.subjectRef)
+  const handlingMode = value.handlingMode
+  const subjectFitState = value.subjectFitState
+  const authorizationSource = value.authorizationSource
+  const forcePolicy = value.forcePolicy
+  const consentConfidence = value.consentConfidence
+  const refusalHandling = value.refusalHandling
+  const isolationBurdenScore = value.isolationBurdenScore
+  const surveillanceBurdenScore = value.surveillanceBurdenScore
+  const containmentStabilityGain = value.containmentStabilityGain
+  const personhoodHarmRisk = value.personhoodHarmRisk
+  const trustDamageRisk = value.trustDamageRisk
+  const legitimacyRisk = value.legitimacyRisk
+  const welfareDebtImpactLabel = normalizeToken(value.welfareDebtImpactLabel)
+
+  if (
+    !id ||
+    !label ||
+    !subjectRef ||
+    !isCoerciveProtocolHandlingMode(handlingMode) ||
+    !isCoerciveProtocolSubjectFitState(subjectFitState) ||
+    typeof authorizationSource !== 'string' ||
+    !AUTHORIZATION_SOURCE_SET.has(authorizationSource) ||
+    typeof forcePolicy !== 'string' ||
+    !FORCE_POLICY_SET.has(forcePolicy) ||
+    !isValidUnitScore(consentConfidence) ||
+    typeof refusalHandling !== 'string' ||
+    !REFUSAL_HANDLING_SET.has(refusalHandling) ||
+    !isValidUnitScore(isolationBurdenScore) ||
+    !isValidUnitScore(surveillanceBurdenScore) ||
+    !isValidUnitScore(containmentStabilityGain) ||
+    !isValidUnitScore(personhoodHarmRisk) ||
+    !isValidUnitScore(trustDamageRisk) ||
+    !isValidUnitScore(legitimacyRisk) ||
+    !welfareDebtImpactLabel
+  ) {
+    return null
+  }
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const dependencyLeverageScore = value.dependencyLeverageScore
+  const medicationRegimenRef = normalizeToken(value.medicationRegimenRef ?? '') || undefined
+  const custodyStatusRef = normalizeToken(value.custodyStatusRef ?? '') || undefined
+  const procedureRef = normalizeToken(value.procedureRef ?? '') || undefined
+  const subjectFitValidationRef = normalizeToken(value.subjectFitValidationRef ?? '') || undefined
+  const complianceMetricOnly =
+    typeof value.complianceMetricOnly === 'boolean' ? value.complianceMetricOnly : undefined
+  const confidence = value.confidence
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+
+  const record: CoerciveProtocolRecord = {
+    id,
+    label,
+    subjectRef,
+    handlingMode,
+    subjectFitState,
+    authorizationSource,
+    forcePolicy,
+    consentConfidence,
+    refusalHandling,
+    isolationBurdenScore,
+    surveillanceBurdenScore,
+    containmentStabilityGain,
+    personhoodHarmRisk,
+    trustDamageRisk,
+    legitimacyRisk,
+    welfareDebtImpactLabel,
+    ...(summary ? { summary } : {}),
+    ...(isValidUnitScore(dependencyLeverageScore) ? { dependencyLeverageScore } : {}),
+    ...(medicationRegimenRef ? { medicationRegimenRef } : {}),
+    ...(custodyStatusRef ? { custodyStatusRef } : {}),
+    ...(procedureRef ? { procedureRef } : {}),
+    ...(subjectFitValidationRef ? { subjectFitValidationRef } : {}),
+    ...(complianceMetricOnly !== undefined ? { complianceMetricOnly } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateCoerciveProtocolRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical protocol map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeCoerciveProtocolRecords(
+  value: unknown,
+  fallback: CoerciveProtocolRecordsMap = {}
+): CoerciveProtocolRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: CoerciveProtocolRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeCoerciveProtocolRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -259,6 +259,7 @@ import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 import type { TherapeuticCareScheduleRecord } from './containedPersonTherapeuticCareRegistry'
+import type { CoerciveProtocolRecord } from './coerciveContainedPersonProtocolRegistry'
 import type { CustodyStatusRecord } from './containedPersonCustodyStatusRegistry'
 import type { MedicationRegimenRecord } from './containedPersonMedicationRegimenRegistry'
 import type { WelfareDebtAccountingRecord } from './welfareDebtAccountingRegistry'
@@ -2687,6 +2688,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   containedPersonCustodyStatusRecords?: Record<string, CustodyStatusRecord>
+
+  /**
+   * SPE-1882 slice 2: persisted coercive contained-person protocol records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  coerciveContainedPersonProtocolRecords?: Record<string, CoerciveProtocolRecord>
 
   /**
    * SPE-1888 slice 1: persisted welfare-debt accounting records (keyed by record id).

--- a/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+} from '../domain/containedPersonMedicationRegimenRegistry'
+import {
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek coercive protocol records integration (SPE-1882 slice 2)', () => {
+  it('preserves coercive protocol records through advanceWeek without mutation', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.coerciveContainedPersonProtocolRecords).toEqual(
+      state.coerciveContainedPersonProtocolRecords
+    )
+  })
+
+  it('does not break welfare-debt creation when coercive protocol records are present', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 3
+    state.containedPersonMedicationRegimenRecords = {
+      [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+    }
+    state.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record =
+      nextState.welfareDebtAccountingRecords?.[
+        'welfare-debt:coercive-procedure:forced-sedation-stabilization:subject:cooperative-field-asset-22'
+      ]
+
+    expect(nextState.coerciveContainedPersonProtocolRecords).toEqual(
+      state.coerciveContainedPersonProtocolRecords
+    )
+    expect(record?.debtCategory).toBe('coerced_medication')
+    expect(record?.severityBand).toBe('critical')
+  })
+})

--- a/src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts
+++ b/src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+  sanitizeCoerciveProtocolRecords,
+  validateCoerciveProtocolRecord,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+
+describe('coerciveContainedPersonProtocolRegistry persistence (SPE-1882 slice 2)', () => {
+  it('defaults starting state to an empty coercive protocol map', () => {
+    expect(createStartingState().coerciveContainedPersonProtocolRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeCoerciveProtocolRecords(
+      {
+        valid: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+        generalized: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+        'wrong-key': {
+          ...EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+          id: 'coercive-protocol:routine-force-generalized',
+        },
+        duplicate: {
+          ...EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          subjectRef: 'subject:test',
+          handlingMode: 'unknown',
+          subjectFitState: 'validated',
+          authorizationSource: 'court_order',
+          forcePolicy: 'proportional',
+          consentConfidence: 0.5,
+          refusalHandling: 'accommodated',
+          isolationBurdenScore: 0.5,
+          surveillanceBurdenScore: 0.5,
+          containmentStabilityGain: 0.5,
+          personhoodHarmRisk: 0.5,
+          trustDamageRisk: 0.5,
+          legitimacyRisk: 0.5,
+          welfareDebtImpactLabel: 'test',
+        },
+        franchiseLabel: {
+          id: 'coercive-protocol:franchise',
+          label: 'SCP division sedation protocol',
+          subjectRef: 'subject:test',
+          handlingMode: 'emergency',
+          subjectFitState: 'validated',
+          authorizationSource: 'emergency_directive',
+          forcePolicy: 'proportional',
+          consentConfidence: 0.2,
+          refusalHandling: 'documented_override',
+          isolationBurdenScore: 0.4,
+          surveillanceBurdenScore: 0.4,
+          containmentStabilityGain: 0.7,
+          personhoodHarmRisk: 0.5,
+          trustDamageRisk: 0.5,
+          legitimacyRisk: 0.4,
+          welfareDebtImpactLabel: 'test',
+        },
+        brandedObjectId: {
+          id: 'coercive-protocol:scp-049-sedation',
+          label: 'Archive sedation protocol',
+          subjectRef: 'subject:test',
+          handlingMode: 'emergency',
+          subjectFitState: 'validated',
+          authorizationSource: 'emergency_directive',
+          forcePolicy: 'proportional',
+          consentConfidence: 0.2,
+          refusalHandling: 'documented_override',
+          isolationBurdenScore: 0.4,
+          surveillanceBurdenScore: 0.4,
+          containmentStabilityGain: 0.7,
+          personhoodHarmRisk: 0.5,
+          trustDamageRisk: 0.5,
+          legitimacyRisk: 0.4,
+          welfareDebtImpactLabel: 'test',
+        },
+        outOfRangeScore: {
+          id: 'coercive-protocol:out-of-range',
+          label: 'Out of range score',
+          subjectRef: 'subject:test',
+          handlingMode: 'compelled',
+          subjectFitState: 'validated',
+          authorizationSource: 'facility_policy',
+          forcePolicy: 'routine_default',
+          consentConfidence: 1.5,
+          refusalHandling: 'ignored',
+          isolationBurdenScore: 0.5,
+          surveillanceBurdenScore: 0.5,
+          containmentStabilityGain: 0.5,
+          personhoodHarmRisk: 0.5,
+          trustDamageRisk: 0.5,
+          legitimacyRisk: 0.5,
+          welfareDebtImpactLabel: 'test',
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['coercive-protocol:emergency-sedation-stabilization']).toEqual(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE
+    )
+    expect(sanitized['coercive-protocol:routine-force-generalized']).toEqual(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.franchiseLabel).toBeUndefined()
+    expect(sanitized.brandedObjectId).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['wrong-key']).toBeUndefined()
+    expect(sanitized.outOfRangeScore).toBeUndefined()
+    expect(Object.keys(sanitized).sort()).toEqual([
+      'coercive-protocol:emergency-sedation-stabilization',
+      'coercive-protocol:routine-force-generalized',
+    ])
+  })
+
+  it('persists warning-only records that remain valid on hydrate', () => {
+    const warningOnly = {
+      id: 'coercive-protocol:warning-only-compelled',
+      label: 'Warning-only compelled protocol',
+      subjectRef: 'subject:cooperative-field-asset-9',
+      handlingMode: 'compelled' as const,
+      subjectFitState: 'generalized' as const,
+      authorizationSource: 'undocumented' as const,
+      forcePolicy: 'routine_default' as const,
+      consentConfidence: 0.15,
+      refusalHandling: 'ignored' as const,
+      isolationBurdenScore: 0.55,
+      surveillanceBurdenScore: 0.48,
+      containmentStabilityGain: 0.62,
+      personhoodHarmRisk: 0.58,
+      trustDamageRisk: 0.52,
+      legitimacyRisk: 0.49,
+      welfareDebtImpactLabel: 'harmful restraint welfare debt likely',
+    }
+
+    expect(validateCoerciveProtocolRecord(warningOnly).valid).toBe(true)
+
+    const sanitized = sanitizeCoerciveProtocolRecords({ [warningOnly.id]: warningOnly }, {})
+
+    expect(sanitized[warningOnly.id]).toEqual(warningOnly)
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.coerciveContainedPersonProtocolRecords).toEqual(
+      state.coerciveContainedPersonProtocolRecords
+    )
+    expect(
+      loaded.coerciveContainedPersonProtocolRecords?.[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]
+        ?.procedureRef
+    ).toBe(EMERGENCY_SEDATION_PROTOCOL_FIXTURE.procedureRef)
+    expect(
+      loaded.coerciveContainedPersonProtocolRecords?.[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]
+        ?.complianceMetricOnly
+    ).toBe(true)
+  })
+
+  it('hydrates persisted coercive protocol records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        coerciveContainedPersonProtocolRecords: {
+          [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+          invalid: {
+            id: 'coercive-protocol:invalid',
+            label: 'SCP division sedation protocol',
+            subjectRef: 'subject:test',
+            handlingMode: 'emergency',
+            subjectFitState: 'validated',
+            authorizationSource: 'emergency_directive',
+            forcePolicy: 'proportional',
+            consentConfidence: 0.2,
+            refusalHandling: 'documented_override',
+            isolationBurdenScore: 0.4,
+            surveillanceBurdenScore: 0.4,
+            containmentStabilityGain: 0.7,
+            personhoodHarmRisk: 0.5,
+            trustDamageRisk: 0.5,
+            legitimacyRisk: 0.4,
+            welfareDebtImpactLabel: 'test',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.coerciveContainedPersonProtocolRecords).toEqual({
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    })
+  })
+
+  it('repeated sanitize is byte-stable for fixture records', () => {
+    const first = sanitizeCoerciveProtocolRecords(
+      { [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE },
+      {}
+    )
+    const second = sanitizeCoerciveProtocolRecords(first, {})
+
+    expect(second).toEqual(first)
+    expect(validateCoerciveProtocolRecord(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)).toEqual(
+      validateCoerciveProtocolRecord(second[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]!)
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Add `coerciveContainedPersonProtocolRecords` to `GameState` with `sanitizeCoerciveProtocolRecords` hydration (mirror SPE-1892 / SPE-1886 slice 2 pattern).
- Wire sanitize through `runTransfer` and default `{}` in `createStartingState`.
- Add persistence round-trip tests and `advanceWeek` preservation regression (welfare-debt hook unchanged).

## Linear

- **Slice:** [SPE-2421](https://linear.app/spectranoir/issue/SPE-2421) — Coercive contained-person protocol GameState persistence (slice 2)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model (parent stays open; weekly orchestration deferred slice 3)

## What shipped

- `CoerciveProtocolRecordsMap` + `sanitizeCoerciveProtocolRecords` in registry
- GameState field + hydrate wire in `runTransfer`
- Persistence + advanceWeek integration tests

## Validation

- `npm run lint`
- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts src/test/coerciveContainedPersonProtocolRegistry.test.ts`

## Docs

- `planning/coercive-contained-person-protocol-model-slice-2.md`

## Deferred (out of slice)

- Weekly orchestration hook in `advanceWeek` → slice 3
- Contradiction-check siblings (SPE-1897+)
- Faction ethics links (SPE-1047 / SPE-1131)
- Full SPE-1882 parent Done