### PR TITLE
feat(SPE-2437): psychological resilience planning mirror UI slice 5

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) planning mirror UI slice 5+ or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) psychological resilience planning mirror UI slice 5 (in progress) or SPE-848 slice 4 planning mirror UI. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `9ded0f61` — shipped: [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) psychological resilience compose cross-join slice 4 @ PR #2743
+**Base `main` SHA:** `cc5b9998` — shipped: [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) psychological resilience compose cross-join slice 4 @ PR #2743
 
-**Recently shipped:** [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) psychological resilience compose cross-join slice 4 @ PR #2743; [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) psychological resilience registry slice 3 @ PR #2741; see `planning/spe-1615-psychological-resilience-registry-slice-4.md`.
+**Recently shipped:** [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) psychological resilience compose cross-join slice 4 @ PR #2743; [SPE-2435](https://linear.app/spectranoir/issue/SPE-2435) psychological resilience registry slice 3 @ PR #2741; see `planning/spe-1615-psychological-resilience-registry-slice-4.md`. **In progress:** [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) mirror UI slice 5 — `planning/spe-1615-psychological-resilience-registry-slice-5.md`.
 
 ## Blocked / waiting
 

--- a/planning/spe-1615-psychological-resilience-registry-slice-5.md
+++ b/planning/spe-1615-psychological-resilience-registry-slice-5.md
@@ -1,0 +1,80 @@
+# SPE-2437 — Psychological resilience registry planning mirror UI (slice 5)
+
+One-page implementation plan. Linear: [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) (child under [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615)). Follows shipped slice 4 (`planning/spe-1615-psychological-resilience-registry-slice-4.md`, PR #2743 / [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2437 — Psychological resilience registry planning mirror UI (slice 5)](https://linear.app/spectranoir/issue/SPE-2437) |
+| **Parent** | [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion             |
+| **Branch** | `jamesdyedbq/spe-1615-psychological-resilience-registry-slice-5`                                           |
+| **Status** | **Ready for PR**                                                                                           |
+| **Base `main` SHA** | `cc5b9998`                                                                                          |
+
+## Goal
+
+Read-only planning/operations mirror over persisted `psychologicalResilienceRecords` with read-time `projectPsychologicalResilienceReview` display (depletion band, exposure elevated, treatment gated) for agent routing visibility, not player-facing canon.
+
+## Prerequisite (on `main` @ `cc5b9998`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/psychologicalResilienceRegistry.ts` (SPE-1615 slice 1)     |
+| Persistence          | `psychologicalResilienceRecords` on `GameState` (SPE-2434)           |
+| Weekly orchestration | `applyWeeklyPsychologicalResilienceDepletionTick` (SPE-2435)         |
+| Compose cross-join   | `composeCoerciveProtocolIntegratedHealthReconciliation` resilience arg (SPE-2436) |
+| Sibling mirror template | `containedPersonTherapeuticCareMirrorView` (SPE-2115 slice 4), `coerciveContainedPersonProtocolMirrorView` (SPE-1882 slice 4) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `getPsychologicalResilienceMirrorView` + `PsychologicalResilienceMirrorPage` | Compose cross-join changes (slice 4) |
+| Route `/psychological-resilience` + Front Desk quick link          | `advanceWeek` orchestration changes           |
+| View + component tests                                             | SPE-130 fatigue-channel conflation            |
+| Slice doc (this file) + backlog handoff                            | Re-validation of hidden/dropped records       |
+| Read-time `projectPsychologicalResilienceReview` display from hydrated records | Full SPE-1615 parent Done |
+
+## Mirror contract
+
+- **Read-only** — no mutations to GameState from the mirror surface.
+- **Hydrated truth only** — display persisted records as hydrated; do not re-run validation to drop entries.
+- **Display guards** — `validatePsychologicalResilienceRecord` surfaces warning-severity issues only; warning-only records remain visible.
+- **Read-time projections** — `projectPsychologicalResilienceReview` at mirror build; not objective truth.
+- **Redaction** — redacted unit scores render as `—`; no hidden truth beyond registry projections.
+- **Empty state** — when `psychologicalResilienceRecords` map is empty after hydrate.
+- **Ordering** — byte-stable sort by record id; exposure sources and complications sorted for display.
+- **Copy** — CP-neutral labels; no franchise tokens in UI strings.
+
+## Acceptance
+
+- [x] Empty `psychologicalResilienceRecords` map renders empty state without throw
+- [x] Records table shows depletion band, exposure elevated, and treatment gated projection labels
+- [x] Redacted exposure scores do not leak hidden values
+- [x] Warning-only records still shown with validation warning labels
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/psychologicalResilienceMirrorView.ts`      |
+| UI     | `src/features/operations/PsychologicalResilienceMirrorPage.tsx`       |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`                                |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/psychologicalResilienceMirrorView.test.ts`, `src/features/operations/PsychologicalResilienceMirrorPage.test.tsx` |
+| Plan   | `planning/spe-1615-psychological-resilience-registry-slice-5.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Surfacing / weekly notes for resilience tension flags | SPE-1908 follow-up | Out of mirror-only boundary |
+| Full SPE-1615 parent Done | SPE-1615 | Parent AC may require additional wire-up beyond mirror UI |
+| SPE-848 slice 4 planning mirror UI | SPE-848 | Parallel registry mirror queue item |
+
+## See also
+
+- `planning/spe-1615-psychological-resilience-registry-slice-4.md`
+- `planning/contained-person-therapeutic-care-registry-slice-4.md` — mirror UI template (SPE-2115)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -102,6 +102,9 @@ const ContainedPersonTherapeuticCareMirrorRoute = createRouteComponent(
 const CoerciveContainedPersonProtocolMirrorRoute = createRouteComponent(
   () => import('../features/operations/CoerciveContainedPersonProtocolMirrorPage')
 )
+const PsychologicalResilienceMirrorRoute = createRouteComponent(
+  () => import('../features/operations/PsychologicalResilienceMirrorPage')
+)
 const NamingHazardDescriptorMirrorRoute = createRouteComponent(
   () => import('../features/operations/NamingHazardDescriptorMirrorPage')
 )
@@ -204,6 +207,10 @@ export default function App() {
         <Route
           path="coercive-contained-person-protocol"
           element={renderLazyRoute(CoerciveContainedPersonProtocolMirrorRoute)}
+        />
+        <Route
+          path="psychological-resilience"
+          element={renderLazyRoute(PsychologicalResilienceMirrorRoute)}
         />
         <Route
           path="naming-hazard-descriptor"

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -33,6 +33,7 @@ export const APP_ROUTES = {
   entityWelfareReclassification: '/entity-welfare-reclassification',
   containedPersonTherapeuticCare: '/contained-person-therapeutic-care',
   coerciveContainedPersonProtocol: '/coercive-contained-person-protocol',
+  psychologicalResilience: '/psychological-resilience',
   namingHazardDescriptor: '/naming-hazard-descriptor',
   containedPersonIntegratedHealthBundle: '/contained-person-integrated-health-bundle',
   welfareDebtAccounting: '/welfare-debt-accounting',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1267,6 +1267,45 @@ export const COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT: Record<string, s
   redactedSuffix: 'Partial redaction',
 }
 
+export const PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Psychological resilience registry',
+  pageSubtitle:
+    'Read-only operations view over persisted operator resilience records and read-time depletion, exposure, and treatment-gating projections.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Persisted records',
+  exposureElevatedLabel: 'Exposure elevated',
+  treatmentGatedLabel: 'Treatment gated',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Depletion bands, exposure scores, and treatment gates mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
+  emptyTitle: 'No psychological resilience records',
+  emptyBody:
+    'Persisted operator resilience records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  recordsHeading: 'Persisted records',
+  recordsSubtitle:
+    'Exposure, depletion, and treatment-gating projections are read-time only, not objective truth.',
+  labelColumn: 'Label',
+  depletionColumn: 'Depletion posture',
+  exposureColumn: 'Exposure',
+  recoveryColumn: 'Recovery channel',
+  projectionColumn: 'Projection signals',
+  confidenceColumn: 'Confidence',
+  operatorRefPrefix: 'Operator:',
+  exposureScorePrefix: 'Exposure score:',
+  exposureEventPrefix: 'Exposure events:',
+  exposureSourcesPrefix: 'Sources:',
+  complicationsPrefix: 'Complications:',
+  counselingRefPrefix: 'Counseling ref:',
+  exposureElevatedSuffix: 'Exposure elevated',
+  treatmentGatedSuffix: 'Treatment gated',
+  depletionAdvancedSuffix: 'Depletion advanced',
+  dutyReliabilitySuffix: 'Duty reliability degraded',
+  restRecoverySuffix: 'Rest recovery eligible',
+  validationWarningPrefix: 'Validation warnings:',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const CONTAINED_PERSON_THERAPEUTIC_CARE_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Contained person therapeutic care registry',

--- a/src/features/operations/PsychologicalResilienceMirrorPage.test.tsx
+++ b/src/features/operations/PsychologicalResilienceMirrorPage.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+} from '../../domain/psychologicalResilienceRegistry'
+import { useGameStore } from '../../app/store/gameStore'
+import PsychologicalResilienceMirrorPage from './PsychologicalResilienceMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/psychological-resilience']}>
+      <Routes>
+        <Route path="/psychological-resilience" element={<PsychologicalResilienceMirrorPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('PsychologicalResilienceMirrorPage (SPE-1615 slice 5)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderMirrorPage()
+
+    expect(
+      screen.getByRole('region', { name: /psychological resilience registry mirror/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty registry state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no psychological resilience records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted records when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted psychological resilience records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(screen.getByText(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.label)).toBeInTheDocument()
+    expect(screen.getByText(PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.label)).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent('Exposure elevated')
+    expect(recordsRegion).toHaveTextContent('Treatment gated')
+  })
+})

--- a/src/features/operations/PsychologicalResilienceMirrorPage.tsx
+++ b/src/features/operations/PsychologicalResilienceMirrorPage.tsx
@@ -1,0 +1,207 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT } from '../../data/copy'
+import { getPsychologicalResilienceMirrorView } from './psychologicalResilienceMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function PsychologicalResilienceMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getPsychologicalResilienceMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Psychological resilience registry mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Registry summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">
+              {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.pageHeading}
+            </h2>
+            <p className="text-sm opacity-60">
+              {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.pageSubtitle}
+            </p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.exposureElevatedLabel}
+            value={String(view.summary.exposureElevatedCount)}
+          />
+          <StatCard
+            label={PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.treatmentGatedLabel}
+            value={String(view.summary.treatmentGatedCount)}
+          />
+          <StatCard
+            label={PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">
+          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.readOnlyNote}
+        </p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty registry state">
+          <h3 className="text-lg font-semibold">
+            {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.emptyTitle}
+          </h3>
+          <p className="text-sm opacity-70">{PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted psychological resilience records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">
+              {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.recordsHeading}
+            </h3>
+            <p className="text-sm opacity-60">
+              {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.recordsSubtitle}
+            </p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">
+                    {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.labelColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.depletionColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.exposureColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.recoveryColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.projectionColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.confidenceColumn}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.operatorRefPrefix}{' '}
+                        {record.operatorRefLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      <p>{record.depletionBandLabel}</p>
+                      {record.complicationLabels.length > 0 ? (
+                        <p className="text-xs opacity-55">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.complicationsPrefix}{' '}
+                          {record.complicationLabels.join('; ')}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <p className="text-xs opacity-55">
+                        {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.exposureScorePrefix}{' '}
+                        {record.exposureScoreLabel}
+                      </p>
+                      <p className="text-xs opacity-55">
+                        {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.exposureEventPrefix}{' '}
+                        {record.exposureEventCountLabel}
+                      </p>
+                      {record.exposureSourceLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.exposureSourcesPrefix}{' '}
+                          {record.exposureSourceLabels.join('; ')}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <p>{record.recoveryChannelLabel}</p>
+                      {record.counselingRefLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.counselingRefPrefix}{' '}
+                          {record.counselingRefLabel}
+                        </p>
+                      ) : null}
+                      {record.restRecoveryEligibleLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.restRecoverySuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.exposureElevatedLabel !== '—' ? (
+                        <p className="text-xs opacity-55">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.exposureElevatedSuffix}
+                        </p>
+                      ) : null}
+                      {record.treatmentGatedLabel !== '—' ? (
+                        <p className="text-xs opacity-55">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.treatmentGatedSuffix}
+                        </p>
+                      ) : null}
+                      {record.depletionAdvancedLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.depletionAdvancedSuffix}
+                        </p>
+                      ) : null}
+                      {record.dutyReliabilityDegradedLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.dutyReliabilitySuffix}
+                        </p>
+                      ) : null}
+                      {record.redacted ? (
+                        <p className="text-xs opacity-45">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.redactedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.confidenceLabel}
+                      {record.validationWarningLabels.length > 0 ? (
+                        <p className="text-xs text-amber-200/80">
+                          {PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT.validationWarningPrefix}{' '}
+                          {record.validationWarningLabels.length}
+                        </p>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -814,6 +814,12 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
         'Review handling modes, containment-care tradeoffs, coercion-risk flags, and owner refs.',
     },
     {
+      label: 'Open psychological resilience mirror',
+      href: APP_ROUTES.psychologicalResilience,
+      description:
+        'Review depletion bands, exposure posture, treatment gating, and duty-reliability projections.',
+    },
+    {
       label: 'Open naming-hazard descriptor mirror',
       href: APP_ROUTES.namingHazardDescriptor,
       description:

--- a/src/features/operations/psychologicalResilienceMirrorView.test.ts
+++ b/src/features/operations/psychologicalResilienceMirrorView.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+  PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+  projectPsychologicalResilienceReview,
+  validatePsychologicalResilienceRecord,
+  type PsychologicalResilienceRecord,
+} from '../../domain/psychologicalResilienceRegistry'
+import {
+  formatPsychologicalResilienceEnumLabel,
+  getPsychologicalResilienceMirrorView,
+} from './psychologicalResilienceMirrorView'
+
+function warningOnlyRecord(): PsychologicalResilienceRecord {
+  return {
+    id: 'psych-resilience:breakdown-warning-only',
+    label: 'Breakdown without treatment flag',
+    operatorRef: 'agent:field-operator-99',
+    depletionBand: 'breakdown',
+    exposureScore: 0.88,
+    exposureEventCount: 6,
+    recoveryChannel: 'treatment_required',
+    treatmentRequired: false,
+    restRecoverable: false,
+  }
+}
+
+function redactedExposureRecord(): PsychologicalResilienceRecord {
+  return {
+    id: 'psych-resilience:redacted-exposure',
+    label: 'Redacted exposure score profile',
+    operatorRef: 'agent:analyst-operator-5',
+    depletionBand: 'strained',
+    exposureScore: 0.55,
+    exposureEventCount: 3,
+    recoveryChannel: 'counseling_recommended',
+    treatmentRequired: false,
+    restRecoverable: true,
+    redactedFields: ['exposureScore'],
+    confidence: 0.62,
+  }
+}
+
+describe('psychologicalResilienceMirrorView (SPE-1615 slice 5)', () => {
+  it('returns empty mirror when psychologicalResilienceRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.psychologicalResilienceRecords).toEqual({})
+
+    const view = getPsychologicalResilienceMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('mirrors depletion band, exposure posture, and recovery channel from hydrated records', () => {
+    const game = createStartingState()
+    game.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE,
+    }
+
+    const view = getPsychologicalResilienceMirrorView(game)
+    const record = view.records[0]
+    const projection = projectPsychologicalResilienceReview(
+      PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE
+    )
+
+    expect(view.isEmpty).toBe(false)
+    expect(record?.depletionBandLabel).toBe('Stable')
+    expect(record?.exposureScoreLabel).toBe(projection.exposureScore?.toFixed(2))
+    expect(record?.exposureElevatedLabel).toBe('—')
+    expect(record?.treatmentGatedLabel).toBe('—')
+    expect(record?.exposureSourceLabels).toEqual(['Impossible Evidence'])
+  })
+
+  it('shows exposure elevated and treatment gated projection labels for staged and breakdown fixtures', () => {
+    const game = createStartingState()
+    game.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+      [PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE,
+    }
+
+    const view = getPsychologicalResilienceMirrorView(game)
+    const stagedRecord = view.records.find(
+      (record) => record.id === PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id
+    )
+    const breakdownRecord = view.records.find(
+      (record) => record.id === PSYCHOLOGICAL_RESILIENCE_TREATMENT_BREAKDOWN_FIXTURE.id
+    )
+
+    expect(view.summary.exposureElevatedCount).toBe(2)
+    expect(view.summary.treatmentGatedCount).toBe(1)
+    expect(view.summary.depletionAdvancedCount).toBe(2)
+    expect(view.summary.dutyReliabilityDegradedCount).toBe(2)
+    expect(stagedRecord?.exposureElevatedLabel).toBe('Yes')
+    expect(stagedRecord?.treatmentGatedLabel).toBe('—')
+    expect(stagedRecord?.complicationLabels).toEqual(['Communication Strain', 'Hypervigilance'])
+    expect(breakdownRecord?.depletionBandLabel).toBe('Breakdown')
+    expect(breakdownRecord?.treatmentGatedLabel).toBe('Yes')
+    expect(breakdownRecord?.restRecoveryEligibleLabel).toBe('—')
+  })
+
+  it('still mirrors warning-only records with validation warning labels', () => {
+    const warningRecord = warningOnlyRecord()
+    expect(validatePsychologicalResilienceRecord(warningRecord).valid).toBe(true)
+
+    const game = createStartingState()
+    game.psychologicalResilienceRecords = {
+      [warningRecord.id]: warningRecord,
+    }
+
+    const view = getPsychologicalResilienceMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.totalRecords).toBe(1)
+    expect(view.summary.treatmentGatedCount).toBe(1)
+    expect(record?.validationWarningLabels.length).toBe(2)
+    expect(record?.depletionBandLabel).toBe('Breakdown')
+  })
+
+  it('does not leak redacted exposure scores in mirror labels', () => {
+    const redactedRecord = redactedExposureRecord()
+    const projection = projectPsychologicalResilienceReview(redactedRecord)
+
+    expect(projection.exposureScore).toBeNull()
+    expect(projection.redacted).toBe(true)
+
+    const game = createStartingState()
+    game.psychologicalResilienceRecords = {
+      [redactedRecord.id]: redactedRecord,
+    }
+
+    const view = getPsychologicalResilienceMirrorView(game)
+    const record = view.records[0]
+
+    expect(record?.exposureScoreLabel).toBe('—')
+    expect(record?.redacted).toBe(true)
+    expect(record?.exposureElevatedLabel).toBe('—')
+  })
+
+  it('orders records by id and is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE,
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+    }
+
+    const view = getPsychologicalResilienceMirrorView(game)
+
+    expect(view.records.map((record) => record.id)).toEqual([
+      PSYCHOLOGICAL_RESILIENCE_STABLE_OPERATOR_FIXTURE.id,
+      PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id,
+    ])
+
+    const first = JSON.stringify(getPsychologicalResilienceMirrorView(game))
+    const second = JSON.stringify(getPsychologicalResilienceMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatPsychologicalResilienceEnumLabel('cognitohazard_contact')).toBe(
+      'Cognitohazard Contact'
+    )
+    expect(formatPsychologicalResilienceEnumLabel('treatment_required')).toBe('Treatment Required')
+  })
+})

