### PR TITLE
feat(SPE-1343): cover narrative dual-incident pairing slice 1

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1888 SPE-1047 / SPE-1131 matrix links remain deferred; SPE-1309 unified engine AC remains open.
+**Next step:** SPE-1343 cover-narrative dual-incident pairing slice 1 — `planning/truth-layer-cover-narrative-pairing-slice-1.md`; mission triage expansion remains **blocked** per `ux/mission-triage.md`.
 
-**Base `main` SHA:** `a681d537` — shipped: SPE-1343 truth-layer record registry slice 4 @ `planning/truth-layer-record-registry-slice-4.md` (PR #2777)
+**Base `main` SHA:** `cb53f843` — in progress: SPE-1343 cover-narrative pairing slice 1 @ `planning/truth-layer-cover-narrative-pairing-slice-1.md`
 
 **Recently shipped:** SPE-1343 truth-layer record registry slice 4 (PR #2777); SPE-2449 truth-layer record registry slice 3 (PR #2776); SPE-2448 truth-layer record registry slice 2 (PR #2774).
 
@@ -233,6 +233,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `truth-layer-record-registry-slice-2.md`                  | **Shipped**    | SPE-2448 / PR #2774; `truthLayerRecords` GameState persistence @ `17f770c1`.                                                                         |
 | `truth-layer-record-registry-slice-3.md`                  | **Shipped**    | SPE-2449 / PR #2776; weekly orchestration hook + myth-as-infrastructure ops projection @ `f00b8870`.                                                 |
 | `truth-layer-record-registry-slice-4.md`                  | **Shipped**    | SPE-1343 slice 4 / PR #2777; truth-layer planning mirror UI @ `a681d537`.                                                                            |
+| `truth-layer-cover-narrative-pairing-slice-1.md`          | **In progress**| SPE-1343 cover narrative + agency operational dual-incident pairing @ `cb53f843`.                                                                    |
 | `spe-1310-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2402 / PR #2673; SPE-1310 stays Backlog — SPE-2117 + SPE-2123 children Done; case lifecycle AC not met @ `936b2576`.                               |
 | `spe-1615-psychological-resilience-registry-slice-1.md`   | **Shipped**    | SPE-2433 / PR #2737; psychological resilience registry domain anchor @ `a8503939`.                                                                      |
 | `spe-1615-psychological-resilience-registry-slice-2.md`   | **Shipped**    | SPE-2434 / PR #2739; `psychologicalResilienceRecords` GameState persistence @ `467fe4d6`.                                                               |

--- a/planning/truth-layer-cover-narrative-pairing-slice-1.md
+++ b/planning/truth-layer-cover-narrative-pairing-slice-1.md
@@ -1,0 +1,78 @@
+# SPE-1343 — Cover narrative + agency operational record dual-incident pairing (slice 1)
+
+One-page implementation plan. Linear: child under [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) (owners [SPE-899](https://linear.app/spectranoir/issue/SPE-899) / [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347)). Follows shipped slice 4 (`planning/truth-layer-record-registry-slice-4.md`, PR #2777).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | Cover narrative + agency operational record dual-incident pairing (slice 1) — child under SPE-1343       |
+| **Status** | **In progress** — branch `spe-1343-truth-layer-cover-narrative-pairing-slice-1` |
+| **Parent** | [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) — Public myth / operational truth split          |
+| **Branch** | `spe-1343-truth-layer-cover-narrative-pairing-slice-1`                                                     |
+| **Base `main` SHA** | `cb53f843`                                                                                          |
+
+## Goal
+
+Wire at least one incident that maintains a public cover narrative alongside a separate agency operational record using persisted `truthLayerRecords` + disclosure registry refs — satisfying parent AC row 4 partial gap deferred from registry slices 3–4.
+
+## Prerequisite (on `main` @ `cb53f843`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/truthLayerRecordRegistry.ts` (SPE-2447 / PR #2772)         |
+| Persistence          | `truthLayerRecords` on `GameState` (SPE-2448 / PR #2774)               |
+| Weekly orchestration | `applyWeeklyTruthLayerTick` (SPE-2449 / PR #2776)                      |
+| Planning mirror UI   | `TruthLayerMirrorPage` (SPE-1343 slice 4 / PR #2777)                   |
+| Disclosure fixture   | `DISCLOSURE_PROGRESSION_FIXTURE` in `publicDisclosureStateRegistry.ts` |
+| Parent incident refs | `COMPETING_TRUTH_LAYERS_FIXTURE` `competingLayers` + `linkedDisclosureRef` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `COVER_NARRATIVE_TRUTH_LAYER_FIXTURE` + `AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE` | New mirror UI                     |
+| `COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES` map   | Mission triage expansion                      |
+| `resolveTruthLayerDualIncidentPairing` + competing-layer resolver  | `advanceWeek` orchestration contract changes  |
+| Disclosure cross-ref via `linkedDisclosureRef`                     | SPE-1464 substrate changes                    |
+| Domain fixture pairing + hydrate round-trip tests                  | SPE-1343 parent status changes                |
+| Slice doc (this file) + backlog handoff                            | Cover-story lifecycle state machine (SPE-1347)|
+
+## Pairing contract
+
+- **Hydrated truth only** — resolve from persisted map entries; null when ref or target missing.
+- **Separate layers** — cover narrative `claim` stays `public_cover`; agency operational `verification` stays `verified` with `evidenceRef`; do not collapse claim/verification.
+- **Sibling refs** — parent `competingLayers` resolves to `cover_narrative` and `operational_record` records by `recordRef`.
+- **Disclosure hook** — `linkedDisclosureRef` resolves against `publicDisclosureRecords` when provided.
+- **Empty map no-op** — missing siblings return null without throw.
+- **Copy** — CP-neutral labels; no franchise tokens.
+
+## Acceptance
+
+- [x] Cover narrative and agency operational fixtures validate independently
+- [x] Parent incident resolves both siblings + linked disclosure from fixture map
+- [x] Cover claim narrative differs from agency operational verification narrative
+- [x] Review projection preserves separate claim/doctrine/verification on each record
+- [x] Empty truth-layer map returns null siblings without throw
+- [x] Dual-incident fixture map round-trips through save/load and hydrate
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/truthLayerRecordRegistry.ts`, `src/domain/truthLayerCoverNarrativePairing.ts` |
+| Tests  | `src/test/truthLayerCoverNarrativePairing.test.ts`                    |
+| Plan   | `planning/truth-layer-cover-narrative-pairing-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Historical-icon normalcy pressure surfaces | SPE-1343 follow-up | Parent AC row 5 |
+| Cover-story lifecycle state machine | SPE-1347 | Out of registry pairing boundary |
+| Witness normalization wire-up | SPE-899 | Out of fixture pairing boundary |
+| Disclosure campaign player UI | SPE-861 | Out of domain wire-up boundary |
+
+## See also
+
+- `planning/truth-layer-record-registry-slice-4.md`
+- `planning/spe-1343-parent-acceptance-review-slice-2.md` — AC row 4 partial evidence

--- a/src/domain/truthLayerCoverNarrativePairing.ts
+++ b/src/domain/truthLayerCoverNarrativePairing.ts
@@ -1,0 +1,123 @@
+/**
+ * SPE-1343 cover-narrative pairing slice 1: dual-incident pairing resolver.
+ *
+ * Wires a public cover narrative record alongside a separate agency operational
+ * record on the same site event, with optional disclosure registry cross-ref.
+ * Does not collapse claim, doctrine, or verification layers.
+ */
+
+import type { PublicDisclosureRecord, PublicDisclosureRecordsMap } from './publicDisclosureStateRegistry'
+import {
+  COMPETING_TRUTH_LAYERS_FIXTURE,
+  COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+  AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE,
+  type CompetingLayerRole,
+  type TruthLayerRecord,
+  type TruthLayerRecordsMap,
+} from './truthLayerRecordRegistry'
+
+// ---------------------------------------------------------------------------
+// Pairing projection
+// ---------------------------------------------------------------------------
+
+export interface TruthLayerDualIncidentPairing {
+  readonly incidentRecord: TruthLayerRecord
+  readonly coverNarrativeRecord: TruthLayerRecord | null
+  readonly operationalRecord: TruthLayerRecord | null
+  readonly linkedDisclosureRecord: PublicDisclosureRecord | null
+}
+
+// ---------------------------------------------------------------------------
+// Authored fixture bundle
+// ---------------------------------------------------------------------------
+
+/** Coastal research campus incident with cover narrative + agency operational siblings. */
+export const COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES: TruthLayerRecordsMap =
+  Object.freeze({
+    [COMPETING_TRUTH_LAYERS_FIXTURE.id]: COMPETING_TRUTH_LAYERS_FIXTURE,
+    [COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.id]: COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+    [AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE.id]: AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE,
+  })
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function resolveCompetingLayerRecord(
+  incidentRecord: TruthLayerRecord,
+  layerRole: CompetingLayerRole,
+  records: TruthLayerRecordsMap
+): TruthLayerRecord | null {
+  const competingLayers = incidentRecord.competingLayers ?? []
+  const match = competingLayers.find((entry) => entry.layerRole === layerRole)
+  if (!match) {
+    return null
+  }
+
+  const recordRef = normalizeToken(match.recordRef)
+  if (!recordRef) {
+    return null
+  }
+
+  return records[recordRef] ?? null
+}
+
+function resolveLinkedDisclosureRecord(
+  incidentRecord: TruthLayerRecord,
+  disclosureRecords: PublicDisclosureRecordsMap | undefined
+): PublicDisclosureRecord | null {
+  const disclosureRef = normalizeToken(incidentRecord.linkedDisclosureRef ?? '')
+  if (!disclosureRef || !disclosureRecords) {
+    return null
+  }
+
+  return disclosureRecords[disclosureRef] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves one competing-layer sibling record from an incident's `competingLayers` refs.
+ * Returns null when the ref is missing or the target record is not in the map.
+ */
+export function resolveTruthLayerCompetingLayerRecord(
+  incidentRecord: TruthLayerRecord,
+  layerRole: CompetingLayerRole,
+  records: TruthLayerRecordsMap
+): TruthLayerRecord | null {
+  return resolveCompetingLayerRecord(incidentRecord, layerRole, records)
+}
+
+/**
+ * Resolves cover-narrative and agency-operational sibling records for one incident,
+ * plus optional linked disclosure record. Empty maps are a no-op without throw.
+ */
+export function resolveTruthLayerDualIncidentPairing(
+  incidentRecord: TruthLayerRecord,
+  truthLayerRecords: TruthLayerRecordsMap,
+  publicDisclosureRecords?: PublicDisclosureRecordsMap
+): TruthLayerDualIncidentPairing {
+  return Object.freeze({
+    incidentRecord,
+    coverNarrativeRecord: resolveCompetingLayerRecord(
+      incidentRecord,
+      'cover_narrative',
+      truthLayerRecords
+    ),
+    operationalRecord: resolveCompetingLayerRecord(
+      incidentRecord,
+      'operational_record',
+      truthLayerRecords
+    ),
+    linkedDisclosureRecord: resolveLinkedDisclosureRecord(
+      incidentRecord,
+      publicDisclosureRecords
+    ),
+  })
+}

--- a/src/domain/truthLayerRecordRegistry.ts
+++ b/src/domain/truthLayerRecordRegistry.ts
@@ -1161,6 +1161,78 @@ export function sanitizeTruthLayerWeeklyProjectionSnapshots(
   return Object.keys(next).length > 0 ? next : fallback
 }
 
+/** Parallel public cover narrative maintained separately from agency operational truth. */
+export const COVER_NARRATIVE_TRUTH_LAYER_FIXTURE: TruthLayerRecord = defineRecord({
+  id: 'truth:regional-press-cover-24',
+  label: 'Regional press cover narrative — coastal research campus',
+  summary: 'Public-facing cover narrative maintained through regional press coordination.',
+  subjectRef: 'site:coastal-research-campus',
+  subjectKind: 'site',
+  parentCaseRef: 'case:containment-response-24',
+  claim: {
+    narrative: 'Industrial solvent leak prompted precautionary campus evacuation.',
+    summary: 'Primary public cover line distributed through regional press.',
+    sourceConfidence: 'public_cover',
+    knowledgeTier: 'partial',
+    lastUpdatedWeek: 22,
+  },
+  doctrine: {
+    narrative: 'Press liaison maintains solvent spill framing per approved comms protocol.',
+    summary: 'Institutional comms doctrine for cover narrative maintenance.',
+    sourceConfidence: 'public_cover',
+    knowledgeTier: 'relayed',
+    lastUpdatedWeek: 22,
+    evidenceRef: 'briefing:comms-playbook-24',
+  },
+  verification: {
+    narrative: 'No independent laboratory confirmation of solvent source; witness timelines diverge.',
+    summary: 'Field verification notes cover narrative lacks corroborating spill evidence.',
+    sourceConfidence: 'rumor',
+    knowledgeTier: 'suspected',
+    lastUpdatedWeek: 23,
+  },
+  linkedDisclosureRef: 'disclosure:coastal-research-campus',
+  correctionPressure: 0.41,
+  confidence: 0.38,
+})
+
+/** Agency operational record with verified seal breach metrics separate from public cover. */
+export const AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE: TruthLayerRecord = defineRecord({
+  id: 'truth:agency-operational-log-24',
+  label: 'Agency operational log — coastal research campus seal breach',
+  summary: 'Agency operational record with seal breach metrics separate from public cover.',
+  subjectRef: 'site:coastal-research-campus',
+  subjectKind: 'site',
+  parentCaseRef: 'case:containment-response-24',
+  claim: {
+    narrative: 'Sub-basement wing containment event logged under response protocol 24.',
+    summary: 'Institutional claim for oversight briefing.',
+    sourceConfidence: 'probable',
+    knowledgeTier: 'observed',
+    lastUpdatedWeek: 23,
+  },
+  doctrine: {
+    narrative: 'Oversight briefing records exposure within modeled tolerance pending review.',
+    summary: 'Institutional doctrine before field verification completed.',
+    sourceConfidence: 'probable',
+    knowledgeTier: 'observed',
+    lastUpdatedWeek: 23,
+    evidenceRef: 'briefing:doctrine-summary-24',
+  },
+  verification: {
+    narrative: 'Seal inspection confirms breach beyond modeled tolerance; two contractors exposed.',
+    summary: 'Field verification from response team after seal inspection.',
+    sourceConfidence: 'verified',
+    knowledgeTier: 'confirmed',
+    lastUpdatedWeek: 24,
+    evidenceRef: 'report:ops-log-24',
+  },
+  linkedDisclosureRef: 'disclosure:coastal-research-campus',
+  correctionPressure: 0.71,
+  mythInfrastructureWeight: 0.22,
+  confidence: 0.67,
+})
+
 /** Actor subject with separate claim/doctrine/verification slots for round-trip checks. */
 export const ACTOR_TRUTH_LAYER_FIXTURE: TruthLayerRecord = defineRecord({
   id: 'truth:regional-oversight-commissioner',

--- a/src/test/truthLayerCoverNarrativePairing.test.ts
+++ b/src/test/truthLayerCoverNarrativePairing.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { DISCLOSURE_PROGRESSION_FIXTURE } from '../domain/publicDisclosureStateRegistry'
+import {
+  AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE,
+  COMPETING_TRUTH_LAYERS_FIXTURE,
+  COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+  projectTruthLayerReviewView,
+  validateTruthLayerRecord,
+} from '../domain/truthLayerRecordRegistry'
+import {
+  COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES,
+  resolveTruthLayerCompetingLayerRecord,
+  resolveTruthLayerDualIncidentPairing,
+} from '../domain/truthLayerCoverNarrativePairing'
+
+describe('truthLayerCoverNarrativePairing (SPE-1343 slice 1)', () => {
+  it('validates cover narrative and agency operational sibling fixtures', () => {
+    const coverResult = validateTruthLayerRecord(COVER_NARRATIVE_TRUTH_LAYER_FIXTURE)
+    const opsResult = validateTruthLayerRecord(AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE)
+
+    expect(coverResult.valid).toBe(true)
+    expect(opsResult.valid).toBe(true)
+    expect(COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.claim.sourceConfidence).toBe('public_cover')
+    expect(AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE.verification.sourceConfidence).toBe('verified')
+    expect(COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.claim.narrative).not.toBe(
+      AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE.verification.narrative
+    )
+  })
+
+  it('resolves coastal research campus dual-incident pairing from fixture map', () => {
+    const pairing = resolveTruthLayerDualIncidentPairing(
+      COMPETING_TRUTH_LAYERS_FIXTURE,
+      COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES,
+      {
+        [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+      }
+    )
+
+    expect(pairing.incidentRecord).toBe(COMPETING_TRUTH_LAYERS_FIXTURE)
+    expect(pairing.coverNarrativeRecord).toBe(COVER_NARRATIVE_TRUTH_LAYER_FIXTURE)
+    expect(pairing.operationalRecord).toBe(AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE)
+    expect(pairing.linkedDisclosureRecord).toBe(DISCLOSURE_PROGRESSION_FIXTURE)
+    expect(pairing.coverNarrativeRecord?.claim.narrative).toMatch(/solvent leak/)
+    expect(pairing.operationalRecord?.verification.narrative).toMatch(/Seal inspection/)
+  })
+
+  it('resolves competing layer refs by role without collapsing claim and verification', () => {
+    const cover = resolveTruthLayerCompetingLayerRecord(
+      COMPETING_TRUTH_LAYERS_FIXTURE,
+      'cover_narrative',
+      COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES
+    )
+    const operational = resolveTruthLayerCompetingLayerRecord(
+      COMPETING_TRUTH_LAYERS_FIXTURE,
+      'operational_record',
+      COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES
+    )
+
+    expect(cover).toBe(COVER_NARRATIVE_TRUTH_LAYER_FIXTURE)
+    expect(operational).toBe(AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE)
+
+    const coverReview = projectTruthLayerReviewView(cover!)
+    const opsReview = projectTruthLayerReviewView(operational!)
+
+    expect(coverReview.claim.narrative).not.toBe(coverReview.verification.narrative)
+    expect(opsReview.claim.narrative).not.toBe(opsReview.verification.narrative)
+    expect(coverReview.claim.narrative).not.toBe(opsReview.verification.narrative)
+  })
+
+  it('returns null siblings for empty map without throw', () => {
+    const pairing = resolveTruthLayerDualIncidentPairing(COMPETING_TRUTH_LAYERS_FIXTURE, {})
+
+    expect(pairing.coverNarrativeRecord).toBeNull()
+    expect(pairing.operationalRecord).toBeNull()
+    expect(pairing.linkedDisclosureRecord).toBeNull()
+  })
+
+  it('round-trips dual-incident fixture map byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.truthLayerRecords = { ...COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES }
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.truthLayerRecords).toEqual(state.truthLayerRecords)
+    expect(
+      loaded.truthLayerRecords?.[COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.id]?.linkedDisclosureRef
+    ).toBe('disclosure:coastal-research-campus')
+    expect(
+      loaded.truthLayerRecords?.[AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE.id]?.verification
+        .evidenceRef
+    ).toBe('report:ops-log-24')
+
+    const pairing = resolveTruthLayerDualIncidentPairing(
+      COMPETING_TRUTH_LAYERS_FIXTURE,
+      loaded.truthLayerRecords ?? {},
+      loaded.publicDisclosureRecords
+    )
+
+    expect(pairing.coverNarrativeRecord).toEqual(COVER_NARRATIVE_TRUTH_LAYER_FIXTURE)
+    expect(pairing.operationalRecord).toEqual(AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE)
+    expect(pairing.linkedDisclosureRecord).toEqual(DISCLOSURE_PROGRESSION_FIXTURE)
+  })
+
+  it('hydrates dual-incident fixture records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        truthLayerRecords: COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES,
+        publicDisclosureRecords: {
+          [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.truthLayerRecords).toEqual(COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES)
+    expect(hydrated.publicDisclosureRecords?.[DISCLOSURE_PROGRESSION_FIXTURE.id]).toEqual(
+      DISCLOSURE_PROGRESSION_FIXTURE
+    )
+  })
+
+  it('produces byte-stable pairing output on repeated runs', () => {
+    const first = JSON.stringify(
+      resolveTruthLayerDualIncidentPairing(
+        COMPETING_TRUTH_LAYERS_FIXTURE,
+        COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES,
+        {
+          [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+        }
+      )
+    )
+    const second = JSON.stringify(
+      resolveTruthLayerDualIncidentPairing(
+        COMPETING_TRUTH_LAYERS_FIXTURE,
+        COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES,
+        {
+          [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+        }
+      )
+    )
+
+    expect(first).toBe(second)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `COVER_NARRATIVE_TRUTH_LAYER_FIXTURE` and `AGENCY_OPERATIONAL_TRUTH_LAYER_FIXTURE` sibling records for the coastal research campus incident
- Add `resolveTruthLayerDualIncidentPairing` resolver wiring `competingLayers` refs to persisted records and optional `linkedDisclosureRef`
- Add domain pairing tests with save/load and hydrate round-trip coverage

## Linear

- **Slice:** Cover narrative + agency operational record dual-incident pairing (slice 1) — child under SPE-1343 (create/set In Progress if not yet filed)
- **Parent:** SPE-1343 — Public myth / operational truth split (stays Done; AC row 4 partial addressed, row 5 still deferred)
- **Owners:** SPE-899 / SPE-1347 (cover-story lifecycle out of slice boundary)

## What shipped

- Authored cover narrative + agency operational truth-layer fixtures keyed to existing `COMPETING_TRUTH_LAYERS_FIXTURE` competing layer refs
- `COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES` bundle + pairing resolver in `truthLayerCoverNarrativePairing.ts`
- Disclosure cross-ref resolves `disclosure:coastal-research-campus` against `publicDisclosureRecords`
- Slice doc `planning/truth-layer-cover-narrative-pairing-slice-1.md` + backlog handoff row

## Validation

- `npm run test:run -- src/test/truthLayerCoverNarrativePairing.test.ts src/test/truthLayerRecordRegistry.test.ts`
- `npm run lint`

## Docs updated

- `planning/truth-layer-cover-narrative-pairing-slice-1.md`
- `planning/backlog.md`

## Parent remains open?

No — SPE-1343 parent stays **Done** on Linear. This slice addresses AC row 4 partial only; historical-icon normalcy pressure (row 5) remains deferred.