### PR TITLE
feat(SPE-2449): truth-layer weekly orchestration hook slice 3

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) truth-layer slice 3+ (weekly orchestration hook or myth-as-infrastructure ops projection); mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
+**Next step:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) truth-layer slice 4+ (planning mirror UI); mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
 
-**Base `main` SHA:** `17f770c1` — shipped: SPE-2448 truth-layer record registry slice 2 @ `planning/truth-layer-record-registry-slice-2.md` (PR #2774)
+**Base `main` SHA:** `f9a66c4c` — shipped: SPE-2449 truth-layer record registry slice 3 @ `planning/truth-layer-record-registry-slice-3.md` (PR pending)
 
-**Recently shipped:** SPE-2448 truth-layer record registry slice 2 (PR #2774); SPE-2447 truth-layer record registry slice 1 (PR #2772); SPE-1343 grooming slice 2 (PR #2769).
+**Recently shipped:** SPE-2449 truth-layer record registry slice 3 (PR pending); SPE-2448 truth-layer record registry slice 2 (PR #2774); SPE-2447 truth-layer record registry slice 1 (PR #2772).
 
 ## Blocked / waiting
 
@@ -231,6 +231,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1343-parent-acceptance-review-slice-2.md`            | **Shipped**    | SPE-2446 / PR #2769; SPE-1343 stays Backlog — registry wave + SPE-2122 follow-on groomed; truth-layer priority @ `b0d319f2`.                            |
 | `truth-layer-record-registry-slice-1.md`                  | **Shipped**    | SPE-2447 / PR #2772; truth-layer record schema (claim / doctrine / verification) @ `080608e6`.                                                       |
 | `truth-layer-record-registry-slice-2.md`                  | **Shipped**    | SPE-2448 / PR #2774; `truthLayerRecords` GameState persistence @ `17f770c1`.                                                                         |
+| `truth-layer-record-registry-slice-3.md`                  | In progress    | SPE-2449; weekly orchestration hook + myth-as-infrastructure ops projection @ `f9a66c4c`.                                                          |
 | `spe-1310-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2402 / PR #2673; SPE-1310 stays Backlog — SPE-2117 + SPE-2123 children Done; case lifecycle AC not met @ `936b2576`.                               |
 | `spe-1615-psychological-resilience-registry-slice-1.md`   | **Shipped**    | SPE-2433 / PR #2737; psychological resilience registry domain anchor @ `a8503939`.                                                                      |
 | `spe-1615-psychological-resilience-registry-slice-2.md`   | **Shipped**    | SPE-2434 / PR #2739; `psychologicalResilienceRecords` GameState persistence @ `467fe4d6`.                                                               |

--- a/planning/truth-layer-record-registry-slice-3.md
+++ b/planning/truth-layer-record-registry-slice-3.md
@@ -1,0 +1,77 @@
+# SPE-1343 — Truth-layer weekly orchestration hook (slice 3)
+
+One-page implementation plan. Linear: [SPE-2449](https://linear.app/spectranoir/issue/SPE-2449) (child under [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343)). Follows shipped [SPE-2448](https://linear.app/spectranoir/issue/SPE-2448) slice 2 (`planning/truth-layer-record-registry-slice-2.md`, PR #2774).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2449 — Truth-layer weekly orchestration hook (slice 3)](https://linear.app/spectranoir/issue/SPE-2449) |
+| **Parent** | [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — Public myth / operational truth split; stays **Backlog** |
+| **Branch** | `spe-1343-truth-layer-record-registry-slice-3`                                                             |
+| **Status** | In progress                                                                                                |
+| **Base `main` SHA** | `f9a66c4c`                                                                                          |
+
+## Goal
+
+Wire persisted `truthLayerRecords` into `advanceWeek` with a weekly orchestration hook that projects myth-as-infrastructure ops signals (`mythInfrastructureActive`, `correctionPressure`, `mythDrivesOpsWithoutVerification`) without collapsing claim, doctrine, and verification layers. Mirror the SPE-2326 disclosure progression orchestration pattern and the SPE-1882 coercive-protocol weekly snapshot pattern.
+
+## Prerequisite (on `main` @ `f9a66c4c`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/truthLayerRecordRegistry.ts` (SPE-2447 / PR #2772)         |
+| Persistence          | `truthLayerRecords` on `GameState` (SPE-2448 / PR #2774)               |
+| Review projection    | `projectTruthLayerReviewView` (slice 1)                                |
+| Sibling weekly hook  | `applyWeeklyPublicDisclosureProgressionTick` (SPE-2326 / PR #2519)     |
+| Snapshot pattern     | `applyWeeklyCoerciveProtocolTick` (SPE-1882 slice 3/5)                |
+
+## Orchestration contract (slice 3)
+
+- **Ops projection** — `projectTruthLayerOpsView(record)` derives myth infrastructure, correction pressure, and layer divergence from separate truth layers; does not collapse claim/doctrine/verification.
+- **Weekly tick** — `applyWeeklyTruthLayerTick(records, week, snapshots)` preserves source records byte-stable; persists `truthLayerWeeklyProjectionSnapshots` keyed by record id.
+- **No-op** — empty `truthLayerRecords` map; re-tick same week is idempotent.
+- **Does not** — extend `PublicDisclosureRecord`, mutate truth-layer record fields, or add mirror UI.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `projectTruthLayerOpsView` + snapshot types in registry module         | SPE-1343 parent Done                          |
+| `applyWeeklyTruthLayerTick` in `truthLayerWeeklyOrchestration.ts`      | Planning mirror UI (slice 4+)                 |
+| `truthLayerWeeklyProjectionSnapshots` on `GameState` + hydrate wire    | Public-disclosure registry runtime changes    |
+| Call from `advanceWeek` after week increment (`result.week`)           | Cover narrative dual-incident pairing         |
+| Targeted domain + `advanceWeek` integration tests                      | Mission triage expansion                      |
+| Slice doc (this file) + backlog handoff                              | Historical-icon normalcy pressure surfaces    |
+
+## Acceptance
+
+- [x] Empty `truthLayerRecords` map is a no-op without throw
+- [x] Fixture records byte-stable through `advanceWeek` tick
+- [x] Weekly ops snapshots persist `mythInfrastructureActive` and `correctionPressure` without collapsing layers
+- [x] Re-applying tick for same post-advance week is idempotent
+- [x] `validateTruthLayerRecord` byte-stable validation unchanged from slice 1
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/truthLayerRecordRegistry.ts`, `src/domain/truthLayerWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/truthLayerWeeklyOrchestration.test.ts`, `src/test/advanceWeek.truthLayerRecords.integration.test.ts`, `src/test/truthLayerRecordRegistry.test.ts` |
+| Plan   | `planning/truth-layer-record-registry-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Planning mirror UI for truth-layer review | SPE-1343 slice 4+ | Mirror follows orchestration pattern |
+| Cover narrative + agency operational record dual-incident pairing | SPE-899 / SPE-1347 | Parent AC row 4 partial |
+| Historical-icon normalcy pressure review surfaces | SPE-1343 follow-up | Parent AC row 5 |
+| Disclosure campaign player UI / post-secrecy orchestration | SPE-1343 / SPE-861 | Parent scope |
+
+## See also
+
+- `planning/truth-layer-record-registry-slice-2.md`
+- `planning/public-disclosure-state-registry-slice-3.md` — sibling weekly hook pattern (SPE-2326)
+- `src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts` — snapshot orchestration pattern

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -203,7 +203,10 @@ import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLoca
 import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
 import { sanitizeSelfCensoringInformationRecords } from '../../domain/selfCensoringInformationRegistry'
 import { sanitizePublicDisclosureRecords } from '../../domain/publicDisclosureStateRegistry'
-import { sanitizeTruthLayerRecords } from '../../domain/truthLayerRecordRegistry'
+import {
+  sanitizeTruthLayerRecords,
+  sanitizeTruthLayerWeeklyProjectionSnapshots,
+} from '../../domain/truthLayerRecordRegistry'
 import { sanitizePatternSourceSeriesRecords } from '../../domain/patternSourceSeriesRegistry'
 import { sanitizeMassAnomalousPopulationEmergenceRecords } from '../../domain/massAnomalousPopulationEmergenceRegistry'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
@@ -8503,6 +8506,11 @@ export function hydrateGame(
     game.truthLayerRecords,
     fallback.truthLayerRecords ?? {}
   )
+  const truthLayerWeeklyProjectionSnapshots = sanitizeTruthLayerWeeklyProjectionSnapshots(
+    game.truthLayerWeeklyProjectionSnapshots,
+    fallback.truthLayerWeeklyProjectionSnapshots ?? {},
+    new Set(Object.keys(truthLayerRecords))
+  )
   const patternSourceSeriesRecords = sanitizePatternSourceSeriesRecords(
     game.patternSourceSeriesRecords,
     fallback.patternSourceSeriesRecords ?? {}
@@ -8687,6 +8695,7 @@ export function hydrateGame(
       selfCensoringInformationRecords,
       publicDisclosureRecords,
       truthLayerRecords,
+      truthLayerWeeklyProjectionSnapshots,
       patternSourceSeriesRecords,
       massAnomalousPopulationEmergenceRecords,
       visualTriggerHazardRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -51,6 +51,7 @@ const startingStateTemplate: GameState = {
   selfCensoringInformationRecords: {},
   publicDisclosureRecords: {},
   truthLayerRecords: {},
+  truthLayerWeeklyProjectionSnapshots: {},
   patternSourceSeriesRecords: {},
   massAnomalousPopulationEmergenceRecords: {},
   visualTriggerHazardRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -255,7 +255,10 @@ import type { PostIncidentReviewRecommendationRecord } from './postIncidentRevie
 import type { RuleDocumentComplianceRecord } from './ruleDocumentComplianceContainmentRegistry'
 import type { SelfCensoringInformationRecord } from './selfCensoringInformationRegistry'
 import type { PublicDisclosureRecord } from './publicDisclosureStateRegistry'
-import type { TruthLayerRecord } from './truthLayerRecordRegistry'
+import type {
+  TruthLayerRecord,
+  TruthLayerWeeklyProjectionSnapshot,
+} from './truthLayerRecordRegistry'
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
@@ -2660,6 +2663,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   truthLayerRecords?: Record<string, TruthLayerRecord>
+
+  /**
+   * SPE-1343 slice 3: persisted weekly myth-as-infrastructure ops projection snapshots (keyed by record id).
+   * Hydration drops invalid entries and orphans not present in truth-layer records.
+   */
+  truthLayerWeeklyProjectionSnapshots?: Record<string, TruthLayerWeeklyProjectionSnapshot>
 
   /**
    * SPE-2110 slice 2: persisted pattern source series records (keyed by record id).

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -270,6 +270,7 @@ import { applyWeeklyVisualTriggerHazardTick } from '../visualTriggerHazardWeekly
 import { applyWeeklyNamingHazardDescriptorTick } from '../namingHazardDescriptorWeeklyOrchestration'
 import { applyWeeklyTherapeuticCareTick } from '../containedPersonTherapeuticCareWeeklyOrchestration'
 import { applyWeeklyCoerciveProtocolTick } from '../coerciveContainedPersonProtocolWeeklyOrchestration'
+import { applyWeeklyTruthLayerTick } from '../truthLayerWeeklyOrchestration'
 import { applyWeeklySurveillanceInterventionTuningTick } from '../surveillanceInterventionTuningWeeklyOrchestration'
 import { applyWeeklyPsychologicalResilienceDepletionTick } from '../psychologicalResilienceWeeklyOrchestration'
 import {
@@ -4638,6 +4639,18 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       currentPublicDisclosureRecords,
       result.week
     )
+  }
+
+  // SPE-1343 slice 3: myth-as-infrastructure ops projection on persisted truth-layer records.
+  const currentTruthLayerRecords = outputWeeklyState.truthLayerRecords ?? {}
+  if (Object.keys(currentTruthLayerRecords).length > 0) {
+    const truthLayerTick = applyWeeklyTruthLayerTick(
+      currentTruthLayerRecords,
+      result.week,
+      outputWeeklyState.truthLayerWeeklyProjectionSnapshots
+    )
+    outputWeeklyState.truthLayerRecords = truthLayerTick.records
+    outputWeeklyState.truthLayerWeeklyProjectionSnapshots = truthLayerTick.snapshots
   }
 
   // SPE-2110 slice 3: advance readiness-gated pattern-source intake processing pipeline.

--- a/src/domain/truthLayerRecordRegistry.ts
+++ b/src/domain/truthLayerRecordRegistry.ts
@@ -157,6 +157,35 @@ export interface TruthLayerReviewProjection {
   readonly unknownFields: readonly string[]
 }
 
+/** SPE-1343 slice 3: ops-facing projection — myth infrastructure and correction pressure without collapsing layers. */
+export interface TruthLayerOpsProjection {
+  readonly recordId: TruthLayerRecordId
+  readonly subjectRef: string
+  readonly subjectKind: TruthLayerSubjectKind
+  readonly mythInfrastructureActive: boolean
+  readonly correctionPressure: number | null
+  readonly layerDivergence: boolean
+  readonly mythDrivesOpsWithoutVerification: boolean
+  readonly claimSourceConfidence: TruthLayerSourceConfidence | null
+  readonly verificationSourceConfidence: TruthLayerSourceConfidence | null
+  readonly redacted: boolean
+}
+
+/** SPE-1343 slice 3: persisted weekly ops projection snapshot for one truth-layer record. */
+export interface TruthLayerWeeklyProjectionSnapshot {
+  readonly recordId: TruthLayerRecordId
+  readonly week: number
+  readonly ops: TruthLayerOpsProjection
+}
+
+export type TruthLayerWeeklyProjectionSnapshotsMap = Record<
+  TruthLayerRecordId,
+  TruthLayerWeeklyProjectionSnapshot
+>
+
+/** Upper bound on persisted weekly projection snapshot entries (byte-stable record-id keys). */
+export const MAX_TRUTH_LAYER_WEEKLY_PROJECTION_SNAPSHOTS = 128
+
 // ---------------------------------------------------------------------------
 // Internal constants
 // ---------------------------------------------------------------------------
@@ -745,6 +774,34 @@ export function projectTruthLayerReviewView(
   })
 }
 
+/**
+ * Projects myth-as-infrastructure ops signals from separate truth layers.
+ * Public myth may drive ops without treating the claim as a verified mechanism.
+ */
+export function projectTruthLayerOpsView(
+  record: TruthLayerRecord,
+  policy: TruthLayerReviewProjectionPolicy = {}
+): TruthLayerOpsProjection {
+  const review = projectTruthLayerReviewView(record, policy)
+  const verificationConfidence = review.verification.sourceConfidence
+  const mythDrivesOpsWithoutVerification =
+    review.mythInfrastructureActive &&
+    (review.layerDivergence || verificationConfidence !== 'verified')
+
+  return Object.freeze({
+    recordId: review.recordId,
+    subjectRef: review.subjectRef,
+    subjectKind: review.subjectKind,
+    mythInfrastructureActive: review.mythInfrastructureActive,
+    correctionPressure: review.correctionPressure,
+    layerDivergence: review.layerDivergence,
+    mythDrivesOpsWithoutVerification,
+    claimSourceConfidence: review.claim.sourceConfidence,
+    verificationSourceConfidence: verificationConfidence,
+    redacted: review.redacted,
+  })
+}
+
 function defineRecord(record: TruthLayerRecord): TruthLayerRecord {
   return Object.freeze({ ...record })
 }
@@ -973,6 +1030,132 @@ export function sanitizeTruthLayerRecords(
 
     seenIds.add(record.id)
     next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
+function sanitizeTruthLayerOpsProjection(
+  value: unknown,
+  recordId: string
+): TruthLayerOpsProjection | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const normalizedRecordId = normalizeToken(value.recordId ?? recordId)
+  if (!normalizedRecordId || normalizedRecordId !== normalizeToken(recordId)) {
+    return null
+  }
+
+  const subjectRef = normalizeToken(value.subjectRef)
+  if (!subjectRef) {
+    return null
+  }
+
+  const subjectKindRaw = value.subjectKind
+  if (typeof subjectKindRaw !== 'string' || !isSubjectKind(subjectKindRaw)) {
+    return null
+  }
+
+  const correctionPressure =
+    value.correctionPressure === null || value.correctionPressure === undefined
+      ? null
+      : isValidUnitScore(value.correctionPressure)
+        ? value.correctionPressure
+        : null
+
+  const claimSourceConfidence =
+    typeof value.claimSourceConfidence === 'string' &&
+    isSourceConfidence(value.claimSourceConfidence)
+      ? value.claimSourceConfidence
+      : null
+
+  const verificationSourceConfidence =
+    typeof value.verificationSourceConfidence === 'string' &&
+    isSourceConfidence(value.verificationSourceConfidence)
+      ? value.verificationSourceConfidence
+      : null
+
+  return Object.freeze({
+    recordId: normalizedRecordId,
+    subjectRef,
+    subjectKind: subjectKindRaw,
+    mythInfrastructureActive: value.mythInfrastructureActive === true,
+    correctionPressure,
+    layerDivergence: value.layerDivergence === true,
+    mythDrivesOpsWithoutVerification: value.mythDrivesOpsWithoutVerification === true,
+    claimSourceConfidence,
+    verificationSourceConfidence,
+    redacted: value.redacted === true,
+  })
+}
+
+function sanitizeTruthLayerWeeklyProjectionSnapshotEntry(
+  key: string,
+  value: unknown
+): TruthLayerWeeklyProjectionSnapshot | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const recordId = normalizeToken(value.recordId ?? key)
+  if (!recordId || recordId !== normalizeToken(key)) {
+    return null
+  }
+
+  const weekRaw = value.week
+  if (typeof weekRaw !== 'number' || !Number.isFinite(weekRaw)) {
+    return null
+  }
+
+  const week = Math.max(1, Math.trunc(weekRaw))
+  const ops = sanitizeTruthLayerOpsProjection(value.ops, recordId)
+  if (!ops || ops.recordId !== recordId) {
+    return null
+  }
+
+  return Object.freeze({
+    recordId,
+    week,
+    ops,
+  })
+}
+
+/** Hydration: canonical weekly projection snapshot map keyed by record id; drops invalid entries. */
+export function sanitizeTruthLayerWeeklyProjectionSnapshots(
+  value: unknown,
+  fallback: TruthLayerWeeklyProjectionSnapshotsMap = {},
+  knownRecordIds?: ReadonlySet<string>
+): TruthLayerWeeklyProjectionSnapshotsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const candidates: TruthLayerWeeklyProjectionSnapshot[] = []
+
+  for (const [key, entry] of Object.entries(value)) {
+    const snapshot = sanitizeTruthLayerWeeklyProjectionSnapshotEntry(key, entry)
+    if (!snapshot) {
+      continue
+    }
+
+    if (knownRecordIds && !knownRecordIds.has(snapshot.recordId)) {
+      continue
+    }
+
+    candidates.push(snapshot)
+  }
+
+  if (candidates.length === 0) {
+    return fallback
+  }
+
+  candidates.sort((left, right) => left.recordId.localeCompare(right.recordId))
+
+  const next: TruthLayerWeeklyProjectionSnapshotsMap = {}
+  for (const snapshot of candidates.slice(0, MAX_TRUTH_LAYER_WEEKLY_PROJECTION_SNAPSHOTS)) {
+    next[snapshot.recordId] = snapshot
   }
 
   return Object.keys(next).length > 0 ? next : fallback

--- a/src/domain/truthLayerWeeklyOrchestration.ts
+++ b/src/domain/truthLayerWeeklyOrchestration.ts
@@ -1,0 +1,179 @@
+/**
+ * SPE-1343 slice 3: weekly orchestration for persisted truth-layer records.
+ *
+ * Pure deterministic tick: runs myth-as-infrastructure ops projections each week,
+ * persists bounded weekly projection snapshots, and preserves source records byte-stable.
+ * Does not extend PublicDisclosureRecord or collapse claim/doctrine/verification layers.
+ */
+
+import {
+  projectTruthLayerOpsView,
+  type TruthLayerOpsProjection,
+  type TruthLayerRecord,
+  type TruthLayerRecordsMap,
+  type TruthLayerWeeklyProjectionSnapshot,
+  type TruthLayerWeeklyProjectionSnapshotsMap,
+} from './truthLayerRecordRegistry'
+
+export interface TruthLayerWeeklyProjectionBundle {
+  readonly recordId: string
+  readonly week: number
+  readonly ops: TruthLayerOpsProjection
+}
+
+export interface TruthLayerWeeklyTickResult {
+  readonly records: TruthLayerRecordsMap
+  readonly snapshots: TruthLayerWeeklyProjectionSnapshotsMap
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function freezeSnapshot(
+  bundle: TruthLayerWeeklyProjectionBundle
+): TruthLayerWeeklyProjectionSnapshot {
+  return Object.freeze({
+    recordId: bundle.recordId,
+    week: bundle.week,
+    ops: bundle.ops,
+  })
+}
+
+function weeklyProjectionSnapshotsEqual(
+  left: TruthLayerWeeklyProjectionSnapshot,
+  right: TruthLayerWeeklyProjectionSnapshot
+): boolean {
+  if (left.recordId !== right.recordId || left.week !== right.week) {
+    return false
+  }
+
+  return JSON.stringify(left.ops) === JSON.stringify(right.ops)
+}
+
+/**
+ * Builds the deterministic weekly ops projection bundle for one truth-layer record.
+ */
+export function buildTruthLayerWeeklyProjectionBundle(
+  record: TruthLayerRecord,
+  week: number
+): TruthLayerWeeklyProjectionBundle {
+  return Object.freeze({
+    recordId: record.id,
+    week: normalizeWeek(week),
+    ops: projectTruthLayerOpsView(record),
+  })
+}
+
+/**
+ * Projects all persisted truth-layer records for the simulation week in stable id order.
+ * Returns an empty frozen array when the map is empty.
+ */
+export function projectTruthLayerRecordsForWeek(
+  records: TruthLayerRecordsMap | null | undefined,
+  week: number
+): readonly TruthLayerWeeklyProjectionBundle[] {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return Object.freeze([])
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const bundles: TruthLayerWeeklyProjectionBundle[] = []
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    bundles.push(buildTruthLayerWeeklyProjectionBundle(record, normalizedWeek))
+  }
+
+  return Object.freeze(bundles)
+}
+
+function persistWeeklyProjectionSnapshots(
+  records: TruthLayerRecordsMap,
+  snapshots: TruthLayerWeeklyProjectionSnapshotsMap,
+  week: number
+): TruthLayerWeeklyProjectionSnapshotsMap {
+  const normalizedWeek = normalizeWeek(week)
+  const recordIds = Object.keys(records).sort((left, right) => left.localeCompare(right))
+  let nextSnapshots: TruthLayerWeeklyProjectionSnapshotsMap | null = null
+
+  for (const recordId of recordIds) {
+    const record = records[recordId]
+    if (!record) {
+      continue
+    }
+
+    const bundle = buildTruthLayerWeeklyProjectionBundle(record, normalizedWeek)
+    const candidate = freezeSnapshot(bundle)
+    const existing = (nextSnapshots ?? snapshots)[recordId]
+
+    if (existing && weeklyProjectionSnapshotsEqual(existing, candidate)) {
+      continue
+    }
+
+    if (!nextSnapshots) {
+      nextSnapshots = { ...snapshots }
+    }
+
+    nextSnapshots[recordId] = candidate
+  }
+
+  const activeRecordIds = new Set(recordIds)
+  const sourceSnapshots = nextSnapshots ?? snapshots
+  for (const snapshotId of Object.keys(sourceSnapshots)) {
+    if (activeRecordIds.has(snapshotId)) {
+      continue
+    }
+
+    if (!nextSnapshots) {
+      nextSnapshots = { ...snapshots }
+    }
+
+    delete nextSnapshots[snapshotId]
+  }
+
+  if (!nextSnapshots) {
+    return snapshots
+  }
+
+  return Object.keys(nextSnapshots).length > 0 ? nextSnapshots : {}
+}
+
+/**
+ * Applies one weekly orchestration pass over persisted truth-layer records.
+ * Runs deterministic ops projections, persists bounded weekly snapshots, and preserves
+ * source records byte-stable. Empty map is a no-op. Re-applying after advance is
+ * idempotent for the same week.
+ */
+export function applyWeeklyTruthLayerTick(
+  records: TruthLayerRecordsMap | null | undefined,
+  week: number,
+  snapshots: TruthLayerWeeklyProjectionSnapshotsMap | null | undefined = {}
+): TruthLayerWeeklyTickResult {
+  const safeRecords = records ?? {}
+  const safeSnapshots = snapshots ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return {
+      records: safeRecords,
+      snapshots: safeSnapshots,
+    }
+  }
+
+  const nextSnapshots = persistWeeklyProjectionSnapshots(safeRecords, safeSnapshots, week)
+
+  return {
+    records: safeRecords,
+    snapshots: nextSnapshots,
+  }
+}

--- a/src/test/advanceWeek.truthLayerRecords.integration.test.ts
+++ b/src/test/advanceWeek.truthLayerRecords.integration.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  ACTOR_TRUTH_LAYER_FIXTURE,
+  COMPETING_TRUTH_LAYERS_FIXTURE,
+  projectTruthLayerOpsView,
+} from '../domain/truthLayerRecordRegistry'
+import { applyWeeklyTruthLayerTick } from '../domain/truthLayerWeeklyOrchestration'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek truth-layer records integration (SPE-1343 slice 3)', () => {
+  it('is a no-op for an empty truth-layer map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.truthLayerRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.truthLayerRecords).toEqual({})
+    expect(nextState.truthLayerWeeklyProjectionSnapshots).toEqual({})
+  })
+
+  it('preserves fixture record references byte-stable after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.week).toBe(5)
+    expect(nextState.truthLayerRecords?.[COMPETING_TRUTH_LAYERS_FIXTURE.id]).toBe(
+      COMPETING_TRUTH_LAYERS_FIXTURE
+    )
+    expect(nextState.truthLayerRecords?.[ACTOR_TRUTH_LAYER_FIXTURE.id]).toBe(
+      ACTOR_TRUTH_LAYER_FIXTURE
+    )
+  })
+
+  it('persists weekly ops projection snapshots through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const snapshot =
+      nextState.truthLayerWeeklyProjectionSnapshots?.[COMPETING_TRUTH_LAYERS_FIXTURE.id]
+
+    expect(snapshot?.week).toBe(5)
+    expect(snapshot?.ops).toEqual(projectTruthLayerOpsView(COMPETING_TRUTH_LAYERS_FIXTURE))
+    expect(snapshot?.ops.mythInfrastructureActive).toBe(true)
+    expect(snapshot?.ops.correctionPressure).toBe(0.62)
+    expect(snapshot?.ops.mythDrivesOpsWithoutVerification).toBe(true)
+  })
+
+  it('is idempotent when truth-layer tick is re-applied at the post-advance week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    }
+
+    const once = advanceWeek(state)
+    const recordsAfterAdvance = once.truthLayerRecords ?? {}
+    const reticked = applyWeeklyTruthLayerTick(
+      recordsAfterAdvance,
+      once.week,
+      once.truthLayerWeeklyProjectionSnapshots
+    )
+
+    expect(reticked.records).toBe(recordsAfterAdvance)
+    expect(reticked.snapshots).toBe(once.truthLayerWeeklyProjectionSnapshots)
+    expect(reticked.records[COMPETING_TRUTH_LAYERS_FIXTURE.id]).toBe(
+      COMPETING_TRUTH_LAYERS_FIXTURE
+    )
+  })
+
+  it('preserves validation fixture byte-stable through advanceWeek tick', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 30
+    state.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.truthLayerRecords?.[COMPETING_TRUTH_LAYERS_FIXTURE.id]).toEqual(
+      COMPETING_TRUTH_LAYERS_FIXTURE
+    )
+    expect(nextState.truthLayerRecords?.[ACTOR_TRUTH_LAYER_FIXTURE.id]).toEqual(
+      ACTOR_TRUTH_LAYER_FIXTURE
+    )
+  })
+})

