### PR TITLE
SPE-1908: Surveillance-isolation burden contradiction-check sibling (slice 9)

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-9.md
+++ b/planning/coercive-contained-person-protocol-model-slice-9.md
@@ -1,0 +1,82 @@
+# SPE-1882 — Coercive protocol surveillance-isolation burden contradiction check (slice 9)
+
+One-page implementation plan. Linear: [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) (registry sibling under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Design anchor: contradiction-check sibling cluster. Follows shipped slice 8 (`planning/coercive-contained-person-protocol-model-slice-8.md`).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-1908 — Contradiction check: Surveillance-isolation burden (slice 9)](https://linear.app/spectranoir/issue/SPE-1908) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–8 shipped)          |
+| **Branch** | `spe-1908-surveillance-isolation-contradiction-check-slice-9`                                              |
+| **Base `main` SHA** | `f551c384`                                                                                          |
+
+## Goal
+
+Implement the fourth and final deterministic contradiction-check sibling for the `surveillance_isolation_burden` registry flag — warning-only review output that distinguishes elevated isolation and surveillance burden from humane contact and personhood-preservation signals.
+
+## Prerequisite (on `main` @ `f551c384`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Persistence          | `coerciveContainedPersonProtocolRecords` on `GameState` (SPE-2421)     |
+| Weekly orchestration | `applyWeeklyCoerciveProtocolTick` + snapshots (SPE-2422 / SPE-2424)    |
+| Mirror UI            | `coerciveContainedPersonProtocolMirrorView` (SPE-2423)                 |
+| Routine-force sibling | `evaluateRoutineForceAuthorizationContradictionCheck` (SPE-2425 slice 6) |
+| Generalized-subject-fit sibling | `evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck` (SPE-2426 slice 7) |
+| Compliance-metric sibling | `evaluateComplianceMetricMasksHarmContradictionCheck` (SPE-1898 slice 8) |
+
+## Sibling contract (slice 9)
+
+- **Flag** — `surveillance_isolation_burden` from `collectContradictionRiskFlags` (both `isolationBurdenScore` and `surveillanceBurdenScore` ≥ threshold).
+- **Function** — `evaluateSurveillanceIsolationBurdenContradictionCheck(record)` returns structured warning-only issues.
+- **Aggregator** — `evaluateCoerciveProtocolContradictionChecks(record)` returns triggered siblings in deterministic flag locale order (compliance metric, generalized subject-fit, routine force, surveillance isolation).
+- **Blocking** — `blocksProcedure` is always `false` per registry contract.
+- **Metadata** — redacted/unknown field propagation on check results.
+- **No parallel system** — siblings live in registry; risk-review flags remain sourced from `collectContradictionRiskFlags`.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Surveillance-isolation contradiction-check types + evaluator       | Mirror UI module changes                      |
+| `evaluateCoerciveProtocolContradictionChecks` aggregator extension   | Welfare-debt accounting math                    |
+| Targeted registry unit tests                                       | Snapshot field contract changes               |
+| Slice 1–8 orchestration/persistence/advanceWeek regression         | Broader SPE-1908 cross-system reconciliation  |
+| Slice doc (this file)                                              | SPE-1882 parent reopen                        |
+|                                                                    | Faction ethics links (SPE-1047 / SPE-1131)    |
+
+## Acceptance
+
+- [x] Surveillance-isolation fixture triggers sibling with sorted warning issues and `blocksProcedure: false`
+- [x] Records below isolation/surveillance threshold return non-triggered no-op sibling
+- [x] Sibling trigger aligns with `surveillance_isolation_burden` flag from `collectContradictionRiskFlags`
+- [x] Redacted/unknown metadata propagates into check output
+- [x] Aggregator returns four triggered siblings in flag locale order for quad-flag fixture
+- [x] `ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE` triggers surveillance sibling without routine-force/generalized/compliance flags
+- [x] Repeated evaluation is byte-stable
+- [x] Slice 1–8 regression + mirror view regression + `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolRegistry.ts`               |
+| Tests  | `src/test/coerciveContainedPersonProtocolRegistry.test.ts`            |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-9.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Broader SPE-1908 cross-system reconciliation (condition bundles, surveillance tuning, psychological resilience) | SPE-1889 / SPE-848 / SPE-1615 | Out of registry-only slice boundary |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of registry contradiction-check boundary |
+| Mirror UI surfaces sibling check detail | SPE-1882 follow-up | Slice 9 is domain-only |
+| SPE-1882 parent closure | SPE-1882 | Registry flag siblings complete; parent may have other AC |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-8.md` — compliance-metric sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-7.md` — generalized-subject-fit sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-6.md` — routine-force sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-1.md` — flag + risk-review contract origin

--- a/src/domain/coerciveContainedPersonProtocolRegistry.ts
+++ b/src/domain/coerciveContainedPersonProtocolRegistry.ts
@@ -244,10 +244,20 @@ export type CoerciveProtocolComplianceMetricContradictionCheckCode =
   | 'compliance_metric_masks_care_harm'
   | 'compliance_metric_masks_personhood_harm'
 
+export type CoerciveProtocolSurveillanceIsolationContradictionCheckCode =
+  | 'surveillance_isolation_elevated_burden'
+  | 'surveillance_isolation_contradicts_voluntary_handling'
+  | 'surveillance_isolation_low_consent_confidence'
+  | 'surveillance_isolation_abusive_without_review_path'
+  | 'surveillance_isolation_deceptive_without_review_path'
+  | 'surveillance_isolation_masks_care_harm'
+  | 'surveillance_isolation_masks_personhood_harm'
+
 export type CoerciveProtocolContradictionCheckCode =
   | CoerciveProtocolRoutineForceContradictionCheckCode
   | CoerciveProtocolGeneralizedSubjectFitContradictionCheckCode
   | CoerciveProtocolComplianceMetricContradictionCheckCode
+  | CoerciveProtocolSurveillanceIsolationContradictionCheckCode
 
 export interface CoerciveProtocolContradictionCheckIssue {
   readonly code: CoerciveProtocolContradictionCheckCode
@@ -1014,6 +1024,77 @@ function buildComplianceMetricMasksHarmContradictionIssues(
   return issues
 }
 
+function buildSurveillanceIsolationBurdenContradictionIssues(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckIssue[] {
+  const issues: CoerciveProtocolContradictionCheckIssue[] = []
+  const id = normalizeToken(record.id)
+  const relatedIds = id ? [id] : undefined
+
+  issues.push({
+    code: 'surveillance_isolation_elevated_burden',
+    severity: 'warning',
+    detail: `Coercive protocol record ${id || '(unknown)'} pairs elevated isolation burden (${record.isolationBurdenScore.toFixed(2)}) with elevated surveillance burden (${record.surveillanceBurdenScore.toFixed(2)}) rather than humane contact preservation.`,
+    relatedIds,
+  })
+
+  if (VOLUNTARY_HANDLING_MODES.has(record.handlingMode)) {
+    issues.push({
+      code: 'surveillance_isolation_contradicts_voluntary_handling',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} pairs surveillance-isolation burden with ${record.handlingMode} handling.`,
+      relatedIds,
+    })
+  }
+
+  if (record.consentConfidence <= CONTRADICTION_CHECK_LOW_CONSENT_CONFIDENCE_THRESHOLD) {
+    issues.push({
+      code: 'surveillance_isolation_low_consent_confidence',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} imposes surveillance-isolation burden while consent confidence remains low (${record.consentConfidence.toFixed(2)}).`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'abusive' && !normalizeToken(record.subjectFitValidationRef ?? '')) {
+    issues.push({
+      code: 'surveillance_isolation_abusive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is abusive with surveillance-isolation burden and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'deceptive' && !normalizeToken(record.subjectFitValidationRef ?? '')) {
+    issues.push({
+      code: 'surveillance_isolation_deceptive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is deceptive with surveillance-isolation burden and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (projectContainmentCareTradeoff(record).stableContainmentDominatesCare) {
+    issues.push({
+      code: 'surveillance_isolation_masks_care_harm',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} reports containment stability gains that may mask surveillance-isolation care harm.`,
+      relatedIds,
+    })
+  }
+
+  if (record.personhoodHarmRisk >= COMPLIANCE_METRIC_ELEVATED_PERSONHOOD_HARM_THRESHOLD) {
+    issues.push({
+      code: 'surveillance_isolation_masks_personhood_harm',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} imposes surveillance-isolation burden while personhood harm risk remains elevated (${record.personhoodHarmRisk.toFixed(2)}).`,
+      relatedIds,
+    })
+  }
+
+  return issues
+}
+
 export function evaluateComplianceMetricMasksHarmContradictionCheck(
   record: CoerciveProtocolRecord
 ): CoerciveProtocolContradictionCheckResult {
@@ -1116,6 +1197,40 @@ export function evaluateRoutineForceAuthorizationContradictionCheck(
   })
 }
 
+export function evaluateSurveillanceIsolationBurdenContradictionCheck(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckResult {
+  const flags = collectContradictionRiskFlags(record)
+  const triggered = flags.includes('surveillance_isolation_burden')
+  const unknownFields = resolveUnknownFields(record)
+  const confidence = resolveConfidence(record)
+  const redacted = isRedacted(record)
+
+  if (!triggered) {
+    return freezeContradictionCheckResult({
+      recordId: record.id,
+      flag: 'surveillance_isolation_burden',
+      triggered: false,
+      blocksProcedure: false,
+      issues: [],
+      confidence,
+      redacted,
+      unknownFields,
+    })
+  }
+
+  return freezeContradictionCheckResult({
+    recordId: record.id,
+    flag: 'surveillance_isolation_burden',
+    triggered: true,
+    blocksProcedure: false,
+    issues: buildSurveillanceIsolationBurdenContradictionIssues(record),
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
 /** Runs implemented contradiction-check siblings in deterministic registry-flag order. */
 export function evaluateCoerciveProtocolContradictionChecks(
   record: CoerciveProtocolRecord
@@ -1124,11 +1239,13 @@ export function evaluateCoerciveProtocolContradictionChecks(
   const generalizedSubjectFitCheck =
     evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(record)
   const routineForceCheck = evaluateRoutineForceAuthorizationContradictionCheck(record)
+  const surveillanceIsolationCheck = evaluateSurveillanceIsolationBurdenContradictionCheck(record)
 
   const triggered = [
     complianceMetricCheck.triggered ? complianceMetricCheck : null,
     generalizedSubjectFitCheck.triggered ? generalizedSubjectFitCheck : null,
     routineForceCheck.triggered ? routineForceCheck : null,
+    surveillanceIsolationCheck.triggered ? surveillanceIsolationCheck : null,
   ].filter((check): check is CoerciveProtocolContradictionCheckResult => check !== null)
 
   return Object.freeze(triggered)

--- a/src/test/coerciveContainedPersonProtocolRegistry.test.ts
+++ b/src/test/coerciveContainedPersonProtocolRegistry.test.ts
@@ -8,6 +8,7 @@ import {
   evaluateComplianceMetricMasksHarmContradictionCheck,
   evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck,
   evaluateRoutineForceAuthorizationContradictionCheck,
+  evaluateSurveillanceIsolationBurdenContradictionCheck,
   projectCoerciveProtocolRiskReview,
   projectContainmentCareTradeoff,
   validateCoerciveProtocolRecord,
@@ -350,6 +351,119 @@ describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882
     )
     const second = evaluateComplianceMetricMasksHarmContradictionCheck(
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+})
+
+describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882 slice 9)', () => {
+  it('triggers surveillance-isolation sibling aligned with contradiction risk flags', () => {
+    const review = projectCoerciveProtocolRiskReview(ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE)
+    const check = evaluateSurveillanceIsolationBurdenContradictionCheck(
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE
+    )
+
+    expect(review.contradictionRiskFlags).toContain('surveillance_isolation_burden')
+    expect(review.contradictionRiskFlags).not.toContain('routine_force_authorization')
+    expect(review.contradictionRiskFlags).not.toContain('generalized_procedure_without_subject_fit')
+    expect(review.contradictionRiskFlags).not.toContain('compliance_metric_masks_harm')
+    expect(check.triggered).toBe(true)
+    expect(check.flag).toBe('surveillance_isolation_burden')
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues.length).toBeGreaterThan(0)
+    expect(check.issues.every((issue) => issue.severity === 'warning')).toBe(true)
+    expect(check.issues.map((issue) => issue.code)).toEqual([
+      'surveillance_isolation_abusive_without_review_path',
+      'surveillance_isolation_elevated_burden',
+      'surveillance_isolation_low_consent_confidence',
+      'surveillance_isolation_masks_personhood_harm',
+    ])
+  })
+
+  it('flags voluntary handling contradictions when surveillance-isolation burden is elevated', () => {
+    const voluntarySurveillance = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:voluntary-surveillance-isolation',
+      handlingMode: 'voluntary' as const,
+    }
+    const check = evaluateSurveillanceIsolationBurdenContradictionCheck(voluntarySurveillance)
+
+    expect(check.triggered).toBe(true)
+    expect(
+      check.issues.some(
+        (issue) => issue.code === 'surveillance_isolation_contradicts_voluntary_handling'
+      )
+    ).toBe(true)
+  })
+
+  it('returns non-triggered no-op when isolation burden is below threshold', () => {
+    const check = evaluateSurveillanceIsolationBurdenContradictionCheck(
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE
+    )
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('returns non-triggered no-op when surveillance burden is below threshold', () => {
+    const belowSurveillanceThreshold = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:below-surveillance-threshold',
+      surveillanceBurdenScore: 0.5,
+    }
+    const check = evaluateSurveillanceIsolationBurdenContradictionCheck(belowSurveillanceThreshold)
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('propagates redacted and unknown metadata into sibling output', () => {
+    const redacted = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      redactedFields: ['isolationBurdenScore'],
+      unknownFields: ['surveillanceBurdenScore'],
+    }
+    const check = evaluateSurveillanceIsolationBurdenContradictionCheck(redacted)
+
+    expect(check.triggered).toBe(true)
+    expect(check.redacted).toBe(true)
+    expect(check.unknownFields).toEqual(['surveillanceBurdenScore'])
+  })
+
+  it('returns surveillance sibling only from aggregator for abusive surveillance fixture', () => {
+    const triggered = evaluateCoerciveProtocolContradictionChecks(
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE
+    )
+
+    expect(triggered.map((check) => check.flag)).toEqual(['surveillance_isolation_burden'])
+  })
+
+  it('returns four triggered siblings in flag locale order for quad-flag fixture', () => {
+    const quadFlag = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:quad-flag-contradiction',
+      isolationBurdenScore: 0.72,
+      surveillanceBurdenScore: 0.71,
+    }
+    const triggered = evaluateCoerciveProtocolContradictionChecks(quadFlag)
+
+    expect(triggered.map((check) => check.flag)).toEqual([
+      'compliance_metric_masks_harm',
+      'generalized_procedure_without_subject_fit',
+      'routine_force_authorization',
+      'surveillance_isolation_burden',
+    ])
+  })
+
+  it('returns byte-stable surveillance-isolation output on repeated calls', () => {
+    const first = evaluateSurveillanceIsolationBurdenContradictionCheck(
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE
+    )
+    const second = evaluateSurveillanceIsolationBurdenContradictionCheck(
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE
     )
 
     expect(JSON.stringify(first)).toBe(JSON.stringify(second))


### PR DESCRIPTION
## Summary

- Implements `evaluateSurveillanceIsolationBurdenContradictionCheck` — the fourth and final registry contradiction-check sibling for the `surveillance_isolation_burden` flag.
- Extends `evaluateCoerciveProtocolContradictionChecks` to return all four triggered siblings in deterministic flag locale order.
- Adds slice 9 planning doc and targeted registry unit tests (including quad-flag aggregator coverage).

## Linear mapping

| Issue | Role |
| --- | --- |
| [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) | Slice issue (registry sibling) |
| [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) | Parent — registry anchor; **remains open** (broader cross-system SPE-1908 reconciliation deferred) |

## What shipped

- `CoerciveProtocolSurveillanceIsolationContradictionCheckCode` + `evaluateSurveillanceIsolationBurdenContradictionCheck`
- Aggregator extended with surveillance-isolation sibling (flag locale order: compliance → generalized → routine force → surveillance)
- Tests: abusive surveillance fixture, threshold no-ops, metadata propagation, quad-flag aggregator, byte stability

## Validation

- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts` (35 passed)
- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts src/test/coerciveContainedPersonProtocolRegistryPersistence.test.ts src/test/coerciveContainedPersonProtocolWeeklyOrchestration.test.ts src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` (61 passed)
- `npm run lint`

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-9.md` (new)
- `planning/backlog.md` — deferred to post-merge

## Parent status

SPE-1882 registry flag siblings are now complete (slices 6–9). Parent stays open for mirror UI and broader SPE-1908 cross-system reconciliation per slice doc deferred table.