### PR TITLE
feat(SPE-2436): psychological resilience compose cross-join slice 4

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) SPE-1908 cross-join follow-up or planning mirror UI slice 4+, SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) planning mirror UI slice 5+ or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `34e7ff4e` — shipped: [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) psychological resilience registry slice 3 @ PR #2741
+**Base `main` SHA:** `38d6a540` — in progress: [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) psychological resilience compose cross-join slice 4
 
 **Recently shipped:** [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) psychological resilience registry slice 3 @ PR #2741; [SPE-2434](https://linear.app/spectranoir/issue/SPE-2434) psychological resilience registry slice 2 @ PR #2739; see `planning/spe-1615-psychological-resilience-registry-slice-3.md`.
 

--- a/planning/spe-1615-psychological-resilience-registry-slice-4.md
+++ b/planning/spe-1615-psychological-resilience-registry-slice-4.md
@@ -1,0 +1,76 @@
+# SPE-2436 — Psychological resilience cross-join in compose (slice 4)
+
+One-page implementation plan. Linear: [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) (child under [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615)). Follows shipped slice 3 (`planning/spe-1615-psychological-resilience-registry-slice-3.md`, PR #2741 / [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2436 — Psychological resilience cross-join in compose (slice 4)](https://linear.app/spectranoir/issue/SPE-2436) |
+| **Parent** | [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion             |
+| **Branch** | `jamesdyedbq/spe-1615-psychological-resilience-registry-slice-4`                                           |
+| **Status** | In Progress                                                                                                |
+| **Base `main` SHA** | `38d6a540`                                                                                          |
+
+## Goal
+
+Extend `composeCoerciveProtocolIntegratedHealthReconciliation` with optional `psychologicalResilienceRecords` map — cross-join hydrated resilience entries by `operatorRef` against protocol/bundle `agent:` operator links; project `projectPsychologicalResilienceReview` tension flags.
+
+## Prerequisite (on `main` @ `38d6a540`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Resilience registry  | `src/domain/psychologicalResilienceRegistry.ts` (SPE-1615 slice 1)     |
+| Persistence          | `psychologicalResilienceRecords` on `GameState` (SPE-2434 / PR #2739) |
+| Weekly orchestration | `src/domain/psychologicalResilienceWeeklyOrchestration.ts` (SPE-2435) |
+| Compose host         | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` (SPE-2430 pattern) |
+
+## Cross-reconciliation contract (slice 4)
+
+- **Match** — `psychologicalResilienceRecord.operatorRef` ↔ `agent:` refs on protocol optional refs (`subjectFitValidationRef`, `procedureRef`, etc.) or bundle link wired refs when protocol–bundle links exist.
+- **Hydrated truth only** — compose over validated resilience entries; skip invalid drops without re-surfacing.
+- **Projections** — `projectPsychologicalResilienceReview` exposes exposure/depletion/duty/treatment-gating signals.
+- **Tension flags** — `psychological_resilience_exposure_elevated`, `psychological_resilience_duty_reliability_degraded`, `psychological_resilience_treatment_gated` from linked projections.
+- **Backward compatible** — optional fifth `psychologicalResilienceRecords` map arg; slice 1–3 compose without resilience unchanged.
+- **Empty maps** — zeroed resilience fields without throw.
+- **Operator ref mismatch** — no-op without throw.
+- **Byte-stable ordering** — resilience ids, projections, tension flags sorted on repeat.
+- **Redaction** — merge per-record `redactedFields` / `unknownFields`; no hidden truth beyond registry projections.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Compose cross-join + resilience tension flags                      | Planning mirror UI                            |
+| Targeted compose tests                                             | `advanceWeek` orchestration changes           |
+| Slice doc (this file) + backlog handoff                            | SPE-130 fatigue-channel conflation            |
+|                                                                    | New persistence fields on protocol/bundle     |
+|                                                                    | Full SPE-1615 parent Done                     |
+
+## Acceptance
+
+- [x] Compose cross-joins staged-depletion fixture when protocol carries matching `agent:` operator link
+- [x] Treatment breakdown fixture surfaces `psychological_resilience_treatment_gated` without flipping compose-owned bundle fields
+- [x] Operator ref mismatch no-ops without throw; empty / missing resilience maps no-op
+- [x] Slice 1–3 compose + surveillance-tuning regression unchanged
+- [x] Registry projection regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts`   |
+| Tests  | `src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts` |
+| Plan   | `planning/spe-1615-psychological-resilience-registry-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Planning mirror UI over resilience records | SPE-1615 slice 5+ | Mirror follows compose cross-join |
+| Surfacing / weekly notes for resilience tension flags | SPE-1908 follow-up | Out of compose-only boundary |
+| Full SPE-1615 parent Done | SPE-1615 | Mirror slice may remain |
+
+## See also
+
+- `planning/spe-1908-cross-system-reconciliation-slice-3.md` — surveillance-tuning cross-join pattern
+- `planning/spe-1615-psychological-resilience-registry-slice-3.md` — weekly orchestration (shipped)

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
@@ -1,11 +1,11 @@
 /**
- * SPE-1908 / SPE-2428 slice 1 + SPE-2430 slice 3: coercive protocol ↔ integrated
- * health bundle cross-system reconciliation compose.
+ * SPE-1908 / SPE-2428 slice 1 + SPE-2430 slice 3 + SPE-2436 slice 4: coercive
+ * protocol ↔ integrated health bundle cross-system reconciliation compose.
  *
  * Pure deterministic linkage between persisted coercive protocol records,
- * integrated health bundles, and surveillance-tuning records via shared subject
- * refs — reuses registry projections only; no new reconciliation engine or
- * hidden truth beyond hydrated maps.
+ * integrated health bundles, surveillance-tuning records, and psychological
+ * resilience records — reuses registry projections only; no new reconciliation
+ * engine or hidden truth beyond hydrated maps.
  */
 
 import {
@@ -25,6 +25,13 @@ import {
   type TherapeuticCareScheduleLink,
 } from './containedPersonIntegratedHealthBundleRegistry'
 import {
+  projectPsychologicalResilienceReview,
+  validatePsychologicalResilienceRecord,
+  type PsychologicalResilienceProjection,
+  type PsychologicalResilienceRecord,
+  type PsychologicalResilienceRecordsMap,
+} from './psychologicalResilienceRegistry'
+import {
   projectSurveillanceInterventionTuningReview,
   validateSurveillanceInterventionTuningRecord,
   type SurveillanceInterventionTuningProjection,
@@ -32,7 +39,7 @@ import {
   type SurveillanceInterventionTuningRecordsMap,
 } from './surveillanceCapacityInterventionTuningRegistry'
 
-export type CoerciveProtocolIntegratedHealthMatchKind = 'subject_ref'
+export type CoerciveProtocolIntegratedHealthMatchKind = 'subject_ref' | 'operator_ref'
 
 export interface CoerciveProtocolIntegratedHealthCrossLink {
   readonly coerciveProtocolId: string
@@ -48,6 +55,9 @@ export type CoerciveProtocolCrossSystemTensionFlag =
   | 'monitoring_substitutes_contact_signal'
   | 'surveillance_tuning_monitoring_exceeds_contact'
   | 'surveillance_tuning_sustained_under_collateral_strain'
+  | 'psychological_resilience_duty_reliability_degraded'
+  | 'psychological_resilience_exposure_elevated'
+  | 'psychological_resilience_treatment_gated'
 
 export interface CoerciveProtocolSurveillanceTuningCrossLink {
   readonly surveillanceTuningId: string
@@ -55,16 +65,25 @@ export interface CoerciveProtocolSurveillanceTuningCrossLink {
   readonly matchKind: CoerciveProtocolIntegratedHealthMatchKind
 }
 
+export interface CoerciveProtocolPsychologicalResilienceCrossLink {
+  readonly psychologicalResilienceId: string
+  readonly operatorRef: string
+  readonly matchKind: CoerciveProtocolIntegratedHealthMatchKind
+}
+
 export interface CoerciveProtocolIntegratedHealthReconciliationSummary {
   readonly subjectRef: string
   readonly links: readonly CoerciveProtocolIntegratedHealthCrossLink[]
   readonly surveillanceTuningLinks: readonly CoerciveProtocolSurveillanceTuningCrossLink[]
+  readonly psychologicalResilienceLinks: readonly CoerciveProtocolPsychologicalResilienceCrossLink[]
   readonly linkedProtocolCount: number
   readonly linkedBundleCount: number
   readonly linkedTuningCount: number
+  readonly linkedResilienceCount: number
   readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
   readonly triggeredContradictionChecks: readonly CoerciveProtocolContradictionCheckResult[]
   readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
+  readonly psychologicalResilienceProjections: readonly PsychologicalResilienceProjection[]
   readonly bundleMentalStateBand: MentalStateBand | null
   readonly bundleHumaneCareRiskScore: number | null
   readonly bundleTherapeuticChannelStates: readonly TherapeuticCareScheduleLink['channelState'][]
@@ -92,6 +111,17 @@ function isHydratedSurveillanceInterventionTuningRecord(
   record: SurveillanceInterventionTuningRecord
 ): boolean {
   return validateSurveillanceInterventionTuningRecord(record).valid
+}
+
+function isHydratedPsychologicalResilienceRecord(
+  record: PsychologicalResilienceRecord
+): boolean {
+  return validatePsychologicalResilienceRecord(record).valid
+}
+
+function isOperatorLinkRef(value: unknown): boolean {
+  const token = normalizeToken(value)
+  return token.startsWith('agent:')
 }
 
 function mergeUnknownFields(
@@ -127,6 +157,88 @@ function listHydratedProtocolsForSubject(
         isHydratedCoerciveProtocolRecord(record)
     )
     .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function collectProtocolBundleOperatorLinks(input: {
+  readonly protocolRecords: readonly CoerciveProtocolRecord[]
+  readonly bundle: ContainedPersonIntegratedHealthBundle | null
+}): readonly string[] {
+  const operatorLinks = new Set<string>()
+
+  for (const record of input.protocolRecords) {
+    for (const candidate of [
+      record.subjectFitValidationRef,
+      record.procedureRef,
+      record.medicationRegimenRef,
+      record.custodyStatusRef,
+    ]) {
+      if (isOperatorLinkRef(candidate)) {
+        operatorLinks.add(normalizeToken(candidate))
+      }
+    }
+  }
+
+  if (input.bundle) {
+    for (const link of input.bundle.therapeuticCareScheduleLinks ?? []) {
+      for (const candidate of [link.scheduleRef, link.wiredRef]) {
+        if (isOperatorLinkRef(candidate)) {
+          operatorLinks.add(normalizeToken(candidate))
+        }
+      }
+    }
+
+    for (const link of input.bundle.medicationRegimenLinks ?? []) {
+      for (const candidate of [link.regimenRef, link.wiredRef]) {
+        if (isOperatorLinkRef(candidate)) {
+          operatorLinks.add(normalizeToken(candidate))
+        }
+      }
+    }
+
+    for (const link of input.bundle.custodyStatusLinks ?? []) {
+      for (const candidate of [link.custodyRef, link.wiredRef]) {
+        if (isOperatorLinkRef(candidate)) {
+          operatorLinks.add(normalizeToken(candidate))
+        }
+      }
+    }
+
+    for (const link of input.bundle.welfareDebtAccountingLinks ?? []) {
+      for (const candidate of [link.debtRef, link.wiredRef]) {
+        if (isOperatorLinkRef(candidate)) {
+          operatorLinks.add(normalizeToken(candidate))
+        }
+      }
+    }
+  }
+
+  return Object.freeze([...operatorLinks].sort((left, right) => left.localeCompare(right)))
+}
+
+function listHydratedPsychologicalResilienceRecordsForOperatorLinks(
+  records: PsychologicalResilienceRecordsMap | undefined,
+  operatorLinks: readonly string[]
+): PsychologicalResilienceRecord[] {
+  if (operatorLinks.length === 0) {
+    return []
+  }
+
+  const operatorLinkSet = new Set(operatorLinks.map((link) => normalizeToken(link)).filter(Boolean))
+
+  return Object.values(records ?? {})
+    .filter(
+      (record) =>
+        operatorLinkSet.has(normalizeToken(record.operatorRef)) &&
+        isHydratedPsychologicalResilienceRecord(record)
+    )
+    .sort((left, right) => {
+      const byOperator = left.operatorRef.localeCompare(right.operatorRef)
+      if (byOperator !== 0) {
+        return byOperator
+      }
+
+      return left.id.localeCompare(right.id)
+    })
 }
 
 function listHydratedSurveillanceTuningRecordsForSubject(
@@ -223,6 +335,28 @@ function collectBundleCrossSystemTensionFlags(input: {
   return Object.freeze([...new Set(flags)].sort((left, right) => left.localeCompare(right)))
 }
 
+function collectPsychologicalResilienceCrossSystemTensionFlags(input: {
+  readonly psychologicalResilienceProjections: readonly PsychologicalResilienceProjection[]
+}): readonly CoerciveProtocolCrossSystemTensionFlag[] {
+  const flags: CoerciveProtocolCrossSystemTensionFlag[] = []
+
+  for (const projection of input.psychologicalResilienceProjections) {
+    if (projection.exposureElevated) {
+      flags.push('psychological_resilience_exposure_elevated')
+    }
+
+    if (projection.dutyReliabilityDegraded) {
+      flags.push('psychological_resilience_duty_reliability_degraded')
+    }
+
+    if (projection.treatmentGated) {
+      flags.push('psychological_resilience_treatment_gated')
+    }
+  }
+
+  return Object.freeze([...new Set(flags)].sort((left, right) => left.localeCompare(right)))
+}
+
 function collectSurveillanceTuningCrossSystemTensionFlags(input: {
   readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
   readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
@@ -250,6 +384,7 @@ function collectCrossSystemTensionFlags(input: {
   readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
   readonly bundle: ContainedPersonIntegratedHealthBundle | null
   readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
+  readonly psychologicalResilienceProjections: readonly PsychologicalResilienceProjection[]
 }): readonly CoerciveProtocolCrossSystemTensionFlag[] {
   return Object.freeze(
     [
@@ -260,6 +395,9 @@ function collectCrossSystemTensionFlags(input: {
       ...collectSurveillanceTuningCrossSystemTensionFlags({
         protocolRiskReviews: input.protocolRiskReviews,
         surveillanceTuningProjections: input.surveillanceTuningProjections,
+      }),
+      ...collectPsychologicalResilienceCrossSystemTensionFlags({
+        psychologicalResilienceProjections: input.psychologicalResilienceProjections,
       }),
     ]
       .filter((flag, index, flags) => flags.indexOf(flag) === index)
@@ -288,11 +426,19 @@ export function listSurveillanceInterventionTuningRecordsForSubject(
   return listHydratedSurveillanceTuningRecordsForSubject(records, subjectRef)
 }
 
+export function listPsychologicalResilienceRecordsForOperatorLinks(
+  records: PsychologicalResilienceRecordsMap | undefined,
+  operatorLinks: readonly string[]
+): PsychologicalResilienceRecord[] {
+  return listHydratedPsychologicalResilienceRecordsForOperatorLinks(records, operatorLinks)
+}
+
 export function composeCoerciveProtocolIntegratedHealthReconciliation(
   protocols: CoerciveProtocolRecordsMap | undefined,
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
   subjectRef: string,
-  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined,
+  psychologicalResilienceRecords?: PsychologicalResilienceRecordsMap | undefined
 ): CoerciveProtocolIntegratedHealthReconciliationSummary {
   const normalizedSubjectRef = normalizeToken(subjectRef) || '(unknown)'
   const protocolRecords = listHydratedProtocolsForSubject(protocols, normalizedSubjectRef)
@@ -323,8 +469,26 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
     tuningRecords.map((record) => projectSurveillanceInterventionTuningReview(record))
   )
 
+  const operatorLinks =
+    bundle && protocolRecords.length > 0
+      ? collectProtocolBundleOperatorLinks({
+          protocolRecords,
+          bundle,
+        })
+      : Object.freeze([] as readonly string[])
+
+  const resilienceRecords = listHydratedPsychologicalResilienceRecordsForOperatorLinks(
+    psychologicalResilienceRecords,
+    operatorLinks
+  )
+
+  const psychologicalResilienceProjections = Object.freeze(
+    resilienceRecords.map((record) => projectPsychologicalResilienceReview(record))
+  )
+
   const links: CoerciveProtocolIntegratedHealthCrossLink[] = []
   const surveillanceTuningLinks: CoerciveProtocolSurveillanceTuningCrossLink[] = []
+  const psychologicalResilienceLinks: CoerciveProtocolPsychologicalResilienceCrossLink[] = []
 
   if (bundle) {
     for (const record of protocolRecords) {
@@ -343,6 +507,16 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
         surveillanceTuningId: tuningRecord.id,
         subjectRef: normalizedSubjectRef,
         matchKind: 'subject_ref',
+      })
+    }
+  }
+
+  if (bundle && links.length > 0 && resilienceRecords.length > 0) {
+    for (const resilienceRecord of resilienceRecords) {
+      psychologicalResilienceLinks.push({
+        psychologicalResilienceId: resilienceRecord.id,
+        operatorRef: normalizeToken(resilienceRecord.operatorRef),
+        matchKind: 'operator_ref',
       })
     }
   }
@@ -370,24 +544,39 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
     return left.surveillanceTuningId.localeCompare(right.surveillanceTuningId)
   })
 
+  psychologicalResilienceLinks.sort((left, right) => {
+    const byOperator = left.operatorRef.localeCompare(right.operatorRef)
+    if (byOperator !== 0) {
+      return byOperator
+    }
+
+    return left.psychologicalResilienceId.localeCompare(right.psychologicalResilienceId)
+  })
+
   const crossSystemTensionFlags = collectCrossSystemTensionFlags({
     protocolRiskReviews,
     bundle,
     surveillanceTuningProjections,
+    psychologicalResilienceProjections,
   })
 
   const linkedProtocolIds = new Set(links.map((link) => link.coerciveProtocolId))
   const linkedTuningIds = new Set(surveillanceTuningLinks.map((link) => link.surveillanceTuningId))
+  const linkedResilienceIds = new Set(
+    psychologicalResilienceLinks.map((link) => link.psychologicalResilienceId)
+  )
   const structuredReasons = [
     `subject:${normalizedSubjectRef}`,
     `link_count:${links.length}`,
     `linked_protocol_count:${linkedProtocolIds.size}`,
     `linked_bundle_count:${bundle ? 1 : 0}`,
     `linked_tuning_count:${linkedTuningIds.size}`,
+    `linked_resilience_count:${linkedResilienceIds.size}`,
     `triggered_contradiction_check_count:${triggeredContradictionChecks.length}`,
     `cross_system_tension_count:${crossSystemTensionFlags.length}`,
     links.some((link) => link.matchKind === 'subject_ref') ? 'match:subject_ref' : 'match:none_subject_ref',
     surveillanceTuningLinks.length > 0 ? 'tuning:linked' : 'tuning:none',
+    psychologicalResilienceLinks.length > 0 ? 'resilience:linked' : 'resilience:none',
     crossSystemTensionFlags.length > 0 ? 'tension:present' : 'tension:none',
   ].sort((left, right) => left.localeCompare(right))
 
@@ -395,29 +584,36 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
     protocolRecords.some((record) => (record.redactedFields ?? []).length > 0) ||
     (bundle?.redactedFields ?? []).length > 0 ||
     tuningRecords.some((record) => (record.redactedFields ?? []).length > 0) ||
+    resilienceRecords.some((record) => (record.redactedFields ?? []).length > 0) ||
     protocolRiskReviews.some((review) => review.redacted) ||
     triggeredContradictionChecks.some((check) => check.redacted) ||
-    surveillanceTuningProjections.some((projection) => projection.redacted)
+    surveillanceTuningProjections.some((projection) => projection.redacted) ||
+    psychologicalResilienceProjections.some((projection) => projection.redacted)
 
   const unknownFields = mergeUnknownFields(
     ...protocolRecords.map((record) => record.unknownFields),
     bundle?.unknownFields,
     ...tuningRecords.map((record) => record.unknownFields),
+    ...resilienceRecords.map((record) => record.unknownFields),
     ...protocolRiskReviews.map((review) => review.unknownFields),
     ...triggeredContradictionChecks.map((check) => check.unknownFields),
-    ...surveillanceTuningProjections.map((projection) => projection.unknownFields)
+    ...surveillanceTuningProjections.map((projection) => projection.unknownFields),
+    ...psychologicalResilienceProjections.map((projection) => projection.unknownFields)
   )
 
   return Object.freeze({
     subjectRef: normalizedSubjectRef,
     links: Object.freeze(links),
     surveillanceTuningLinks: Object.freeze(surveillanceTuningLinks),
+    psychologicalResilienceLinks: Object.freeze(psychologicalResilienceLinks),
     linkedProtocolCount: linkedProtocolIds.size,
     linkedBundleCount: bundle ? 1 : 0,
     linkedTuningCount: linkedTuningIds.size,
+    linkedResilienceCount: linkedResilienceIds.size,
     protocolRiskReviews,
     triggeredContradictionChecks,
     surveillanceTuningProjections,
+    psychologicalResilienceProjections,
     bundleMentalStateBand: bundle?.mentalStateBand ?? null,
     bundleHumaneCareRiskScore: bundle?.humaneCareRiskScore ?? null,
     bundleTherapeuticChannelStates: collectTherapeuticChannelStates(bundle),
@@ -432,7 +628,8 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
 export function composeAllCoerciveProtocolIntegratedHealthReconciliations(
   protocols: CoerciveProtocolRecordsMap | undefined,
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined,
-  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined,
+  psychologicalResilienceRecords?: PsychologicalResilienceRecordsMap | undefined
 ): readonly CoerciveProtocolIntegratedHealthReconciliationSummary[] {
   const subjectRefs = new Set<string>()
 
@@ -455,7 +652,8 @@ export function composeAllCoerciveProtocolIntegratedHealthReconciliations(
           protocols,
           bundles,
           subjectRef,
-          surveillanceTuningRecords
+          surveillanceTuningRecords,
+          psychologicalResilienceRecords
         )
       )
       .filter((summary) => summary.links.length > 0)

--- a/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
+++ b/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
@@ -9,9 +9,15 @@ import {
   composeAllCoerciveProtocolIntegratedHealthReconciliations,
   composeCoerciveProtocolIntegratedHealthReconciliation,
   listCoerciveProtocolsForIntegratedHealthSubject,
+  listPsychologicalResilienceRecordsForOperatorLinks,
   listSurveillanceInterventionTuningRecordsForSubject,
   resolveIntegratedHealthBundleForSubject,
 } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliation'
+import {
+  PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+  validatePsychologicalResilienceRecord,
+} from '../domain/psychologicalResilienceRegistry'
 import {
   SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
   validateSurveillanceInterventionTuningRecord,
@@ -32,16 +38,21 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliation (SPE-2428 slice 1)
 
     expect(summary.links).toEqual([])
     expect(summary.surveillanceTuningLinks).toEqual([])
+    expect(summary.psychologicalResilienceLinks).toEqual([])
     expect(summary.linkedProtocolCount).toBe(0)
     expect(summary.linkedBundleCount).toBe(0)
     expect(summary.linkedTuningCount).toBe(0)
+    expect(summary.linkedResilienceCount).toBe(0)
     expect(summary.protocolRiskReviews).toEqual([])
     expect(summary.triggeredContradictionChecks).toEqual([])
     expect(summary.surveillanceTuningProjections).toEqual([])
+    expect(summary.psychologicalResilienceProjections).toEqual([])
     expect(summary.crossSystemTensionFlags).toEqual([])
     expect(summary.structuredReasons).toContain('link_count:0')
     expect(summary.structuredReasons).toContain('linked_tuning_count:0')
+    expect(summary.structuredReasons).toContain('linked_resilience_count:0')
     expect(summary.structuredReasons).toContain('tuning:none')
+    expect(summary.structuredReasons).toContain('resilience:none')
     expect(summary.structuredReasons).toContain('tension:none')
   })
 
@@ -205,6 +216,140 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliation (SPE-2428 slice 1)
     expect(first).toEqual(second)
     expect(first).toHaveLength(1)
     expect(first[0]?.subjectRef).toBe('subject:cooperative-field-asset-22')
+  })
+
+  it('cross-joins psychological resilience record by operator ref with protocol operator link', () => {
+    expect(
+      validatePsychologicalResilienceRecord(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE).valid
+    ).toBe(true)
+
+    const protocolWithOperatorLink = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      subjectFitValidationRef: PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef,
+    }
+    const protocols = {
+      [protocolWithOperatorLink.id]: protocolWithOperatorLink,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    const psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef,
+      undefined,
+      psychologicalResilienceRecords
+    )
+
+    expect(summary.linkedResilienceCount).toBe(1)
+    expect(summary.psychologicalResilienceLinks).toHaveLength(1)
+    expect(summary.psychologicalResilienceLinks[0]?.matchKind).toBe('operator_ref')
+    expect(summary.psychologicalResilienceLinks[0]?.operatorRef).toBe(
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef
+    )
+    expect(summary.psychologicalResilienceProjections[0]?.exposureElevated).toBe(true)
+    expect(summary.psychologicalResilienceProjections[0]?.dutyReliabilityDegraded).toBe(true)
+    expect(summary.psychologicalResilienceProjections[0]?.treatmentGated).toBe(false)
+    expect(summary.crossSystemTensionFlags).toEqual([
+      'monitoring_substitutes_contact_signal',
+      'psychological_resilience_duty_reliability_degraded',
+      'psychological_resilience_exposure_elevated',
+      'surveillance_burden_low_humane_care_risk',
+      'surveillance_burden_no_active_contact_channel',
+      'surveillance_burden_stable_mental_state',
+    ])
+    expect(summary.structuredReasons).toContain('linked_resilience_count:1')
+    expect(summary.structuredReasons).toContain('resilience:linked')
+  })
+
+  it('surfaces treatment-gated tension flag for breakdown resilience without flipping compose fields', () => {
+    const protocolWithOperatorLink = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      subjectFitValidationRef: PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.operatorRef,
+    }
+    const protocols = {
+      [protocolWithOperatorLink.id]: protocolWithOperatorLink,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    const psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef,
+      undefined,
+      psychologicalResilienceRecords
+    )
+
+    expect(summary.linkedResilienceCount).toBe(1)
+    expect(summary.psychologicalResilienceProjections[0]?.treatmentGated).toBe(true)
+    expect(summary.crossSystemTensionFlags).toContain('psychological_resilience_treatment_gated')
+    expect(summary.linkedProtocolCount).toBe(1)
+    expect(summary.linkedBundleCount).toBe(1)
+    expect(summary.bundleMentalStateBand).toBe('stable')
+  })
+
+  it('no-ops psychological resilience cross-join when operator ref mismatches protocol operator link', () => {
+    const protocolWithOperatorLink = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      subjectFitValidationRef: 'agent:unrelated-operator-99',
+    }
+    const protocols = {
+      [protocolWithOperatorLink.id]: protocolWithOperatorLink,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    const psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef,
+      undefined,
+      psychologicalResilienceRecords
+    )
+
+    expect(summary.psychologicalResilienceLinks).toEqual([])
+    expect(summary.linkedResilienceCount).toBe(0)
+    expect(summary.psychologicalResilienceProjections).toEqual([])
+    expect(summary.crossSystemTensionFlags).not.toContain('psychological_resilience_exposure_elevated')
+    expect(summary.structuredReasons).toContain('resilience:none')
+  })
+
+  it('lists hydrated psychological resilience records for operator links in stable order', () => {
+    const operatorLinks = [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef]
+    const psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+
+    expect(
+      listPsychologicalResilienceRecordsForOperatorLinks(
+        psychologicalResilienceRecords,
+        operatorLinks
+      ).map((record) => record.id)
+    ).toEqual([PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id])
   })
 
   it('skips invalid hydrate drops without re-surfacing them', () => {


### PR DESCRIPTION
## Summary

- Extend `composeCoerciveProtocolIntegratedHealthReconciliation` with optional fifth `psychologicalResilienceRecords` map arg and `composeAll` passthrough.
- Cross-join hydrated resilience records by `operator_ref` against `agent:` operator links on protocol optional refs and bundle wired refs when protocol–bundle links exist.
- Project `projectPsychologicalResilienceReview` tension flags: `psychological_resilience_exposure_elevated`, `psychological_resilience_duty_reliability_degraded`, `psychological_resilience_treatment_gated`.

## Linear

- **Slice:** [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) — Psychological resilience cross-join in compose (slice 4)
- **Parent:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion (remains open)

## What shipped

- `coerciveProtocolIntegratedHealthCrossReconciliation.ts` operator_ref cross-links, resilience projections, tension flags, structured reasons
- Targeted compose tests: cross-join match, treatment-gated breakdown, operator mismatch no-op, list helper
- Slice doc: `planning/spe-1615-psychological-resilience-registry-slice-4.md`

## Validation

- `npm run lint`
- `npm run test:run -- src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts src/test/psychologicalResilienceRegistry.test.ts src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts`

## Docs updated

- `planning/spe-1615-psychological-resilience-registry-slice-4.md`
- `planning/backlog.md`

## Parent remains open

SPE-1615 parent stays open — planning mirror UI slice deferred.