### PR TITLE
SPE-1898: Compliance-metric contradiction-check sibling (slice 8)

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-8.md
+++ b/planning/coercive-contained-person-protocol-model-slice-8.md
@@ -1,0 +1,80 @@
+# SPE-1882 — Coercive protocol compliance-metric contradiction check (slice 8)
+
+One-page implementation plan. Linear: [SPE-1898](https://linear.app/spectranoir/issue/SPE-1898) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Design anchor: contradiction-check sibling cluster. Follows shipped slice 7 (`planning/coercive-contained-person-protocol-model-slice-7.md`).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-1898 — Contradiction check: Compliance metric versus personhood damage (slice 8)](https://linear.app/spectranoir/issue/SPE-1898) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–7 shipped)          |
+| **Branch** | `spe-1898-compliance-metric-contradiction-check-slice-8`                                                   |
+| **Base `main` SHA** | `32308116`                                                                                          |
+
+## Goal
+
+Implement the third deterministic contradiction-check sibling for the `compliance_metric_masks_harm` registry flag — warning-only review output that distinguishes compliance-only success metrics from personhood and care-harm signals.
+
+## Prerequisite (on `main` @ `32308116`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Persistence          | `coerciveContainedPersonProtocolRecords` on `GameState` (SPE-2421)     |
+| Weekly orchestration | `applyWeeklyCoerciveProtocolTick` + snapshots (SPE-2422 / SPE-2424)    |
+| Mirror UI            | `coerciveContainedPersonProtocolMirrorView` (SPE-2423)                 |
+| Routine-force sibling | `evaluateRoutineForceAuthorizationContradictionCheck` (SPE-2425 slice 6) |
+| Generalized-subject-fit sibling | `evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck` (SPE-2426 slice 7) |
+
+## Sibling contract (slice 8)
+
+- **Flag** — `compliance_metric_masks_harm` from `collectContradictionRiskFlags` (`complianceMetricOnly === true`).
+- **Function** — `evaluateComplianceMetricMasksHarmContradictionCheck(record)` returns structured warning-only issues.
+- **Aggregator** — `evaluateCoerciveProtocolContradictionChecks(record)` returns triggered siblings in deterministic flag locale order (compliance metric, generalized subject-fit, routine force).
+- **Blocking** — `blocksProcedure` is always `false` per registry contract.
+- **Metadata** — redacted/unknown field propagation on check results.
+- **No parallel system** — siblings live in registry; risk-review flags remain sourced from `collectContradictionRiskFlags`.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Compliance-metric contradiction-check types + evaluator            | Mirror UI module changes                      |
+| `evaluateCoerciveProtocolContradictionChecks` aggregator extension | Welfare-debt accounting math                    |
+| Targeted registry unit tests                                       | Snapshot field contract changes               |
+| Slice 1–7 orchestration/persistence/advanceWeek regression         | Remaining flag sibling (SPE-1908)             |
+| Slice doc (this file)                                              | SPE-1882 parent reopen                        |
+|                                                                    | Faction ethics links (SPE-1047 / SPE-1131)    |
+
+## Acceptance
+
+- [x] Compliance-metric fixture triggers sibling with sorted warning issues and `blocksProcedure: false`
+- [x] Records without `complianceMetricOnly: true` return non-triggered no-op sibling
+- [x] Sibling trigger aligns with `compliance_metric_masks_harm` flag from `collectContradictionRiskFlags`
+- [x] Redacted/unknown metadata propagates into check output
+- [x] Aggregator returns three triggered siblings in flag locale order for triple-flag fixture
+- [x] Repeated evaluation is byte-stable
+- [x] Slice 1–7 regression + mirror view regression + `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolRegistry.ts`               |
+| Tests  | `src/test/coerciveContainedPersonProtocolRegistry.test.ts`            |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-8.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Surveillance-isolation burden sibling | SPE-1908 | Out of slice 8 boundary |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of registry contradiction-check boundary |
+| SPE-1889 integrated health bundle compose | SPE-1889 | Out of slice 8 boundary |
+| Mirror UI surfaces sibling check detail | SPE-1882 follow-up | Slice 8 is domain-only |
+| Broader SPE-1898 cross-system reconciliation | SPE-861 / SPE-1743 / SPE-1670 | Out of registry-only slice boundary |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-7.md` — generalized-subject-fit sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-6.md` — routine-force sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-1.md` — flag + risk-review contract origin

--- a/src/domain/coerciveContainedPersonProtocolRegistry.ts
+++ b/src/domain/coerciveContainedPersonProtocolRegistry.ts
@@ -235,9 +235,19 @@ export type CoerciveProtocolGeneralizedSubjectFitContradictionCheckCode =
   | 'generalized_procedure_masks_care_harm'
   | 'generalized_procedure_compliance_metric_only'
 
+export type CoerciveProtocolComplianceMetricContradictionCheckCode =
+  | 'compliance_metric_operational_only'
+  | 'compliance_metric_contradicts_voluntary_handling'
+  | 'compliance_metric_low_consent_confidence'
+  | 'compliance_metric_abusive_without_review_path'
+  | 'compliance_metric_deceptive_without_review_path'
+  | 'compliance_metric_masks_care_harm'
+  | 'compliance_metric_masks_personhood_harm'
+
 export type CoerciveProtocolContradictionCheckCode =
   | CoerciveProtocolRoutineForceContradictionCheckCode
   | CoerciveProtocolGeneralizedSubjectFitContradictionCheckCode
+  | CoerciveProtocolComplianceMetricContradictionCheckCode
 
 export interface CoerciveProtocolContradictionCheckIssue {
   readonly code: CoerciveProtocolContradictionCheckCode
@@ -773,6 +783,7 @@ export function projectContainmentCareTradeoff(
 }
 
 const CONTRADICTION_CHECK_LOW_CONSENT_CONFIDENCE_THRESHOLD = 0.35
+const COMPLIANCE_METRIC_ELEVATED_PERSONHOOD_HARM_THRESHOLD = 0.5
 
 const VOLUNTARY_HANDLING_MODES = new Set<CoerciveProtocolHandlingMode>(['voluntary', 'negotiated'])
 
@@ -932,6 +943,111 @@ function buildGeneralizedProcedureWithoutSubjectFitContradictionIssues(
   return issues
 }
 
+function buildComplianceMetricMasksHarmContradictionIssues(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckIssue[] {
+  const issues: CoerciveProtocolContradictionCheckIssue[] = []
+  const id = normalizeToken(record.id)
+  const relatedIds = id ? [id] : undefined
+
+  issues.push({
+    code: 'compliance_metric_operational_only',
+    severity: 'warning',
+    detail: `Coercive protocol record ${id || '(unknown)'} relies on compliance metrics as the sole success measure rather than personhood-preservation outputs.`,
+    relatedIds,
+  })
+
+  if (VOLUNTARY_HANDLING_MODES.has(record.handlingMode)) {
+    issues.push({
+      code: 'compliance_metric_contradicts_voluntary_handling',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} pairs compliance-only metrics with ${record.handlingMode} handling.`,
+      relatedIds,
+    })
+  }
+
+  if (record.consentConfidence <= CONTRADICTION_CHECK_LOW_CONSENT_CONFIDENCE_THRESHOLD) {
+    issues.push({
+      code: 'compliance_metric_low_consent_confidence',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} tracks compliance metrics while consent confidence remains low (${record.consentConfidence.toFixed(2)}).`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'abusive' && !normalizeToken(record.subjectFitValidationRef ?? '')) {
+    issues.push({
+      code: 'compliance_metric_abusive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is abusive with compliance-only metrics and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'deceptive' && !normalizeToken(record.subjectFitValidationRef ?? '')) {
+    issues.push({
+      code: 'compliance_metric_deceptive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is deceptive with compliance-only metrics and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (projectContainmentCareTradeoff(record).stableContainmentDominatesCare) {
+    issues.push({
+      code: 'compliance_metric_masks_care_harm',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} reports containment stability gains that may mask compliance-metric care harm.`,
+      relatedIds,
+    })
+  }
+
+  if (record.personhoodHarmRisk >= COMPLIANCE_METRIC_ELEVATED_PERSONHOOD_HARM_THRESHOLD) {
+    issues.push({
+      code: 'compliance_metric_masks_personhood_harm',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} tracks compliance metrics while personhood harm risk remains elevated (${record.personhoodHarmRisk.toFixed(2)}).`,
+      relatedIds,
+    })
+  }
+
+  return issues
+}
+
+export function evaluateComplianceMetricMasksHarmContradictionCheck(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckResult {
+  const flags = collectContradictionRiskFlags(record)
+  const triggered = flags.includes('compliance_metric_masks_harm')
+  const unknownFields = resolveUnknownFields(record)
+  const confidence = resolveConfidence(record)
+  const redacted = isRedacted(record)
+
+  if (!triggered) {
+    return freezeContradictionCheckResult({
+      recordId: record.id,
+      flag: 'compliance_metric_masks_harm',
+      triggered: false,
+      blocksProcedure: false,
+      issues: [],
+      confidence,
+      redacted,
+      unknownFields,
+    })
+  }
+
+  return freezeContradictionCheckResult({
+    recordId: record.id,
+    flag: 'compliance_metric_masks_harm',
+    triggered: true,
+    blocksProcedure: false,
+    issues: buildComplianceMetricMasksHarmContradictionIssues(record),
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
 export function evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(
   record: CoerciveProtocolRecord
 ): CoerciveProtocolContradictionCheckResult {
@@ -1004,11 +1120,13 @@ export function evaluateRoutineForceAuthorizationContradictionCheck(
 export function evaluateCoerciveProtocolContradictionChecks(
   record: CoerciveProtocolRecord
 ): readonly CoerciveProtocolContradictionCheckResult[] {
+  const complianceMetricCheck = evaluateComplianceMetricMasksHarmContradictionCheck(record)
   const generalizedSubjectFitCheck =
     evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(record)
   const routineForceCheck = evaluateRoutineForceAuthorizationContradictionCheck(record)
 
   const triggered = [
+    complianceMetricCheck.triggered ? complianceMetricCheck : null,
     generalizedSubjectFitCheck.triggered ? generalizedSubjectFitCheck : null,
     routineForceCheck.triggered ? routineForceCheck : null,
   ].filter((check): check is CoerciveProtocolContradictionCheckResult => check !== null)

--- a/src/test/coerciveContainedPersonProtocolRegistry.test.ts
+++ b/src/test/coerciveContainedPersonProtocolRegistry.test.ts
@@ -5,6 +5,7 @@ import {
   ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
   classifyCoerciveProtocolHandlingPosture,
   evaluateCoerciveProtocolContradictionChecks,
+  evaluateComplianceMetricMasksHarmContradictionCheck,
   evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck,
   evaluateRoutineForceAuthorizationContradictionCheck,
   projectCoerciveProtocolRiskReview,
@@ -54,6 +55,7 @@ describe('coerciveContainedPersonProtocolRegistry (SPE-1882 slice 1)', () => {
     expect(review.coercionRiskScore).toBeGreaterThan(0.5)
     expect(review.contradictionRiskFlags).toContain('routine_force_authorization')
     expect(review.contradictionRiskFlags).toContain('generalized_procedure_without_subject_fit')
+    expect(review.contradictionRiskFlags).toContain('compliance_metric_masks_harm')
     expect(review.blocksProcedure).toBe(false)
   })
 
@@ -169,6 +171,7 @@ describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882
     const skipped = evaluateCoerciveProtocolContradictionChecks(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)
 
     expect(triggered.map((check) => check.flag)).toEqual([
+      'compliance_metric_masks_harm',
       'generalized_procedure_without_subject_fit',
       'routine_force_authorization',
     ])
@@ -263,6 +266,89 @@ describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
     )
     const second = evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+})
+
+describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882 slice 8)', () => {
+  it('triggers compliance-metric sibling aligned with contradiction risk flags', () => {
+    const review = projectCoerciveProtocolRiskReview(ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE)
+    const check = evaluateComplianceMetricMasksHarmContradictionCheck(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+
+    expect(review.contradictionRiskFlags).toContain('compliance_metric_masks_harm')
+    expect(check.triggered).toBe(true)
+    expect(check.flag).toBe('compliance_metric_masks_harm')
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues.length).toBeGreaterThan(0)
+    expect(check.issues.every((issue) => issue.severity === 'warning')).toBe(true)
+    expect(check.issues.map((issue) => issue.code)).toEqual([
+      'compliance_metric_low_consent_confidence',
+      'compliance_metric_masks_care_harm',
+      'compliance_metric_masks_personhood_harm',
+      'compliance_metric_operational_only',
+    ])
+  })
+
+  it('flags voluntary handling contradictions when compliance metrics are operational only', () => {
+    const voluntaryCompliance = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:voluntary-compliance-metric',
+      handlingMode: 'voluntary' as const,
+    }
+    const check = evaluateComplianceMetricMasksHarmContradictionCheck(voluntaryCompliance)
+
+    expect(check.triggered).toBe(true)
+    expect(
+      check.issues.some((issue) => issue.code === 'compliance_metric_contradicts_voluntary_handling')
+    ).toBe(true)
+  })
+
+  it('returns non-triggered no-op when complianceMetricOnly is absent', () => {
+    const check = evaluateComplianceMetricMasksHarmContradictionCheck(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE
+    )
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('returns non-triggered no-op when complianceMetricOnly is false', () => {
+    const withoutComplianceMetric = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:without-compliance-metric',
+      complianceMetricOnly: false,
+    }
+    const check = evaluateComplianceMetricMasksHarmContradictionCheck(withoutComplianceMetric)
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('propagates redacted and unknown metadata into sibling output', () => {
+    const redacted = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      redactedFields: ['complianceMetricOnly'],
+      unknownFields: ['personhoodHarmRisk'],
+    }
+    const check = evaluateComplianceMetricMasksHarmContradictionCheck(redacted)
+
+    expect(check.triggered).toBe(true)
+    expect(check.redacted).toBe(true)
+    expect(check.unknownFields).toEqual(['personhoodHarmRisk'])
+  })
+
+  it('returns byte-stable compliance-metric output on repeated calls', () => {
+    const first = evaluateComplianceMetricMasksHarmContradictionCheck(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+    const second = evaluateComplianceMetricMasksHarmContradictionCheck(
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
     )
 


### PR DESCRIPTION
## Summary

- Implements `evaluateComplianceMetricMasksHarmContradictionCheck` for the `compliance_metric_masks_harm` registry flag (warning-only, `blocksProcedure: false`).
- Extends `evaluateCoerciveProtocolContradictionChecks` aggregator to return triggered siblings in flag locale order: compliance metric → generalized subject-fit → routine force.
- Adds slice 8 plan doc and targeted registry unit tests; triple-flag fixture now yields three siblings.

## Linear

- **Slice issue:** [SPE-1898](https://linear.app/spectranoir/issue/SPE-1898) — Contradiction check: Compliance metric versus personhood damage
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model (remains open)

## What shipped

- `CoerciveProtocolComplianceMetricContradictionCheckCode` + builder/evaluator in `coerciveContainedPersonProtocolRegistry.ts`
- Aggregator extension for deterministic three-sibling ordering
- Slice 8 tests + aggregator order update for `ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE`
- `planning/coercive-contained-person-protocol-model-slice-8.md`

## Validation

- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts` (27 passed)
- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` (53 passed)
- `npm run lint`

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-8.md` (new)
- `planning/backlog.md` deferred to post-merge

## Parent status

SPE-1882 remains open — surveillance-isolation burden sibling (SPE-1908) still deferred.