### PR TITLE
feat(SPE-2428): coercive protocol integrated health cross-reconciliation slice 1

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Broader [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) cross-system reconciliation (condition bundles, surveillance tuning, psychological resilience) or broader SPE-1898 cross-system reconciliation. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) cross-system reconciliation slice 2 (SPE-848 surveillance tuning + SPE-1615 psychological resilience joins when runtime anchors exist) or broader SPE-1898 cross-system reconciliation. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `4dad2c98` (shipped: [SPE-2427](https://linear.app/spectranoir/issue/SPE-2427) mirror contradiction-check sibling detail slice 10 @ PR #2725)
+**Base `main` SHA:** `fed02b6a` (in flight: [SPE-2428](https://linear.app/spectranoir/issue/SPE-2428) coercive protocol ↔ integrated health bundle cross-reconciliation slice 1)
 
 **Recently shipped:** [SPE-2427](https://linear.app/spectranoir/issue/SPE-2427) mirror contradiction-check sibling detail slice 10 @ PR #2725; [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) surveillance-isolation contradiction-check slice 9 @ PR #2723; see `planning/coercive-contained-person-protocol-model-slice-10.md`.
 

--- a/planning/spe-1908-cross-system-reconciliation-slice-1.md
+++ b/planning/spe-1908-cross-system-reconciliation-slice-1.md
@@ -1,0 +1,79 @@
+# SPE-1908 — Coercive protocol ↔ integrated health bundle cross-system reconciliation (slice 1)
+
+One-page implementation plan. Linear: [SPE-2428](https://linear.app/spectranoir/issue/SPE-2428) (child under [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)). Follows shipped slice 10 (`planning/coercive-contained-person-protocol-model-slice-10.md`, PR #2725 / [SPE-2427](https://linear.app/spectranoir/issue/SPE-2427)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2428 — Coercive protocol ↔ integrated health bundle cross-system reconciliation (slice 1)](https://linear.app/spectranoir/issue/SPE-2428) |
+| **Status** | **Ready for PR**                                                                                           |
+| **Parent** | [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — surveillance-isolation contradiction check umbrella |
+| **Branch** | `spe-1908-cross-system-reconciliation-slice-1`                                                           |
+| **Base `main` SHA** | `fed02b6a`                                                                                          |
+
+## Goal
+
+Deterministic cross-registry compose helper linking persisted coercive protocol records to integrated health bundles via shared `subjectRef` — first wire-up slice for broader SPE-1908 reconciliation (condition bundles, surveillance tuning, psychological resilience).
+
+## Prerequisite (on `main` @ `fed02b6a`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Contradiction siblings | `evaluateCoerciveProtocolContradictionChecks` aggregator (slices 6–9) |
+| Integrated health bundle | `src/domain/containedPersonIntegratedHealthBundleRegistry.ts` (SPE-1889) |
+| Cross-link pattern     | `informationIntakeNamingHazardCrossLink.ts` (SPE-2358)                 |
+
+## Cross-reconciliation contract (slice 1)
+
+- **Match** — `coerciveProtocolRecord.subjectRef` ↔ `integratedHealthBundle.subjectRef` (bundle map key).
+- **Hydrated truth only** — compose over validated persisted entries; skip invalid drops without re-surfacing.
+- **Projections** — `projectCoerciveProtocolRiskReview` + triggered `evaluateCoerciveProtocolContradictionChecks`; bundle `mentalStateBand`, `humaneCareRiskScore`, therapeutic channel states from hydrated bundle only.
+- **Tension flags** — when `surveillance_isolation_burden` in risk review contradicts bundle stable mental state, low humane-care risk, or absent active contact channels.
+- **Empty maps** — zeroed summary without throw.
+- **Byte-stable ordering** — subject refs, protocol ids, tension flags, structured reasons sorted on repeat.
+- **Redaction** — merge per-record `redactedFields` / `unknownFields`; no hidden truth beyond registry projections.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coerciveProtocolIntegratedHealthCrossReconciliation.ts` compose   | Mirror UI / advanceWeek hooks                 |
+| Surveillance-tension bundle fixture (subject-22)                   | SPE-848 surveillance tuning registry          |
+| Targeted registry integration tests                                | SPE-1615 psychological resilience registry    |
+| Slice doc (this file) + backlog handoff                            | Contradiction-check evaluator changes         |
+|                                                                    | Faction ethics links (SPE-1047 / SPE-1131)    |
+|                                                                    | SPE-1908 parent Done (multi-owner AC remains) |
+
+## Acceptance
+
+- [x] Empty maps return zeroed summary without throw
+- [x] Abusive surveillance protocol + subject-22 bundle links with surveillance-isolation contradiction checks and cross-system tension flags
+- [x] Protocol without matching bundle omits links; tension flags empty
+- [x] Invalid hydrate drops skipped without re-surfacing
+- [x] Byte-stable ordering on repeated compose
+- [x] Slice 1–10 coercive protocol regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts`, `src/domain/containedPersonIntegratedHealthBundleRegistry.ts` |
+| Tests  | `src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts` |
+| Plan   | `planning/spe-1908-cross-system-reconciliation-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-848 surveillance tuning cross-join | SPE-848 | No runtime registry anchor yet |
+| SPE-1615 psychological resilience cross-join | SPE-1615 | No runtime registry anchor yet |
+| Reconciliation surfacing in mirror / weekly report | SPE-1908 follow-up | Compose-only boundary |
+| Mirror reads persisted weekly snapshots | SPE-1882 follow-up | Slice 10 deferred row |
+| SPE-1908 parent closure | SPE-1908 | Multi-owner reconciliation AC not met |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-9.md` — surveillance-isolation sibling origin
+- `planning/coercive-contained-person-protocol-model-slice-10.md` — mirror sibling detail (deferred cross-system row)
+- `planning/information-intake-naming-hazard-cross-link-slice-1.md` — sibling compose pattern

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
@@ -1,0 +1,323 @@
+/**
+ * SPE-1908 / SPE-2428 slice 1: coercive protocol ↔ integrated health bundle
+ * cross-system reconciliation compose.
+ *
+ * Pure deterministic linkage between persisted coercive protocol records and
+ * integrated health bundles via shared subject refs — reuses registry projections
+ * only; no new reconciliation engine or hidden truth beyond hydrated maps.
+ */
+
+import {
+  evaluateCoerciveProtocolContradictionChecks,
+  projectCoerciveProtocolRiskReview,
+  validateCoerciveProtocolRecord,
+  type CoerciveProtocolContradictionCheckResult,
+  type CoerciveProtocolRecord,
+  type CoerciveProtocolRecordsMap,
+  type CoerciveProtocolRiskReviewProjection,
+} from './coerciveContainedPersonProtocolRegistry'
+import {
+  validateContainedPersonIntegratedHealthBundle,
+  type ContainedPersonIntegratedHealthBundle,
+  type ContainedPersonIntegratedHealthBundleRecordsMap,
+  type MentalStateBand,
+  type TherapeuticCareScheduleLink,
+} from './containedPersonIntegratedHealthBundleRegistry'
+
+export type CoerciveProtocolIntegratedHealthMatchKind = 'subject_ref'
+
+export interface CoerciveProtocolIntegratedHealthCrossLink {
+  readonly coerciveProtocolId: string
+  readonly integratedHealthBundleId: string
+  readonly subjectRef: string
+  readonly matchKind: CoerciveProtocolIntegratedHealthMatchKind
+}
+
+export type CoerciveProtocolCrossSystemTensionFlag =
+  | 'surveillance_burden_stable_mental_state'
+  | 'surveillance_burden_no_active_contact_channel'
+  | 'surveillance_burden_low_humane_care_risk'
+  | 'monitoring_substitutes_contact_signal'
+
+export interface CoerciveProtocolIntegratedHealthReconciliationSummary {
+  readonly subjectRef: string
+  readonly links: readonly CoerciveProtocolIntegratedHealthCrossLink[]
+  readonly linkedProtocolCount: number
+  readonly linkedBundleCount: number
+  readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
+  readonly triggeredContradictionChecks: readonly CoerciveProtocolContradictionCheckResult[]
+  readonly bundleMentalStateBand: MentalStateBand | null
+  readonly bundleHumaneCareRiskScore: number | null
+  readonly bundleTherapeuticChannelStates: readonly TherapeuticCareScheduleLink['channelState'][]
+  readonly crossSystemTensionFlags: readonly CoerciveProtocolCrossSystemTensionFlag[]
+  readonly structuredReasons: readonly string[]
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isHydratedCoerciveProtocolRecord(record: CoerciveProtocolRecord): boolean {
+  return validateCoerciveProtocolRecord(record).valid
+}
+
+function isHydratedIntegratedHealthBundle(
+  bundle: ContainedPersonIntegratedHealthBundle
+): boolean {
+  return validateContainedPersonIntegratedHealthBundle(bundle).valid
+}
+
+function mergeUnknownFields(
+  ...sources: readonly (readonly string[] | undefined)[]
+): readonly string[] {
+  const merged = new Set<string>()
+
+  for (const source of sources) {
+    for (const field of source ?? []) {
+      const token = normalizeToken(field)
+      if (token) {
+        merged.add(token)
+      }
+    }
+  }
+
+  return Object.freeze([...merged].sort((left, right) => left.localeCompare(right)))
+}
+
+function listHydratedProtocolsForSubject(
+  protocols: CoerciveProtocolRecordsMap | undefined,
+  subjectRef: string
+): CoerciveProtocolRecord[] {
+  const normalizedSubjectRef = normalizeToken(subjectRef)
+  if (!normalizedSubjectRef) {
+    return []
+  }
+
+  return Object.values(protocols ?? {})
+    .filter(
+      (record) =>
+        normalizeToken(record.subjectRef) === normalizedSubjectRef &&
+        isHydratedCoerciveProtocolRecord(record)
+    )
+    .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function resolveHydratedBundleForSubject(
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
+  subjectRef: string
+): ContainedPersonIntegratedHealthBundle | null {
+  const normalizedSubjectRef = normalizeToken(subjectRef)
+  if (!normalizedSubjectRef) {
+    return null
+  }
+
+  const bundle = bundles?.[normalizedSubjectRef]
+  if (!bundle || !isHydratedIntegratedHealthBundle(bundle)) {
+    return null
+  }
+
+  return bundle
+}
+
+function hasSurveillanceIsolationBurden(
+  reviews: readonly CoerciveProtocolRiskReviewProjection[]
+): boolean {
+  return reviews.some((review) =>
+    review.contradictionRiskFlags.includes('surveillance_isolation_burden')
+  )
+}
+
+function collectTherapeuticChannelStates(
+  bundle: ContainedPersonIntegratedHealthBundle | null
+): readonly TherapeuticCareScheduleLink['channelState'][] {
+  const links = bundle?.therapeuticCareScheduleLinks ?? []
+  return Object.freeze(
+    [...links]
+      .map((link) => link.channelState)
+      .sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function hasActiveTherapeuticContactChannel(
+  bundle: ContainedPersonIntegratedHealthBundle | null
+): boolean {
+  return (bundle?.therapeuticCareScheduleLinks ?? []).some(
+    (link) => link.channelState === 'active'
+  )
+}
+
+function collectCrossSystemTensionFlags(input: {
+  readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
+  readonly bundle: ContainedPersonIntegratedHealthBundle | null
+}): readonly CoerciveProtocolCrossSystemTensionFlag[] {
+  if (!hasSurveillanceIsolationBurden(input.protocolRiskReviews)) {
+    return Object.freeze([])
+  }
+
+  const flags: CoerciveProtocolCrossSystemTensionFlag[] = []
+  const mentalStateBand = input.bundle?.mentalStateBand
+
+  if (mentalStateBand === 'stable') {
+    flags.push('surveillance_burden_stable_mental_state')
+  }
+
+  const humaneCareRiskScore = input.bundle?.humaneCareRiskScore
+  if (humaneCareRiskScore !== undefined && humaneCareRiskScore !== null && humaneCareRiskScore < 0.25) {
+    flags.push('surveillance_burden_low_humane_care_risk')
+  }
+
+  const therapeuticLinks = input.bundle?.therapeuticCareScheduleLinks ?? []
+  if (therapeuticLinks.length > 0 && !hasActiveTherapeuticContactChannel(input.bundle)) {
+    flags.push('surveillance_burden_no_active_contact_channel')
+  }
+
+  if (!hasActiveTherapeuticContactChannel(input.bundle)) {
+    flags.push('monitoring_substitutes_contact_signal')
+  }
+
+  return Object.freeze([...new Set(flags)].sort((left, right) => left.localeCompare(right)))
+}
+
+export function listCoerciveProtocolsForIntegratedHealthSubject(
+  protocols: CoerciveProtocolRecordsMap | undefined,
+  subjectRef: string
+): CoerciveProtocolRecord[] {
+  return listHydratedProtocolsForSubject(protocols, subjectRef)
+}
+
+export function resolveIntegratedHealthBundleForSubject(
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
+  subjectRef: string
+): ContainedPersonIntegratedHealthBundle | null {
+  return resolveHydratedBundleForSubject(bundles, subjectRef)
+}
+
+export function composeCoerciveProtocolIntegratedHealthReconciliation(
+  protocols: CoerciveProtocolRecordsMap | undefined,
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
+  subjectRef: string
+): CoerciveProtocolIntegratedHealthReconciliationSummary {
+  const normalizedSubjectRef = normalizeToken(subjectRef) || '(unknown)'
+  const protocolRecords = listHydratedProtocolsForSubject(protocols, normalizedSubjectRef)
+  const bundle = resolveHydratedBundleForSubject(bundles, normalizedSubjectRef)
+
+  const protocolRiskReviews = Object.freeze(
+    protocolRecords.map((record) => projectCoerciveProtocolRiskReview(record))
+  )
+
+  const triggeredContradictionChecks = Object.freeze(
+    protocolRecords
+      .flatMap((record) => evaluateCoerciveProtocolContradictionChecks(record))
+      .sort((left, right) => {
+        const byFlag = left.flag.localeCompare(right.flag)
+        if (byFlag !== 0) {
+          return byFlag
+        }
+
+        return left.recordId.localeCompare(right.recordId)
+      })
+  )
+
+  const links: CoerciveProtocolIntegratedHealthCrossLink[] = []
+
+  if (bundle) {
+    for (const record of protocolRecords) {
+      links.push({
+        coerciveProtocolId: record.id,
+        integratedHealthBundleId: bundle.id,
+        subjectRef: normalizedSubjectRef,
+        matchKind: 'subject_ref',
+      })
+    }
+  }
+
+  links.sort((left, right) => {
+    const bySubject = left.subjectRef.localeCompare(right.subjectRef)
+    if (bySubject !== 0) {
+      return bySubject
+    }
+
+    const byProtocol = left.coerciveProtocolId.localeCompare(right.coerciveProtocolId)
+    if (byProtocol !== 0) {
+      return byProtocol
+    }
+
+    return left.integratedHealthBundleId.localeCompare(right.integratedHealthBundleId)
+  })
+
+  const crossSystemTensionFlags = collectCrossSystemTensionFlags({
+    protocolRiskReviews,
+    bundle,
+  })
+
+  const linkedProtocolIds = new Set(links.map((link) => link.coerciveProtocolId))
+  const structuredReasons = [
+    `subject:${normalizedSubjectRef}`,
+    `link_count:${links.length}`,
+    `linked_protocol_count:${linkedProtocolIds.size}`,
+    `linked_bundle_count:${bundle ? 1 : 0}`,
+    `triggered_contradiction_check_count:${triggeredContradictionChecks.length}`,
+    `cross_system_tension_count:${crossSystemTensionFlags.length}`,
+    links.some((link) => link.matchKind === 'subject_ref') ? 'match:subject_ref' : 'match:none_subject_ref',
+    crossSystemTensionFlags.length > 0 ? 'tension:present' : 'tension:none',
+  ].sort((left, right) => left.localeCompare(right))
+
+  const redacted =
+    protocolRecords.some((record) => (record.redactedFields ?? []).length > 0) ||
+    (bundle?.redactedFields ?? []).length > 0 ||
+    protocolRiskReviews.some((review) => review.redacted) ||
+    triggeredContradictionChecks.some((check) => check.redacted)
+
+  const unknownFields = mergeUnknownFields(
+    ...protocolRecords.map((record) => record.unknownFields),
+    bundle?.unknownFields,
+    ...protocolRiskReviews.map((review) => review.unknownFields),
+    ...triggeredContradictionChecks.map((check) => check.unknownFields)
+  )
+
+  return Object.freeze({
+    subjectRef: normalizedSubjectRef,
+    links: Object.freeze(links),
+    linkedProtocolCount: linkedProtocolIds.size,
+    linkedBundleCount: bundle ? 1 : 0,
+    protocolRiskReviews,
+    triggeredContradictionChecks,
+    bundleMentalStateBand: bundle?.mentalStateBand ?? null,
+    bundleHumaneCareRiskScore: bundle?.humaneCareRiskScore ?? null,
+    bundleTherapeuticChannelStates: collectTherapeuticChannelStates(bundle),
+    crossSystemTensionFlags,
+    structuredReasons,
+    redacted,
+    unknownFields,
+  })
+}
+
+/** Compose reconciliation summaries for every subject ref with protocol–bundle links. */
+export function composeAllCoerciveProtocolIntegratedHealthReconciliations(
+  protocols: CoerciveProtocolRecordsMap | undefined,
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+): readonly CoerciveProtocolIntegratedHealthReconciliationSummary[] {
+  const subjectRefs = new Set<string>()
+
+  for (const record of Object.values(protocols ?? {})) {
+    if (!isHydratedCoerciveProtocolRecord(record)) {
+      continue
+    }
+
+    const subjectRef = normalizeToken(record.subjectRef)
+    if (subjectRef && bundles?.[subjectRef] && isHydratedIntegratedHealthBundle(bundles[subjectRef])) {
+      subjectRefs.add(subjectRef)
+    }
+  }
+
+  return Object.freeze(
+    [...subjectRefs]
+      .sort((left, right) => left.localeCompare(right))
+      .map((subjectRef) =>
+        composeCoerciveProtocolIntegratedHealthReconciliation(protocols, bundles, subjectRef)
+      )
+      .filter((summary) => summary.links.length > 0)
+  )
+}

--- a/src/domain/containedPersonIntegratedHealthBundleRegistry.ts
+++ b/src/domain/containedPersonIntegratedHealthBundleRegistry.ts
@@ -864,6 +864,37 @@ export function sanitizeContainedPersonIntegratedHealthBundles(
 // Fixtures (tests / planning mirror)
 // ---------------------------------------------------------------------------
 
+/** Bundle paired with abusive surveillance-isolation coercive protocol (subject-22). */
+export const INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE: ContainedPersonIntegratedHealthBundle =
+  Object.freeze({
+    id: 'subject:cooperative-field-asset-22',
+    label: 'Cooperative field asset 22 integrated health bundle',
+    subjectRef: 'subject:cooperative-field-asset-22',
+    mentalStateBand: 'stable',
+    humaneCareRiskScore: 0.12,
+    therapeuticCareScheduleLinks: Object.freeze([
+      Object.freeze({
+        scheduleRef: 'care-schedule:cooperative-checkin-compliance-drift',
+        wiredRef: 'therapeutic-care:care-schedule:cooperative-checkin-compliance-drift',
+        careMode: 'cooperative_checkin',
+        channelState: 'degraded',
+        missedSessionStreak: 3,
+        complianceRiskScore: 0.58,
+        lockdownEscalationLikely: true,
+      }),
+    ]),
+    custodyStatusLinks: Object.freeze([
+      Object.freeze({
+        custodyRef: 'custody-status:former-hostile-hold',
+        wiredRef: 'custody-status:former-hostile-hold',
+        custodyStage: 'contained_person',
+        formerRoleCategory: 'hostile_actor',
+        restrictionLevel: 'elevated',
+        rightsReviewPending: true,
+      }),
+    ]),
+  })
+
 export const INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE: ContainedPersonIntegratedHealthBundle =
   Object.freeze({
     id: 'subject:contained-person-field-links',

--- a/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
+++ b/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  validateCoerciveProtocolRecord,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+import {
+  composeAllCoerciveProtocolIntegratedHealthReconciliations,
+  composeCoerciveProtocolIntegratedHealthReconciliation,
+  listCoerciveProtocolsForIntegratedHealthSubject,
+  resolveIntegratedHealthBundleForSubject,
+} from '../domain/coerciveProtocolIntegratedHealthCrossReconciliation'
+import {
+  INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+  INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+  validateContainedPersonIntegratedHealthBundle,
+} from '../domain/containedPersonIntegratedHealthBundleRegistry'
+
+describe('coerciveProtocolIntegratedHealthCrossReconciliation (SPE-2428 slice 1)', () => {
+  it('returns empty summary for empty maps without throw', () => {
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      undefined,
+      undefined,
+      'subject:missing'
+    )
+
+    expect(summary.links).toEqual([])
+    expect(summary.linkedProtocolCount).toBe(0)
+    expect(summary.linkedBundleCount).toBe(0)
+    expect(summary.protocolRiskReviews).toEqual([])
+    expect(summary.triggeredContradictionChecks).toEqual([])
+    expect(summary.crossSystemTensionFlags).toEqual([])
+    expect(summary.structuredReasons).toContain('link_count:0')
+    expect(summary.structuredReasons).toContain('tension:none')
+  })
+
+  it('links abusive surveillance protocol to bundle by subject ref with tension flags', () => {
+    expect(validateCoerciveProtocolRecord(ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE).valid).toBe(
+      true
+    )
+    expect(
+      validateContainedPersonIntegratedHealthBundle(INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE)
+        .valid
+    ).toBe(true)
+
+    const protocols = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef
+    )
+
+    expect(summary.linkedProtocolCount).toBe(1)
+    expect(summary.linkedBundleCount).toBe(1)
+    expect(summary.links).toHaveLength(1)
+    expect(summary.links[0]?.matchKind).toBe('subject_ref')
+    expect(summary.protocolRiskReviews[0]?.contradictionRiskFlags).toContain(
+      'surveillance_isolation_burden'
+    )
+    expect(summary.triggeredContradictionChecks.some((check) => check.flag === 'surveillance_isolation_burden')).toBe(
+      true
+    )
+    expect(summary.bundleMentalStateBand).toBe('stable')
+    expect(summary.bundleTherapeuticChannelStates).toEqual(['degraded'])
+    expect(summary.crossSystemTensionFlags).toEqual([
+      'monitoring_substitutes_contact_signal',
+      'surveillance_burden_low_humane_care_risk',
+      'surveillance_burden_no_active_contact_channel',
+      'surveillance_burden_stable_mental_state',
+    ])
+    expect(summary.structuredReasons).toContain('tension:present')
+  })
+
+  it('omits links when bundle is missing for a protocol subject', () => {
+    const protocols = {
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      {},
+      EMERGENCY_SEDATION_PROTOCOL_FIXTURE.subjectRef
+    )
+
+    expect(summary.links).toEqual([])
+    expect(summary.linkedBundleCount).toBe(0)
+    expect(summary.protocolRiskReviews).toHaveLength(1)
+    expect(summary.crossSystemTensionFlags).toEqual([])
+  })
+
+  it('lists hydrated protocols and resolves bundle for subject in stable id order', () => {
+    const protocols = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+
+    expect(
+      listCoerciveProtocolsForIntegratedHealthSubject(
+        protocols,
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef
+      ).map((record) => record.id)
+    ).toEqual([ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id])
+
+    expect(
+      resolveIntegratedHealthBundleForSubject(
+        bundles,
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef
+      )?.id
+    ).toBe(INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.id)
+  })
+
+  it('composeAll returns summaries in subject locale order with byte-stable repeat', () => {
+    const protocols = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+      [INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+    }
+
+    const first = composeAllCoerciveProtocolIntegratedHealthReconciliations(protocols, bundles)
+    const second = composeAllCoerciveProtocolIntegratedHealthReconciliations(protocols, bundles)
+
+    expect(first).toEqual(second)
+    expect(first).toHaveLength(1)
+    expect(first[0]?.subjectRef).toBe('subject:cooperative-field-asset-22')
+  })
+
+  it('skips invalid hydrate drops without re-surfacing them', () => {
+    const invalidProtocol = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      id: '',
+    }
+    const invalidBundle = {
+      ...INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+      id: '',
+    }
+
+    expect(validateCoerciveProtocolRecord(invalidProtocol).valid).toBe(false)
+    expect(validateContainedPersonIntegratedHealthBundle(invalidBundle).valid).toBe(false)
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      { 'coercive-protocol:invalid': invalidProtocol },
+      { 'subject:invalid': invalidBundle },
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef
+    )
+
+    expect(summary.links).toEqual([])
+    expect(summary.linkedProtocolCount).toBe(0)
+    expect(summary.linkedBundleCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `coerciveProtocolIntegratedHealthCrossReconciliation.ts` compose module joining persisted coercive protocol records to integrated health bundles by shared `subjectRef`.
- Reuse `projectCoerciveProtocolRiskReview` and `evaluateCoerciveProtocolContradictionChecks`; surface bundle mental-state and therapeutic channel projections only.
- Add deterministic cross-system tension flags when surveillance-isolation burden contradicts bundle contact/mental-state signals; subject-22 surveillance tension fixture + targeted tests.

## Linear mapping

- **Slice:** [SPE-2428](https://linear.app/spectranoir/issue/SPE-2428) — Coercive protocol ↔ integrated health bundle cross-system reconciliation (slice 1)
- **Parent:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — Surveillance-isolation cross-system reconciliation umbrella (stays open)
- **Related:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882), [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889)

## What shipped

Cross-registry wire-up compose helper (no new reconciliation engine, no mirror UI, no evaluator changes).

## Validation

- `npm run test:run -- src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts src/test/coerciveContainedPersonProtocolRegistry.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`
- `npm run lint`

## Docs

- `planning/spe-1908-cross-system-reconciliation-slice-1.md`
- `planning/backlog.md` handoff updated

## Parent status

SPE-1908 remains **In Progress** — SPE-848 / SPE-1615 runtime joins deferred.