### PR TITLE
SPE-2422: coercive protocol weekly orchestration hook (slice 3)

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-3.md
+++ b/planning/coercive-contained-person-protocol-model-slice-3.md
@@ -1,0 +1,73 @@
+# SPE-1882 — Coercive contained-person protocol weekly orchestration hook (slice 3)
+
+One-page implementation plan. Linear: [SPE-2422](https://linear.app/spectranoir/issue/SPE-2422) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Follows shipped slice 2 (`planning/coercive-contained-person-protocol-model-slice-2.md`, PR #2711 / [SPE-2421](https://linear.app/spectranoir/issue/SPE-2421)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2422 — Coercive contained-person protocol weekly orchestration hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2422) |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–2 shipped)          |
+| **Branch** | `spe-1882-coercive-protocol-weekly-hook-slice-3`                                                           |
+| **Base `main` SHA** | `a40cb18f`                                                                                          |
+
+## Goal
+
+Wire persisted `coerciveContainedPersonProtocolRecords` into `advanceWeek` with a pure domain tick: run deterministic tradeoff and coercion-risk projections each week while preserving source records byte-stable.
+
+## Prerequisite (on `main` @ `a40cb18f`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Persistence          | `coerciveContainedPersonProtocolRecords` on `GameState` (SPE-2421)     |
+| Welfare-debt hook    | `coerciveProcedureWelfareDebtCreation.ts` (SPE-1888 slice 5)           |
+| Sibling weekly hooks | `containedPersonTherapeuticCareWeeklyOrchestration.ts` (SPE-2343)      |
+
+## Orchestration tick contract (slice 3)
+
+- **Projection pass** — for each persisted record, compute `projectContainmentCareTradeoff` and `projectCoerciveProtocolRiskReview` deterministically; projections are not persisted this slice.
+- **Record preservation** — source `CoerciveProtocolRecord` entries are never mutated; owner refs (`procedureRef`, `medicationRegimenRef`, `custodyStatusRef`) byte-stable.
+- **One pass per week** — bounded orchestration over the map; re-tick same week is idempotent (same map reference when unchanged).
+- **No-op** — empty map returns without throw.
+- **No welfare-debt duplication** — tick does not create or mutate `welfareDebtAccountingRecords`.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyCoerciveProtocolTick` in domain module                 | New persistence fields, UI                    |
+| Call from `advanceWeek` after therapeutic care tick, before welfare-debt creation | Contradiction-check siblings (SPE-1897+) |
+| Targeted domain + `advanceWeek` integration tests                  | Sanitize/hydration changes (slice 2)          |
+| Slice doc (this file) + backlog handoff                            | Registry schema/validation changes (slice 1)  |
+
+## Acceptance
+
+- [x] Empty `coerciveContainedPersonProtocolRecords` map is a no-op without throw
+- [x] Projections run deterministically for fixture records during tick
+- [x] Records byte-stable after `advanceWeek`; owner refs preserved
+- [x] Re-applying tick after advance is idempotent for the same week
+- [x] Welfare-debt creation regression green when protocol records present
+- [x] Slice 1 registry + slice 2 persistence tests unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts`, `src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Persisted projection snapshots | SPE-1882 follow-up | Slice 3 is wire-up stub only |
+| Contradiction-check sibling implementations | SPE-1897+ | Registry exposes flags only |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of weekly-hook boundary |
+| SPE-1889 integrated health bundle compose | SPE-1889 | Out of weekly-hook boundary |
+| Full SPE-1882 parent Done | SPE-1882 | Multiple slices remain |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-2.md`
+- `planning/contained-person-therapeutic-care-registry-slice-3.md`

--- a/src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts
+++ b/src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts
@@ -1,0 +1,97 @@
+/**
+ * SPE-1882 slice 3: weekly orchestration for persisted coercive protocol records.
+ *
+ * Pure deterministic tick: runs tradeoff and coercion-risk projections each week
+ * while preserving source records. Does not mutate welfare-debt accounting,
+ * implement contradiction-check siblings, or add persistence fields.
+ */
+
+import {
+  projectCoerciveProtocolRiskReview,
+  projectContainmentCareTradeoff,
+  type CoerciveProtocolId,
+  type CoerciveProtocolRecord,
+  type CoerciveProtocolRecordsMap,
+  type CoerciveProtocolRiskReviewProjection,
+  type ContainmentCareTradeoffProjection,
+} from './coerciveContainedPersonProtocolRegistry'
+
+export interface CoerciveProtocolWeeklyProjectionBundle {
+  readonly recordId: CoerciveProtocolId
+  readonly week: number
+  readonly tradeoff: ContainmentCareTradeoffProjection
+  readonly riskReview: CoerciveProtocolRiskReviewProjection
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+/**
+ * Builds the deterministic weekly projection bundle for one protocol record.
+ * Projections are derived from registry slice 1 helpers only.
+ */
+export function buildCoerciveProtocolWeeklyProjectionBundle(
+  record: CoerciveProtocolRecord,
+  week: number
+): CoerciveProtocolWeeklyProjectionBundle {
+  return Object.freeze({
+    recordId: record.id,
+    week: normalizeWeek(week),
+    tradeoff: projectContainmentCareTradeoff(record),
+    riskReview: projectCoerciveProtocolRiskReview(record),
+  })
+}
+
+/**
+ * Projects all persisted protocol records for the simulation week in stable id order.
+ * Returns an empty frozen array when the map is empty.
+ */
+export function projectCoerciveProtocolRecordsForWeek(
+  records: CoerciveProtocolRecordsMap | null | undefined,
+  week: number
+): readonly CoerciveProtocolWeeklyProjectionBundle[] {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return Object.freeze([])
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const bundles: CoerciveProtocolWeeklyProjectionBundle[] = []
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    bundles.push(buildCoerciveProtocolWeeklyProjectionBundle(record, normalizedWeek))
+  }
+
+  return Object.freeze(bundles)
+}
+
+/**
+ * Applies one weekly orchestration pass over persisted coercive protocol records.
+ * Runs deterministic projections but preserves source records byte-stable.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklyCoerciveProtocolTick(
+  records: CoerciveProtocolRecordsMap | null | undefined,
+  week: number
+): CoerciveProtocolRecordsMap {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  projectCoerciveProtocolRecordsForWeek(safeRecords, week)
+
+  return safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -269,6 +269,7 @@ import { applyWeeklyEntityWelfareReclassificationTick } from '../entityWelfareRe
 import { applyWeeklyVisualTriggerHazardTick } from '../visualTriggerHazardWeeklyOrchestration'
 import { applyWeeklyNamingHazardDescriptorTick } from '../namingHazardDescriptorWeeklyOrchestration'
 import { applyWeeklyTherapeuticCareTick } from '../containedPersonTherapeuticCareWeeklyOrchestration'
+import { applyWeeklyCoerciveProtocolTick } from '../coerciveContainedPersonProtocolWeeklyOrchestration'
 import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   resolveCoerciveProcedureExecutionDrafts,
@@ -4719,6 +4720,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
   if (Object.keys(currentTherapeuticCareRecords).length > 0) {
     outputWeeklyState.containedPersonTherapeuticCareRecords = applyWeeklyTherapeuticCareTick(
       currentTherapeuticCareRecords,
+      result.week
+    )
+  }
+
+  // SPE-1882 slice 3: deterministic tradeoff and coercion-risk projections on protocol records.
+  const currentCoerciveProtocolRecords = outputWeeklyState.coerciveContainedPersonProtocolRecords ?? {}
+  if (Object.keys(currentCoerciveProtocolRecords).length > 0) {
+    outputWeeklyState.coerciveContainedPersonProtocolRecords = applyWeeklyCoerciveProtocolTick(
+      currentCoerciveProtocolRecords,
       result.week
     )
   }

--- a/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
@@ -4,9 +4,11 @@ import {
   COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
 } from '../domain/containedPersonMedicationRegimenRegistry'
 import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
   ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
 } from '../domain/coerciveContainedPersonProtocolRegistry'
+import { applyWeeklyCoerciveProtocolTick } from '../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -57,5 +59,76 @@ describe('advanceWeek coercive protocol records integration (SPE-1882 slice 2)',
     )
     expect(record?.debtCategory).toBe('coerced_medication')
     expect(record?.severityBand).toBe('critical')
+  })
+})
+
+describe('advanceWeek coercive protocol records integration (SPE-1882 slice 3)', () => {
+  it('is a no-op for an empty protocol map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coerciveContainedPersonProtocolRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.coerciveContainedPersonProtocolRecords).toEqual({})
+  })
+
+  it('preserves fixture record references byte-stable after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.week).toBe(5)
+    expect(
+      nextState.coerciveContainedPersonProtocolRecords?.[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]
+    ).toBe(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    expect(
+      nextState.coerciveContainedPersonProtocolRecords?.[
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id
+      ]
+    ).toBe(ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE)
+  })
+
+  it('preserves owner refs on protocol records after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const nextRecord =
+      nextState.coerciveContainedPersonProtocolRecords?.[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]
+
+    expect(nextRecord?.medicationRegimenRef).toBe(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE.medicationRegimenRef
+    )
+    expect(nextRecord?.custodyStatusRef).toBe(EMERGENCY_SEDATION_PROTOCOL_FIXTURE.custodyStatusRef)
+    expect(nextRecord?.procedureRef).toBe(EMERGENCY_SEDATION_PROTOCOL_FIXTURE.procedureRef)
+  })
+
+  it('is idempotent when protocol tick is re-applied at the post-advance week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const once = advanceWeek(state)
+    const recordsAfterAdvance = once.coerciveContainedPersonProtocolRecords ?? {}
+    const reticked = applyWeeklyCoerciveProtocolTick(recordsAfterAdvance, once.week)
+
+    expect(reticked).toBe(recordsAfterAdvance)
+    expect(reticked[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]).toBe(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
   })
 })

--- a/src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts
+++ b/src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+  projectCoerciveProtocolRiskReview,
+  projectContainmentCareTradeoff,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+import {
+  applyWeeklyCoerciveProtocolTick,
+  buildCoerciveProtocolWeeklyProjectionBundle,
+  projectCoerciveProtocolRecordsForWeek,
+} from '../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
+
+describe('coerciveContainedPersonProtocolWeeklyOrchestration (SPE-1882 slice 3)', () => {
+  it('is a no-op for an empty protocol map without throwing', () => {
+    const records = {}
+
+    expect(applyWeeklyCoerciveProtocolTick(records, 4)).toBe(records)
+    expect(projectCoerciveProtocolRecordsForWeek(records, 4)).toEqual([])
+  })
+
+  it('is a no-op for null or undefined maps', () => {
+    expect(applyWeeklyCoerciveProtocolTick(null, 2)).toEqual({})
+    expect(applyWeeklyCoerciveProtocolTick(undefined, 2)).toEqual({})
+    expect(projectCoerciveProtocolRecordsForWeek(null, 2)).toEqual([])
+  })
+
+  it('builds projection bundles matching registry helpers', () => {
+    const bundle = buildCoerciveProtocolWeeklyProjectionBundle(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      7
+    )
+
+    expect(bundle.recordId).toBe(EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id)
+    expect(bundle.week).toBe(7)
+    expect(bundle.tradeoff).toEqual(
+      projectContainmentCareTradeoff(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    )
+    expect(bundle.riskReview).toEqual(
+      projectCoerciveProtocolRiskReview(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    )
+  })
+
+  it('projects records in stable sorted id order', () => {
+    const records = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+
+    const bundles = projectCoerciveProtocolRecordsForWeek(records, 3)
+
+    expect(bundles.map((bundle) => bundle.recordId)).toEqual([
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id,
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id,
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id,
+    ])
+    expect(bundles.every((bundle) => bundle.week === 3)).toBe(true)
+  })
+
+  it('preserves source records when tick runs projections', () => {
+    const records = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const next = applyWeeklyCoerciveProtocolTick(records, 5)
+
+    expect(next).toBe(records)
+    expect(next[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]).toBe(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    expect(next[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]).toBe(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+  })
+
+  it('is idempotent when re-applied at the same week', () => {
+    const records = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+
+    const once = applyWeeklyCoerciveProtocolTick(records, 4)
+    const twice = applyWeeklyCoerciveProtocolTick(once, 4)
+
+    expect(twice).toBe(once)
+    expect(twice).toBe(records)
+  })
+
+  it('normalizes non-finite week values to week 1 for projection bundles', () => {
+    const bundle = buildCoerciveProtocolWeeklyProjectionBundle(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      Number.NaN
+    )
+
+    expect(bundle.week).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Add pplyWeeklyCoerciveProtocolTick in coerciveContainedPersonProtocolWeeklyOrchestration.ts — runs deterministic projectContainmentCareTradeoff and projectCoerciveProtocolRiskReview projections each week while preserving source records byte-stable.
- Wire the tick into dvanceWeek after therapeutic care orchestration and before welfare-debt creation (SPE-1888 slice 5).
- Extend integration tests and add focused weekly orchestration unit tests.

## Linear

- **Slice:** [SPE-2422](https://linear.app/spectranoir/issue/SPE-2422) — Coercive contained-person protocol weekly orchestration hook (slice 3)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — remains open (orchestration stub only)

## What shipped

- Weekly projection pass over coerciveContainedPersonProtocolRecords without record mutation or welfare-debt duplication
- Empty-map no-op, idempotent re-tick, owner-ref preservation regression

## Validation

- 
pm run lint
- 
pm run test:run -- src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts src/test/coerciveContainedPersonProtocolRegistry.test.ts src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts (28 tests)

## Docs updated

- planning/coercive-contained-person-protocol-model-slice-3.md (new)
- planning/backlog.md — pending merge closeout

Made with [Cursor](https://cursor.com)