### PR TITLE
SPE-2424: persist coercive protocol weekly projection snapshots (slice 5)

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-5.md
+++ b/planning/coercive-contained-person-protocol-model-slice-5.md
@@ -1,0 +1,79 @@
+# SPE-1882 — Coercive contained-person protocol weekly projection snapshots (slice 5)
+
+One-page implementation plan. Linear: [SPE-2424](https://linear.app/spectranoir/issue/SPE-2424) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Follows shipped slice 4 (`planning/coercive-contained-person-protocol-model-slice-4.md`, PR #2715 / [SPE-2423](https://linear.app/spectranoir/issue/SPE-2423)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2424 — Coercive contained-person protocol weekly projection snapshots (slice 5)](https://linear.app/spectranoir/issue/SPE-2424) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–4 shipped)          |
+| **Branch** | `spe-1882-coercive-protocol-projection-snapshots-slice-5`                                                  |
+| **Base `main` SHA** | `25a6e9a1`                                                                                          |
+
+## Goal
+
+Persist bounded weekly tradeoff and coercion-risk projection snapshots on `GameState`, hydrate/sanitize on load, and wire the persistence pass into `applyWeeklyCoerciveProtocolTick` without changing mirror UI or welfare-debt math.
+
+## Prerequisite (on `main` @ `25a6e9a1`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Persistence          | `coerciveContainedPersonProtocolRecords` on `GameState` (SPE-2421)     |
+| Weekly orchestration | `applyWeeklyCoerciveProtocolTick` projection pass (SPE-2422)           |
+| Mirror UI            | `coerciveContainedPersonProtocolMirrorView` (SPE-2423)                 |
+
+## Snapshot contract (slice 5)
+
+- **Field** — `coerciveContainedPersonProtocolWeeklyProjectionSnapshots` keyed by byte-stable protocol record id.
+- **Payload** — `{ recordId, week, tradeoff, riskReview }` from registry projection helpers.
+- **Tick pass** — `applyWeeklyCoerciveProtocolTick` writes/updates snapshots for active records; prunes removed record ids.
+- **Idempotency** — re-tick same week with unchanged records returns same snapshot map reference.
+- **No-op** — empty protocol map returns records and snapshots unchanged without throw.
+- **Bounds** — sanitize caps map size (`MAX_COERCIVE_PROTOCOL_WEEKLY_PROJECTION_SNAPSHOTS`) and unknown-field list length; drops orphan snapshot keys not in hydrated protocol records.
+- **Metadata** — redacted/unknown field propagation preserved in tradeoff and risk-review projections.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Snapshot types + sanitize in registry                              | Mirror UI module changes                      |
+| `coerciveContainedPersonProtocolWeeklyProjectionSnapshots` on `GameState` | Contradiction-check siblings (SPE-1897+) |
+| `applyWeeklyCoerciveProtocolTick` persistence pass + `advanceWeek` wire | Welfare-debt accounting math           |
+| `runTransfer` hydrate/sanitize                                     | Medication/custody registry changes           |
+| Targeted orchestration + persistence + advanceWeek tests           | SPE-1882 parent Done                            |
+| Slice doc (this file)                                              | Faction ethics links (SPE-1047 / SPE-1131)    |
+
+## Acceptance
+
+- [x] Empty protocol map tick is a no-op for records and snapshots without throw
+- [x] Weekly tick persists tradeoff + risk-review snapshots keyed by record id
+- [x] Re-tick same week is idempotent (stable snapshot map reference)
+- [x] Save/load and hydrate round-trip snapshots byte-stable
+- [x] Redacted/unknown metadata propagates into persisted projections
+- [x] Sanitize drops invalid entries, orphan ids, and enforces snapshot bounds
+- [x] Slice 1–4 regression + `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolRegistry.ts`, `src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts`, `src/domain/models.ts`, `src/domain/sim/advanceWeek.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts`, `src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts`, `src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-5.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Contradiction-check sibling implementations | SPE-1897+ | Registry exposes flags only |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of snapshot persistence boundary |
+| SPE-1889 integrated health bundle compose | SPE-1889 | Out of snapshot persistence boundary |
+| Mirror UI reads persisted snapshots instead of read-time projection | SPE-1882 follow-up | Slice 5 persists only; mirror unchanged |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-3.md` — tick contract origin
+- `planning/coercive-contained-person-protocol-model-slice-4.md` — mirror UI (read-time projections)

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -209,7 +209,7 @@ import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entit
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
 import { sanitizeCustodyStatusRecords } from '../../domain/containedPersonCustodyStatusRegistry'
 import { sanitizeWelfareDebtAccountingRecords } from '../../domain/welfareDebtAccountingRegistry'
-import { sanitizeCoerciveProtocolRecords } from '../../domain/coerciveContainedPersonProtocolRegistry'
+import { sanitizeCoerciveProtocolRecords, sanitizeCoerciveProtocolWeeklyProjectionSnapshots } from '../../domain/coerciveContainedPersonProtocolRegistry'
 import { sanitizeMedicationRegimenRecords } from '../../domain/containedPersonMedicationRegimenRegistry'
 import { sanitizeContainedPersonIntegratedHealthBundles } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
 import { sanitizeVisualTriggerHazardRecords } from '../../domain/visualTriggerHazardRegistry'
@@ -8511,6 +8511,12 @@ export function hydrateGame(
     game.coerciveContainedPersonProtocolRecords,
     fallback.coerciveContainedPersonProtocolRecords ?? {}
   )
+  const coerciveContainedPersonProtocolWeeklyProjectionSnapshots =
+    sanitizeCoerciveProtocolWeeklyProjectionSnapshots(
+      game.coerciveContainedPersonProtocolWeeklyProjectionSnapshots,
+      fallback.coerciveContainedPersonProtocolWeeklyProjectionSnapshots ?? {},
+      new Set(Object.keys(coerciveContainedPersonProtocolRecords))
+    )
   const welfareDebtAccountingRecords = sanitizeWelfareDebtAccountingRecords(
     game.welfareDebtAccountingRecords,
     fallback.welfareDebtAccountingRecords ?? {}
@@ -8655,6 +8661,7 @@ export function hydrateGame(
       containedPersonMedicationRegimenRecords,
       containedPersonCustodyStatusRecords,
       coerciveContainedPersonProtocolRecords,
+      coerciveContainedPersonProtocolWeeklyProjectionSnapshots,
       welfareDebtAccountingRecords,
       containedPersonIntegratedHealthBundles,
       candidates,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -58,6 +58,7 @@ const startingStateTemplate: GameState = {
   containedPersonMedicationRegimenRecords: {},
   containedPersonCustodyStatusRecords: {},
   coerciveContainedPersonProtocolRecords: {},
+  coerciveContainedPersonProtocolWeeklyProjectionSnapshots: {},
   welfareDebtAccountingRecords: {},
   containedPersonIntegratedHealthBundles: {},
   factions: createInitialFactionState(),

--- a/src/domain/coerciveContainedPersonProtocolRegistry.ts
+++ b/src/domain/coerciveContainedPersonProtocolRegistry.ts
@@ -219,6 +219,24 @@ export interface CoerciveProtocolRiskReviewProjection {
   readonly unknownFields: readonly string[]
 }
 
+/** SPE-1882 slice 5: persisted weekly tradeoff + risk-review projection snapshot for one protocol record. */
+export interface CoerciveProtocolWeeklyProjectionSnapshot {
+  readonly recordId: CoerciveProtocolId
+  readonly week: number
+  readonly tradeoff: ContainmentCareTradeoffProjection
+  readonly riskReview: CoerciveProtocolRiskReviewProjection
+}
+
+export type CoerciveProtocolWeeklyProjectionSnapshotsMap = Record<
+  CoerciveProtocolId,
+  CoerciveProtocolWeeklyProjectionSnapshot
+>
+
+/** Upper bound on persisted weekly projection snapshot entries (byte-stable record-id keys). */
+export const MAX_COERCIVE_PROTOCOL_WEEKLY_PROJECTION_SNAPSHOTS = 128
+
+const MAX_COERCIVE_PROTOCOL_PROJECTION_UNKNOWN_FIELDS = 32
+
 // ---------------------------------------------------------------------------
 // Internal constants
 // ---------------------------------------------------------------------------
@@ -228,6 +246,13 @@ const SUBJECT_FIT_STATE_SET = new Set<string>(COERCIVE_PROTOCOL_SUBJECT_FIT_STAT
 const AUTHORIZATION_SOURCE_SET = new Set<string>(COERCIVE_PROTOCOL_AUTHORIZATION_SOURCES)
 const FORCE_POLICY_SET = new Set<string>(COERCIVE_PROTOCOL_FORCE_POLICIES)
 const REFUSAL_HANDLING_SET = new Set<string>(COERCIVE_PROTOCOL_REFUSAL_HANDLING)
+const HANDLING_POSTURE_SET = new Set<string>(COERCIVE_PROTOCOL_HANDLING_POSTURES)
+const CONTRADICTION_RISK_FLAG_SET = new Set<string>([
+  'routine_force_authorization',
+  'generalized_procedure_without_subject_fit',
+  'compliance_metric_masks_harm',
+  'surveillance_isolation_burden',
+])
 
 const LEGALLY_AUTHORIZED_SOURCES = new Set<CoerciveProtocolAuthorizationSource>(['court_order'])
 
@@ -985,6 +1010,184 @@ function sanitizeCoerciveProtocolRecordEntry(value: unknown): CoerciveProtocolRe
   }
 
   return record
+}
+
+function parseBoundedStringList(value: unknown, maxEntries: number): readonly string[] {
+  return parseStringList(value).slice(0, maxEntries)
+}
+
+function sanitizeProjectionConfidence(value: unknown): number | null {
+  return isValidUnitScore(value) ? value : null
+}
+
+function sanitizeContainmentCareTradeoffProjection(
+  value: unknown,
+  recordId: CoerciveProtocolId
+): ContainmentCareTradeoffProjection | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const label = normalizeToken(value.label)
+  const handlingMode = value.handlingMode
+  const welfareDebtImpactLabel = normalizeToken(value.welfareDebtImpactLabel)
+
+  if (
+    !label ||
+    !isCoerciveProtocolHandlingMode(handlingMode) ||
+    !welfareDebtImpactLabel ||
+    !isValidUnitScore(value.containmentStabilityGain) ||
+    !isValidUnitScore(value.personhoodHarmRisk) ||
+    !isValidUnitScore(value.trustDamageRisk) ||
+    !isValidUnitScore(value.legitimacyRisk)
+  ) {
+    return null
+  }
+
+  return Object.freeze({
+    recordId,
+    label,
+    handlingMode,
+    containmentStabilityGain: roundUnitScore(value.containmentStabilityGain),
+    personhoodHarmRisk: roundUnitScore(value.personhoodHarmRisk),
+    trustDamageRisk: roundUnitScore(value.trustDamageRisk),
+    legitimacyRisk: roundUnitScore(value.legitimacyRisk),
+    stableContainmentDominatesCare: value.stableContainmentDominatesCare === true,
+    welfareDebtImpactLabel,
+    confidence: sanitizeProjectionConfidence(value.confidence),
+    redacted: value.redacted === true,
+    unknownFields: Object.freeze(
+      parseBoundedStringList(value.unknownFields, MAX_COERCIVE_PROTOCOL_PROJECTION_UNKNOWN_FIELDS)
+    ),
+  })
+}
+
+function sanitizeCoerciveProtocolRiskReviewProjection(
+  value: unknown,
+  recordId: CoerciveProtocolId
+): CoerciveProtocolRiskReviewProjection | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const label = normalizeToken(value.label)
+  const handlingPosture = value.handlingPosture
+  const forcePolicy = value.forcePolicy
+  const subjectFitState = value.subjectFitState
+
+  if (
+    !label ||
+    typeof handlingPosture !== 'string' ||
+    !HANDLING_POSTURE_SET.has(handlingPosture) ||
+    !isValidUnitScore(value.coercionRiskScore) ||
+    !isCoerciveProtocolSubjectFitState(subjectFitState) ||
+    typeof forcePolicy !== 'string' ||
+    !FORCE_POLICY_SET.has(forcePolicy)
+  ) {
+    return null
+  }
+
+  const contradictionRiskFlags = parseBoundedStringList(
+    value.contradictionRiskFlags,
+    MAX_COERCIVE_PROTOCOL_PROJECTION_UNKNOWN_FIELDS
+  ).filter((flag): flag is CoerciveProtocolContradictionRiskFlag =>
+    CONTRADICTION_RISK_FLAG_SET.has(flag)
+  )
+
+  return Object.freeze({
+    recordId,
+    label,
+    handlingPosture: handlingPosture as CoerciveProtocolHandlingPosture,
+    coercionRiskScore: roundUnitScore(value.coercionRiskScore),
+    contradictionRiskFlags: Object.freeze(
+      [...contradictionRiskFlags].sort((left, right) => left.localeCompare(right))
+    ),
+    blocksProcedure: value.blocksProcedure === true,
+    subjectFitState,
+    forcePolicy: forcePolicy as CoerciveProtocolForcePolicy,
+    confidence: sanitizeProjectionConfidence(value.confidence),
+    redacted: value.redacted === true,
+    unknownFields: Object.freeze(
+      parseBoundedStringList(value.unknownFields, MAX_COERCIVE_PROTOCOL_PROJECTION_UNKNOWN_FIELDS)
+    ),
+  })
+}
+
+function sanitizeCoerciveProtocolWeeklyProjectionSnapshotEntry(
+  key: string,
+  value: unknown
+): CoerciveProtocolWeeklyProjectionSnapshot | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const recordId = normalizeToken(value.recordId ?? key)
+  if (!recordId || recordId !== normalizeToken(key)) {
+    return null
+  }
+
+  const weekRaw = value.week
+  if (typeof weekRaw !== 'number' || !Number.isFinite(weekRaw)) {
+    return null
+  }
+
+  const week = Math.max(1, Math.trunc(weekRaw))
+  const tradeoff = sanitizeContainmentCareTradeoffProjection(value.tradeoff, recordId)
+  const riskReview = sanitizeCoerciveProtocolRiskReviewProjection(value.riskReview, recordId)
+
+  if (!tradeoff || !riskReview) {
+    return null
+  }
+
+  if (tradeoff.recordId !== recordId || riskReview.recordId !== recordId) {
+    return null
+  }
+
+  return Object.freeze({
+    recordId,
+    week,
+    tradeoff,
+    riskReview,
+  })
+}
+
+/** Hydration: canonical weekly projection snapshot map keyed by record id; drops invalid entries. */
+export function sanitizeCoerciveProtocolWeeklyProjectionSnapshots(
+  value: unknown,
+  fallback: CoerciveProtocolWeeklyProjectionSnapshotsMap = {},
+  knownRecordIds?: ReadonlySet<string>
+): CoerciveProtocolWeeklyProjectionSnapshotsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const candidates: CoerciveProtocolWeeklyProjectionSnapshot[] = []
+
+  for (const [key, entry] of Object.entries(value)) {
+    const snapshot = sanitizeCoerciveProtocolWeeklyProjectionSnapshotEntry(key, entry)
+    if (!snapshot) {
+      continue
+    }
+
+    if (knownRecordIds && !knownRecordIds.has(snapshot.recordId)) {
+      continue
+    }
+
+    candidates.push(snapshot)
+  }
+
+  if (candidates.length === 0) {
+    return fallback
+  }
+
+  candidates.sort((left, right) => left.recordId.localeCompare(right.recordId))
+
+  const next: CoerciveProtocolWeeklyProjectionSnapshotsMap = {}
+  for (const snapshot of candidates.slice(0, MAX_COERCIVE_PROTOCOL_WEEKLY_PROJECTION_SNAPSHOTS)) {
+    next[snapshot.recordId] = snapshot
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
 }
 
 /** Hydration: canonical protocol map keyed by record id; drops invalid and duplicate-id entries. */

