### PR TITLE
feat(SPE-2447): truth-layer record registry schema slice 1

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) truth-layer record schema slice 1 (claim / doctrine / verification per actor, site, or event); mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
+**Next step:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) truth-layer record schema slice 2 (GameState persistence + SPE-677 / SPE-58 wire-up) after [SPE-2447](https://linear.app/spectranoir/issue/SPE-2447) slice 1 merges; mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
 
-**Base `main` SHA:** `b0d319f2` — shipped: SPE-1343 parent acceptance review grooming slice 2 @ `planning/spe-1343-parent-acceptance-review-slice-2.md` (PR #2769)
+**Base `main` SHA:** `1808d653` — in flight: SPE-2447 truth-layer record registry slice 1 @ `planning/truth-layer-record-registry-slice-1.md` (branch `spe-1343-truth-layer-record-registry-slice-1`)
 
 **Recently shipped:** SPE-1343 grooming slice 2 parent acceptance review (PR #2769); SPE-1309 grooming slice 2 (PR #2766); SPE-1888 grooming slice 3 (PR #2764).
 
@@ -229,6 +229,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1888-parent-acceptance-review-slice-3.md`            | **Shipped**    | PR #2764; SPE-1888 stays Backlog — slices 7–8 cross-link surfacing groomed; SPE-1047 / SPE-1131 matrix deferred @ `d3185252`.                          |
 | `spe-1343-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2401 / PR #2671; SPE-1343 stays Backlog — SPE-2109 child Done; truth-layer split AC not met @ `8cf2b869`.                                           |
 | `spe-1343-parent-acceptance-review-slice-2.md`            | **Shipped**    | SPE-2446 / PR #2769; SPE-1343 stays Backlog — registry wave + SPE-2122 follow-on groomed; truth-layer priority @ `b0d319f2`.                            |
+| `truth-layer-record-registry-slice-1.md`                  | **In Progress** | SPE-2447; truth-layer record schema (claim / doctrine / verification) @ `1808d653`.                                                                    |
 | `spe-1310-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2402 / PR #2673; SPE-1310 stays Backlog — SPE-2117 + SPE-2123 children Done; case lifecycle AC not met @ `936b2576`.                               |
 | `spe-1615-psychological-resilience-registry-slice-1.md`   | **Shipped**    | SPE-2433 / PR #2737; psychological resilience registry domain anchor @ `a8503939`.                                                                      |
 | `spe-1615-psychological-resilience-registry-slice-2.md`   | **Shipped**    | SPE-2434 / PR #2739; `psychologicalResilienceRecords` GameState persistence @ `467fe4d6`.                                                               |

--- a/planning/truth-layer-record-registry-slice-1.md
+++ b/planning/truth-layer-record-registry-slice-1.md
@@ -1,0 +1,98 @@
+# SPE-2447 — Truth-layer record registry slice 1
+
+One-page implementation plan. Linear: [SPE-2447](https://linear.app/spectranoir/issue/SPE-2447) (child under [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343)). Follows shipped [SPE-2109](https://linear.app/spectranoir/issue/SPE-2109) public disclosure registry and grooming [SPE-2446](https://linear.app/spectranoir/issue/SPE-2446).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2447 — Truth-layer record registry slice 1](https://linear.app/spectranoir/issue/SPE-2447)         |
+| **Parent** | [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — Public myth / operational truth split; stays **Backlog** |
+| **Branch** | `spe-1343-truth-layer-record-registry-slice-1`                                                             |
+| **Status** | **Ready for PR**                                                                                           |
+| **Base `main` SHA** | `1808d653`                                                                                          |
+
+## Goal
+
+Add a pure deterministic **truth-layer record registry** for simultaneous claim, doctrine, and verification layers per actor, site, or event — without extending `PublicDisclosureRecord` or importing franchise/source-literal tokens.
+
+## Prerequisite (on `main` @ `1808d653`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Public disclosure registry | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109) — explicitly defers truth-layer records |
+| Source-confidence vocabulary | `AuthoritySourceConfidence` in `src/domain/authorityGraph.ts` (SPE-788) |
+| Knowledge-state vocabulary | `KnowledgeTier` in `src/domain/knowledge.ts` (SPE-58)                  |
+| Parent grooming      | [SPE-2446](https://linear.app/spectranoir/issue/SPE-2446) — truth-layer priority 1 |
+
+## Gap (pre-slice)
+
+- No bounded schema for claim / doctrine / verification layers per actor, site, or event.
+- No deterministic validation preserving separate truth layers on one case.
+- No review projection helper surfacing layer divergence without collapsing to objective truth.
+
+## Scope (this slice)
+
+| In                                                                                                                                 | Out                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `TruthLayerRecordId` + `TruthLayerRecord` in `src/domain/truthLayerRecordRegistry.ts`                                              | GameState persistence                         |
+| `claim`, `doctrine`, `verification` layer slots with source-confidence / knowledge-tier hints                                      | SPE-677 / SPE-58 runtime wire-up              |
+| `competingLayers` refs for parallel cover / operational records on same case                                                       | Myth-as-infrastructure ops hook (priority 2)  |
+| `validateTruthLayerRecord(record)` — deterministic lint (warnings + errors)                                                    | Public-disclosure registry field extensions   |
+| `projectTruthLayerReviewView(record, policy)` — separate review surfaces                                                         | Planning mirror UI                            |
+| Focused tests in `src/test/truthLayerRecordRegistry.test.ts`                                                                       | Full SPE-1343 parent Done                     |
+
+## Record contract (deterministic)
+
+### Core fields
+
+- **subjectRef / subjectKind** — actor, site, or event anchor.
+- **claim** — public or subject-facing narrative slot (`narrative`, optional `sourceConfidence`, `knowledgeTier`, `evidenceRef`).
+- **doctrine** — institutional record slot (same sub-shape).
+- **verification** — operationally verified slot (same sub-shape).
+- **competingLayers** — `{ recordRef, layerRole, note? }[]` for parallel truth records on the same case.
+- **correctionPressure** — 0..1 scalar (review surface hook).
+- **mythInfrastructureWeight** — 0..1 scalar; myth may affect ops without verification (projection flag only in slice 1).
+- **linkedDisclosureRef** — optional hook to disclosure record; does not extend `PublicDisclosureRecord`.
+- **confidence / unknown / redacted** — projection legibility without dumping hidden truth.
+
+### Validation rules (examples)
+
+- Missing `id`, `label`, `subjectRef`, or any layer `narrative` → error.
+- Invalid `subjectKind`, source confidence, knowledge tier, or unit score → error.
+- Franchise / source-literal token in any string field → error.
+- `verification` marked `verified` without `evidenceRef` → warning.
+- Identical `claim` and `verification` narratives → warning (`collapsed_claim_and_verification`).
+- `mythInfrastructureWeight` > 0 with verified identical claim/verification → warning.
+
+## Acceptance
+
+- [x] Fixture: competing truth layers on one site event with distinct claim/doctrine/verification.
+- [x] Separate claim/doctrine/verification round-trip on actor fixture.
+- [x] Negative: franchise token in label or layer narrative → error.
+- [x] Review projection surfaces layer divergence without collapsing layers.
+- [x] Repeated validation byte-stable.
+- [x] `npm run lint` + targeted `npm run test:run` green.
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| GameState persistence + hydrate wire | SPE-1343 slice 2 | Registry anchor must land first |
+| SPE-677 / SPE-58 knowledge-state wire-up | SPE-1343 slice 2+ | Parent constraint; schema uses compatible types only |
+| Myth-as-infrastructure ops projection | SPE-1343 follow-up | Parent AC row 2; depends on persisted records |
+| Cover narrative + agency operational record dual-incident pairing | SPE-899 / SPE-1347 | Parent AC row 4 partial |
+| Historical-icon normalcy pressure review surfaces | SPE-1343 follow-up | Parent AC row 5 |
+| Planning mirror UI | SPE-1343 slice 4+ | Mirror follows persistence pattern |
+
+## File touch list (expected)
+
+| Area   | Files                                                       |
+| ------ | ----------------------------------------------------------- |
+| Domain | `src/domain/truthLayerRecordRegistry.ts`                    |
+| Tests  | `src/test/truthLayerRecordRegistry.test.ts`                 |
+| Plan   | `planning/truth-layer-record-registry-slice-1.md`, `planning/backlog.md` |
+
+## See also
+
+- `planning/spe-1343-parent-acceptance-review-slice-2.md` — truth-layer priority table
+- `src/domain/publicDisclosureStateRegistry.ts` — sibling registry; do not extend for truth layers
+- `src/domain/selfCensoringInformationRegistry.ts` — validation + projection conventions

--- a/src/domain/truthLayerRecordRegistry.ts
+++ b/src/domain/truthLayerRecordRegistry.ts
@@ -1,0 +1,830 @@
+/**
+ * SPE-1343 slice 1: truth-layer record registry.
+ *
+ * Pure deterministic registry for simultaneous claim, doctrine, and verification
+ * layers per actor, site, or event — distinct from public disclosure progression
+ * (SPE-2109) and without extending PublicDisclosureRecord.
+ */
+
+import type { AuthoritySourceConfidence } from './authorityGraph'
+import type { KnowledgeTier } from './knowledge'
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type TruthLayerRecordId = string
+
+export type TruthLayerSubjectKind = 'actor' | 'site' | 'event'
+
+export const TRUTH_LAYER_SUBJECT_KINDS: readonly TruthLayerSubjectKind[] = [
+  'actor',
+  'site',
+  'event',
+] as const
+
+export type CompetingLayerRole =
+  | 'claim'
+  | 'doctrine'
+  | 'verification'
+  | 'cover_narrative'
+  | 'public_myth'
+  | 'operational_record'
+
+export const COMPETING_LAYER_ROLES: readonly CompetingLayerRole[] = [
+  'claim',
+  'doctrine',
+  'verification',
+  'cover_narrative',
+  'public_myth',
+  'operational_record',
+] as const
+
+// Re-export for slice 2+ wire-up to authority graph and knowledge state.
+export type TruthLayerSourceConfidence = AuthoritySourceConfidence
+export type TruthLayerKnowledgeTier = KnowledgeTier
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface TruthLayerSlot {
+  readonly narrative: string
+  readonly summary?: string
+  readonly sourceConfidence?: TruthLayerSourceConfidence
+  readonly knowledgeTier?: TruthLayerKnowledgeTier
+  readonly lastUpdatedWeek?: number
+  readonly evidenceRef?: string
+}
+
+export interface CompetingTruthLayerRef {
+  readonly recordRef: string
+  readonly layerRole: CompetingLayerRole
+  readonly note?: string
+}
+
+export interface TruthLayerRecord {
+  readonly id: TruthLayerRecordId
+  readonly label: string
+  readonly summary?: string
+  readonly subjectRef: string
+  readonly subjectKind: TruthLayerSubjectKind
+  readonly parentCaseRef?: string
+  readonly claim: TruthLayerSlot
+  readonly doctrine: TruthLayerSlot
+  readonly verification: TruthLayerSlot
+  readonly competingLayers?: readonly CompetingTruthLayerRef[]
+  readonly correctionPressure?: number
+  readonly mythInfrastructureWeight?: number
+  readonly linkedDisclosureRef?: string
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type TruthLayerValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_subject_ref'
+  | 'invalid_subject_kind'
+  | 'empty_claim_narrative'
+  | 'empty_doctrine_narrative'
+  | 'empty_verification_narrative'
+  | 'invalid_source_confidence'
+  | 'invalid_knowledge_tier'
+  | 'invalid_last_updated_week'
+  | 'invalid_correction_pressure'
+  | 'invalid_myth_infrastructure_weight'
+  | 'invalid_confidence'
+  | 'invalid_competing_layer_role'
+  | 'empty_competing_record_ref'
+  | 'verified_without_evidence_ref'
+  | 'collapsed_claim_and_verification'
+  | 'myth_weight_with_verified_mechanism'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+
+export interface TruthLayerValidationIssue {
+  readonly code: TruthLayerValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface TruthLayerValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly TruthLayerValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Review projection
+// ---------------------------------------------------------------------------
+
+export interface TruthLayerReviewProjectionPolicy {
+  readonly minimumConfidence?: number
+  readonly redactUnknown?: boolean
+  readonly mythInfrastructureThreshold?: number
+}
+
+export interface TruthLayerSlotProjection {
+  readonly narrative: string | null
+  readonly summary: string | null
+  readonly sourceConfidence: TruthLayerSourceConfidence | null
+  readonly knowledgeTier: TruthLayerKnowledgeTier | null
+  readonly redacted: boolean
+}
+
+export interface TruthLayerReviewProjection {
+  readonly recordId: TruthLayerRecordId
+  readonly label: string
+  readonly summary: string | null
+  readonly subjectRef: string
+  readonly subjectKind: TruthLayerSubjectKind
+  readonly claim: TruthLayerSlotProjection
+  readonly doctrine: TruthLayerSlotProjection
+  readonly verification: TruthLayerSlotProjection
+  readonly layerDivergence: boolean
+  readonly competingLayerCount: number
+  readonly correctionPressure: number | null
+  readonly mythInfrastructureActive: boolean
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const SUBJECT_KIND_SET = new Set<string>(TRUTH_LAYER_SUBJECT_KINDS)
+const COMPETING_LAYER_ROLE_SET = new Set<string>(COMPETING_LAYER_ROLES)
+
+const SOURCE_CONFIDENCE_SET = new Set<string>([
+  'verified',
+  'probable',
+  'rumor',
+  'hostile_dossier',
+  'public_cover',
+  'redacted',
+  'contradicted',
+  'unknown',
+])
+
+const KNOWLEDGE_TIER_SET = new Set<string>([
+  'unknown',
+  'partial',
+  'relayed',
+  'pending-relay',
+  'suspected',
+  'observed',
+  'confirmed',
+  'operationalized',
+  'institutionalized',
+])
+
+export const FRANCHISE_TOKEN_PATTERN =
+  /\b(scp|mtf|mobile task force|foundation|goc|gru|uiu|chaos insurgency|goi-|group of interest|broken masquerade|masquerade breach)\b/i
+
+const DEFAULT_MYTH_INFRASTRUCTURE_THRESHOLD = 0.35
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return Object.freeze(
+    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function asCompetingLayers(value: unknown): readonly CompetingTruthLayerRef[] {
+  return Array.isArray(value) ? value : []
+}
+
+function pushIssue(issues: TruthLayerValidationIssue[], issue: TruthLayerValidationIssue) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: TruthLayerValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value === Math.trunc(value)
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function freezeValidationResult(issues: TruthLayerValidationIssue[]): TruthLayerValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function isSourceConfidence(value: string): value is TruthLayerSourceConfidence {
+  return SOURCE_CONFIDENCE_SET.has(value)
+}
+
+function isKnowledgeTier(value: string): value is TruthLayerKnowledgeTier {
+  return KNOWLEDGE_TIER_SET.has(value)
+}
+
+function isSubjectKind(value: string): value is TruthLayerSubjectKind {
+  return SUBJECT_KIND_SET.has(value)
+}
+
+function isCompetingLayerRoleValue(value: string): value is CompetingLayerRole {
+  return COMPETING_LAYER_ROLE_SET.has(value)
+}
+
+function scanFranchiseTokens(
+  issues: TruthLayerValidationIssue[],
+  id: string,
+  label: string,
+  record: TruthLayerRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Truth-layer record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Truth-layer record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const stringFields: Array<{ field: string; value: string | undefined }> = [
+    { field: 'summary', value: record.summary },
+    { field: 'subjectRef', value: record.subjectRef },
+    { field: 'parentCaseRef', value: record.parentCaseRef },
+    { field: 'linkedDisclosureRef', value: record.linkedDisclosureRef },
+  ]
+
+  for (const { field, value } of stringFields) {
+    const token = normalizeToken(value ?? '')
+    if (token && containsFranchiseToken(token)) {
+      pushIssue(issues, {
+        code: 'franchise_token_in_field',
+        severity: 'error',
+        detail: `Truth-layer record ${id || '(unknown)'} field ${field} contains a franchise or source-literal token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const slotName of ['claim', 'doctrine', 'verification'] as const) {
+    const slot = record[slotName]
+    if (!slot || typeof slot !== 'object') {
+      continue
+    }
+
+    for (const token of [slot.narrative, slot.summary, slot.evidenceRef]) {
+      const normalized = normalizeToken(token ?? '')
+      if (normalized && containsFranchiseToken(normalized)) {
+        pushIssue(issues, {
+          code: 'franchise_token_in_field',
+          severity: 'error',
+          detail: `Truth-layer record ${id || '(unknown)'} ${slotName} contains a franchise or source-literal token.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+    }
+  }
+
+  for (const entry of asCompetingLayers(record.competingLayers)) {
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+
+    for (const token of [entry.recordRef, entry.note]) {
+      const normalized = normalizeToken(token ?? '')
+      if (normalized && containsFranchiseToken(normalized)) {
+        pushIssue(issues, {
+          code: 'franchise_token_in_field',
+          severity: 'error',
+          detail: `Truth-layer record ${id || '(unknown)'} competingLayers contains a franchise or source-literal token.`,
+          relatedIds: id ? [id] : undefined,
+        })
+      }
+    }
+  }
+}
+
+function validateTruthLayerSlot(
+  issues: TruthLayerValidationIssue[],
+  id: string,
+  slotName: 'claim' | 'doctrine' | 'verification',
+  slot: TruthLayerSlot | undefined,
+  emptyCode: TruthLayerValidationCode
+) {
+  if (!slot || typeof slot !== 'object') {
+    pushIssue(issues, {
+      code: emptyCode,
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} requires ${slotName}.narrative.`,
+      relatedIds: id ? [id] : undefined,
+    })
+    return
+  }
+
+  if (!normalizeToken(slot.narrative)) {
+    pushIssue(issues, {
+      code: emptyCode,
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} requires ${slotName}.narrative.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    slot.sourceConfidence !== undefined &&
+    !isSourceConfidence(slot.sourceConfidence)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_source_confidence',
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} ${slotName} has invalid sourceConfidence ${String(slot.sourceConfidence)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (slot.knowledgeTier !== undefined && !isKnowledgeTier(slot.knowledgeTier)) {
+    pushIssue(issues, {
+      code: 'invalid_knowledge_tier',
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} ${slotName} has invalid knowledgeTier ${String(slot.knowledgeTier)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (slot.lastUpdatedWeek !== undefined && !isFiniteWeek(slot.lastUpdatedWeek)) {
+    pushIssue(issues, {
+      code: 'invalid_last_updated_week',
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} ${slotName} lastUpdatedWeek is invalid.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    slotName === 'verification' &&
+    slot.sourceConfidence === 'verified' &&
+    !normalizeToken(slot.evidenceRef ?? '')
+  ) {
+    pushIssue(issues, {
+      code: 'verified_without_evidence_ref',
+      severity: 'warning',
+      detail: `Truth-layer record ${id || '(unknown)'} verification marked verified without evidenceRef.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+}
+
+function resolveSlotProjection(
+  slot: TruthLayerSlot,
+  slotKey: 'claim' | 'doctrine' | 'verification',
+  record: TruthLayerRecord,
+  policy: TruthLayerReviewProjectionPolicy
+): TruthLayerSlotProjection {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+  const narrativeRedacted =
+    redactedFields.has(slotKey) ||
+    redactedFields.has(`${slotKey}.narrative`) ||
+    (policy.redactUnknown === true && unknownFields.includes(`${slotKey}.narrative`))
+
+  const summaryRedacted =
+    redactedFields.has(`${slotKey}.summary`) ||
+    (policy.redactUnknown === true && unknownFields.includes(`${slotKey}.summary`))
+
+  const confidenceRedacted =
+    redactedFields.has(`${slotKey}.sourceConfidence`) ||
+    (policy.redactUnknown === true && unknownFields.includes(`${slotKey}.sourceConfidence`))
+
+  const tierRedacted =
+    redactedFields.has(`${slotKey}.knowledgeTier`) ||
+    (policy.redactUnknown === true && unknownFields.includes(`${slotKey}.knowledgeTier`))
+
+  return Object.freeze({
+    narrative: narrativeRedacted ? null : normalizeToken(slot.narrative) || null,
+    summary: summaryRedacted ? null : normalizeToken(slot.summary ?? '') || null,
+    sourceConfidence:
+      confidenceRedacted || slot.sourceConfidence === undefined
+        ? null
+        : slot.sourceConfidence,
+    knowledgeTier:
+      tierRedacted || slot.knowledgeTier === undefined ? null : slot.knowledgeTier,
+    redacted: narrativeRedacted || summaryRedacted || confidenceRedacted || tierRedacted,
+  })
+}
+
+function resolveConfidence(
+  record: TruthLayerRecord,
+  policy: TruthLayerReviewProjectionPolicy
+): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (redactedFields.has('confidence')) {
+    return null
+  }
+
+  const confidence = record.confidence ?? null
+  if (
+    confidence !== null &&
+    policy.minimumConfidence !== undefined &&
+    confidence < policy.minimumConfidence
+  ) {
+    return null
+  }
+
+  if (policy.redactUnknown === true && unknownFields.includes('confidence')) {
+    return null
+  }
+
+  return confidence
+}
+
+function narrativesDiverge(record: TruthLayerRecord): boolean {
+  const claim = normalizeToken(record.claim?.narrative ?? '')
+  const doctrine = normalizeToken(record.doctrine?.narrative ?? '')
+  const verification = normalizeToken(record.verification?.narrative ?? '')
+
+  if (!claim || !doctrine || !verification) {
+    return false
+  }
+
+  return claim !== doctrine || doctrine !== verification || claim !== verification
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isTruthLayerSubjectKind(value: string): value is TruthLayerSubjectKind {
+  return isSubjectKind(value)
+}
+
+export function isCompetingLayerRole(value: string): value is CompetingLayerRole {
+  return COMPETING_LAYER_ROLE_SET.has(value)
+}
+
+export function isTruthLayerSourceConfidence(value: string): value is TruthLayerSourceConfidence {
+  return isSourceConfidence(value)
+}
+
+export function isTruthLayerKnowledgeTier(value: string): value is TruthLayerKnowledgeTier {
+  return isKnowledgeTier(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateTruthLayerRecord(record: TruthLayerRecord): TruthLayerValidationResult {
+  const issues: TruthLayerValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const subjectRef = normalizeToken(record.subjectRef)
+
+  if (!id) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Truth-layer record is missing id.',
+    })
+  }
+
+  if (!label) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Truth-layer record is missing label.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!subjectRef) {
+    pushIssue(issues, {
+      code: 'missing_subject_ref',
+      severity: 'error',
+      detail: 'Truth-layer record is missing subjectRef.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanFranchiseTokens(issues, id, label, record)
+
+  if (!isSubjectKind(record.subjectKind)) {
+    pushIssue(issues, {
+      code: 'invalid_subject_kind',
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} has invalid subjectKind ${String(record.subjectKind)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  validateTruthLayerSlot(issues, id, 'claim', record.claim, 'empty_claim_narrative')
+  validateTruthLayerSlot(issues, id, 'doctrine', record.doctrine, 'empty_doctrine_narrative')
+  validateTruthLayerSlot(
+    issues,
+    id,
+    'verification',
+    record.verification,
+    'empty_verification_narrative'
+  )
+
+  if (record.correctionPressure !== undefined && !isValidUnitScore(record.correctionPressure)) {
+    pushIssue(issues, {
+      code: 'invalid_correction_pressure',
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} correctionPressure must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.mythInfrastructureWeight !== undefined &&
+    !isValidUnitScore(record.mythInfrastructureWeight)
+  ) {
+    pushIssue(issues, {
+      code: 'invalid_myth_infrastructure_weight',
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} mythInfrastructureWeight must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: `Truth-layer record ${id || '(unknown)'} confidence must be a finite number between 0 and 1.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const entry of asCompetingLayers(record.competingLayers)) {
+    if (!entry || typeof entry !== 'object') {
+      pushIssue(issues, {
+        code: 'empty_competing_record_ref',
+        severity: 'error',
+        detail: `Truth-layer record ${id || '(unknown)'} competingLayers contains invalid entry.`,
+        relatedIds: id ? [id] : undefined,
+      })
+      continue
+    }
+
+    if (!normalizeToken(entry.recordRef)) {
+      pushIssue(issues, {
+        code: 'empty_competing_record_ref',
+        severity: 'error',
+        detail: `Truth-layer record ${id || '(unknown)'} competingLayers requires recordRef.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (!isCompetingLayerRoleValue(entry.layerRole)) {
+      pushIssue(issues, {
+        code: 'invalid_competing_layer_role',
+        severity: 'error',
+        detail: `Truth-layer record ${id || '(unknown)'} has invalid competing layer role ${String(entry.layerRole)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  const claimNarrative = normalizeToken(record.claim?.narrative ?? '')
+  const verificationNarrative = normalizeToken(record.verification?.narrative ?? '')
+  if (claimNarrative && verificationNarrative && claimNarrative === verificationNarrative) {
+    pushIssue(issues, {
+      code: 'collapsed_claim_and_verification',
+      severity: 'warning',
+      detail: `Truth-layer record ${id || '(unknown)'} claim and verification narratives are identical.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const mythWeight = record.mythInfrastructureWeight ?? 0
+  const verificationConfidence = record.verification?.sourceConfidence
+  if (
+    mythWeight > 0 &&
+    verificationConfidence === 'verified' &&
+    claimNarrative &&
+    verificationNarrative &&
+    claimNarrative === verificationNarrative
+  ) {
+    pushIssue(issues, {
+      code: 'myth_weight_with_verified_mechanism',
+      severity: 'warning',
+      detail: `Truth-layer record ${id || '(unknown)'} mythInfrastructureWeight is set while public claim is treated as verified mechanism.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * Projects separate claim, doctrine, and verification review surfaces.
+ * Does not collapse layers into a single objective truth.
+ */
+export function projectTruthLayerReviewView(
+  record: TruthLayerRecord,
+  policy: TruthLayerReviewProjectionPolicy = {}
+): TruthLayerReviewProjection {
+  const recordId = normalizeToken(record.id) || '(unknown)'
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = sortedStringArray(record.unknownFields)
+  const mythThreshold = policy.mythInfrastructureThreshold ?? DEFAULT_MYTH_INFRASTRUCTURE_THRESHOLD
+
+  const summaryRedacted = redactedFields.has('summary')
+  const summary = summaryRedacted ? null : normalizeToken(record.summary ?? '') || null
+
+  const claim = resolveSlotProjection(record.claim, 'claim', record, policy)
+  const doctrine = resolveSlotProjection(record.doctrine, 'doctrine', record, policy)
+  const verification = resolveSlotProjection(record.verification, 'verification', record, policy)
+
+  const correctionRedacted =
+    redactedFields.has('correctionPressure') ||
+    (policy.redactUnknown === true && unknownFields.includes('correctionPressure'))
+
+  const correctionPressure =
+    correctionRedacted || record.correctionPressure === undefined
+      ? null
+      : record.correctionPressure
+
+  const mythWeight = record.mythInfrastructureWeight ?? 0
+  const mythInfrastructureActive = mythWeight >= mythThreshold
+
+  const confidence = resolveConfidence(record, policy)
+  const redacted =
+    summaryRedacted ||
+    claim.redacted ||
+    doctrine.redacted ||
+    verification.redacted ||
+    correctionRedacted ||
+    redactedFields.has('confidence') ||
+    (confidence === null &&
+      record.confidence !== undefined &&
+      policy.minimumConfidence !== undefined)
+
+  return Object.freeze({
+    recordId,
+    label: normalizeToken(record.label) || '(unknown)',
+    summary,
+    subjectRef: normalizeToken(record.subjectRef) || '(unknown)',
+    subjectKind: isSubjectKind(record.subjectKind) ? record.subjectKind : 'event',
+    claim,
+    doctrine,
+    verification,
+    layerDivergence: narrativesDiverge(record),
+    competingLayerCount: asCompetingLayers(record.competingLayers).filter(
+      (entry) => entry && typeof entry === 'object' && normalizeToken(entry.recordRef)
+    ).length,
+    correctionPressure,
+    mythInfrastructureActive,
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
+function defineRecord(record: TruthLayerRecord): TruthLayerRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Site event with competing public myth, institutional doctrine, and ops verification layers. */
+export const COMPETING_TRUTH_LAYERS_FIXTURE: TruthLayerRecord = defineRecord({
+  id: 'truth:coastal-research-campus-incident',
+  label: 'Coastal research campus containment divergence',
+  summary: 'Public cover narrative, institutional doctrine, and field verification diverge on the same site event.',
+  subjectRef: 'site:coastal-research-campus',
+  subjectKind: 'site',
+  parentCaseRef: 'case:containment-response-24',
+  claim: {
+    narrative: 'Industrial solvent leak prompted precautionary campus evacuation.',
+    summary: 'Public-facing cover narrative distributed through regional press offices.',
+    sourceConfidence: 'public_cover',
+    knowledgeTier: 'partial',
+    lastUpdatedWeek: 22,
+  },
+  doctrine: {
+    narrative: 'Containment breach contained to sub-basement wing; civilian exposure within modeled tolerance.',
+    summary: 'Institutional doctrine record for oversight briefing.',
+    sourceConfidence: 'probable',
+    knowledgeTier: 'observed',
+    lastUpdatedWeek: 23,
+    evidenceRef: 'briefing:doctrine-summary-24',
+  },
+  verification: {
+    narrative: 'Anomalous residue breached secondary seal; two contractors exposed beyond modeled tolerance.',
+    summary: 'Field verification from response team after seal inspection.',
+    sourceConfidence: 'verified',
+    knowledgeTier: 'confirmed',
+    lastUpdatedWeek: 24,
+    evidenceRef: 'report:field-verification-24',
+  },
+  competingLayers: [
+    {
+      recordRef: 'truth:regional-press-cover-24',
+      layerRole: 'cover_narrative',
+      note: 'Parallel public cover record maintained by comms cell.',
+    },
+    {
+      recordRef: 'truth:agency-operational-log-24',
+      layerRole: 'operational_record',
+      note: 'Agency operational record with seal breach metrics.',
+    },
+  ],
+  correctionPressure: 0.62,
+  mythInfrastructureWeight: 0.48,
+  linkedDisclosureRef: 'disclosure:coastal-research-campus',
+  confidence: 0.55,
+})
+
+/** Actor subject with separate claim/doctrine/verification slots for round-trip checks. */
+export const ACTOR_TRUTH_LAYER_FIXTURE: TruthLayerRecord = defineRecord({
+  id: 'truth:regional-oversight-commissioner',
+  label: 'Regional oversight commissioner testimony layers',
+  subjectRef: 'actor:regional-oversight-commissioner',
+  subjectKind: 'actor',
+  parentCaseRef: 'case:oversight-hearing-11',
+  claim: {
+    narrative: 'Commissioner asserts routine industrial oversight with no anomalous findings.',
+    sourceConfidence: 'public_cover',
+    knowledgeTier: 'suspected',
+    lastUpdatedWeek: 30,
+  },
+  doctrine: {
+    narrative: 'Commission staff record notes elevated containment liaison requests.',
+    sourceConfidence: 'probable',
+    knowledgeTier: 'observed',
+    lastUpdatedWeek: 31,
+    evidenceRef: 'memo:liaison-request-11',
+  },
+  verification: {
+    narrative: 'Liaison logs confirm commissioner received sealed briefing materials.',
+    sourceConfidence: 'verified',
+    knowledgeTier: 'confirmed',
+    lastUpdatedWeek: 32,
+    evidenceRef: 'log:briefing-delivery-11',
+  },
+  correctionPressure: 0.28,
+  confidence: 0.61,
+})

--- a/src/test/truthLayerRecordRegistry.test.ts
+++ b/src/test/truthLayerRecordRegistry.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ACTOR_TRUTH_LAYER_FIXTURE,
+  COMPETING_LAYER_ROLES,
+  COMPETING_TRUTH_LAYERS_FIXTURE,
+  TRUTH_LAYER_SUBJECT_KINDS,
+  projectTruthLayerReviewView,
+  validateTruthLayerRecord,
+  type TruthLayerRecord,
+} from '../domain/truthLayerRecordRegistry'
+
+function baseRecord(overrides: Partial<TruthLayerRecord> = {}): TruthLayerRecord {
+  return {
+    id: 'truth:test-base',
+    label: 'Test base record',
+    subjectRef: 'event:test-incident',
+    subjectKind: 'event',
+    claim: { narrative: 'Public claim narrative.' },
+    doctrine: { narrative: 'Institutional doctrine narrative.' },
+    verification: { narrative: 'Field verification narrative.' },
+    ...overrides,
+  }
+}
+
+describe('truthLayerRecordRegistry (SPE-1343 slice 1)', () => {
+  it('validates fixture with competing truth layers on one site event', () => {
+    const result = validateTruthLayerRecord(COMPETING_TRUTH_LAYERS_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toHaveLength(0)
+    expect(COMPETING_TRUTH_LAYERS_FIXTURE.competingLayers).toHaveLength(2)
+    expect(COMPETING_TRUTH_LAYERS_FIXTURE.subjectKind).toBe('site')
+    expect(COMPETING_TRUTH_LAYERS_FIXTURE.claim.narrative).not.toBe(
+      COMPETING_TRUTH_LAYERS_FIXTURE.verification.narrative
+    )
+  })
+
+  it('round-trips claim, doctrine, and verification slots separately', () => {
+    const result = validateTruthLayerRecord(ACTOR_TRUTH_LAYER_FIXTURE)
+
+    expect(result.valid).toBe(true)
+    expect(ACTOR_TRUTH_LAYER_FIXTURE.claim.narrative).toMatch(/asserts routine industrial oversight/)
+    expect(ACTOR_TRUTH_LAYER_FIXTURE.doctrine.narrative).toMatch(/liaison requests/)
+    expect(ACTOR_TRUTH_LAYER_FIXTURE.verification.narrative).toMatch(/sealed briefing materials/)
+    expect(ACTOR_TRUTH_LAYER_FIXTURE.claim.sourceConfidence).toBe('public_cover')
+    expect(ACTOR_TRUTH_LAYER_FIXTURE.doctrine.knowledgeTier).toBe('observed')
+    expect(ACTOR_TRUTH_LAYER_FIXTURE.verification.evidenceRef).toMatch(/^log:/)
+  })
+
+  it('projects separate review surfaces without collapsing layers', () => {
+    const projection = projectTruthLayerReviewView(COMPETING_TRUTH_LAYERS_FIXTURE)
+
+    expect(projection.layerDivergence).toBe(true)
+    expect(projection.claim.narrative).toMatch(/solvent leak/)
+    expect(projection.doctrine.narrative).toMatch(/sub-basement wing/)
+    expect(projection.verification.narrative).toMatch(/secondary seal/)
+    expect(projection.competingLayerCount).toBe(2)
+    expect(projection.mythInfrastructureActive).toBe(true)
+    expect(projection.correctionPressure).toBe(0.62)
+  })
+
+  it('errors on franchise token in record label', () => {
+    const result = validateTruthLayerRecord(
+      baseRecord({
+        label: 'Foundation cover narrative review',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+
+  it('errors on franchise token in claim narrative', () => {
+    const result = validateTruthLayerRecord(
+      baseRecord({
+        claim: { narrative: 'SCP containment breach reported in local press.' },
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_field')).toBe(true)
+  })
+
+  it('warns when claim and verification narratives collapse to the same text', () => {
+    const result = validateTruthLayerRecord(
+      baseRecord({
+        claim: { narrative: 'Identical narrative text.' },
+        doctrine: { narrative: 'Different doctrine narrative.' },
+        verification: { narrative: 'Identical narrative text.' },
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'collapsed_claim_and_verification',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('warns when verification is marked verified without evidenceRef', () => {
+    const result = validateTruthLayerRecord(
+      baseRecord({
+        verification: {
+          narrative: 'Verified field narrative without evidence ref.',
+          sourceConfidence: 'verified',
+        },
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'verified_without_evidence_ref',
+        severity: 'warning',
+      }),
+    ])
+  })
+
+  it('round-trips subject kind and competing layer role unions on validation', () => {
+    const record = baseRecord({
+      subjectKind: 'actor',
+      competingLayers: COMPETING_LAYER_ROLES.map((layerRole, index) => ({
+        recordRef: `truth:competing-${index}`,
+        layerRole,
+      })),
+    })
+
+    const result = validateTruthLayerRecord(record)
+
+    expect(result.valid).toBe(true)
+    expect(TRUTH_LAYER_SUBJECT_KINDS).toContain(record.subjectKind)
+    expect(record.competingLayers).toHaveLength(COMPETING_LAYER_ROLES.length)
+  })
+
+  it('validates untrusted payloads without throwing when fields are missing or nullish', () => {
+    const result = validateTruthLayerRecord({} as TruthLayerRecord)
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.map((issue) => issue.code).sort()).toEqual(
+      [
+        'empty_claim_narrative',
+        'empty_doctrine_narrative',
+        'empty_verification_narrative',
+        'invalid_subject_kind',
+        'missing_id',
+        'missing_label',
+        'missing_subject_ref',
+      ].sort()
+    )
+  })
+
+  it('projects review view with policy redaction on individual layer slots', () => {
+    const record = baseRecord({
+      redactedFields: ['claim.narrative', 'verification.sourceConfidence'],
+      unknownFields: ['doctrine.summary'],
+      doctrine: {
+        narrative: 'Doctrine narrative with hidden summary.',
+        summary: 'Hidden doctrine summary.',
+      },
+      verification: {
+        narrative: 'Verification narrative.',
+        sourceConfidence: 'verified',
+        evidenceRef: 'report:test',
+      },
+    })
+
+    const projection = projectTruthLayerReviewView(record, { redactUnknown: true })
+
+    expect(projection.claim.narrative).toBeNull()
+    expect(projection.claim.redacted).toBe(true)
+    expect(projection.doctrine.summary).toBeNull()
+    expect(projection.verification.sourceConfidence).toBeNull()
+    expect(projection.redacted).toBe(true)
+  })
+
+  it('produces byte-stable validation output on repeated runs', () => {
+    const record = baseRecord({
+      correctionPressure: 0.44,
+      mythInfrastructureWeight: 0.51,
+      competingLayers: [
+        { recordRef: 'truth:parallel-cover', layerRole: 'cover_narrative' },
+      ],
+    })
+
+    const first = JSON.stringify(validateTruthLayerRecord(record))
+    const second = JSON.stringify(validateTruthLayerRecord(record))
+
+    expect(first).toBe(second)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/domain/truthLayerRecordRegistry.ts` with `TruthLayerRecord` carrying separate **claim**, **doctrine**, and **verification** layer slots per actor/site/event subject.
- Deterministic `validateTruthLayerRecord` (franchise-token rejection, layer-collapse warnings, byte-stable output) and `projectTruthLayerReviewView` review projection without collapsing layers.
- Focused tests and slice doc; backlog handoff updated for slice 2 follow-up.

## Linear

- **Slice:** [SPE-2447](https://linear.app/spectranoir/issue/SPE-2447) — Truth-layer record registry slice 1
- **Parent:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — remains **Backlog** (schema-only slice; parent AC not met)

## What shipped

- Pure domain module + tests only
- No `PublicDisclosureRecord` field extensions
- No GameState persistence or UI

## Validation

- `npm run test:run -- src/test/truthLayerRecordRegistry.test.ts` (11 tests)
- `npm run lint`

## Docs updated

- `planning/truth-layer-record-registry-slice-1.md`
- `planning/backlog.md` (handoff row + planning index)

## Parent remains open

SPE-1343 parent acceptance criteria (myth-as-infrastructure ops, dual-incident pairing, historical-icon surfaces) are deferred to follow-on slices.