### PR TITLE
feat(SPE-2444): welfare-debt cross-link weekly report surfacing (slice 8)

### DIFF
--- a/planning/welfare-debt-accounting-registry-slice-8.md
+++ b/planning/welfare-debt-accounting-registry-slice-8.md
@@ -1,0 +1,77 @@
+# SPE-1888 — Welfare-debt cross-link weekly report surfacing (slice 8)
+
+One-page implementation plan. Linear: [SPE-2444](https://linear.app/spectranoir/issue/SPE-2444) (child under [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888)). Follows shipped slice 7 (`planning/welfare-debt-accounting-registry-slice-7.md`, PR #2760).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2444 — Welfare-debt cross-link surfacing in weekly report notes (slice 8)](https://linear.app/spectranoir/issue/SPE-2444) |
+| **Parent** | [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — parent stays **Backlog** until SPE-1047 / SPE-1131 matrix AC met |
+| **Branch** | `spe-1888-welfare-debt-cross-link-surfacing-slice-8`                                                       |
+| **Status** | **In progress**                                                                                            |
+| **Base `main` SHA** | `b183ea76`                                                                                          |
+
+## Goal
+
+Surface existing `composeAllWelfareDebtAccountingCrossLinks` / `formatWelfareDebtAccountingCrossLinkLabels` output as read-only weekly report notes when welfare-debt records coexist with integrated-health bundles and/or coercive protocol records — mirror the naming-hazard surfacing pattern ([SPE-2406](https://linear.app/spectranoir/issue/SPE-2406)).
+
+## Prerequisite (on `main` @ `b183ea76`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Cross-link compose   | `welfareDebtAccountingCrossLinks.ts` (SPE-1888 slice 7 / PR #2760)     |
+| Ledger audit + mirror | `welfareDebtAccountingRegistry.ts`, `welfareDebtAccountingMirrorView.ts` |
+| Naming-hazard template | `informationIntakeNamingHazardCrossLinkSurfacing.ts` (SPE-2406)      |
+| Weekly note hook pattern | `advanceWeek.ts` naming-hazard + coercive reconciliation blocks   |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `welfareDebtAccountingCrossLinkSurfacing.ts` label helpers         | SPE-1888 slice 7 compose changes              |
+| `welfareDebtAccountingCrossLinkWeeklyReportNotes.ts`               | SPE-1047 faction ethics engine                |
+| `welfare_debt.accounting_cross_link` report note type              | SPE-1131 accountability matrix                |
+| `advanceWeek` hook after welfare-debt tick                         | New persistence fields                        |
+| Targeted unit + integration tests                                  | Mission triage chips                          |
+| Slice doc (this file) + backlog handoff                            | SPE-1888 parent Done                          |
+
+## Surfacing contract
+
+- **Read-only** — compose at read time; no new GameState fields.
+- **Safe labels** — opaque wired refs from `formatWelfareDebtAccountingCrossLinkLabels` only.
+- **Empty maps** — no-op; no throw.
+- **Hydrated truth only** — invalid/skipped records do not re-surface.
+- **Sibling gate** — welfare-debt records plus non-empty integrated-health and/or coercive protocol maps.
+- **Byte-stable ordering** — debt refs and link labels sorted on repeat.
+- **Weekly notes** — one note per summary with cross-link labels; emit after welfare-debt tick.
+
+## Acceptance
+
+- [ ] Empty maps no-op without throw
+- [ ] Weekly report note uses audit-line labels when fixtures coexist
+- [ ] `advanceWeek` integration asserts cross-link note when fixtures coexist
+- [ ] `reportNoteTypeAudit` covers new note type
+- [ ] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/welfareDebtAccountingCrossLinkSurfacing.ts`, `src/domain/welfareDebtAccountingCrossLinkWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| View   | `src/features/report/reportNoteView.ts`                               |
+| Tests  | `src/test/welfareDebtAccountingCrossLinkSurfacing.test.ts`, `src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts`, `src/test/reportNoteTypeAudit.test.ts`, `src/features/report/reportNoteView.test.ts` |
+| Plan   | `planning/welfare-debt-accounting-registry-slice-8.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Faction ethics matrix runtime | SPE-1047 | Parent AC remainder |
+| Moral-legal accountability matrix | SPE-1131 | Same |
+| Mission triage chips for welfare-debt cross-links | Mission triage | Blocked per backlog |
+| SPE-1888 parent Done | SPE-1888 | Ethics/accountability matrix AC still open |
+
+## See also
+
+- `planning/welfare-debt-accounting-registry-slice-7.md`
+- `planning/naming-hazard-cross-link-surfacing-slice-1.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -346,6 +346,7 @@ export const REPORT_NOTE_TYPES = [
   'system.equipment_recovered',
   'information_intake.verification',
   'information_intake.naming_hazard_cross_link',
+  'welfare_debt.accounting_cross_link',
   'coercive_protocol.integrated_health_reconciliation',
   'post_incident_review.follow_on',
   'post_incident_review.closeout_reward_payout',
@@ -618,6 +619,14 @@ const REPORT_NOTE_METADATA_ALLOWLIST: Partial<Record<ReportNoteType, readonly st
     'linkedReportCount',
     'linkedDescriptorCount',
     'structuredReasons',
+    'week',
+  ],
+  'welfare_debt.accounting_cross_link': [
+    'debtRef',
+    'subjectRef',
+    'integratedHealthLinkCount',
+    'coerciveProtocolLinkCount',
+    'crossLinkLabels',
     'week',
   ],
   'coercive_protocol.integrated_health_reconciliation': [

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1529,6 +1529,7 @@ export type ReportNoteType =
   | 'system.equipment_recovered'
   | 'information_intake.verification'
   | 'information_intake.naming_hazard_cross_link'
+  | 'welfare_debt.accounting_cross_link'
   | 'coercive_protocol.integrated_health_reconciliation'
   | 'post_incident_review.follow_on'
   | 'post_incident_review.closeout_reward_payout'

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -308,6 +308,7 @@ import { applyWeeklyCaseLifecycleTick } from '../caseLifecycleWeeklyOrchestratio
 import { applyWeeklyIntakeCorroborationTick } from '../informationIntakeWeeklyCorroboration'
 import { buildWeeklyCoerciveProtocolIntegratedHealthReconciliationReportNotes } from '../coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes'
 import { buildWeeklyIntakeNamingHazardCrossLinkReportNotes } from '../informationIntakeNamingHazardCrossLinkWeeklyReportNotes'
+import { buildWeeklyWelfareDebtAccountingCrossLinkReportNotes } from '../welfareDebtAccountingCrossLinkWeeklyReportNotes'
 import { buildWeeklyIntakeVerificationReportNotes } from '../informationIntakeWeeklyReportNotes'
 import { decayRumorPackets, type CivicRumorPacket } from '../civicRumorChannel'
 import { decayCreditPackets, type CivicCreditPacket } from '../civicCreditChannel'
@@ -4819,6 +4820,40 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       currentWelfareDebtAccountingRecords,
       result.week
     )
+  }
+
+  // SPE-1888 slice 8: surface welfare-debt cross-link labels in weekly report notes.
+  const nextWelfareDebtRecordsForCrossLink = outputWeeklyState.welfareDebtAccountingRecords ?? {}
+  const nextBundlesForWelfareDebtCrossLink =
+    outputWeeklyState.containedPersonIntegratedHealthBundles ?? {}
+  const nextCoerciveProtocolsForWelfareDebtCrossLink =
+    outputWeeklyState.coerciveContainedPersonProtocolRecords ?? {}
+  if (
+    Object.keys(nextWelfareDebtRecordsForCrossLink).length > 0 &&
+    (Object.keys(nextBundlesForWelfareDebtCrossLink).length > 0 ||
+      Object.keys(nextCoerciveProtocolsForWelfareDebtCrossLink).length > 0) &&
+    result.reports.length > 0
+  ) {
+    const lastWeeklyReport = result.reports[result.reports.length - 1]
+    const welfareDebtCrossLinkNotes = buildWeeklyWelfareDebtAccountingCrossLinkReportNotes({
+      nextRecords: nextWelfareDebtRecordsForCrossLink,
+      nextBundles: nextBundlesForWelfareDebtCrossLink,
+      nextCoerciveProtocolRecords: nextCoerciveProtocolsForWelfareDebtCrossLink,
+      week: result.week,
+      sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
+      baseTimestamp: noteBaseTimestamp,
+    })
+
+    if (welfareDebtCrossLinkNotes.length > 0) {
+      const reports = [...result.reports]
+      const lastReportIndex = reports.length - 1
+      const lastReport = reports[lastReportIndex]
+      reports[lastReportIndex] = {
+        ...lastReport,
+        notes: [...(lastReport.notes ?? []), ...welfareDebtCrossLinkNotes],
+      }
+      result.reports = reports
+    }
   }
 
   // SPE-2117 slice 3: cadence-due recurrenceCount and lastOccurrenceWeek advance on recurrent catastrophes.

--- a/src/domain/welfareDebtAccountingCrossLinkSurfacing.ts
+++ b/src/domain/welfareDebtAccountingCrossLinkSurfacing.ts
@@ -1,0 +1,53 @@
+/**
+ * SPE-1888 slice 8: read-only surfacing for welfare-debt ↔ sibling-registry cross-links.
+ *
+ * Formats compose output for weekly report notes — safe opaque wired refs only;
+ * no changes to slice 7 compose contracts.
+ */
+
+import type { CoerciveProtocolRecordsMap } from './coerciveContainedPersonProtocolRegistry'
+import type { ContainedPersonIntegratedHealthBundleRecordsMap } from './containedPersonIntegratedHealthBundleRegistry'
+import {
+  composeAllWelfareDebtAccountingCrossLinks,
+  formatWelfareDebtAccountingCrossLinkAuditLine,
+  formatWelfareDebtAccountingCrossLinkLabels,
+  type WelfareDebtAccountingCrossLinkSummary,
+} from './welfareDebtAccountingCrossLinks'
+import type { WelfareDebtAccountingRecordsMap } from './welfareDebtAccountingRegistry'
+
+export function composeAllWelfareDebtAccountingCrossLinkSummaries(input: {
+  records: WelfareDebtAccountingRecordsMap | null | undefined
+  bundles?: ContainedPersonIntegratedHealthBundleRecordsMap | null | undefined
+  coerciveProtocolRecords?: CoerciveProtocolRecordsMap | null | undefined
+}): readonly WelfareDebtAccountingCrossLinkSummary[] {
+  const safeRecords = input.records ?? {}
+  const safeBundles = input.bundles ?? {}
+  const safeProtocols = input.coerciveProtocolRecords ?? {}
+
+  if (Object.keys(safeRecords).length === 0) {
+    return []
+  }
+
+  if (Object.keys(safeBundles).length === 0 && Object.keys(safeProtocols).length === 0) {
+    return []
+  }
+
+  const summaries = composeAllWelfareDebtAccountingCrossLinks({
+    records: safeRecords,
+    bundles: input.bundles,
+    coerciveProtocolRecords: input.coerciveProtocolRecords,
+  })
+
+  return Object.freeze(
+    summaries.filter((summary) => formatWelfareDebtAccountingCrossLinkLabels(summary).length > 0)
+  )
+}
+
+export function formatWelfareDebtAccountingCrossLinkNoteContent(
+  summary: WelfareDebtAccountingCrossLinkSummary
+): string {
+  return formatWelfareDebtAccountingCrossLinkAuditLine(summary).replace(
+    /^Cross-links/,
+    'Welfare-debt cross-link'
+  )
+}

--- a/src/domain/welfareDebtAccountingCrossLinkWeeklyReportNotes.ts
+++ b/src/domain/welfareDebtAccountingCrossLinkWeeklyReportNotes.ts
@@ -1,0 +1,65 @@
+/**
+ * SPE-1888 slice 8: weekly report notes for welfare-debt ↔ sibling-registry cross-links.
+ *
+ * Emits deterministic notes when linked maps coexist — no new persistence.
+ */
+
+import type { CoerciveProtocolRecordsMap } from './coerciveContainedPersonProtocolRegistry'
+import type { ContainedPersonIntegratedHealthBundleRecordsMap } from './containedPersonIntegratedHealthBundleRegistry'
+import type { ReportNote } from './models'
+import { createDeterministicReportNote } from './reportNotes'
+import {
+  composeAllWelfareDebtAccountingCrossLinkSummaries,
+  formatWelfareDebtAccountingCrossLinkNoteContent,
+} from './welfareDebtAccountingCrossLinkSurfacing'
+import type { WelfareDebtAccountingRecordsMap } from './welfareDebtAccountingRegistry'
+import { formatWelfareDebtAccountingCrossLinkLabels } from './welfareDebtAccountingCrossLinks'
+
+/**
+ * Builds weekly report notes when welfare-debt records coexist with integrated-health
+ * bundles and/or coercive protocol records with hydrated cross-links.
+ */
+export function buildWeeklyWelfareDebtAccountingCrossLinkReportNotes(input: {
+  nextRecords: WelfareDebtAccountingRecordsMap | null | undefined
+  nextBundles: ContainedPersonIntegratedHealthBundleRecordsMap | null | undefined
+  nextCoerciveProtocolRecords: CoerciveProtocolRecordsMap | null | undefined
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const nextSummaries = composeAllWelfareDebtAccountingCrossLinkSummaries({
+    records: input.nextRecords,
+    bundles: input.nextBundles,
+    coerciveProtocolRecords: input.nextCoerciveProtocolRecords,
+  })
+
+  if (nextSummaries.length === 0) {
+    return []
+  }
+
+  const notes: ReportNote[] = []
+  let sequence = input.sequenceStart
+
+  for (const summary of nextSummaries) {
+    notes.push(
+      createDeterministicReportNote(
+        formatWelfareDebtAccountingCrossLinkNoteContent(summary),
+        input.week,
+        sequence,
+        input.baseTimestamp,
+        'welfare_debt.accounting_cross_link',
+        {
+          debtRef: summary.debtRef,
+          subjectRef: summary.subjectRef,
+          integratedHealthLinkCount: summary.integratedHealthLinks.length,
+          coerciveProtocolLinkCount: summary.coerciveProtocolLinks.length,
+          crossLinkLabels: [...formatWelfareDebtAccountingCrossLinkLabels(summary)],
+          week: input.week,
+        }
+      )
+    )
+    sequence += 1
+  }
+
+  return notes
+}

--- a/src/features/report/reportNoteView.test.ts
+++ b/src/features/report/reportNoteView.test.ts
@@ -58,6 +58,7 @@ const EXPECTED_CATEGORY_BY_TYPE = {
   'hub.rumor': 'system',
   'information_intake.verification': 'information_intake',
   'information_intake.naming_hazard_cross_link': 'information_intake',
+  'welfare_debt.accounting_cross_link': 'system',
   'coercive_protocol.integrated_health_reconciliation': 'system',
   'post_incident_review.follow_on': 'post_incident_review',
   'post_incident_review.closeout_reward_payout': 'post_incident_review',

--- a/src/features/report/reportNoteView.ts
+++ b/src/features/report/reportNoteView.ts
@@ -46,6 +46,7 @@ const RECRUITMENT_NOTE_TYPES: ReportNoteType[] = [
 ]
 
 const SYSTEM_NOTE_TYPES: ReportNoteType[] = [
+  'welfare_debt.accounting_cross_link',
   'coercive_protocol.integrated_health_reconciliation',
   'system.week_delta',
   'system.party_cards_drawn',

--- a/src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts
+++ b/src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../domain/welfareDebtAccountingRegistry'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek welfare-debt cross-link integration (SPE-1888 slice 8)', () => {
+  it('is a no-op for welfare-debt cross-link notes when sibling maps are empty', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const crossLinkNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'welfare_debt.accounting_cross_link') ??
+      []
+
+    expect(crossLinkNotes).toEqual([])
+  })
+
+  it('surfaces welfare-debt cross-link notes when linked fixtures coexist', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+    state.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE.id]:
+        INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const crossLinkNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'welfare_debt.accounting_cross_link') ??
+      []
+
+    expect(crossLinkNotes.length).toBeGreaterThan(0)
+    expect(crossLinkNotes[0]?.content).toContain('Welfare-debt cross-link')
+    expect(crossLinkNotes[0]?.content).toContain(COERCIVE_RESTRAINT_LEDGER_FIXTURE.id)
+    expect(crossLinkNotes[0]?.content).toContain('integrated-health:')
+  })
+})

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -58,6 +58,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
     producer: 'informationIntakeNamingHazardCrossLinkWeeklyReportNotes',
     category: 'information_intake',
   },
