### PR TITLE
feat(SPE-2439): surveillance-tuning cross-reconciliation surfacing slice 4

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -24,6 +24,8 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Base `main` SHA:** `dbd88079` — shipped: [SPE-2438](https://linear.app/spectranoir/issue/SPE-2438) surveillance tuning planning mirror UI slice 4 @ PR #2747
 
+**In progress:** [SPE-2439](https://linear.app/spectranoir/issue/SPE-2439) surveillance-tuning cross-reconciliation surfacing slice 4 under SPE-1908 — see `planning/spe-1908-cross-system-reconciliation-slice-4.md`.
+
 **Recently shipped:** [SPE-2438](https://linear.app/spectranoir/issue/SPE-2438) surveillance tuning planning mirror UI slice 4 @ PR #2747; [SPE-2437](https://linear.app/spectranoir/issue/SPE-2437) psychological resilience planning mirror UI slice 5 @ PR #2745; see `planning/spe-848-surveillance-tuning-registry-slice-4.md`.
 
 ## Blocked / waiting

--- a/planning/spe-1908-cross-system-reconciliation-slice-4.md
+++ b/planning/spe-1908-cross-system-reconciliation-slice-4.md
@@ -1,0 +1,77 @@
+# SPE-1908 — Surveillance-tuning cross-reconciliation surfacing (slice 4)
+
+One-page implementation plan. Linear: [SPE-2439](https://linear.app/spectranoir/issue/SPE-2439) (child under [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)). Follows shipped slice 3 (`planning/spe-1908-cross-system-reconciliation-slice-3.md`, PR #2731 / [SPE-2430](https://linear.app/spectranoir/issue/SPE-2430)) and sibling slice 2 (`planning/spe-1908-cross-system-reconciliation-slice-2.md`, PR #2729 / [SPE-2429](https://linear.app/spectranoir/issue/SPE-2429)). Deferred from `planning/spe-848-surveillance-tuning-registry-slice-4.md`.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2439 — Surveillance-tuning cross-reconciliation surfacing (slice 4)](https://linear.app/spectranoir/issue/SPE-2439) |
+| **Parent** | [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — surveillance-isolation contradiction check umbrella |
+| **Branch** | `jamesdyedbq/spe-1908-cross-system-reconciliation-slice-4`                                                 |
+| **Base `main` SHA** | `e2becf77`                                                                                          |
+
+## Goal
+
+Surface `composeAllCoerciveProtocolIntegratedHealthReconciliations` surveillance-tuning tension flags and cross-link labels in coercive protocol mirror and weekly report notes — read-only follow-up once SPE-2430 compose cross-join and SPE-848 persistence exist.
+
+## Prerequisite (on `main` @ `e2becf77`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Cross-reconciliation compose + tuning cross-join | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` (SPE-2430) |
+| Cross-reconciliation surfacing (protocol/bundle) | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts` (SPE-2429) |
+| Surveillance tuning persistence | `surveillanceInterventionTuningRecords` on `GameState` (SPE-2431) |
+| Surveillance tuning mirror label vocabulary | `surveillanceInterventionTuningMirrorView.ts` (SPE-2438) |
+
+## Surfacing contract (slice 4)
+
+- **Read-only** — pass `surveillanceInterventionTuningRecords` into compose at read time; no new GameState fields.
+- **Safe labels** — tuning record ids + labels only; no projection score or redacted field leakage in surfacing strings.
+- **Tension flags** — `surveillance_tuning_monitoring_exceeds_contact` and `surveillance_tuning_sustained_under_collateral_strain` via existing compose when tuning map coexists.
+- **Empty maps** — no-op; slice 2 surfacing unchanged when tuning absent.
+- **Mirror** — coercive protocol mirror passes tuning records into compose summaries for per-record `crossSystemTensionFlagLabels`.
+- **Weekly notes** — emit when protocol + bundle maps coexist; include tuning segment and `linkedTuningCount` when tuning linked.
+- **Byte-stable ordering** — tension flags and tuning ids sorted on repeat.
+- **No compose changes** — SPE-2430 contracts unchanged.
+- **No tuning mirror UI changes** — SPE-2438 unchanged.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts` tuning pass-through + labels | SPE-2430 compose changes |
+| `coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts` tuning wiring | SPE-2438 mirror UI changes |
+| Coercive protocol mirror tuning-aware compose | `surveillanceInterventionTuningWeeklyOrchestration.ts` |
+| `advanceWeek` note wiring for tuning records | SPE-1615 psychological resilience surfacing |
+| Targeted surfacing + mirror + advanceWeek tests | Contradiction-check evaluator changes |
+| Slice doc (this file) + backlog handoff | SPE-1908 parent re-closure |
+
+## Acceptance
+
+- [x] Empty tuning maps no-op without throw; slice 2 regression unchanged
+- [x] Mirror surfaces surveillance-tuning tension flags for abusive surveillance + subject-22 bundle + tuning fixture
+- [x] Weekly report note includes tuning cross-link labels and tuning tension flags when maps coexist
+- [x] Redacted projection fields do not leak in surfacing labels
+- [x] `advanceWeek` integration asserts tuning-aware reconciliation note when fixtures coexist
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts`, `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts` |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` |
+| Tests  | `src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts`, `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts` |
+| Plan   | `planning/spe-1908-cross-system-reconciliation-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1615 psychological resilience surfacing | SPE-1615 | Out of surveillance-tuning-only boundary |
+| SPE-1908 parent closure | SPE-1908 | Multi-owner reconciliation AC not met |
+
+## See also
+
+- `planning/spe-1908-cross-system-reconciliation-slice-2.md`
+- `planning/spe-1908-cross-system-reconciliation-slice-3.md`
+- `planning/spe-848-surveillance-tuning-registry-slice-4.md`

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts
@@ -1,9 +1,9 @@
 /**
- * SPE-1908 / SPE-2429 slice 2: read-only surfacing for coercive protocol ↔ integrated
- * health bundle cross-reconciliation compose output.
+ * SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4: read-only surfacing for coercive
+ * protocol ↔ integrated health bundle cross-reconciliation compose output.
  *
  * Formats compose summaries for mirror labels and weekly report notes — no changes to
- * SPE-2428 compose contracts.
+ * SPE-2428 / SPE-2430 compose contracts.
  */
 
 import type {
@@ -19,6 +19,16 @@ import type {
   ContainedPersonIntegratedHealthBundle,
   ContainedPersonIntegratedHealthBundleRecordsMap,
 } from './containedPersonIntegratedHealthBundleRegistry'
+import type {
+  SurveillanceInterventionTuningRecord,
+  SurveillanceInterventionTuningRecordsMap,
+} from './surveillanceCapacityInterventionTuningRegistry'
+
+const SURVEILLANCE_TUNING_CROSS_SYSTEM_TENSION_FLAGS: ReadonlySet<CoerciveProtocolCrossSystemTensionFlag> =
+  new Set([
+    'surveillance_tuning_monitoring_exceeds_contact',
+    'surveillance_tuning_sustained_under_collateral_strain',
+  ])
 
 export function formatCoerciveProtocolCrossLinkLabel(record: CoerciveProtocolRecord): string {
   return `${record.id} (${record.label})`
@@ -28,6 +38,12 @@ export function formatIntegratedHealthBundleCrossLinkLabel(
   bundle: ContainedPersonIntegratedHealthBundle
 ): string {
   return `${bundle.id} (${bundle.label})`
+}
+
+export function formatSurveillanceTuningCrossLinkLabel(
+  record: SurveillanceInterventionTuningRecord
+): string {
+  return `${record.id} (${record.label})`
 }
 
 export function formatCrossSystemTensionFlagLabel(flag: CoerciveProtocolCrossSystemTensionFlag): string {
@@ -51,14 +67,24 @@ function bundleBySubjectRef(
   return bundles?.[subjectRef]
 }
 
+function tuningById(
+  records: SurveillanceInterventionTuningRecordsMap | undefined,
+  tuningId: string
+): SurveillanceInterventionTuningRecord | undefined {
+  return records?.[tuningId]
+}
+
 export function formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabels(input: {
   summary: CoerciveProtocolIntegratedHealthReconciliationSummary
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
 }): {
   readonly protocolLabels: readonly string[]
   readonly bundleLabel: string | null
+  readonly tuningLabels: readonly string[]
   readonly tensionFlagLabels: readonly string[]
+  readonly surveillanceTuningTensionFlagLabels: readonly string[]
 } {
   const protocolIds = [
     ...new Set(input.summary.links.map((link) => link.coerciveProtocolId)),
@@ -72,14 +98,31 @@ export function formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabel
   const bundle = bundleBySubjectRef(input.bundles, input.summary.subjectRef)
   const bundleLabel = bundle ? formatIntegratedHealthBundleCrossLinkLabel(bundle) : null
 
+  const tuningIds = [
+    ...new Set(input.summary.surveillanceTuningLinks.map((link) => link.surveillanceTuningId)),
+  ].sort((left, right) => left.localeCompare(right))
+
+  const tuningLabels = tuningIds
+    .map((tuningId) => tuningById(input.surveillanceTuningRecords, tuningId))
+    .filter((record): record is SurveillanceInterventionTuningRecord => record !== undefined)
+    .map((record) => formatSurveillanceTuningCrossLinkLabel(record))
+
   const tensionFlagLabels = Object.freeze(
     input.summary.crossSystemTensionFlags.map((flag) => formatCrossSystemTensionFlagLabel(flag))
+  )
+
+  const surveillanceTuningTensionFlagLabels = Object.freeze(
+    input.summary.crossSystemTensionFlags
+      .filter((flag) => SURVEILLANCE_TUNING_CROSS_SYSTEM_TENSION_FLAGS.has(flag))
+      .map((flag) => formatCrossSystemTensionFlagLabel(flag))
   )
 
   return {
     protocolLabels: Object.freeze(protocolLabels),
     bundleLabel,
+    tuningLabels: Object.freeze(tuningLabels),
     tensionFlagLabels,
+    surveillanceTuningTensionFlagLabels,
   }
 }
 
@@ -87,21 +130,25 @@ export function formatCoerciveProtocolIntegratedHealthReconciliationNoteContent(
   summary: CoerciveProtocolIntegratedHealthReconciliationSummary
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
 }): string {
-  const { protocolLabels, bundleLabel, tensionFlagLabels } =
+  const { protocolLabels, bundleLabel, tuningLabels, tensionFlagLabels } =
     formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabels(input)
   const protocolSegment =
     protocolLabels.length > 0 ? protocolLabels.join('; ') : 'no linked coercive protocols'
   const bundleSegment = bundleLabel ?? 'no linked integrated health bundle'
+  const tuningSegment =
+    tuningLabels.length > 0 ? tuningLabels.join('; ') : 'no linked surveillance tuning records'
   const tensionSegment =
     tensionFlagLabels.length > 0 ? tensionFlagLabels.join('; ') : 'no cross-system tension flags'
 
-  return `Coercive protocol cross-link — ${input.summary.subjectRef}: ${input.summary.linkedProtocolCount} protocol(s), ${input.summary.linkedBundleCount} bundle(s). Tension flags: ${tensionSegment}. Protocols: ${protocolSegment}. Bundle: ${bundleSegment}.`
+  return `Coercive protocol cross-link — ${input.summary.subjectRef}: ${input.summary.linkedProtocolCount} protocol(s), ${input.summary.linkedBundleCount} bundle(s), ${input.summary.linkedTuningCount} tuning record(s). Tension flags: ${tensionSegment}. Protocols: ${protocolSegment}. Bundle: ${bundleSegment}. Tuning: ${tuningSegment}.`
 }
 
 export function composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries(input: {
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
 }): readonly CoerciveProtocolIntegratedHealthReconciliationSummary[] {
   if (!input.protocols || !input.bundles) {
     return []
@@ -111,17 +158,23 @@ export function composeAllCoerciveProtocolIntegratedHealthReconciliationSummarie
     return []
   }
 
-  return composeAllCoerciveProtocolIntegratedHealthReconciliations(input.protocols, input.bundles)
+  return composeAllCoerciveProtocolIntegratedHealthReconciliations(
+    input.protocols,
+    input.bundles,
+    input.surveillanceTuningRecords
+  )
 }
 
 export function resolveCoerciveProtocolIntegratedHealthReconciliationForSubject(input: {
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
+  surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
   subjectRef: string
 }): CoerciveProtocolIntegratedHealthReconciliationSummary | null {
   const summaries = composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
     protocols: input.protocols,
     bundles: input.bundles,
+    surveillanceTuningRecords: input.surveillanceTuningRecords,
   })
 
   return summaries.find((summary) => summary.subjectRef === input.subjectRef) ?? null

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts
@@ -1,12 +1,13 @@
 /**
- * SPE-1908 / SPE-2429 slice 2: weekly report notes for coercive protocol ↔ integrated
- * health bundle cross-reconciliation.
+ * SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4: weekly report notes for coercive
+ * protocol ↔ integrated health bundle cross-reconciliation.
  *
  * Emits deterministic notes when linked maps coexist — no new persistence.
  */
 
 import type { CoerciveProtocolRecordsMap } from './coerciveContainedPersonProtocolRegistry'
 import type { ContainedPersonIntegratedHealthBundleRecordsMap } from './containedPersonIntegratedHealthBundleRegistry'
+import type { SurveillanceInterventionTuningRecordsMap } from './surveillanceCapacityInterventionTuningRegistry'
 import {
   composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries,
   formatCoerciveProtocolIntegratedHealthReconciliationNoteContent,
@@ -21,6 +22,7 @@ import { createDeterministicReportNote } from './reportNotes'
 export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes(input: {
   nextProtocols: CoerciveProtocolRecordsMap | null | undefined
   nextBundles: ContainedPersonIntegratedHealthBundleRecordsMap | null | undefined
+  nextSurveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | null | undefined
   week: number
   sequenceStart: number
   baseTimestamp?: number
@@ -28,6 +30,7 @@ export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportN
   const nextSummaries = composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
     protocols: input.nextProtocols ?? undefined,
     bundles: input.nextBundles ?? undefined,
+    surveillanceTuningRecords: input.nextSurveillanceTuningRecords ?? undefined,
   })
 
   if (nextSummaries.length === 0) {
@@ -44,6 +47,7 @@ export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportN
           summary,
           protocols: input.nextProtocols ?? undefined,
           bundles: input.nextBundles ?? undefined,
+          surveillanceTuningRecords: input.nextSurveillanceTuningRecords ?? undefined,
         }),
         input.week,
         sequence,
@@ -53,6 +57,7 @@ export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportN
           subjectRef: summary.subjectRef,
           linkedProtocolCount: summary.linkedProtocolCount,
           linkedBundleCount: summary.linkedBundleCount,
+          linkedTuningCount: summary.linkedTuningCount,
           crossSystemTensionFlags: [...summary.crossSystemTensionFlags],
           structuredReasons: [...summary.structuredReasons],
           week: input.week,

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4718,11 +4718,13 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     }
   }
 
-  // SPE-1908 / SPE-2429 slice 2: surface coercive protocol ↔ integrated health cross-reconciliation in weekly report notes.
+  // SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4: surface coercive protocol ↔ integrated health cross-reconciliation in weekly report notes.
   const nextCoerciveProtocolsForReconciliation =
     outputWeeklyState.coerciveContainedPersonProtocolRecords ?? {}
   const nextIntegratedHealthBundlesForReconciliation =
     outputWeeklyState.containedPersonIntegratedHealthBundles ?? {}
+  const nextSurveillanceTuningRecordsForReconciliation =
+    outputWeeklyState.surveillanceInterventionTuningRecords ?? {}
   if (
     Object.keys(nextCoerciveProtocolsForReconciliation).length > 0 &&
     Object.keys(nextIntegratedHealthBundlesForReconciliation).length > 0 &&
@@ -4732,6 +4734,7 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     const reconciliationNotes = buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
       nextProtocols: nextCoerciveProtocolsForReconciliation,
       nextBundles: nextIntegratedHealthBundlesForReconciliation,
+      nextSurveillanceTuningRecords: nextSurveillanceTuningRecordsForReconciliation,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -11,6 +11,7 @@ import {
   type CoerciveProtocolRecord,
 } from '../../domain/coerciveContainedPersonProtocolRegistry'
 import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
+import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
 import {
   formatCoerciveProtocolEnumLabel,
   getCoerciveContainedPersonProtocolMirrorView,
@@ -300,5 +301,36 @@ describe('coerciveContainedPersonProtocolMirrorView (SPE-2429 slice 2)', () => {
       'Surveillance Burden No Active Contact Channel',
       'Surveillance Burden Stable Mental State',
     ])
+  })
+})
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-2439 slice 4)', () => {
+  it('surfaces surveillance-tuning tension flags when tuning records coexist', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    game.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    game.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.crossSystemTensionSubjectCount).toBe(1)
+    expect(record?.crossSystemTensionFlagLabels).toEqual([
+      'Monitoring Substitutes Contact Signal',
+      'Surveillance Burden Low Humane Care Risk',
+      'Surveillance Burden No Active Contact Channel',
+      'Surveillance Burden Stable Mental State',
+      'Surveillance Tuning Monitoring Exceeds Contact',
+      'Surveillance Tuning Sustained Under Collateral Strain',
+    ])
+    expect(record?.crossSystemTensionFlagLabels.join('; ')).not.toContain('0.88')
   })
 })

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -204,6 +204,7 @@ export function getCoerciveContainedPersonProtocolMirrorView(
   const reconciliationSummaries = composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
     protocols: game.coerciveContainedPersonProtocolRecords,
     bundles: game.containedPersonIntegratedHealthBundles,
+    surveillanceTuningRecords: game.surveillanceInterventionTuningRecords,
   })
   const tensionLabelsBySubject = buildCrossSystemTensionFlagLabelsBySubject(reconciliationSummaries)
 

--- a/src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts
@@ -3,6 +3,7 @@ import { createStartingState } from '../data/startingState'
 import { ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE } from '../domain/coerciveContainedPersonProtocolRegistry'
 import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../domain/surveillanceCapacityInterventionTuningRegistry'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
   for (const currentCase of Object.values(state.cases)) {
@@ -55,5 +56,38 @@ describe('advanceWeek coercive protocol integrated health reconciliation integra
       ) ?? []
 
     expect(reconciliationNotes).toEqual([])
+  })
+})
+
+describe('advanceWeek coercive protocol integrated health reconciliation integration (SPE-2439 slice 4)', () => {
+  it('surfaces surveillance-tuning tension flags when tuning records coexist', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coerciveContainedPersonProtocolRecords = {
+      [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+        ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+    }
+    state.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    state.surveillanceInterventionTuningRecords = {
+      [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const reconciliationNotes =
+      weeklyReport?.notes?.filter(
+        (note) => note.type === 'coercive_protocol.integrated_health_reconciliation'
+      ) ?? []
+
+    expect(reconciliationNotes.length).toBeGreaterThan(0)
+    expect(reconciliationNotes[0]?.content).toContain('1 tuning record(s)')
+    expect(reconciliationNotes[0]?.content).toContain('Surveillance Tuning Monitoring Exceeds Contact')
+    expect(reconciliationNotes[0]?.content).toContain(
+      `${SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id} (${SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.label})`
+    )
+    expect(reconciliationNotes[0]?.metadata?.linkedTuningCount).toBe(1)
   })
 })

--- a/src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts
+++ b/src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts
@@ -9,10 +9,12 @@ import {
   formatCoerciveProtocolIntegratedHealthReconciliationNoteContent,
   formatCrossSystemTensionFlagLabel,
   formatIntegratedHealthBundleCrossLinkLabel,
+  formatSurveillanceTuningCrossLinkLabel,
 } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing'
 import { composeCoerciveProtocolIntegratedHealthReconciliation } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliation'
 import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
 import { buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes'
+import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../domain/surveillanceCapacityInterventionTuningRegistry'
 
 const SURVEILLANCE_PROTOCOLS = {
   [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
@@ -22,6 +24,10 @@ const SURVEILLANCE_PROTOCOLS = {
 const SURVEILLANCE_BUNDLES = {
   [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
     INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+}
+
+const SURVEILLANCE_TUNING_RECORDS = {
+  [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
 }
 
 describe('coerciveProtocolIntegratedHealthCrossReconciliationSurfacing (SPE-2429 slice 2)', () => {
@@ -101,5 +107,87 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliationSurfacing (SPE-2429
         sequenceStart: 1,
       })
     ).toEqual([])
+  })
+})
+
+describe('coerciveProtocolIntegratedHealthCrossReconciliationSurfacing (SPE-2439 slice 4)', () => {
+  it('formats surveillance tuning cross-link labels from persisted id and label only', () => {
+    expect(formatSurveillanceTuningCrossLinkLabel(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE)).toBe(
+      `${SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id} (${SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.label})`
+    )
+    expect(formatCrossSystemTensionFlagLabel('surveillance_tuning_monitoring_exceeds_contact')).toBe(
+      'Surveillance Tuning Monitoring Exceeds Contact'
+    )
+  })
+
+  it('passes surveillance tuning records into compose summaries without throw on empty maps', () => {
+    expect(
+      composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+        protocols: SURVEILLANCE_PROTOCOLS,
+        bundles: SURVEILLANCE_BUNDLES,
+        surveillanceTuningRecords: {},
+      })
+    ).toHaveLength(1)
+    expect(
+      composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+        protocols: SURVEILLANCE_PROTOCOLS,
+        bundles: SURVEILLANCE_BUNDLES,
+        surveillanceTuningRecords: undefined,
+      })[0]?.linkedTuningCount
+    ).toBe(0)
+  })
+
+  it('surfaces surveillance-tuning tension flags and tuning labels when tuning map coexists', () => {
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      SURVEILLANCE_PROTOCOLS,
+      SURVEILLANCE_BUNDLES,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef,
+      SURVEILLANCE_TUNING_RECORDS
+    )
+
+    const notes = buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+      nextProtocols: SURVEILLANCE_PROTOCOLS,
+      nextBundles: SURVEILLANCE_BUNDLES,
+      nextSurveillanceTuningRecords: SURVEILLANCE_TUNING_RECORDS,
+      week: 3,
+      sequenceStart: 1,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.content).toBe(
+      formatCoerciveProtocolIntegratedHealthReconciliationNoteContent({
+        summary,
+        protocols: SURVEILLANCE_PROTOCOLS,
+        bundles: SURVEILLANCE_BUNDLES,
+        surveillanceTuningRecords: SURVEILLANCE_TUNING_RECORDS,
+      })
+    )
+    expect(notes[0]?.content).toContain('1 tuning record(s)')
+    expect(notes[0]?.content).toContain(
+      formatSurveillanceTuningCrossLinkLabel(SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE)
+    )
+    expect(notes[0]?.content).toContain('Surveillance Tuning Monitoring Exceeds Contact')
+    expect(notes[0]?.content).toContain('Surveillance Tuning Sustained Under Collateral Strain')
+    expect(notes[0]?.content).not.toContain('0.88')
+    expect(notes[0]?.metadata?.linkedTuningCount).toBe(1)
+  })
+
+  it('keeps byte-stable surveillance-tuning tension flag ordering in note metadata', () => {
+    const notes = buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+      nextProtocols: SURVEILLANCE_PROTOCOLS,
+      nextBundles: SURVEILLANCE_BUNDLES,
+      nextSurveillanceTuningRecords: SURVEILLANCE_TUNING_RECORDS,
+      week: 3,
+      sequenceStart: 1,
+    })
+
+    expect(notes[0]?.metadata?.crossSystemTensionFlags).toEqual([
+      'monitoring_substitutes_contact_signal',
+      'surveillance_burden_low_humane_care_risk',
+      'surveillance_burden_no_active_contact_channel',
+      'surveillance_burden_stable_mental_state',
+      'surveillance_tuning_monitoring_exceeds_contact',
+      'surveillance_tuning_sustained_under_collateral_strain',
+    ])
   })
 })


### PR DESCRIPTION
## Summary

- Extend cross-reconciliation surfacing to pass \surveillanceInterventionTuningRecords\ into compose at read time (mirror + weekly notes).
- Add safe tuning cross-link labels (id + label only) and include tuning segment / \linkedTuningCount\ in weekly report note content and metadata.
- Wire \dvanceWeek\ reconciliation note builder with tuning records; no compose or tuning orchestration changes.

## Linear

- **Slice:** [SPE-2439](https://linear.app/spectranoir/issue/SPE-2439) — Surveillance-tuning cross-reconciliation surfacing (slice 4)
- **Parent:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — remains **Backlog** (psychological resilience surfacing deferred)

## What shipped

Surfacing-only slice: coercive protocol mirror tension flags, weekly report notes, and label helpers now tuning-aware via existing SPE-2430 compose cross-join.

## Validation

- \
pm run lint\
- \
pm run test:run -- src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts\

## Docs

- \planning/spe-1908-cross-system-reconciliation-slice-4.md\
- \planning/backlog.md\

Made with [Cursor](https://cursor.com)