### PR TITLE
feat(SPE-2438): surveillance tuning planning mirror UI slice 4

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) slice 4 planning mirror UI or [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) parent acceptance review. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) parent acceptance review or next registry mirror queue item. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `ca2e081c` — shipped: [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) psychological resilience planning mirror UI slice 5 @ PR #2745
+**Base `main` SHA:** `2188f941` — in progress: [SPE-2438](https://linear.app/spectranoir/issue/SPE-2438) surveillance tuning planning mirror UI slice 4 (`planning/spe-848-surveillance-tuning-registry-slice-4.md`)
 
-**Recently shipped:** [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) psychological resilience planning mirror UI slice 5 @ PR #2745; [SPE-2436](https://linear.app/spectranoir/issue/SPE-2436) psychological resilience compose cross-join slice 4 @ PR #2743; see `planning/spe-1615-psychological-resilience-registry-slice-5.md`.
+**Recently shipped:** [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) psychological resilience planning mirror UI slice 5 @ PR #2745; [SPE-2432](https://linear.app/spectranoir/issue/SPE-2432) surveillance tuning weekly orchestration slice 3 @ PR #2735; see `planning/spe-1615-psychological-resilience-registry-slice-5.md` and `planning/spe-848-surveillance-tuning-registry-slice-3.md`.
 
 ## Blocked / waiting
 

--- a/planning/spe-848-surveillance-tuning-registry-slice-4.md
+++ b/planning/spe-848-surveillance-tuning-registry-slice-4.md
@@ -1,0 +1,79 @@
+# SPE-2438 — Surveillance tuning registry planning mirror UI (slice 4)
+
+One-page implementation plan. Linear: [SPE-2438](https://linear.app/spectranoir/issue/SPE-2438) (child under [SPE-848](https://linear.app/spectranoir/issue/SPE-848)). Follows shipped slice 3 (`planning/spe-848-surveillance-tuning-registry-slice-3.md`, PR #2735 / [SPE-2432](https://linear.app/spectranoir/issue/SPE-2432)).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2438 — Surveillance tuning registry planning mirror UI (slice 4)](https://linear.app/spectranoir/issue/SPE-2438) |
+| **Parent** | [SPE-848](https://linear.app/spectranoir/issue/SPE-848) — Surveillance and capacity intervention tuning     |
+| **Branch** | `jamesdyedbq/spe-848-surveillance-tuning-registry-slice-4`                                                 |
+| **Status** | **Ready for PR**                                                                                           |
+| **Base `main` SHA** | `2188f941`                                                                                          |
+
+## Goal
+
+Read-only planning/operations mirror over persisted `surveillanceInterventionTuningRecords` with read-time `projectSurveillanceInterventionTuningReview` display (intervention level, monitoring/contact separation, collateral strain, horizon outcomes) for agent routing visibility, not player-facing canon.
+
+## Prerequisite (on `main` @ `2188f941`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/surveillanceCapacityInterventionTuningRegistry.ts` (SPE-848 slice 1) |
+| Persistence          | `surveillanceInterventionTuningRecords` on `GameState` (SPE-2431)    |
+| Weekly orchestration | `applyWeeklySurveillanceInterventionTuningTick` (SPE-2432)           |
+| Sibling mirror template | `psychologicalResilienceMirrorView` (SPE-2437), `containedPersonTherapeuticCareMirrorView` (SPE-2115 slice 4) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `getSurveillanceInterventionTuningMirrorView` + `SurveillanceInterventionTuningMirrorPage` | Weekly orchestration changes (slice 3) |
+| Route `/surveillance-intervention-tuning` + Front Desk quick link    | Compose cross-join changes                    |
+| View + component tests                                             | `advanceWeek` orchestration changes           |
+| Slice doc (this file) + backlog handoff                            | Re-validation of hidden/dropped records       |
+| Read-time `projectSurveillanceInterventionTuningReview` display from hydrated records | Full SPE-848 parent re-open beyond mirror |
+
+## Mirror contract
+
+- **Read-only** — no mutations to GameState from the mirror surface.
+- **Hydrated truth only** — display persisted records as hydrated; do not re-run validation to drop entries.
+- **Display guards** — `validateSurveillanceInterventionTuningRecord` surfaces warning-severity issues only; warning-only records remain visible.
+- **Read-time projections** — `projectSurveillanceInterventionTuningReview` at mirror build; not objective truth.
+- **Redaction** — redacted unit scores render as `—`; no hidden truth beyond registry projections.
+- **Empty state** — when `surveillanceInterventionTuningRecords` map is empty after hydrate.
+- **Ordering** — byte-stable sort by record id; horizon outcome labels sorted by band.
+- **Copy** — CP-neutral labels; no franchise tokens in UI strings.
+
+## Acceptance
+
+- [x] Empty `surveillanceInterventionTuningRecords` map renders empty state without throw
+- [x] Records table shows intervention level, monitoring exceeds contact, and sustained-under-collateral-strain projection labels
+- [x] Redacted surveillance signal scores do not leak hidden values
+- [x] Warning-only records still shown with validation warning labels
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/surveillanceInterventionTuningMirrorView.ts` |
+| UI     | `src/features/operations/SurveillanceInterventionTuningMirrorPage.tsx`  |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`                                |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/surveillanceInterventionTuningMirrorView.test.ts`, `src/features/operations/SurveillanceInterventionTuningMirrorPage.test.tsx` |
+| Plan   | `planning/spe-848-surveillance-tuning-registry-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| ---- | --------------- | ------------ |
+| Surveillance-tuning surfacing in weekly report notes | SPE-2430 follow-up | Out of mirror-only boundary |
+| SPE-1615 psychological resilience cross-join | SPE-1615 | No runtime registry anchor yet |
+| Full SPE-848 parent acceptance review | SPE-848 | Mirror slice does not re-open parent Done status |
+
+## See also
+
+- `planning/spe-848-surveillance-tuning-registry-slice-3.md`
+- `planning/spe-1615-psychological-resilience-registry-slice-5.md` — mirror UI template (SPE-2437)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -105,6 +105,9 @@ const CoerciveContainedPersonProtocolMirrorRoute = createRouteComponent(
 const PsychologicalResilienceMirrorRoute = createRouteComponent(
   () => import('../features/operations/PsychologicalResilienceMirrorPage')
 )
+const SurveillanceInterventionTuningMirrorRoute = createRouteComponent(
+  () => import('../features/operations/SurveillanceInterventionTuningMirrorPage')
+)
 const NamingHazardDescriptorMirrorRoute = createRouteComponent(
   () => import('../features/operations/NamingHazardDescriptorMirrorPage')
 )
@@ -211,6 +214,10 @@ export default function App() {
         <Route
           path="psychological-resilience"
           element={renderLazyRoute(PsychologicalResilienceMirrorRoute)}
+        />
+        <Route
+          path="surveillance-intervention-tuning"
+          element={renderLazyRoute(SurveillanceInterventionTuningMirrorRoute)}
         />
         <Route
           path="naming-hazard-descriptor"

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -34,6 +34,7 @@ export const APP_ROUTES = {
   containedPersonTherapeuticCare: '/contained-person-therapeutic-care',
   coerciveContainedPersonProtocol: '/coercive-contained-person-protocol',
   psychologicalResilience: '/psychological-resilience',
+  surveillanceInterventionTuning: '/surveillance-intervention-tuning',
   namingHazardDescriptor: '/naming-hazard-descriptor',
   containedPersonIntegratedHealthBundle: '/contained-person-integrated-health-bundle',
   welfareDebtAccounting: '/welfare-debt-accounting',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1306,6 +1306,42 @@ export const PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT: Record<string, string> = {
   redactedSuffix: 'Partial redaction',
 }
 
+export const SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Surveillance intervention tuning registry',
+  pageSubtitle:
+    'Read-only operations view over persisted intervention tuning records and read-time surveillance, contact, and collateral-strain projections.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Persisted records',
+  monitoringExceedsContactLabel: 'Monitoring exceeds contact',
+  sustainedUnderCollateralStrainLabel: 'Sustained under collateral strain',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Intervention levels, signal scores, and horizon outcomes mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
+  emptyTitle: 'No surveillance intervention tuning records',
+  emptyBody:
+    'Persisted intervention tuning records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  recordsHeading: 'Persisted records',
+  recordsSubtitle:
+    'Monitoring/contact separation and collateral-strain projections are read-time only, not objective truth.',
+  labelColumn: 'Label',
+  interventionColumn: 'Intervention level',
+  signalsColumn: 'Signal scores',
+  horizonColumn: 'Horizon outcomes',
+  projectionColumn: 'Projection signals',
+  confidenceColumn: 'Confidence',
+  subjectRefPrefix: 'Subject:',
+  surveillanceSignalPrefix: 'Surveillance signal:',
+  meaningfulContactPrefix: 'Meaningful contact:',
+  healthcareLoadPrefix: 'Healthcare load:',
+  collateralStrainPrefix: 'Collateral strain:',
+  tuningRationalePrefix: 'Tuning rationale:',
+  monitoringExceedsContactSuffix: 'Monitoring exceeds contact',
+  sustainedUnderCollateralStrainSuffix: 'Sustained under collateral strain',
+  validationWarningPrefix: 'Validation warnings:',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const CONTAINED_PERSON_THERAPEUTIC_CARE_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Contained person therapeutic care registry',

--- a/src/features/operations/SurveillanceInterventionTuningMirrorPage.test.tsx
+++ b/src/features/operations/SurveillanceInterventionTuningMirrorPage.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
+import { useGameStore } from '../../app/store/gameStore'
+import SurveillanceInterventionTuningMirrorPage from './SurveillanceInterventionTuningMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/surveillance-intervention-tuning']}>
+      <Routes>
+        <Route
+          path="/surveillance-intervention-tuning"
+          element={<SurveillanceInterventionTuningMirrorPage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('SurveillanceInterventionTuningMirrorPage (SPE-848 slice 4)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderMirrorPage()
+
+    expect(
+      screen.getByRole('region', { name: /surveillance intervention tuning registry mirror/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty registry state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no surveillance intervention tuning records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted records when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted surveillance intervention tuning records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(screen.getByText(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.label)).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent('Monitoring exceeds contact')
+    expect(recordsRegion).toHaveTextContent('Sustained under collateral strain')
+  })
+})

--- a/src/features/operations/SurveillanceInterventionTuningMirrorPage.tsx
+++ b/src/features/operations/SurveillanceInterventionTuningMirrorPage.tsx
@@ -1,0 +1,204 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT } from '../../data/copy'
+import { getSurveillanceInterventionTuningMirrorView } from './surveillanceInterventionTuningMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function SurveillanceInterventionTuningMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getSurveillanceInterventionTuningMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Surveillance intervention tuning registry mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Registry summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">
+              {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.pageHeading}
+            </h2>
+            <p className="text-sm opacity-60">
+              {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.pageSubtitle}
+            </p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.monitoringExceedsContactLabel}
+            value={String(view.summary.monitoringExceedsContactCount)}
+          />
+          <StatCard
+            label={
+              SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.sustainedUnderCollateralStrainLabel
+            }
+            value={String(view.summary.sustainedUnderCollateralStrainCount)}
+          />
+          <StatCard
+            label={SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">
+          {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.readOnlyNote}
+        </p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty registry state">
+          <h3 className="text-lg font-semibold">
+            {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.emptyTitle}
+          </h3>
+          <p className="text-sm opacity-70">{SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted surveillance intervention tuning records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">
+              {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.recordsHeading}
+            </h3>
+            <p className="text-sm opacity-60">
+              {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.recordsSubtitle}
+            </p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">
+                    {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.labelColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.interventionColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.signalsColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.horizonColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.projectionColumn}
+                  </th>
+                  <th className="px-2 py-2">
+                    {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.confidenceColumn}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.subjectRefPrefix}{' '}
+                        {record.subjectRefLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      <p>{record.interventionLevelLabel}</p>
+                      {record.tuningRationaleRefLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.tuningRationalePrefix}{' '}
+                          {record.tuningRationaleRefLabel}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <p className="text-xs opacity-55">
+                        {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.surveillanceSignalPrefix}{' '}
+                        {record.surveillanceSignalScoreLabel}
+                      </p>
+                      <p className="text-xs opacity-55">
+                        {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.meaningfulContactPrefix}{' '}
+                        {record.meaningfulContactScoreLabel}
+                      </p>
+                      {record.healthcareLoadScoreLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.healthcareLoadPrefix}{' '}
+                          {record.healthcareLoadScoreLabel}
+                        </p>
+                      ) : null}
+                      {record.collateralStrainScoreLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.collateralStrainPrefix}{' '}
+                          {record.collateralStrainScoreLabel}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.horizonOutcomeLabels.length > 0 ? (
+                        record.horizonOutcomeLabels.map((label) => (
+                          <p key={label} className="text-xs opacity-55">
+                            {label}
+                          </p>
+                        ))
+                      ) : (
+                        <p className="text-xs opacity-45">—</p>
+                      )}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.monitoringExceedsContactLabel !== '—' ? (
+                        <p className="text-xs opacity-55">
+                          {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.monitoringExceedsContactSuffix}
+                        </p>
+                      ) : null}
+                      {record.sustainedUnderCollateralStrainLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {
+                            SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.sustainedUnderCollateralStrainSuffix
+                          }
+                        </p>
+                      ) : null}
+                      {record.redacted ? (
+                        <p className="text-xs opacity-45">
+                          {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.redactedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.confidenceLabel}
+                      {record.validationWarningLabels.length > 0 ? (
+                        <p className="text-xs text-amber-200/80">
+                          {SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT.validationWarningPrefix}{' '}
+                          {record.validationWarningLabels.length}
+                        </p>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -820,6 +820,12 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
         'Review depletion bands, exposure posture, treatment gating, and duty-reliability projections.',
     },
     {
+      label: 'Open surveillance intervention tuning mirror',
+      href: APP_ROUTES.surveillanceInterventionTuning,
+      description:
+        'Review intervention levels, surveillance/contact signal separation, horizon outcomes, and collateral-strain projections.',
+    },
+    {
       label: 'Open naming-hazard descriptor mirror',
       href: APP_ROUTES.namingHazardDescriptor,
       description:

--- a/src/features/operations/surveillanceInterventionTuningMirrorView.test.ts
+++ b/src/features/operations/surveillanceInterventionTuningMirrorView.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  projectSurveillanceInterventionTuningReview,
+  SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+  validateSurveillanceInterventionTuningRecord,
+  type SurveillanceInterventionTuningRecord,
+} from '../../domain/surveillanceCapacityInterventionTuningRegistry'
+import {
+  formatSurveillanceInterventionTuningEnumLabel,
+  getSurveillanceInterventionTuningMirrorView,
+} from './surveillanceInterventionTuningMirrorView'
+
+function relaxedWithoutRationaleRecord(): SurveillanceInterventionTuningRecord {
+  return {
+    id: 'surveillance-tuning:relaxed-warning-only',
+    label: 'Relaxed under high surveillance without rationale',
+    subjectRef: 'subject:field-asset-44',
+    currentInterventionLevel: 'relaxed',
+    surveillanceSignalScore: 0.72,
+    meaningfulContactScore: 0.18,
+    healthcareLoadScore: 0.35,
+    collateralStrainScore: 0.22,
+  }
+}
+
+function redactedSurveillanceRecord(): SurveillanceInterventionTuningRecord {
+  return {
+    id: 'surveillance-tuning:redacted-signal',
+    label: 'Redacted surveillance signal profile',
+    subjectRef: 'subject:analyst-asset-7',
+    currentInterventionLevel: 'sustained',
+    surveillanceSignalScore: 0.8,
+    meaningfulContactScore: 0.2,
+    redactedFields: ['surveillanceSignalScore'],
+    confidence: 0.58,
+  }
+}
+
+describe('surveillanceInterventionTuningMirrorView (SPE-848 slice 4)', () => {
+  it('returns empty mirror when surveillanceInterventionTuningRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.surveillanceInterventionTuningRecords).toEqual({})
+
+    const view = getSurveillanceInterventionTuningMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('mirrors intervention level, signal scores, and horizon outcomes from hydrated records', () => {
+    const game = createStartingState()
+    game.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    const view = getSurveillanceInterventionTuningMirrorView(game)
+    const record = view.records[0]
+    const projection = projectSurveillanceInterventionTuningReview(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE)
+
+    expect(view.isEmpty).toBe(false)
+    expect(record?.interventionLevelLabel).toBe('Sustained')
+    expect(record?.surveillanceSignalScoreLabel).toBe(projection.surveillanceSignalScore?.toFixed(2))
+    expect(record?.meaningfulContactScoreLabel).toBe(projection.meaningfulContactScore?.toFixed(2))
+    expect(record?.monitoringExceedsContactLabel).toBe('Yes')
+    expect(record?.sustainedUnderCollateralStrainLabel).toBe('Yes')
+    expect(record?.horizonOutcomeLabels).toEqual([
+      'Short: Elevated Isolation Pressure',
+      'Medium: Compliance Metric Stable',
+      'Long: Legitimacy Erosion Risk',
+    ])
+  })
+
+  it('aggregates monitoring and collateral-strain projection counts', () => {
+    const game = createStartingState()
+    game.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+      [relaxedWithoutRationaleRecord().id]: relaxedWithoutRationaleRecord(),
+    }
+
+    const view = getSurveillanceInterventionTuningMirrorView(game)
+
+    expect(view.summary.monitoringExceedsContactCount).toBe(2)
+    expect(view.summary.sustainedUnderCollateralStrainCount).toBe(1)
+    expect(view.summary.totalRecords).toBe(2)
+  })
+
+  it('still mirrors warning-only records with validation warning labels', () => {
+    const warningRecord = relaxedWithoutRationaleRecord()
+    expect(validateSurveillanceInterventionTuningRecord(warningRecord).valid).toBe(true)
+
+    const game = createStartingState()
+    game.surveillanceInterventionTuningRecords = {
+      [warningRecord.id]: warningRecord,
+    }
+
+    const view = getSurveillanceInterventionTuningMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.totalRecords).toBe(1)
+    expect(record?.validationWarningLabels.length).toBe(1)
+    expect(record?.interventionLevelLabel).toBe('Relaxed')
+  })
+
+  it('does not leak redacted surveillance signal scores in mirror labels', () => {
+    const redactedRecord = redactedSurveillanceRecord()
+    const projection = projectSurveillanceInterventionTuningReview(redactedRecord)
+
+    expect(projection.surveillanceSignalScore).toBeNull()
+    expect(projection.redacted).toBe(true)
+
+    const game = createStartingState()
+    game.surveillanceInterventionTuningRecords = {
+      [redactedRecord.id]: redactedRecord,
+    }
+
+    const view = getSurveillanceInterventionTuningMirrorView(game)
+    const record = view.records[0]
+
+    expect(record?.surveillanceSignalScoreLabel).toBe('—')
+    expect(record?.redacted).toBe(true)
+    expect(record?.monitoringExceedsContactLabel).toBe('—')
+  })
+
+  it('orders records by id and is byte-stable for repeated mirror builds', () => {
+    const warningRecord = relaxedWithoutRationaleRecord()
+    const game = createStartingState()
+    game.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+      [warningRecord.id]: warningRecord,
+    }
+
+    const view = getSurveillanceInterventionTuningMirrorView(game)
+
+    expect(view.records.map((record) => record.id)).toEqual([
+      SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id,
+      warningRecord.id,
+    ])
+
+    const first = JSON.stringify(getSurveillanceInterventionTuningMirrorView(game))
+    const second = JSON.stringify(getSurveillanceInterventionTuningMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatSurveillanceInterventionTuningEnumLabel('alternative_support')).toBe(
+      'Alternative Support'
+    )
+    expect(formatSurveillanceInterventionTuningEnumLabel('elevated_isolation_pressure')).toBe(
+      'Elevated Isolation Pressure'
+    )
+  })
+})

--- a/src/features/operations/surveillanceInterventionTuningMirrorView.ts
+++ b/src/features/operations/surveillanceInterventionTuningMirrorView.ts
@@ -1,0 +1,192 @@
+import type { GameState } from '../../domain/models'
+import {
+  INTERVENTION_HORIZON_BANDS,
+  projectSurveillanceInterventionTuningReview,
+  validateSurveillanceInterventionTuningRecord,
+  type InterventionHorizonOutcome,
+  type SurveillanceInterventionTuningRecord,
+} from '../../domain/surveillanceCapacityInterventionTuningRegistry'
+
+export interface SurveillanceInterventionTuningMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  subjectRefLabel: string
+  interventionLevelLabel: string
+  surveillanceSignalScoreLabel: string
+  meaningfulContactScoreLabel: string
+  healthcareLoadScoreLabel: string
+  collateralStrainScoreLabel: string
+  horizonOutcomeLabels: readonly string[]
+  monitoringExceedsContactLabel: string
+  sustainedUnderCollateralStrainLabel: string
+  tuningRationaleRefLabel: string
+  validationWarningLabels: readonly string[]
+  unknownFieldLabels: readonly string[]
+  confidenceLabel: string
+  redacted: boolean
+}
+
+export interface SurveillanceInterventionTuningMirrorSummaryView {
+  totalRecords: number
+  monitoringExceedsContactCount: number
+  sustainedUnderCollateralStrainCount: number
+  week: number
+}
+
+export interface SurveillanceInterventionTuningMirrorView {
+  isEmpty: boolean
+  summary: SurveillanceInterventionTuningMirrorSummaryView
+  records: readonly SurveillanceInterventionTuningMirrorRecordView[]
+}
+
+export function formatSurveillanceInterventionTuningEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(game: GameState): SurveillanceInterventionTuningRecord[] {
+  const map = game.surveillanceInterventionTuningRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatConfidence(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatUnitScore(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatYesNo(value: boolean): string {
+  return value ? 'Yes' : '—'
+}
+
+function formatOptionalRef(value: string | undefined): string {
+  return value?.trim() ? value : '—'
+}
+
+function sortedUnknownFieldLabels(unknownFields: readonly string[] | undefined): readonly string[] {
+  return Object.freeze([...(unknownFields ?? [])].sort((left, right) => left.localeCompare(right)))
+}
+
+function formatHealthcareLoadScore(record: SurveillanceInterventionTuningRecord): string {
+  const redactedFields = new Set(record.redactedFields ?? [])
+  if (redactedFields.has('healthcareLoadScore')) {
+    return '—'
+  }
+
+  const value = record.healthcareLoadScore
+  if (value === undefined || value === null) {
+    return '—'
+  }
+
+  return formatUnitScore(value)
+}
+
+function sortedHorizonOutcomeLabels(
+  record: SurveillanceInterventionTuningRecord
+): readonly string[] {
+  const horizonOutcomes = record.horizonOutcomes
+  if (!horizonOutcomes) {
+    return Object.freeze([])
+  }
+
+  return Object.freeze(
+    INTERVENTION_HORIZON_BANDS.flatMap((band) => {
+      const outcome = horizonOutcomes[band]
+      if (!outcome) {
+        return []
+      }
+
+      return [`${formatSurveillanceInterventionTuningEnumLabel(band)}: ${formatHorizonOutcomeLabel(outcome)}`]
+    })
+  )
+}
+
+function formatHorizonOutcomeLabel(value: InterventionHorizonOutcome): string {
+  return formatSurveillanceInterventionTuningEnumLabel(value)
+}
+
+function toRecordView(
+  record: SurveillanceInterventionTuningRecord
+): SurveillanceInterventionTuningMirrorRecordView {
+  const projection = projectSurveillanceInterventionTuningReview(record)
+  const validation = validateSurveillanceInterventionTuningRecord(record)
+
+  const validationWarningLabels = Object.freeze(
+    validation.issues
+      .filter((issue) => issue.severity === 'warning')
+      .map((issue) => issue.detail)
+  )
+
+  const summaryLabel = record.summary?.trim() ? record.summary : '—'
+
+  return Object.freeze({
+    id: record.id,
+    label: record.label,
+    summaryLabel,
+    subjectRefLabel: record.subjectRef,
+    interventionLevelLabel: formatSurveillanceInterventionTuningEnumLabel(
+      record.currentInterventionLevel
+    ),
+    surveillanceSignalScoreLabel: formatUnitScore(projection.surveillanceSignalScore),
+    meaningfulContactScoreLabel: formatUnitScore(projection.meaningfulContactScore),
+    healthcareLoadScoreLabel: formatHealthcareLoadScore(record),
+    collateralStrainScoreLabel: formatUnitScore(projection.collateralStrainScore),
+    horizonOutcomeLabels: sortedHorizonOutcomeLabels(record),
+    monitoringExceedsContactLabel: formatYesNo(projection.monitoringExceedsContact),
+    sustainedUnderCollateralStrainLabel: formatYesNo(projection.sustainedUnderCollateralStrain),
+    tuningRationaleRefLabel: formatOptionalRef(record.tuningRationaleRef),
+    validationWarningLabels,
+    unknownFieldLabels: sortedUnknownFieldLabels(projection.unknownFields),
+    confidenceLabel: formatConfidence(projection.confidence),
+    redacted: projection.redacted,
+  })
+}
+
+/** Read-only mirror over hydrated `surveillanceInterventionTuningRecords`; does not re-validate dropped entries. */
+export function getSurveillanceInterventionTuningMirrorView(
+  game: GameState
+): SurveillanceInterventionTuningMirrorView {
+  const records = listPersistedRecords(game)
+  const week = game.week
+
+  let monitoringExceedsContactCount = 0
+  let sustainedUnderCollateralStrainCount = 0
+
+  const recordViews = records.map((record) => {
+    const projection = projectSurveillanceInterventionTuningReview(record)
+
+    if (projection.monitoringExceedsContact) {
+      monitoringExceedsContactCount += 1
+    }
+
+    if (projection.sustainedUnderCollateralStrain) {
+      sustainedUnderCollateralStrainCount += 1
+    }
+
+    return toRecordView(record)
+  })
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      totalRecords: records.length,
+      monitoringExceedsContactCount,
+      sustainedUnderCollateralStrainCount,
+      week,
+    }),
+    records: Object.freeze(recordViews),
+  })
+}