+  'welfare_debt.accounting_cross_link': {
+    status: 'active',
+    producer: 'welfareDebtAccountingCrossLinkWeeklyReportNotes',
+    category: 'system',
+  },
   'coercive_protocol.integrated_health_reconciliation': {
     status: 'active',
     producer: 'coerciveProtocolIntegratedHealthCrossReconciliationWeeklyReportNotes',
@@ -84,7 +89,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(43)
+    expect(entries).toHaveLength(44)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })

--- a/src/test/welfareDebtAccountingCrossLinkSurfacing.test.ts
+++ b/src/test/welfareDebtAccountingCrossLinkSurfacing.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE } from '../domain/coerciveContainedPersonProtocolRegistry'
+import { INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
+import {
+  composeAllWelfareDebtAccountingCrossLinkSummaries,
+  formatWelfareDebtAccountingCrossLinkNoteContent,
+} from '../domain/welfareDebtAccountingCrossLinkSurfacing'
+import { buildWeeklyWelfareDebtAccountingCrossLinkReportNotes } from '../domain/welfareDebtAccountingCrossLinkWeeklyReportNotes'
+import {
+  composeWelfareDebtAccountingCrossLinksForRecord,
+  formatWelfareDebtAccountingCrossLinkLabels,
+} from '../domain/welfareDebtAccountingCrossLinks'
+import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../domain/welfareDebtAccountingRegistry'
+
+describe('welfareDebtAccountingCrossLinkSurfacing (SPE-1888 slice 8)', () => {
+  it('no-ops compose summaries when records map is empty', () => {
+    expect(
+      composeAllWelfareDebtAccountingCrossLinkSummaries({
+        records: {},
+        bundles: {
+          [INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE.id]:
+            INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+        },
+      })
+    ).toEqual([])
+  })
+
+  it('no-ops compose summaries when sibling maps are empty', () => {
+    expect(
+      composeAllWelfareDebtAccountingCrossLinkSummaries({
+        records: {
+          [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        },
+        bundles: {},
+        coerciveProtocolRecords: {},
+      })
+    ).toEqual([])
+  })
+
+  it('formats weekly note content from audit line with welfare-debt prefix', () => {
+    const summary = composeWelfareDebtAccountingCrossLinksForRecord(
+      COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      {
+        bundles: {
+          [INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE.id]:
+            INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+        },
+      }
+    )
+
+    expect(summary).not.toBeNull()
+    expect(formatWelfareDebtAccountingCrossLinkNoteContent(summary!)).toContain(
+      'Welfare-debt cross-link'
+    )
+    expect(formatWelfareDebtAccountingCrossLinkNoteContent(summary!)).toContain(
+      COERCIVE_RESTRAINT_LEDGER_FIXTURE.id
+    )
+  })
+
+  it('builds weekly report notes when cross-linked maps coexist', () => {
+    const bundles = {
+      [INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE.id]:
+        INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+    }
+    const records = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+    const summary = composeWelfareDebtAccountingCrossLinksForRecord(
+      COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      { bundles }
+    )
+
+    const notes = buildWeeklyWelfareDebtAccountingCrossLinkReportNotes({
+      nextRecords: records,
+      nextBundles: bundles,
+      nextCoerciveProtocolRecords: {},
+      week: 3,
+      sequenceStart: 1,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.type).toBe('welfare_debt.accounting_cross_link')
+    expect(notes[0]?.content).toBe(formatWelfareDebtAccountingCrossLinkNoteContent(summary!))
+    expect(notes[0]?.metadata?.crossLinkLabels).toEqual(
+      formatWelfareDebtAccountingCrossLinkLabels(summary!)
+    )
+  })
+
+  it('no-ops weekly report notes when only welfare-debt records exist', () => {
+    expect(
+      buildWeeklyWelfareDebtAccountingCrossLinkReportNotes({
+        nextRecords: {
+          [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        },
+        nextBundles: {},
+        nextCoerciveProtocolRecords: {},
+        week: 4,
+        sequenceStart: 1,
+      })
+    ).toEqual([])
+  })
+
+  it('surfaces coercive protocol cross-links when protocol map coexists', () => {
+    const records = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    const protocols = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const notes = buildWeeklyWelfareDebtAccountingCrossLinkReportNotes({
+      nextRecords: records,
+      nextBundles: {},
+      nextCoerciveProtocolRecords: protocols,
+      week: 5,
+      sequenceStart: 1,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.metadata?.coerciveProtocolLinkCount).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Add read-only welfare-debt cross-link surfacing modules mirroring SPE-2406 naming-hazard pattern.
- Wire `buildWeeklyWelfareDebtAccountingCrossLinkReportNotes` into `advanceWeek` after the welfare-debt tick when ledger records coexist with integrated-health bundles and/or coercive protocol records.
- Register new report note type `welfare_debt.accounting_cross_link` with hydration, audit registry, and report view category mapping.

## Linear

- **Slice:** [SPE-2444](https://linear.app/spectranoir/issue/SPE-2444) — Welfare-debt cross-link surfacing in weekly report notes (slice 8)
- **Parent:** [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — stays **Backlog** (SPE-1047 / SPE-1131 matrix AC still open)

## What shipped

- `welfareDebtAccountingCrossLinkSurfacing.ts` + `welfareDebtAccountingCrossLinkWeeklyReportNotes.ts`
- `advanceWeek` weekly note hook after welfare-debt tick
- `planning/welfare-debt-accounting-registry-slice-8.md`

## Validation

- `npm run lint`
- `npm run test:run -- src/test/welfareDebtAccountingCrossLinkSurfacing.test.ts src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts src/test/welfareDebtAccountingCrossLinks.test.ts src/test/welfareDebtAccountingLedgerAudit.test.ts src/features/operations/welfareDebtAccountingMirrorView.test.ts`

## Docs updated

- `planning/welfare-debt-accounting-registry-slice-8.md` (new)
- `planning/backlog.md` handoff deferred to merge closeout

Made with [Cursor](https://cursor.com)