### PR TITLE
feat(SPE-2441): staff-duty cross-reconciliation compose slice 1

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -22,7 +22,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Next step:** Next registry mirror queue item or backlog hygiene pass. Mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `2c168f0c` — shipped: [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016) staff exclusion vs support-duty contradiction-check @ `planning/spe-2016-staff-exclusion-contradiction-check-slice.md` / PR #2753
+**Base `main` SHA:** `6cdb63d8` — in progress: [SPE-2441](https://linear.app/spectranoir/issue/SPE-2441) staff-duty cross-reconciliation compose @ `planning/spe-2016-cross-system-reconciliation-slice-1.md`
 
 **Recently shipped:** [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016) staff exclusion vs support-duty contradiction-check sibling @ PR #2753; [SPE-1908](https://linear.app/spectranoir/issue/SPE-1908) parent owner-map reconciliation @ PR #2752.
 

--- a/planning/spe-2016-cross-system-reconciliation-slice-1.md
+++ b/planning/spe-2016-cross-system-reconciliation-slice-1.md
@@ -1,0 +1,76 @@
+# SPE-2016 — Staff-duty cross-reconciliation compose (slice 1)
+
+One-page implementation plan. Linear: [SPE-2441](https://linear.app/spectranoir/issue/SPE-2441) (child under [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016)). Deferred from `planning/spe-2016-staff-exclusion-contradiction-check-slice.md`.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2441 — Staff-duty cross-reconciliation compose (slice 1)](https://linear.app/spectranoir/issue/SPE-2441) |
+| **Status** | **Shipped** — pending PR merge                                                                            |
+| **Parent** | [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016) — staff exclusion vs support-duty obligations    |
+| **Branch** | `jamesdyedbq/spe-2016-staff-exclusion-cross-reconciliation-slice-1`                                        |
+| **Base `main` SHA** | `6cdb63d8`                                                                                          |
+
+## Goal
+
+Extend `composeCoerciveProtocolIntegratedHealthReconciliation` to surface staff-exclusion tension flags when `staff_exclusion_support_duty` coexists with integrated-health and/or psychological-resilience cross-links — consult-only compose hook; no new persistence or owner-ledger implementation.
+
+## Prerequisite (on `main` @ `6cdb63d8`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Staff-exclusion contradiction-check sibling | `evaluateStaffExclusionSupportDutyContradictionCheck` (SPE-2016 / PR #2753) |
+| Cross-reconciliation compose | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts` (SPE-2428–2440) |
+| Psychological resilience cross-join | SPE-2436 tension flags (`psychological_resilience_duty_reliability_degraded`, etc.) |
+| Bundle contact-channel tension | `surveillance_burden_no_active_contact_channel` consult anchor |
+
+## Cross-reconciliation contract (slice 1)
+
+- **Staff-side gate** — `evaluateStaffExclusionSupportDutyContradictionCheck` triggered on hydrated protocol record; requires integrated-health bundle cross-link (`bundle !== null`). No `surveillance_isolation_burden` gate — staff-duty boundary distinct from contained-person surveillance cross-join.
+- **Issue-derived flags** — `staff_exclusion_support_duty_obligation_elevated`, `staff_exclusion_exposure_risk_not_separated`, `staff_exclusion_medical_access_not_routed`, `staff_exclusion_accommodation_access_not_routed` from triggered check issues.
+- **Compound cross-tensions** — `staff_exclusion_resilience_duty_reliability_cross_tension` when resilience duty degraded coexists; `staff_exclusion_bundle_no_active_contact_cross_tension` when bundle has no active therapeutic contact channel.
+- **Consult-only** — reuses existing resilience/bundle tension anchors; no medical ledger, accommodation, or denial doctrine implementation.
+- **Byte-stable ordering** — tension flags sorted on repeat.
+- **Backward compatible** — SPE-2428–2440 compose regression unchanged when staff-exclusion flag absent.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Staff-duty tension flags in compose                                 | SPE-1908 surfacing / weekly notes             |
+| `INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE`           | Medical policy ledger (SPE-2074)              |
+| Targeted cross-reconciliation unit tests                           | Accommodation implementation (SPE-2005)       |
+| Slice doc (this file) + `planning/backlog.md` handoff                | Institutional denial doctrine (SPE-2001)    |
+|                                                                    | Medical outcome audit (SPE-2003)              |
+
+## Acceptance
+
+- [x] `STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE` + bundle triggers staff-duty tension flags without surveillance-isolation flags
+- [x] Records below staff-exclusion threshold or missing bundle return no staff-duty tension flags
+- [x] Resilience duty-degraded cross-tension surfaces when operator-linked resilience coexists
+- [x] Byte-stable tension-flag ordering on repeat
+- [x] SPE-2428–2440 cross-reconciliation regression green
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts`, `src/domain/containedPersonIntegratedHealthBundleRegistry.ts` |
+| Tests  | `src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts` |
+| Plan   | `planning/spe-2016-cross-system-reconciliation-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Staff-duty tension surfacing in mirror / weekly notes | SPE-1908 follow-up | Out of compose-only boundary |
+| Medical policy ledger implementation | SPE-2074 | Routed via `medicalAccessStateRef` |
+| Accommodation request ledger | SPE-2005 | Routed via `accommodationAccessRef` |
+| Institutional denial doctrine enforcement | SPE-2001 | Routed via `denialDoctrinePressureRef` |
+| Medical outcome deviation audit | SPE-2003 | Medical access owner |
+
+## See also
+
+- `planning/spe-2016-staff-exclusion-contradiction-check-slice.md`
+- `planning/spe-1615-psychological-resilience-registry-slice-4.md`
+- `planning/spe-1908-owner-reconciliation-slice.md`

--- a/planning/spe-2016-staff-exclusion-contradiction-check-slice.md
+++ b/planning/spe-2016-staff-exclusion-contradiction-check-slice.md
@@ -64,7 +64,7 @@ Implement a bounded contradiction-check sibling for staff exclusion and support-
 
 | Item | Owner | Why |
 | --- | --- | --- |
-| Cross-reconciliation compose for staff-duty tension flags | SPE-1908 follow-up / SPE-1615 | Out of registry-only slice boundary; consult existing tension flags only |
+| Cross-reconciliation compose for staff-duty tension flags | [SPE-2441](https://linear.app/spectranoir/issue/SPE-2441) | Shipped in `planning/spe-2016-cross-system-reconciliation-slice-1.md` |
 | Medical policy ledger implementation | SPE-2074 | Routed via `medicalAccessStateRef` — not duplicated here |
 | Accommodation request ledger | SPE-2005 | Routed via `accommodationAccessRef` |
 | Institutional denial doctrine enforcement | SPE-2001 | Routed via `denialDoctrinePressureRef` |

--- a/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
+++ b/src/domain/coerciveProtocolIntegratedHealthCrossReconciliation.ts
@@ -10,12 +10,14 @@
 
 import {
   evaluateCoerciveProtocolContradictionChecks,
+  evaluateStaffExclusionSupportDutyContradictionCheck,
   projectCoerciveProtocolRiskReview,
   validateCoerciveProtocolRecord,
   type CoerciveProtocolContradictionCheckResult,
   type CoerciveProtocolRecord,
   type CoerciveProtocolRecordsMap,
   type CoerciveProtocolRiskReviewProjection,
+  type CoerciveProtocolStaffExclusionSupportDutyContradictionCheckCode,
 } from './coerciveContainedPersonProtocolRegistry'
 import {
   validateContainedPersonIntegratedHealthBundle,
@@ -58,6 +60,12 @@ export type CoerciveProtocolCrossSystemTensionFlag =
   | 'psychological_resilience_duty_reliability_degraded'
   | 'psychological_resilience_exposure_elevated'
   | 'psychological_resilience_treatment_gated'
+  | 'staff_exclusion_support_duty_obligation_elevated'
+  | 'staff_exclusion_exposure_risk_not_separated'
+  | 'staff_exclusion_medical_access_not_routed'
+  | 'staff_exclusion_accommodation_access_not_routed'
+  | 'staff_exclusion_resilience_duty_reliability_cross_tension'
+  | 'staff_exclusion_bundle_no_active_contact_cross_tension'
 
 export interface CoerciveProtocolSurveillanceTuningCrossLink {
   readonly surveillanceTuningId: string
@@ -357,6 +365,82 @@ function collectPsychologicalResilienceCrossSystemTensionFlags(input: {
   return Object.freeze([...new Set(flags)].sort((left, right) => left.localeCompare(right)))
 }
 
+const STAFF_EXCLUSION_CROSS_SYSTEM_ISSUE_CODES = new Set<CoerciveProtocolStaffExclusionSupportDutyContradictionCheckCode>([
+  'staff_exclusion_support_duty_obligation_elevated',
+  'staff_exclusion_exposure_risk_not_separated',
+  'staff_exclusion_medical_access_not_routed',
+  'staff_exclusion_accommodation_access_not_routed',
+])
+
+function mapStaffExclusionIssueToCrossSystemTensionFlag(
+  code: CoerciveProtocolStaffExclusionSupportDutyContradictionCheckCode
+): CoerciveProtocolCrossSystemTensionFlag | null {
+  if (!STAFF_EXCLUSION_CROSS_SYSTEM_ISSUE_CODES.has(code)) {
+    return null
+  }
+
+  return code
+}
+
+function collectStaffExclusionCrossSystemTensionFlags(input: {
+  readonly protocolRecords: readonly CoerciveProtocolRecord[]
+  readonly bundle: ContainedPersonIntegratedHealthBundle | null
+  readonly psychologicalResilienceProjections: readonly PsychologicalResilienceProjection[]
+  readonly bundleCrossSystemTensionFlags: readonly CoerciveProtocolCrossSystemTensionFlag[]
+  readonly resilienceCrossSystemTensionFlags: readonly CoerciveProtocolCrossSystemTensionFlag[]
+}): readonly CoerciveProtocolCrossSystemTensionFlag[] {
+  if (!input.bundle) {
+    return Object.freeze([])
+  }
+
+  const hasStaffExclusionDuty = input.protocolRecords.some((record) => {
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(record)
+    return check.triggered
+  })
+
+  if (!hasStaffExclusionDuty) {
+    return Object.freeze([])
+  }
+
+  const flags: CoerciveProtocolCrossSystemTensionFlag[] = []
+
+  for (const record of input.protocolRecords) {
+    const check = evaluateStaffExclusionSupportDutyContradictionCheck(record)
+    if (!check.triggered) {
+      continue
+    }
+
+    for (const issue of check.issues) {
+      const tensionFlag = mapStaffExclusionIssueToCrossSystemTensionFlag(
+        issue.code as CoerciveProtocolStaffExclusionSupportDutyContradictionCheckCode
+      )
+      if (tensionFlag) {
+        flags.push(tensionFlag)
+      }
+    }
+  }
+
+  const resilienceDutyDegraded =
+    input.resilienceCrossSystemTensionFlags.includes(
+      'psychological_resilience_duty_reliability_degraded'
+    ) || input.psychologicalResilienceProjections.some((projection) => projection.dutyReliabilityDegraded)
+
+  if (resilienceDutyDegraded && input.psychologicalResilienceProjections.length > 0) {
+    flags.push('staff_exclusion_resilience_duty_reliability_cross_tension')
+  }
+
+  const bundleNoActiveContact =
+    input.bundleCrossSystemTensionFlags.includes('surveillance_burden_no_active_contact_channel') ||
+    ((input.bundle.therapeuticCareScheduleLinks ?? []).length > 0 &&
+      !hasActiveTherapeuticContactChannel(input.bundle))
+
+  if (bundleNoActiveContact) {
+    flags.push('staff_exclusion_bundle_no_active_contact_cross_tension')
+  }
+
+  return Object.freeze([...new Set(flags)].sort((left, right) => left.localeCompare(right)))
+}
+
 function collectSurveillanceTuningCrossSystemTensionFlags(input: {
   readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
   readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
@@ -381,23 +465,34 @@ function collectSurveillanceTuningCrossSystemTensionFlags(input: {
 }
 
 function collectCrossSystemTensionFlags(input: {
+  readonly protocolRecords: readonly CoerciveProtocolRecord[]
   readonly protocolRiskReviews: readonly CoerciveProtocolRiskReviewProjection[]
   readonly bundle: ContainedPersonIntegratedHealthBundle | null
   readonly surveillanceTuningProjections: readonly SurveillanceInterventionTuningProjection[]
   readonly psychologicalResilienceProjections: readonly PsychologicalResilienceProjection[]
 }): readonly CoerciveProtocolCrossSystemTensionFlag[] {
+  const bundleCrossSystemTensionFlags = collectBundleCrossSystemTensionFlags({
+    protocolRiskReviews: input.protocolRiskReviews,
+    bundle: input.bundle,
+  })
+  const resilienceCrossSystemTensionFlags = collectPsychologicalResilienceCrossSystemTensionFlags({
+    psychologicalResilienceProjections: input.psychologicalResilienceProjections,
+  })
+
   return Object.freeze(
     [
-      ...collectBundleCrossSystemTensionFlags({
-        protocolRiskReviews: input.protocolRiskReviews,
-        bundle: input.bundle,
-      }),
+      ...bundleCrossSystemTensionFlags,
       ...collectSurveillanceTuningCrossSystemTensionFlags({
         protocolRiskReviews: input.protocolRiskReviews,
         surveillanceTuningProjections: input.surveillanceTuningProjections,
       }),
-      ...collectPsychologicalResilienceCrossSystemTensionFlags({
+      ...resilienceCrossSystemTensionFlags,
+      ...collectStaffExclusionCrossSystemTensionFlags({
+        protocolRecords: input.protocolRecords,
+        bundle: input.bundle,
         psychologicalResilienceProjections: input.psychologicalResilienceProjections,
+        bundleCrossSystemTensionFlags,
+        resilienceCrossSystemTensionFlags,
       }),
     ]
       .filter((flag, index, flags) => flags.indexOf(flag) === index)
@@ -554,6 +649,7 @@ export function composeCoerciveProtocolIntegratedHealthReconciliation(
   })
 
   const crossSystemTensionFlags = collectCrossSystemTensionFlags({
+    protocolRecords,
     protocolRiskReviews,
     bundle,
     surveillanceTuningProjections,

--- a/src/domain/containedPersonIntegratedHealthBundleRegistry.ts
+++ b/src/domain/containedPersonIntegratedHealthBundleRegistry.ts
@@ -864,6 +864,37 @@ export function sanitizeContainedPersonIntegratedHealthBundles(
 // Fixtures (tests / planning mirror)
 // ---------------------------------------------------------------------------
 
+/** Bundle paired with staff-exclusion support-duty coercive protocol (subject-09). */
+export const INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE: ContainedPersonIntegratedHealthBundle =
+  Object.freeze({
+    id: 'subject:contained-support-personnel-09',
+    label: 'Contained support personnel 09 integrated health bundle',
+    subjectRef: 'subject:contained-support-personnel-09',
+    mentalStateBand: 'strained',
+    humaneCareRiskScore: 0.41,
+    therapeuticCareScheduleLinks: Object.freeze([
+      Object.freeze({
+        scheduleRef: 'care-schedule:support-personnel-peer-contact-suspended',
+        wiredRef: 'therapeutic-care:care-schedule:support-personnel-peer-contact-suspended',
+        careMode: 'cooperative_checkin',
+        channelState: 'suspended',
+        missedSessionStreak: 2,
+        complianceRiskScore: 0.47,
+        lockdownEscalationLikely: false,
+      }),
+    ]),
+    custodyStatusLinks: Object.freeze([
+      Object.freeze({
+        custodyRef: 'custody-status:privilege-suspended-hold',
+        wiredRef: 'custody-status:privilege-suspended-hold',
+        custodyStage: 'contained_person',
+        formerRoleCategory: 'support_personnel',
+        restrictionLevel: 'elevated',
+        rightsReviewPending: true,
+      }),
+    ]),
+  })
+
 /** Bundle paired with abusive surveillance-isolation coercive protocol (subject-22). */
 export const INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE: ContainedPersonIntegratedHealthBundle =
   Object.freeze({

--- a/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
+++ b/src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
   EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
   validateCoerciveProtocolRecord,
 } from '../domain/coerciveContainedPersonProtocolRegistry'
 import {
@@ -23,6 +24,7 @@ import {
   validateSurveillanceInterventionTuningRecord,
 } from '../domain/surveillanceCapacityInterventionTuningRegistry'
 import {
+  INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE,
   INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE,
   INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
   validateContainedPersonIntegratedHealthBundle,
@@ -350,6 +352,139 @@ describe('coerciveProtocolIntegratedHealthCrossReconciliation (SPE-2428 slice 1)
         operatorLinks
       ).map((record) => record.id)
     ).toEqual([PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id])
+  })
+
+  it('surfaces staff-exclusion tension flags when support-duty flag coexists with bundle cross-link', () => {
+    expect(validateCoerciveProtocolRecord(STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE).valid).toBe(
+      true
+    )
+    expect(
+      validateContainedPersonIntegratedHealthBundle(INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE)
+        .valid
+    ).toBe(true)
+
+    const protocols = {
+      [STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE.id]: STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE.subjectRef
+    )
+
+    expect(summary.triggeredContradictionChecks.some((check) => check.flag === 'staff_exclusion_support_duty')).toBe(
+      true
+    )
+    expect(summary.crossSystemTensionFlags).toEqual([
+      'staff_exclusion_accommodation_access_not_routed',
+      'staff_exclusion_bundle_no_active_contact_cross_tension',
+      'staff_exclusion_exposure_risk_not_separated',
+      'staff_exclusion_medical_access_not_routed',
+      'staff_exclusion_support_duty_obligation_elevated',
+    ])
+    expect(summary.crossSystemTensionFlags).not.toContain('surveillance_burden_stable_mental_state')
+    expect(summary.crossSystemTensionFlags).not.toContain('surveillance_isolation_burden')
+    expect(summary.structuredReasons).toContain('tension:present')
+  })
+
+  it('no-ops staff-exclusion tension flags when bundle is missing for staff-duty protocol', () => {
+    const protocols = {
+      [STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE.id]: STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      {},
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE.subjectRef
+    )
+
+    expect(summary.triggeredContradictionChecks.some((check) => check.flag === 'staff_exclusion_support_duty')).toBe(
+      true
+    )
+    expect(summary.crossSystemTensionFlags).toEqual([])
+    expect(summary.structuredReasons).toContain('tension:none')
+  })
+
+  it('no-ops staff-exclusion tension flags when support-duty threshold is not met', () => {
+    const belowThreshold = {
+      ...STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+      staffExclusionBurdenScore: 0.4,
+    }
+    const protocols = {
+      [belowThreshold.id]: belowThreshold,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      belowThreshold.subjectRef
+    )
+
+    expect(summary.triggeredContradictionChecks).toEqual([])
+    expect(summary.crossSystemTensionFlags).toEqual([])
+  })
+
+  it('surfaces staff-exclusion resilience cross-tension when duty reliability is degraded', () => {
+    const protocolWithOperatorLink = {
+      ...STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE,
+      subjectFitValidationRef: PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.operatorRef,
+    }
+    const protocols = {
+      [protocolWithOperatorLink.id]: protocolWithOperatorLink,
+    }
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE.subjectRef]:
+        INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE,
+    }
+    const psychologicalResilienceRecords = {
+      [PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE.id]:
+        PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE,
+    }
+
+    const summary = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE.subjectRef,
+      undefined,
+      psychologicalResilienceRecords
+    )
+
+    expect(summary.linkedResilienceCount).toBe(1)
+    expect(summary.crossSystemTensionFlags).toContain(
+      'staff_exclusion_resilience_duty_reliability_cross_tension'
+    )
+    expect(summary.crossSystemTensionFlags).toContain(
+      'psychological_resilience_duty_reliability_degraded'
+    )
+    expect(summary.crossSystemTensionFlags).toContain(
+      'staff_exclusion_bundle_no_active_contact_cross_tension'
+    )
+
+    const first = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE.subjectRef,
+      undefined,
+      psychologicalResilienceRecords
+    )
+    const second = composeCoerciveProtocolIntegratedHealthReconciliation(
+      protocols,
+      bundles,
+      STAFF_EXCLUSION_SUPPORT_DUTY_PROTOCOL_FIXTURE.subjectRef,
+      undefined,
+      psychologicalResilienceRecords
+    )
+
+    expect(first.crossSystemTensionFlags).toEqual(second.crossSystemTensionFlags)
   })
 
   it('skips invalid hydrate drops without re-surfacing them', () => {


### PR DESCRIPTION
## Summary

- Extend cross-reconciliation compose with staff-exclusion tension flags when `staff_exclusion_support_duty` coexists with integrated-health and/or psychological-resilience cross-links
- Reuse `evaluateStaffExclusionSupportDutyContradictionCheck`; staff-side gate distinct from surveillance-isolation cross-join
- Add `INTEGRATED_HEALTH_BUNDLE_STAFF_EXCLUSION_TENSION_FIXTURE` and targeted compose tests

## Linear

- Slice: [SPE-2441](https://linear.app/spectranoir/issue/SPE-2441)
- Parent: [SPE-2016](https://linear.app/spectranoir/issue/SPE-2016)
- Consult anchors: SPE-1908 / SPE-2428-2440

## What shipped

- Six staff-duty cross-system tension flags in compose (four issue-derived + two compound cross-tensions)
- Slice doc: `planning/spe-2016-cross-system-reconciliation-slice-1.md`
- Backlog handoff updated

## Validation

- `npm run lint`
- `npm run test:run -- src/test/coerciveProtocolIntegratedHealthCrossReconciliation.test.ts`
- `npm run test:run -- src/test/coerciveContainedPersonProtocolRegistry.test.ts src/test/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing.test.ts`

## Parent status

SPE-2016 remains Done; SPE-1908 unchanged (compose hook only, no surfacing changes).

Made with [Cursor](https://cursor.com)