### PR TITLE
feat(SPE-2435): psychological resilience weekly depletion orchestration slice 3

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological resilience registry slice 3 (weekly depletion orchestration), SPE-1908 cross-join follow-up, or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) psychological resilience registry slice 3 (weekly depletion orchestration in flight), then SPE-1908 cross-join follow-up or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `467fe4d6` — shipped: [SPE-2434](https://linear.app/spectranoir/issue/SPE-2434) psychological resilience registry slice 2 @ PR #2739
+**Base `main` SHA:** `2b76942f` — in flight: [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) psychological resilience registry slice 3; branch `jamesdyedbq/spe-1615-psychological-resilience-registry-slice-3`
 
 **Recently shipped:** [SPE-2434](https://linear.app/spectranoir/issue/SPE-2434) psychological resilience registry slice 2 @ PR #2739; [SPE-2433](https://linear.app/spectranoir/issue/SPE-2433) psychological resilience registry slice 1 @ PR #2737; see `planning/spe-1615-psychological-resilience-registry-slice-2.md`.
 

--- a/planning/spe-1615-psychological-resilience-registry-slice-3.md
+++ b/planning/spe-1615-psychological-resilience-registry-slice-3.md
@@ -1,0 +1,74 @@
+# SPE-2435 — Psychological resilience registry weekly advanceWeek depletion orchestration hook (slice 3)
+
+One-page implementation plan. Linear: [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) (child under [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615)). Follows shipped slice 2 (`planning/spe-1615-psychological-resilience-registry-slice-2.md`, PR #2739 / [SPE-2434](https://linear.app/spectranoir/issue/SPE-2434)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2435 — Psychological resilience registry weekly advanceWeek depletion orchestration hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2435) |
+| **Parent** | [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion             |
+| **Branch** | `jamesdyedbq/spe-1615-psychological-resilience-registry-slice-3`                                           |
+| **Status** | In Progress                                                                                                |
+| **Base `main` SHA** | `2b76942f`                                                                                          |
+
+## Goal
+
+Wire persisted `psychologicalResilienceRecords` into `advanceWeek` with a pure domain weekly depletion tick: one-step band transitions from projected exposure score/event count while preserving treatment/rest flags unless an explicit breakdown transition applies.
+
+## Prerequisite (on `main` @ `2b76942f`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Resilience registry  | `src/domain/psychologicalResilienceRegistry.ts` (SPE-1615 slice 1)     |
+| Persistence          | `psychologicalResilienceRecords` on `GameState` (SPE-2434 / PR #2739) |
+| Sibling weekly hook  | `src/domain/surveillanceInterventionTuningWeeklyOrchestration.ts` (SPE-2432) |
+| Fixture              | `PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE`                    |
+
+## Orchestration tick contract (slice 3)
+
+- **stable → strained** — `exposureElevated` (score ≥ 0.6) or `exposureEventCount` ≥ 3.
+- **strained → depleted** — `exposureScore` ≥ 0.55 and `exposureEventCount` ≥ 4.
+- **depleted → compromised** — `exposureScore` ≥ 0.65, `exposureEventCount` ≥ 5, and active complications.
+- **compromised → breakdown** — `exposureScore` ≥ 0.8 and `exposureEventCount` ≥ 7; explicit breakdown gate sets `treatmentRequired: true`, `restRecoverable: false`, `recoveryChannel: treatment_required`.
+- **Terminal** — `breakdown` records do not advance further; treatment/rest flags preserved.
+- **Validation gate** — invalid post-tick candidates preserve the source record.
+- **One composite step per week** — at most one band step per record per tick; re-tick same week is idempotent.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyPsychologicalResilienceDepletionTick` in domain module | SPE-1908 compose wire-up                      |
+| Call from `advanceWeek` after week increment (`result.week`)       | Planning mirror UI                            |
+| Targeted domain + `advanceWeek` integration tests                  | SPE-130 fatigue-channel conflation            |
+| Slice doc (this file) + backlog handoff                            | Full SPE-1615 parent Done                     |
+
+## Acceptance
+
+- [x] Empty `psychologicalResilienceRecords` map is a no-op without throw
+- [x] Staged depletion fixture escalates to `compromised` while preserving treatment/rest flags
+- [x] Treatment breakdown fixture remains idempotent at `breakdown`
+- [x] Stable operator fixture unchanged on low exposure
+- [x] Re-tick after advance is idempotent
+- [x] `advanceWeek` integration matches direct weekly tick output
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/psychologicalResilienceWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/psychologicalResilienceWeeklyOrchestration.test.ts`, `src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts` |
+| Plan   | `planning/spe-1615-psychological-resilience-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| SPE-1908 cross-join compose wiring | SPE-1615 slice 4+ | Orchestration must land before compose cross-join |
+| Planning mirror UI over resilience records | SPE-1615 slice 4+ | Mirror follows orchestration pattern |
+| Full SPE-1615 parent Done | SPE-1615 | Mirror + cross-join slices may remain |
+
+## See also
+
+- `planning/spe-1615-psychological-resilience-registry-slice-2.md` — persistence slice
+- `planning/spe-848-surveillance-tuning-registry-slice-3.md` — sibling weekly-hook pattern

--- a/src/domain/psychologicalResilienceWeeklyOrchestration.ts
+++ b/src/domain/psychologicalResilienceWeeklyOrchestration.ts
@@ -1,0 +1,189 @@
+/**
+ * SPE-1615 slice 3: weekly orchestration for persisted psychological resilience records.
+ *
+ * Pure deterministic tick: project exposure/depletion signals and advance depletionBand
+ * one bounded step when score/event-count thresholds warrant. Preserves treatment/rest
+ * flags unless an explicit breakdown transition applies.
+ */
+
+import {
+  projectPsychologicalResilienceReview,
+  validatePsychologicalResilienceRecord,
+  type PsychologicalResilienceProjection,
+  type PsychologicalResilienceRecord,
+  type PsychologicalResilienceRecordsMap,
+  type ResilienceDepletionBand,
+} from './psychologicalResilienceRegistry'
+
+const STABLE_TO_STRAINED_EVENT_COUNT_THRESHOLD = 3
+const STRAINED_TO_DEPLETED_SCORE_THRESHOLD = 0.55
+const STRAINED_TO_DEPLETED_EVENT_COUNT_THRESHOLD = 4
+const DEPLETED_TO_COMPROMISED_SCORE_THRESHOLD = 0.65
+const DEPLETED_TO_COMPROMISED_EVENT_COUNT_THRESHOLD = 5
+const COMPROMISED_TO_BREAKDOWN_SCORE_THRESHOLD = 0.8
+const COMPROMISED_TO_BREAKDOWN_EVENT_COUNT_THRESHOLD = 7
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function freezeRecord(record: PsychologicalResilienceRecord): PsychologicalResilienceRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Target depletion band from weekly projection signals; undefined when no transition applies. */
+export function resolveTargetDepletionBandFromProjection(
+  record: PsychologicalResilienceRecord,
+  projection: PsychologicalResilienceProjection
+): ResilienceDepletionBand | undefined {
+  const band = record.depletionBand
+  const exposureScore = projection.exposureScore
+  const exposureEventCount = projection.exposureEventCount
+
+  if (band === 'breakdown') {
+    return undefined
+  }
+
+  if (band === 'stable') {
+    if (
+      projection.exposureElevated ||
+      exposureEventCount >= STABLE_TO_STRAINED_EVENT_COUNT_THRESHOLD
+    ) {
+      return 'strained'
+    }
+
+    return undefined
+  }
+
+  if (exposureScore === null) {
+    return undefined
+  }
+
+  if (band === 'strained') {
+    if (
+      exposureScore >= STRAINED_TO_DEPLETED_SCORE_THRESHOLD &&
+      exposureEventCount >= STRAINED_TO_DEPLETED_EVENT_COUNT_THRESHOLD
+    ) {
+      return 'depleted'
+    }
+
+    return undefined
+  }
+
+  if (band === 'depleted') {
+    if (
+      exposureScore >= DEPLETED_TO_COMPROMISED_SCORE_THRESHOLD &&
+      exposureEventCount >= DEPLETED_TO_COMPROMISED_EVENT_COUNT_THRESHOLD &&
+      projection.complicationActive
+    ) {
+      return 'compromised'
+    }
+
+    return undefined
+  }
+
+  if (band === 'compromised') {
+    if (
+      exposureScore >= COMPROMISED_TO_BREAKDOWN_SCORE_THRESHOLD &&
+      exposureEventCount >= COMPROMISED_TO_BREAKDOWN_EVENT_COUNT_THRESHOLD
+    ) {
+      return 'breakdown'
+    }
+
+    return undefined
+  }
+
+  return undefined
+}
+
+function applyBreakdownTreatmentGate(
+  record: PsychologicalResilienceRecord
+): PsychologicalResilienceRecord {
+  return {
+    ...record,
+    treatmentRequired: true,
+    restRecoverable: false,
+    recoveryChannel: 'treatment_required',
+  }
+}
+
+function buildWeeklyAdvanceCandidate(
+  record: PsychologicalResilienceRecord
+): PsychologicalResilienceRecord | undefined {
+  const projection = projectPsychologicalResilienceReview(record)
+  const targetBand = resolveTargetDepletionBandFromProjection(record, projection)
+
+  if (!targetBand || targetBand === record.depletionBand) {
+    return undefined
+  }
+
+  const candidate: PsychologicalResilienceRecord = {
+    ...record,
+    depletionBand: targetBand,
+  }
+
+  if (targetBand === 'breakdown') {
+    return applyBreakdownTreatmentGate(candidate)
+  }
+
+  return candidate
+}
+
+/**
+ * Advances one resilience record for the simulation week using projected exposure semantics.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advancePsychologicalResilienceRecordForWeek(
+  record: PsychologicalResilienceRecord,
+  week: number
+): PsychologicalResilienceRecord {
+  normalizeWeek(week)
+  const candidate = buildWeeklyAdvanceCandidate(record)
+  if (!candidate) {
+    return record
+  }
+
+  if (!validatePsychologicalResilienceRecord(candidate).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly psychological-resilience depletion pass over persisted records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklyPsychologicalResilienceDepletionTick(
+  records: PsychologicalResilienceRecordsMap | null | undefined,
+  week: number
+): PsychologicalResilienceRecordsMap {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: PsychologicalResilienceRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advancePsychologicalResilienceRecordForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[recordId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -271,6 +271,7 @@ import { applyWeeklyNamingHazardDescriptorTick } from '../namingHazardDescriptor
 import { applyWeeklyTherapeuticCareTick } from '../containedPersonTherapeuticCareWeeklyOrchestration'
 import { applyWeeklyCoerciveProtocolTick } from '../coerciveContainedPersonProtocolWeeklyOrchestration'
 import { applyWeeklySurveillanceInterventionTuningTick } from '../surveillanceInterventionTuningWeeklyOrchestration'
+import { applyWeeklyPsychologicalResilienceDepletionTick } from '../psychologicalResilienceWeeklyOrchestration'
 import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   resolveCoerciveProcedureExecutionDrafts,
@@ -4777,6 +4778,17 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.surveillanceInterventionTuningRecords =
       applyWeeklySurveillanceInterventionTuningTick(
         currentSurveillanceInterventionTuningRecords,
+        result.week
+      )
+  }
+
+  // SPE-1615 slice 3: depletion-band advance on psychological resilience records.
+  const currentPsychologicalResilienceRecords =
+    outputWeeklyState.psychologicalResilienceRecords ?? {}
+  if (Object.keys(currentPsychologicalResilienceRecords).length > 0) {
+    outputWeeklyState.psychologicalResilienceRecords =
+      applyWeeklyPsychologicalResilienceDepletionTick(
+        currentPsychologicalResilienceRecords,
         result.week
       )
   }

--- a/src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts
+++ b/src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import { createStartingState } from '../data/startingState'
 import {
+  PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE,
   PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
   PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
 } from '../domain/psychologicalResilienceRegistry'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyWeeklyPsychologicalResilienceDepletionTick } from '../domain/psychologicalResilienceWeeklyOrchestration'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
   for (const currentCase of Object.values(state.cases)) {
@@ -17,7 +19,7 @@ function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) 
   }
 }
 
-describe('advanceWeek psychological resilience records integration (SPE-1615 slice 2)', () => {
+describe('advanceWeek psychological resilience records integration (SPE-1615 slice 3)', () => {
   it('is a no-op for an empty resilience map without throwing', () => {
     const state = createStartingState()
     freezeCasesForQuietWeek(state)
@@ -28,7 +30,70 @@ describe('advanceWeek psychological resilience records integration (SPE-1615 sli
     expect(nextState.psychologicalResilienceRecords).toEqual({})
   })
 
-  it('preserves psychological resilience records through advanceWeek without mutation', () => {
+  it('advances staged depletion fixture to compromised through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const advanced =
+      nextState.psychologicalResilienceRecords?.[
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id
+      ]
+
+    expect(nextState.week).toBe(2)
+    expect(advanced?.depletionBand).toBe('compromised')
+    expect(advanced?.treatmentRequired).toBe(false)
+    expect(advanced?.restRecoverable).toBe(true)
+    expect(advanced?.operatorRef).toBe(
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef
+    )
+  })
+
+  it('preserves treatment breakdown fixture at breakdown with unchanged gating flags', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.psychologicalResilienceRecords).toEqual(state.psychologicalResilienceRecords)
+    expect(
+      nextState.psychologicalResilienceRecords?.[
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id
+      ]?.treatmentRequired
+    ).toBe(true)
+    expect(
+      nextState.psychologicalResilienceRecords?.[
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id
+      ]?.restRecoverable
+    ).toBe(false)
+  })
+
+  it('keeps stable operator fixture unchanged through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.psychologicalResilienceRecords).toEqual(state.psychologicalResilienceRecords)
+    expect(
+      nextState.psychologicalResilienceRecords?.[PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE.id]
+        ?.depletionBand
+    ).toBe('stable')
+  })
+
+  it('matches direct weekly tick output inside advanceWeek', () => {
     const state = createStartingState()
     freezeCasesForQuietWeek(state)
     state.psychologicalResilienceRecords = {
@@ -39,22 +104,11 @@ describe('advanceWeek psychological resilience records integration (SPE-1615 sli
     }
 
     const nextState = advanceWeek(state)
+    const direct = applyWeeklyPsychologicalResilienceDepletionTick(
+      state.psychologicalResilienceRecords,
+      nextState.week
+    )
 
-    expect(nextState.psychologicalResilienceRecords).toEqual(state.psychologicalResilienceRecords)
-    expect(nextState.week).toBe(2)
-    expect(
-      nextState.psychologicalResilienceRecords?.[PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]
-        ?.operatorRef
-    ).toBe(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef)
-    expect(
-      nextState.psychologicalResilienceRecords?.[
-        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id
-      ]?.treatmentRequired
-    ).toBe(true)
-    expect(
-      nextState.psychologicalResilienceRecords?.[
-        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id
-      ]?.restRecoverable
-    ).toBe(true)
+    expect(nextState.psychologicalResilienceRecords).toEqual(direct)
   })
 })

--- a/src/test/psychologicalResilienceWeeklyOrchestration.test.ts
+++ b/src/test/psychologicalResilienceWeeklyOrchestration.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+  projectPsychologicalResilienceReview,
+  type PsychologicalResilienceRecord,
+} from '../domain/psychologicalResilienceRegistry'
+import {
+  advancePsychologicalResilienceRecordForWeek,
+  applyWeeklyPsychologicalResilienceDepletionTick,
+  resolveTargetDepletionBandFromProjection,
+} from '../domain/psychologicalResilienceWeeklyOrchestration'
+
+function baseRecord(
+  overrides: Partial<PsychologicalResilienceRecord> = {}
+): PsychologicalResilienceRecord {
+  return {
+    id: 'psych-resilience:weekly-orchestration-test',
+    label: 'Weekly orchestration test record',
+    operatorRef: 'agent:weekly-orchestration-test',
+    depletionBand: 'stable',
+    exposureScore: 0.2,
+    exposureEventCount: 1,
+    recoveryChannel: 'rest_recoverable',
+    treatmentRequired: false,
+    restRecoverable: true,
+    ...overrides,
+  }
+}
+
+describe('psychologicalResilienceWeeklyOrchestration (SPE-1615 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklyPsychologicalResilienceDepletionTick({}, 4)).toEqual({})
+    expect(applyWeeklyPsychologicalResilienceDepletionTick(undefined, 4)).toEqual({})
+  })
+
+  it('keeps stable operator fixture unchanged when exposure remains low', () => {
+    const advanced = advancePsychologicalResilienceRecordForWeek(
+      PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE,
+      2
+    )
+
+    expect(advanced).toBe(PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE)
+    expect(advanced.depletionBand).toBe('stable')
+    expect(advanced.restRecoverable).toBe(true)
+    expect(advanced.treatmentRequired).toBe(false)
+  })
+
+  it('escalates staged depletion fixture from depleted to compromised while preserving treatment flags', () => {
+    const projection = projectPsychologicalResilienceReview(
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE
+    )
+
+    expect(
+      resolveTargetDepletionBandFromProjection(
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+        projection
+      )
+    ).toBe('compromised')
+
+    const advanced = advancePsychologicalResilienceRecordForWeek(
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      2
+    )
+
+    expect(advanced).not.toBe(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE)
+    expect(advanced.depletionBand).toBe('compromised')
+    expect(advanced.treatmentRequired).toBe(false)
+    expect(advanced.restRecoverable).toBe(true)
+    expect(advanced.recoveryChannel).toBe('counseling_recommended')
+    expect(advanced.operatorRef).toBe(
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef
+    )
+  })
+
+  it('keeps treatment breakdown fixture idempotent at breakdown', () => {
+    const advanced = advancePsychologicalResilienceRecordForWeek(
+      PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+      2
+    )
+
+    expect(advanced).toBe(PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE)
+    expect(advanced.depletionBand).toBe('breakdown')
+    expect(advanced.treatmentRequired).toBe(true)
+    expect(advanced.restRecoverable).toBe(false)
+  })
+
+  it('escalates stable records when exposure event count crosses the strained threshold', () => {
+    const record = baseRecord({
+      id: 'psych-resilience:strained-escalation',
+      exposureScore: 0.35,
+      exposureEventCount: 3,
+    })
+    const projection = projectPsychologicalResilienceReview(record)
+
+    expect(resolveTargetDepletionBandFromProjection(record, projection)).toBe('strained')
+
+    const advanced = advancePsychologicalResilienceRecordForWeek(record, 2)
+
+    expect(advanced.depletionBand).toBe('strained')
+    expect(advanced.treatmentRequired).toBe(false)
+    expect(advanced.restRecoverable).toBe(true)
+  })
+
+  it('applies explicit breakdown treatment gate when compromised records cross breakdown thresholds', () => {
+    const record = baseRecord({
+      id: 'psych-resilience:breakdown-escalation',
+      depletionBand: 'compromised',
+      exposureScore: 0.86,
+      exposureEventCount: 7,
+      activeComplications: ['fixation'],
+      recoveryChannel: 'counseling_recommended',
+      treatmentRequired: false,
+      restRecoverable: true,
+    })
+
+    const advanced = advancePsychologicalResilienceRecordForWeek(record, 2)
+
+    expect(advanced.depletionBand).toBe('breakdown')
+    expect(advanced.treatmentRequired).toBe(true)
+    expect(advanced.restRecoverable).toBe(false)
+    expect(advanced.recoveryChannel).toBe('treatment_required')
+  })
+
+  it('is idempotent when re-applied after advance', () => {
+    const first = advancePsychologicalResilienceRecordForWeek(
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      2
+    )
+    const second = advancePsychologicalResilienceRecordForWeek(first, 2)
+
+    expect(second).toBe(first)
+    expect(
+      applyWeeklyPsychologicalResilienceDepletionTick(
+        { [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]: first },
+        2
+      )
+    ).toEqual({
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]: first,
+    })
+  })
+
+  it('preserves source record when post-tick candidate fails validation', () => {
+    const record = baseRecord({
+      id: '',
+      depletionBand: 'stable',
+      exposureScore: 0.72,
+      exposureEventCount: 4,
+    })
+
+    const advanced = advancePsychologicalResilienceRecordForWeek(record, 2)
+
+    expect(advanced).toBe(record)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyPsychologicalResilienceDepletionTick` with deterministic one-step depletion-band transitions from projected exposure score/event count.
- Wire weekly tick into `advanceWeek` after week increment; preserve treatment/rest flags unless explicit breakdown gate applies.
- Add domain orchestration tests and extend `advanceWeek` integration tests for escalation/depletion and direct-tick parity.

## Linear

- **Slice:** [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) — Psychological resilience registry weekly advanceWeek depletion orchestration hook (slice 3)
- **Parent:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion (remains open)

## What shipped

- `src/domain/psychologicalResilienceWeeklyOrchestration.ts`
- `advanceWeek` hook for `psychologicalResilienceRecords`
- `src/test/psychologicalResilienceWeeklyOrchestration.test.ts`
- Extended `src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts`
- `planning/spe-1615-psychological-resilience-registry-slice-3.md`

## Validation

- `npm run lint`
- `npm run test:run -- src/test/psychologicalResilienceWeeklyOrchestration.test.ts src/test/advanceWeek.psychologicalResilienceRecords.integration.test.ts src/test/psychologicalResilienceRegistry.test.ts src/test/psychologicalResilienceRegistryPersistence.test.ts`

## Docs updated

- `planning/spe-1615-psychological-resilience-registry-slice-3.md`
- `planning/backlog.md` handoff

## Parent status

SPE-1615 remains open — SPE-1908 compose cross-join and planning mirror UI deferred.