### PR TITLE
feat(SPE-2429): coercive protocol integrated health cross-reconciliation surfacing slice 2

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) cross-system reconciliation slice 2 (SPE-848 surveillance tuning + SPE-1615 psychological resilience joins when runtime anchors exist) or broader SPE-1898 cross-system reconciliation. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) surveillance tuning registry anchor + SPE-1908 cross-system reconciliation slice 3 (surveillance-tuning cross-join when runtime anchor exists) or [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience join; broader SPE-1898 cross-system reconciliation. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `e1e29ed2` (shipped: [SPE-2428](https://linear.app/spectranoir/issue/SPE-2428) coercive protocol ↔ integrated health bundle cross-reconciliation slice 1 @ PR #2727)
+**Base `main` SHA:** `0b3b7b79` (in flight: [SPE-2429](https://linear.app/spectranoir/issue/SPE-2429) cross-reconciliation surfacing slice 2)
 
 **Recently shipped:** [SPE-2428](https://linear.app/spectranoir/issue/SPE-2428) cross-system reconciliation slice 1 @ PR #2727; [SPE-2427](https://linear.app/spectranoir/issue/SPE-2427) mirror contradiction-check sibling detail slice 10 @ PR #2725; see `planning/spe-1908-cross-system-reconciliation-slice-1.md`.
 

--- a/planning/spe-1908-cross-system-reconciliation-slice-2.md
+++ b/planning/spe-1908-cross-system-reconciliation-slice-2.md
@@ -1,0 +1,80 @@
+# SPE-1908 — Coercive protocol ↔ integrated health bundle cross-reconciliation surfacing (slice 2)
+
+One-page implementation plan. Linear: [SPE-2429](https://linear.app/spectranoir/issue/SPE-2429) (child under [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)). Follows shipped slice 1 (`planning/spe-1908-cross-system-reconciliation-slice-1.md`, PR #2727 / [SPE-2428](https://linear.app/spectranoir/issue/SPE-2428)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2429 — Coercive protocol ↔ integrated health bundle cross-reconciliation surfacing (slice 2)](https://linear.app/spectranoir/issue/SPE-2429) |
+| **Status** | In progress                                                                                                |
+| **Parent** | [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — surveillance-isolation contradiction check umbrella |
+| **Branch** | `spe-1908-cross-system-reconciliation-slice-2`                                                           |
+| **Base `main` SHA** | `0b3b7b79`                                                                                          |
+
+## Goal
+
+Surface `composeAllCoerciveProtocolIntegratedHealthReconciliations` output as read-only labels in coercive protocol mirror and weekly report notes — follow-up to SPE-2428 compose-only slice.
+
+## Path choice
+
+**Surfacing** (this slice) — SPE-848 has no runtime surveillance-tuning registry anchor yet; surfacing unblocks parent reconciliation visibility first.
+
+## Prerequisite (on `main` @ `0b3b7b79`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Cross-reconciliation compose | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` (SPE-2428) |
+| Coercive protocol mirror | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` (SPE-1882 slices 4–10) |
+| Surfacing pattern    | `informationIntakeNamingHazardCrossLinkSurfacing.ts` (SPE-2406)        |
+
+## Surfacing contract (slice 2)
+
+- **Read-only** — compose at read time; no new GameState fields.
+- **Safe labels** — protocol ids + labels; bundle ids + labels; tension flags as enum labels only.
+- **Empty maps** — no-op; no throw.
+- **Mirror** — per-record `crossSystemTensionFlagLabels` when subject ref links protocol to bundle; summary counts for linked/tension subjects.
+- **Weekly notes** — emit when linked maps coexist after weekly tick (`coercive_protocol.integrated_health_reconciliation` type).
+- **No compose changes** — SPE-2428 contracts unchanged.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts`  | SPE-2428 compose changes                      |
+| `coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts` | SPE-848 surveillance tuning cross-join |
+| Coercive protocol mirror tension-flag surfacing                    | SPE-1615 psychological resilience cross-join  |
+| `advanceWeek` + report note type wiring                            | Contradiction-check evaluator changes         |
+| Targeted surfacing + mirror + advanceWeek tests                    | Faction ethics links (SPE-1047 / SPE-1131)    |
+| Slice doc (this file) + backlog handoff                            | SPE-1908 parent re-closure                    |
+
+## Acceptance
+
+- [x] Empty maps no-op without throw
+- [x] Mirror surfaces tension flags for abusive surveillance + subject-22 bundle fixture
+- [x] Weekly report note uses safe cross-link labels when fixtures coexist
+- [x] `advanceWeek` integration asserts reconciliation note when fixtures coexist
+- [x] Slice 1 compose regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts`, `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts`, `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx`, `src/features/report/reportNoteView.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts`, `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx`, `src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts`, `src/test/reportNoteTypeAudit.test.ts`, `src/features/report/reportNoteView.test.ts` |
+| Plan   | `planning/spe-1908-cross-system-reconciliation-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-848 surveillance tuning cross-join | SPE-848 | No runtime registry anchor yet |
+| SPE-1615 psychological resilience cross-join | SPE-1615 | No runtime registry anchor yet |
+| Mirror reads persisted weekly snapshots | SPE-1882 follow-up | Out of surfacing boundary |
+
+## See also
+
+- `planning/spe-1908-cross-system-reconciliation-slice-1.md`
+- `planning/naming-hazard-cross-link-surfacing-slice-1.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -344,6 +344,7 @@ export const REPORT_NOTE_TYPES = [
   'system.equipment_recovered',
   'information_intake.verification',
   'information_intake.naming_hazard_cross_link',
+  'coercive_protocol.integrated_health_reconciliation',
   'post_incident_review.follow_on',
   'post_incident_review.closeout_reward_payout',
 ] as const satisfies readonly ReportNoteType[]
@@ -614,6 +615,14 @@ const REPORT_NOTE_METADATA_ALLOWLIST: Partial<Record<ReportNoteType, readonly st
     'topicRef',
     'linkedReportCount',
     'linkedDescriptorCount',
+    'structuredReasons',
+    'week',
+  ],
+  'coercive_protocol.integrated_health_reconciliation': [
+    'subjectRef',
+    'linkedProtocolCount',
+    'linkedBundleCount',
+    'crossSystemTensionFlags',
     'structuredReasons',
     'week',
   ],

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1260,6 +1260,9 @@ export const COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT: Record<string, s
   coercionRiskPrefix: 'Coercion risk:',
   contradictionCheckPrefix: 'Contradiction checks:',
   contradictionCheckUnknownFieldsPrefix: 'Unknown fields:',
+  crossSystemTensionPrefix: 'Cross-system tension:',
+  integratedHealthLinkedSubjectsLabel: 'Integrated health links',
+  crossSystemTensionSubjectsLabel: 'Cross-system tension subjects',
   validationWarningPrefix: 'Validation warnings:',
   redactedSuffix: 'Partial redaction',
 }

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts
@@ -1,0 +1,128 @@
+/**
+ * SPE-1908 / SPE-2429 slice 2: read-only surfacing for coercive protocol ↔ integrated
+ * health bundle cross-reconciliation compose output.
+ *
+ * Formats compose summaries for mirror labels and weekly report notes — no changes to
+ * SPE-2428 compose contracts.
+ */
+
+import type {
+  CoerciveProtocolRecord,
+  CoerciveProtocolRecordsMap,
+} from './coerciveContainedPersonProtocolRegistry'
+import {
+  composeAllCoerciveProtocolIntegratedHealthReconciliations,
+  type CoerciveProtocolCrossSystemTensionFlag,
+  type CoerciveProtocolIntegratedHealthReconciliationSummary,
+} from './coerciveProtocolIntegratedHealthCrossReconciliation'
+import type {
+  ContainedPersonIntegratedHealthBundle,
+  ContainedPersonIntegratedHealthBundleRecordsMap,
+} from './containedPersonIntegratedHealthBundleRegistry'
+
+export function formatCoerciveProtocolCrossLinkLabel(record: CoerciveProtocolRecord): string {
+  return `${record.id} (${record.label})`
+}
+
+export function formatIntegratedHealthBundleCrossLinkLabel(
+  bundle: ContainedPersonIntegratedHealthBundle
+): string {
+  return `${bundle.id} (${bundle.label})`
+}
+
+export function formatCrossSystemTensionFlagLabel(flag: CoerciveProtocolCrossSystemTensionFlag): string {
+  return flag
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function protocolById(
+  protocols: CoerciveProtocolRecordsMap | undefined,
+  protocolId: string
+): CoerciveProtocolRecord | undefined {
+  return protocols?.[protocolId]
+}
+
+function bundleBySubjectRef(
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
+  subjectRef: string
+): ContainedPersonIntegratedHealthBundle | undefined {
+  return bundles?.[subjectRef]
+}
+
+export function formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabels(input: {
+  summary: CoerciveProtocolIntegratedHealthReconciliationSummary
+  protocols: CoerciveProtocolRecordsMap | undefined
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+}): {
+  readonly protocolLabels: readonly string[]
+  readonly bundleLabel: string | null
+  readonly tensionFlagLabels: readonly string[]
+} {
+  const protocolIds = [
+    ...new Set(input.summary.links.map((link) => link.coerciveProtocolId)),
+  ].sort((left, right) => left.localeCompare(right))
+
+  const protocolLabels = protocolIds
+    .map((protocolId) => protocolById(input.protocols, protocolId))
+    .filter((record): record is CoerciveProtocolRecord => record !== undefined)
+    .map((record) => formatCoerciveProtocolCrossLinkLabel(record))
+
+  const bundle = bundleBySubjectRef(input.bundles, input.summary.subjectRef)
+  const bundleLabel = bundle ? formatIntegratedHealthBundleCrossLinkLabel(bundle) : null
+
+  const tensionFlagLabels = Object.freeze(
+    input.summary.crossSystemTensionFlags.map((flag) => formatCrossSystemTensionFlagLabel(flag))
+  )
+
+  return {
+    protocolLabels: Object.freeze(protocolLabels),
+    bundleLabel,
+    tensionFlagLabels,
+  }
+}
+
+export function formatCoerciveProtocolIntegratedHealthReconciliationNoteContent(input: {
+  summary: CoerciveProtocolIntegratedHealthReconciliationSummary
+  protocols: CoerciveProtocolRecordsMap | undefined
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+}): string {
+  const { protocolLabels, bundleLabel, tensionFlagLabels } =
+    formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabels(input)
+  const protocolSegment =
+    protocolLabels.length > 0 ? protocolLabels.join('; ') : 'no linked coercive protocols'
+  const bundleSegment = bundleLabel ?? 'no linked integrated health bundle'
+  const tensionSegment =
+    tensionFlagLabels.length > 0 ? tensionFlagLabels.join('; ') : 'no cross-system tension flags'
+
+  return `Coercive protocol cross-link — ${input.summary.subjectRef}: ${input.summary.linkedProtocolCount} protocol(s), ${input.summary.linkedBundleCount} bundle(s). Tension flags: ${tensionSegment}. Protocols: ${protocolSegment}. Bundle: ${bundleSegment}.`
+}
+
+export function composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries(input: {
+  protocols: CoerciveProtocolRecordsMap | undefined
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+}): readonly CoerciveProtocolIntegratedHealthReconciliationSummary[] {
+  if (!input.protocols || !input.bundles) {
+    return []
+  }
+
+  if (Object.keys(input.protocols).length === 0 || Object.keys(input.bundles).length === 0) {
+    return []
+  }
+
+  return composeAllCoerciveProtocolIntegratedHealthReconciliations(input.protocols, input.bundles)
+}
+
+export function resolveCoerciveProtocolIntegratedHealthReconciliationForSubject(input: {
+  protocols: CoerciveProtocolRecordsMap | undefined
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+  subjectRef: string
+}): CoerciveProtocolIntegratedHealthReconciliationSummary | null {
+  const summaries = composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+    protocols: input.protocols,
+    bundles: input.bundles,
+  })
+
+  return summaries.find((summary) => summary.subjectRef === input.subjectRef) ?? null
+}

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts
@@ -1,0 +1,66 @@
+/**
+ * SPE-1908 / SPE-2429 slice 2: weekly report notes for coercive protocol ↔ integrated
+ * health bundle cross-reconciliation.
+ *
+ * Emits deterministic notes when linked maps coexist — no new persistence.
+ */
+
+import type { CoerciveProtocolRecordsMap } from './coerciveContainedPersonProtocolRegistry'
+import type { ContainedPersonIntegratedHealthBundleRecordsMap } from './containedPersonIntegratedHealthBundleRegistry'
+import {
+  composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries,
+  formatCoerciveProtocolIntegratedHealthReconciliationNoteContent,
+} from './coerciveProtocolIntegratedHealthCrossReconciliationSurfacing'
+import type { ReportNote } from './models'
+import { createDeterministicReportNote } from './reportNotes'
+
+/**
+ * Builds weekly report notes when coercive protocol records and integrated health bundles
+ * co-exist with subject-ref links.
+ */
+export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes(input: {
+  nextProtocols: CoerciveProtocolRecordsMap | null | undefined
+  nextBundles: ContainedPersonIntegratedHealthBundleRecordsMap | null | undefined
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const nextSummaries = composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+    protocols: input.nextProtocols ?? undefined,
+    bundles: input.nextBundles ?? undefined,
+  })
+
+  if (nextSummaries.length === 0) {
+    return []
+  }
+
+  const notes: ReportNote[] = []
+  let sequence = input.sequenceStart
+
+  for (const summary of nextSummaries) {
+    notes.push(
+      createDeterministicReportNote(
+        formatCoerciveProtocolIntegratedHealthReconciliationNoteContent({
+          summary,
+          protocols: input.nextProtocols ?? undefined,
+          bundles: input.nextBundles ?? undefined,
+        }),
+        input.week,
+        sequence,
+        input.baseTimestamp,
+        'coercive_protocol.integrated_health_reconciliation',
+        {
+          subjectRef: summary.subjectRef,
+          linkedProtocolCount: summary.linkedProtocolCount,
+          linkedBundleCount: summary.linkedBundleCount,
+          crossSystemTensionFlags: [...summary.crossSystemTensionFlags],
+          structuredReasons: [...summary.structuredReasons],
+          week: input.week,
+        }
+      )
+    )
+    sequence += 1
+  }
+
+  return notes
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1527,6 +1527,7 @@ export type ReportNoteType =
   | 'system.equipment_recovered'
   | 'information_intake.verification'
   | 'information_intake.naming_hazard_cross_link'
+  | 'coercive_protocol.integrated_health_reconciliation'
   | 'post_incident_review.follow_on'
   | 'post_incident_review.closeout_reward_payout'
 

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -304,6 +304,7 @@ import { applyWeeklyPostIncidentReviewCreationTick, resolveQualifyingIncidentRev
 import { applyWeeklyRuleDocumentComplianceTick } from '../ruleDocumentComplianceWeeklyOrchestration'
 import { applyWeeklyCaseLifecycleTick } from '../caseLifecycleWeeklyOrchestration'
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
+import { buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes } from '../coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes'
 import { buildWeeklyIntakeNamingHazardCrossLinkReportNotes } from '../informationIntakeNamingHazardCrossLinkWeeklyReportNotes'
 import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
@@ -4710,6 +4711,37 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       reports[lastReportIndex] = {
         ...lastReport,
         notes: [...(lastReport.notes ?? []), ...crossLinkNotes],
+      }
+      result.reports = reports
+    }
+  }
+
+  // SPE-1908 / SPE-2429 slice 2: surface coercive protocol ↔ integrated health cross-reconciliation in weekly report notes.
+  const nextCoerciveProtocolsForReconciliation =
+    outputWeeklyState.coerciveContainedPersonProtocolRecords ?? {}
+  const nextIntegratedHealthBundlesForReconciliation =
+    outputWeeklyState.containedPersonIntegratedHealthBundles ?? {}
+  if (
+    Object.keys(nextCoerciveProtocolsForReconciliation).length > 0 &&
+    Object.keys(nextIntegratedHealthBundlesForReconciliation).length > 0 &&
+    result.reports.length > 0
+  ) {
+    const lastWeeklyReport = result.reports[result.reports.length - 1]
+    const reconciliationNotes = buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+      nextProtocols: nextCoerciveProtocolsForReconciliation,
+      nextBundles: nextIntegratedHealthBundlesForReconciliation,
+      week: result.week,
+      sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
+      baseTimestamp: noteBaseTimestamp,
+    })
+
+    if (reconciliationNotes.length > 0) {
+      const reports = [...result.reports]
+      const lastReportIndex = reports.length - 1
+      const lastReport = reports[lastReportIndex]
+      reports[lastReportIndex] = {
+        ...lastReport,
+        notes: [...(lastReport.notes ?? []), ...reconciliationNotes],
       }
       result.reports = reports
     }

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
@@ -9,6 +9,7 @@ import {
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
   evaluateCoerciveProtocolContradictionChecks,
 } from '../../domain/coerciveContainedPersonProtocolRegistry'
+import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
 import { useGameStore } from '../../app/store/gameStore'
 import CoerciveContainedPersonProtocolMirrorPage from './CoerciveContainedPersonProtocolMirrorPage'
 
@@ -90,5 +91,30 @@ describe('CoerciveContainedPersonProtocolMirrorPage (SPE-1882 slice 4)', () => {
     expect(recordsRegion).toHaveTextContent(/contradiction checks:/i)
     expect(recordsRegion).toHaveTextContent(/surveillance isolation burden/i)
     expect(recordsRegion).toHaveTextContent(triggered[0]?.issues[0]?.detail ?? '')
+  })
+})
+
+describe('CoerciveContainedPersonProtocolMirrorPage (SPE-2429 slice 2)', () => {
+  it('renders cross-system tension flags when protocol and bundle share subject ref', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    game.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted coercive contained person protocol records/i,
+    })
+
+    expect(recordsRegion).toHaveTextContent(/cross-system tension:/i)
+    expect(recordsRegion).toHaveTextContent(/surveillance burden stable mental state/i)
+    expect(screen.getByText(/cross-system tension subjects/i)).toBeInTheDocument()
   })
 })

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
@@ -38,7 +38,7 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
           </Link>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
           <StatCard
             label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.totalRecordsLabel}
             value={String(view.summary.totalRecords)}
@@ -50,6 +50,16 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
           <StatCard
             label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.abusivePostureLabel}
             value={String(view.summary.abusivePostureCount)}
+          />
+          <StatCard
+            label={
+              COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.integratedHealthLinkedSubjectsLabel
+            }
+            value={String(view.summary.integratedHealthLinkedSubjectCount)}
+          />
+          <StatCard
+            label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.crossSystemTensionSubjectsLabel}
+            value={String(view.summary.crossSystemTensionSubjectCount)}
           />
           <StatCard
             label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.weekLabel}
@@ -193,6 +203,12 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
                             </div>
                           ))}
                         </div>
+                      ) : null}
+                      {record.crossSystemTensionFlagLabels.length > 0 ? (
+                        <p className="mt-1 text-xs opacity-45">
+                          {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.crossSystemTensionPrefix}{' '}
+                          {record.crossSystemTensionFlagLabels.join('; ')}
+                        </p>
                       ) : null}
                       <p className="text-xs opacity-45">
                         {record.forcePolicyLabel} · {record.refusalHandlingLabel}

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -10,6 +10,7 @@ import {
   validateCoerciveProtocolRecord,
   type CoerciveProtocolRecord,
 } from '../../domain/coerciveContainedPersonProtocolRegistry'
+import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
 import {
   formatCoerciveProtocolEnumLabel,
   getCoerciveContainedPersonProtocolMirrorView,
@@ -258,6 +259,46 @@ describe('coerciveContainedPersonProtocolMirrorView (SPE-1882 slice 10)', () => 
       'Generalized Procedure Without Subject Fit',
       'Routine Force Authorization',
       'Surveillance Isolation Burden',
+    ])
+  })
+})
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-2429 slice 2)', () => {
+  it('returns zero cross-system tension counts when integrated health bundles are absent', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.summary.integratedHealthLinkedSubjectCount).toBe(0)
+    expect(view.summary.crossSystemTensionSubjectCount).toBe(0)
+    expect(view.records[0]?.crossSystemTensionFlagLabels).toEqual([])
+  })
+
+  it('surfaces cross-system tension flags when protocol and bundle share subject ref', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    game.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.integratedHealthLinkedSubjectCount).toBe(1)
+    expect(view.summary.crossSystemTensionSubjectCount).toBe(1)
+    expect(record?.crossSystemTensionFlagLabels).toEqual([
+      'Monitoring Substitutes Contact Signal',
+      'Surveillance Burden Low Humane Care Risk',
+      'Surveillance Burden No Active Contact Channel',
+      'Surveillance Burden Stable Mental State',
     ])
   })
 })

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -8,6 +8,11 @@ import {
   type CoerciveProtocolContradictionRiskFlag,
   type CoerciveProtocolRecord,
 } from '../../domain/coerciveContainedPersonProtocolRegistry'
+import type { CoerciveProtocolIntegratedHealthReconciliationSummary } from '../../domain/coerciveProtocolIntegratedHealthCrossReconciliation'
+import {
+  composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries,
+  formatCrossSystemTensionFlagLabel,
+} from '../../domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing'
 
 export interface CoerciveProtocolContradictionCheckMirrorView {
   flagLabel: string
@@ -38,6 +43,7 @@ export interface CoerciveContainedPersonProtocolMirrorRecordView {
   coercionRiskScoreLabel: string
   contradictionRiskFlagLabels: readonly string[]
   contradictionCheckViews: readonly CoerciveProtocolContradictionCheckMirrorView[]
+  crossSystemTensionFlagLabels: readonly string[]
   medicationRegimenRefLabel: string
   custodyStatusRefLabel: string
   procedureRefLabel: string
@@ -53,6 +59,8 @@ export interface CoerciveContainedPersonProtocolMirrorSummaryView {
   stableContainmentDominatesCareCount: number
   abusivePostureCount: number
   contradictionFlaggedCount: number
+  integratedHealthLinkedSubjectCount: number
+  crossSystemTensionSubjectCount: number
   week: number
 }
 
@@ -118,7 +126,27 @@ function toContradictionCheckView(
   })
 }
 
-function toRecordView(record: CoerciveProtocolRecord): CoerciveContainedPersonProtocolMirrorRecordView {
+function buildCrossSystemTensionFlagLabelsBySubject(
+  summaries: readonly CoerciveProtocolIntegratedHealthReconciliationSummary[]
+): ReadonlyMap<string, readonly string[]> {
+  const labelsBySubject = new Map<string, readonly string[]>()
+
+  for (const summary of summaries) {
+    labelsBySubject.set(
+      summary.subjectRef,
+      Object.freeze(
+        summary.crossSystemTensionFlags.map((flag) => formatCrossSystemTensionFlagLabel(flag))
+      )
+    )
+  }
+
+  return labelsBySubject
+}
+
+function toRecordView(
+  record: CoerciveProtocolRecord,
+  crossSystemTensionFlagLabels: readonly string[]
+): CoerciveContainedPersonProtocolMirrorRecordView {
   const tradeoff = projectContainmentCareTradeoff(record)
   const riskReview = projectCoerciveProtocolRiskReview(record)
   const contradictionChecks = evaluateCoerciveProtocolContradictionChecks(record)
@@ -155,6 +183,7 @@ function toRecordView(record: CoerciveProtocolRecord): CoerciveContainedPersonPr
       riskReview.contradictionRiskFlags.map((flag) => formatContradictionRiskFlagLabel(flag))
     ),
     contradictionCheckViews: Object.freeze(contradictionChecks.map(toContradictionCheckView)),
+    crossSystemTensionFlagLabels: Object.freeze([...crossSystemTensionFlagLabels]),
     medicationRegimenRefLabel: formatOptionalRef(record.medicationRegimenRef),
     custodyStatusRefLabel: formatOptionalRef(record.custodyStatusRef),
     procedureRefLabel: formatOptionalRef(record.procedureRef),
@@ -172,10 +201,23 @@ export function getCoerciveContainedPersonProtocolMirrorView(
 ): CoerciveContainedPersonProtocolMirrorView {
   const records = listPersistedRecords(game)
   const week = game.week
+  const reconciliationSummaries = composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+    protocols: game.coerciveContainedPersonProtocolRecords,
+    bundles: game.containedPersonIntegratedHealthBundles,
+  })
+  const tensionLabelsBySubject = buildCrossSystemTensionFlagLabelsBySubject(reconciliationSummaries)
 
   let stableContainmentDominatesCareCount = 0
   let abusivePostureCount = 0
   let contradictionFlaggedCount = 0
+  const integratedHealthLinkedSubjectCount = reconciliationSummaries.length
+  let crossSystemTensionSubjectCount = 0
+
+  for (const summary of reconciliationSummaries) {
+    if (summary.crossSystemTensionFlags.length > 0) {
+      crossSystemTensionSubjectCount += 1
+    }
+  }
 
   const recordViews = records.map((record) => {
     const tradeoff = projectContainmentCareTradeoff(record)
@@ -193,7 +235,10 @@ export function getCoerciveContainedPersonProtocolMirrorView(
       contradictionFlaggedCount += 1
     }
 
-    return toRecordView(record)
+    return toRecordView(
+      record,
+      tensionLabelsBySubject.get(record.subjectRef) ?? []
+    )
   })
 
   return Object.freeze({
@@ -203,6 +248,8 @@ export function getCoerciveContainedPersonProtocolMirrorView(
       stableContainmentDominatesCareCount,
       abusivePostureCount,
       contradictionFlaggedCount,
+      integratedHealthLinkedSubjectCount,
+      crossSystemTensionSubjectCount,
       week,
     }),
     records: Object.freeze(recordViews),

--- a/src/features/report/reportNoteView.test.ts
+++ b/src/features/report/reportNoteView.test.ts
@@ -58,6 +58,7 @@ const EXPECTED_CATEGORY_BY_TYPE = {
   'hub.rumor': 'system',
   'information_intake.verification': 'information_intake',
   'information_intake.naming_hazard_cross_link': 'information_intake',
+  'coercive_protocol.integrated_health_reconciliation': 'system',
   'post_incident_review.follow_on': 'post_incident_review',
   'post_incident_review.closeout_reward_payout': 'post_incident_review',
 } satisfies Record<ReportNoteType, ReportNoteCategory>

--- a/src/features/report/reportNoteView.ts
+++ b/src/features/report/reportNoteView.ts
@@ -46,6 +46,7 @@ const RECRUITMENT_NOTE_TYPES: ReportNoteType[] = [
 ]
 
 const SYSTEM_NOTE_TYPES: ReportNoteType[] = [
+  'coercive_protocol.integrated_health_reconciliation',
   'system.week_delta',
   'system.party_cards_drawn',
   'system.equipment_recovered',

--- a/src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE } from '../domain/coerciveContainedPersonProtocolRegistry'
+import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek coercive protocol integrated health reconciliation integration (SPE-2429 slice 2)', () => {
+  it('surfaces cross-reconciliation notes when linked fixtures coexist', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    state.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const reconciliationNotes =
+      weeklyReport?.notes?.filter(
+        (note) => note.type === 'coercive_protocol.integrated_health_reconciliation'
+      ) ?? []
+
+    expect(reconciliationNotes.length).toBeGreaterThan(0)
+    expect(reconciliationNotes[0]?.content).toContain('Coercive protocol cross-link')
+    expect(reconciliationNotes[0]?.content).toContain('subject:cooperative-field-asset-22')
+  })
+
+  it('is a no-op when either map is empty', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const reconciliationNotes =
+      weeklyReport?.notes?.filter(
+        (note) => note.type === 'coercive_protocol.integrated_health_reconciliation'
+      ) ?? []
+
+    expect(reconciliationNotes).toEqual([])
+  })
+})

--- a/src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts
+++ b/src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+import {
+  composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries,
+  formatCoerciveProtocolCrossLinkLabel,
+  formatCoerciveProtocolIntegratedHealthReconciliationNoteContent,
+  formatCrossSystemTensionFlagLabel,
+  formatIntegratedHealthBundleCrossLinkLabel,
+} from '../domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing'
+import { composeCoerciveProtocolIntegratedHealthReconciliation } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliation'
+import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
+import { buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes'
+
+const SURVEILLANCE_PROTOCOLS = {
+  [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+    ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+}
+
+const SURVEILLANCE_BUNDLES = {
+  [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+    INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+}
+
+describe('coerciveProtocolIntegratedHealthCrossReconciliationSurfacing (SPE-2429 slice 2)', () => {
+  it('formats cross-link labels from persisted record and bundle fields', () => {
+    expect(
+      formatCoerciveProtocolCrossLinkLabel(ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE)
+    ).toBe(
+      `${ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id} (${ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.label})`
+    )
+    expect(
+      formatIntegratedHealthBundleCrossLinkLabel(INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE)
+    ).toBe(
+      `${INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.id} (${INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.label})`
+    )
+    expect(formatCrossSystemTensionFlagLabel('surveillance_burden_stable_mental_state')).toBe(
+      'Surveillance Burden Stable Mental State'
+    )
+  })
+
+  it('returns no summaries for empty maps without throw', () => {
+    expect(
+      composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+        protocols: undefined,
+        bundles: undefined,
+      })
+    ).toEqual([])
+    expect(
+      composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+        protocols: {},
+        bundles: {},
+      })
+    ).toEqual([])
+  })
+
+  it('builds weekly report notes when linked maps coexist', () => {
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      SURVEILLANCE_PROTOCOLS,
+      SURVEILLANCE_BUNDLES,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef
+    )
+
+    const notes = buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+      nextProtocols: SURVEILLANCE_PROTOCOLS,
+      nextBundles: SURVEILLANCE_BUNDLES,
+      week: 3,
+      sequenceStart: 1,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.type).toBe('coercive_protocol.integrated_health_reconciliation')
+    expect(notes[0]?.content).toBe(
+      formatCoerciveProtocolIntegratedHealthReconciliationNoteContent({
+        summary,
+        protocols: SURVEILLANCE_PROTOCOLS,
+        bundles: SURVEILLANCE_BUNDLES,
+      })
+    )
+    expect(notes[0]?.content).toContain('Coercive protocol cross-link')
+    expect(notes[0]?.content).toContain('subject:cooperative-field-asset-22')
+    expect(notes[0]?.content).toContain('Surveillance Burden Stable Mental State')
+  })
+
+  it('returns no weekly notes when either map is empty', () => {
+    expect(
+      buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+        nextProtocols: SURVEILLANCE_PROTOCOLS,
+        nextBundles: {},
+        week: 3,
+        sequenceStart: 1,
+      })
+    ).toEqual([])
+    expect(
+      buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+        nextProtocols: {},
+        nextBundles: SURVEILLANCE_BUNDLES,
+        week: 3,
+        sequenceStart: 1,
+      })
+    ).toEqual([])
+  })
+})

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -58,6 +58,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
     producer: 'informationIntakeNamingHazardCrossLinkWeeklyReportNotes',
     category: 'information_intake',
   },
+  'coercive_protocol.integrated_health_reconciliation': {
+    status: 'active',
+    producer: 'coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes',
+    category: 'system',
+  },
   'post_incident_review.follow_on': {
     status: 'active',
     producer: 'postIncidentReviewFollowOnWeeklyReportNotes',
@@ -79,7 +84,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(42)
+    expect(entries).toHaveLength(43)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Surface `composeAllCoerciveProtocolIntegratedHealthReconciliations` output as read-only labels in the coercive protocol mirror (per-record cross-system tension flags + summary counts) and weekly report notes (`coercive_protocol.integrated_health_reconciliation`).
- Follows the SPE-2406 naming-hazard cross-link surfacing pattern; no changes to SPE-2428 compose contracts or contradiction-check evaluators.
- Chose surfacing over SPE-848 anchor slice because surveillance-tuning registry has no runtime anchor yet.

## Linear

- **Slice:** [SPE-2429](https://linear.app/spectranoir/issue/SPE-2429) — Coercive protocol ↔ integrated health bundle cross-reconciliation surfacing (slice 2)
- **Parent:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)
- **Prior slice:** [SPE-2428](https://linear.app/spectranoir/issue/SPE-2428) (compose, shipped PR #2727)

## What shipped

- `coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts` + weekly report notes module
- Coercive protocol mirror tension-flag surfacing + page UI
- `advanceWeek` integration; report note type + runTransfer wiring

## Validation

- `npm run lint`
- `npm run test:run -- src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts`

## Docs updated

- `planning/spe-1908-cross-system-reconciliation-slice-2.md`
- `planning/backlog.md`

## Parent status

SPE-1908 remains open for deferred SPE-848 / SPE-1615 cross-joins when runtime anchors exist.