### PR TITLE
feat(SPE-2454): welfare-debt matrix records GameState persistence (slice 10)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,7 +20,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1309 unified engine AC remains open; SPE-1888 GameState matrix persistence or SPE-1882 coercive protocol model if welfare-debt follow-on is prioritized; SPE-1347 cover-story lifecycle or SPE-861 disclosure UI if truth-layer follow-on is prioritized.
+**Next step:** mission triage expansion remains **blocked** per `ux/mission-triage.md`; SPE-1309 unified engine AC remains open; SPE-1888 weekly matrix-only surfacing or SPE-1882 coercive protocol model if welfare-debt follow-on is prioritized; SPE-1347 cover-story lifecycle or SPE-861 disclosure UI if truth-layer follow-on is prioritized.
 
 **Base `main` SHA:** `8642663c` — shipped: SPE-1888 parent acceptance review grooming slice 5 @ `planning/spe-1888-parent-acceptance-review-slice-5.md` (SPE-2453 / PR #2788)
 
@@ -231,6 +231,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1888-parent-acceptance-review-slice-4.md`            | **Shipped**    | SPE-2452 / PR #2785; SPE-1888 stays Backlog — doc vs Linear auto-close reconciliation; matrix AC row 5 still Partial @ `67f3d3bf`.                    |
 | `welfare-debt-accounting-registry-slice-9.md`             | **Shipped**    | PR #2786; SPE-1047 / SPE-1131 matrix cross-link compose @ `198094c6`.                                                                                   |
 | `spe-1888-parent-acceptance-review-slice-5.md`            | **Shipped**    | SPE-2453 / PR #2788; SPE-1888 stays Backlog — row 5 AC Yes after slice 9; doc vs Linear auto-close reconciliation @ `8642663c`.                   |
+| `welfare-debt-accounting-registry-slice-10.md`            | **In progress** | SPE-2454; `factionEthicsRecords` / `accountabilityMatrixRecords` GameState persistence + mirror/advanceWeek pass-through @ `d737e829`. |
 | `spe-1343-parent-acceptance-review-slice-1.md`            | **Shipped**    | SPE-2401 / PR #2671; SPE-1343 stays Backlog — SPE-2109 child Done; truth-layer split AC not met @ `8cf2b869`.                                           |
 | `spe-1343-parent-acceptance-review-slice-2.md`            | **Shipped**    | SPE-2446 / PR #2769; SPE-1343 stays Backlog — registry wave + SPE-2122 follow-on groomed; truth-layer priority @ `b0d319f2`.                            |
 | `truth-layer-record-registry-slice-1.md`                  | **Shipped**    | SPE-2447 / PR #2772; truth-layer record schema (claim / doctrine / verification) @ `080608e6`.                                                       |

--- a/planning/welfare-debt-accounting-registry-slice-10.md
+++ b/planning/welfare-debt-accounting-registry-slice-10.md
@@ -1,0 +1,72 @@
+# SPE-1888 — Welfare-debt matrix records GameState persistence (slice 10)
+
+One-page implementation plan. Linear: child under [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) (create/link slice issue on merge). Follows shipped slice 9 (`planning/welfare-debt-accounting-registry-slice-9.md`, PR #2786) and grooming [SPE-2453](https://linear.app/spectranoir/issue/SPE-2453).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2454 — Welfare-debt matrix records GameState persistence (slice 10)](https://linear.app/spectranoir/issue/SPE-2454) |
+| **Parent** | [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — parent stays **Backlog** until full SPE-1047/1131 scope + SPE-1882 deferred items close |
+| **Branch** | `spe-1888-welfare-debt-matrix-persistence-slice-10`                                                        |
+| **Status** | **In progress**                                                                                            |
+| **Base `main` SHA** | `d737e829`                                                                                          |
+
+## Goal
+
+Persist validated [SPE-1047](https://linear.app/spectranoir/issue/SPE-1047) `FactionEthicsMatrixRecord` and [SPE-1131](https://linear.app/spectranoir/issue/SPE-1131) `MoralLegalAccountabilityMatrixRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Pass persisted maps through welfare-debt mirror compose and `advanceWeek` cross-link surfacing — no full matrix policy engines.
+
+## Prerequisite (on `main` @ `d737e829`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Matrix schema anchor | `factionEthicsMatrixRegistry.ts`, `moralLegalAccountabilityMatrixRegistry.ts` (slice 9 / PR #2786) |
+| Cross-link compose   | `welfareDebtAccountingCrossLinks.ts` optional map pass-through (slice 9) |
+| Weekly surfacing     | `welfareDebtAccountingCrossLinkSurfacing.ts` (slice 8 / PR #2763)      |
+| Grooming slice 5     | `planning/spe-1888-parent-acceptance-review-slice-5.md` (SPE-2453)   |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `factionEthicsRecords` / `accountabilityMatrixRecords` on `GameState` | Full SPE-1047 parent AC                     |
+| `sanitizeFactionEthicsMatrixRecords` / `sanitizeMoralLegalAccountabilityMatrixRecords` + `runTransfer` hydrate | Full SPE-1131 parent AC                 |
+| Default `{}` in `createStartingState`                              | Mission triage chips                          |
+| Mirror + `advanceWeek` matrix map pass-through to cross-link compose | Weekly matrix-only surfacing guard change   |
+| Targeted persistence + integration tests                           | SPE-1888 parent Done                          |
+| Slice doc (this file) + backlog handoff                            | Full SPE-1882 coercive protocol model         |
+
+## Acceptance
+
+- [x] Empty maps default on starting state and hydrate without throw
+- [x] Valid fixtures round-trip through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] Mirror cross-link labels hydrate matrix wired refs when maps on state
+- [x] `advanceWeek` preserves matrix maps and passes them into cross-link compose when sibling maps coexist
+- [x] Opaque fallback retained when matrix maps absent on state
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/factionEthicsMatrixRegistry.ts`, `src/domain/moralLegalAccountabilityMatrixRegistry.ts`, `src/domain/models.ts`, `src/domain/welfareDebtAccountingCrossLinkSurfacing.ts`, `src/domain/welfareDebtAccountingCrossLinkWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Features | `src/features/operations/welfareDebtAccountingMirrorView.ts`      |
+| Tests  | `src/test/matrixRecordsRegistryPersistence.test.ts`, `src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts`, `src/features/operations/welfareDebtAccountingMirrorView.test.ts` |
+| Plan   | `planning/welfare-debt-accounting-registry-slice-10.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Weekly report matrix-only surfacing guard | SPE-1888 follow-up | Slice 8 guard unchanged; matrix labels surface when bundles/protocols coexist |
+| Full faction ethics policy engine | SPE-1047 | Parent AC remainder beyond schema anchor |
+| Full accountability matrix engine | SPE-1131 | Parent AC remainder beyond schema anchor |
+| Full coercive contained-person protocol model | SPE-1882 | Out of registry wave |
+| SPE-1888 parent Done | SPE-1888 | Full SPE-1047/1131 parent scope still open |
+
+## See also
+
+- `planning/welfare-debt-accounting-registry-slice-9.md`
+- `planning/spe-1888-parent-acceptance-review-slice-5.md`
+- `planning/truth-layer-record-registry-slice-2.md` — persistence pattern (SPE-2448)

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -212,6 +212,8 @@ import { sanitizeMassAnomalousPopulationEmergenceRecords } from '../../domain/ma
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
 import { sanitizeCustodyStatusRecords } from '../../domain/containedPersonCustodyStatusRegistry'
+import { sanitizeFactionEthicsMatrixRecords } from '../../domain/factionEthicsMatrixRegistry'
+import { sanitizeMoralLegalAccountabilityMatrixRecords } from '../../domain/moralLegalAccountabilityMatrixRegistry'
 import { sanitizeWelfareDebtAccountingRecords } from '../../domain/welfareDebtAccountingRegistry'
 import { sanitizeCoerciveProtocolRecords, sanitizeCoerciveProtocolWeeklyProjectionSnapshots } from '../../domain/coerciveContainedPersonProtocolRegistry'
 import { sanitizeMedicationRegimenRecords } from '../../domain/containedPersonMedicationRegimenRegistry'
@@ -8554,6 +8556,14 @@ export function hydrateGame(
     game.welfareDebtAccountingRecords,
     fallback.welfareDebtAccountingRecords ?? {}
   )
+  const factionEthicsRecords = sanitizeFactionEthicsMatrixRecords(
+    game.factionEthicsRecords,
+    fallback.factionEthicsRecords ?? {}
+  )
+  const accountabilityMatrixRecords = sanitizeMoralLegalAccountabilityMatrixRecords(
+    game.accountabilityMatrixRecords,
+    fallback.accountabilityMatrixRecords ?? {}
+  )
   const containedPersonIntegratedHealthBundles = sanitizeContainedPersonIntegratedHealthBundles(
     game.containedPersonIntegratedHealthBundles,
     fallback.containedPersonIntegratedHealthBundles ?? {}
@@ -8706,6 +8716,8 @@ export function hydrateGame(
       coerciveContainedPersonProtocolRecords,
       coerciveContainedPersonProtocolWeeklyProjectionSnapshots,
       welfareDebtAccountingRecords,
+      factionEthicsRecords,
+      accountabilityMatrixRecords,
       containedPersonIntegratedHealthBundles,
       surveillanceInterventionTuningRecords,
       psychologicalResilienceRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -62,6 +62,8 @@ const startingStateTemplate: GameState = {
   coerciveContainedPersonProtocolRecords: {},
   coerciveContainedPersonProtocolWeeklyProjectionSnapshots: {},
   welfareDebtAccountingRecords: {},
+  factionEthicsRecords: {},
+  accountabilityMatrixRecords: {},
   containedPersonIntegratedHealthBundles: {},
   surveillanceInterventionTuningRecords: {},
   psychologicalResilienceRecords: {},

--- a/src/domain/factionEthicsMatrixRegistry.ts
+++ b/src/domain/factionEthicsMatrixRegistry.ts
@@ -245,6 +245,101 @@ export function projectFactionEthicsMatrixReview(
   })
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+function sanitizeFactionEthicsMatrixRecordEntry(value: unknown): FactionEthicsMatrixRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const factionId = normalizeToken(value.factionId)
+  const reviewOwnerLabel = normalizeToken(value.reviewOwnerLabel)
+  const permissibilityVerdict = value.permissibilityVerdict
+
+  if (
+    !id ||
+    !label ||
+    !factionId ||
+    !reviewOwnerLabel ||
+    typeof permissibilityVerdict !== 'string' ||
+    !PERMISSIBILITY_VERDICT_SET.has(permissibilityVerdict) ||
+    typeof value.authorizationRequired !== 'boolean'
+  ) {
+    return null
+  }
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const subjectRef = normalizeToken(value.subjectRef ?? '') || undefined
+  const doctrineRef = normalizeToken(value.doctrineRef ?? '') || undefined
+  const confidence = value.confidence
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+
+  const record: FactionEthicsMatrixRecord = {
+    id,
+    label,
+    factionId,
+    reviewOwnerLabel,
+    permissibilityVerdict: permissibilityVerdict as EthicsPermissibilityVerdict,
+    authorizationRequired: value.authorizationRequired,
+    ...(summary ? { summary } : {}),
+    ...(subjectRef ? { subjectRef } : {}),
+    ...(doctrineRef ? { doctrineRef } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateFactionEthicsMatrixRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical faction ethics matrix map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeFactionEthicsMatrixRecords(
+  value: unknown,
+  fallback: FactionEthicsMatrixRecordsMap = {}
+): FactionEthicsMatrixRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: FactionEthicsMatrixRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeFactionEthicsMatrixRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 export function listHydratedFactionEthicsMatrixRecordsForReviewOwnerLabel(
   records: FactionEthicsMatrixRecordsMap | undefined,
   reviewOwnerLabel: string

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -269,6 +269,8 @@ import type {
 } from './coerciveContainedPersonProtocolRegistry'
 import type { CustodyStatusRecord } from './containedPersonCustodyStatusRegistry'
 import type { MedicationRegimenRecord } from './containedPersonMedicationRegimenRegistry'
+import type { FactionEthicsMatrixRecord } from './factionEthicsMatrixRegistry'
+import type { MoralLegalAccountabilityMatrixRecord } from './moralLegalAccountabilityMatrixRegistry'
 import type { WelfareDebtAccountingRecord } from './welfareDebtAccountingRegistry'
 import type { ContainedPersonIntegratedHealthBundle } from './containedPersonIntegratedHealthBundleRegistry'
 import type { SurveillanceInterventionTuningRecord } from './surveillanceCapacityInterventionTuningRegistry'
@@ -2732,6 +2734,18 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   welfareDebtAccountingRecords?: Record<string, WelfareDebtAccountingRecord>
+
+  /**
+   * SPE-1047 slice 2: persisted faction ethics matrix records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  factionEthicsRecords?: Record<string, FactionEthicsMatrixRecord>
+
+  /**
+   * SPE-1131 slice 2: persisted moral-legal accountability matrix records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  accountabilityMatrixRecords?: Record<string, MoralLegalAccountabilityMatrixRecord>
 
   /**
    * SPE-1889 slice 5: persisted contained-person integrated health bundles (keyed by subject ref).

--- a/src/domain/moralLegalAccountabilityMatrixRegistry.ts
+++ b/src/domain/moralLegalAccountabilityMatrixRegistry.ts
@@ -261,6 +261,112 @@ export function projectMoralLegalAccountabilityMatrixReview(
   })
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseStringList(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+}
+
+function sanitizeMoralLegalAccountabilityMatrixRecordEntry(
+  value: unknown
+): MoralLegalAccountabilityMatrixRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const mitigationPathLabel = normalizeToken(value.mitigationPathLabel)
+  const moralOutcome = value.moralOutcome
+  const legalOutcome = value.legalOutcome
+  const institutionalOutcome = value.institutionalOutcome
+  const publicOutcome = value.publicOutcome
+  const responsibilityClass = value.responsibilityClass
+
+  if (
+    !id ||
+    !label ||
+    !mitigationPathLabel ||
+    typeof moralOutcome !== 'string' ||
+    !ACCOUNTABILITY_OUTCOME_SET.has(moralOutcome) ||
+    typeof legalOutcome !== 'string' ||
+    !ACCOUNTABILITY_OUTCOME_SET.has(legalOutcome) ||
+    typeof institutionalOutcome !== 'string' ||
+    !ACCOUNTABILITY_OUTCOME_SET.has(institutionalOutcome) ||
+    typeof publicOutcome !== 'string' ||
+    !ACCOUNTABILITY_OUTCOME_SET.has(publicOutcome) ||
+    typeof responsibilityClass !== 'string' ||
+    !RESPONSIBILITY_CLASS_SET.has(responsibilityClass)
+  ) {
+    return null
+  }
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const subjectRef = normalizeToken(value.subjectRef ?? '') || undefined
+  const confidence = value.confidence
+  const unknownFields = parseStringList(value.unknownFields)
+  const redactedFields = parseStringList(value.redactedFields)
+
+  const record: MoralLegalAccountabilityMatrixRecord = {
+    id,
+    label,
+    mitigationPathLabel,
+    moralOutcome: moralOutcome as AccountabilityOutcome,
+    legalOutcome: legalOutcome as AccountabilityOutcome,
+    institutionalOutcome: institutionalOutcome as AccountabilityOutcome,
+    publicOutcome: publicOutcome as AccountabilityOutcome,
+    responsibilityClass: responsibilityClass as ResponsibilityApplicability,
+    ...(summary ? { summary } : {}),
+    ...(subjectRef ? { subjectRef } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateMoralLegalAccountabilityMatrixRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical accountability matrix map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeMoralLegalAccountabilityMatrixRecords(
+  value: unknown,
+  fallback: MoralLegalAccountabilityMatrixRecordsMap = {}
+): MoralLegalAccountabilityMatrixRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: MoralLegalAccountabilityMatrixRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeMoralLegalAccountabilityMatrixRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
 export function listHydratedAccountabilityMatrixRecordsForMitigationPathLabel(
   records: MoralLegalAccountabilityMatrixRecordsMap | undefined,
   mitigationPathLabel: string

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4841,6 +4841,9 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.containedPersonIntegratedHealthBundles ?? {}
   const nextCoerciveProtocolsForWelfareDebtCrossLink =
     outputWeeklyState.coerciveContainedPersonProtocolRecords ?? {}
+  const nextFactionEthicsRecordsForCrossLink = outputWeeklyState.factionEthicsRecords ?? {}
+  const nextAccountabilityMatrixRecordsForCrossLink =
+    outputWeeklyState.accountabilityMatrixRecords ?? {}
   if (
     Object.keys(nextWelfareDebtRecordsForCrossLink).length > 0 &&
     (Object.keys(nextBundlesForWelfareDebtCrossLink).length > 0 ||
@@ -4852,6 +4855,8 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       nextRecords: nextWelfareDebtRecordsForCrossLink,
       nextBundles: nextBundlesForWelfareDebtCrossLink,
       nextCoerciveProtocolRecords: nextCoerciveProtocolsForWelfareDebtCrossLink,
+      factionEthicsRecords: nextFactionEthicsRecordsForCrossLink,
+      accountabilityMatrixRecords: nextAccountabilityMatrixRecordsForCrossLink,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,

--- a/src/domain/welfareDebtAccountingCrossLinkSurfacing.ts
+++ b/src/domain/welfareDebtAccountingCrossLinkSurfacing.ts
@@ -7,6 +7,8 @@
 
 import type { CoerciveProtocolRecordsMap } from './coerciveContainedPersonProtocolRegistry'
 import type { ContainedPersonIntegratedHealthBundleRecordsMap } from './containedPersonIntegratedHealthBundleRegistry'
+import type { FactionEthicsMatrixRecordsMap } from './factionEthicsMatrixRegistry'
+import type { MoralLegalAccountabilityMatrixRecordsMap } from './moralLegalAccountabilityMatrixRegistry'
 import {
   composeAllWelfareDebtAccountingCrossLinks,
   formatWelfareDebtAccountingCrossLinkAuditLine,
@@ -19,6 +21,8 @@ export function composeAllWelfareDebtAccountingCrossLinkSummaries(input: {
   records: WelfareDebtAccountingRecordsMap | null | undefined
   bundles?: ContainedPersonIntegratedHealthBundleRecordsMap | null | undefined
   coerciveProtocolRecords?: CoerciveProtocolRecordsMap | null | undefined
+  factionEthicsRecords?: FactionEthicsMatrixRecordsMap | null | undefined
+  accountabilityMatrixRecords?: MoralLegalAccountabilityMatrixRecordsMap | null | undefined
 }): readonly WelfareDebtAccountingCrossLinkSummary[] {
   const safeRecords = input.records ?? {}
   const safeBundles = input.bundles ?? {}
@@ -36,6 +40,8 @@ export function composeAllWelfareDebtAccountingCrossLinkSummaries(input: {
     records: safeRecords,
     bundles: input.bundles,
     coerciveProtocolRecords: input.coerciveProtocolRecords,
+    factionEthicsRecords: input.factionEthicsRecords,
+    accountabilityMatrixRecords: input.accountabilityMatrixRecords,
   })
 
   return Object.freeze(

--- a/src/domain/welfareDebtAccountingCrossLinkWeeklyReportNotes.ts
+++ b/src/domain/welfareDebtAccountingCrossLinkWeeklyReportNotes.ts
@@ -6,6 +6,8 @@
 
 import type { CoerciveProtocolRecordsMap } from './coerciveContainedPersonProtocolRegistry'
 import type { ContainedPersonIntegratedHealthBundleRecordsMap } from './containedPersonIntegratedHealthBundleRegistry'
+import type { FactionEthicsMatrixRecordsMap } from './factionEthicsMatrixRegistry'
+import type { MoralLegalAccountabilityMatrixRecordsMap } from './moralLegalAccountabilityMatrixRegistry'
 import type { ReportNote } from './models'
 import { createDeterministicReportNote } from './reportNotes'
 import {
@@ -23,6 +25,8 @@ export function buildWeeklyWelfareDebtAccountingCrossLinkReportNotes(input: {
   nextRecords: WelfareDebtAccountingRecordsMap | null | undefined
   nextBundles: ContainedPersonIntegratedHealthBundleRecordsMap | null | undefined
   nextCoerciveProtocolRecords: CoerciveProtocolRecordsMap | null | undefined
+  factionEthicsRecords?: FactionEthicsMatrixRecordsMap | null | undefined
+  accountabilityMatrixRecords?: MoralLegalAccountabilityMatrixRecordsMap | null | undefined
   week: number
   sequenceStart: number
   baseTimestamp?: number
@@ -31,6 +35,8 @@ export function buildWeeklyWelfareDebtAccountingCrossLinkReportNotes(input: {
     records: input.nextRecords,
     bundles: input.nextBundles,
     coerciveProtocolRecords: input.nextCoerciveProtocolRecords,
+    factionEthicsRecords: input.factionEthicsRecords,
+    accountabilityMatrixRecords: input.accountabilityMatrixRecords,
   })
 
   if (nextSummaries.length === 0) {

--- a/src/features/operations/welfareDebtAccountingMirrorView.test.ts
+++ b/src/features/operations/welfareDebtAccountingMirrorView.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../../data/startingState'
 import { INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
+import { ETHICS_REVIEW_BOARD_MATRIX_FIXTURE } from '../../domain/factionEthicsMatrixRegistry'
+import { INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE } from '../../domain/moralLegalAccountabilityMatrixRegistry'
 import {
   COERCIVE_RESTRAINT_LEDGER_FIXTURE,
   FORCED_SEDATION_CYCLE_FIXTURE,
@@ -167,5 +169,35 @@ describe('welfareDebtAccountingMirrorView (SPE-1888 slice 2)', () => {
       true
     )
     expect(record?.crossLinkLabels.some((label) => label.startsWith('review_owner:'))).toBe(true)
+  })
+
+  it('hydrates matrix wired refs from persisted GameState maps in cross-link labels', () => {
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+    game.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE.id]:
+        INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+    }
+    game.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    game.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+
+    const record = getWelfareDebtAccountingMirrorView(game).records[0]
+
+    expect(record?.crossLinkLabels).toEqual(
+      expect.arrayContaining([
+        'faction-ethics:faction-ethics:ethics-review-board-routing',
+        'accountability-matrix:accountability-matrix:independent-welfare-audit',
+      ])
+    )
+    expect(record?.crossLinkLabels.some((label) => label.startsWith('review_owner:'))).toBe(false)
+    expect(record?.crossLinkLabels.some((label) => label.startsWith('mitigation-path:'))).toBe(
+      false
+    )
   })
 })

--- a/src/features/operations/welfareDebtAccountingMirrorView.ts
+++ b/src/features/operations/welfareDebtAccountingMirrorView.ts
@@ -92,6 +92,8 @@ function toRecordView(
   const crossLinkSummary = composeWelfareDebtAccountingCrossLinksForRecord(record, {
     bundles: game.containedPersonIntegratedHealthBundles,
     coerciveProtocolRecords: game.coerciveContainedPersonProtocolRecords,
+    factionEthicsRecords: game.factionEthicsRecords,
+    accountabilityMatrixRecords: game.accountabilityMatrixRecords,
   })
   const crossLinkLabels = crossLinkSummary
     ? formatWelfareDebtAccountingCrossLinkLabels(crossLinkSummary)

--- a/src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts
+++ b/src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
 import { INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE } from '../domain/containedPersonIntegratedHealthBundleRegistry'
+import { ETHICS_REVIEW_BOARD_MATRIX_FIXTURE } from '../domain/factionEthicsMatrixRegistry'
+import { INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE } from '../domain/moralLegalAccountabilityMatrixRegistry'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../domain/welfareDebtAccountingRegistry'
 
@@ -52,5 +54,39 @@ describe('advanceWeek welfare-debt cross-link integration (SPE-1888 slice 8)', (
     expect(crossLinkNotes[0]?.content).toContain('Welfare-debt cross-link')
     expect(crossLinkNotes[0]?.content).toContain(COERCIVE_RESTRAINT_LEDGER_FIXTURE.id)
     expect(crossLinkNotes[0]?.content).toContain('integrated-health:')
+  })
+
+  it('passes persisted matrix records into cross-link compose when sibling maps coexist', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+    state.containedPersonIntegratedHealthBundles = {
+      [INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE.id]:
+        INTEGRATED_HEALTH_BUNDLE_WITH_FIELD_LINKS_FIXTURE,
+    }
+    state.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    state.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const crossLinkNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'welfare_debt.accounting_cross_link') ??
+      []
+
+    expect(crossLinkNotes.length).toBeGreaterThan(0)
+    expect(crossLinkNotes[0]?.metadata?.crossLinkLabels).toEqual(
+      expect.arrayContaining([
+        'faction-ethics:faction-ethics:ethics-review-board-routing',
+        'accountability-matrix:accountability-matrix:independent-welfare-audit',
+      ])
+    )
+    expect(nextState.factionEthicsRecords).toEqual(state.factionEthicsRecords)
+    expect(nextState.accountabilityMatrixRecords).toEqual(state.accountabilityMatrixRecords)
   })
 })

--- a/src/test/matrixRecordsRegistryPersistence.test.ts
+++ b/src/test/matrixRecordsRegistryPersistence.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+  PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE,
+  sanitizeFactionEthicsMatrixRecords,
+} from '../domain/factionEthicsMatrixRegistry'
+import {
+  EXTERNAL_OVERSIGHT_ESCALATION_MATRIX_FIXTURE,
+  INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+  sanitizeMoralLegalAccountabilityMatrixRecords,
+} from '../domain/moralLegalAccountabilityMatrixRegistry'
+
+describe('matrix records registry persistence (SPE-1888 slice 10)', () => {
+  it('defaults starting state to empty faction ethics and accountability matrix maps', () => {
+    const state = createStartingState()
+
+    expect(state.factionEthicsRecords).toEqual({})
+    expect(state.accountabilityMatrixRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id faction ethics entries during sanitize without throwing', () => {
+    const sanitized = sanitizeFactionEthicsMatrixRecords({
+      valid: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+      panel: PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE,
+      duplicate: {
+        ...ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+        label: 'duplicate label should lose',
+      },
+      invalid: {
+        id: '',
+        label: 'bad',
+        factionId: 'oversight',
+        reviewOwnerLabel: 'ethics review board',
+        permissibilityVerdict: 'permitted',
+        authorizationRequired: true,
+      },
+      franchiseLabel: {
+        id: 'faction-ethics:franchise',
+        label: 'Foundation ethics routing',
+        factionId: 'oversight',
+        reviewOwnerLabel: 'ethics review board',
+        permissibilityVerdict: 'restricted',
+        authorizationRequired: false,
+      },
+    })
+
+    expect(sanitized[ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]).toEqual(
+      ETHICS_REVIEW_BOARD_MATRIX_FIXTURE
+    )
+    expect(sanitized[PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE.id]).toEqual(
+      PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE
+    )
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized['faction-ethics:franchise']).toBeUndefined()
+    expect(Object.keys(sanitized).sort()).toEqual([
+      ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id,
+      PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE.id,
+    ])
+  })
+
+  it('drops invalid and duplicate-id accountability matrix entries during sanitize without throwing', () => {
+    const sanitized = sanitizeMoralLegalAccountabilityMatrixRecords({
+      audit: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+      escalation: EXTERNAL_OVERSIGHT_ESCALATION_MATRIX_FIXTURE,
+      duplicate: {
+        ...INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+        label: 'duplicate label should lose',
+      },
+      invalid: {
+        id: '',
+        label: 'bad',
+        mitigationPathLabel: 'independent welfare audit',
+        moralOutcome: 'blamed',
+        legalOutcome: 'deferred',
+        institutionalOutcome: 'blamed',
+        publicOutcome: 'deferred',
+        responsibilityClass: 'immoral',
+      },
+    })
+
+    expect(sanitized[INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]).toEqual(
+      INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE
+    )
+    expect(sanitized[EXTERNAL_OVERSIGHT_ESCALATION_MATRIX_FIXTURE.id]).toEqual(
+      EXTERNAL_OVERSIGHT_ESCALATION_MATRIX_FIXTURE
+    )
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized.invalid).toBeUndefined()
+    expect(Object.keys(sanitized).sort()).toEqual([
+      EXTERNAL_OVERSIGHT_ESCALATION_MATRIX_FIXTURE.id,
+      INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id,
+    ])
+  })
+
+  it('round-trips matrix fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    state.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.factionEthicsRecords).toEqual(state.factionEthicsRecords)
+    expect(loaded.accountabilityMatrixRecords).toEqual(state.accountabilityMatrixRecords)
+  })
+
+  it('hydrates persisted matrix records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        factionEthicsRecords: {
+          [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+          invalid: {
+            id: 'faction-ethics:invalid',
+            label: 'Invalid ethics record',
+            factionId: '',
+            reviewOwnerLabel: 'ethics review board',
+            permissibilityVerdict: 'permitted',
+            authorizationRequired: true,
+          },
+        },
+        accountabilityMatrixRecords: {
+          [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.factionEthicsRecords).toEqual({
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    })
+    expect(hydrated.accountabilityMatrixRecords).toEqual({
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `factionEthicsRecords` and `accountabilityMatrixRecords` to `GameState` with sanitize/hydration in `runTransfer` and default `{}` in `createStartingState`
- Pass persisted matrix maps through welfare-debt mirror compose and `advanceWeek` cross-link surfacing (opaque fallback when maps absent)
- Add targeted persistence, mirror, and integration tests plus slice doc / backlog handoff

## Linear
- Slice: [SPE-2454](https://linear.app/spectranoir/issue/SPE-2454)
- Parent: [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — stays **Backlog**

## What shipped
GameState persistence for SPE-1047/SPE-1131 matrix record anchors; mirror/advanceWeek pass-through only — no full matrix policy engines.

## Validation
- `npm run lint`
- `npm run test:run -- src/test/matrixRecordsRegistryPersistence.test.ts src/test/advanceWeek.welfareDebtAccountingCrossLink.integration.test.ts src/features/operations/welfareDebtAccountingMirrorView.test.ts`
- Full suite: 5900/5901 pass; 1 pre-existing failure on main in `advanceWeek.containedPersonIntegratedHealthBundleWelfareDebt.integration.test.ts` (unchanged by this PR)

## Docs updated
- `planning/welfare-debt-accounting-registry-slice-10.md`
- `planning/backlog.md`

## Parent remains open
SPE-1888 parent **Backlog** — weekly matrix-only surfacing, SPE-1882 coercive protocol model, and full SPE-1047/1131 parent scope deferred.

Made with [Cursor](https://cursor.com)