### PR TITLE
feat(SPE-2016): staff exclusion vs support-duty contradiction-check sibling

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Next registry mirror queue item or backlog hygiene pass. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
+**Next step:** [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016) staff exclusion vs support-duty contradiction-check sibling @ `planning/spe-2016-staff-exclusion-contradiction-check-slice.md`. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `fa049b03` — shipped: [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) parent owner-map reconciliation @ `planning/spe-1908-owner-reconciliation-slice.md`
+**Base `main` SHA:** `809e46a1` — in progress: [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016) @ branch `jamesdyedbq/spe-2016-staff-exclusion-contradiction-check`
 
-**Recently shipped:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) parent owner-map reconciliation / harvest fold-in (hygiene); [SPE-2440](https://linear.app/spectranoir/issue/SPE-2440) psychological-resilience cross-reconciliation surfacing slice 5 @ PR #2751; see `planning/spe-1908-owner-reconciliation-slice.md`.
+**Recently shipped:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) parent owner-map reconciliation / harvest fold-in (hygiene) @ PR #2752; [SPE-2440](https://linear.app/spectranoir/issue/SPE-2440) psychological-resilience cross-reconciliation surfacing slice 5 @ PR #2751.
 
 ## Blocked / waiting
 

--- a/planning/spe-2016-staff-exclusion-contradiction-check-slice.md
+++ b/planning/spe-2016-staff-exclusion-contradiction-check-slice.md
@@ -1,0 +1,76 @@
+# SPE-2016 — Staff exclusion versus support-duty contradiction check
+
+One-page implementation plan. Linear: [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016) (staff-duty sibling to shipped [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908)). Design anchor: contradiction-check sibling cluster in `coerciveContainedPersonProtocolRegistry.ts`.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2016 — Contradiction check: Staff exclusion versus support-duty obligations](https://linear.app/spectranoir/issue/SPE-2016) |
+| **Status** | Ready for PR                                                                                               |
+| **Parent** | None (staff-duty owner; related to SPE-1908 contained-person cross-join)                                   |
+| **Branch** | `jamesdyedbq/spe-2016-staff-exclusion-contradiction-check`                                                 |
+| **Base `main` SHA** | `809e46a1`                                                                                          |
+
+## Goal
+
+Implement a bounded contradiction-check sibling for staff exclusion and support-service denial scenarios — warning-only output that separates exposure risk, support-duty obligation, medical/access state, and isolation burden; routes fixes to medical/accommodation/denial-doctrine owners without duplicating their implementations.
+
+## Prerequisite (on `main` @ `809e46a1`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Contained-person surveillance-isolation sibling | `evaluateSurveillanceIsolationBurdenContradictionCheck` (SPE-1908 slice 9) |
+| Contradiction aggregator | `evaluateCoerciveProtocolContradictionChecks` (slices 6–9)          |
+| Cross-reconciliation tension flags | `psychological_resilience_duty_reliability_degraded`, `surveillance_burden_no_active_contact_channel` (consult anchors only) |
+| SPE-1908 owner fold-in | Fold-in comment on SPE-2016 confirming staff-duty boundary            |
+
+## Sibling contract
+
+- **Flag** — `staff_exclusion_support_duty` from `collectContradictionRiskFlags` (both `staffExclusionBurdenScore` ≥ 0.65 and `supportDutyObligationScore` ≥ 0.5).
+- **Function** — `evaluateStaffExclusionSupportDutyContradictionCheck(record)` returns structured warning-only issues separating exposure risk, support-duty obligation, medical/access routing, and isolation-burden substitution.
+- **Aggregator** — `evaluateCoerciveProtocolContradictionChecks(record)` returns triggered siblings in deterministic flag locale order (compliance metric, generalized subject-fit, routine force, staff exclusion, surveillance isolation).
+- **Blocking** — `blocksProcedure` is always `false` per registry contract.
+- **Owner refs** — `medicalAccessStateRef`, `accommodationAccessRef`, `denialDoctrinePressureRef` on record only; no medical ledger or accommodation implementation in this slice.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Staff-exclusion contradiction-check types + evaluator              | SPE-1908 compose/surfacing changes            |
+| Optional staff-side record fields + fixture                        | Medical policy ledger (SPE-2074)              |
+| `evaluateCoerciveProtocolContradictionChecks` aggregator extension | Accommodation implementation (SPE-2005)       |
+| Targeted registry unit tests                                       | Institutional denial doctrine model (SPE-2001)|
+| Slice doc (this file) + `planning/backlog.md` handoff              | Medical outcome audit (SPE-2003)              |
+
+## Acceptance
+
+- [x] Staff-exclusion fixture triggers sibling with sorted warning issues and `blocksProcedure: false`
+- [x] Records below staff-exclusion or support-duty threshold return non-triggered no-op sibling
+- [x] Sibling trigger aligns with `staff_exclusion_support_duty` flag from `collectContradictionRiskFlags`
+- [x] Issues separately flag exposure risk, support-duty obligation, medical/access routing, isolation-burden substitution, and denial-as-contamination reduction
+- [x] Redacted/unknown metadata propagates into check output
+- [x] Aggregator returns five triggered siblings in flag locale order for pent-flag fixture
+- [x] Repeated evaluation is byte-stable
+- [x] Existing contradiction-check sibling regression + `npm run lint` green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveContainedPersonProtocolRegistry.ts`               |
+| Tests  | `src/test/coerciveContainedPersonProtocolRegistry.test.ts`            |
+| Plan   | `planning/spe-2016-staff-exclusion-contradiction-check-slice.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Cross-reconciliation compose for staff-duty tension flags | SPE-1908 follow-up / SPE-1615 | Out of registry-only slice boundary; consult existing tension flags only |
+| Medical policy ledger implementation | SPE-2074 | Routed via `medicalAccessStateRef` — not duplicated here |
+| Accommodation request ledger | SPE-2005 | Routed via `accommodationAccessRef` |
+| Institutional denial doctrine enforcement | SPE-2001 | Routed via `denialDoctrinePressureRef` |
+| Medical outcome deviation audit | SPE-2003 | Medical access owner — not duplicated here |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-9.md` — contained-person surveillance-isolation sibling origin
+- `planning/spe-1908-owner-reconciliation-slice.md` — SPE-2016 fold-in and owner map

--- a/src/domain/coerciveContainedPersonProtocolRegistry.ts
+++ b/src/domain/coerciveContainedPersonProtocolRegistry.ts
@@ -100,6 +100,7 @@ export type CoerciveProtocolContradictionRiskFlag =
   | 'routine_force_authorization'
   | 'generalized_procedure_without_subject_fit'
   | 'compliance_metric_masks_harm'
+  | 'staff_exclusion_support_duty'
   | 'surveillance_isolation_burden'
 
 // ---------------------------------------------------------------------------
@@ -133,6 +134,18 @@ export interface CoerciveProtocolRecord {
   readonly legitimacyRisk: number
   readonly welfareDebtImpactLabel: string
   readonly complianceMetricOnly?: boolean
+  /** Staff-side exclusion burden presented as containment safety (SPE-2016). */
+  readonly staffExclusionBurdenScore?: number
+  /** Elevated support-duty obligation while staff exclusion is active (SPE-2016). */
+  readonly supportDutyObligationScore?: number
+  /** Separately tracked exposure risk — must not collapse into exclusion burden (SPE-2016). */
+  readonly exposureRiskScore?: number
+  /** Owner ref to medical policy / outcome audit (SPE-2074 / SPE-2003) — no ledger duplication. */
+  readonly medicalAccessStateRef?: string
+  /** Owner ref to accommodation request ledger (SPE-2005) — no ledger duplication. */
+  readonly accommodationAccessRef?: string
+  /** Owner ref to institutional denial doctrine pressure (SPE-2001) — no model duplication. */
+  readonly denialDoctrinePressureRef?: string
   readonly confidence?: number
   readonly unknownFields?: readonly string[]
   readonly redactedFields?: readonly string[]
@@ -155,6 +168,9 @@ export type CoerciveProtocolValidationCode =
   | 'invalid_dependency_leverage_score'
   | 'invalid_isolation_burden_score'
   | 'invalid_surveillance_burden_score'
+  | 'invalid_staff_exclusion_burden_score'
+  | 'invalid_support_duty_obligation_score'
+  | 'invalid_exposure_risk_score'
   | 'invalid_containment_stability_gain'
   | 'invalid_personhood_harm_risk'
   | 'invalid_trust_damage_risk'
@@ -253,10 +269,26 @@ export type CoerciveProtocolSurveillanceIsolationContradictionCheckCode =
   | 'surveillance_isolation_masks_care_harm'
   | 'surveillance_isolation_masks_personhood_harm'
 
+export type CoerciveProtocolStaffExclusionSupportDutyContradictionCheckCode =
+  | 'staff_exclusion_elevated_burden'
+  | 'staff_exclusion_contradicts_voluntary_handling'
+  | 'staff_exclusion_low_consent_confidence'
+  | 'staff_exclusion_abusive_without_review_path'
+  | 'staff_exclusion_deceptive_without_review_path'
+  | 'staff_exclusion_exposure_risk_not_separated'
+  | 'staff_exclusion_support_duty_obligation_elevated'
+  | 'staff_exclusion_medical_access_not_routed'
+  | 'staff_exclusion_accommodation_access_not_routed'
+  | 'staff_exclusion_isolation_burden_substitution'
+  | 'staff_exclusion_denial_as_contamination_reduction'
+  | 'staff_exclusion_masks_care_harm'
+  | 'staff_exclusion_masks_personhood_harm'
+
 export type CoerciveProtocolContradictionCheckCode =
   | CoerciveProtocolRoutineForceContradictionCheckCode
   | CoerciveProtocolGeneralizedSubjectFitContradictionCheckCode
   | CoerciveProtocolComplianceMetricContradictionCheckCode
+  | CoerciveProtocolStaffExclusionSupportDutyContradictionCheckCode
   | CoerciveProtocolSurveillanceIsolationContradictionCheckCode
 
 export interface CoerciveProtocolContradictionCheckIssue {
@@ -310,6 +342,7 @@ const CONTRADICTION_RISK_FLAG_SET = new Set<string>([
   'routine_force_authorization',
   'generalized_procedure_without_subject_fit',
   'compliance_metric_masks_harm',
+  'staff_exclusion_support_duty',
   'surveillance_isolation_burden',
 ])
 
@@ -329,6 +362,8 @@ export const FRANCHISE_TOKEN_PATTERN =
 export const BRANDED_OBJECT_NUMBER_PATTERN = /\bSCP[\s-]?\d{3,4}\b/i
 
 const SURVEILLANCE_ISOLATION_BURDEN_THRESHOLD = 0.65
+const STAFF_EXCLUSION_BURDEN_THRESHOLD = 0.65
+const SUPPORT_DUTY_OBLIGATION_THRESHOLD = 0.5
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -612,6 +647,39 @@ export function validateCoerciveProtocolRecord(
       code: 'invalid_surveillance_burden_score',
       severity: 'error',
       detail: `Coercive protocol record ${id || '(unknown)'} has invalid surveillanceBurdenScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.staffExclusionBurdenScore !== undefined &&
+    !isValidUnitScore(record.staffExclusionBurdenScore)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_staff_exclusion_burden_score',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid staffExclusionBurdenScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.supportDutyObligationScore !== undefined &&
+    !isValidUnitScore(record.supportDutyObligationScore)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_support_duty_obligation_score',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid supportDutyObligationScore.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.exposureRiskScore !== undefined && !isValidUnitScore(record.exposureRiskScore)) {
+    pushIssue(issues, {
+      code: 'invalid_exposure_risk_score',
+      severity: 'error',
+      detail: `Coercive protocol record ${id || '(unknown)'} has invalid exposureRiskScore.`,
       relatedIds: id ? [id] : undefined,
     })
   }