--- a/src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts
+++ b/src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts
@@ -1,9 +1,9 @@
 /**
- * SPE-1882 slice 3: weekly orchestration for persisted coercive protocol records.
+ * SPE-1882 slice 3/5: weekly orchestration for persisted coercive protocol records.
  *
- * Pure deterministic tick: runs tradeoff and coercion-risk projections each week
- * while preserving source records. Does not mutate welfare-debt accounting,
- * implement contradiction-check siblings, or add persistence fields.
+ * Pure deterministic tick: runs tradeoff and coercion-risk projections each week,
+ * persists bounded weekly projection snapshots, and preserves source records byte-stable.
+ * Does not mutate welfare-debt accounting or implement contradiction-check siblings.
  */
 
 import {
@@ -13,6 +13,8 @@ import {
   type CoerciveProtocolRecord,
   type CoerciveProtocolRecordsMap,
   type CoerciveProtocolRiskReviewProjection,
+  type CoerciveProtocolWeeklyProjectionSnapshot,
+  type CoerciveProtocolWeeklyProjectionSnapshotsMap,
   type ContainmentCareTradeoffProjection,
 } from './coerciveContainedPersonProtocolRegistry'
 
@@ -23,12 +25,42 @@ export interface CoerciveProtocolWeeklyProjectionBundle {
   readonly riskReview: CoerciveProtocolRiskReviewProjection
 }
 
+export interface CoerciveProtocolWeeklyTickResult {
+  readonly records: CoerciveProtocolRecordsMap
+  readonly snapshots: CoerciveProtocolWeeklyProjectionSnapshotsMap
+}
+
 function normalizeWeek(week: number): number {
   if (!Number.isFinite(week)) {
     return 1
   }
 
   return Math.max(1, Math.trunc(week))
+}
+
+function freezeSnapshot(
+  bundle: CoerciveProtocolWeeklyProjectionBundle
+): CoerciveProtocolWeeklyProjectionSnapshot {
+  return Object.freeze({
+    recordId: bundle.recordId,
+    week: bundle.week,
+    tradeoff: bundle.tradeoff,
+    riskReview: bundle.riskReview,
+  })
+}
+
+function weeklyProjectionSnapshotsEqual(
+  left: CoerciveProtocolWeeklyProjectionSnapshot,
+  right: CoerciveProtocolWeeklyProjectionSnapshot
+): boolean {
+  if (left.recordId !== right.recordId || left.week !== right.week) {
+    return false
+  }
+
+  return (
+    JSON.stringify(left.tradeoff) === JSON.stringify(right.tradeoff) &&
+    JSON.stringify(left.riskReview) === JSON.stringify(right.riskReview)
+  )
 }
 
 /**
@@ -76,22 +108,82 @@ export function projectCoerciveProtocolRecordsForWeek(
   return Object.freeze(bundles)
 }
 
+function persistWeeklyProjectionSnapshots(
+  records: CoerciveProtocolRecordsMap,
+  snapshots: CoerciveProtocolWeeklyProjectionSnapshotsMap,
+  week: number
+): CoerciveProtocolWeeklyProjectionSnapshotsMap {
+  const normalizedWeek = normalizeWeek(week)
+  const recordIds = Object.keys(records).sort((left, right) => left.localeCompare(right))
+  let nextSnapshots: CoerciveProtocolWeeklyProjectionSnapshotsMap | null = null
+
+  for (const recordId of recordIds) {
+    const record = records[recordId]
+    if (!record) {
+      continue
+    }
+
+    const bundle = buildCoerciveProtocolWeeklyProjectionBundle(record, normalizedWeek)
+    const candidate = freezeSnapshot(bundle)
+    const existing = (nextSnapshots ?? snapshots)[recordId]
+
+    if (existing && weeklyProjectionSnapshotsEqual(existing, candidate)) {
+      continue
+    }
+
+    if (!nextSnapshots) {
+      nextSnapshots = { ...snapshots }
+    }
+
+    nextSnapshots[recordId] = candidate
+  }
+
+  const activeRecordIds = new Set(recordIds)
+  const sourceSnapshots = nextSnapshots ?? snapshots
+  for (const snapshotId of Object.keys(sourceSnapshots)) {
+    if (activeRecordIds.has(snapshotId)) {
+      continue
+    }
+
+    if (!nextSnapshots) {
+      nextSnapshots = { ...snapshots }
+    }
+
+    delete nextSnapshots[snapshotId]
+  }
+
+  if (!nextSnapshots) {
+    return snapshots
+  }
+
+  return Object.keys(nextSnapshots).length > 0 ? nextSnapshots : {}
+}
+
 /**
  * Applies one weekly orchestration pass over persisted coercive protocol records.
- * Runs deterministic projections but preserves source records byte-stable.
- * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ * Runs deterministic projections, persists bounded weekly snapshots, and preserves
+ * source records byte-stable. Empty map is a no-op. Re-applying after advance is
+ * idempotent for the same week.
  */
 export function applyWeeklyCoerciveProtocolTick(
   records: CoerciveProtocolRecordsMap | null | undefined,
-  week: number
-): CoerciveProtocolRecordsMap {
+  week: number,
+  snapshots: CoerciveProtocolWeeklyProjectionSnapshotsMap | null | undefined = {}
+): CoerciveProtocolWeeklyTickResult {
   const safeRecords = records ?? {}
+  const safeSnapshots = snapshots ?? {}
   const recordIds = Object.keys(safeRecords)
   if (recordIds.length === 0) {
-    return safeRecords
+    return {
+      records: safeRecords,
+      snapshots: safeSnapshots,
+    }
   }
 
-  projectCoerciveProtocolRecordsForWeek(safeRecords, week)
+  const nextSnapshots = persistWeeklyProjectionSnapshots(safeRecords, safeSnapshots, week)
 
-  return safeRecords
+  return {
+    records: safeRecords,
+    snapshots: nextSnapshots,
+  }
 }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -259,7 +259,10 @@ import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 import type { TherapeuticCareScheduleRecord } from './containedPersonTherapeuticCareRegistry'
-import type { CoerciveProtocolRecord } from './coerciveContainedPersonProtocolRegistry'
+import type {
+  CoerciveProtocolRecord,
+  CoerciveProtocolWeeklyProjectionSnapshot,
+} from './coerciveContainedPersonProtocolRegistry'
 import type { CustodyStatusRecord } from './containedPersonCustodyStatusRegistry'
 import type { MedicationRegimenRecord } from './containedPersonMedicationRegimenRegistry'
 import type { WelfareDebtAccountingRecord } from './welfareDebtAccountingRegistry'
@@ -2694,6 +2697,15 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   coerciveContainedPersonProtocolRecords?: Record<string, CoerciveProtocolRecord>
+
+  /**
+   * SPE-1882 slice 5: persisted weekly tradeoff/risk-review projection snapshots (keyed by record id).
+   * Hydration drops invalid entries and orphans not present in protocol records.
+   */
+  coerciveContainedPersonProtocolWeeklyProjectionSnapshots?: Record<
+    string,
+    CoerciveProtocolWeeklyProjectionSnapshot
+  >
 
   /**
    * SPE-1888 slice 1: persisted welfare-debt accounting records (keyed by record id).

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4724,13 +4724,17 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     )
   }
 
-  // SPE-1882 slice 3: deterministic tradeoff and coercion-risk projections on protocol records.
+  // SPE-1882 slice 3/5: deterministic tradeoff and coercion-risk projections on protocol records.
   const currentCoerciveProtocolRecords = outputWeeklyState.coerciveContainedPersonProtocolRecords ?? {}
   if (Object.keys(currentCoerciveProtocolRecords).length > 0) {
-    outputWeeklyState.coerciveContainedPersonProtocolRecords = applyWeeklyCoerciveProtocolTick(
+    const coerciveProtocolTick = applyWeeklyCoerciveProtocolTick(
       currentCoerciveProtocolRecords,
-      result.week
+      result.week,
+      outputWeeklyState.coerciveContainedPersonProtocolWeeklyProjectionSnapshots
     )
+    outputWeeklyState.coerciveContainedPersonProtocolRecords = coerciveProtocolTick.records
+    outputWeeklyState.coerciveContainedPersonProtocolWeeklyProjectionSnapshots =
+      coerciveProtocolTick.snapshots
   }
 
   // SPE-1888 slice 5: welfare-debt creation when coercive procedures execute with containment improvement.

--- a/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
@@ -7,6 +7,8 @@ import {
   ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
   ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+  projectCoerciveProtocolRiskReview,
+  projectContainmentCareTradeoff,
 } from '../domain/coerciveContainedPersonProtocolRegistry'
 import { applyWeeklyCoerciveProtocolTick } from '../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
 import { advanceWeek } from '../domain/sim/advanceWeek'
@@ -124,11 +126,39 @@ describe('advanceWeek coercive protocol records integration (SPE-1882 slice 3)',
 
     const once = advanceWeek(state)
     const recordsAfterAdvance = once.coerciveContainedPersonProtocolRecords ?? {}
-    const reticked = applyWeeklyCoerciveProtocolTick(recordsAfterAdvance, once.week)
+    const reticked = applyWeeklyCoerciveProtocolTick(
+      recordsAfterAdvance,
+      once.week,
+      once.coerciveContainedPersonProtocolWeeklyProjectionSnapshots
+    )
 
-    expect(reticked).toBe(recordsAfterAdvance)
-    expect(reticked[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]).toBe(
+    expect(reticked.records).toBe(recordsAfterAdvance)
+    expect(reticked.snapshots).toBe(once.coerciveContainedPersonProtocolWeeklyProjectionSnapshots)
+    expect(reticked.records[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]).toBe(
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+  })
+
+  it('persists weekly projection snapshots through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const snapshot =
+      nextState.coerciveContainedPersonProtocolWeeklyProjectionSnapshots?.[
+        EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id
+      ]
+
+    expect(snapshot?.week).toBe(5)
+    expect(snapshot?.tradeoff).toEqual(
+      projectContainmentCareTradeoff(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    )
+    expect(snapshot?.riskReview).toEqual(
+      projectCoerciveProtocolRiskReview(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
     )
   })
 })

--- a/src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts
+++ b/src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts
@@ -8,12 +8,19 @@ import {
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
   ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
   sanitizeCoerciveProtocolRecords,
+  sanitizeCoerciveProtocolWeeklyProjectionSnapshots,
   validateCoerciveProtocolRecord,
+  projectContainmentCareTradeoff,
+  projectCoerciveProtocolRiskReview,
 } from '../domain/coerciveContainedPersonProtocolRegistry'
+import { applyWeeklyCoerciveProtocolTick } from '../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
 
 describe('coerciveContainedPersonProtocolRegistry persistence (SPE-1882 slice 2)', () => {
   it('defaults starting state to an empty coercive protocol map', () => {
     expect(createStartingState().coerciveContainedPersonProtocolRecords).toEqual({})
+    expect(createStartingState().coerciveContainedPersonProtocolWeeklyProjectionSnapshots).toEqual(
+      {}
+    )
   })
 
   it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
@@ -220,6 +227,91 @@ describe('coerciveContainedPersonProtocolRegistry persistence (SPE-1882 slice 2)
     expect(second).toEqual(first)
     expect(validateCoerciveProtocolRecord(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)).toEqual(
       validateCoerciveProtocolRecord(second[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]!)
+    )
+  })
+})
+
+describe('coerciveContainedPersonProtocolRegistry weekly projection snapshots (SPE-1882 slice 5)', () => {
+  it('drops invalid snapshot entries and orphan record ids during sanitize', () => {
+    const tick = applyWeeklyCoerciveProtocolTick(
+      {
+        [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      },
+      3
+    )
+    const sanitized = sanitizeCoerciveProtocolWeeklyProjectionSnapshots(
+      {
+        ...tick.snapshots,
+        orphan: {
+          recordId: 'coercive-protocol:orphan',
+          week: 3,
+          tradeoff: tick.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]!.tradeoff,
+          riskReview: tick.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]!.riskReview,
+        },
+        'wrong-key': {
+          recordId: EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id,
+          week: 3,
+          tradeoff: tick.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]!.tradeoff,
+          riskReview: tick.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]!.riskReview,
+        },
+      },
+      {},
+      new Set([EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id])
+    )
+
+    expect(sanitized).toEqual(tick.snapshots)
+  })
+
+  it('round-trips weekly projection snapshots through save/load', () => {
+    const state = createStartingState()
+    state.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+    state.coerciveContainedPersonProtocolWeeklyProjectionSnapshots =
+      applyWeeklyCoerciveProtocolTick(
+        state.coerciveContainedPersonProtocolRecords,
+        8
+      ).snapshots
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.coerciveContainedPersonProtocolWeeklyProjectionSnapshots).toEqual(
+      state.coerciveContainedPersonProtocolWeeklyProjectionSnapshots
+    )
+    expect(
+      loaded.coerciveContainedPersonProtocolWeeklyProjectionSnapshots?.[
+        EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id
+      ]?.tradeoff
+    ).toEqual(projectContainmentCareTradeoff(EMERGENCY_SEDATION_PROTOCOL_FIXTURE))
+    expect(
+      loaded.coerciveContainedPersonProtocolWeeklyProjectionSnapshots?.[
+        EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id
+      ]?.riskReview
+    ).toEqual(projectCoerciveProtocolRiskReview(EMERGENCY_SEDATION_PROTOCOL_FIXTURE))
+  })
+
+  it('hydrates persisted weekly projection snapshots through import parsing', () => {
+    const tick = applyWeeklyCoerciveProtocolTick(
+      {
+        [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      },
+      2
+    )
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        coerciveContainedPersonProtocolRecords: {
+          [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]:
+            ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+        },
+        coerciveContainedPersonProtocolWeeklyProjectionSnapshots: tick.snapshots,
+      },
+      fallback
+    )
+
+    expect(hydrated.coerciveContainedPersonProtocolWeeklyProjectionSnapshots).toEqual(
+      tick.snapshots
     )
   })
 })

--- a/src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts
+++ b/src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts
@@ -15,14 +15,18 @@ import {
 describe('coerciveContainedPersonProtocolWeeklyOrchestration (SPE-1882 slice 3)', () => {
   it('is a no-op for an empty protocol map without throwing', () => {
     const records = {}
+    const snapshots = {}
 
-    expect(applyWeeklyCoerciveProtocolTick(records, 4)).toBe(records)
+    expect(applyWeeklyCoerciveProtocolTick(records, 4, snapshots)).toEqual({
+      records,
+      snapshots,
+    })
     expect(projectCoerciveProtocolRecordsForWeek(records, 4)).toEqual([])
   })
 
   it('is a no-op for null or undefined maps', () => {
-    expect(applyWeeklyCoerciveProtocolTick(null, 2)).toEqual({})
-    expect(applyWeeklyCoerciveProtocolTick(undefined, 2)).toEqual({})
+    expect(applyWeeklyCoerciveProtocolTick(null, 2)).toEqual({ records: {}, snapshots: {} })
+    expect(applyWeeklyCoerciveProtocolTick(undefined, 2)).toEqual({ records: {}, snapshots: {} })
     expect(projectCoerciveProtocolRecordsForWeek(null, 2)).toEqual([])
   })
 
@@ -68,9 +72,11 @@ describe('coerciveContainedPersonProtocolWeeklyOrchestration (SPE-1882 slice 3)'
 
     const next = applyWeeklyCoerciveProtocolTick(records, 5)
 
-    expect(next).toBe(records)
-    expect(next[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]).toBe(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
-    expect(next[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]).toBe(
+    expect(next.records).toBe(records)
+    expect(next.records[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]).toBe(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE
+    )
+    expect(next.records[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]).toBe(
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
     )
   })
@@ -81,10 +87,11 @@ describe('coerciveContainedPersonProtocolWeeklyOrchestration (SPE-1882 slice 3)'
     }
 
     const once = applyWeeklyCoerciveProtocolTick(records, 4)
-    const twice = applyWeeklyCoerciveProtocolTick(once, 4)
+    const twice = applyWeeklyCoerciveProtocolTick(once.records, 4, once.snapshots)
 
-    expect(twice).toBe(once)
-    expect(twice).toBe(records)
+    expect(twice.records).toBe(once.records)
+    expect(twice.snapshots).toBe(once.snapshots)
+    expect(twice.records).toBe(records)
   })
 
   it('normalizes non-finite week values to week 1 for projection bundles', () => {
@@ -94,5 +101,67 @@ describe('coerciveContainedPersonProtocolWeeklyOrchestration (SPE-1882 slice 3)'
     )
 
     expect(bundle.week).toBe(1)
+  })
+})
+
+describe('coerciveContainedPersonProtocolWeeklyOrchestration (SPE-1882 slice 5)', () => {
+  it('persists weekly projection snapshots keyed by record id', () => {
+    const records = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const tick = applyWeeklyCoerciveProtocolTick(records, 6)
+
+    expect(Object.keys(tick.snapshots).sort()).toEqual([
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id,
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id,
+    ])
+    expect(tick.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]?.week).toBe(6)
+    expect(tick.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]?.tradeoff).toEqual(
+      projectContainmentCareTradeoff(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    )
+    expect(tick.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]?.riskReview).toEqual(
+      projectCoerciveProtocolRiskReview(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
+    )
+  })
+
+  it('propagates redacted and unknown field metadata into persisted projections', () => {
+    const redactedRecord = {
+      ...EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      unknownFields: ['consentConfidence'],
+      redactedFields: ['consentConfidence'],
+    }
+    const records = { [redactedRecord.id]: redactedRecord }
+
+    const tick = applyWeeklyCoerciveProtocolTick(records, 2)
+    const snapshot = tick.snapshots[redactedRecord.id]
+
+    expect(snapshot?.tradeoff.redacted).toBe(true)
+    expect(snapshot?.tradeoff.unknownFields).toEqual(['consentConfidence'])
+    expect(snapshot?.riskReview.redacted).toBe(true)
+    expect(snapshot?.riskReview.unknownFields).toEqual(['consentConfidence'])
+  })
+
+  it('updates snapshots when week advances and prunes removed record ids', () => {
+    const records = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const weekFour = applyWeeklyCoerciveProtocolTick(records, 4)
+    const weekFiveRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+    const weekFive = applyWeeklyCoerciveProtocolTick(
+      weekFiveRecords,
+      5,
+      weekFour.snapshots
+    )
+
+    expect(weekFive.snapshots[EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]?.week).toBe(5)
+    expect(
+      weekFive.snapshots[ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]
+    ).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Add \coerciveContainedPersonProtocolWeeklyProjectionSnapshots\ on \GameState\ with sanitize/hydrate in \unTransfer\ (byte-stable record-id keys, bounded map size, orphan pruning).
- Extend \pplyWeeklyCoerciveProtocolTick\ to persist tradeoff + risk-review projection snapshots each week while preserving source records; wire through \dvanceWeek\.
- Add slice 5 planning doc and targeted orchestration, persistence, and integration tests.

## Linear

- **Slice:** [SPE-2424](https://linear.app/spectranoir/issue/SPE-2424)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)

## What shipped

Bounded weekly projection snapshot persistence for coercive contained-person protocol records. No mirror UI, welfare-debt, or contradiction-check changes.

## Validation

- \
pm run lint\
- \
pm run test:run -- src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts src/test/coerciveContainedPersonProtocolRegistry.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts\

## Docs updated

- \planning/coercive-contained-person-protocol-model-slice-5.md\

## Parent status

SPE-1882 remains **Done** (slice 5 closes deferred projection persistence from slice 3/4); contradiction-check siblings (SPE-1897+) still deferred.

Made with [Cursor](https://cursor.com)