### PR TITLE
feat(SPE-2434): psychological resilience registry GameState persistence slice 2

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience registry slice 2 (GameState persistence), SPE-1908 cross-join follow-up, or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience registry slice 3 (weekly depletion orchestration), SPE-1908 cross-join follow-up, or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `a8503939` — shipped: [SPE-2433](https://linear.app/spectranoir/issue/SPE-2433) psychological resilience registry slice 1 @ PR #2737
+**Base `main` SHA:** `c6beab29` — in progress: [SPE-2434](https://linear.app/spectranoir/issue/SPE-2434) psychological resilience registry slice 2 (GameState persistence)
 
 **Recently shipped:** [SPE-2433](https://linear.app/spectranoir/issue/SPE-2433) psychological resilience registry slice 1 @ PR #2737; [SPE-2432](https://linear.app/spectranoir/issue/SPE-2432) surveillance tuning weekly orchestration slice 3 @ PR #2735; see `planning/spe-1615-psychological-resilience-registry-slice-1.md`.
 

--- a/planning/spe-1615-psychological-resilience-registry-slice-2.md
+++ b/planning/spe-1615-psychological-resilience-registry-slice-2.md
@@ -1,0 +1,67 @@
+# SPE-2434 — Psychological resilience registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: [SPE-2434](https://linear.app/spectranoir/issue/SPE-2434) (child under [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615)). Follows shipped slice 1 registry anchor (`src/domain/psychologicalResilienceRegistry.ts`).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2434 — Psychological resilience registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2434) |
+| **Parent** | [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion             |
+| **Branch** | `jamesdyedbq/spe-1615-psychological-resilience-registry-slice-2`                                           |
+| **Status** | **In progress**                                                                                            |
+| **Base `main` SHA** | `c6beab29`                                                                                          |
+
+## Goal
+
+Persist validated `PsychologicalResilienceRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Mirror SPE-2431 / SPE-848 slice 2 persistence pattern. Weekly depletion orchestration deferred to a later slice.
+
+## Prerequisite (on `main` @ `c6beab29`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Resilience registry  | `src/domain/psychologicalResilienceRegistry.ts` (SPE-1615 slice 1)     |
+| Fixture              | `PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE`                    |
+| Persistence pattern  | `sanitizeSurveillanceInterventionTuningRecords` (SPE-848 slice 2)      |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `psychologicalResilienceRecords` on `GameState`                      | Weekly `advanceWeek` depletion orchestration  |
+| `sanitizePsychologicalResilienceRecords` + `runTransfer` hydrate wire | SPE-1908 compose wire-up                   |
+| `validatePsychologicalResilienceRecord` on hydrate; drop invalid, no throw | Planning mirror UI                    |
+| Default `{}` in `createStartingState`                              | Full SPE-1615 parent Done                     |
+| Persistence + advanceWeek preservation regression tests            |                                               |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] Owner refs (`operatorRef`) byte-stable after round-trip
+- [x] Treatment/rest flags preserved through round-trip
+- [x] `advanceWeek` preserves resilience records unchanged
+- [x] Slice 1 registry tests unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/models.ts`                                                |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/psychologicalResilienceRegistryPersistence.test.ts`, `src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts` |
+| Plan   | `planning/spe-1615-psychological-resilience-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Weekly depletion orchestration hook in `advanceWeek` | SPE-1615 slice 3+ | Persistence must land before orchestration |
+| SPE-1908 cross-join compose wiring | SPE-1615 slice 3+ | Populated maps not required for persistence |
+| Planning mirror UI | SPE-1615 slice 4+ | Mirror follows persistence pattern |
+| Full SPE-1615 parent Done | SPE-1615 | Multiple slices remain |
+
+## See also
+
+- `planning/spe-1615-psychological-resilience-registry-slice-1.md` — registry anchor (shipped)
+- `planning/spe-848-surveillance-tuning-registry-slice-2.md` — persistence-only slice pattern

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -213,6 +213,7 @@ import { sanitizeCoerciveProtocolRecords, sanitizeCoerciveProtocolWeeklyProjecti
 import { sanitizeMedicationRegimenRecords } from '../../domain/containedPersonMedicationRegimenRegistry'
 import { sanitizeContainedPersonIntegratedHealthBundles } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
 import { sanitizeSurveillanceInterventionTuningRecords } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
+import { sanitizePsychologicalResilienceRecords } from '../../domain/psychologicalResilienceRegistry'
 import { sanitizeVisualTriggerHazardRecords } from '../../domain/visualTriggerHazardRegistry'
 import {
   buildCandidateEvaluation,
@@ -8539,6 +8540,10 @@ export function hydrateGame(
     game.surveillanceInterventionTuningRecords,
     fallback.surveillanceInterventionTuningRecords ?? {}
   )
+  const psychologicalResilienceRecords = sanitizePsychologicalResilienceRecords(
+    game.psychologicalResilienceRecords,
+    fallback.psychologicalResilienceRecords ?? {}
+  )
   const factions = hasPersistedFactions
     ? sanitizeFactionsMap(game.factions, fallback.factions)
     : fallback.factions
@@ -8679,6 +8684,7 @@ export function hydrateGame(
       welfareDebtAccountingRecords,
       containedPersonIntegratedHealthBundles,
       surveillanceInterventionTuningRecords,
+      psychologicalResilienceRecords,
       candidates,
       recruitmentPool,
       teams,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -62,6 +62,7 @@ const startingStateTemplate: GameState = {
   welfareDebtAccountingRecords: {},
   containedPersonIntegratedHealthBundles: {},
   surveillanceInterventionTuningRecords: {},
+  psychologicalResilienceRecords: {},
   factions: createInitialFactionState(),
 
   agency: {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -268,6 +268,7 @@ import type { MedicationRegimenRecord } from './containedPersonMedicationRegimen
 import type { WelfareDebtAccountingRecord } from './welfareDebtAccountingRegistry'
 import type { ContainedPersonIntegratedHealthBundle } from './containedPersonIntegratedHealthBundleRegistry'
 import type { SurveillanceInterventionTuningRecord } from './surveillanceCapacityInterventionTuningRegistry'
+import type { PsychologicalResilienceRecord } from './psychologicalResilienceRegistry'
 import type { VisualTriggerHazardRecord } from './visualTriggerHazardRegistry'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
@@ -2726,6 +2727,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   surveillanceInterventionTuningRecords?: Record<string, SurveillanceInterventionTuningRecord>
+
+  /**
+   * SPE-1615 slice 2: persisted psychological resilience records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  psychologicalResilienceRecords?: Record<string, PsychologicalResilienceRecord>
 
   /** Optional active compromised-authority runtime packet (SPE-746). */
   compromisedAuthority?: CompromisedAuthorityState

--- a/src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts
+++ b/src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import {
+  PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+} from '../domain/psychologicalResilienceRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek psychological resilience records integration (SPE-1615 slice 2)', () => {
+  it('is a no-op for an empty resilience map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.psychologicalResilienceRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.psychologicalResilienceRecords).toEqual({})
+  })
+
+  it('preserves psychological resilience records through advanceWeek without mutation', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.psychologicalResilienceRecords).toEqual(state.psychologicalResilienceRecords)
+    expect(nextState.week).toBe(2)
+    expect(
+      nextState.psychologicalResilienceRecords?.[PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]
+        ?.operatorRef
+    ).toBe(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef)
+    expect(
+      nextState.psychologicalResilienceRecords?.[
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id
+      ]?.treatmentRequired
+    ).toBe(true)
+    expect(
+      nextState.psychologicalResilienceRecords?.[
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id
+      ]?.restRecoverable
+    ).toBe(true)
+  })
+})

--- a/src/test/psychologicalResilienceRegistryPersistence.test.ts
+++ b/src/test/psychologicalResilienceRegistryPersistence.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+  sanitizePsychologicalResilienceRecords,
+  validatePsychologicalResilienceRecord,
+} from '../domain/psychologicalResilienceRegistry'
+
+describe('psychologicalResilienceRegistry persistence (SPE-1615 slice 2)', () => {
+  it('defaults starting state to an empty psychological resilience map', () => {
+    expect(createStartingState().psychologicalResilienceRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const altRecord = {
+      ...PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      id: 'psych-resilience:alt-operator',
+      operatorRef: 'agent:alt-operator',
+    }
+    const fallback = {}
+    const sanitized = sanitizePsychologicalResilienceRecords(
+      {
+        valid: PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+        alt: altRecord,
+        'wrong-key': {
+          ...altRecord,
+          label: 'wrong map key should lose to canonical id entry',
+        },
+        duplicate: {
+          ...PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          operatorRef: 'agent:test',
+          depletionBand: 'unknown',
+          exposureScore: 0.5,
+          exposureEventCount: 1,
+          recoveryChannel: 'rest_recoverable',
+          treatmentRequired: false,
+          restRecoverable: true,
+        },
+        franchiseLabel: {
+          ...PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+          id: 'psych-resilience:franchise',
+          label: 'SCP division resilience profile',
+        },
+        brandedObjectId: {
+          ...PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+          id: 'psych-resilience:scp-049',
+          label: 'Archive resilience profile',
+        },
+        outOfRangeScore: {
+          ...PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+          id: 'psych-resilience:out-of-range',
+          exposureScore: 1.5,
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized[PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]).toEqual(
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE
+    )
+    expect(sanitized[altRecord.id]).toEqual(altRecord)
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.franchiseLabel).toBeUndefined()
+    expect(sanitized.brandedObjectId).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['wrong-key']).toBeUndefined()
+    expect(sanitized.outOfRangeScore).toBeUndefined()
+    expect(Object.keys(sanitized).sort()).toEqual(
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id, altRecord.id].sort()
+    )
+  })
+
+  it('persists warning-only records that remain valid on hydrate', () => {
+    const warningOnly = {
+      ...PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      id: 'psych-resilience:breakdown-warning-only',
+      depletionBand: 'breakdown' as const,
+      treatmentRequired: false,
+      restRecoverable: true,
+      recoveryChannel: 'treatment_required' as const,
+    }
+
+    expect(validatePsychologicalResilienceRecord(warningOnly).valid).toBe(true)
+
+    const sanitized = sanitizePsychologicalResilienceRecords({ [warningOnly.id]: warningOnly }, {})
+
+    expect(sanitized[warningOnly.id]).toEqual(warningOnly)
+    expect(sanitized[warningOnly.id]?.treatmentRequired).toBe(false)
+    expect(sanitized[warningOnly.id]?.restRecoverable).toBe(true)
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.psychologicalResilienceRecords).toEqual(state.psychologicalResilienceRecords)
+    expect(
+      loaded.psychologicalResilienceRecords?.[PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]
+        ?.operatorRef
+    ).toBe(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef)
+    expect(
+      loaded.psychologicalResilienceRecords?.[
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id
+      ]?.treatmentRequired
+    ).toBe(true)
+    expect(
+      loaded.psychologicalResilienceRecords?.[
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id
+      ]?.restRecoverable
+    ).toBe(false)
+  })
+
+  it('hydrates persisted psychological resilience records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        psychologicalResilienceRecords: {
+          [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+            PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+          invalid: {
+            ...PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+            id: 'psych-resilience:invalid',
+            label: 'SCP division resilience profile',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.psychologicalResilienceRecords).toEqual({
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+    })
+  })
+
+  it('repeated sanitize is byte-stable for fixture records', () => {
+    const first = sanitizePsychologicalResilienceRecords(
+      {
+        [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+          PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      },
+      {}
+    )
+    const second = sanitizePsychologicalResilienceRecords(first, {})
+
+    expect(second).toEqual(first)
+    expect(
+      validatePsychologicalResilienceRecord(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE)
+    ).toEqual(
+      validatePsychologicalResilienceRecord(
+        second[PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]!
+      )
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Add `psychologicalResilienceRecords` to `GameState` with `sanitizePsychologicalResilienceRecords` hydrate in `runTransfer` and default `{}` in `createStartingState`.
- Add persistence round-trip tests and `advanceWeek` preservation integration tests for psychological resilience records.
- Slice doc: `planning/spe-1615-psychological-resilience-registry-slice-2.md`.

## Linear

- **Slice:** [SPE-2434](https://linear.app/spectranoir/issue/SPE-2434) — Psychological resilience registry GameState persistence (slice 2)
- **Parent:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion (remains open)

## What shipped

- `psychologicalResilienceRecords` field on `GameState` (`models.ts`)
- Hydrate wire in `runTransfer.ts` using slice 1 `sanitizePsychologicalResilienceRecords`
- Default empty map in `startingState.ts`
- `psychologicalResilienceRegistryPersistence.test.ts` — serialize/import round-trip, invalid/duplicate drop, operatorRef + treatment/rest flag stability
- `advanceWeek.psychologicalResilienceRecords.integration.test.ts` — preservation-only (no depletion tick)

## Out of scope (deferred)

- Weekly depletion orchestration in `advanceWeek`
- SPE-1908 compose wire-up
- Planning mirror UI

## Validation

- `npm run lint`
- `npm run test:run -- src/test/psychologicalResilienceRegistryPersistence.test.ts src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts src/test/psychologicalResilienceRegistry.test.ts`

## Docs updated

- `planning/spe-1615-psychological-resilience-registry-slice-2.md`
- `planning/backlog.md` handoff

## Parent status

SPE-1615 parent remains open — slice 3+ (orchestration, cross-join, mirror) still deferred.