### PR TITLE
feat(SPE-2448): truth-layer record registry GameState persistence slice 2

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) truth-layer record schema slice 2 (GameState persistence + SPE-677 / SPE-58 wire-up) after [SPE-2447](https://linear.app/spectranoir/issue/SPE-2447) slice 1 merges; mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
+**Next step:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) truth-layer slice 3+ (weekly orchestration hook or myth-as-infrastructure ops projection) after [SPE-2448](https://linear.app/spectranoir/issue/SPE-2448) slice 2 merges; mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
 
-**Base `main` SHA:** `080608e6` — shipped: SPE-2447 truth-layer record registry slice 1 @ `planning/truth-layer-record-registry-slice-1.md` (PR #2772)
+**Base `main` SHA:** `9e050dd0` — in flight: SPE-2448 truth-layer record registry slice 2 @ `planning/truth-layer-record-registry-slice-2.md` (PR #2774)
 
 **Recently shipped:** SPE-2447 truth-layer record registry slice 1 (PR #2772); SPE-1343 grooming slice 2 (PR #2769); SPE-1309 grooming slice 2 (PR #2766).
 
@@ -230,6 +230,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1343-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2401 / PR #2671; SPE-1343 stays Backlog — SPE-2109 child Done; truth-layer split AC not met @ `8cf2b869`.                                           |
 | `spe-1343-parent-acceptance-review-slice-2.md`            | **Shipped**    | SPE-2446 / PR #2769; SPE-1343 stays Backlog — registry wave + SPE-2122 follow-on groomed; truth-layer priority @ `b0d319f2`.                            |
 | `truth-layer-record-registry-slice-1.md`                  | **Shipped**    | SPE-2447 / PR #2772; truth-layer record schema (claim / doctrine / verification) @ `080608e6`.                                                       |
+| `truth-layer-record-registry-slice-2.md`                  | **In flight**  | SPE-2448 / PR #2774; `truthLayerRecords` GameState persistence @ `9e050dd0`.                                                                         |
 | `spe-1310-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2402 / PR #2673; SPE-1310 stays Backlog — SPE-2117 + SPE-2123 children Done; case lifecycle AC not met @ `936b2576`.                               |
 | `spe-1615-psychological-resilience-registry-slice-1.md`   | **Shipped**    | SPE-2433 / PR #2737; psychological resilience registry domain anchor @ `a8503939`.                                                                      |
 | `spe-1615-psychological-resilience-registry-slice-2.md`   | **Shipped**    | SPE-2434 / PR #2739; `psychologicalResilienceRecords` GameState persistence @ `467fe4d6`.                                                               |

--- a/planning/truth-layer-record-registry-slice-2.md
+++ b/planning/truth-layer-record-registry-slice-2.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2448](https://linear.app/spectranoir/
 | **Linear** | [SPE-2448 — Truth-layer record registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2448) |
 | **Parent** | [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — Public myth operational truth split; stays **Backlog** |
 | **Branch** | `spe-1343-truth-layer-record-registry-slice-2`                                                             |
-| **Status** | **In progress**                                                                                            |
+| **Status** | **Shipped** — PR #2774                                                                                     |
 | **Base `main` SHA** | `9e050dd0`                                                                                          |
 
 ## Goal

--- a/planning/truth-layer-record-registry-slice-2.md
+++ b/planning/truth-layer-record-registry-slice-2.md
@@ -1,0 +1,69 @@
+# SPE-1343 — Truth-layer record registry GameState persistence (slice 2)
+
+One-page implementation plan. Linear: [SPE-2448](https://linear.app/spectranoir/issue/SPE-2448) (child under [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343)). Follows shipped [SPE-2447](https://linear.app/spectranoir/issue/SPE-2447) slice 1 (`planning/truth-layer-record-registry-slice-1.md`, PR #2772).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2448 — Truth-layer record registry GameState persistence (slice 2)](https://linear.app/spectranoir/issue/SPE-2448) |
+| **Parent** | [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — Public myth operational truth split; stays **Backlog** |
+| **Branch** | `spe-1343-truth-layer-record-registry-slice-2`                                                             |
+| **Status** | **In progress**                                                                                            |
+| **Base `main` SHA** | `9e050dd0`                                                                                          |
+
+## Goal
+
+Persist validated `TruthLayerRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Reuse `AuthoritySourceConfidence` (SPE-677) and `KnowledgeTier` (SPE-58) at runtime where records reference them.
+
+## Prerequisite (on `main` @ `9e050dd0`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/truthLayerRecordRegistry.ts` (SPE-2447 / PR #2772)         |
+| Fixtures             | `COMPETING_TRUTH_LAYERS_FIXTURE`, `ACTOR_TRUTH_LAYER_FIXTURE`          |
+| Sibling persistence  | `publicDisclosureRecords` (SPE-2325 / PR #2517)                        |
+| Source-confidence vocabulary | `AuthoritySourceConfidence` in `src/domain/authorityGraph.ts` (SPE-677) |
+| Knowledge-state vocabulary | `KnowledgeTier` in `src/domain/knowledge.ts` (SPE-58)                  |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `truthLayerRecords` on `GameState`                                  | Weekly orchestration hook                     |
+| `sanitizeTruthLayerRecords` + `runTransfer` hydrate wire             | Mirror UI                                     |
+| `validateTruthLayerRecord` on hydrate; drop invalid, no throw       | Myth-as-infrastructure ops projection (priority 2) |
+| Default `{}` in `createStartingState`                              | SPE-1343 parent Done                          |
+| Sanitize unit tests + save/import round-trip (byte-stable)         | PublicDisclosureRecord extensions             |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] `competingLayers` / slot fields byte-stable after round-trip
+- [x] Runtime wire-up: `AuthoritySourceConfidence` + `KnowledgeTier` on hydrated slots
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/truthLayerRecordRegistry.ts`, `src/domain/models.ts`    |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/truthLayerRecordRegistry.test.ts`                           |
+| Plan   | `planning/truth-layer-record-registry-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Weekly truth-layer progression hook | SPE-1343 slice 3+ | Persistence must land before orchestration |
+| Myth-as-infrastructure ops projection | SPE-1343 follow-up | Parent AC row 2; depends on persisted records |
+| Planning mirror UI | SPE-1343 slice 4+ | Mirror follows persistence pattern |
+| Cover narrative + agency operational record dual-incident pairing | SPE-899 / SPE-1347 | Parent AC row 4 partial |
+| Historical-icon normalcy pressure review surfaces | SPE-1343 follow-up | Parent AC row 5 |
+
+## See also
+
+- `planning/truth-layer-record-registry-slice-1.md`
+- `planning/public-disclosure-state-registry-slice-2.md` — persistence pattern (SPE-2325)
+- `src/domain/publicDisclosureStateRegistry.ts` — sibling registry; do not extend for truth layers

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -203,6 +203,7 @@ import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLoca
 import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
 import { sanitizeSelfCensoringInformationRecords } from '../../domain/selfCensoringInformationRegistry'
 import { sanitizePublicDisclosureRecords } from '../../domain/publicDisclosureStateRegistry'
+import { sanitizeTruthLayerRecords } from '../../domain/truthLayerRecordRegistry'
 import { sanitizePatternSourceSeriesRecords } from '../../domain/patternSourceSeriesRegistry'
 import { sanitizeMassAnomalousPopulationEmergenceRecords } from '../../domain/massAnomalousPopulationEmergenceRegistry'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
@@ -8498,6 +8499,10 @@ export function hydrateGame(
     game.publicDisclosureRecords,
     fallback.publicDisclosureRecords ?? {}
   )
+  const truthLayerRecords = sanitizeTruthLayerRecords(
+    game.truthLayerRecords,
+    fallback.truthLayerRecords ?? {}
+  )
   const patternSourceSeriesRecords = sanitizePatternSourceSeriesRecords(
     game.patternSourceSeriesRecords,
     fallback.patternSourceSeriesRecords ?? {}
@@ -8681,6 +8686,7 @@ export function hydrateGame(
       ruleDocumentComplianceRecords,
       selfCensoringInformationRecords,
       publicDisclosureRecords,
+      truthLayerRecords,
       patternSourceSeriesRecords,
       massAnomalousPopulationEmergenceRecords,
       visualTriggerHazardRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -50,6 +50,7 @@ const startingStateTemplate: GameState = {
   ruleDocumentComplianceRecords: {},
   selfCensoringInformationRecords: {},
   publicDisclosureRecords: {},
+  truthLayerRecords: {},
   patternSourceSeriesRecords: {},
   massAnomalousPopulationEmergenceRecords: {},
   visualTriggerHazardRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -255,6 +255,7 @@ import type { PostIncidentReviewRecommendationRecord } from './postIncidentRevie
 import type { RuleDocumentComplianceRecord } from './ruleDocumentComplianceContainmentRegistry'
 import type { SelfCensoringInformationRecord } from './selfCensoringInformationRegistry'
 import type { PublicDisclosureRecord } from './publicDisclosureStateRegistry'
+import type { TruthLayerRecord } from './truthLayerRecordRegistry'
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
@@ -2653,6 +2654,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   publicDisclosureRecords?: Record<string, PublicDisclosureRecord>
+
+  /**
+   * SPE-1343 slice 2: persisted truth-layer records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  truthLayerRecords?: Record<string, TruthLayerRecord>
 
   /**
    * SPE-2110 slice 2: persisted pattern source series records (keyed by record id).

--- a/src/domain/truthLayerRecordRegistry.ts
+++ b/src/domain/truthLayerRecordRegistry.ts
@@ -798,6 +798,186 @@ export const COMPETING_TRUTH_LAYERS_FIXTURE: TruthLayerRecord = defineRecord({
   confidence: 0.55,
 })
 
+// ---------------------------------------------------------------------------
+// Persistence (SPE-1343 slice 2)
+// ---------------------------------------------------------------------------
+
+export type TruthLayerRecordsMap = Record<TruthLayerRecordId, TruthLayerRecord>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+function parseTruthLayerSlot(value: unknown): TruthLayerSlot | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const narrative = normalizeToken(value.narrative)
+  if (!narrative) {
+    return null
+  }
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const sourceConfidence =
+    typeof value.sourceConfidence === 'string' && isSourceConfidence(value.sourceConfidence)
+      ? value.sourceConfidence
+      : undefined
+  const knowledgeTier =
+    typeof value.knowledgeTier === 'string' && isKnowledgeTier(value.knowledgeTier)
+      ? value.knowledgeTier
+      : undefined
+  const lastUpdatedWeek = isFiniteWeek(value.lastUpdatedWeek) ? value.lastUpdatedWeek : undefined
+  const evidenceRef = normalizeToken(value.evidenceRef ?? '') || undefined
+
+  return {
+    narrative,
+    ...(summary ? { summary } : {}),
+    ...(sourceConfidence ? { sourceConfidence } : {}),
+    ...(knowledgeTier ? { knowledgeTier } : {}),
+    ...(lastUpdatedWeek !== undefined ? { lastUpdatedWeek } : {}),
+    ...(evidenceRef ? { evidenceRef } : {}),
+  }
+}
+
+function parseCompetingLayers(value: unknown): readonly CompetingTruthLayerRef[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const layers: CompetingTruthLayerRef[] = []
+
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue
+    }
+
+    const recordRef = normalizeToken(entry.recordRef)
+    const layerRole = entry.layerRole
+    if (
+      !recordRef ||
+      typeof layerRole !== 'string' ||
+      !isCompetingLayerRoleValue(layerRole)
+    ) {
+      continue
+    }
+
+    const note =
+      typeof entry.note === 'string' && entry.note.trim().length > 0
+        ? entry.note.trim()
+        : undefined
+
+    layers.push(note ? { recordRef, layerRole, note } : { recordRef, layerRole })
+  }
+
+  return layers
+}
+
+function sanitizeTruthLayerRecordEntry(value: unknown): TruthLayerRecord | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const subjectRef = normalizeToken(value.subjectRef)
+  const subjectKind = value.subjectKind
+  const claim = parseTruthLayerSlot(value.claim)
+  const doctrine = parseTruthLayerSlot(value.doctrine)
+  const verification = parseTruthLayerSlot(value.verification)
+
+  if (
+    !id ||
+    !label ||
+    !subjectRef ||
+    typeof subjectKind !== 'string' ||
+    !isSubjectKind(subjectKind) ||
+    !claim ||
+    !doctrine ||
+    !verification
+  ) {
+    return null
+  }
+
+  const competingLayers = parseCompetingLayers(value.competingLayers)
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const parentCaseRef = normalizeToken(value.parentCaseRef ?? '') || undefined
+  const linkedDisclosureRef = normalizeToken(value.linkedDisclosureRef ?? '') || undefined
+  const correctionPressure = value.correctionPressure
+  const mythInfrastructureWeight = value.mythInfrastructureWeight
+  const confidence = value.confidence
+
+  const record: TruthLayerRecord = {
+    id,
+    label,
+    subjectRef,
+    subjectKind,
+    claim,
+    doctrine,
+    verification,
+    ...(summary ? { summary } : {}),
+    ...(parentCaseRef ? { parentCaseRef } : {}),
+    ...(competingLayers.length > 0 ? { competingLayers } : {}),
+    ...(isValidUnitScore(correctionPressure) ? { correctionPressure } : {}),
+    ...(isValidUnitScore(mythInfrastructureWeight) ? { mythInfrastructureWeight } : {}),
+    ...(linkedDisclosureRef ? { linkedDisclosureRef } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateTruthLayerRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical record map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeTruthLayerRecords(
+  value: unknown,
+  fallback: TruthLayerRecordsMap = {}
+): TruthLayerRecordsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const next: TruthLayerRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeTruthLayerRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 /** Actor subject with separate claim/doctrine/verification slots for round-trip checks. */
 export const ACTOR_TRUTH_LAYER_FIXTURE: TruthLayerRecord = defineRecord({
   id: 'truth:regional-oversight-commissioner',

--- a/src/test/truthLayerRecordRegistry.test.ts
+++ b/src/test/truthLayerRecordRegistry.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import type { AuthoritySourceConfidence } from '../domain/authorityGraph'
+import type { KnowledgeTier } from '../domain/knowledge'
 import {
   ACTOR_TRUTH_LAYER_FIXTURE,
   COMPETING_LAYER_ROLES,
   COMPETING_TRUTH_LAYERS_FIXTURE,
   TRUTH_LAYER_SUBJECT_KINDS,
+  isTruthLayerKnowledgeTier,
+  isTruthLayerSourceConfidence,
   projectTruthLayerReviewView,
+  sanitizeTruthLayerRecords,
   validateTruthLayerRecord,
   type TruthLayerRecord,
 } from '../domain/truthLayerRecordRegistry'
@@ -188,5 +196,150 @@ describe('truthLayerRecordRegistry (SPE-1343 slice 1)', () => {
     const second = JSON.stringify(validateTruthLayerRecord(record))
 
     expect(first).toBe(second)
+  })
+})
+
+describe('truthLayerRecordRegistry persistence (SPE-1343 slice 2)', () => {
+  it('defaults starting state to an empty truth-layer map', () => {
+    expect(createStartingState().truthLayerRecords).toEqual({})
+  })
+
+  it('reuses AuthoritySourceConfidence and KnowledgeTier at runtime on hydrated slots', () => {
+    const claimConfidence = COMPETING_TRUTH_LAYERS_FIXTURE.claim.sourceConfidence
+    const doctrineTier = COMPETING_TRUTH_LAYERS_FIXTURE.doctrine.knowledgeTier
+
+    expect(claimConfidence).toBeDefined()
+    expect(doctrineTier).toBeDefined()
+    expect(isTruthLayerSourceConfidence(claimConfidence as string)).toBe(true)
+    expect(isTruthLayerKnowledgeTier(doctrineTier as string)).toBe(true)
+
+    const confidence: AuthoritySourceConfidence = claimConfidence as AuthoritySourceConfidence
+    const tier: KnowledgeTier = doctrineTier as KnowledgeTier
+
+    expect(confidence).toBe('public_cover')
+    expect(tier).toBe('observed')
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeTruthLayerRecords(
+      {
+        valid: COMPETING_TRUTH_LAYERS_FIXTURE,
+        actor: ACTOR_TRUTH_LAYER_FIXTURE,
+        'wrong-key': {
+          ...COMPETING_TRUTH_LAYERS_FIXTURE,
+          id: 'truth:regional-oversight-commissioner',
+        },
+        duplicate: {
+          ...COMPETING_TRUTH_LAYERS_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          subjectRef: 'event:test',
+          subjectKind: 'event',
+          claim: { narrative: 'claim' },
+          doctrine: { narrative: 'doctrine' },
+          verification: { narrative: 'verification' },
+        },
+        franchiseLabel: {
+          id: 'truth:franchise',
+          label: 'Foundation cover narrative review',
+          subjectRef: 'event:test',
+          subjectKind: 'event',
+          claim: { narrative: 'Public claim narrative.' },
+          doctrine: { narrative: 'Institutional doctrine narrative.' },
+          verification: { narrative: 'Field verification narrative.' },
+        },
+        invalidConfidence: {
+          id: 'truth:invalid-confidence',
+          label: 'Invalid source confidence',
+          subjectRef: 'event:test',
+          subjectKind: 'event',
+          claim: { narrative: 'Public claim narrative.', sourceConfidence: 'not_a_level' },
+          doctrine: { narrative: 'Institutional doctrine narrative.' },
+          verification: { narrative: 'Field verification narrative.' },
+        },
+        invalidTier: {
+          id: 'truth:invalid-tier',
+          label: 'Invalid knowledge tier',
+          subjectRef: 'event:test',
+          subjectKind: 'event',
+          claim: { narrative: 'Public claim narrative.' },
+          doctrine: { narrative: 'Institutional doctrine narrative.', knowledgeTier: 'not_a_tier' },
+          verification: { narrative: 'Field verification narrative.' },
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized['truth:coastal-research-campus-incident']).toEqual(
+      COMPETING_TRUTH_LAYERS_FIXTURE
+    )
+    expect(sanitized['truth:regional-oversight-commissioner']).toEqual(ACTOR_TRUTH_LAYER_FIXTURE)
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.franchiseLabel).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['wrong-key']).toBeUndefined()
+    expect(sanitized['truth:invalid-confidence']?.claim.sourceConfidence).toBeUndefined()
+    expect(sanitized['truth:invalid-confidence']?.claim.narrative).toBe('Public claim narrative.')
+    expect(sanitized['truth:invalid-tier']?.doctrine.knowledgeTier).toBeUndefined()
+    expect(sanitized['truth:invalid-tier']?.doctrine.narrative).toBe(
+      'Institutional doctrine narrative.'
+    )
+    expect(Object.keys(sanitized).sort()).toEqual([
+      'truth:coastal-research-campus-incident',
+      'truth:invalid-confidence',
+      'truth:invalid-tier',
+      'truth:regional-oversight-commissioner',
+    ])
+  })
+
+  it('round-trips fixture records with nested arrays byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.truthLayerRecords).toEqual(state.truthLayerRecords)
+    expect(
+      loaded.truthLayerRecords?.[COMPETING_TRUTH_LAYERS_FIXTURE.id]?.competingLayers
+    ).toEqual(COMPETING_TRUTH_LAYERS_FIXTURE.competingLayers)
+    expect(loaded.truthLayerRecords?.[COMPETING_TRUTH_LAYERS_FIXTURE.id]?.claim).toEqual(
+      COMPETING_TRUTH_LAYERS_FIXTURE.claim
+    )
+    expect(loaded.truthLayerRecords?.[ACTOR_TRUTH_LAYER_FIXTURE.id]?.verification).toEqual(
+      ACTOR_TRUTH_LAYER_FIXTURE.verification
+    )
+  })
+
+  it('hydrates persisted truth-layer records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        truthLayerRecords: {
+          [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+          invalid: {
+            id: 'truth:invalid',
+            label: 'Foundation cover narrative review',
+            subjectRef: 'event:test',
+            subjectKind: 'event',
+            claim: { narrative: 'Public claim narrative.' },
+            doctrine: { narrative: 'Institutional doctrine narrative.' },
+            verification: { narrative: 'Field verification narrative.' },
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.truthLayerRecords).toEqual({
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Add `truthLayerRecords` map to `GameState` with `sanitizeTruthLayerRecords` hydration in the domain module and `runTransfer` wire-up.
- Reuse `AuthoritySourceConfidence` (SPE-677) and `KnowledgeTier` (SPE-58) at runtime where records reference them; drop invalid/duplicate-id entries without throwing.
- Extend tests for sanitize round-trip, duplicate-id drop, invalid payload handling, and save/import hydrate integration.

## Linear

- **Slice:** [SPE-2448](https://linear.app/spectranoir/issue/SPE-2448) — Truth-layer record registry GameState persistence (slice 2)
- **Parent:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — Public myth operational truth split (remains **Backlog**)

## What shipped

- `sanitizeTruthLayerRecords` + `TruthLayerRecordsMap` in `src/domain/truthLayerRecordRegistry.ts`
- `GameState.truthLayerRecords` field + default `{}` in `createStartingState`
- Hydrate wire in `src/app/store/runTransfer.ts`
- Persistence tests in `src/test/truthLayerRecordRegistry.test.ts`
- Slice doc: `planning/truth-layer-record-registry-slice-2.md`

## Validation

- `npm run test:run -- src/test/truthLayerRecordRegistry.test.ts`
- `npm run lint`

## Docs updated

- `planning/truth-layer-record-registry-slice-2.md`

## Parent status

SPE-1343 parent remains open — persistence-only slice; myth-as-infrastructure ops hook and mirror UI deferred.