--- a/src/test/truthLayerRecordRegistry.test.ts
+++ b/src/test/truthLayerRecordRegistry.test.ts
@@ -11,6 +11,7 @@ import {
   TRUTH_LAYER_SUBJECT_KINDS,
   isTruthLayerKnowledgeTier,
   isTruthLayerSourceConfidence,
+  projectTruthLayerOpsView,
   projectTruthLayerReviewView,
   sanitizeTruthLayerRecords,
   validateTruthLayerRecord,
@@ -341,5 +342,35 @@ describe('truthLayerRecordRegistry persistence (SPE-1343 slice 2)', () => {
     expect(hydrated.truthLayerRecords).toEqual({
       [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
     })
+  })
+})
+
+describe('truthLayerRecordRegistry weekly snapshots (SPE-1343 slice 3)', () => {
+  it('defaults starting state to an empty weekly projection snapshot map', () => {
+    expect(createStartingState().truthLayerWeeklyProjectionSnapshots).toEqual({})
+  })
+
+  it('round-trips weekly ops projection snapshots through save/load', () => {
+    const state = createStartingState()
+    state.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    }
+    state.truthLayerWeeklyProjectionSnapshots = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: {
+        recordId: COMPETING_TRUTH_LAYERS_FIXTURE.id,
+        week: 12,
+        ops: projectTruthLayerOpsView(COMPETING_TRUTH_LAYERS_FIXTURE),
+      },
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.truthLayerWeeklyProjectionSnapshots).toEqual(
+      state.truthLayerWeeklyProjectionSnapshots
+    )
+    expect(
+      loaded.truthLayerWeeklyProjectionSnapshots?.[COMPETING_TRUTH_LAYERS_FIXTURE.id]?.ops
+        .mythInfrastructureActive
+    ).toBe(true)
   })
 })