@@ -1024,6 +1092,132 @@ function buildComplianceMetricMasksHarmContradictionIssues(
   return issues
 }
 
+function buildStaffExclusionSupportDutyContradictionIssues(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckIssue[] {
+  const issues: CoerciveProtocolContradictionCheckIssue[] = []
+  const id = normalizeToken(record.id)
+  const relatedIds = id ? [id] : undefined
+  const staffExclusionBurden = record.staffExclusionBurdenScore ?? 0
+  const supportDutyObligation = record.supportDutyObligationScore ?? 0
+
+  issues.push({
+    code: 'staff_exclusion_elevated_burden',
+    severity: 'warning',
+    detail: `Coercive protocol record ${id || '(unknown)'} excludes staff or support personnel from services (burden ${staffExclusionBurden.toFixed(2)}) presented as containment safety rather than humane contact preservation.`,
+    relatedIds,
+  })
+
+  issues.push({
+    code: 'staff_exclusion_support_duty_obligation_elevated',
+    severity: 'warning',
+    detail: `Coercive protocol record ${id || '(unknown)'} retains elevated support-duty obligation (${supportDutyObligation.toFixed(2)}) while staff exclusion is active — duty-of-care must remain separable from exclusion burden.`,
+    relatedIds,
+  })
+
+  if (record.exposureRiskScore === undefined) {
+    issues.push({
+      code: 'staff_exclusion_exposure_risk_not_separated',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} applies staff exclusion without a separately tracked exposureRiskScore — exposure risk must not collapse into exclusion or surveillance burden.`,
+      relatedIds,
+    })
+  }
+
+  if (!normalizeToken(record.medicalAccessStateRef ?? '')) {
+    issues.push({
+      code: 'staff_exclusion_medical_access_not_routed',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} excludes staff without a medicalAccessStateRef — medical/access state must be routed to medical policy and outcome-audit owners, not inferred from exclusion.`,
+      relatedIds,
+    })
+  }
+
+  if (!normalizeToken(record.accommodationAccessRef ?? '')) {
+    issues.push({
+      code: 'staff_exclusion_accommodation_access_not_routed',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} excludes staff without an accommodationAccessRef — accommodation access must remain separable from support-service denial.`,
+      relatedIds,
+    })
+  }
+
+  if (
+    record.isolationBurdenScore >= SURVEILLANCE_ISOLATION_BURDEN_THRESHOLD &&
+    record.surveillanceBurdenScore >= SURVEILLANCE_ISOLATION_BURDEN_THRESHOLD
+  ) {
+    issues.push({
+      code: 'staff_exclusion_isolation_burden_substitution',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} pairs staff exclusion with elevated isolation (${record.isolationBurdenScore.toFixed(2)}) and surveillance (${record.surveillanceBurdenScore.toFixed(2)}) burden — isolation burden must not substitute for support-duty contact.`,
+      relatedIds,
+    })
+  }
+
+  if (VOLUNTARY_HANDLING_MODES.has(record.handlingMode)) {
+    issues.push({
+      code: 'staff_exclusion_contradicts_voluntary_handling',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} pairs staff exclusion with ${record.handlingMode} handling.`,
+      relatedIds,
+    })
+  }
+
+  if (record.consentConfidence <= CONTRADICTION_CHECK_LOW_CONSENT_CONFIDENCE_THRESHOLD) {
+    issues.push({
+      code: 'staff_exclusion_low_consent_confidence',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} applies staff exclusion while consent confidence remains low (${record.consentConfidence.toFixed(2)}).`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'abusive' && !normalizeToken(record.subjectFitValidationRef ?? '')) {
+    issues.push({
+      code: 'staff_exclusion_abusive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is abusive with staff exclusion and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (record.handlingMode === 'deceptive' && !normalizeToken(record.subjectFitValidationRef ?? '')) {
+    issues.push({
+      code: 'staff_exclusion_deceptive_without_review_path',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} is deceptive with staff exclusion and no validation or review ref.`,
+      relatedIds,
+    })
+  }
+
+  if (projectContainmentCareTradeoff(record).stableContainmentDominatesCare) {
+    issues.push({
+      code: 'staff_exclusion_denial_as_contamination_reduction',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} treats support-service denial as clean contamination reduction while containment stability dominates care harm.`,
+      relatedIds,
+    })
+
+    issues.push({
+      code: 'staff_exclusion_masks_care_harm',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} reports containment stability gains that may mask staff-exclusion care harm.`,
+      relatedIds,
+    })
+  }
+
+  if (record.personhoodHarmRisk >= COMPLIANCE_METRIC_ELEVATED_PERSONHOOD_HARM_THRESHOLD) {
+    issues.push({
+      code: 'staff_exclusion_masks_personhood_harm',
+      severity: 'warning',
+      detail: `Coercive protocol record ${id || '(unknown)'} applies staff exclusion while personhood harm risk remains elevated (${record.personhoodHarmRisk.toFixed(2)}).`,
+      relatedIds,
+    })
+  }
+
+  return issues
+}
+
 function buildSurveillanceIsolationBurdenContradictionIssues(
   record: CoerciveProtocolRecord
 ): CoerciveProtocolContradictionCheckIssue[] {
@@ -1197,6 +1391,40 @@ export function evaluateRoutineForceAuthorizationContradictionCheck(
   })
 }
 
+export function evaluateStaffExclusionSupportDutyContradictionCheck(
+  record: CoerciveProtocolRecord
+): CoerciveProtocolContradictionCheckResult {
+  const flags = collectContradictionRiskFlags(record)
+  const triggered = flags.includes('staff_exclusion_support_duty')
+  const unknownFields = resolveUnknownFields(record)
+  const confidence = resolveConfidence(record)
+  const redacted = isRedacted(record)
+
+  if (!triggered) {
+    return freezeContradictionCheckResult({
+      recordId: record.id,
+      flag: 'staff_exclusion_support_duty',
+      triggered: false,
+      blocksProcedure: false,
+      issues: [],
+      confidence,
+      redacted,
+      unknownFields,
+    })
+  }
+
+  return freezeContradictionCheckResult({
+    recordId: record.id,
+    flag: 'staff_exclusion_support_duty',
+    triggered: true,
+    blocksProcedure: false,
+    issues: buildStaffExclusionSupportDutyContradictionIssues(record),
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
 export function evaluateSurveillanceIsolationBurdenContradictionCheck(
   record: CoerciveProtocolRecord
 ): CoerciveProtocolContradictionCheckResult {
@@ -1239,12 +1467,14 @@ export function evaluateCoerciveProtocolContradictionChecks(
   const generalizedSubjectFitCheck =
     evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck(record)
   const routineForceCheck = evaluateRoutineForceAuthorizationContradictionCheck(record)
+  const staffExclusionCheck = evaluateStaffExclusionSupportDutyContradictionCheck(record)
   const surveillanceIsolationCheck = evaluateSurveillanceIsolationBurdenContradictionCheck(record)
 
   const triggered = [
     complianceMetricCheck.triggered ? complianceMetricCheck : null,
     generalizedSubjectFitCheck.triggered ? generalizedSubjectFitCheck : null,
     routineForceCheck.triggered ? routineForceCheck : null,
+    staffExclusionCheck.triggered ? staffExclusionCheck : null,
     surveillanceIsolationCheck.triggered ? surveillanceIsolationCheck : null,
   ].filter((check): check is CoerciveProtocolContradictionCheckResult => check !== null)
 
@@ -1266,6 +1496,15 @@ function collectContradictionRiskFlags(
 
   if (record.complianceMetricOnly === true) {
     flags.push('compliance_metric_masks_harm')
+  }
+
+  if (
+    isValidUnitScore(record.staffExclusionBurdenScore) &&
+    isValidUnitScore(record.supportDutyObligationScore) &&
+    record.staffExclusionBurdenScore >= STAFF_EXCLUSION_BURDEN_THRESHOLD &&
+    record.supportDutyObligationScore >= SUPPORT_DUTY_OBLIGATION_THRESHOLD
+  ) {
+    flags.push('staff_exclusion_support_duty')
   }
 
   if (
@@ -1387,6 +1626,32 @@ export const ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE: CoerciveProtocolRecord 
   confidence: 0.69,
 })
 
+/** Staff exclusion protocol with elevated support-duty obligation and missing owner refs. */
+export const STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE: CoerciveProtocolRecord = defineRecord({
+  id: 'coercive-protocol:staff-exclusion-support-duty',
+  label: 'Staff exclusion support-service denial protocol',
+  summary:
+    'Staff and contained-support personnel excluded from peer contact and medical channels while support-duty obligations remain elevated; welfare and reporting risk may increase.',
+  subjectRef: 'subject:contained-support-personnel-09',
+  handlingMode: 'abusive',
+  subjectFitState: 'mismatch',
+  authorizationSource: 'facility_policy',
+  forcePolicy: 'escalated',
+  consentConfidence: 0.11,
+  refusalHandling: 'ignored',
+  isolationBurdenScore: 0.52,
+  surveillanceBurdenScore: 0.48,
+  staffExclusionBurdenScore: 0.81,
+  supportDutyObligationScore: 0.73,
+  custodyStatusRef: 'custody-status:privilege-suspended-hold',
+  containmentStabilityGain: 0.77,
+  personhoodHarmRisk: 0.71,
+  trustDamageRisk: 0.68,
+  legitimacyRisk: 0.62,
+  welfareDebtImpactLabel: 'staff exclusion welfare debt likely',
+  confidence: 0.71,
+})
+
 /** Abusive surveillance-isolation protocol with high burden scores. */
 export const ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE: CoerciveProtocolRecord = defineRecord({
   id: 'coercive-protocol:abusive-surveillance-isolation',
@@ -1490,6 +1755,13 @@ function sanitizeCoerciveProtocolRecordEntry(value: unknown): CoerciveProtocolRe
   const subjectFitValidationRef = normalizeToken(value.subjectFitValidationRef ?? '') || undefined
   const complianceMetricOnly =
     typeof value.complianceMetricOnly === 'boolean' ? value.complianceMetricOnly : undefined
+  const staffExclusionBurdenScore = value.staffExclusionBurdenScore
+  const supportDutyObligationScore = value.supportDutyObligationScore
+  const exposureRiskScore = value.exposureRiskScore
+  const medicalAccessStateRef = normalizeToken(value.medicalAccessStateRef ?? '') || undefined
+  const accommodationAccessRef = normalizeToken(value.accommodationAccessRef ?? '') || undefined
+  const denialDoctrinePressureRef =
+    normalizeToken(value.denialDoctrinePressureRef ?? '') || undefined
   const confidence = value.confidence
   const unknownFields = parseStringList(value.unknownFields)
   const redactedFields = parseStringList(value.redactedFields)
@@ -1518,6 +1790,12 @@ function sanitizeCoerciveProtocolRecordEntry(value: unknown): CoerciveProtocolRe
     ...(procedureRef ? { procedureRef } : {}),
     ...(subjectFitValidationRef ? { subjectFitValidationRef } : {}),
     ...(complianceMetricOnly !== undefined ? { complianceMetricOnly } : {}),
+    ...(isValidUnitScore(staffExclusionBurdenScore) ? { staffExclusionBurdenScore } : {}),
+    ...(isValidUnitScore(supportDutyObligationScore) ? { supportDutyObligationScore } : {}),
+    ...(isValidUnitScore(exposureRiskScore) ? { exposureRiskScore } : {}),
+    ...(medicalAccessStateRef ? { medicalAccessStateRef } : {}),
+    ...(accommodationAccessRef ? { accommodationAccessRef } : {}),
+    ...(denialDoctrinePressureRef ? { denialDoctrinePressureRef } : {}),
     ...(isValidUnitScore(confidence) ? { confidence } : {}),
     ...(unknownFields.length > 0 ? { unknownFields } : {}),
     ...(redactedFields.length > 0 ? { redactedFields } : {}),

--- a/src/test/coerciveContainedPersonProtocolRegistry.test.ts
+++ b/src/test/coerciveContainedPersonProtocolRegistry.test.ts
@@ -3,11 +3,13 @@ import {
   ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
   ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+  STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
   classifyCoerciveProtocolHandlingPosture,
   evaluateCoerciveProtocolContradictionChecks,
   evaluateComplianceMetricMasksHarmContradictionCheck,
   evaluateGeneralizedProcedureWithoutSubjectFitContradictionCheck,
   evaluateRoutineForceAuthorizationContradictionCheck,
+  evaluateStaffExclusionSupportDutyContradictionCheck,
   evaluateSurveillanceIsolationBurdenContradictionCheck,
   projectCoerciveProtocolRiskReview,
   projectContainmentCareTradeoff,
@@ -464,6 +466,141 @@ describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-1882
     )
     const second = evaluateSurveillanceIsolationBurdenContradictionCheck(
       ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE
+    )
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second))
+  })
+})
+
+describe('coerciveContainedPersonProtocolRegistry contradiction checks (SPE-2016)', () => {
+  it('triggers staff-exclusion sibling aligned with contradiction risk flags', () => {
+    const review = projectCoerciveProtocolRiskReview(STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE)
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE
+    )
+
+    expect(review.contradictionRiskFlags).toContain('staff_exclusion_support_duty')
+    expect(review.contradictionRiskFlags).not.toContain('surveillance_isolation_burden')
+    expect(check.triggered).toBe(true)
+    expect(check.flag).toBe('staff_exclusion_support_duty')
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues.length).toBeGreaterThan(0)
+    expect(check.issues.every((issue) => issue.severity === 'warning')).toBe(true)
+    expect(check.issues.map((issue) => issue.code)).toEqual([
+      'staff_exclusion_abusive_without_review_path',
+      'staff_exclusion_accommodation_access_not_routed',
+      'staff_exclusion_denial_as_contamination_reduction',
+      'staff_exclusion_elevated_burden',
+      'staff_exclusion_exposure_risk_not_separated',
+      'staff_exclusion_low_consent_confidence',
+      'staff_exclusion_masks_care_harm',
+      'staff_exclusion_masks_personhood_harm',
+      'staff_exclusion_medical_access_not_routed',
+      'staff_exclusion_support_duty_obligation_elevated',
+    ])
+  })
+
+  it('flags isolation-burden substitution when surveillance and isolation burden are also elevated', () => {
+    const withIsolationSubstitution = {
+      ...STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:staff-exclusion-isolation-substitution',
+      isolationBurdenScore: 0.74,
+      surveillanceBurdenScore: 0.69,
+    }
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(withIsolationSubstitution)
+
+    expect(
+      check.issues.some((issue) => issue.code === 'staff_exclusion_isolation_burden_substitution')
+    ).toBe(true)
+  })
+
+  it('flags voluntary handling contradictions when staff exclusion burden is elevated', () => {
+    const voluntaryStaffExclusion = {
+      ...STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:voluntary-staff-exclusion',
+      handlingMode: 'voluntary' as const,
+    }
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(voluntaryStaffExclusion)
+
+    expect(check.triggered).toBe(true)
+    expect(
+      check.issues.some((issue) => issue.code === 'staff_exclusion_contradicts_voluntary_handling')
+    ).toBe(true)
+  })
+
+  it('returns non-triggered no-op when staff exclusion burden is below threshold', () => {
+    const belowExclusionThreshold = {
+      ...STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:below-staff-exclusion-threshold',
+      staffExclusionBurdenScore: 0.42,
+    }
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(belowExclusionThreshold)
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('returns non-triggered no-op when support-duty obligation is below threshold', () => {
+    const belowObligationThreshold = {
+      ...STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:below-support-duty-threshold',
+      supportDutyObligationScore: 0.32,
+    }
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(belowObligationThreshold)
+
+    expect(check.triggered).toBe(false)
+    expect(check.blocksProcedure).toBe(false)
+    expect(check.issues).toEqual([])
+  })
+
+  it('propagates redacted and unknown metadata into sibling output', () => {
+    const redacted = {
+      ...STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+      redactedFields: ['staffExclusionBurdenScore'],
+      unknownFields: ['supportDutyObligationScore'],
+    }
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(redacted)
+
+    expect(check.triggered).toBe(true)
+    expect(check.redacted).toBe(true)
+    expect(check.unknownFields).toEqual(['supportDutyObligationScore'])
+  })
+
+  it('returns staff-exclusion sibling only from aggregator for staff exclusion fixture', () => {
+    const triggered = evaluateCoerciveProtocolContradictionChecks(
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE
+    )
+
+    expect(triggered.map((check) => check.flag)).toEqual(['staff_exclusion_support_duty'])
+  })
+
+  it('returns five triggered siblings in flag locale order for pent-flag fixture', () => {
+    const pentFlag = {
+      ...ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      id: 'coercive-protocol:pent-flag-contradiction',
+      isolationBurdenScore: 0.72,
+      surveillanceBurdenScore: 0.71,
+      staffExclusionBurdenScore: 0.78,
+      supportDutyObligationScore: 0.66,
+    }
+    const triggered = evaluateCoerciveProtocolContradictionChecks(pentFlag)
+
+    expect(triggered.map((check) => check.flag)).toEqual([
+      'compliance_metric_masks_harm',
+      'generalized_procedure_without_subject_fit',
+      'routine_force_authorization',
+      'staff_exclusion_support_duty',
+      'surveillance_isolation_burden',
+    ])
+  })
+
+  it('returns byte-stable staff-exclusion output on repeated calls', () => {
+    const first = evaluateStaffExclusionSupportDutyContradictionCheck(
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE
+    )
+    const second = evaluateStaffExclusionSupportDutyContradictionCheck(
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE
     )
 
     expect(JSON.stringify(first)).toBe(JSON.stringify(second))


### PR DESCRIPTION
## Summary

- Implements \evaluateStaffExclusionSupportDutyContradictionCheck\ as a fifth contradiction-check sibling in the coercive protocol registry (staff-duty boundary parallel to shipped SPE-1908 contained-person surveillance-isolation sibling).
- Adds optional staff-side record fields (\staffExclusionBurdenScore\, \supportDutyObligationScore\, \exposureRiskScore\, owner refs) and \STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE\.
- Warning-only issues separate exposure risk, support-duty obligation, medical/access routing, isolation-burden substitution, and denial-as-contamination reduction; \locksProcedure\ remains \alse\.
- Extends \evaluateCoerciveProtocolContradictionChecks\ aggregator with deterministic flag locale ordering.

## Linear

- **Slice:** [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016) — Contradiction check: Staff exclusion versus support-duty obligations
- **Related:** [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) (contained-person sibling, shipped)

## What shipped

- Registry flag \staff_exclusion_support_duty\ + evaluator + fixture
- Targeted unit tests (trigger/no-trigger, byte-stable ordering, pent-flag aggregator, sibling regression)
- \planning/spe-2016-staff-exclusion-contradiction-check-slice.md\
- \planning/backlog.md\ handoff

## Validation

- \
pm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts\ (44 passed)
- \
pm run test:run -- src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts\ (16 passed)
- \
pm run lint\

## Docs updated

- \planning/spe-2016-staff-exclusion-contradiction-check-slice.md\
- \planning/backlog.md\

## Parent status

No parent issue — SPE-2016 is the staff-duty owner. Medical/accommodation/denial-doctrine implementations remain deferred to SPE-2074 / SPE-2005 / SPE-2001 / SPE-2003.

Made with [Cursor](https://cursor.com)