--- a/src/features/operations/psychologicalResilienceMirrorView.ts
+++ b/src/features/operations/psychologicalResilienceMirrorView.ts
@@ -1,0 +1,197 @@
+import type { GameState } from '../../domain/models'
+import {
+  projectPsychologicalResilienceReview,
+  validatePsychologicalResilienceRecord,
+  type PsychologicalResilienceRecord,
+  type ResilienceComplication,
+  type ResilienceExposureSource,
+} from '../../domain/psychologicalResilienceRegistry'
+
+export interface PsychologicalResilienceMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  operatorRefLabel: string
+  depletionBandLabel: string
+  exposureScoreLabel: string
+  exposureEventCountLabel: string
+  recoveryChannelLabel: string
+  exposureSourceLabels: readonly string[]
+  complicationLabels: readonly string[]
+  exposureElevatedLabel: string
+  depletionAdvancedLabel: string
+  treatmentGatedLabel: string
+  restRecoveryEligibleLabel: string
+  dutyReliabilityDegradedLabel: string
+  counselingRefLabel: string
+  validationWarningLabels: readonly string[]
+  unknownFieldLabels: readonly string[]
+  confidenceLabel: string
+  redacted: boolean
+}
+
+export interface PsychologicalResilienceMirrorSummaryView {
+  totalRecords: number
+  exposureElevatedCount: number
+  treatmentGatedCount: number
+  depletionAdvancedCount: number
+  dutyReliabilityDegradedCount: number
+  week: number
+}
+
+export interface PsychologicalResilienceMirrorView {
+  isEmpty: boolean
+  summary: PsychologicalResilienceMirrorSummaryView
+  records: readonly PsychologicalResilienceMirrorRecordView[]
+}
+
+export function formatPsychologicalResilienceEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(game: GameState): PsychologicalResilienceRecord[] {
+  const map = game.psychologicalResilienceRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatConfidence(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatUnitScore(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatYesNo(value: boolean): string {
+  return value ? 'Yes' : '—'
+}
+
+function formatOptionalRef(value: string | undefined): string {
+  return value?.trim() ? value : '—'
+}
+
+function sortedEnumLabels<T extends string>(
+  values: readonly T[] | undefined,
+  formatter: (value: T) => string
+): readonly string[] {
+  if (!values || values.length === 0) {
+    return Object.freeze([])
+  }
+
+  return Object.freeze(
+    [...values]
+      .sort((left, right) => left.localeCompare(right))
+      .map((value) => formatter(value))
+  )
+}
+
+function sortedExposureSourceLabels(
+  sources: readonly ResilienceExposureSource[] | undefined
+): readonly string[] {
+  return sortedEnumLabels(sources, formatPsychologicalResilienceEnumLabel)
+}
+
+function sortedComplicationLabels(
+  complications: readonly ResilienceComplication[] | undefined
+): readonly string[] {
+  return sortedEnumLabels(complications, formatPsychologicalResilienceEnumLabel)
+}
+
+function sortedUnknownFieldLabels(unknownFields: readonly string[] | undefined): readonly string[] {
+  return Object.freeze([...(unknownFields ?? [])].sort((left, right) => left.localeCompare(right)))
+}
+
+function toRecordView(record: PsychologicalResilienceRecord): PsychologicalResilienceMirrorRecordView {
+  const projection = projectPsychologicalResilienceReview(record)
+  const validation = validatePsychologicalResilienceRecord(record)
+
+  const validationWarningLabels = Object.freeze(
+    validation.issues
+      .filter((issue) => issue.severity === 'warning')
+      .map((issue) => issue.detail)
+  )
+
+  const summaryLabel = record.summary?.trim() ? record.summary : '—'
+
+  return Object.freeze({
+    id: record.id,
+    label: record.label,
+    summaryLabel,
+    operatorRefLabel: record.operatorRef,
+    depletionBandLabel: formatPsychologicalResilienceEnumLabel(record.depletionBand),
+    exposureScoreLabel: formatUnitScore(projection.exposureScore),
+    exposureEventCountLabel: String(record.exposureEventCount),
+    recoveryChannelLabel: formatPsychologicalResilienceEnumLabel(record.recoveryChannel),
+    exposureSourceLabels: sortedExposureSourceLabels(record.exposureSources),
+    complicationLabels: sortedComplicationLabels(record.activeComplications),
+    exposureElevatedLabel: formatYesNo(projection.exposureElevated),
+    depletionAdvancedLabel: formatYesNo(projection.depletionAdvanced),
+    treatmentGatedLabel: formatYesNo(projection.treatmentGated),
+    restRecoveryEligibleLabel: formatYesNo(projection.restRecoveryEligible),
+    dutyReliabilityDegradedLabel: formatYesNo(projection.dutyReliabilityDegraded),
+    counselingRefLabel: formatOptionalRef(record.counselingRef),
+    validationWarningLabels,
+    unknownFieldLabels: sortedUnknownFieldLabels(projection.unknownFields),
+    confidenceLabel: formatConfidence(projection.confidence),
+    redacted: projection.redacted,
+  })
+}
+
+/** Read-only mirror over hydrated `psychologicalResilienceRecords`; does not re-validate dropped entries. */
+export function getPsychologicalResilienceMirrorView(
+  game: GameState
+): PsychologicalResilienceMirrorView {
+  const records = listPersistedRecords(game)
+  const week = game.week
+
+  let exposureElevatedCount = 0
+  let treatmentGatedCount = 0
+  let depletionAdvancedCount = 0
+  let dutyReliabilityDegradedCount = 0
+
+  const recordViews = records.map((record) => {
+    const projection = projectPsychologicalResilienceReview(record)
+
+    if (projection.exposureElevated) {
+      exposureElevatedCount += 1
+    }
+
+    if (projection.treatmentGated) {
+      treatmentGatedCount += 1
+    }
+
+    if (projection.depletionAdvanced) {
+      depletionAdvancedCount += 1
+    }
+
+    if (projection.dutyReliabilityDegraded) {
+      dutyReliabilityDegradedCount += 1
+    }
+
+    return toRecordView(record)
+  })
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      totalRecords: records.length,
+      exposureElevatedCount,
+      treatmentGatedCount,
+      depletionAdvancedCount,
+      dutyReliabilityDegradedCount,
+      week,
+    }),
+    records: Object.freeze(recordViews),
+  })
+}


### PR DESCRIPTION
## Summary

- Add read-only mirror view + page over persisted `psychologicalResilienceRecords` with `projectPsychologicalResilienceReview` projection labels (depletion band, exposure elevated, treatment gated)
- Wire route `/psychological-resilience`, Front Desk quick link, and CP-neutral copy
- Targeted mirror view + page tests; slice doc and backlog handoff

## Linear

- **Slice:** [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) — Psychological resilience registry planning mirror UI (slice 5)
- **Parent:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) — Psychological resilience depletion (remains open)

## What shipped

- `getPsychologicalResilienceMirrorView` + `PsychologicalResilienceMirrorPage`
- Route + Front Desk quick link
- Redaction-safe exposure score display; byte-stable record ordering

## Validation

- `npm run test:run -- src/features/operations/psychologicalResilienceMirrorView.test.ts src/features/operations/PsychologicalResilienceMirrorPage.test.ts`
- `npm run lint`

## Docs updated

- `planning/spe-1615-psychological-resilience-registry-slice-5.md`
- `planning/backlog.md`

## Parent status

SPE-1615 parent remains **Backlog** — mirror slice only; full parent AC not claimed.

Made with [Cursor](https://cursor.com)