### PR TITLE
feat(SPE-2440): psychological-resilience cross-reconciliation surfacing slice 5

### DIFF
--- a/planning/spe-1908-cross-system-reconciliation-slice-5.md
+++ b/planning/spe-1908-cross-system-reconciliation-slice-5.md
@@ -1,0 +1,76 @@
+# SPE-1908 — Psychological-resilience cross-reconciliation surfacing (slice 5)
+
+One-page implementation plan. Linear: [SPE-2440](https://linear.app/spectranoir/issue/SPE-2440) (child under [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)). Follows shipped slice 4 (`planning/spe-1908-cross-system-reconciliation-slice-4.md`, PR #2749 / [SPE-2439](https://linear.app/spectranoir/issue/SPE-2439)). Deferred from `planning/spe-1615-psychological-resilience-registry-slice-4.md`.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2440 — Psychological-resilience cross-reconciliation surfacing (slice 5)](https://linear.app/spectranoir/issue/SPE-2440) |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — surveillance-isolation contradiction check umbrella |
+| **Branch** | `jamesdyedbq/spe-1908-cross-system-reconciliation-slice-5`                                                 |
+| **Base `main` SHA** | `6aaee42e`                                                                                          |
+
+## Goal
+
+Surface `composeAllCoerciveProtocolIntegratedHealthReconciliations` psychological-resilience tension flags and cross-link labels in coercive protocol mirror and weekly report notes — read-only follow-up once SPE-2436 compose cross-join and SPE-1615 persistence exist.
+
+## Prerequisite (on `main` @ `6aaee42e`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Cross-reconciliation compose + resilience cross-join | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` (SPE-2436) |
+| Cross-reconciliation surfacing (protocol/bundle/tuning) | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts` (SPE-2429 / SPE-2439) |
+| Psychological resilience persistence | `psychologicalResilienceRecords` on `GameState` (SPE-2434) |
+| Psychological resilience mirror label vocabulary | `psychologicalResilienceMirrorView.ts` (SPE-2437) |
+
+## Surfacing contract (slice 5)
+
+- **Read-only** — pass `psychologicalResilienceRecords` into compose at read time; no new GameState fields.
+- **Safe labels** — resilience record ids + labels only; no projection score or redacted field leakage in surfacing strings.
+- **Tension flags** — `psychological_resilience_exposure_elevated`, `psychological_resilience_duty_reliability_degraded`, and `psychological_resilience_treatment_gated` via existing compose when resilience map coexists.
+- **Empty maps** — no-op; slice 2/4 surfacing unchanged when resilience absent.
+- **Mirror** — coercive protocol mirror passes resilience records into compose summaries for per-record `crossSystemTensionFlagLabels`.
+- **Weekly notes** — emit when protocol + bundle maps coexist; include resilience segment and `linkedResilienceCount` when resilience linked.
+- **Byte-stable ordering** — tension flags and resilience ids sorted on repeat.
+- **No compose changes** — SPE-2436 contracts unchanged.
+- **No resilience mirror UI changes** — SPE-2437 unchanged.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts` resilience pass-through + labels | SPE-2436 compose changes |
+| `coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts` resilience wiring | SPE-2437 mirror UI changes |
+| Coercive protocol mirror resilience-aware compose | `psychologicalResilienceWeeklyOrchestration.ts` |
+| `advanceWeek` note wiring for resilience records | Contradiction-check evaluator changes |
+| Targeted surfacing + mirror + advanceWeek tests | SPE-1908 parent re-closure |
+| Slice doc (this file) + backlog handoff | Unrelated registries |
+
+## Acceptance
+
+- [ ] Empty resilience maps no-op without throw; slice 2/4 regression unchanged
+- [ ] Mirror surfaces psychological-resilience tension flags for abusive surveillance + subject-22 bundle + staged-depletion resilience fixture
+- [ ] Weekly report note includes resilience cross-link labels and resilience tension flags when maps coexist
+- [ ] Redacted projection fields do not leak in surfacing labels
+- [ ] `advanceWeek` integration asserts resilience-aware reconciliation note when fixtures coexist
+- [ ] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts`, `src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts` |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` |
+| Tests  | `src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts`, `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts` |
+| Plan   | `planning/spe-1908-cross-system-reconciliation-slice-5.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1908 parent closure | SPE-1908 | Multi-owner reconciliation AC not met |
+
+## See also
+
+- `planning/spe-1908-cross-system-reconciliation-slice-4.md`
+- `planning/spe-1615-psychological-resilience-registry-slice-4.md`

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.ts
@@ -1,6 +1,6 @@
 /**
- * SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4: read-only surfacing for coercive
- * protocol ↔ integrated health bundle cross-reconciliation compose output.
+ * SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4 + SPE-2440 slice 5: read-only surfacing
+ * for coercive protocol ↔ integrated health bundle cross-reconciliation compose output.
  *
  * Formats compose summaries for mirror labels and weekly report notes — no changes to
  * SPE-2428 / SPE-2430 compose contracts.
@@ -20,6 +20,10 @@ import type {
   ContainedPersonIntegratedHealthBundleRecordsMap,
 } from './containedPersonIntegratedHealthBundleRegistry'
 import type {
+  PsychologicalResilienceRecord,
+  PsychologicalResilienceRecordsMap,
+} from './psychologicalResilienceRegistry'
+import type {
   SurveillanceInterventionTuningRecord,
   SurveillanceInterventionTuningRecordsMap,
 } from './surveillanceCapacityInterventionTuningRegistry'
@@ -28,6 +32,13 @@ const SURVEILLANCE_TUNING_CROSS_SYSTEM_TENSION_FLAGS: ReadonlySet<CoerciveProtoc
   new Set([
     'surveillance_tuning_monitoring_exceeds_contact',
     'surveillance_tuning_sustained_under_collateral_strain',
+  ])
+
+const PSYCHOLOGICAL_RESILIENCE_CROSS_SYSTEM_TENSION_FLAGS: ReadonlySet<CoerciveProtocolCrossSystemTensionFlag> =
+  new Set([
+    'psychological_resilience_duty_reliability_degraded',
+    'psychological_resilience_exposure_elevated',
+    'psychological_resilience_treatment_gated',
   ])
 
 export function formatCoerciveProtocolCrossLinkLabel(record: CoerciveProtocolRecord): string {
@@ -42,6 +53,12 @@ export function formatIntegratedHealthBundleCrossLinkLabel(
 
 export function formatSurveillanceTuningCrossLinkLabel(
   record: SurveillanceInterventionTuningRecord
+): string {
+  return `${record.id} (${record.label})`
+}
+
+export function formatPsychologicalResilienceCrossLinkLabel(
+  record: PsychologicalResilienceRecord
 ): string {
   return `${record.id} (${record.label})`
 }
@@ -74,17 +91,27 @@ function tuningById(
   return records?.[tuningId]
 }
 
+function resilienceById(
+  records: PsychologicalResilienceRecordsMap | undefined,
+  resilienceId: string
+): PsychologicalResilienceRecord | undefined {
+  return records?.[resilienceId]
+}
+
 export function formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabels(input: {
   summary: CoerciveProtocolIntegratedHealthReconciliationSummary
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
   surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
+  psychologicalResilienceRecords?: PsychologicalResilienceRecordsMap | undefined
 }): {
   readonly protocolLabels: readonly string[]
   readonly bundleLabel: string | null
   readonly tuningLabels: readonly string[]
+  readonly resilienceLabels: readonly string[]
   readonly tensionFlagLabels: readonly string[]
   readonly surveillanceTuningTensionFlagLabels: readonly string[]
+  readonly psychologicalResilienceTensionFlagLabels: readonly string[]
 } {
   const protocolIds = [
     ...new Set(input.summary.links.map((link) => link.coerciveProtocolId)),
@@ -107,6 +134,17 @@ export function formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabel
     .filter((record): record is SurveillanceInterventionTuningRecord => record !== undefined)
     .map((record) => formatSurveillanceTuningCrossLinkLabel(record))
 
+  const resilienceIds = [
+    ...new Set(
+      input.summary.psychologicalResilienceLinks.map((link) => link.psychologicalResilienceId)
+    ),
+  ].sort((left, right) => left.localeCompare(right))
+
+  const resilienceLabels = resilienceIds
+    .map((resilienceId) => resilienceById(input.psychologicalResilienceRecords, resilienceId))
+    .filter((record): record is PsychologicalResilienceRecord => record !== undefined)
+    .map((record) => formatPsychologicalResilienceCrossLinkLabel(record))
+
   const tensionFlagLabels = Object.freeze(
     input.summary.crossSystemTensionFlags.map((flag) => formatCrossSystemTensionFlagLabel(flag))
   )
@@ -117,12 +155,20 @@ export function formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabel
       .map((flag) => formatCrossSystemTensionFlagLabel(flag))
   )
 
+  const psychologicalResilienceTensionFlagLabels = Object.freeze(
+    input.summary.crossSystemTensionFlags
+      .filter((flag) => PSYCHOLOGICAL_RESILIENCE_CROSS_SYSTEM_TENSION_FLAGS.has(flag))
+      .map((flag) => formatCrossSystemTensionFlagLabel(flag))
+  )
+
   return {
     protocolLabels: Object.freeze(protocolLabels),
     bundleLabel,
     tuningLabels: Object.freeze(tuningLabels),
+    resilienceLabels: Object.freeze(resilienceLabels),
     tensionFlagLabels,
     surveillanceTuningTensionFlagLabels,
+    psychologicalResilienceTensionFlagLabels,
   }
 }
 
@@ -131,24 +177,30 @@ export function formatCoerciveProtocolIntegratedHealthReconciliationNoteContent(
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
   surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
+  psychologicalResilienceRecords?: PsychologicalResilienceRecordsMap | undefined
 }): string {
-  const { protocolLabels, bundleLabel, tuningLabels, tensionFlagLabels } =
+  const { protocolLabels, bundleLabel, tuningLabels, resilienceLabels, tensionFlagLabels } =
     formatCoerciveProtocolIntegratedHealthReconciliationSummaryLabels(input)
   const protocolSegment =
     protocolLabels.length > 0 ? protocolLabels.join('; ') : 'no linked coercive protocols'
   const bundleSegment = bundleLabel ?? 'no linked integrated health bundle'
   const tuningSegment =
     tuningLabels.length > 0 ? tuningLabels.join('; ') : 'no linked surveillance tuning records'
+  const resilienceSegment =
+    resilienceLabels.length > 0
+      ? resilienceLabels.join('; ')
+      : 'no linked psychological resilience records'
   const tensionSegment =
     tensionFlagLabels.length > 0 ? tensionFlagLabels.join('; ') : 'no cross-system tension flags'
 
-  return `Coercive protocol cross-link — ${input.summary.subjectRef}: ${input.summary.linkedProtocolCount} protocol(s), ${input.summary.linkedBundleCount} bundle(s), ${input.summary.linkedTuningCount} tuning record(s). Tension flags: ${tensionSegment}. Protocols: ${protocolSegment}. Bundle: ${bundleSegment}. Tuning: ${tuningSegment}.`
+  return `Coercive protocol cross-link — ${input.summary.subjectRef}: ${input.summary.linkedProtocolCount} protocol(s), ${input.summary.linkedBundleCount} bundle(s), ${input.summary.linkedTuningCount} tuning record(s), ${input.summary.linkedResilienceCount} resilience record(s). Tension flags: ${tensionSegment}. Protocols: ${protocolSegment}. Bundle: ${bundleSegment}. Tuning: ${tuningSegment}. Resilience: ${resilienceSegment}.`
 }
 
 export function composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries(input: {
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
   surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
+  psychologicalResilienceRecords?: PsychologicalResilienceRecordsMap | undefined
 }): readonly CoerciveProtocolIntegratedHealthReconciliationSummary[] {
   if (!input.protocols || !input.bundles) {
     return []
@@ -161,7 +213,8 @@ export function composeAllCoerciveProtocolIntegratedHealthReconciliationSummarie
   return composeAllCoerciveProtocolIntegratedHealthReconciliations(
     input.protocols,
     input.bundles,
-    input.surveillanceTuningRecords
+    input.surveillanceTuningRecords,
+    input.psychologicalResilienceRecords
   )
 }
 
@@ -169,12 +222,14 @@ export function resolveCoerciveProtocolIntegratedHealthReconciliationForSubject(
   protocols: CoerciveProtocolRecordsMap | undefined
   bundles: ContainedPersonIntegratedHealthBundleRecordsMap | undefined
   surveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | undefined
+  psychologicalResilienceRecords?: PsychologicalResilienceRecordsMap | undefined
   subjectRef: string
 }): CoerciveProtocolIntegratedHealthReconciliationSummary | null {
   const summaries = composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
     protocols: input.protocols,
     bundles: input.bundles,
     surveillanceTuningRecords: input.surveillanceTuningRecords,
+    psychologicalResilienceRecords: input.psychologicalResilienceRecords,
   })
 
   return summaries.find((summary) => summary.subjectRef === input.subjectRef) ?? null

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes.ts
@@ -1,12 +1,13 @@
 /**
- * SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4: weekly report notes for coercive
- * protocol ↔ integrated health bundle cross-reconciliation.
+ * SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4 + SPE-2440 slice 5: weekly report notes
+ * for coercive protocol ↔ integrated health bundle cross-reconciliation.
  *
  * Emits deterministic notes when linked maps coexist — no new persistence.
  */
 
 import type { CoerciveProtocolRecordsMap } from './coerciveContainedPersonProtocolRegistry'
 import type { ContainedPersonIntegratedHealthBundleRecordsMap } from './containedPersonIntegratedHealthBundleRegistry'
+import type { PsychologicalResilienceRecordsMap } from './psychologicalResilienceRegistry'
 import type { SurveillanceInterventionTuningRecordsMap } from './surveillanceCapacityInterventionTuningRegistry'
 import {
   composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries,
@@ -23,6 +24,7 @@ export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportN
   nextProtocols: CoerciveProtocolRecordsMap | null | undefined
   nextBundles: ContainedPersonIntegratedHealthBundleRecordsMap | null | undefined
   nextSurveillanceTuningRecords?: SurveillanceInterventionTuningRecordsMap | null | undefined
+  nextPsychologicalResilienceRecords?: PsychologicalResilienceRecordsMap | null | undefined
   week: number
   sequenceStart: number
   baseTimestamp?: number
@@ -31,6 +33,7 @@ export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportN
     protocols: input.nextProtocols ?? undefined,
     bundles: input.nextBundles ?? undefined,
     surveillanceTuningRecords: input.nextSurveillanceTuningRecords ?? undefined,
+    psychologicalResilienceRecords: input.nextPsychologicalResilienceRecords ?? undefined,
   })
 
   if (nextSummaries.length === 0) {
@@ -48,6 +51,7 @@ export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportN
           protocols: input.nextProtocols ?? undefined,
           bundles: input.nextBundles ?? undefined,
           surveillanceTuningRecords: input.nextSurveillanceTuningRecords ?? undefined,
+          psychologicalResilienceRecords: input.nextPsychologicalResilienceRecords ?? undefined,
         }),
         input.week,
         sequence,
@@ -58,6 +62,7 @@ export function buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportN
           linkedProtocolCount: summary.linkedProtocolCount,
           linkedBundleCount: summary.linkedBundleCount,
           linkedTuningCount: summary.linkedTuningCount,
+          linkedResilienceCount: summary.linkedResilienceCount,
           crossSystemTensionFlags: [...summary.crossSystemTensionFlags],
           structuredReasons: [...summary.structuredReasons],
           week: input.week,

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4718,13 +4718,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     }
   }
 
-  // SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4: surface coercive protocol ↔ integrated health cross-reconciliation in weekly report notes.
+  // SPE-1908 / SPE-2429 slice 2 + SPE-2439 slice 4 + SPE-2440 slice 5: surface coercive protocol ↔ integrated health cross-reconciliation in weekly report notes.
   const nextCoerciveProtocolsForReconciliation =
     outputWeeklyState.coerciveContainedPersonProtocolRecords ?? {}
   const nextIntegratedHealthBundlesForReconciliation =
     outputWeeklyState.containedPersonIntegratedHealthBundles ?? {}
   const nextSurveillanceTuningRecordsForReconciliation =
     outputWeeklyState.surveillanceInterventionTuningRecords ?? {}
+  const nextPsychologicalResilienceRecordsForReconciliation =
+    outputWeeklyState.psychologicalResilienceRecords ?? {}
   if (
     Object.keys(nextCoerciveProtocolsForReconciliation).length > 0 &&
     Object.keys(nextIntegratedHealthBundlesForReconciliation).length > 0 &&
@@ -4735,6 +4737,7 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       nextProtocols: nextCoerciveProtocolsForReconciliation,
       nextBundles: nextIntegratedHealthBundlesForReconciliation,
       nextSurveillanceTuningRecords: nextSurveillanceTuningRecordsForReconciliation,
+      nextPsychologicalResilienceRecords: nextPsychologicalResilienceRecordsForReconciliation,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -11,6 +11,7 @@ import {
   type CoerciveProtocolRecord,
 } from '../../domain/coerciveContainedPersonProtocolRegistry'
 import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
+import { PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE } from '../../domain/psychologicalResilienceRegistry'
 import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
 import {
   formatCoerciveProtocolEnumLabel,
@@ -332,5 +333,41 @@ describe('coerciveContainedPersonProtocolMirrorView (SPE-2439 slice 4)', () => {
       'Surveillance Tuning Sustained Under Collateral Strain',
     ])
     expect(record?.crossSystemTensionFlagLabels.join('; ')).not.toContain('0.88')
+  })
+})
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-2440 slice 5)', () => {
+  it('surfaces psychological-resilience tension flags when resilience records coexist', () => {
+    const protocolWithOperatorLink = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      subjectFitValidationRef: PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef,
+    }
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [protocolWithOperatorLink.id]: protocolWithOperatorLink,
+    }
+    game.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    game.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.crossSystemTensionSubjectCount).toBe(1)
+    expect(record?.crossSystemTensionFlagLabels).toEqual([
+      'Monitoring Substitutes Contact Signal',
+      'Psychological Resilience Duty Reliability Degraded',
+      'Psychological Resilience Exposure Elevated',
+      'Surveillance Burden Low Humane Care Risk',
+      'Surveillance Burden No Active Contact Channel',
+      'Surveillance Burden Stable Mental State',
+    ])
+    expect(record?.crossSystemTensionFlagLabels.join('; ')).not.toContain('0.72')
+    expect(record?.crossSystemTensionFlagLabels.join('; ')).not.toContain('0.79')
   })
 })

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -205,6 +205,7 @@ export function getCoerciveContainedPersonProtocolMirrorView(
     protocols: game.coerciveContainedPersonProtocolRecords,
     bundles: game.containedPersonIntegratedHealthBundles,
     surveillanceTuningRecords: game.surveillanceInterventionTuningRecords,
+    psychologicalResilienceRecords: game.psychologicalResilienceRecords,
   })
   const tensionLabelsBySubject = buildCrossSystemTensionFlagLabelsBySubject(reconciliationSummaries)
 

--- a/src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts
@@ -3,6 +3,7 @@ import { createStartingState } from '../data/startingState'
 import { ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE } from '../domain/coerciveContainedPersonProtocolRegistry'
 import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE } from '../domain/psychologicalResilienceRegistry'
 import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../domain/surveillanceCapacityInterventionTuningRegistry'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -89,5 +90,42 @@ describe('advanceWeek coercive protocol integrated health reconciliation integra
       `${SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id} (${SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.label})`
     )
     expect(reconciliationNotes[0]?.metadata?.linkedTuningCount).toBe(1)
+  })
+})
+
+describe('advanceWeek coercive protocol integrated health reconciliation integration (SPE-2440 slice 5)', () => {
+  it('surfaces psychological-resilience tension flags when resilience records coexist', () => {
+    const protocolWithOperatorLink = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      subjectFitValidationRef: PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef,
+    }
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coerciveContainedPersonProtocolRecords = {
+      [protocolWithOperatorLink.id]: protocolWithOperatorLink,
+    }
+    state.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
+    }
+    state.psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const reconciliationNotes =
+      weeklyReport?.notes?.filter(
+        (note) => note.type === 'coercive_protocol.integrated_health_reconciliation'
+      ) ?? []
+
+    expect(reconciliationNotes.length).toBeGreaterThan(0)
+    expect(reconciliationNotes[0]?.content).toContain('1 resilience record(s)')
+    expect(reconciliationNotes[0]?.content).toContain('Psychological Resilience Exposure Elevated')
+    expect(reconciliationNotes[0]?.content).toContain(
+      `${PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id} (${PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.label})`
+    )
+    expect(reconciliationNotes[0]?.metadata?.linkedResilienceCount).toBe(1)
   })
 })

--- a/src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts
+++ b/src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts
@@ -9,11 +9,13 @@ import {
   formatCoerciveProtocolIntegratedHealthReconciliationNoteContent,
   formatCrossSystemTensionFlagLabel,
   formatIntegratedHealthBundleCrossLinkLabel,
+  formatPsychologicalResilienceCrossLinkLabel,
   formatSurveillanceTuningCrossLinkLabel,
 } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing'
 import { composeCoerciveProtocolIntegratedHealthReconciliation } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliation'
 import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
 import { buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes } from '../domain/coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes'
+import { PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE } from '../domain/psychologicalResilienceRegistry'
 import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../domain/surveillanceCapacityInterventionTuningRegistry'
 
 const SURVEILLANCE_PROTOCOLS = {
@@ -28,6 +30,20 @@ const SURVEILLANCE_BUNDLES = {
 
 const SURVEILLANCE_TUNING_RECORDS = {
   [SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE.id]: SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE,
+}
+
+const RESILIENCE_PROTOCOL = {
+  ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  subjectFitValidationRef: PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef,
+}
+
+const RESILIENCE_PROTOCOLS = {
+  [RESILIENCE_PROTOCOL.id]: RESILIENCE_PROTOCOL,
+}
+
+const PSYCHOLOGICAL_RESILIENCE_RECORDS = {
+  [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+    PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
 }
 
 describe('coerciveProtocolIntegratedHealthCrossReconciliationSurfacing (SPE-2429 slice 2)', () => {
@@ -188,6 +204,92 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliationSurfacing (SPE-2439
       'surveillance_burden_stable_mental_state',
       'surveillance_tuning_monitoring_exceeds_contact',
       'surveillance_tuning_sustained_under_collateral_strain',
+    ])
+  })
+})
+
+describe('coerciveProtocolIntegratedHealthCrossReconciliationSurfacing (SPE-2440 slice 5)', () => {
+  it('formats psychological resilience cross-link labels from persisted id and label only', () => {
+    expect(
+      formatPsychologicalResilienceCrossLinkLabel(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE)
+    ).toBe(
+      `${PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id} (${PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.label})`
+    )
+    expect(formatCrossSystemTensionFlagLabel('psychological_resilience_exposure_elevated')).toBe(
+      'Psychological Resilience Exposure Elevated'
+    )
+  })
+
+  it('passes psychological resilience records into compose summaries without throw on empty maps', () => {
+    expect(
+      composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+        protocols: RESILIENCE_PROTOCOLS,
+        bundles: SURVEILLANCE_BUNDLES,
+        psychologicalResilienceRecords: {},
+      })
+    ).toHaveLength(1)
+    expect(
+      composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries({
+        protocols: RESILIENCE_PROTOCOLS,
+        bundles: SURVEILLANCE_BUNDLES,
+        psychologicalResilienceRecords: undefined,
+      })[0]?.linkedResilienceCount
+    ).toBe(0)
+  })
+
+  it('surfaces psychological-resilience tension flags and resilience labels when resilience map coexists', () => {
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      RESILIENCE_PROTOCOLS,
+      SURVEILLANCE_BUNDLES,
+      ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.subjectRef,
+      undefined,
+      PSYCHOLOGICAL_RESILIENCE_RECORDS
+    )
+
+    const notes = buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+      nextProtocols: RESILIENCE_PROTOCOLS,
+      nextBundles: SURVEILLANCE_BUNDLES,
+      nextPsychologicalResilienceRecords: PSYCHOLOGICAL_RESILIENCE_RECORDS,
+      week: 3,
+      sequenceStart: 1,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.content).toBe(
+      formatCoerciveProtocolIntegratedHealthReconciliationNoteContent({
+        summary,
+        protocols: RESILIENCE_PROTOCOLS,
+        bundles: SURVEILLANCE_BUNDLES,
+        psychologicalResilienceRecords: PSYCHOLOGICAL_RESILIENCE_RECORDS,
+      })
+    )
+    expect(notes[0]?.content).toContain('1 resilience record(s)')
+    expect(notes[0]?.content).toContain(
+      formatPsychologicalResilienceCrossLinkLabel(PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE)
+    )
+    expect(notes[0]?.content).toContain('Psychological Resilience Exposure Elevated')
+    expect(notes[0]?.content).toContain('Psychological Resilience Duty Reliability Degraded')
+    expect(notes[0]?.content).not.toContain('0.72')
+    expect(notes[0]?.content).not.toContain('0.79')
+    expect(notes[0]?.metadata?.linkedResilienceCount).toBe(1)
+  })
+
+  it('keeps byte-stable psychological-resilience tension flag ordering in note metadata', () => {
+    const notes = buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes({
+      nextProtocols: RESILIENCE_PROTOCOLS,
+      nextBundles: SURVEILLANCE_BUNDLES,
+      nextPsychologicalResilienceRecords: PSYCHOLOGICAL_RESILIENCE_RECORDS,
+      week: 3,
+      sequenceStart: 1,
+    })
+
+    expect(notes[0]?.metadata?.crossSystemTensionFlags).toEqual([
+      'monitoring_substitutes_contact_signal',
+      'psychological_resilience_duty_reliability_degraded',
+      'psychological_resilience_exposure_elevated',
+      'surveillance_burden_low_humane_care_risk',
+      'surveillance_burden_no_active_contact_channel',
+      'surveillance_burden_stable_mental_state',
     ])
   })
 })


### PR DESCRIPTION
## Summary

- Extend cross-reconciliation surfacing helpers to pass `psychologicalResilienceRecords` into compose at read time (id + label cross-links; tension-flag labels only).
- Wire resilience-aware weekly report notes and coercive protocol mirror tension labels; pass resilience records through `advanceWeek` note builder.
- Add targeted surfacing, mirror, and `advanceWeek` integration tests; slice doc `planning/spe-1908-cross-system-reconciliation-slice-5.md`.

## Linear

- **Slice:** [SPE-2440](https://linear.app/spectranoir/issue/SPE-2440) — Psychological-resilience cross-reconciliation surfacing (slice 5)
- **Parent:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) — remains **Backlog** (parent AC not met)

## What shipped

Read-only surfacing of SPE-2436 compose psychological-resilience tension flags in coercive protocol mirror and weekly report notes. No compose changes (SPE-2436), no resilience mirror UI changes (SPE-2437).

## Validation

- `npm run lint`
- `npm run test:run -- src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts src/test/advanceWeek.coerciveProtocolIntegratedHealthReconciliation.integration.test.ts`

## Docs updated

- `planning/spe-1908-cross-system-reconciliation-slice-5.md` (new)

## Parent remains open

Yes — SPE-1908 umbrella reconciliation AC not fully satisfied by this child slice alone.

Made with [Cursor](https://cursor.com)