### PR TITLE
feat(SPE-2432): surveillance tuning weekly advanceWeek orchestration slice 3

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) advanceWeek orchestration hook for surveillance tuning registry (post [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431) persistence), or [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience cross-join; broader SPE-1898 cross-system reconciliation. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience registry slice 1 (cross-join follow-up from SPE-1908), or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `d112159d` — shipped: [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431) surveillance tuning registry persistence slice 2 @ PR #2733
+**Base `main` SHA:** `f272a1ba` — in progress: [SPE-2432](https://linear.app/spectranoir/issue/SPE-2432) surveillance tuning weekly orchestration slice 3 @ branch `spe-848-surveillance-tuning-weekly-hook-slice-3`
 
 **Recently shipped:** [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431) surveillance tuning registry persistence slice 2 @ PR #2733; [SPE-2430](https://linear.app/spectranoir/issue/SPE-2430) surveillance-tuning cross-join slice 3 @ PR #2731; see `planning/spe-848-surveillance-tuning-registry-slice-2.md`.
 

--- a/planning/spe-848-surveillance-tuning-registry-slice-3.md
+++ b/planning/spe-848-surveillance-tuning-registry-slice-3.md
@@ -1,0 +1,74 @@
+# SPE-2432 — Surveillance tuning registry weekly advanceWeek orchestration hook (slice 3)
+
+One-page implementation plan. Linear: [SPE-2432](https://linear.app/spectranoir/issue/SPE-2432) (child under [SPE-848](https://linear.app/spectranoir/issue/SPE-848)). Follows shipped slice 2 (`planning/spe-848-surveillance-tuning-registry-slice-2.md`, PR #2733 / [SPE-2431](https://linear.app/spectranoir/issue/SPE-2431)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2432 — Surveillance tuning registry weekly advanceWeek orchestration hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2432) |
+| **Parent** | [SPE-848](https://linear.app/spectranoir/issue/SPE-848) — Surveillance and capacity intervention tuning     |
+| **Branch** | `spe-848-surveillance-tuning-weekly-hook-slice-3`                                                          |
+| **Status** | **Shipped** — pending PR                                                                                   |
+| **Base `main` SHA** | `f272a1ba`                                                                                          |
+
+## Goal
+
+Wire persisted `surveillanceInterventionTuningRecords` into `advanceWeek` with a pure domain weekly tick: intervention-level transitions from surveillance/capacity/collateral signals and horizon outcome refresh under the current intervention frame.
+
+## Prerequisite (on `main` @ `f272a1ba`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Tuning registry      | `src/domain/surveillanceCapacityInterventionTuningRegistry.ts` (SPE-848 slice 1) |
+| Persistence          | `surveillanceInterventionTuningRecords` on `GameState` (SPE-2431 / PR #2733) |
+| Cross-join compose   | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` (SPE-2430) |
+| Fixture              | `SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE`                               |
+
+## Orchestration tick contract (slice 3)
+
+- **Escalation** — `relaxed` → `sustained` when surveillance ≥ 0.65 and (monitoring exceeds contact or healthcare load ≥ 0.4); `alternative_support` → `sustained` when surveillance ≥ 0.75 with monitoring/contact mismatch; `sustained` → `escalated` when surveillance ≥ 0.8, monitoring exceeds contact, and healthcare load ≥ 0.5.
+- **Collateral relaxation** — `sustained`/`escalated` → `alternative_support` when collateral strain ≥ 0.55 and surveillance < 0.5; or when sustained-under-collateral-strain projection holds and healthcare load < 0.5 (capacity allows de-escalation despite surveillance).
+- **De-escalation step** — `escalated` → `sustained` when collateral ≥ 0.55 and surveillance < 0.6.
+- **Horizon refresh** — recompute short/medium/long `horizonOutcomes` from projection + intervention frame each tick; idempotent when level and horizons already match.
+- **Validation gate** — invalid post-tick candidates preserve the source record.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklySurveillanceInterventionTuningTick` in domain module   | Planning mirror UI                            |
+| Call from `advanceWeek` after week increment (`result.week`)         | SPE-1615 psychological resilience cross-join  |
+| Targeted domain + `advanceWeek` integration tests                  | Surveillance-tuning mirror/report surfacing   |
+| Slice doc (this file) + backlog handoff                            | Full SPE-848 parent Done                      |
+
+## Acceptance
+
+- [x] Empty `surveillanceInterventionTuningRecords` map is a no-op without throw
+- [x] Relaxed records escalate to `sustained` when surveillance and healthcare load rise together
+- [x] Subject-22 fixture relaxes to `alternative_support` under collateral strain with capacity headroom
+- [x] Horizon outcomes refresh under one intervention frame
+- [x] Re-tick after advance is idempotent
+- [x] `advanceWeek` integration matches direct weekly tick output
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/surveillanceInterventionTuningWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/surveillanceInterventionTuningWeeklyOrchestration.test.ts`, `src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts` |
+| Plan   | `planning/spe-848-surveillance-tuning-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Planning mirror UI over tuning records | SPE-848 slice 4+ | Orchestration must land before mirror projections |
+| SPE-1615 psychological resilience cross-join | SPE-1615 | No runtime registry anchor yet |
+| Surveillance-tuning surfacing in mirror / weekly notes | SPE-2430 follow-up | Out of orchestration-only boundary |
+| Full SPE-848 parent Done | SPE-848 | Mirror + broader AC may remain |
+
+## See also
+
+- `planning/spe-848-surveillance-tuning-registry-slice-2.md` — persistence slice
+- `planning/contained-person-therapeutic-care-registry-slice-3.md` — sibling weekly-hook pattern
+- `planning/rule-document-compliance-containment-registry-slice-3.md` — projection-driven transition pattern

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -270,6 +270,7 @@ import { applyWeeklyVisualTriggerHazardTick } from '../visualTriggerHazardWeekly
 import { applyWeeklyNamingHazardDescriptorTick } from '../namingHazardDescriptorWeeklyOrchestration'
 import { applyWeeklyTherapeuticCareTick } from '../containedPersonTherapeuticCareWeeklyOrchestration'
 import { applyWeeklyCoerciveProtocolTick } from '../coerciveContainedPersonProtocolWeeklyOrchestration'
+import { applyWeeklySurveillanceInterventionTuningTick } from '../surveillanceInterventionTuningWeeklyOrchestration'
 import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   resolveCoerciveProcedureExecutionDrafts,
@@ -4767,6 +4768,17 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.coerciveContainedPersonProtocolRecords = coerciveProtocolTick.records
     outputWeeklyState.coerciveContainedPersonProtocolWeeklyProjectionSnapshots =
       coerciveProtocolTick.snapshots
+  }
+
+  // SPE-848 slice 3: intervention-level and horizon-outcome advance on surveillance tuning records.
+  const currentSurveillanceInterventionTuningRecords =
+    outputWeeklyState.surveillanceInterventionTuningRecords ?? {}
+  if (Object.keys(currentSurveillanceInterventionTuningRecords).length > 0) {
+    outputWeeklyState.surveillanceInterventionTuningRecords =
+      applyWeeklySurveillanceInterventionTuningTick(
+        currentSurveillanceInterventionTuningRecords,
+        result.week
+      )
   }
 
   // SPE-1888 slice 5: welfare-debt creation when coercive procedures execute with containment improvement.

--- a/src/domain/surveillanceInterventionTuningWeeklyOrchestration.ts
+++ b/src/domain/surveillanceInterventionTuningWeeklyOrchestration.ts
@@ -1,0 +1,254 @@
+/**
+ * SPE-848 slice 3: weekly orchestration for persisted surveillance intervention tuning records.
+ *
+ * Pure deterministic tick: reproject surveillance/contact/collateral signals, advance
+ * intervention level when capacity and strain bands warrant bounded transitions, and
+ * refresh short/medium/long horizon outcomes under the current intervention frame.
+ */
+
+import {
+  projectSurveillanceInterventionTuningReview,
+  validateSurveillanceInterventionTuningRecord,
+  type InterventionHorizonOutcome,
+  type InterventionHorizonOutcomes,
+  type InterventionLevel,
+  type SurveillanceInterventionTuningProjection,
+  type SurveillanceInterventionTuningRecord,
+  type SurveillanceInterventionTuningRecordsMap,
+} from './surveillanceCapacityInterventionTuningRegistry'
+
+const HIGH_SURVEILLANCE_ESCALATION_THRESHOLD = 0.65
+const STRONG_SURVEILLANCE_ESCALATION_THRESHOLD = 0.75
+const VERY_HIGH_SURVEILLANCE_ESCALATION_THRESHOLD = 0.8
+const LOW_SURVEILLANCE_RELAXATION_THRESHOLD = 0.5
+const MODERATE_SURVEILLANCE_DEESCALATION_THRESHOLD = 0.6
+const HEALTHCARE_LOAD_CAPACITY_THRESHOLD = 0.4
+const HEALTHCARE_LOAD_ESCALATION_THRESHOLD = 0.5
+const HEALTHCARE_LOAD_RELAXATION_CEILING = 0.5
+const HIGH_COLLATERAL_STRAIN_THRESHOLD = 0.55
+
+const SUSTAINED_LEVELS: ReadonlySet<InterventionLevel> = new Set(['sustained', 'escalated'])
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function freezeRecord(
+  record: SurveillanceInterventionTuningRecord
+): SurveillanceInterventionTuningRecord {
+  return Object.freeze({ ...record })
+}
+
+function resolveHealthcareLoadScore(record: SurveillanceInterventionTuningRecord): number | null {
+  const score = record.healthcareLoadScore
+  if (score === undefined || score === null) {
+    return null
+  }
+
+  return score
+}
+
+function resolveCollateralStrainScore(record: SurveillanceInterventionTuningRecord): number | null {
+  const score = record.collateralStrainScore
+  if (score === undefined || score === null) {
+    return null
+  }
+
+  return score
+}
+
+function horizonOutcomesEqual(
+  left: InterventionHorizonOutcomes | undefined,
+  right: InterventionHorizonOutcomes
+): boolean {
+  if (!left) {
+    return false
+  }
+
+  return left.short === right.short && left.medium === right.medium && left.long === right.long
+}
+
+/** Target intervention level from weekly projection signals; undefined when no transition applies. */
+export function resolveTargetInterventionLevelFromProjection(
+  record: SurveillanceInterventionTuningRecord,
+  projection: SurveillanceInterventionTuningProjection
+): InterventionLevel | undefined {
+  const level = record.currentInterventionLevel
+  const surveillance = projection.surveillanceSignalScore
+  const collateral = projection.collateralStrainScore ?? resolveCollateralStrainScore(record)
+  const healthcareLoad = resolveHealthcareLoadScore(record)
+
+  if (surveillance === null) {
+    return undefined
+  }
+
+  if (
+    (level === 'sustained' || level === 'escalated') &&
+    collateral !== null &&
+    collateral >= HIGH_COLLATERAL_STRAIN_THRESHOLD &&
+    surveillance < LOW_SURVEILLANCE_RELAXATION_THRESHOLD
+  ) {
+    return 'alternative_support'
+  }
+
+  if (
+    SUSTAINED_LEVELS.has(level) &&
+    projection.sustainedUnderCollateralStrain &&
+    healthcareLoad !== null &&
+    healthcareLoad < HEALTHCARE_LOAD_RELAXATION_CEILING
+  ) {
+    return 'alternative_support'
+  }
+
+  if (
+    level === 'escalated' &&
+    collateral !== null &&
+    collateral >= HIGH_COLLATERAL_STRAIN_THRESHOLD &&
+    surveillance < MODERATE_SURVEILLANCE_DEESCALATION_THRESHOLD
+  ) {
+    return 'sustained'
+  }
+
+  if (
+    level === 'relaxed' &&
+    surveillance >= HIGH_SURVEILLANCE_ESCALATION_THRESHOLD &&
+    (projection.monitoringExceedsContact ||
+      (healthcareLoad !== null && healthcareLoad >= HEALTHCARE_LOAD_CAPACITY_THRESHOLD))
+  ) {
+    return 'sustained'
+  }
+
+  if (
+    level === 'alternative_support' &&
+    surveillance >= STRONG_SURVEILLANCE_ESCALATION_THRESHOLD &&
+    projection.monitoringExceedsContact &&
+    (collateral === null || collateral < HIGH_COLLATERAL_STRAIN_THRESHOLD)
+  ) {
+    return 'sustained'
+  }
+
+  if (
+    level === 'sustained' &&
+    surveillance >= VERY_HIGH_SURVEILLANCE_ESCALATION_THRESHOLD &&
+    projection.monitoringExceedsContact &&
+    healthcareLoad !== null &&
+    healthcareLoad >= HEALTHCARE_LOAD_ESCALATION_THRESHOLD
+  ) {
+    return 'escalated'
+  }
+
+  return undefined
+}
+
+/** Refreshes horizon outcome bands from the current intervention frame and projection signals. */
+export function deriveWeeklyInterventionHorizonOutcomes(
+  record: SurveillanceInterventionTuningRecord,
+  projection: SurveillanceInterventionTuningProjection
+): InterventionHorizonOutcomes {
+  const short: InterventionHorizonOutcome = projection.monitoringExceedsContact
+    ? 'elevated_isolation_pressure'
+    : 'contact_recovery_signal'
+
+  const medium: InterventionHorizonOutcome =
+    projection.sustainedUnderCollateralStrain ||
+    (projection.collateralStrainScore !== null &&
+      projection.collateralStrainScore >= HIGH_COLLATERAL_STRAIN_THRESHOLD)
+      ? 'collateral_strain_elevated'
+      : 'compliance_metric_stable'
+
+  let longOutcome: InterventionHorizonOutcome = 'compliance_metric_stable'
+  if (record.currentInterventionLevel === 'alternative_support') {
+    longOutcome = 'contact_recovery_signal'
+  } else if (projection.sustainedUnderCollateralStrain) {
+    longOutcome = 'legitimacy_erosion_risk'
+  }
+
+  return Object.freeze({
+    short,
+    medium: medium,
+    long: longOutcome,
+  })
+}
+
+function buildWeeklyAdvanceCandidate(
+  record: SurveillanceInterventionTuningRecord
+): SurveillanceInterventionTuningRecord | undefined {
+  const projection = projectSurveillanceInterventionTuningReview(record)
+  const targetLevel = resolveTargetInterventionLevelFromProjection(record, projection)
+  const horizonOutcomes = deriveWeeklyInterventionHorizonOutcomes(
+    targetLevel ? { ...record, currentInterventionLevel: targetLevel } : record,
+    projection
+  )
+
+  const levelChanged = targetLevel !== undefined && targetLevel !== record.currentInterventionLevel
+  const horizonsChanged = !horizonOutcomesEqual(record.horizonOutcomes, horizonOutcomes)
+
+  if (!levelChanged && !horizonsChanged) {
+    return undefined
+  }
+
+  return {
+    ...record,
+    ...(levelChanged ? { currentInterventionLevel: targetLevel } : {}),
+    horizonOutcomes,
+  }
+}
+
+/**
+ * Advances one tuning record for the simulation week using projected signal semantics.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceSurveillanceInterventionTuningRecordForWeek(
+  record: SurveillanceInterventionTuningRecord,
+  week: number
+): SurveillanceInterventionTuningRecord {
+  normalizeWeek(week)
+  const candidate = buildWeeklyAdvanceCandidate(record)
+  if (!candidate) {
+    return record
+  }
+
+  if (!validateSurveillanceInterventionTuningRecord(candidate).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly surveillance-intervention tuning pass over persisted records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklySurveillanceInterventionTuningTick(
+  records: SurveillanceInterventionTuningRecordsMap | null | undefined,
+  week: number
+): SurveillanceInterventionTuningRecordsMap {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: SurveillanceInterventionTuningRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceSurveillanceInterventionTuningRecordForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[recordId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts
+++ b/src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../domain/surveillanceCapacityInterventionTuningRegistry'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyWeeklySurveillanceInterventionTuningTick } from '../domain/surveillanceInterventionTuningWeeklyOrchestration'
+import type { SurveillanceInterventionTuningRecord } from '../domain/surveillanceCapacityInterventionTuningRegistry'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
   for (const currentCase of Object.values(state.cases)) {
@@ -14,21 +16,21 @@ function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) 
   }
 }
 
-describe('advanceWeek surveillance intervention tuning records integration (SPE-848 slice 2)', () => {
-  it('preserves surveillance tuning records through advanceWeek without mutation', () => {
-    const state = createStartingState()
-    freezeCasesForQuietWeek(state)
-    state.surveillanceInterventionTuningRecords = {
-      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
-    }
+function escalationCandidateRecord(): SurveillanceInterventionTuningRecord {
+  return {
+    id: 'surveillance-tuning:integration-escalation',
+    label: 'Integration escalation candidate',
+    subjectRef: 'subject:integration-escalation',
+    currentInterventionLevel: 'relaxed',
+    surveillanceSignalScore: 0.72,
+    meaningfulContactScore: 0.18,
+    healthcareLoadScore: 0.55,
+    collateralStrainScore: 0.2,
+    tuningRationaleRef: 'tuning-rationale:integration-escalation',
+  }
+}
 
-    const nextState = advanceWeek(state)
-
-    expect(nextState.surveillanceInterventionTuningRecords).toEqual(
-      state.surveillanceInterventionTuningRecords
-    )
-  })
-
+describe('advanceWeek surveillance intervention tuning records integration (SPE-848 slice 3)', () => {
   it('is a no-op for an empty tuning map without throwing', () => {
     const state = createStartingState()
     freezeCasesForQuietWeek(state)
@@ -37,5 +39,54 @@ describe('advanceWeek surveillance intervention tuning records integration (SPE-
     const nextState = advanceWeek(state)
 
     expect(nextState.surveillanceInterventionTuningRecords).toEqual({})
+  })
+
+  it('advances subject-22 fixture to alternative_support through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const advanced =
+      nextState.surveillanceInterventionTuningRecords?.[SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]
+
+    expect(nextState.week).toBe(2)
+    expect(advanced?.currentInterventionLevel).toBe('alternative_support')
+    expect(advanced?.horizonOutcomes?.long).toBe('contact_recovery_signal')
+  })
+
+  it('escalates relaxed records when advanceWeek reaches a high-signal week', () => {
+    const record = escalationCandidateRecord()
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.surveillanceInterventionTuningRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state)
+    const advanced = nextState.surveillanceInterventionTuningRecords?.[record.id]
+
+    expect(nextState.week).toBe(2)
+    expect(advanced?.currentInterventionLevel).toBe('sustained')
+    expect(advanced?.subjectRef).toBe(record.subjectRef)
+  })
+
+  it('matches direct weekly tick output inside advanceWeek', () => {
+    const record = escalationCandidateRecord()
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.surveillanceInterventionTuningRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state)
+    const direct = applyWeeklySurveillanceInterventionTuningTick(
+      state.surveillanceInterventionTuningRecords,
+      nextState.week
+    )
+
+    expect(nextState.surveillanceInterventionTuningRecords).toEqual(direct)
   })
 })

--- a/src/test/surveillanceInterventionTuningWeeklyOrchestration.test.ts
+++ b/src/test/surveillanceInterventionTuningWeeklyOrchestration.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+  projectSurveillanceInterventionTuningReview,
+  type SurveillanceInterventionTuningRecord,
+} from '../domain/surveillanceCapacityInterventionTuningRegistry'
+import {
+  advanceSurveillanceInterventionTuningRecordForWeek,
+  applyWeeklySurveillanceInterventionTuningTick,
+  deriveWeeklyInterventionHorizonOutcomes,
+  resolveTargetInterventionLevelFromProjection,
+} from '../domain/surveillanceInterventionTuningWeeklyOrchestration'
+
+function baseRecord(
+  overrides: Partial<SurveillanceInterventionTuningRecord> = {}
+): SurveillanceInterventionTuningRecord {
+  return {
+    id: 'surveillance-tuning:weekly-orchestration-test',
+    label: 'Weekly orchestration test record',
+    subjectRef: 'subject:weekly-orchestration-test',
+    currentInterventionLevel: 'relaxed',
+    surveillanceSignalScore: 0.3,
+    meaningfulContactScore: 0.6,
+    healthcareLoadScore: 0.2,
+    collateralStrainScore: 0.2,
+    tuningRationaleRef: 'tuning-rationale:weekly-orchestration-test',
+    ...overrides,
+  }
+}
+
+describe('surveillanceInterventionTuningWeeklyOrchestration (SPE-848 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklySurveillanceInterventionTuningTick({}, 4)).toEqual({})
+    expect(applyWeeklySurveillanceInterventionTuningTick(undefined, 4)).toEqual({})
+  })
+
+  it('escalates relaxed records when surveillance and healthcare load rise together', () => {
+    const record = baseRecord({
+      id: 'surveillance-tuning:escalation-candidate',
+      currentInterventionLevel: 'relaxed',
+      surveillanceSignalScore: 0.72,
+      meaningfulContactScore: 0.18,
+      healthcareLoadScore: 0.55,
+    })
+    const projection = projectSurveillanceInterventionTuningReview(record)
+
+    expect(resolveTargetInterventionLevelFromProjection(record, projection)).toBe('sustained')
+
+    const advanced = advanceSurveillanceInterventionTuningRecordForWeek(record, 3)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.currentInterventionLevel).toBe('sustained')
+    expect(advanced.horizonOutcomes?.short).toBe('elevated_isolation_pressure')
+  })
+
+  it('relaxes sustained records under collateral strain when healthcare capacity allows', () => {
+    const record = baseRecord({
+      id: 'surveillance-tuning:collateral-relaxation',
+      currentInterventionLevel: 'sustained',
+      surveillanceSignalScore: 0.88,
+      meaningfulContactScore: 0.14,
+      healthcareLoadScore: 0.42,
+      collateralStrainScore: 0.71,
+      horizonOutcomes: {
+        short: 'elevated_isolation_pressure',
+        medium: 'compliance_metric_stable',
+        long: 'legitimacy_erosion_risk',
+      },
+    })
+
+    const advanced = advanceSurveillanceInterventionTuningRecordForWeek(record, 2)
+
+    expect(advanced).not.toBe(record)
+    expect(advanced.currentInterventionLevel).toBe('alternative_support')
+    expect(advanced.horizonOutcomes?.long).toBe('contact_recovery_signal')
+    expect(advanced.horizonOutcomes?.medium).toBe('collateral_strain_elevated')
+  })
+
+  it('relaxes sustained records when surveillance is low and collateral strain is high', () => {
+    const record = baseRecord({
+      id: 'surveillance-tuning:low-signal-relaxation',
+      currentInterventionLevel: 'sustained',
+      surveillanceSignalScore: 0.35,
+      meaningfulContactScore: 0.55,
+      collateralStrainScore: 0.62,
+    })
+
+    const advanced = advanceSurveillanceInterventionTuningRecordForWeek(record, 2)
+
+    expect(advanced.currentInterventionLevel).toBe('alternative_support')
+  })
+
+  it('advances subject-22 fixture to alternative_support with refreshed horizons', () => {
+    const advanced = advanceSurveillanceInterventionTuningRecordForWeek(
+      SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+      2
+    )
+
+    expect(advanced.currentInterventionLevel).toBe('alternative_support')
+    expect(advanced.subjectRef).toBe(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.subjectRef)
+    expect(advanced.tuningRationaleRef).toBe(
+      SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.tuningRationaleRef
+    )
+  })
+
+  it('is idempotent when re-applied after advance', () => {
+    const record = baseRecord({
+      id: 'surveillance-tuning:idempotent',
+      currentInterventionLevel: 'sustained',
+      surveillanceSignalScore: 0.88,
+      meaningfulContactScore: 0.14,
+      healthcareLoadScore: 0.42,
+      collateralStrainScore: 0.71,
+    })
+
+    const first = advanceSurveillanceInterventionTuningRecordForWeek(record, 2)
+    const second = advanceSurveillanceInterventionTuningRecordForWeek(first, 2)
+
+    expect(second).toBe(first)
+    expect(applyWeeklySurveillanceInterventionTuningTick({ [record.id]: first }, 2)).toEqual({
+      [record.id]: first,
+    })
+  })
+
+  it('derives horizon outcomes from projection and intervention frame', () => {
+    const record = baseRecord({ currentInterventionLevel: 'alternative_support' })
+    const projection = projectSurveillanceInterventionTuningReview(record)
+
+    expect(deriveWeeklyInterventionHorizonOutcomes(record, projection)).toEqual({
+      short: 'contact_recovery_signal',
+      medium: 'compliance_metric_stable',
+      long: 'contact_recovery_signal',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add \pplyWeeklySurveillanceInterventionTuningTick\ with deterministic intervention-level transitions (escalation from surveillance/capacity signals, relaxation from collateral strain with hysteresis) and horizon outcome refresh.
- Wire the tick into \dvanceWeek\ after coercive protocol weekly orchestration.
- Extend integration tests to assert subject-22 relaxes to \lternative_support\ and escalation paths through \dvanceWeek\.

## Linear mapping

- **Slice:** [SPE-2432](https://linear.app/spectranoir/issue/SPE-2432)
- **Parent:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848)
- **Parent remains open:** SPE-848 stays open for mirror UI / broader AC

## Validation

- \
pm run test:run -- src/test/surveillanceInterventionTuningWeeklyOrchestration.test.ts src/test/advanceWeek.surveillanceInterventionTuningRecords.integration.test.ts\
- \
pm run lint\

## Docs updated

- \planning/spe-848-surveillance-tuning-registry-slice-3.md\
- \planning/backlog.md\ (handoff)

Made with [Cursor](https://cursor.com)