### PR TITLE
feat(SPE-2430): surveillance-tuning cross-join in cross-reconciliation compose

### DIFF
--- a/planning/spe-1908-cross-system-reconciliation-slice-3.md
+++ b/planning/spe-1908-cross-system-reconciliation-slice-3.md
@@ -1,0 +1,76 @@
+# SPE-1908 — Coercive protocol ↔ integrated health bundle cross-reconciliation surveillance-tuning cross-join (slice 3)
+
+One-page implementation plan. Linear: [SPE-2430](https://linear.app/spectranoir/issue/SPE-2430) (child under [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)). Follows shipped slice 2 (`planning/spe-1908-cross-system-reconciliation-slice-2.md`, PR #2729 / [SPE-2429](https://linear.app/spectranoir/issue/SPE-2429)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2430 — Surveillance-tuning cross-join in compose (slice 3)](https://linear.app/spectranoir/issue/SPE-2430) |
+| **Status** | Ready for PR                                                                                               |
+| **Parent** | [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — surveillance-isolation contradiction check umbrella |
+| **Branch** | `spe-1908-cross-system-reconciliation-slice-3`                                                           |
+| **Base `main` SHA** | `fdf4cdfc`                                                                                          |
+
+## Goal
+
+Extend `composeCoerciveProtocolIntegratedHealthReconciliation` with surveillance-tuning registry projections once a runtime [SPE-848](https://linear.app/spectranoir/issue/SPE-848) anchor exists — third wire-up slice for broader SPE-1908 cross-system reconciliation.
+
+## Prerequisite (shipped in same PR)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Cross-reconciliation compose | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` (SPE-2428) |
+| Cross-reconciliation surfacing | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts` (SPE-2429) |
+| Surveillance tuning registry anchor | `src/domain/surveillanceCapacityInterventionTuningRegistry.ts` (SPE-848 slice 1) |
+
+## Cross-reconciliation contract (slice 3)
+
+- **Match** — `surveillanceInterventionTuningRecord.subjectRef` ↔ protocol/bundle subject ref when protocol–bundle links exist.
+- **Hydrated truth only** — compose over validated tuning entries; skip invalid drops without re-surfacing.
+- **Projections** — `projectSurveillanceInterventionTuningReview` exposes monitoring-vs-contact separation and sustained-under-collateral-strain signals.
+- **Tension flags** — when `surveillance_isolation_burden` in protocol risk review and tuning projection shows `monitoringExceedsContact` or `sustainedUnderCollateralStrain`.
+- **Backward compatible** — optional fourth `surveillanceTuningRecords` map arg; slice 1–2 compose without tuning unchanged.
+- **Empty maps** — zeroed tuning fields without throw.
+- **Byte-stable ordering** — tuning ids, projections, tension flags sorted on repeat.
+- **Redaction** — merge per-record `redactedFields` / `unknownFields`; no hidden truth beyond registry projections.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `surveillanceCapacityInterventionTuningRegistry.ts` anchor           | GameState persistence for tuning records      |
+| Compose cross-join + tuning tension flags                          | Contradiction-check evaluator changes           |
+| Targeted registry + compose tests                                  | Surfacing changes (generic tension label helper covers new flags) |
+| Slice doc (this file) + backlog handoff                            | SPE-1615 psychological resilience cross-join  |
+|                                                                    | Faction ethics links (SPE-1047 / SPE-1131)    |
+|                                                                    | SPE-1908 parent re-closure                    |
+
+## Acceptance
+
+- [x] SPE-848 registry anchor validates subject-22 fixture and projects monitoring/contact separation
+- [x] Compose cross-joins tuning record with abusive surveillance + subject-22 bundle fixture
+- [x] New tuning tension flags appear when protocol has surveillance-isolation burden
+- [x] Empty / missing tuning maps no-op without throw; slice 1–2 regression unchanged
+- [x] Slice 2 surfacing regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/surveillanceCapacityInterventionTuningRegistry.ts`, `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` |
+| Tests  | `src/test/surveillanceCapacityInterventionTuningRegistry.test.ts`, `src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts` |
+| Plan   | `planning/spe-1908-cross-system-reconciliation-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-848 GameState persistence + advanceWeek hook | SPE-848 | Registry anchor only in slice 3 |
+| SPE-1615 psychological resilience cross-join | SPE-1615 | No runtime registry anchor yet |
+| Surveillance-tuning surfacing in mirror / weekly notes | SPE-2430 follow-up | Out of compose-only boundary |
+| SPE-1908 parent closure | SPE-1908 | Multi-owner reconciliation AC not met |
+
+## See also
+
+- `planning/spe-1908-cross-system-reconciliation-slice-1.md`
+- `planning/spe-1908-cross-system-reconciliation-slice-2.md`

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
@@ -1,10 +1,11 @@
 /**
- * SPE-1908 / SPE-2428 slice 1: coercive protocol ↔ integrated health bundle
- * cross-system reconciliation compose.
+ * SPE-1908 / SPE-2428 slice 1 + SPE-2430 slice 3: coercive protocol ↔ integrated
+ * health bundle cross-system reconciliation compose.
  *
- * Pure deterministic linkage between persisted coercive protocol records and
- * integrated health bundles via shared subject refs — reuses registry projections
- * only; no new reconciliation engine or hidden truth beyond hydrated maps.
+ * Pure deterministic linkage between persisted coercive protocol records,
+ * integrated health bundles, and surveillance-tuning records via shared subject
+ * refs — reuses registry projections only; no new reconciliation engine or
+ * hidden truth beyond hydrated maps.
  */
 
 import {
@@ -23,6 +24,13 @@ import {
   type MentalStateBand,
   type TherapeuticCareScheduleLink,
 } from './containedPersonIntegratedHealthBundleRegistry'
+import {
+  projectSurveillanceInterventionTuningReview,
+  validateSurveillanceInterventionTuningRecord,
+  type SurveillanceInterventionTuningProjection,
+  type SurveillanceInterventionTuningRecord,
+  type SurveillanceInterventionTuningRecordsMap,
+} from './surveillanceCapacityInterventionTuningRegistry'
 
 export type CoerciveProtocolIntegratedHealthMatchKind = 'subject_ref'
 
@@ -38,14 +46,25 @@ export type CoerciveProtocolCrossSystemTensionFlag =
   | 'surveillance_burden_no_active_contact_channel'
   | 'surveillance_burden_low_humane_care_risk'
   | 'monitoring_substitutes_contact_signal'
+  | 'surveillance_tuning_monitoring_exceeds_contact'
+  | 'surveillance_tuning_sustained_under_collateral_strain'
+
+export interface CoerciveProtocolSurveillanceTuningCrossLink {
+  readonly surveillanceTuningId: string
+  readonly subjectRef: string
+  readonly matchKind: CoerciveProtocolIntegratedHealthMatchKind
+}
 
 export interface CoerciveProtocolIntegratedHealthReconciliationSummary {
   readonly subjectRef: string
   readonly links: readonly CoerciveProtocolIntegratedHealthCrossLink[]
+  readonly surveillanceTuningLinks: readonly CoerciveProtocolSurveillanceTuningCrossLink[]
   readonly linkedProtocolCount: number
   readonly linkedBundleCount: number
+  readonly linkedTuningCount: number
   readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
   readonly triggeredContradictionChecks: readonly CoerciveProtocolContradictionCheckResult[]
+  readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
   readonly bundleMentalStateBand: MentalStateBand | null
   readonly bundleHumaneCareRiskScore: number | null
   readonly bundleTherapeuticChannelStates: readonly TherapeuticCareScheduleLink['channelState'][]
@@ -67,6 +86,12 @@ function isHydratedIntegratedHealthBundle(
   bundle: ContainedPersonIntegratedHealthBundle
 ): boolean {
   return validateContainedPersonIntegratedHealthBundle(bundle).valid
+}
+
+function isHydratedSurveillanceInterventionTuningRecord(
+  record: SurveillanceInterventionTuningRecord
+): boolean {
+  return validateSurveillanceInterventionTuningRecord(record).valid
 }
 
 function mergeUnknownFields(
@@ -100,6 +125,24 @@ function listHydratedProtocolsForSubject(
       (record) =>
         normalizeToken(record.subjectRef) === normalizedSubjectRef &&
         isHydratedCoerciveProtocolRecord(record)
+    )
+    .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function listHydratedSurveillanceTuningRecordsForSubject(
+  records: SurveillanceInterventionTuningRecordsMap | undefined,
+  subjectRef: string
+): SurveillanceInterventionTuningRecord[] {
+  const normalizedSubjectRef = normalizeToken(subjectRef)
+  if (!normalizedSubjectRef) {
+    return []
+  }
+
+  return Object.values(records ?? {})
+    .filter(
+      (record) =>
+        normalizeToken(record.subjectRef) === normalizedSubjectRef &&
+        isHydratedSurveillanceInterventionTuningRecord(record)
     )
     .sort((left, right) => left.id.localeCompare(right.id))
 }
@@ -148,7 +191,7 @@ function hasActiveTherapeuticContactChannel(
   )
 }
 
-function collectCrossSystemTensionFlags(input: {
+function collectBundleCrossSystemTensionFlags(input: {
   readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
   readonly bundle: ContainedPersonIntegratedHealthBundle | null
 }): readonly CoerciveProtocolCrossSystemTensionFlag[] {
@@ -180,6 +223,50 @@ function collectCrossSystemTensionFlags(input: {
   return Object.freeze([...new Set(flags)].sort((left, right) => left.localeCompare(right)))
 }
 
+function collectSurveillanceTuningCrossSystemTensionFlags(input: {
+  readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
+  readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
+}): readonly CoerciveProtocolCrossSystemTensionFlag[] {
+  if (!hasSurveillanceIsolationBurden(input.protocolRiskReviews)) {
+    return Object.freeze([])
+  }
+
+  const flags: CoerciveProtocolCrossSystemTensionFlag[] = []
+
+  for (const projection of input.surveillanceTuningProjections) {
+    if (projection.monitoringExceedsContact) {
+      flags.push('surveillance_tuning_monitoring_exceeds_contact')
+    }
+
+    if (projection.sustainedUnderCollateralStrain) {
+      flags.push('surveillance_tuning_sustained_under_collateral_strain')
+    }
+  }
+
+  return Object.freeze([...new Set(flags)].sort((left, right) => left.localeCompare(right)))
+}
+
+function collectCrossSystemTensionFlags(input: {
+  readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
+  readonly bundle: ContainedPersonIntegratedHealthBundle | null
+  readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
+}): readonly CoerciveProtocolCrossSystemTensionFlag[] {
+  return Object.freeze(
+    [
+      ...collectBundleCrossSystemTensionFlags({
+        protocolRiskReviews: input.protocolRiskReviews,
+        bundle: input.bundle,
+      }),
+      ...collectSurveillanceTuningCrossSystemTensionFlags({
+        protocolRiskReviews: input.protocolRiskReviews,
+        surveillanceTuningProjections: input.surveillanceTuningProjections,
+      }),
+    ]
+      .filter((flag, index, flags) => flags.indexOf(flag) === index)
+      .sort((left, right) => left.localeCompare(right))
+  )
+}
+
 export function listCoerciveProtocolsForIntegratedHealthSubject(
   protocols: CoerciveProtocolRecordsMap | undefined,
   subjectRef: string
@@ -194,14 +281,26 @@ export function resolveIntegratedHealthBundleForSubject(
   return resolveHydratedBundleForSubject(bundles, subjectRef)
 }
 
+export function listSurveillanceInterventionTuningRecordsForSubject(
+  records: SurveillanceInterventionTuningRecordsMap | undefined,
+  subjectRef: string
+): SurveillanceInterventionTuningRecord[] {
+  return listHydratedSurveillanceTuningRecordsForSubject(records, subjectRef)
+}
+
 export function composeCoerciveProtocolIntegratedHealthReconciliation(
   protocols: CoerciveProtocolRecordsMap | undefined,
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
-  subjectRef: string
+  subjectRef: string,
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
 ): CoerciveProtocolIntegratedHealthReconciliationSummary {
   const normalizedSubjectRef = normalizeToken(subjectRef) || '(unknown)'
   const protocolRecords = listHydratedProtocolsForSubject(protocols, normalizedSubjectRef)
   const bundle = resolveHydratedBundleForSubject(bundles, normalizedSubjectRef)
+  const tuningRecords = listHydratedSurveillanceTuningRecordsForSubject(
+    surveillanceTuningRecords,
+    normalizedSubjectRef
+  )
 
   const protocolRiskReviews = Object.freeze(
     protocolRecords.map((record) => projectCoerciveProtocolRiskReview(record))
@@ -220,13 +319,28 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
       })
   )
 
+  const surveillanceTuningProjections = Object.freeze(
+    tuningRecords.map((record) => projectSurveillanceInterventionTuningReview(record))
+  )
+
   const links: CoerciveProtocolIntegratedHealthCrossLink[] = []
+  const surveillanceTuningLinks: CoerciveProtocolSurveillanceTuningCrossLink[] = []
 
   if (bundle) {
     for (const record of protocolRecords) {
       links.push({
         coerciveProtocolId: record.id,
         integratedHealthBundleId: bundle.id,
+        subjectRef: normalizedSubjectRef,
+        matchKind: 'subject_ref',
+      })
+    }
+  }
+
+  if (bundle && tuningRecords.length > 0) {
+    for (const tuningRecord of tuningRecords) {
+      surveillanceTuningLinks.push({
+        surveillanceTuningId: tuningRecord.id,
         subjectRef: normalizedSubjectRef,
         matchKind: 'subject_ref',
       })
@@ -247,43 +361,63 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
     return left.integratedHealthBundleId.localeCompare(right.integratedHealthBundleId)
   })
 
+  surveillanceTuningLinks.sort((left, right) => {
+    const bySubject = left.subjectRef.localeCompare(right.subjectRef)
+    if (bySubject !== 0) {
+      return bySubject
+    }
+
+    return left.surveillanceTuningId.localeCompare(right.surveillanceTuningId)
+  })
+
   const crossSystemTensionFlags = collectCrossSystemTensionFlags({
     protocolRiskReviews,
     bundle,
+    surveillanceTuningProjections,
   })
 
   const linkedProtocolIds = new Set(links.map((link) => link.coerciveProtocolId))
+  const linkedTuningIds = new Set(surveillanceTuningLinks.map((link) => link.surveillanceTuningId))
   const structuredReasons = [
     `subject:${normalizedSubjectRef}`,
     `link_count:${links.length}`,
     `linked_protocol_count:${linkedProtocolIds.size}`,
     `linked_bundle_count:${bundle ? 1 : 0}`,
+    `linked_tuning_count:${linkedTuningIds.size}`,
     `triggered_contradiction_check_count:${triggeredContradictionChecks.length}`,
     `cross_system_tension_count:${crossSystemTensionFlags.length}`,
     links.some((link) => link.matchKind === 'subject_ref') ? 'match:subject_ref' : 'match:none_subject_ref',
+    surveillanceTuningLinks.length > 0 ? 'tuning:linked' : 'tuning:none',
     crossSystemTensionFlags.length > 0 ? 'tension:present' : 'tension:none',
   ].sort((left, right) => left.localeCompare(right))
 
   const redacted =
     protocolRecords.some((record) => (record.redactedFields ?? []).length > 0) ||
     (bundle?.redactedFields ?? []).length > 0 ||
+    tuningRecords.some((record) => (record.redactedFields ?? []).length > 0) ||
     protocolRiskReviews.some((review) => review.redacted) ||
-    triggeredContradictionChecks.some((check) => check.redacted)
+    triggeredContradictionChecks.some((check) => check.redacted) ||
+    surveillanceTuningProjections.some((projection) => projection.redacted)
 
   const unknownFields = mergeUnknownFields(
     ...protocolRecords.map((record) => record.unknownFields),
     bundle?.unknownFields,
+    ...tuningRecords.map((record) => record.unknownFields),
     ...protocolRiskReviews.map((review) => review.unknownFields),
-    ...triggeredContradictionChecks.map((check) => check.unknownFields)
+    ...triggeredContradictionChecks.map((check) => check.unknownFields),
+    ...surveillanceTuningProjections.map((projection) => projection.unknownFields)
   )
 
   return Object.freeze({
     subjectRef: normalizedSubjectRef,
     links: Object.freeze(links),
+    surveillanceTuningLinks: Object.freeze(surveillanceTuningLinks),
     linkedProtocolCount: linkedProtocolIds.size,
     linkedBundleCount: bundle ? 1 : 0,
+    linkedTuningCount: linkedTuningIds.size,
     protocolRiskReviews,
     triggeredContradictionChecks,
+    surveillanceTuningProjections,
     bundleMentalStateBand: bundle?.mentalStateBand ?? null,
     bundleHumaneCareRiskScore: bundle?.humaneCareRiskScore ?? null,
     bundleTherapeuticChannelStates: collectTherapeuticChannelStates(bundle),
@@ -297,7 +431,8 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
 /** Compose reconciliation summaries for every subject ref with protocol–bundle links. */
 export function composeAllCoerciveProtocolIntegratedHealthReconciliations(
   protocols: CoerciveProtocolRecordsMap | undefined,
-  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+  bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
 ): readonly CoerciveProtocolIntegratedHealthReconciliationSummary[] {
   const subjectRefs = new Set<string>()
 
@@ -316,7 +451,12 @@ export function composeAllCoerciveProtocolIntegratedHealthReconciliations(
     [...subjectRefs]
       .sort((left, right) => left.localeCompare(right))
       .map((subjectRef) =>
-        composeCoerciveProtocolIntegratedHealthReconciliation(protocols, bundles, subjectRef)
+        composeCoerciveProtocolIntegratedHealthReconciliation(
+          protocols,
+          bundles,
+          subjectRef,
+          surveillanceTuningRecords
+        )
       )
       .filter((summary) => summary.links.length > 0)
   )

--- a/src/domain/surveillanceCapacityInterventionTuningRegistry.ts
+++ b/src/domain/surveillanceCapacityInterventionTuningRegistry.ts
@@ -1,0 +1,594 @@
+/**
+ * SPE-848 slice 1: surveillance and capacity intervention tuning registry anchor.
+ *
+ * Pure deterministic registry separating surveillance signal from meaningful contact
+ * and tracking intervention level, collateral strain, and horizon outcomes — distinct
+ * from coercive protocol registry (SPE-1882) and integrated health bundles (SPE-1889).
+ */
+
+import {
+  BRANDED_OBJECT_NUMBER_PATTERN,
+  FRANCHISE_TOKEN_PATTERN,
+} from './containedPersonTherapeuticCareRegistry'
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type SurveillanceInterventionTuningId = string
+
+export type InterventionLevel = 'relaxed' | 'sustained' | 'escalated' | 'alternative_support'
+
+export const INTERVENTION_LEVELS: readonly InterventionLevel[] = [
+  'relaxed',
+  'sustained',
+  'escalated',
+  'alternative_support',
+] as const
+
+export type InterventionHorizonOutcome =
+  | 'elevated_isolation_pressure'
+  | 'compliance_metric_stable'
+  | 'legitimacy_erosion_risk'
+  | 'collateral_strain_elevated'
+  | 'contact_recovery_signal'
+
+export const INTERVENTION_HORIZON_OUTCOMES: readonly InterventionHorizonOutcome[] = [
+  'elevated_isolation_pressure',
+  'compliance_metric_stable',
+  'legitimacy_erosion_risk',
+  'collateral_strain_elevated',
+  'contact_recovery_signal',
+] as const
+
+export type InterventionHorizonBand = 'short' | 'medium' | 'long'
+
+export const INTERVENTION_HORIZON_BANDS: readonly InterventionHorizonBand[] = [
+  'short',
+  'medium',
+  'long',
+] as const
+
+export interface InterventionHorizonOutcomes {
+  readonly short?: InterventionHorizonOutcome
+  readonly medium?: InterventionHorizonOutcome
+  readonly long?: InterventionHorizonOutcome
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface SurveillanceInterventionTuningRecord {
+  readonly id: SurveillanceInterventionTuningId
+  readonly label: string
+  readonly summary?: string
+  readonly subjectRef: string
+  readonly currentInterventionLevel: InterventionLevel
+  readonly surveillanceSignalScore: number
+  readonly meaningfulContactScore: number
+  readonly healthcareLoadScore?: number | null
+  readonly collateralStrainScore?: number | null
+  readonly horizonOutcomes?: InterventionHorizonOutcomes
+  readonly tuningRationaleRef?: string
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type SurveillanceInterventionTuningValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_subject_ref'
+  | 'invalid_intervention_level'
+  | 'invalid_surveillance_signal_score'
+  | 'invalid_meaningful_contact_score'
+  | 'invalid_healthcare_load_score'
+  | 'invalid_collateral_strain_score'
+  | 'invalid_confidence'
+  | 'invalid_horizon_outcome'
+  | 'relaxed_under_high_surveillance_without_rationale'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_field'
+
+export interface SurveillanceInterventionTuningValidationIssue {
+  readonly code: SurveillanceInterventionTuningValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface SurveillanceInterventionTuningValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly SurveillanceInterventionTuningValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Projection
+// ---------------------------------------------------------------------------
+
+export interface SurveillanceInterventionTuningProjectionPolicy {
+  readonly minimumConfidence?: number
+  readonly redactUnknown?: boolean
+  readonly highSurveillanceThreshold?: number
+  readonly lowContactThreshold?: number
+}
+
+export interface SurveillanceInterventionTuningProjection {
+  readonly recordId: SurveillanceInterventionTuningId
+  readonly label: string
+  readonly subjectRef: string
+  readonly currentInterventionLevel: InterventionLevel
+  readonly surveillanceSignalScore: number | null
+  readonly meaningfulContactScore: number | null
+  readonly collateralStrainScore: number | null
+  readonly monitoringExceedsContact: boolean
+  readonly sustainedUnderCollateralStrain: boolean
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const INTERVENTION_LEVEL_SET = new Set<string>(INTERVENTION_LEVELS)
+const HORIZON_OUTCOME_SET = new Set<string>(INTERVENTION_HORIZON_OUTCOMES)
+
+const DEFAULT_HIGH_SURVEILLANCE_THRESHOLD = 0.65
+const DEFAULT_LOW_CONTACT_THRESHOLD = 0.25
+const DEFAULT_HIGH_COLLATERAL_STRAIN_THRESHOLD = 0.55
+
+const SUSTAINED_INTERVENTION_LEVELS: ReadonlySet<InterventionLevel> = new Set([
+  'sustained',
+  'escalated',
+])
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return Object.freeze(
+    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function pushIssue(
+  issues: SurveillanceInterventionTuningValidationIssue[],
+  issue: SurveillanceInterventionTuningValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: SurveillanceInterventionTuningValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function clampUnit(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+function roundUnit(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.round(clampUnit(value) * 1000) / 1000
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function freezeValidationResult(
+  issues: SurveillanceInterventionTuningValidationIssue[]
+): SurveillanceInterventionTuningValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function scanForbiddenTokens(
+  issues: SurveillanceInterventionTuningValidationIssue[],
+  id: string,
+  label: string,
+  record: SurveillanceInterventionTuningRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const stringFields: Array<{ field: string; value: string | undefined }> = [
+    { field: 'summary', value: record.summary },
+    { field: 'subjectRef', value: record.subjectRef },
+    { field: 'tuningRationaleRef', value: record.tuningRationaleRef },
+  ]
+
+  for (const { field, value } of stringFields) {
+    const token = normalizeToken(value ?? '')
+    if (!token) {
+      continue
+    }
+
+    if (containsFranchiseToken(token)) {
+      pushIssue(issues, {
+        code: 'franchise_token_in_field',
+        severity: 'error',
+        detail: `Surveillance intervention tuning record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (containsBrandedObjectNumber(token)) {
+      pushIssue(issues, {
+        code: 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Surveillance intervention tuning record ${id || '(unknown)'} field ${field} contains a branded object number.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+}
+
+function resolveOptionalUnitScore(
+  record: SurveillanceInterventionTuningRecord,
+  field: keyof SurveillanceInterventionTuningRecord,
+  policy: SurveillanceInterventionTuningProjectionPolicy
+): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (redactedFields.has(field)) {
+    return null
+  }
+
+  if (policy.redactUnknown === true && unknownFields.includes(field)) {
+    return null
+  }
+
+  const value = record[field]
+  if (value === undefined || value === null) {
+    return null
+  }
+
+  return isValidUnitScore(value) ? roundUnit(value) : null
+}
+
+function resolveConfidence(
+  record: SurveillanceInterventionTuningRecord,
+  policy: SurveillanceInterventionTuningProjectionPolicy
+): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (redactedFields.has('confidence')) {
+    return null
+  }
+
+  const confidence = record.confidence ?? null
+  if (
+    confidence !== null &&
+    policy.minimumConfidence !== undefined &&
+    confidence < policy.minimumConfidence
+  ) {
+    return null
+  }
+
+  if (policy.redactUnknown === true && unknownFields.includes('confidence')) {
+    return null
+  }
+
+  return confidence !== null && isValidUnitScore(confidence) ? roundUnit(confidence) : null
+}
+
+function isInterventionHorizonOutcome(value: unknown): value is InterventionHorizonOutcome {
+  return typeof value === 'string' && HORIZON_OUTCOME_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isInterventionLevel(value: unknown): value is InterventionLevel {
+  return typeof value === 'string' && INTERVENTION_LEVEL_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateSurveillanceInterventionTuningRecord(
+  record: SurveillanceInterventionTuningRecord
+): SurveillanceInterventionTuningValidationResult {
+  const issues: SurveillanceInterventionTuningValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const subjectRef = normalizeToken(record.subjectRef)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Surveillance intervention tuning record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Surveillance intervention tuning record is missing label.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!subjectRef) {
+    pushIssue(issues, {
+      code: 'missing_subject_ref',
+      severity: 'error',
+      detail: 'Surveillance intervention tuning record is missing subjectRef.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isInterventionLevel(record.currentInterventionLevel)) {
+    pushIssue(issues, {
+      code: 'invalid_intervention_level',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record ${id || '(unknown)'} has invalid currentInterventionLevel.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.surveillanceSignalScore)) {
+    pushIssue(issues, {
+      code: 'invalid_surveillance_signal_score',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record ${id || '(unknown)'} has invalid surveillanceSignalScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.meaningfulContactScore)) {
+    pushIssue(issues, {
+      code: 'invalid_meaningful_contact_score',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record ${id || '(unknown)'} has invalid meaningfulContactScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.healthcareLoadScore !== undefined &&
+    record.healthcareLoadScore !== null &&
+    !isValidUnitScore(record.healthcareLoadScore)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_healthcare_load_score',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record ${id || '(unknown)'} has invalid healthcareLoadScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.collateralStrainScore !== undefined &&
+    record.collateralStrainScore !== null &&
+    !isValidUnitScore(record.collateralStrainScore)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_collateral_strain_score',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record ${id || '(unknown)'} has invalid collateralStrainScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Surveillance intervention tuning record ${id || '(unknown)'} has invalid confidence.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const horizonOutcomes = record.horizonOutcomes
+  if (horizonOutcomes) {
+    for (const band of INTERVENTION_HORIZON_BANDS) {
+      const outcome = horizonOutcomes[band]
+      if (outcome !== undefined && !isInterventionHorizonOutcome(outcome)) {
+        pushIssue(issues, {
+          code: 'invalid_horizon_outcome',
+          severity: 'error',
+          detail: `Surveillance intervention tuning record ${id || '(unknown)'} has invalid ${band} horizon outcome.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+    }
+  }
+
+  if (
+    record.currentInterventionLevel === 'relaxed' &&
+    isValidUnitScore(record.surveillanceSignalScore) &&
+    record.surveillanceSignalScore >= DEFAULT_HIGH_SURVEILLANCE_THRESHOLD &&
+    !normalizeToken(record.tuningRationaleRef ?? '')
+  ) {
+    pushIssue(issues, {
+      code: 'relaxed_under_high_surveillance_without_rationale',
+      severity: 'warning',
+      detail: `Surveillance intervention tuning record ${id || '(unknown)'} is relaxed under high surveillance signal without tuningRationaleRef.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanForbiddenTokens(issues, id, label, record)
+
+  return freezeValidationResult(issues)
+}
+
+export function projectSurveillanceInterventionTuningReview(
+  record: SurveillanceInterventionTuningRecord,
+  policy: SurveillanceInterventionTuningProjectionPolicy = {}
+): SurveillanceInterventionTuningProjection {
+  const highSurveillanceThreshold =
+    typeof policy.highSurveillanceThreshold === 'number' &&
+    Number.isFinite(policy.highSurveillanceThreshold)
+      ? clampUnit(policy.highSurveillanceThreshold)
+      : DEFAULT_HIGH_SURVEILLANCE_THRESHOLD
+  const lowContactThreshold =
+    typeof policy.lowContactThreshold === 'number' && Number.isFinite(policy.lowContactThreshold)
+      ? clampUnit(policy.lowContactThreshold)
+      : DEFAULT_LOW_CONTACT_THRESHOLD
+
+  const surveillanceSignalScore = resolveOptionalUnitScore(
+    record,
+    'surveillanceSignalScore',
+    policy
+  )
+  const meaningfulContactScore = resolveOptionalUnitScore(record, 'meaningfulContactScore', policy)
+  const collateralStrainScore = resolveOptionalUnitScore(record, 'collateralStrainScore', policy)
+
+  const monitoringExceedsContact =
+    surveillanceSignalScore !== null &&
+    meaningfulContactScore !== null &&
+    surveillanceSignalScore >= highSurveillanceThreshold &&
+    meaningfulContactScore < lowContactThreshold
+
+  const sustainedUnderCollateralStrain =
+    SUSTAINED_INTERVENTION_LEVELS.has(record.currentInterventionLevel) &&
+    collateralStrainScore !== null &&
+    collateralStrainScore >= DEFAULT_HIGH_COLLATERAL_STRAIN_THRESHOLD
+
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = sortedStringArray(record.unknownFields)
+
+  return Object.freeze({
+    recordId: record.id,
+    label: record.label,
+    subjectRef: record.subjectRef,
+    currentInterventionLevel: record.currentInterventionLevel,
+    surveillanceSignalScore,
+    meaningfulContactScore,
+    collateralStrainScore,
+    monitoringExceedsContact,
+    sustainedUnderCollateralStrain,
+    confidence: resolveConfidence(record, policy),
+    redacted: redactedFields.size > 0,
+    unknownFields,
+  })
+}
+
+export type SurveillanceInterventionTuningRecordsMap = Record<
+  SurveillanceInterventionTuningId,
+  SurveillanceInterventionTuningRecord
+>
+
+/** Tuning record paired with abusive surveillance-isolation coercive protocol (subject-22). */
+export const SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE: SurveillanceInterventionTuningRecord =
+  Object.freeze({
+    id: 'surveillance-tuning:cooperative-field-asset-22',
+    label: 'Subject 22 surveillance intervention tuning',
+    summary:
+      'Sustained intervention under high surveillance signal and low meaningful contact with elevated collateral strain.',
+    subjectRef: 'subject:cooperative-field-asset-22',
+    currentInterventionLevel: 'sustained',
+    surveillanceSignalScore: 0.88,
+    meaningfulContactScore: 0.14,
+    healthcareLoadScore: 0.42,
+    collateralStrainScore: 0.71,
+    horizonOutcomes: Object.freeze({
+      short: 'elevated_isolation_pressure',
+      medium: 'compliance_metric_stable',
+      long: 'legitimacy_erosion_risk',
+    }),
+    tuningRationaleRef: 'tuning-rationale:surveillance-capacity-review-22',
+    confidence: 0.76,
+  })

--- a/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
+++ b/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
@@ -9,8 +9,13 @@ import {
   composeAllCoerciveProtocolIntegratedHealthReconciliations,
   composeCoerciveProtocolIntegratedHealthReconciliation,
   listCoerciveProtocolsForIntegratedHealthSubject,
+  listSurveillanceInterventionTuningRecordsForSubject,
   resolveIntegratedHealthBundleForSubject,
 } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliation'
+import {
+  SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+  validateSurveillanceInterventionTuningRecord,
+} from '../domain/surveillanceCapacityInterventionTuningRegistry'
 import {
   INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
   INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
@@ -26,12 +31,17 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliation (SPE-2428 slice 1)
     )
 
     expect(summary.links).toEqual([])
+    expect(summary.surveillanceTuningLinks).toEqual([])
     expect(summary.linkedProtocolCount).toBe(0)
     expect(summary.linkedBundleCount).toBe(0)
+    expect(summary.linkedTuningCount).toBe(0)
     expect(summary.protocolRiskReviews).toEqual([])
     expect(summary.triggeredContradictionChecks).toEqual([])
+    expect(summary.surveillanceTuningProjections).toEqual([])
     expect(summary.crossSystemTensionFlags).toEqual([])
     expect(summary.structuredReasons).toContain('link_count:0')
+    expect(summary.structuredReasons).toContain('linked_tuning_count:0')
+    expect(summary.structuredReasons).toContain('tuning:none')
     expect(summary.structuredReasons).toContain('tension:none')
   })
 
@@ -78,6 +88,49 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliation (SPE-2428 slice 1)
       'surveillance_burden_stable_mental_state',
     ])
     expect(summary.structuredReasons).toContain('tension:present')
+    expect(summary.structuredReasons).toContain('tuning:none')
+    expect(summary.linkedTuningCount).toBe(0)
+  })
+
+  it('cross-joins surveillance tuning record with protocol and bundle by subject ref', () => {
+    expect(validateSurveillanceInterventionTuningRecord(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE).valid).toBe(
+      true
+    )
+
+    const protocols = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    const surveillanceTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef,
+      surveillanceTuningRecords
+    )
+
+    expect(summary.linkedTuningCount).toBe(1)
+    expect(summary.surveillanceTuningLinks).toHaveLength(1)
+    expect(summary.surveillanceTuningLinks[0]?.matchKind).toBe('subject_ref')
+    expect(summary.surveillanceTuningProjections[0]?.monitoringExceedsContact).toBe(true)
+    expect(summary.surveillanceTuningProjections[0]?.sustainedUnderCollateralStrain).toBe(true)
+    expect(summary.crossSystemTensionFlags).toEqual([
+      'monitoring_substitutes_contact_signal',
+      'surveillance_burden_low_humane_care_risk',
+      'surveillance_burden_no_active_contact_channel',
+      'surveillance_burden_stable_mental_state',
+      'surveillance_tuning_monitoring_exceeds_contact',
+      'surveillance_tuning_sustained_under_collateral_strain',
+    ])
+    expect(summary.structuredReasons).toContain('linked_tuning_count:1')
+    expect(summary.structuredReasons).toContain('tuning:linked')
   })
 
   it('omits links when bundle is missing for a protocol subject', () => {
@@ -121,6 +174,17 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliation (SPE-2428 slice 1)
         ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef
       )?.id
     ).toBe(INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.id)
+
+    const tuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    expect(
+      listSurveillanceInterventionTuningRecordsForSubject(
+        tuningRecords,
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef
+      ).map((record) => record.id)
+    ).toEqual([SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id])
   })
 
   it('composeAll returns summaries in subject locale order with byte-stable repeat', () => {

--- a/src/test/surveillanceCapacityInterventionTuningRegistry.test.ts
+++ b/src/test/surveillanceCapacityInterventionTuningRegistry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  projectSurveillanceInterventionTuningReview,
+  SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+  validateSurveillanceInterventionTuningRecord,
+} from '../domain/surveillanceCapacityInterventionTuningRegistry'
+
+describe('surveillanceCapacityInterventionTuningRegistry (SPE-848 slice 1)', () => {
+  it('validates subject-22 fixture and projects monitoring/contact separation', () => {
+    const first = validateSurveillanceInterventionTuningRecord(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE)
+    const second = validateSurveillanceInterventionTuningRecord(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE)
+
+    expect(first.valid).toBe(true)
+    expect(first).toEqual(second)
+
+    const projection = projectSurveillanceInterventionTuningReview(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE)
+
+    expect(projection.monitoringExceedsContact).toBe(true)
+    expect(projection.sustainedUnderCollateralStrain).toBe(true)
+    expect(projection.surveillanceSignalScore).toBe(0.88)
+    expect(projection.meaningfulContactScore).toBe(0.14)
+    expect(projection.collateralStrainScore).toBe(0.71)
+  })
+
+  it('warns when relaxed under high surveillance without rationale ref', () => {
+    const record = {
+      ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+      id: 'surveillance-tuning:relaxed-without-rationale',
+      currentInterventionLevel: 'relaxed' as const,
+      tuningRationaleRef: undefined,
+    }
+
+    const result = validateSurveillanceInterventionTuningRecord(record)
+
+    expect(result.valid).toBe(true)
+    expect(result.issues.some((issue) => issue.code === 'relaxed_under_high_surveillance_without_rationale')).toBe(
+      true
+    )
+  })
+
+  it('rejects franchise tokens in label', () => {
+    const record = {
+      ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+      id: 'surveillance-tuning:invalid-franchise',
+      label: 'SCP division surveillance tuning',
+    }
+
+    const result = validateSurveillanceInterventionTuningRecord(record)
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Ships SPE-848 minimal registry anchor (\surveillanceCapacityInterventionTuningRegistry.ts\) with validation, projection, and subject-22 fixture.
- Extends \composeCoerciveProtocolIntegratedHealthReconciliation\ with optional surveillance-tuning cross-join by \subjectRef\, tuning projections, and two new cross-system tension flags.
- Backward compatible: slice 1-2 compose and surfacing unchanged when tuning map is omitted.

## Linear

- **Slice:** [SPE-2430](https://linear.app/spectranoir/issue/SPE-2430)
- **Parent:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)
- **Registry anchor:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) (minimal anchor in this PR; parent remains open)

## What shipped

- Registry anchor + compose cross-join + targeted tests
- Slice doc: \planning/spe-1908-cross-system-reconciliation-slice-3.md\

## Validation

- \
pm run test:run -- src/test/surveillanceCapacityInterventionTuningRegistry.test.ts src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts\
- \
pm run lint\

## Docs updated

- \planning/spe-1908-cross-system-reconciliation-slice-3.md\

## Parent status

SPE-1908 remains open (SPE-1615 psychological resilience cross-join and SPE-848 persistence deferred).

Made with [Cursor](https://cursor.com)