### PR TITLE
SPE-2423: coercive protocol planning mirror UI (slice 4)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) follow-up — persisted projection snapshots or planning mirror UI over coercive protocol records (slice 3 orchestration stub shipped). Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) follow-up — persisted weekly projection snapshots on GameState (alternate to mirror UI; slice 4 mirror shipped) or contradiction-check siblings ([SPE-1897+](https://linear.app/spectranoir/issue/SPE-1897)). Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `cfad608f` (shipped: [SPE-2422](https://linear.app/spectranoir/issue/SPE-2422) coercive protocol weekly orchestration hook slice 3 @ PR #2713)
+**Base `main` SHA:** `5d792229` (in progress: [SPE-2423](https://linear.app/spectranoir/issue/SPE-2423) coercive protocol planning mirror UI slice 4)
 
 **Recently shipped:** [SPE-2422](https://linear.app/spectranoir/issue/SPE-2422) coercive protocol weekly orchestration hook slice 3 @ PR #2713; [SPE-2421](https://linear.app/spectranoir/issue/SPE-2421) coercive protocol GameState persistence slice 2 @ PR #2711; see `planning/coercive-contained-person-protocol-model-slice-3.md`.
 

--- a/planning/coercive-contained-person-protocol-model-slice-4.md
+++ b/planning/coercive-contained-person-protocol-model-slice-4.md
@@ -1,0 +1,82 @@
+# SPE-1882 — Coercive contained-person protocol planning mirror UI (slice 4)
+
+One-page implementation plan. Linear: [SPE-2423](https://linear.app/spectranoir/issue/SPE-2423) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Follows shipped slice 3 (`planning/coercive-contained-person-protocol-model-slice-3.md`, PR #2713 / [SPE-2422](https://linear.app/spectranoir/issue/SPE-2422)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2423 — Coercive contained-person protocol planning mirror UI (slice 4)](https://linear.app/spectranoir/issue/SPE-2423) |
+| **Status** | **Ready for PR**                                                                                           |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–3 shipped)          |
+| **Branch** | `spe-1882-coercive-protocol-mirror-ui-slice-4`                                                             |
+| **Base `main` SHA** | `5d792229`                                                                                          |
+
+## Goal
+
+Read-only planning/operations mirror over persisted `coerciveContainedPersonProtocolRecords` with read-time `projectContainmentCareTradeoff` and `projectCoerciveProtocolRiskReview` display for agent routing visibility, not player-facing canon.
+
+## Prerequisite (on `main` @ `5d792229`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Persistence          | `coerciveContainedPersonProtocolRecords` on `GameState` (SPE-2421)     |
+| Weekly orchestration | `applyWeeklyCoerciveProtocolTick` (SPE-2422)                           |
+| Sibling mirror template | `containedPersonTherapeuticCareMirrorView` (SPE-2344)               |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `getCoerciveContainedPersonProtocolMirrorView` + mirror page       | New persistence fields                     |
+| Route `/coercive-contained-person-protocol` + Front Desk quick link | Weekly tick / sanitize contract changes       |
+| View + component tests                                             | Contradiction-check siblings (SPE-1897+)      |
+| Slice doc (this file) + backlog handoff                            | Welfare-debt accounting math changes          |
+| Read-time tradeoff + risk-review projections from hydrated records | SPE-1882 parent Done                            |
+| Owner refs display only (byte-stable)                              | SPE-1889 health-bundle wire-up                |
+
+## Mirror contract
+
+- **Read-only** — no mutations to GameState from the mirror surface.
+- **Hydrated truth only** — display persisted records as hydrated; do not re-run validation to drop entries.
+- **Display guards** — `validateCoerciveProtocolRecord` surfaces warning-severity issues only; warning-only records remain visible.
+- **Read-time projections** — `projectContainmentCareTradeoff` and `projectCoerciveProtocolRiskReview` at mirror build; not objective truth.
+- **Empty state** — when `coerciveContainedPersonProtocolRecords` map is empty after hydrate.
+- **Ordering** — byte-stable sort by record id; owner refs displayed as stored.
+- **Copy** — CP-neutral labels; no franchise tokens in UI strings.
+
+## Acceptance
+
+- [x] Empty `coerciveContainedPersonProtocolRecords` map renders empty state without throw
+- [x] Records table shows handling mode, tradeoff scores, and coercion-risk review projections
+- [x] Abusive posture and contradiction-risk flags display distinctly
+- [x] Warning-only records still shown with validation warning labels
+- [x] Owner refs (medication, custody, procedure, subject-fit validation) display byte-stable
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests + slice 1–3 regression green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` |
+| UI     | `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx` |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`                                |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Persisted weekly projection snapshots | SPE-1882 follow-up | Slice 3 contract; projections computed but not persisted |
+| Contradiction-check sibling implementations | SPE-1897+ | Registry exposes flags only |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of mirror UI boundary |
+| SPE-1889 integrated health bundle compose | SPE-1889 | Out of mirror UI boundary |
+| Full SPE-1882 parent Done | SPE-1882 | Multiple slices remain |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-3.md`
+- `planning/contained-person-therapeutic-care-registry-slice-4.md` — mirror UI template (SPE-2344)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -99,6 +99,9 @@ const EntityWelfareReclassificationMirrorRoute = createRouteComponent(
 const ContainedPersonTherapeuticCareMirrorRoute = createRouteComponent(
   () => import('../features/operations/ContainedPersonTherapeuticCareMirrorPage')
 )
+const CoerciveContainedPersonProtocolMirrorRoute = createRouteComponent(
+  () => import('../features/operations/CoerciveContainedPersonProtocolMirrorPage')
+)
 const NamingHazardDescriptorMirrorRoute = createRouteComponent(
   () => import('../features/operations/NamingHazardDescriptorMirrorPage')
 )
@@ -197,6 +200,10 @@ export default function App() {
         <Route
           path="contained-person-therapeutic-care"
           element={renderLazyRoute(ContainedPersonTherapeuticCareMirrorRoute)}
+        />
+        <Route
+          path="coercive-contained-person-protocol"
+          element={renderLazyRoute(CoerciveContainedPersonProtocolMirrorRoute)}
         />
         <Route
           path="naming-hazard-descriptor"

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -32,6 +32,7 @@ export const APP_ROUTES = {
   visualTriggerHazard: '/visual-trigger-hazard',
   entityWelfareReclassification: '/entity-welfare-reclassification',
   containedPersonTherapeuticCare: '/contained-person-therapeutic-care',
+  coerciveContainedPersonProtocol: '/coercive-contained-person-protocol',
   namingHazardDescriptor: '/naming-hazard-descriptor',
   containedPersonIntegratedHealthBundle: '/contained-person-integrated-health-bundle',
   welfareDebtAccounting: '/welfare-debt-accounting',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1227,6 +1227,41 @@ export const NAMING_HAZARD_DESCRIPTOR_MIRROR_UI_TEXT: Record<string, string> = {
   validationWarningPrefix: 'Validation warnings:',
 }
 
+export const COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Coercive contained-person protocol registry',
+  pageSubtitle:
+    'Read-only operations view over persisted coercive protocol records and read-time containment-care tradeoff plus coercion-risk review projections.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Persisted records',
+  stableContainmentLabel: 'Stable containment dominates',
+  abusivePostureLabel: 'Abusive posture',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Handling modes, tradeoff scores, and coercion-risk flags mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
+  emptyTitle: 'No coercive contained person protocol records',
+  emptyBody:
+    'Persisted coercive protocol records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  recordsHeading: 'Persisted records',
+  recordsSubtitle:
+    'Tradeoff and risk-review projections are read-time only, not objective truth. Owner refs display as stored.',
+  labelColumn: 'Label',
+  handlingColumn: 'Handling posture',
+  tradeoffColumn: 'Containment vs care',
+  riskReviewColumn: 'Coercion risk review',
+  ownerRefsColumn: 'Owner refs',
+  confidenceColumn: 'Confidence',
+  subjectRefPrefix: 'Subject:',
+  subjectFitPrefix: 'Subject fit:',
+  consentPrefix: 'Consent confidence:',
+  stabilityGainPrefix: 'Stability gain:',
+  harmRiskPrefix: 'Harm risks:',
+  stableContainmentSuffix: 'Stable containment dominates care',
+  coercionRiskPrefix: 'Coercion risk:',
+  validationWarningPrefix: 'Validation warnings:',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const CONTAINED_PERSON_THERAPEUTIC_CARE_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Contained person therapeutic care registry',

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+} from '../../domain/coerciveContainedPersonProtocolRegistry'
+import { useGameStore } from '../../app/store/gameStore'
+import CoerciveContainedPersonProtocolMirrorPage from './CoerciveContainedPersonProtocolMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/coercive-contained-person-protocol']}>
+      <Routes>
+        <Route
+          path="/coercive-contained-person-protocol"
+          element={<CoerciveContainedPersonProtocolMirrorPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('CoerciveContainedPersonProtocolMirrorPage (SPE-1882 slice 4)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderMirrorPage()
+
+    expect(
+      screen.getByRole('region', { name: /coercive contained person protocol registry mirror/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty registry state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no coercive contained person protocol records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted records when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted coercive contained person protocol records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(EMERGENCY_SEDATION_PROTOCOL_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent(ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent('Emergency')
+    expect(recordsRegion).toHaveTextContent('Abusive')
+    expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT } from '../../data/copy'
+import { getCoerciveContainedPersonProtocolMirrorView } from './coerciveContainedPersonProtocolMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function CoerciveContainedPersonProtocolMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getCoerciveContainedPersonProtocolMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Coercive contained person protocol registry mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Registry summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">
+              {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.pageHeading}
+            </h2>
+            <p className="text-sm opacity-60">
+              {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.pageSubtitle}
+            </p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.stableContainmentLabel}
+            value={String(view.summary.stableContainmentDominatesCareCount)}
+          />
+          <StatCard
+            label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.abusivePostureLabel}
+            value={String(view.summary.abusivePostureCount)}
+          />
+          <StatCard
+            label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">
+          {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.readOnlyNote}
+        </p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty registry state">
+          <h3 className="text-lg font-semibold">
+            {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.emptyTitle}
+          </h3>
+          <p className="text-sm opacity-70">{COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted coercive contained person protocol records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">
+              {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.recordsHeading}
+            </h3>
+            <p className="text-sm opacity-60">
+              {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.recordsSubtitle}
+            </p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">
+                    {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.labelColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.handlingColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.tradeoffColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.riskReviewColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.ownerRefsColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.confidenceColumn}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.subjectRefPrefix}{' '}
+                        {record.subjectRefLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      <p>{record.handlingModeLabel}</p>
+                      <p className="text-xs opacity-55">{record.handlingPostureLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.subjectFitPrefix}{' '}
+                        {record.subjectFitStateLabel}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.consentPrefix}{' '}
+                        {record.consentConfidenceLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      <p className="text-xs opacity-55">
+                        {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.stabilityGainPrefix}{' '}
+                        {record.containmentStabilityGainLabel}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.harmRiskPrefix}{' '}
+                        {record.personhoodHarmRiskLabel} / {record.trustDamageRiskLabel} /{' '}
+                        {record.legitimacyRiskLabel}
+                      </p>
+                      {record.stableContainmentDominatesCareLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.stableContainmentSuffix}
+                        </p>
+                      ) : null}
+                      <p className="text-xs opacity-45">{record.welfareDebtImpactLabel}</p>
+                      {record.redacted ? (
+                        <p className="text-xs opacity-45">
+                          {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.redactedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <p className="text-xs opacity-55">
+                        {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.coercionRiskPrefix}{' '}
+                        {record.coercionRiskScoreLabel}
+                      </p>
+                      {record.contradictionRiskFlagLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {record.contradictionRiskFlagLabels.join('; ')}
+                        </p>
+                      ) : null}
+                      <p className="text-xs opacity-45">
+                        {record.forcePolicyLabel} · {record.refusalHandlingLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.medicationRegimenRefLabel !== '—' ? (
+                        <p className="text-xs opacity-55">{record.medicationRegimenRefLabel}</p>
+                      ) : null}
+                      {record.custodyStatusRefLabel !== '—' ? (
+                        <p className="text-xs opacity-45">{record.custodyStatusRefLabel}</p>
+                      ) : null}
+                      {record.procedureRefLabel !== '—' ? (
+                        <p className="text-xs opacity-45">{record.procedureRefLabel}</p>
+                      ) : null}
+                      {record.subjectFitValidationRefLabel !== '—' ? (
+                        <p className="text-xs opacity-45">{record.subjectFitValidationRefLabel}</p>
+                      ) : null}
+                      {record.medicationRegimenRefLabel === '—' &&
+                      record.custodyStatusRefLabel === '—' &&
+                      record.procedureRefLabel === '—' &&
+                      record.subjectFitValidationRefLabel === '—' ? (
+                        <p className="text-xs opacity-45">—</p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.confidenceLabel}
+                      {record.validationWarningLabels.length > 0 ? (
+                        <p className="text-xs text-amber-200/80">
+                          {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.validationWarningPrefix}{' '}
+                          {record.validationWarningLabels.length}
+                        </p>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+  projectCoerciveProtocolRiskReview,
+  projectContainmentCareTradeoff,
+  validateCoerciveProtocolRecord,
+  type CoerciveProtocolRecord,
+} from '../../domain/coerciveContainedPersonProtocolRegistry'
+import {
+  formatCoerciveProtocolEnumLabel,
+  getCoerciveContainedPersonProtocolMirrorView,
+} from './coerciveContainedPersonProtocolMirrorView'
+
+function warningOnlyRecord(): CoerciveProtocolRecord {
+  return {
+    id: 'coercive-protocol:compelled-undocumented',
+    label: 'Compelled protocol without documented authorization',
+    subjectRef: 'subject:cooperative-field-asset-41',
+    handlingMode: 'compelled',
+    subjectFitState: 'validated',
+    authorizationSource: 'undocumented',
+    forcePolicy: 'proportional',
+    consentConfidence: 0.25,
+    refusalHandling: 'documented_override',
+    isolationBurdenScore: 0.4,
+    surveillanceBurdenScore: 0.35,
+    containmentStabilityGain: 0.55,
+    personhoodHarmRisk: 0.48,
+    trustDamageRisk: 0.42,
+    legitimacyRisk: 0.38,
+    welfareDebtImpactLabel: 'coerced restraint welfare debt likely',
+    confidence: 0.71,
+  }
+}
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-1882 slice 4)', () => {
+  it('returns empty mirror when coerciveContainedPersonProtocolRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.coerciveContainedPersonProtocolRecords).toEqual({})
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('mirrors handling mode, tradeoff scores, and coercion risk from hydrated records', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+    const tradeoff = projectContainmentCareTradeoff(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    const riskReview = projectCoerciveProtocolRiskReview(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+
+    expect(view.isEmpty).toBe(false)
+    expect(record?.handlingModeLabel).toBe('Emergency')
+    expect(record?.handlingPostureLabel).toBe('Emergency')
+    expect(record?.containmentStabilityGainLabel).toBe(tradeoff.containmentStabilityGain.toFixed(2))
+    expect(record?.coercionRiskScoreLabel).toBe(riskReview.coercionRiskScore.toFixed(2))
+    expect(record?.medicationRegimenRefLabel).toBe('medication-regimen:coercive-sedative-beta')
+    expect(record?.custodyStatusRefLabel).toBe('custody-status:former-hostile-hold')
+    expect(record?.procedureRefLabel).toBe('coercive-procedure:forced-sedation-stabilization')
+  })
+
+  it('shows stable containment and abusive posture summary counts', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const abusiveRecord = view.records.find(
+      (record) => record.id === ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id
+    )
+
+    expect(view.summary.stableContainmentDominatesCareCount).toBe(1)
+    expect(view.summary.abusivePostureCount).toBe(1)
+    expect(view.summary.contradictionFlaggedCount).toBe(1)
+    expect(abusiveRecord?.handlingPostureLabel).toBe('Abusive')
+    expect(abusiveRecord?.contradictionRiskFlagLabels).toContain('Surveillance Isolation Burden')
+    expect(abusiveRecord?.stableContainmentDominatesCareLabel).toBe('—')
+  })
+
+  it('still mirrors warning-only records with validation warning labels', () => {
+    const warningRecord = warningOnlyRecord()
+    expect(validateCoerciveProtocolRecord(warningRecord).valid).toBe(true)
+
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [warningRecord.id]: warningRecord,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.totalRecords).toBe(1)
+    expect(record?.validationWarningLabels.length).toBe(1)
+    expect(record?.handlingModeLabel).toBe('Compelled')
+  })
+
+  it('surfaces contradiction flags for routine force generalized fixture', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.contradictionFlaggedCount).toBe(1)
+    expect(record?.contradictionRiskFlagLabels).toContain('Routine Force Authorization')
+    expect(record?.contradictionRiskFlagLabels).toContain(
+      'Generalized Procedure Without Subject Fit'
+    )
+    expect(record?.subjectFitValidationRefLabel).toBe('—')
+  })
+
+  it('orders records by id and is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.records.map((record) => record.id)).toEqual([
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id,
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id,
+    ])
+
+    const first = JSON.stringify(getCoerciveContainedPersonProtocolMirrorView(game))
+    const second = JSON.stringify(getCoerciveContainedPersonProtocolMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatCoerciveProtocolEnumLabel('court_order')).toBe('Court Order')
+    expect(formatCoerciveProtocolEnumLabel('routine_force_authorization')).toBe(
+      'Routine Force Authorization'
+    )
+  })
+})

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -1,0 +1,185 @@
+import type { GameState } from '../../domain/models'
+import {
+  projectCoerciveProtocolRiskReview,
+  projectContainmentCareTradeoff,
+  validateCoerciveProtocolRecord,
+  type CoerciveProtocolContradictionRiskFlag,
+  type CoerciveProtocolRecord,
+} from '../../domain/coerciveContainedPersonProtocolRegistry'
+
+export interface CoerciveContainedPersonProtocolMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  subjectRefLabel: string
+  handlingModeLabel: string
+  handlingPostureLabel: string
+  subjectFitStateLabel: string
+  authorizationSourceLabel: string
+  forcePolicyLabel: string
+  consentConfidenceLabel: string
+  refusalHandlingLabel: string
+  welfareDebtImpactLabel: string
+  containmentStabilityGainLabel: string
+  personhoodHarmRiskLabel: string
+  trustDamageRiskLabel: string
+  legitimacyRiskLabel: string
+  stableContainmentDominatesCareLabel: string
+  coercionRiskScoreLabel: string
+  contradictionRiskFlagLabels: readonly string[]
+  medicationRegimenRefLabel: string
+  custodyStatusRefLabel: string
+  procedureRefLabel: string
+  subjectFitValidationRefLabel: string
+  validationWarningLabels: readonly string[]
+  unknownFieldLabels: readonly string[]
+  confidenceLabel: string
+  redacted: boolean
+}
+
+export interface CoerciveContainedPersonProtocolMirrorSummaryView {
+  totalRecords: number
+  stableContainmentDominatesCareCount: number
+  abusivePostureCount: number
+  contradictionFlaggedCount: number
+  week: number
+}
+
+export interface CoerciveContainedPersonProtocolMirrorView {
+  isEmpty: boolean
+  summary: CoerciveContainedPersonProtocolMirrorSummaryView
+  records: readonly CoerciveContainedPersonProtocolMirrorRecordView[]
+}
+
+export function formatCoerciveProtocolEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(game: GameState): CoerciveProtocolRecord[] {
+  const map = game.coerciveContainedPersonProtocolRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatConfidence(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatUnitScore(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatYesNo(value: boolean): string {
+  return value ? 'Yes' : '—'
+}
+
+function formatOptionalRef(value: string | undefined): string {
+  return value?.trim() ? value : '—'
+}
+
+function formatContradictionRiskFlagLabel(flag: CoerciveProtocolContradictionRiskFlag): string {
+  return formatCoerciveProtocolEnumLabel(flag)
+}
+
+function sortedUnknownFieldLabels(unknownFields: readonly string[] | undefined): readonly string[] {
+  return Object.freeze([...(unknownFields ?? [])].sort((left, right) => left.localeCompare(right)))
+}
+
+function toRecordView(record: CoerciveProtocolRecord): CoerciveContainedPersonProtocolMirrorRecordView {
+  const tradeoff = projectContainmentCareTradeoff(record)
+  const riskReview = projectCoerciveProtocolRiskReview(record)
+  const validation = validateCoerciveProtocolRecord(record)
+
+  const validationWarningLabels = Object.freeze(
+    validation.issues
+      .filter((issue) => issue.severity === 'warning')
+      .map((issue) => issue.detail)
+  )
+
+  const summaryLabel = record.summary?.trim() ? record.summary : '—'
+
+  return Object.freeze({
+    id: record.id,
+    label: record.label,
+    summaryLabel,
+    subjectRefLabel: record.subjectRef,
+    handlingModeLabel: formatCoerciveProtocolEnumLabel(record.handlingMode),
+    handlingPostureLabel: formatCoerciveProtocolEnumLabel(riskReview.handlingPosture),
+    subjectFitStateLabel: formatCoerciveProtocolEnumLabel(record.subjectFitState),
+    authorizationSourceLabel: formatCoerciveProtocolEnumLabel(record.authorizationSource),
+    forcePolicyLabel: formatCoerciveProtocolEnumLabel(record.forcePolicy),
+    consentConfidenceLabel: formatUnitScore(record.consentConfidence),
+    refusalHandlingLabel: formatCoerciveProtocolEnumLabel(record.refusalHandling),
+    welfareDebtImpactLabel: tradeoff.welfareDebtImpactLabel,
+    containmentStabilityGainLabel: formatUnitScore(tradeoff.containmentStabilityGain),
+    personhoodHarmRiskLabel: formatUnitScore(tradeoff.personhoodHarmRisk),
+    trustDamageRiskLabel: formatUnitScore(tradeoff.trustDamageRisk),
+    legitimacyRiskLabel: formatUnitScore(tradeoff.legitimacyRisk),
+    stableContainmentDominatesCareLabel: formatYesNo(tradeoff.stableContainmentDominatesCare),
+    coercionRiskScoreLabel: formatUnitScore(riskReview.coercionRiskScore),
+    contradictionRiskFlagLabels: Object.freeze(
+      riskReview.contradictionRiskFlags.map((flag) => formatContradictionRiskFlagLabel(flag))
+    ),
+    medicationRegimenRefLabel: formatOptionalRef(record.medicationRegimenRef),
+    custodyStatusRefLabel: formatOptionalRef(record.custodyStatusRef),
+    procedureRefLabel: formatOptionalRef(record.procedureRef),
+    subjectFitValidationRefLabel: formatOptionalRef(record.subjectFitValidationRef),
+    validationWarningLabels,
+    unknownFieldLabels: sortedUnknownFieldLabels(riskReview.unknownFields),
+    confidenceLabel: formatConfidence(riskReview.confidence),
+    redacted: tradeoff.redacted || riskReview.redacted,
+  })
+}
+
+/** Read-only mirror over hydrated `coerciveContainedPersonProtocolRecords`; does not re-validate dropped entries. */
+export function getCoerciveContainedPersonProtocolMirrorView(
+  game: GameState
+): CoerciveContainedPersonProtocolMirrorView {
+  const records = listPersistedRecords(game)
+  const week = game.week
+
+  let stableContainmentDominatesCareCount = 0
+  let abusivePostureCount = 0
+  let contradictionFlaggedCount = 0
+
+  const recordViews = records.map((record) => {
+    const tradeoff = projectContainmentCareTradeoff(record)
+    const riskReview = projectCoerciveProtocolRiskReview(record)
+
+    if (tradeoff.stableContainmentDominatesCare) {
+      stableContainmentDominatesCareCount += 1
+    }
+
+    if (riskReview.handlingPosture === 'abusive') {
+      abusivePostureCount += 1
+    }
+
+    if (riskReview.contradictionRiskFlags.length > 0) {
+      contradictionFlaggedCount += 1
+    }
+
+    return toRecordView(record)
+  })
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      totalRecords: records.length,
+      stableContainmentDominatesCareCount,
+      abusivePostureCount,
+      contradictionFlaggedCount,
+      week,
+    }),
+    records: Object.freeze(recordViews),
+  })
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -808,6 +808,12 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
         'Review care cadence, channel posture, missed-session streaks, and compliance risk projections.',
     },
     {
+      label: 'Open coercive contained-person protocol mirror',
+      href: APP_ROUTES.coerciveContainedPersonProtocol,
+      description:
+        'Review handling modes, containment-care tradeoffs, coercion-risk flags, and owner refs.',
+    },
+    {
       label: 'Open naming-hazard descriptor mirror',
       href: APP_ROUTES.namingHazardDescriptor,
       description:


### PR DESCRIPTION
## Summary

- Add read-only planning mirror over persisted `coerciveContainedPersonProtocolRecords` with read-time `projectContainmentCareTradeoff` and `projectCoerciveProtocolRiskReview` display.
- Wire route `/coercive-contained-person-protocol`, Front Desk quick link, and CP-neutral copy strings.
- Mirror view + page tests; slice 1–3 registry/persistence/weekly regression unchanged.

## Linear mapping

- **Slice:** [SPE-2423](https://linear.app/spectranoir/issue/SPE-2423) — Coercive contained-person protocol planning mirror UI (slice 4)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — remains open (projection snapshots, contradiction-check siblings, SPE-1889 compose deferred)

## What shipped

- `getCoerciveContainedPersonProtocolMirrorView` + `CoerciveContainedPersonProtocolMirrorPage`
- Empty state, warning-only records, owner ref display, abusive/contradiction summary counts
- `planning/coercive-contained-person-protocol-model-slice-4.md` + backlog handoff

## Validation

- `npm run lint`
- `npx vitest run` on mirror view/page tests + slice 1–3 coercive protocol tests (37 passed)

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-4.md`
- `planning/backlog.md`

## Parent remains open

SPE-1882 parent not closed — persisted projection snapshots, SPE-1897+ contradiction checks, SPE-1047/SPE-1131 ethics links, and SPE-1889 health-bundle compose remain deferred.