### PR TITLE
SPE-2426: generalized subject-fit contradiction check (slice 7)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1907](https://linear.app/spectranoir/issue/SPE-1907) generalized subject-fit contradiction-check sibling (next registry flag), or [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889) health-bundle compose for protocol records. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1898](https://linear.app/spectranoir/issue/SPE-1898) compliance-metric-masks-harm contradiction-check sibling (next registry flag), or [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) surveillance-isolation burden sibling. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `2110a497` (shipped: [SPE-2425](https://linear.app/spectranoir/issue/SPE-2425) routine force authorization contradiction-check slice 6 @ PR #2719)
+**Base `main` SHA:** `52688ee1` (in flight: [SPE-2426](https://linear.app/spectranoir/issue/SPE-2426) generalized subject-fit contradiction-check slice 7)
 
 **Recently shipped:** [SPE-2425](https://linear.app/spectranoir/issue/SPE-2425) routine force authorization contradiction-check slice 6 @ PR #2719; [SPE-2424](https://linear.app/spectranoir/issue/SPE-2424) coercive protocol weekly projection snapshots slice 5 @ PR #2717; see `planning/coercive-contained-person-protocol-model-slice-6.md`.
 

--- a/planning/coercive-contained-person-protocol-model-slice-7.md
+++ b/planning/coercive-contained-person-protocol-model-slice-7.md
@@ -1,0 +1,78 @@
+# SPE-1882 — Coercive protocol generalized subject-fit contradiction check (slice 7)
+
+One-page implementation plan. Linear: [SPE-2426](https://linear.app/spectranoir/issue/SPE-2426) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Design anchor: [SPE-1907](https://linear.app/spectranoir/issue/SPE-1907) contradiction-check sibling cluster. Follows shipped slice 6 (`planning/coercive-contained-person-protocol-model-slice-6.md`).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2426 — Coercive protocol generalized subject-fit contradiction check (slice 7)](https://linear.app/spectranoir/issue/SPE-2426) |
+| **Status** | **Ready for PR**                                                                                           |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–6 shipped)          |
+| **Branch** | `spe-1907-generalized-subject-fit-contradiction-check-slice-7`                                             |
+| **Base `main` SHA** | `52688ee1`                                                                                          |
+
+## Goal
+
+Implement the second deterministic contradiction-check sibling for the `generalized_procedure_without_subject_fit` registry flag — warning-only review output that distinguishes generalized procedure scaling without subject-fit validation from validated reuse.
+
+## Prerequisite (on `main` @ `52688ee1`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Persistence          | `coerciveContainedPersonProtocolRecords` on `GameState` (SPE-2421)     |
+| Weekly orchestration | `applyWeeklyCoerciveProtocolTick` + snapshots (SPE-2422 / SPE-2424)    |
+| Mirror UI            | `coerciveContainedPersonProtocolMirrorView` (SPE-2423)                 |
+| Routine-force sibling | `evaluateRoutineForceAuthorizationContradictionCheck` (SPE-2425 slice 6) |
+
+## Sibling contract (slice 7)
+
+- **Flag** — `generalized_procedure_without_subject_fit` from `collectContradictionRiskFlags` (`subjectFitState === 'generalized'` without `subjectFitValidationRef`).
+- **Function** — `evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(record)` returns structured warning-only issues.
+- **Aggregator** — `evaluateCoerciveProtocolContradictionChecks(record)` returns triggered siblings in deterministic flag locale order (generalized subject-fit, then routine force).
+- **Blocking** — `blocksProcedure` is always `false` per registry contract.
+- **Metadata** — redacted/unknown field propagation on check results.
+- **No parallel system** — siblings live in registry; risk-review flags remain sourced from `collectContradictionRiskFlags`.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Generalized-subject-fit contradiction-check types + evaluator      | Mirror UI module changes                      |
+| `evaluateCoerciveProtocolContradictionChecks` aggregator extension | Welfare-debt accounting math                    |
+| Targeted registry unit tests                                       | Snapshot field contract changes               |
+| Slice 1–6 orchestration/persistence/advanceWeek regression         | Remaining flag siblings (SPE-1898 / SPE-1908) |
+| Slice doc (this file)                                              | SPE-1882 parent reopen                        |
+|                                                                    | Faction ethics links (SPE-1047 / SPE-1131)    |
+
+## Acceptance
+
+- [x] Generalized-subject-fit fixture triggers sibling with sorted warning issues and `blocksProcedure: false`
+- [x] Validated subject-fit or present validation ref returns non-triggered no-op sibling
+- [x] Sibling trigger aligns with `generalized_procedure_without_subject_fit` flag from `collectContradictionRiskFlags`
+- [x] Redacted/unknown metadata propagates into check output
+- [x] Aggregator returns both triggered siblings in flag locale order for dual-flag fixture
+- [x] Repeated evaluation is byte-stable
+- [x] Slice 1–6 regression + mirror view regression + `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolRegistry.ts`               |
+| Tests  | `src/test/coerciveContainedPersonProtocolRegistry.test.ts`            |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-7.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Compliance-metric-masks-harm sibling | SPE-1898 | Out of slice 7 boundary |
+| Surveillance-isolation burden sibling | SPE-1908 | Out of slice 7 boundary |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of registry contradiction-check boundary |
+| SPE-1889 integrated health bundle compose | SPE-1889 | Out of slice 7 boundary |
+| Mirror UI surfaces sibling check detail | SPE-1882 follow-up | Slice 7 is domain-only |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-6.md` — routine-force sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-1.md` — flag + risk-review contract origin

--- a/src/domain/coerciveContainedPersonProtocolRegistry.ts
+++ b/src/domain/coerciveContainedPersonProtocolRegistry.ts
@@ -226,8 +226,21 @@ export type CoerciveProtocolRoutineForceContradictionCheckCode =
   | 'routine_force_undocumented_refusal_override'
   | 'routine_force_masks_care_harm'
 
+export type CoerciveProtocolGeneralizedSubjectFitContradictionCheckCode =
+  | 'generalized_procedure_without_subject_fit_validation'
+  | 'generalized_procedure_contradicts_voluntary_handling'
+  | 'generalized_procedure_low_consent_confidence'
+  | 'generalized_procedure_abusive_without_review_path'
+  | 'generalized_procedure_deceptive_without_review_path'
+  | 'generalized_procedure_masks_care_harm'
+  | 'generalized_procedure_compliance_metric_only'
+
+export type CoerciveProtocolContradictionCheckCode =
+  | CoerciveProtocolRoutineForceContradictionCheckCode
+  | CoerciveProtocolGeneralizedSubjectFitContradictionCheckCode
+
 export interface CoerciveProtocolContradictionCheckIssue {
-  readonly code: CoerciveProtocolRoutineForceContradictionCheckCode
+  readonly code: CoerciveProtocolContradictionCheckCode
   readonly detail: string
   readonly severity: 'warning'
   readonly relatedIds?: readonly string[]
@@ -759,7 +772,7 @@ export function projectContainmentCareTradeoff(
   })
 }
 
-const ROUTINE_FORCE_LOW_CONSENT_CONFIDENCE_THRESHOLD = 0.35
+const CONTRADICTION_CHECK_LOW_CONSENT_CONFIDENCE_THRESHOLD = 0.35
 
 const VOLUNTARY_HANDLING_MODES = new Set<CoerciveProtocolHandlingMode>(['voluntary', 'negotiated'])
 
@@ -818,7 +831,7 @@ function buildRoutineForceAuthorizationContradictionIssues(
     })
   }
 
-  if (record.consentConfidence <= ROUTINE_FORCE_LOW_CONSENT_CONFIDENCE_THRESHOLD) {
+  if (record.consentConfidence <= CONTRADICTION_CHECK_LOW_CONSENT_CONFIDENCE_THRESHOLD) {
     issues.push({
       code: 'routine_force_low_consent_confidence',
       severity: 'warning',
@@ -846,6 +859,111 @@ function buildRoutineForceAuthorizationContradictionIssues(
   }
 
   return issues
+}
+
+function buildGeneralizedProcedureWithoutSubjectFitContradictionIssues(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckIssue[] {
+  const issues: CoerciveProtocolContradictionCheckIssue[] = []
+  const id = normalizeToken(record.id)
+  const relatedIds = id ? [id] : undefined
+
+  issues.push({
+    code: 'generalized_procedure_without_subject_fit_validation',
+    severity: 'warning',
+    detail: `Coercive protocol record ${id || '(unknown)'} scales a generalized procedure without subject-fit validation artifact.`,
+    relatedIds,
+  })
+
+  if (VOLUNTARY_HANDLING_MODES.has(record.handlingMode)) {
+    issues.push({
+      code: 'generalized_procedure_contradicts_voluntary_handling',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} pairs generalized subject fit with ${record.handlingMode} handling.`,
+      relatedIds,
+    })
+  }
+
+  if (record.consentConfidence <= CONTRADICTION_CHECK_LOW_CONSENT_CONFIDENCE_THRESHOLD) {
+    issues.push({
+      code: 'generalized_procedure_low_consent_confidence',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} generalizes procedure use while consent confidence remains low (${record.consentConfidence.toFixed(2)}).`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'abusive') {
+    issues.push({
+      code: 'generalized_procedure_abusive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is abusive with generalized subject fit and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'deceptive') {
+    issues.push({
+      code: 'generalized_procedure_deceptive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is deceptive with generalized subject fit and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (projectContainmentCareTradeoff(record).stableContainmentDominatesCare) {
+    issues.push({
+      code: 'generalized_procedure_masks_care_harm',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} reports containment stability gains that may mask generalized-procedure care harm.`,
+      relatedIds,
+    })
+  }
+
+  if (record.complianceMetricOnly === true) {
+    issues.push({
+      code: 'generalized_procedure_compliance_metric_only',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} relies on compliance metrics while generalizing procedure without subject-fit validation.`,
+      relatedIds,
+    })
+  }
+
+  return issues
+}
+
+export function evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckResult {
+  const flags = collectContradictionRiskFlags(record)
+  const triggered = flags.includes('generalized_procedure_without_subject_fit')
+  const unknownFields = resolveUnknownFields(record)
+  const confidence = resolveConfidence(record)
+  const redacted = isRedacted(record)
+
+  if (!triggered) {
+    return freezeContradictionCheckResult({
+      recordId: record.id,
+      flag: 'generalized_procedure_without_subject_fit',
+      triggered: false,
+      blocksProcedure: false,
+      issues: [],
+      confidence,
+      redacted,
+      unknownFields,
+    })
+  }
+
+  return freezeContradictionCheckResult({
+    recordId: record.id,
+    flag: 'generalized_procedure_without_subject_fit',
+    triggered: true,
+    blocksProcedure: false,
+    issues: buildGeneralizedProcedureWithoutSubjectFitContradictionIssues(record),
+    confidence,
+    redacted,
+    unknownFields,
+  })
 }
 
 export function evaluateRoutineForceAuthorizationContradictionCheck(
@@ -886,11 +1004,16 @@ export function evaluateRoutineForceAuthorizationContradictionCheck(
 export function evaluateCoerciveProtocolContradictionChecks(
   record: CoerciveProtocolRecord
 ): readonly CoerciveProtocolContradictionCheckResult[] {
+  const generalizedSubjectFitCheck =
+    evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(record)
   const routineForceCheck = evaluateRoutineForceAuthorizationContradictionCheck(record)
 
-  return Object.freeze(
-    routineForceCheck.triggered ? [routineForceCheck] : []
-  )
+  const triggered = [
+    generalizedSubjectFitCheck.triggered ? generalizedSubjectFitCheck : null,
+    routineForceCheck.triggered ? routineForceCheck : null,
+  ].filter((check): check is CoerciveProtocolContradictionCheckResult => check !== null)
+
+  return Object.freeze(triggered)
 }
 
 function collectContradictionRiskFlags(

--- a/src/test/coerciveContainedPersonProtocolRegistry.test.ts
+++ b/src/test/coerciveContainedPersonProtocolRegistry.test.ts
@@ -5,6 +5,7 @@ import {
   ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
   classifyCoerciveProtocolHandlingPosture,
   evaluateCoerciveProtocolContradictionChecks,
+  evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck,
   evaluateRoutineForceAuthorizationContradictionCheck,
   projectCoerciveProtocolRiskReview,
   projectContainmentCareTradeoff,
@@ -167,8 +168,10 @@ describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882
     )
     const skipped = evaluateCoerciveProtocolContradictionChecks(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
 
-    expect(triggered).toHaveLength(1)
-    expect(triggered[0]?.flag).toBe('routine_force_authorization')
+    expect(triggered.map((check) => check.flag)).toEqual([
+      'generalized_procedure_without_subject_fit',
+      'routine_force_authorization',
+    ])
     expect(skipped).toEqual([])
   })
 
@@ -177,6 +180,89 @@ describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
     )
     const second = evaluateRoutineForceAuthorizationContradictionCheck(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+})
+
+describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882 slice 7)', () => {
+  it('triggers generalized-subject-fit sibling aligned with contradiction risk flags', () => {
+    const review = projectCoerciveProtocolRiskReview(ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE)
+    const check = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+
+    expect(review.contradictionRiskFlags).toContain('generalized_procedure_without_subject_fit')
+    expect(check.triggered).toBe(true)
+    expect(check.flag).toBe('generalized_procedure_without_subject_fit')
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues.length).toBeGreaterThan(0)
+    expect(check.issues.every((issue) => issue.severity === 'warning')).toBe(true)
+    expect(check.issues.map((issue) => issue.code)).toEqual([
+      'generalized_procedure_compliance_metric_only',
+      'generalized_procedure_low_consent_confidence',
+      'generalized_procedure_masks_care_harm',
+      'generalized_procedure_without_subject_fit_validation',
+    ])
+  })
+
+  it('flags voluntary handling contradictions when subject fit is generalized', () => {
+    const voluntaryGeneralized = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:voluntary-generalized',
+      handlingMode: 'voluntary' as const,
+    }
+    const check = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(voluntaryGeneralized)
+
+    expect(check.triggered).toBe(true)
+    expect(
+      check.issues.some((issue) => issue.code === 'generalized_procedure_contradicts_voluntary_handling')
+    ).toBe(true)
+  })
+
+  it('returns non-triggered no-op when subject-fit validation ref is present', () => {
+    const validatedGeneralized = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:validated-generalized',
+      subjectFitValidationRef: 'review-artifact:generalized-fit-review-31',
+    }
+    const check = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(validatedGeneralized)
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('returns non-triggered no-op for validated subject-fit state', () => {
+    const check = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE
+    )
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('propagates redacted and unknown metadata into sibling output', () => {
+    const redacted = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      redactedFields: ['subjectFitState'],
+      unknownFields: ['subjectFitValidationRef'],
+    }
+    const check = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(redacted)
+
+    expect(check.triggered).toBe(true)
+    expect(check.redacted).toBe(true)
+    expect(check.unknownFields).toEqual(['subjectFitValidationRef'])
+  })
+
+  it('returns byte-stable generalized-subject-fit output on repeated calls', () => {
+    const first = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+    const second = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
     )
 


### PR DESCRIPTION
## Summary

- Add `evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck` sibling for the `generalized_procedure_without_subject_fit` registry flag (warning-only, `blocksProcedure: false`).
- Extend `evaluateCoerciveProtocolContradictionChecks` aggregator to return triggered siblings in deterministic flag locale order (generalized subject-fit, then routine force).
- Add slice 7 planning doc and registry unit tests; update backlog handoff.

## Linear

- **Slice:** [SPE-2426](https://linear.app/spectranoir/issue/SPE-2426) — Coercive protocol generalized subject-fit contradiction check (slice 7)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model (remains **Done**; slice 7 is domain-only)
- **Design anchor:** [SPE-1907](https://linear.app/spectranoir/issue/SPE-1907) — Procedure generalization without subject-fit validation

## Validation

- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts`
- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts`
- `npm run test:run -- src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts`
- `npm run lint`

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-7.md`
- `planning/backlog.md`