### PR TITLE
SPE-2427: Coercive protocol mirror contradiction-check sibling detail (slice 10)

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-10.md
+++ b/planning/coercive-contained-person-protocol-model-slice-10.md
@@ -1,0 +1,76 @@
+# SPE-1882 — Coercive protocol mirror contradiction-check sibling detail (slice 10)
+
+One-page implementation plan. Linear: [SPE-2427](https://linear.app/spectranoir/issue/SPE-2427) (child under [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882)). Follows shipped slice 9 (`planning/coercive-contained-person-protocol-model-slice-9.md`, PR #2723 / [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2427 — Mirror contradiction-check sibling detail (slice 10)](https://linear.app/spectranoir/issue/SPE-2427) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–9 shipped)          |
+| **Branch** | `spe-1882-mirror-contradiction-check-slice-10`                                                             |
+| **Base `main` SHA** | `4e6f46fe`                                                                                          |
+
+## Goal
+
+Surface `evaluateCoerciveProtocolContradictionChecks` read-time output in `coerciveContainedPersonProtocolMirrorView` for records with triggered siblings — agent-routing visibility over warning-only sibling issue detail, not player-facing canon.
+
+## Prerequisite (on `main` @ `4e6f46fe`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Persistence          | `coerciveContainedPersonProtocolRecords` on `GameState` (SPE-2421)     |
+| Weekly orchestration | `applyWeeklyCoerciveProtocolTick` + snapshots (SPE-2422 / SPE-2424)    |
+| Mirror UI (base)     | `coerciveContainedPersonProtocolMirrorView` (SPE-2423)                 |
+| Contradiction siblings | `evaluateCoerciveProtocolContradictionChecks` aggregator (slices 6–9) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Mirror view projects triggered sibling checks + sorted issue detail | Registry evaluator logic changes              |
+| Mirror page displays sibling check detail in risk-review column     | Snapshot field contract changes               |
+| Targeted mirror view + page tests                                    | Welfare-debt accounting math                  |
+| Slice doc (this file) + backlog handoff                              | Broader SPE-1908 cross-system reconciliation  |
+|                                                                    | Faction ethics links (SPE-1047 / SPE-1131)    |
+
+## Mirror contract
+
+- **Read-only** — mirror calls `evaluateCoerciveProtocolContradictionChecks` at build time only; no GameState mutation.
+- **Triggered only** — aggregator returns empty array when no siblings trigger; mirror omits detail rows.
+- **Deterministic ordering** — sibling checks follow aggregator flag locale order; issue details follow registry sort (code, then detail).
+- **Redaction** — per-check `redacted` and `unknownFields` surfaced; no hidden truth beyond registry projections.
+- **No parallel system** — reuse existing mirror projection patterns from slices 1–5; risk-review flags remain from `projectCoerciveProtocolRiskReview`.
+
+## Acceptance
+
+- [ ] Records with triggered siblings show flag label + sorted issue detail labels
+- [ ] No-trigger fixture (`EMERGENCY_SEDATION_PROTOCOL_FIXTURE`) has empty `contradictionCheckViews`
+- [ ] Redacted fixture propagates per-check redaction without exposing masked fields
+- [ ] Quad-flag fixture shows four siblings in flag locale order
+- [ ] Mirror page renders sibling issue detail for abusive surveillance fixture
+- [ ] Registry/orchestration regression unchanged
+- [ ] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` |
+| UI     | `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx` |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-10.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Broader SPE-1908 cross-system reconciliation | SPE-1889 / SPE-848 / SPE-1615 | Out of mirror-only boundary |
+| Faction ethics + accountability matrix links | SPE-1047 / SPE-1131 | Out of mirror UI boundary |
+| Mirror reads persisted weekly snapshots instead of read-time projection | SPE-1882 follow-up | Slice 5 persists; mirror still read-time |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-9.md` — surveillance-isolation sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-4.md` — base mirror UI origin

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1258,6 +1258,8 @@ export const COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT: Record<string, s
   harmRiskPrefix: 'Harm risks:',
   stableContainmentSuffix: 'Stable containment dominates care',
   coercionRiskPrefix: 'Coercion risk:',
+  contradictionCheckPrefix: 'Contradiction checks:',
+  contradictionCheckUnknownFieldsPrefix: 'Unknown fields:',
   validationWarningPrefix: 'Validation warnings:',
   redactedSuffix: 'Partial redaction',
 }

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
@@ -7,6 +7,7 @@ import { createStartingState } from '../../data/startingState'
 import {
   ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  evaluateCoerciveProtocolContradictionChecks,
 } from '../../domain/coerciveContainedPersonProtocolRegistry'
 import { useGameStore } from '../../app/store/gameStore'
 import CoerciveContainedPersonProtocolMirrorPage from './CoerciveContainedPersonProtocolMirrorPage'
@@ -67,5 +68,27 @@ describe('CoerciveContainedPersonProtocolMirrorPage (SPE-1882 slice 4)', () => {
       'href',
       '/'
     )
+  })
+
+  it('renders contradiction-check sibling issue detail for abusive surveillance fixture', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const triggered = evaluateCoerciveProtocolContradictionChecks(
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE
+    )
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted coercive contained person protocol records/i,
+    })
+
+    expect(recordsRegion).toHaveTextContent(/contradiction checks:/i)
+    expect(recordsRegion).toHaveTextContent(/surveillance isolation burden/i)
+    expect(recordsRegion).toHaveTextContent(triggered[0]?.issues[0]?.detail ?? '')
   })
 })

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
@@ -164,6 +164,36 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
                           {record.contradictionRiskFlagLabels.join('; ')}
                         </p>
                       ) : null}
+                      {record.contradictionCheckViews.length > 0 ? (
+                        <div className="mt-1 space-y-1 text-xs opacity-45">
+                          <p>
+                            {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.contradictionCheckPrefix}
+                          </p>
+                          {record.contradictionCheckViews.map((check) => (
+                            <div key={check.flagLabel}>
+                              <p className="opacity-55">{check.flagLabel}</p>
+                              {check.issueDetailLabels.map((detail) => (
+                                <p key={detail} className="pl-2 opacity-45">
+                                  {detail}
+                                </p>
+                              ))}
+                              {check.redacted ? (
+                                <p className="pl-2 opacity-45">
+                                  {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.redactedSuffix}
+                                </p>
+                              ) : null}
+                              {check.unknownFieldLabels.length > 0 ? (
+                                <p className="pl-2 opacity-45">
+                                  {
+                                    COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.contradictionCheckUnknownFieldsPrefix
+                                  }{' '}
+                                  {check.unknownFieldLabels.join(', ')}
+                                </p>
+                              ) : null}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
                       <p className="text-xs opacity-45">
                         {record.forcePolicyLabel} · {record.refusalHandlingLabel}
                       </p>

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -4,6 +4,7 @@ import {
   ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
   ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+  evaluateCoerciveProtocolContradictionChecks,
   projectCoerciveProtocolRiskReview,
   projectContainmentCareTradeoff,
   validateCoerciveProtocolRecord,
@@ -150,5 +151,113 @@ describe('coerciveContainedPersonProtocolMirrorView (SPE-1882 slice 4)', () => {
     expect(formatCoerciveProtocolEnumLabel('routine_force_authorization')).toBe(
       'Routine Force Authorization'
     )
+  })
+})
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-1882 slice 10)', () => {
+  it('returns empty contradiction check views for no-trigger fixture', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(evaluateCoerciveProtocolContradictionChecks(EMERGENCY_SEDATION_PROTOCOL_FIXTURE)).toEqual(
+      []
+    )
+    expect(record?.contradictionCheckViews).toEqual([])
+  })
+
+  it('surfaces triggered sibling issue detail in deterministic flag order', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+    const triggered = evaluateCoerciveProtocolContradictionChecks(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+    )
+
+    expect(record?.contradictionCheckViews.map((check) => check.flagLabel)).toEqual([
+      'Compliance Metric Masks Harm',
+      'Generalized Procedure Without Subject Fit',
+      'Routine Force Authorization',
+    ])
+    expect(record?.contradictionCheckViews.map((check) => check.issueDetailLabels.length)).toEqual(
+      triggered.map((check) => check.issues.length)
+    )
+    expect(
+      record?.contradictionCheckViews.every(
+        (check, index) =>
+          check.issueDetailLabels.join('\n') ===
+          triggered[index]?.issues.map((issue) => issue.detail).join('\n')
+      )
+    ).toBe(true)
+  })
+
+  it('surfaces single surveillance-isolation sibling for abusive fixture', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+    const triggered = evaluateCoerciveProtocolContradictionChecks(
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE
+    )
+
+    expect(record?.contradictionCheckViews).toHaveLength(1)
+    expect(record?.contradictionCheckViews[0]?.flagLabel).toBe('Surveillance Isolation Burden')
+    expect(record?.contradictionCheckViews[0]?.issueDetailLabels).toEqual(
+      triggered[0]?.issues.map((issue) => issue.detail)
+    )
+  })
+
+  it('propagates redacted and unknown metadata into contradiction check views', () => {
+    const redacted = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      redactedFields: ['forcePolicy'],
+      unknownFields: ['refusalHandling'],
+    }
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [redacted.id]: redacted,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(record?.contradictionCheckViews.length).toBeGreaterThan(0)
+    expect(record?.contradictionCheckViews.every((check) => check.redacted)).toBe(true)
+    expect(record?.contradictionCheckViews[0]?.unknownFieldLabels).toEqual(['refusalHandling'])
+  })
+
+  it('surfaces four triggered siblings for quad-flag fixture', () => {
+    const quadFlag = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:quad-flag-contradiction',
+      isolationBurdenScore: 0.72,
+      surveillanceBurdenScore: 0.71,
+    }
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [quadFlag.id]: quadFlag,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(record?.contradictionCheckViews.map((check) => check.flagLabel)).toEqual([
+      'Compliance Metric Masks Harm',
+      'Generalized Procedure Without Subject Fit',
+      'Routine Force Authorization',
+      'Surveillance Isolation Burden',
+    ])
   })
 })

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -1,11 +1,21 @@
 import type { GameState } from '../../domain/models'
 import {
+  evaluateCoerciveProtocolContradictionChecks,
   projectCoerciveProtocolRiskReview,
   projectContainmentCareTradeoff,
   validateCoerciveProtocolRecord,
+  type CoerciveProtocolContradictionCheckResult,
   type CoerciveProtocolContradictionRiskFlag,
   type CoerciveProtocolRecord,
 } from '../../domain/coerciveContainedPersonProtocolRegistry'
+
+export interface CoerciveProtocolContradictionCheckMirrorView {
+  flagLabel: string
+  issueDetailLabels: readonly string[]
+  redacted: boolean
+  unknownFieldLabels: readonly string[]
+  confidenceLabel: string
+}
 
 export interface CoerciveContainedPersonProtocolMirrorRecordView {
   id: string
@@ -27,6 +37,7 @@ export interface CoerciveContainedPersonProtocolMirrorRecordView {
   stableContainmentDominatesCareLabel: string
   coercionRiskScoreLabel: string
   contradictionRiskFlagLabels: readonly string[]
+  contradictionCheckViews: readonly CoerciveProtocolContradictionCheckMirrorView[]
   medicationRegimenRefLabel: string
   custodyStatusRefLabel: string
   procedureRefLabel: string
@@ -95,9 +106,22 @@ function sortedUnknownFieldLabels(unknownFields: readonly string[] | undefined):
   return Object.freeze([...(unknownFields ?? [])].sort((left, right) => left.localeCompare(right)))
 }
 
+function toContradictionCheckView(
+  check: CoerciveProtocolContradictionCheckResult
+): CoerciveProtocolContradictionCheckMirrorView {
+  return Object.freeze({
+    flagLabel: formatContradictionRiskFlagLabel(check.flag),
+    issueDetailLabels: Object.freeze(check.issues.map((issue) => issue.detail)),
+    redacted: check.redacted,
+    unknownFieldLabels: sortedUnknownFieldLabels(check.unknownFields),
+    confidenceLabel: formatConfidence(check.confidence),
+  })
+}
+
 function toRecordView(record: CoerciveProtocolRecord): CoerciveContainedPersonProtocolMirrorRecordView {
   const tradeoff = projectContainmentCareTradeoff(record)
   const riskReview = projectCoerciveProtocolRiskReview(record)
+  const contradictionChecks = evaluateCoerciveProtocolContradictionChecks(record)
   const validation = validateCoerciveProtocolRecord(record)
 
   const validationWarningLabels = Object.freeze(
@@ -130,6 +154,7 @@ function toRecordView(record: CoerciveProtocolRecord): CoerciveContainedPersonPr
     contradictionRiskFlagLabels: Object.freeze(
       riskReview.contradictionRiskFlags.map((flag) => formatContradictionRiskFlagLabel(flag))
     ),
+    contradictionCheckViews: Object.freeze(contradictionChecks.map(toContradictionCheckView)),
     medicationRegimenRefLabel: formatOptionalRef(record.medicationRegimenRef),
     custodyStatusRefLabel: formatOptionalRef(record.custodyStatusRef),
     procedureRefLabel: formatOptionalRef(record.procedureRef),


### PR DESCRIPTION
## Summary

- Surface `evaluateCoerciveProtocolContradictionChecks` output in `coerciveContainedPersonProtocolMirrorView` for records with triggered siblings (flag label, sorted issue detail, redaction/unknown metadata).
- Render sibling check detail in the coercive protocol mirror page risk-review column.
- Add slice 10 planning doc.

## Linear

- **Slice:** [SPE-2427](https://linear.app/spectranoir/issue/SPE-2427) — Coercive protocol mirror contradiction-check sibling detail (slice 10)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model (parent remains Done; mirror follow-up only)

## What shipped

Read-only mirror projection of triggered contradiction-check siblings with deterministic flag/issue ordering. No registry, snapshot, or orchestration contract changes.

## Validation

- `npm run test:run -- src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx src/test/coerciveContainedPersonProtocolRegistry.test.ts`
- `npm run lint`

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-10.md`
- `planning/backlog.md` (post-merge handoff)

## Parent status

SPE-1882 parent stays **Done** — this slice closes the deferred mirror UI row from slices 6–9 only.