### PR TITLE
SPE-2431: surveillance tuning registry GameState persistence (slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) GameState persistence + advanceWeek hook for surveillance tuning registry, or [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience cross-join; broader SPE-1898 cross-system reconciliation. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) advanceWeek orchestration hook for surveillance tuning registry (post [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431) persistence), or [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience cross-join; broader SPE-1898 cross-system reconciliation. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `f24cc2e5` (shipped: [SPE-2430](https://linear.app/spectranoir/issue/SPE-2430) surveillance-tuning cross-join slice 3 @ PR #2731)
+**Base `main` SHA:** `94231fb3` (in progress: [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431) surveillance tuning registry persistence slice 2)
 
 **Recently shipped:** [SPE-2430](https://linear.app/spectranoir/issue/SPE-2430) surveillance-tuning cross-join slice 3 @ PR #2731; [SPE-2429](https://linear.app/spectranoir/issue/SPE-2429) cross-reconciliation surfacing slice 2 @ PR #2729; see `planning/spe-1908-cross-system-reconciliation-slice-3.md`.
 

--- a/planning/spe-848-surveillance-tuning-registry-slice-2.md
+++ b/planning/spe-848-surveillance-tuning-registry-slice-2.md
@@ -1,0 +1,65 @@
+# SPE-2431 — Surveillance tuning registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431) (child under [SPE-848](https://linear.app/spectranoir/issue/SPE-848)). Follows shipped slice 1 registry anchor (`src/domain/surveillanceCapacityInterventionTuningRegistry.ts`).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2431 — Surveillance tuning registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2431) |
+| **Parent** | [SPE-848](https://linear.app/spectranoir/issue/SPE-848) — Surveillance and capacity intervention tuning     |
+| **Branch** | `jamesdyedbq/spe-848-surveillance-tuning-registry-slice-2`                                                 |
+| **Status** | **Ready for PR**                                                                                           |
+| **Base `main` SHA** | `94231fb3`                                                                                          |
+
+## Goal
+
+Persist validated `SurveillanceInterventionTuningRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Mirror SPE-1882 / SPE-1886 slice 2 persistence pattern. Weekly orchestration hook deferred to a later slice.
+
+## Prerequisite (on `main` @ `94231fb3`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Tuning registry      | `src/domain/surveillanceCapacityInterventionTuningRegistry.ts` (SPE-848 slice 1) |
+| Fixture              | `SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE`                               |
+| Coercive persistence pattern | `sanitizeCoerciveProtocolRecords` in `coerciveContainedPersonProtocolRegistry.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `surveillanceInterventionTuningRecords` on `GameState`               | Weekly `advanceWeek` orchestration hook       |
+| `sanitizeSurveillanceInterventionTuningRecords` + `runTransfer` hydrate wire | Compose / contradiction evaluators / surfacing |
+| `validateSurveillanceInterventionTuningRecord` on hydrate; drop invalid, no throw | Full SPE-848 parent Done                 |
+| Default `{}` in `createStartingState`                              |                                               |
+| Persistence + advanceWeek preservation regression tests            |                                               |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] Owner refs (`subjectRef`, `tuningRationaleRef`) byte-stable after round-trip
+- [x] `advanceWeek` preserves tuning records unchanged
+- [x] Slice 1 registry tests unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/surveillanceCapacityInterventionTuningRegistry.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/surveillanceCapacityInterventionTuningRegistryPersistence.test.ts`, `src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts` |
+| Plan   | `planning/spe-848-surveillance-tuning-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Weekly orchestration hook in `advanceWeek` | SPE-848 slice 3+ | Persistence must land before orchestration |
+| Cross-system reconciliation compose wiring | SPE-1908 / SPE-2430 follow-ups | Populated maps not required for persistence |
+| Full SPE-848 parent Done | SPE-848 | Multiple slices remain |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-2.md` — persistence-only slice pattern
+- `planning/spe-1908-cross-system-reconciliation-slice-3.md` — surveillance-tuning cross-join (shipped)

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -212,6 +212,7 @@ import { sanitizeWelfareDebtAccountingRecords } from '../../domain/welfareDebtAc
 import { sanitizeCoerciveProtocolRecords, sanitizeCoerciveProtocolWeeklyProjectionSnapshots } from '../../domain/coerciveContainedPersonProtocolRegistry'
 import { sanitizeMedicationRegimenRecords } from '../../domain/containedPersonMedicationRegimenRegistry'
 import { sanitizeContainedPersonIntegratedHealthBundles } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
+import { sanitizeSurveillanceInterventionTuningRecords } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
 import { sanitizeVisualTriggerHazardRecords } from '../../domain/visualTriggerHazardRegistry'
 import {
   buildCandidateEvaluation,
@@ -8534,6 +8535,10 @@ export function hydrateGame(
     game.containedPersonIntegratedHealthBundles,
     fallback.containedPersonIntegratedHealthBundles ?? {}
   )
+  const surveillanceInterventionTuningRecords = sanitizeSurveillanceInterventionTuningRecords(
+    game.surveillanceInterventionTuningRecords,
+    fallback.surveillanceInterventionTuningRecords ?? {}
+  )
   const factions = hasPersistedFactions
     ? sanitizeFactionsMap(game.factions, fallback.factions)
     : fallback.factions
@@ -8673,6 +8678,7 @@ export function hydrateGame(
       coerciveContainedPersonProtocolWeeklyProjectionSnapshots,
       welfareDebtAccountingRecords,
       containedPersonIntegratedHealthBundles,
+      surveillanceInterventionTuningRecords,
       candidates,
       recruitmentPool,
       teams,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -61,6 +61,7 @@ const startingStateTemplate: GameState = {
   coerciveContainedPersonProtocolWeeklyProjectionSnapshots: {},
   welfareDebtAccountingRecords: {},
   containedPersonIntegratedHealthBundles: {},
+  surveillanceInterventionTuningRecords: {},
   factions: createInitialFactionState(),
 
   agency: {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -267,6 +267,7 @@ import type { CustodyStatusRecord } from './containedPersonCustodyStatusRegistry
 import type { MedicationRegimenRecord } from './containedPersonMedicationRegimenRegistry'
 import type { WelfareDebtAccountingRecord } from './welfareDebtAccountingRegistry'
 import type { ContainedPersonIntegratedHealthBundle } from './containedPersonIntegratedHealthBundleRegistry'
+import type { SurveillanceInterventionTuningRecord } from './surveillanceCapacityInterventionTuningRegistry'
 import type { VisualTriggerHazardRecord } from './visualTriggerHazardRegistry'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
@@ -2719,6 +2720,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   containedPersonIntegratedHealthBundles?: Record<string, ContainedPersonIntegratedHealthBundle>
+
+  /**
+   * SPE-848 slice 2: persisted surveillance intervention tuning records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  surveillanceInterventionTuningRecords?: Record<string, SurveillanceInterventionTuningRecord>
 
   /** Optional active compromised-authority runtime packet (SPE-746). */
   compromisedAuthority?: CompromisedAuthorityState

--- a/src/domain/surveillanceCapacityInterventionTuningRegistry.ts
+++ b/src/domain/surveillanceCapacityInterventionTuningRegistry.ts
@@ -571,6 +571,125 @@ export type SurveillanceInterventionTuningRecordsMap = Record<
   SurveillanceInterventionTuningRecord
 >
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  return sortedStringArray(value)
+}
+
+function sanitizeHorizonOutcomes(value: unknown): InterventionHorizonOutcomes | undefined {
+  if (!isPlainRecord(value)) {
+    return undefined
+  }
+
+  const next: Partial<InterventionHorizonOutcomes> = {}
+
+  for (const band of INTERVENTION_HORIZON_BANDS) {
+    const outcome = value[band]
+    if (outcome !== undefined && isInterventionHorizonOutcome(outcome)) {
+      next[band] = outcome
+    }
+  }
+
+  return Object.keys(next).length > 0 ? Object.freeze(next) : undefined
+}
+
+function sanitizeSurveillanceInterventionTuningRecordEntry(
+  value: unknown
+): SurveillanceInterventionTuningRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const subjectRef = normalizeToken(value.subjectRef)
+  const currentInterventionLevel = value.currentInterventionLevel
+  const surveillanceSignalScore = value.surveillanceSignalScore
+  const meaningfulContactScore = value.meaningfulContactScore
+
+  if (
+    !id ||
+    !label ||
+    !subjectRef ||
+    !isInterventionLevel(currentInterventionLevel) ||
+    !isValidUnitScore(surveillanceSignalScore) ||
+    !isValidUnitScore(meaningfulContactScore)
+  ) {
+    return null
+  }
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const healthcareLoadScore = value.healthcareLoadScore
+  const collateralStrainScore = value.collateralStrainScore
+  const horizonOutcomes = sanitizeHorizonOutcomes(value.horizonOutcomes)
+  const tuningRationaleRef = normalizeToken(value.tuningRationaleRef ?? '') || undefined
+  const confidence = value.confidence
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+
+  const record: SurveillanceInterventionTuningRecord = {
+    id,
+    label,
+    subjectRef,
+    currentInterventionLevel,
+    surveillanceSignalScore,
+    meaningfulContactScore,
+    ...(summary ? { summary } : {}),
+    ...(healthcareLoadScore === null
+      ? { healthcareLoadScore: null }
+      : isValidUnitScore(healthcareLoadScore)
+        ? { healthcareLoadScore }
+        : {}),
+    ...(collateralStrainScore === null
+      ? { collateralStrainScore: null }
+      : isValidUnitScore(collateralStrainScore)
+        ? { collateralStrainScore }
+        : {}),
+    ...(horizonOutcomes ? { horizonOutcomes } : {}),
+    ...(tuningRationaleRef ? { tuningRationaleRef } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateSurveillanceInterventionTuningRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical tuning map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeSurveillanceInterventionTuningRecords(
+  value: unknown,
+  fallback: SurveillanceInterventionTuningRecordsMap = {}
+): SurveillanceInterventionTuningRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: SurveillanceInterventionTuningRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeSurveillanceInterventionTuningRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 /** Tuning record paired with abusive surveillance-isolation coercive protocol (subject-22). */
 export const SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE: SurveillanceInterventionTuningRecord =
   Object.freeze({

--- a/src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts
+++ b/src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../domain/surveillanceCapacityInterventionTuningRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek surveillance intervention tuning records integration (SPE-848 slice 2)', () => {
+  it('preserves surveillance tuning records through advanceWeek without mutation', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.surveillanceInterventionTuningRecords).toEqual(
+      state.surveillanceInterventionTuningRecords
+    )
+  })
+
+  it('is a no-op for an empty tuning map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.surveillanceInterventionTuningRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.surveillanceInterventionTuningRecords).toEqual({})
+  })
+})

--- a/src/test/surveillanceCapacityInterventionTuningRegistryPersistence.test.ts
+++ b/src/test/surveillanceCapacityInterventionTuningRegistryPersistence.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+  sanitizeSurveillanceInterventionTuningRecords,
+  validateSurveillanceInterventionTuningRecord,
+} from '../domain/surveillanceCapacityInterventionTuningRegistry'
+
+describe('surveillanceCapacityInterventionTuningRegistry persistence (SPE-848 slice 2)', () => {
+  it('defaults starting state to an empty surveillance tuning map', () => {
+    expect(createStartingState().surveillanceInterventionTuningRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const altRecord = {
+      ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+      id: 'surveillance-tuning:alt-subject',
+      subjectRef: 'subject:alt',
+    }
+    const fallback = {}
+    const sanitized = sanitizeSurveillanceInterventionTuningRecords(
+      {
+        valid: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+        alt: altRecord,
+        'wrong-key': {
+          ...altRecord,
+          label: 'wrong map key should lose to canonical id entry',
+        },
+        duplicate: {
+          ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          subjectRef: 'subject:test',
+          currentInterventionLevel: 'unknown',
+          surveillanceSignalScore: 0.5,
+          meaningfulContactScore: 0.5,
+        },
+        franchiseLabel: {
+          ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+          id: 'surveillance-tuning:franchise',
+          label: 'SCP division surveillance tuning',
+        },
+        brandedObjectId: {
+          ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+          id: 'surveillance-tuning:scp-049',
+          label: 'Archive surveillance tuning',
+        },
+        outOfRangeScore: {
+          ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+          id: 'surveillance-tuning:out-of-range',
+          surveillanceSignalScore: 1.5,
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized[SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]).toEqual(
+      SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE
+    )
+    expect(sanitized[altRecord.id]).toEqual(altRecord)
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.franchiseLabel).toBeUndefined()
+    expect(sanitized.brandedObjectId).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['wrong-key']).toBeUndefined()
+    expect(sanitized.outOfRangeScore).toBeUndefined()
+    expect(Object.keys(sanitized).sort()).toEqual(
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id, altRecord.id].sort()
+    )
+  })
+
+  it('persists warning-only records that remain valid on hydrate', () => {
+    const warningOnly = {
+      ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+      id: 'surveillance-tuning:relaxed-without-rationale',
+      currentInterventionLevel: 'relaxed' as const,
+      tuningRationaleRef: undefined,
+    }
+
+    expect(validateSurveillanceInterventionTuningRecord(warningOnly).valid).toBe(true)
+
+    const sanitized = sanitizeSurveillanceInterventionTuningRecords(
+      { [warningOnly.id]: warningOnly },
+      {}
+    )
+
+    expect(sanitized[warningOnly.id]).toEqual(warningOnly)
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.surveillanceInterventionTuningRecords).toEqual(
+      state.surveillanceInterventionTuningRecords
+    )
+    expect(
+      loaded.surveillanceInterventionTuningRecords?.[SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]
+        ?.tuningRationaleRef
+    ).toBe(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.tuningRationaleRef)
+    expect(
+      loaded.surveillanceInterventionTuningRecords?.[SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]
+        ?.subjectRef
+    ).toBe(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.subjectRef)
+  })
+
+  it('hydrates persisted surveillance tuning records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        surveillanceInterventionTuningRecords: {
+          [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+          invalid: {
+            ...SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+            id: 'surveillance-tuning:invalid',
+            label: 'SCP division surveillance tuning',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.surveillanceInterventionTuningRecords).toEqual({
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    })
+  })
+
+  it('repeated sanitize is byte-stable for fixture records', () => {
+    const first = sanitizeSurveillanceInterventionTuningRecords(
+      { [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE },
+      {}
+    )
+    const second = sanitizeSurveillanceInterventionTuningRecords(first, {})
+
+    expect(second).toEqual(first)
+    expect(validateSurveillanceInterventionTuningRecord(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE)).toEqual(
+      validateSurveillanceInterventionTuningRecord(second[SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]!)
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Add `surveillanceInterventionTuningRecords` to `GameState` with `sanitizeSurveillanceInterventionTuningRecords` hydration (drops invalid/duplicate-id entries without throwing).
- Wire `runTransfer` hydrate and `createStartingState` default `{}`.
- Add persistence round-trip, import-parse, and `advanceWeek` preservation tests.

## Linear mapping

- **Slice:** [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431) — Surveillance tuning registry GameState persistence (slice 2)
- **Parent:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) — Surveillance and capacity intervention tuning (remains open)

## What shipped

- `sanitizeSurveillanceInterventionTuningRecords` in `surveillanceCapacityInterventionTuningRegistry.ts`
- `GameState.surveillanceInterventionTuningRecords` field + starting-state default
- `runTransfer` hydrate wire
- Persistence + advanceWeek preservation tests
- Slice doc: `planning/spe-848-surveillance-tuning-registry-slice-2.md`

## Validation

- `npm run test:run -- src/test/surveillanceCapacityInterventionTuningRegistryPersistence.test.ts src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts src/test/surveillanceCapacityInterventionTuningRegistry.test.ts`
- `npm run lint`

## Docs updated

- `planning/spe-848-surveillance-tuning-registry-slice-2.md`
- `planning/backlog.md`

## Parent status

SPE-848 remains **Backlog** — advanceWeek orchestration hook and broader tuning AC deferred to follow-up slices.