--- a/src/test/truthLayerWeeklyOrchestration.test.ts
+++ b/src/test/truthLayerWeeklyOrchestration.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ACTOR_TRUTH_LAYER_FIXTURE,
+  COMPETING_TRUTH_LAYERS_FIXTURE,
+  projectTruthLayerOpsView,
+} from '../domain/truthLayerRecordRegistry'
+import {
+  applyWeeklyTruthLayerTick,
+  buildTruthLayerWeeklyProjectionBundle,
+  projectTruthLayerRecordsForWeek,
+} from '../domain/truthLayerWeeklyOrchestration'
+
+describe('truthLayerWeeklyOrchestration (SPE-1343 slice 3)', () => {
+  it('is a no-op for an empty truth-layer map without throwing', () => {
+    const records = {}
+    const snapshots = {}
+
+    expect(applyWeeklyTruthLayerTick(records, 4, snapshots)).toEqual({
+      records,
+      snapshots,
+    })
+    expect(projectTruthLayerRecordsForWeek(records, 4)).toEqual([])
+  })
+
+  it('is a no-op for null or undefined maps', () => {
+    expect(applyWeeklyTruthLayerTick(null, 2)).toEqual({ records: {}, snapshots: {} })
+    expect(applyWeeklyTruthLayerTick(undefined, 2)).toEqual({ records: {}, snapshots: {} })
+    expect(projectTruthLayerRecordsForWeek(null, 2)).toEqual([])
+  })
+
+  it('builds projection bundles matching registry ops helper', () => {
+    const bundle = buildTruthLayerWeeklyProjectionBundle(COMPETING_TRUTH_LAYERS_FIXTURE, 7)
+
+    expect(bundle.recordId).toBe(COMPETING_TRUTH_LAYERS_FIXTURE.id)
+    expect(bundle.week).toBe(7)
+    expect(bundle.ops).toEqual(projectTruthLayerOpsView(COMPETING_TRUTH_LAYERS_FIXTURE))
+    expect(bundle.ops.mythInfrastructureActive).toBe(true)
+    expect(bundle.ops.correctionPressure).toBe(0.62)
+    expect(bundle.ops.mythDrivesOpsWithoutVerification).toBe(true)
+    expect(bundle.ops.layerDivergence).toBe(true)
+  })
+
+  it('projects records in stable sorted id order', () => {
+    const records = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const bundles = projectTruthLayerRecordsForWeek(records, 3)
+
+    expect(bundles.map((bundle) => bundle.recordId)).toEqual([
+      COMPETING_TRUTH_LAYERS_FIXTURE.id,
+      ACTOR_TRUTH_LAYER_FIXTURE.id,
+    ])
+    expect(bundles.every((bundle) => bundle.week === 3)).toBe(true)
+  })
+
+  it('preserves source records when tick runs projections', () => {
+    const records = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const next = applyWeeklyTruthLayerTick(records, 5)
+
+    expect(next.records).toBe(records)
+    expect(next.records[COMPETING_TRUTH_LAYERS_FIXTURE.id]).toBe(COMPETING_TRUTH_LAYERS_FIXTURE)
+    expect(next.records[ACTOR_TRUTH_LAYER_FIXTURE.id]).toBe(ACTOR_TRUTH_LAYER_FIXTURE)
+  })
+
+  it('is idempotent when re-applied at the same week', () => {
+    const records = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    }
+
+    const once = applyWeeklyTruthLayerTick(records, 4)
+    const twice = applyWeeklyTruthLayerTick(once.records, 4, once.snapshots)
+
+    expect(twice.records).toBe(once.records)
+    expect(twice.snapshots).toBe(once.snapshots)
+    expect(twice.records).toBe(records)
+  })
+
+  it('normalizes non-finite week values to week 1 for projection bundles', () => {
+    const bundle = buildTruthLayerWeeklyProjectionBundle(
+      COMPETING_TRUTH_LAYERS_FIXTURE,
+      Number.NaN
+    )
+
+    expect(bundle.week).toBe(1)
+  })
+
+  it('persists weekly ops projection snapshots keyed by record id', () => {
+    const records = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const tick = applyWeeklyTruthLayerTick(records, 6)
+
+    expect(Object.keys(tick.snapshots).sort()).toEqual([
+      COMPETING_TRUTH_LAYERS_FIXTURE.id,
+      ACTOR_TRUTH_LAYER_FIXTURE.id,
+    ])
+    expect(tick.snapshots[COMPETING_TRUTH_LAYERS_FIXTURE.id]?.week).toBe(6)
+    expect(tick.snapshots[COMPETING_TRUTH_LAYERS_FIXTURE.id]?.ops).toEqual(
+      projectTruthLayerOpsView(COMPETING_TRUTH_LAYERS_FIXTURE)
+    )
+    expect(tick.snapshots[ACTOR_TRUTH_LAYER_FIXTURE.id]?.ops.mythInfrastructureActive).toBe(false)
+    expect(tick.snapshots[ACTOR_TRUTH_LAYER_FIXTURE.id]?.ops.correctionPressure).toBe(0.28)
+  })
+
+  it('updates snapshots when week advances and prunes removed record ids', () => {
+    const records = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const weekFour = applyWeeklyTruthLayerTick(records, 4)
+    const weekFiveRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    }
+    const weekFive = applyWeeklyTruthLayerTick(weekFiveRecords, 5, weekFour.snapshots)
+
+    expect(weekFive.snapshots[COMPETING_TRUTH_LAYERS_FIXTURE.id]?.week).toBe(5)
+    expect(weekFive.snapshots[ACTOR_TRUTH_LAYER_FIXTURE.id]).toBeUndefined()
+  })
+})
+
+describe('projectTruthLayerOpsView (SPE-1343 slice 3)', () => {
+  it('surfaces myth infrastructure and correction pressure without collapsing layers', () => {
+    const ops = projectTruthLayerOpsView(COMPETING_TRUTH_LAYERS_FIXTURE)
+
+    expect(ops.mythInfrastructureActive).toBe(true)
+    expect(ops.correctionPressure).toBe(0.62)
+    expect(ops.layerDivergence).toBe(true)
+    expect(ops.claimSourceConfidence).toBe('public_cover')
+    expect(ops.verificationSourceConfidence).toBe('verified')
+    expect(ops.mythDrivesOpsWithoutVerification).toBe(true)
+  })
+
+  it('does not treat inactive myth weight as ops driver', () => {
+    const ops = projectTruthLayerOpsView(ACTOR_TRUTH_LAYER_FIXTURE)
+
+    expect(ops.mythInfrastructureActive).toBe(false)
+    expect(ops.mythDrivesOpsWithoutVerification).toBe(false)
+    expect(ops.correctionPressure).toBe(0.28)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `projectTruthLayerOpsView` and `applyWeeklyTruthLayerTick` to project myth-as-infrastructure ops signals (`mythInfrastructureActive`, `correctionPressure`, `mythDrivesOpsWithoutVerification`) from persisted truth-layer records without collapsing claim/doctrine/verification layers.
- Persist `truthLayerWeeklyProjectionSnapshots` on `GameState` with hydrate wire; call tick from `advanceWeek` after week increment (mirror SPE-2326 / SPE-1882 orchestration patterns).
- Source `truthLayerRecords` remain byte-stable through weekly ticks.

## Linear

- **Slice:** [SPE-2449](https://linear.app/spectranoir/issue/SPE-2449) — Truth-layer weekly orchestration hook (slice 3)
- **Parent:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — stays **Backlog** (orchestration-only slice)

## What shipped

- `src/domain/truthLayerWeeklyOrchestration.ts` — weekly tick + projection bundles
- `src/domain/truthLayerRecordRegistry.ts` — ops projection types, snapshot sanitize
- `advanceWeek` wire-up, `GameState` / `runTransfer` / `startingState` persistence
- Unit + integration tests mirroring public disclosure and coercive protocol weekly hooks

## Validation

- `npm run test:run -- src/test/truthLayerWeeklyOrchestration.test.ts src/test/advanceWeek.truthLayerRecords.integration.test.ts src/test/truthLayerRecordRegistry.test.ts`
- `npm run lint`

## Docs updated

- `planning/truth-layer-record-registry-slice-3.md`
- `planning/backlog.md` handoff row

## Parent status

SPE-1343 parent remains **Backlog** — truth-layer split AC not fully met; mirror UI deferred to slice 4+.