### PR DESCRIPTION
## Summary

- Add read-only `getSurveillanceInterventionTuningMirrorView` + `SurveillanceInterventionTuningMirrorPage` over persisted `surveillanceInterventionTuningRecords` with `projectSurveillanceInterventionTuningReview` labels (intervention level, monitoring/contact separation, collateral strain, horizon outcomes).
- Wire route `/surveillance-intervention-tuning`, Front Desk quick link, and CP-neutral copy.
- Add targeted view + page unit tests; slice doc and backlog handoff.

## Linear mapping

- **Slice:** [SPE-2438](https://linear.app/spectranoir/issue/SPE-2438) — Surveillance tuning registry planning mirror UI (slice 4)
- **Parent:** [SPE-848](https://linear.app/spectranoir/issue/SPE-848) — Surveillance and capacity intervention tuning (parent remains Done; mirror-only slice)

## What shipped

Mirror-only UI — no orchestration, advanceWeek, or compose cross-join changes.

## Validation

- `npm run lint`
- `npx vitest run src/features/operations/surveillanceInterventionTuningMirrorView.test.ts src/features/operations/SurveillanceInterventionTuningMirrorPage.test.tsx`

## Docs updated

- `planning/spe-848-surveillance-tuning-registry-slice-4.md`
- `planning/backlog.md`