### PR TITLE
feat(SPE-1343): truth-layer record registry planning mirror UI slice 4

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) truth-layer slice 4+ (planning mirror UI); mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
+**Next step:** mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open; truth-layer slice 4 mirror UI in flight @ `planning/truth-layer-record-registry-slice-4.md`.
 
-**Base `main` SHA:** `f00b8870` — shipped: SPE-2449 truth-layer record registry slice 3 @ `planning/truth-layer-record-registry-slice-3.md` (PR #2776)
+**Base `main` SHA:** `86e0bd4d` — in flight: SPE-1343 truth-layer record registry slice 4 (planning mirror UI) @ `planning/truth-layer-record-registry-slice-4.md`
 
 **Recently shipped:** SPE-2449 truth-layer record registry slice 3 (PR #2776); SPE-2448 truth-layer record registry slice 2 (PR #2774); SPE-2447 truth-layer record registry slice 1 (PR #2772).
 
@@ -232,6 +232,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `truth-layer-record-registry-slice-1.md`                  | **Shipped**    | SPE-2447 / PR #2772; truth-layer record schema (claim / doctrine / verification) @ `080608e6`.                                                       |
 | `truth-layer-record-registry-slice-2.md`                  | **Shipped**    | SPE-2448 / PR #2774; `truthLayerRecords` GameState persistence @ `17f770c1`.                                                                         |
 | `truth-layer-record-registry-slice-3.md`                  | **Shipped**    | SPE-2449 / PR #2776; weekly orchestration hook + myth-as-infrastructure ops projection @ `f00b8870`.                                                 |
+| `truth-layer-record-registry-slice-4.md`                  | **In progress**| SPE-1343 slice 4; truth-layer planning mirror UI @ `86e0bd4d`.                                                                                       |
 | `spe-1310-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2402 / PR #2673; SPE-1310 stays Backlog — SPE-2117 + SPE-2123 children Done; case lifecycle AC not met @ `936b2576`.                               |
 | `spe-1615-psychological-resilience-registry-slice-1.md`   | **Shipped**    | SPE-2433 / PR #2737; psychological resilience registry domain anchor @ `a8503939`.                                                                      |
 | `spe-1615-psychological-resilience-registry-slice-2.md`   | **Shipped**    | SPE-2434 / PR #2739; `psychologicalResilienceRecords` GameState persistence @ `467fe4d6`.                                                               |

--- a/planning/truth-layer-record-registry-slice-4.md
+++ b/planning/truth-layer-record-registry-slice-4.md
@@ -1,0 +1,77 @@
+# SPE-1343 — Truth-layer record registry planning mirror UI (slice 4)
+
+One-page implementation plan. Linear: child under [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343). Follows shipped slice 3 (`planning/truth-layer-record-registry-slice-3.md`, PR #2776).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | Truth-layer record registry planning mirror UI (slice 4) — child under SPE-1343                            |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — Public myth / operational truth split          |
+| **Branch** | `spe-1343-truth-layer-record-registry-slice-4`                                                           |
+| **Base `main` SHA** | `86e0bd4d`                                                                                          |
+
+## Goal
+
+Read-only planning/operations mirror over persisted `truthLayerRecords` and `truthLayerWeeklyProjectionSnapshots` — for agent routing visibility, not player-facing canon.
+
+## Prerequisite (on `main` @ `86e0bd4d`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/truthLayerRecordRegistry.ts` (SPE-2447 / PR #2772)         |
+| Persistence          | `truthLayerRecords` on `GameState` (SPE-2448 / PR #2774)               |
+| Weekly orchestration | `applyWeeklyTruthLayerTick` (SPE-2449 / PR #2776)                      |
+| Sibling mirror template | `PublicDisclosureMirrorPage` (SPE-2331 / PR #2529)                  |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `getTruthLayerMirrorView` + `TruthLayerMirrorPage`               | New persistence fields                     |
+| Route `/truth-layer-records` + Front Desk quick link               | Weekly tick / sanitize contract changes       |
+| Separate claim/doctrine/verification review slot display           | SPE-1343 parent status changes               |
+| Ops flags + weekly snapshot column from persisted snapshots        | PublicDisclosureRecord extensions             |
+| View + component tests                                             | Mission triage expansion                      |
+| Slice doc (this file) + backlog handoff                            | Re-validation of hidden/dropped records       |
+
+## Mirror contract
+
+- **Read-only** — no mutations to GameState from the mirror surface.
+- **Hydrated truth only** — display persisted records as hydrated; do not re-run validation or surface dropped invalid entries.
+- **Separate layers** — claim, doctrine, and verification stay distinct in display; no collapsed objective truth column.
+- **Ops flags** — `mythInfrastructureActive` and `correctionPressure` from review projection; weekly snapshot column from persisted `truthLayerWeeklyProjectionSnapshots`.
+- **Empty state** — when `truthLayerRecords` map is empty after hydrate.
+- **Copy** — CP-neutral labels; no franchise tokens in UI strings.
+
+## Acceptance
+
+- [x] Empty `truthLayerRecords` map renders empty state without throw
+- [x] Records table shows separate claim, doctrine, and verification slots from `projectTruthLayerReviewView`
+- [x] Ops flags and weekly snapshot display persisted projection without collapsing layers
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/truthLayerMirrorView.ts`                     |
+| UI     | `src/features/operations/TruthLayerMirrorPage.tsx`                    |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`, `src/app/appShellRoutePaths.ts` |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/truthLayerMirrorView.test.ts`, `src/features/operations/TruthLayerMirrorPage.test.tsx` |
+| Plan   | `planning/truth-layer-record-registry-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Cover narrative dual-incident pairing | SPE-899 / SPE-1347 | Parent AC row 4 partial |
+| Historical-icon normalcy pressure surfaces | SPE-1343 follow-up | Parent AC row 5 |
+| Disclosure campaign player UI | SPE-861 | Out of registry mirror boundary |
+
+## See also
+
+- `planning/truth-layer-record-registry-slice-3.md`
+- `planning/public-disclosure-state-registry-slice-4.md` — mirror UI template (SPE-2331)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -87,6 +87,9 @@ const SelfCensoringInformationMirrorRoute = createRouteComponent(
 const PublicDisclosureMirrorRoute = createRouteComponent(
   () => import('../features/operations/PublicDisclosureMirrorPage')
 )
+const TruthLayerMirrorRoute = createRouteComponent(
+  () => import('../features/operations/TruthLayerMirrorPage')
+)
 const MassAnomalousPopulationEmergenceMirrorRoute = createRouteComponent(
   () => import('../features/operations/MassAnomalousPopulationEmergenceMirrorPage')
 )
@@ -191,6 +194,7 @@ export default function App() {
           path="public-disclosure-state"
           element={renderLazyRoute(PublicDisclosureMirrorRoute)}
         />
+        <Route path="truth-layer-records" element={renderLazyRoute(TruthLayerMirrorRoute)} />
         <Route
           path="mass-anomalous-population-emergence"
           element={renderLazyRoute(MassAnomalousPopulationEmergenceMirrorRoute)}

--- a/src/app/appShellRoutePaths.ts
+++ b/src/app/appShellRoutePaths.ts
@@ -25,6 +25,7 @@ export const APP_SHELL_STATIC_ROUTE_PATHS = [
   'pattern-source-series',
   'self-censoring-information',
   'public-disclosure-state',
+  'truth-layer-records',
   'mass-anomalous-population-emergence',
   'visual-trigger-hazard',
   'entity-welfare-reclassification',

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -28,6 +28,7 @@ export const APP_ROUTES = {
   patternSourceSeries: '/pattern-source-series',
   selfCensoringInformation: '/self-censoring-information',
   publicDisclosureState: '/public-disclosure-state',
+  truthLayerRecords: '/truth-layer-records',
   massAnomalousPopulationEmergence: '/mass-anomalous-population-emergence',
   visualTriggerHazard: '/visual-trigger-hazard',
   entityWelfareReclassification: '/entity-welfare-reclassification',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -903,6 +903,45 @@ export const SELF_CENSORING_INFORMATION_MIRROR_UI_TEXT: Record<string, string> =
   redactedSuffix: 'Partial redaction',
 }
 
+export const TRUTH_LAYER_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Truth-layer record registry',
+  pageSubtitle:
+    'Read-only operations view over persisted claim, doctrine, and verification layers plus weekly ops projection snapshots.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Persisted records',
+  layerDivergenceLabel: 'Layer divergence',
+  mythInfrastructureActiveLabel: 'Myth infrastructure active',
+  correctionPressureLabel: 'Correction pressure',
+  weekLabel: 'Simulation week',
+  readOnlyNote:
+    'Claim, doctrine, and verification slots mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
+  emptyTitle: 'No truth-layer records',
+  emptyBody:
+    'Persisted truth-layer records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  recordsHeading: 'Persisted records',
+  recordsSubtitle:
+    'Review slots stay separate; weekly snapshot column displays persisted ops projection when available.',
+  labelColumn: 'Label',
+  claimColumn: 'Claim layer',
+  doctrineColumn: 'Doctrine layer',
+  verificationColumn: 'Verification layer',
+  opsFlagsColumn: 'Ops flags',
+  weeklySnapshotColumn: 'Weekly snapshot',
+  claimSlotLabel: 'Claim',
+  doctrineSlotLabel: 'Doctrine',
+  verificationSlotLabel: 'Verification',
+  confidenceColumn: 'Confidence',
+  confidencePrefix: 'Source:',
+  tierPrefix: 'Tier:',
+  layerDivergencePrefix: 'Layer divergence:',
+  competingLayerSuffix: 'competing layer ref(s)',
+  unknownFieldsPrefix: 'Unknown fields:',
+  snapshotWeekPrefix: 'Snapshot week',
+  mythDrivesOpsPrefix: 'Myth drives ops without verification:',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const PUBLIC_DISCLOSURE_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Public disclosure state registry',

--- a/src/features/operations/TruthLayerMirrorPage.test.tsx
+++ b/src/features/operations/TruthLayerMirrorPage.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  ACTOR_TRUTH_LAYER_FIXTURE,
+  COMPETING_TRUTH_LAYERS_FIXTURE,
+} from '../../domain/truthLayerRecordRegistry'
+import { applyWeeklyTruthLayerTick } from '../../domain/truthLayerWeeklyOrchestration'
+import { useGameStore } from '../../app/store/gameStore'
+import TruthLayerMirrorPage from './TruthLayerMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/truth-layer-records']}>
+      <Routes>
+        <Route path="/truth-layer-records" element={<TruthLayerMirrorPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('TruthLayerMirrorPage (SPE-1343 slice 4)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderMirrorPage()
+
+    expect(
+      screen.getByRole('region', { name: /truth-layer record registry mirror/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty registry state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no truth-layer records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted records with separate review slots and weekly snapshot', () => {
+    const game = createStartingState()
+    game.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+    const tick = applyWeeklyTruthLayerTick(game.truthLayerRecords, 15)
+    game.truthLayerWeeklyProjectionSnapshots = tick.snapshots
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted truth-layer records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(COMPETING_TRUTH_LAYERS_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent(ACTOR_TRUTH_LAYER_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent('Industrial solvent leak prompted precautionary campus evacuation.')
+    expect(recordsRegion).toHaveTextContent('Containment breach contained to sub-basement wing')
+    expect(recordsRegion).toHaveTextContent('Anomalous residue breached secondary seal')
+    expect(recordsRegion).toHaveTextContent('Myth infrastructure active: Yes')
+    expect(recordsRegion).toHaveTextContent('Correction pressure: 0.62')
+    expect(recordsRegion).toHaveTextContent('Snapshot week W15')
+    expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/features/operations/TruthLayerMirrorPage.tsx
+++ b/src/features/operations/TruthLayerMirrorPage.tsx
@@ -1,0 +1,205 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { TRUTH_LAYER_MIRROR_UI_TEXT } from '../../data/copy'
+import { getTruthLayerMirrorView } from './truthLayerMirrorView'
+import type { TruthLayerMirrorSlotView } from './truthLayerMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function SlotCell({ slot, slotName }: { slot: TruthLayerMirrorSlotView; slotName: string }) {
+  return (
+    <td className="px-2 py-2 align-top">
+      <p className="text-xs uppercase tracking-[0.16em] opacity-45">{slotName}</p>
+      <p className="font-medium">{slot.narrativeLabel}</p>
+      {slot.summaryLabel !== '—' ? (
+        <p className="text-xs opacity-55">{slot.summaryLabel}</p>
+      ) : null}
+      <p className="text-xs opacity-45">
+        {TRUTH_LAYER_MIRROR_UI_TEXT.confidencePrefix} {slot.sourceConfidenceLabel}
+      </p>
+      <p className="text-xs opacity-45">
+        {TRUTH_LAYER_MIRROR_UI_TEXT.tierPrefix} {slot.knowledgeTierLabel}
+      </p>
+      {slot.redacted ? (
+        <p className="text-xs opacity-55">{TRUTH_LAYER_MIRROR_UI_TEXT.redactedSuffix}</p>
+      ) : null}
+    </td>
+  )
+}
+
+export default function TruthLayerMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getTruthLayerMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Truth-layer record registry mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Registry summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {TRUTH_LAYER_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">{TRUTH_LAYER_MIRROR_UI_TEXT.pageHeading}</h2>
+            <p className="text-sm opacity-60">{TRUTH_LAYER_MIRROR_UI_TEXT.pageSubtitle}</p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {TRUTH_LAYER_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={TRUTH_LAYER_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={TRUTH_LAYER_MIRROR_UI_TEXT.layerDivergenceLabel}
+            value={String(view.summary.layerDivergenceCount)}
+          />
+          <StatCard
+            label={TRUTH_LAYER_MIRROR_UI_TEXT.mythInfrastructureActiveLabel}
+            value={String(view.summary.mythInfrastructureActiveCount)}
+          />
+          <StatCard
+            label={TRUTH_LAYER_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">{TRUTH_LAYER_MIRROR_UI_TEXT.readOnlyNote}</p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty registry state">
+          <h3 className="text-lg font-semibold">{TRUTH_LAYER_MIRROR_UI_TEXT.emptyTitle}</h3>
+          <p className="text-sm opacity-70">{TRUTH_LAYER_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted truth-layer records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">{TRUTH_LAYER_MIRROR_UI_TEXT.recordsHeading}</h3>
+            <p className="text-sm opacity-60">{TRUTH_LAYER_MIRROR_UI_TEXT.recordsSubtitle}</p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">{TRUTH_LAYER_MIRROR_UI_TEXT.labelColumn}</th>
+                  <th className="px-2 py-2">{TRUTH_LAYER_MIRROR_UI_TEXT.claimColumn}</th>
+                  <th className="px-2 py-2">{TRUTH_LAYER_MIRROR_UI_TEXT.doctrineColumn}</th>
+                  <th className="px-2 py-2">{TRUTH_LAYER_MIRROR_UI_TEXT.verificationColumn}</th>
+                  <th className="px-2 py-2">{TRUTH_LAYER_MIRROR_UI_TEXT.opsFlagsColumn}</th>
+                  <th className="px-2 py-2">{TRUTH_LAYER_MIRROR_UI_TEXT.weeklySnapshotColumn}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {record.subjectKindLabel}: {record.subjectRef}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {TRUTH_LAYER_MIRROR_UI_TEXT.layerDivergencePrefix}{' '}
+                        {record.layerDivergenceLabel}
+                      </p>
+                      {record.competingLayerCount > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {record.competingLayerCount}{' '}
+                          {TRUTH_LAYER_MIRROR_UI_TEXT.competingLayerSuffix}
+                        </p>
+                      ) : null}
+                      <p className="text-xs opacity-45">
+                        {TRUTH_LAYER_MIRROR_UI_TEXT.confidenceColumn}: {record.confidenceLabel}
+                      </p>
+                      {record.unknownFieldsLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {TRUTH_LAYER_MIRROR_UI_TEXT.unknownFieldsPrefix}{' '}
+                          {record.unknownFieldsLabel}
+                        </p>
+                      ) : null}
+                      {record.redacted ? (
+                        <p className="text-xs opacity-55">
+                          {TRUTH_LAYER_MIRROR_UI_TEXT.redactedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <SlotCell slot={record.claim} slotName={TRUTH_LAYER_MIRROR_UI_TEXT.claimSlotLabel} />
+                    <SlotCell
+                      slot={record.doctrine}
+                      slotName={TRUTH_LAYER_MIRROR_UI_TEXT.doctrineSlotLabel}
+                    />
+                    <SlotCell
+                      slot={record.verification}
+                      slotName={TRUTH_LAYER_MIRROR_UI_TEXT.verificationSlotLabel}
+                    />
+                    <td className="px-2 py-2 align-top">
+                      <p className="text-xs">
+                        {TRUTH_LAYER_MIRROR_UI_TEXT.mythInfrastructureActiveLabel}:{' '}
+                        {record.mythInfrastructureActiveLabel}
+                      </p>
+                      <p className="text-xs">
+                        {TRUTH_LAYER_MIRROR_UI_TEXT.correctionPressureLabel}:{' '}
+                        {record.correctionPressureLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2 align-top">
+                      {record.weeklySnapshot ? (
+                        <>
+                          <p className="text-xs">
+                            {TRUTH_LAYER_MIRROR_UI_TEXT.snapshotWeekPrefix} W
+                            {record.weeklySnapshot.week}
+                          </p>
+                          <p className="text-xs">
+                            {TRUTH_LAYER_MIRROR_UI_TEXT.mythInfrastructureActiveLabel}:{' '}
+                            {record.weeklySnapshot.mythInfrastructureActiveLabel}
+                          </p>
+                          <p className="text-xs">
+                            {TRUTH_LAYER_MIRROR_UI_TEXT.correctionPressureLabel}:{' '}
+                            {record.weeklySnapshot.correctionPressureLabel}
+                          </p>
+                          <p className="text-xs">
+                            {TRUTH_LAYER_MIRROR_UI_TEXT.layerDivergencePrefix}{' '}
+                            {record.weeklySnapshot.layerDivergenceLabel}
+                          </p>
+                          <p className="text-xs">
+                            {TRUTH_LAYER_MIRROR_UI_TEXT.mythDrivesOpsPrefix}{' '}
+                            {record.weeklySnapshot.mythDrivesOpsWithoutVerificationLabel}
+                          </p>
+                          {record.weeklySnapshot.redacted ? (
+                            <p className="text-xs opacity-55">
+                              {TRUTH_LAYER_MIRROR_UI_TEXT.redactedSuffix}
+                            </p>
+                          ) : null}
+                        </>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -784,6 +784,12 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
       description: 'Review awareness levels, fallout phases, and regional trust projections.',
     },
     {
+      label: 'Open truth-layer mirror',
+      href: APP_ROUTES.truthLayerRecords,
+      description:
+        'Review separate claim, doctrine, and verification layers plus myth infrastructure ops flags.',
+    },
+    {
       label: 'Open population emergence mirror',
       href: APP_ROUTES.massAnomalousPopulationEmergence,
       description:

--- a/src/features/operations/truthLayerMirrorView.test.ts
+++ b/src/features/operations/truthLayerMirrorView.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  ACTOR_TRUTH_LAYER_FIXTURE,
+  COMPETING_TRUTH_LAYERS_FIXTURE,
+  projectTruthLayerOpsView,
+} from '../../domain/truthLayerRecordRegistry'
+import { applyWeeklyTruthLayerTick } from '../../domain/truthLayerWeeklyOrchestration'
+import {
+  formatTruthLayerEnumLabel,
+  getTruthLayerMirrorView,
+} from './truthLayerMirrorView'
+
+describe('truthLayerMirrorView (SPE-1343 slice 4)', () => {
+  it('returns empty mirror when truthLayerRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.truthLayerRecords).toEqual({})
+
+    const view = getTruthLayerMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.summary.weeklySnapshotCount).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('mirrors separate claim, doctrine, and verification slots without collapsing layers', () => {
+    const game = createStartingState()
+    game.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    }
+
+    const view = getTruthLayerMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.isEmpty).toBe(false)
+    expect(view.summary.layerDivergenceCount).toBe(1)
+    expect(view.summary.mythInfrastructureActiveCount).toBe(1)
+    expect(record?.claim.narrativeLabel).toMatch(/solvent leak/)
+    expect(record?.doctrine.narrativeLabel).toMatch(/sub-basement wing/)
+    expect(record?.verification.narrativeLabel).toMatch(/secondary seal/)
+    expect(record?.claim.narrativeLabel).not.toBe(record?.verification.narrativeLabel)
+    expect(record?.mythInfrastructureActiveLabel).toBe('Yes')
+    expect(record?.correctionPressureLabel).toBe('0.62')
+    expect(record?.claim.sourceConfidenceLabel).toBe('Public Cover')
+    expect(record?.verification.sourceConfidenceLabel).toBe('Verified')
+    expect(record?.competingLayerCount).toBe(2)
+  })
+
+  it('displays persisted weekly ops snapshot round-trip', () => {
+    const game = createStartingState()
+    game.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    }
+    const tick = applyWeeklyTruthLayerTick(game.truthLayerRecords, 12)
+    game.truthLayerWeeklyProjectionSnapshots = tick.snapshots
+
+    const view = getTruthLayerMirrorView(game)
+    const record = view.records[0]
+    const expectedOps = projectTruthLayerOpsView(COMPETING_TRUTH_LAYERS_FIXTURE)
+
+    expect(view.summary.weeklySnapshotCount).toBe(1)
+    expect(record?.weeklySnapshot?.week).toBe(12)
+    expect(record?.weeklySnapshot?.mythInfrastructureActiveLabel).toBe('Yes')
+    expect(record?.weeklySnapshot?.correctionPressureLabel).toBe('0.62')
+    expect(record?.weeklySnapshot?.layerDivergenceLabel).toBe('Yes')
+    expect(record?.weeklySnapshot?.mythDrivesOpsWithoutVerificationLabel).toBe(
+      expectedOps.mythDrivesOpsWithoutVerification ? 'Yes' : 'No'
+    )
+  })
+
+  it('mirrors actor fixture with lower correction pressure', () => {
+    const game = createStartingState()
+    game.truthLayerRecords = {
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+
+    const view = getTruthLayerMirrorView(game)
+    const record = view.records[0]
+
+    expect(record?.subjectKindLabel).toBe('Actor')
+    expect(record?.mythInfrastructureActiveLabel).toBe('No')
+    expect(record?.correctionPressureLabel).toBe('0.28')
+    expect(record?.weeklySnapshot).toBeNull()
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatTruthLayerEnumLabel('public_cover')).toBe('Public Cover')
+    expect(formatTruthLayerEnumLabel('hostile_dossier')).toBe('Hostile Dossier')
+  })
+
+  it('is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.truthLayerRecords = {
+      [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+      [ACTOR_TRUTH_LAYER_FIXTURE.id]: ACTOR_TRUTH_LAYER_FIXTURE,
+    }
+    const tick = applyWeeklyTruthLayerTick(game.truthLayerRecords, 8)
+    game.truthLayerWeeklyProjectionSnapshots = tick.snapshots
+
+    const first = JSON.stringify(getTruthLayerMirrorView(game))
+    const second = JSON.stringify(getTruthLayerMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/features/operations/truthLayerMirrorView.ts
+++ b/src/features/operations/truthLayerMirrorView.ts
@@ -1,0 +1,197 @@
+import type { GameState } from '../../domain/models'
+import {
+  projectTruthLayerReviewView,
+  type TruthLayerRecord,
+  type TruthLayerSlotProjection,
+  type TruthLayerWeeklyProjectionSnapshot,
+} from '../../domain/truthLayerRecordRegistry'
+
+export interface TruthLayerMirrorSlotView {
+  narrativeLabel: string
+  summaryLabel: string
+  sourceConfidenceLabel: string
+  knowledgeTierLabel: string
+  redacted: boolean
+}
+
+export interface TruthLayerMirrorSnapshotView {
+  week: number
+  mythInfrastructureActiveLabel: string
+  correctionPressureLabel: string
+  layerDivergenceLabel: string
+  mythDrivesOpsWithoutVerificationLabel: string
+  claimSourceConfidenceLabel: string
+  verificationSourceConfidenceLabel: string
+  redacted: boolean
+}
+
+export interface TruthLayerMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  subjectRef: string
+  subjectKindLabel: string
+  claim: TruthLayerMirrorSlotView
+  doctrine: TruthLayerMirrorSlotView
+  verification: TruthLayerMirrorSlotView
+  layerDivergenceLabel: string
+  competingLayerCount: number
+  mythInfrastructureActiveLabel: string
+  correctionPressureLabel: string
+  confidenceLabel: string
+  unknownFieldsLabel: string
+  redacted: boolean
+  weeklySnapshot: TruthLayerMirrorSnapshotView | null
+}
+
+export interface TruthLayerMirrorSummaryView {
+  totalRecords: number
+  layerDivergenceCount: number
+  mythInfrastructureActiveCount: number
+  weeklySnapshotCount: number
+  week: number
+}
+
+export interface TruthLayerMirrorView {
+  isEmpty: boolean
+  summary: TruthLayerMirrorSummaryView
+  records: readonly TruthLayerMirrorRecordView[]
+}
+
+export function formatTruthLayerEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(game: GameState): TruthLayerRecord[] {
+  const map = game.truthLayerRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatConfidence(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatBoolean(value: boolean): string {
+  return value ? 'Yes' : 'No'
+}
+
+function formatNullableEnum(value: string | null | undefined): string {
+  if (!value) {
+    return '—'
+  }
+
+  return formatTruthLayerEnumLabel(value)
+}
+
+function formatSlotNarrative(slot: TruthLayerSlotProjection): string {
+  if (slot.redacted) {
+    return '[Redacted]'
+  }
+
+  return slot.narrative ?? '—'
+}
+
+function formatSlotSummary(slot: TruthLayerSlotProjection): string {
+  if (slot.redacted) {
+    return '[Redacted]'
+  }
+
+  return slot.summary ?? '—'
+}
+
+function toSlotView(slot: TruthLayerSlotProjection): TruthLayerMirrorSlotView {
+  return Object.freeze({
+    narrativeLabel: formatSlotNarrative(slot),
+    summaryLabel: formatSlotSummary(slot),
+    sourceConfidenceLabel: formatNullableEnum(slot.sourceConfidence),
+    knowledgeTierLabel: formatNullableEnum(slot.knowledgeTier),
+    redacted: slot.redacted,
+  })
+}
+
+function toSnapshotView(
+  snapshot: TruthLayerWeeklyProjectionSnapshot
+): TruthLayerMirrorSnapshotView {
+  const ops = snapshot.ops
+
+  return Object.freeze({
+    week: snapshot.week,
+    mythInfrastructureActiveLabel: formatBoolean(ops.mythInfrastructureActive),
+    correctionPressureLabel: formatConfidence(ops.correctionPressure),
+    layerDivergenceLabel: formatBoolean(ops.layerDivergence),
+    mythDrivesOpsWithoutVerificationLabel: formatBoolean(ops.mythDrivesOpsWithoutVerification),
+    claimSourceConfidenceLabel: formatNullableEnum(ops.claimSourceConfidence),
+    verificationSourceConfidenceLabel: formatNullableEnum(ops.verificationSourceConfidence),
+    redacted: ops.redacted,
+  })
+}
+
+function toRecordView(
+  record: TruthLayerRecord,
+  snapshot: TruthLayerWeeklyProjectionSnapshot | undefined
+): TruthLayerMirrorRecordView {
+  const projection = projectTruthLayerReviewView(record)
+
+  const summaryLabel =
+    projection.summary ??
+    (projection.redacted && record.summary ? '[Redacted]' : '—')
+
+  return Object.freeze({
+    id: record.id,
+    label: record.label,
+    summaryLabel,
+    subjectRef: projection.subjectRef,
+    subjectKindLabel: formatTruthLayerEnumLabel(projection.subjectKind),
+    claim: toSlotView(projection.claim),
+    doctrine: toSlotView(projection.doctrine),
+    verification: toSlotView(projection.verification),
+    layerDivergenceLabel: formatBoolean(projection.layerDivergence),
+    competingLayerCount: projection.competingLayerCount,
+    mythInfrastructureActiveLabel: formatBoolean(projection.mythInfrastructureActive),
+    correctionPressureLabel: formatConfidence(projection.correctionPressure),
+    confidenceLabel: formatConfidence(projection.confidence),
+    unknownFieldsLabel:
+      projection.unknownFields.length > 0 ? projection.unknownFields.join(', ') : '—',
+    redacted: projection.redacted,
+    weeklySnapshot: snapshot ? toSnapshotView(snapshot) : null,
+  })
+}
+
+/** Read-only mirror over hydrated `truthLayerRecords` and weekly projection snapshots. */
+export function getTruthLayerMirrorView(game: GameState): TruthLayerMirrorView {
+  const records = listPersistedRecords(game)
+  const snapshots = game.truthLayerWeeklyProjectionSnapshots ?? {}
+
+  const layerDivergenceCount = records.filter((record) => {
+    const projection = projectTruthLayerReviewView(record)
+    return projection.layerDivergence
+  }).length
+
+  const mythInfrastructureActiveCount = records.filter((record) => {
+    const projection = projectTruthLayerReviewView(record)
+    return projection.mythInfrastructureActive
+  }).length
+
+  const weeklySnapshotCount = records.filter((record) => snapshots[record.id] !== undefined).length
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      totalRecords: records.length,
+      layerDivergenceCount,
+      mythInfrastructureActiveCount,
+      weeklySnapshotCount,
+      week: game.week,
+    }),
+    records: Object.freeze(
+      records.map((record) => toRecordView(record, snapshots[record.id]))
+    ),
+  })
+}


### PR DESCRIPTION
## Summary
- Add read-only truth-layer planning mirror at `/truth-layer-records` following the PublicDisclosureMirrorPage (SPE-2331) pattern.
- Surface separate claim, doctrine, and verification review slots plus ops flags (`mythInfrastructureActive`, `correctionPressure`) and persisted weekly projection snapshots.
- Front Desk quick link, view/component tests, slice doc, and backlog handoff row.

## Linear
- Parent: [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) (slice 4 child — create/update on merge)

## What shipped
- `getTruthLayerMirrorView` + `TruthLayerMirrorPage`
- Route `/truth-layer-records` + operations desk quick link
- No runtime mutation; no PublicDisclosureRecord extensions

## Validation
- `npm run lint`
- `npm run test:run -- src/features/operations/truthLayerMirrorView.test.ts src/features/operations/TruthLayerMirrorPage.test.tsx`

## Docs updated
- `planning/truth-layer-record-registry-slice-4.md`
- `planning/backlog.md`

## Parent status
- SPE-1343 parent remains unchanged (already Done on Linear).

Made with [Cursor](https://cursor.com)