### PR TITLE
SPE-2457: cover-story lifecycle persistence + weekly orchestration hook (slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1347 cover-story lifecycle slice 2 (GameState persistence + weekly hook) or SPE-861 disclosure UI if truth-layer follow-on is prioritized; SPE-1309 unified engine owner slice if cognitive-hazard engine is prioritized.
+**Next step:** SPE-1347 cover-story lifecycle slice 3 (planning mirror UI) or SPE-861 disclosure UI if truth-layer follow-on is prioritized; SPE-1309 unified engine owner slice if cognitive-hazard engine is prioritized.
 
-**Base `main` SHA:** `44e49f09` — shipped: SPE-1347 cover-story lifecycle registry slice 1 @ `planning/cover-story-lifecycle-slice-1.md` (PR #2799)
+**Base `main` SHA:** `18579682` — in progress: SPE-1347 cover-story lifecycle slice 2 @ `planning/cover-story-lifecycle-slice-2.md` (branch `spe-1347-cover-story-lifecycle-slice-2`)
 
 **Recently shipped:** SPE-1347 cover-story lifecycle registry slice 1 (PR #2799); SPE-1882 coercive protocol mirror snapshot read slice 11 (PR #2798).
 

--- a/planning/cover-story-lifecycle-slice-2.md
+++ b/planning/cover-story-lifecycle-slice-2.md
@@ -1,0 +1,80 @@
+# SPE-1347 — Cover-story lifecycle persistence + weekly orchestration (slice 2)
+
+One-page implementation plan. Linear: child under [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347). Follows shipped registry slice 1 (`planning/cover-story-lifecycle-slice-1.md`, PR #2799).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2457 — Cover-story lifecycle GameState persistence + weekly orchestration hook (slice 2)](https://linear.app/spectranoir/issue/SPE-2457) |
+| **Status** | **In progress** — branch `spe-1347-cover-story-lifecycle-slice-2`                                        |
+| **Parent** | [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347) — Cover-story lifecycle state machine; stays **Backlog** |
+| **Branch** | `spe-1347-cover-story-lifecycle-slice-2`                                                                   |
+| **Base `main` SHA** | `18579682`                                                                                          |
+
+## Goal
+
+Persist validated `CoverStoryRecord` entries on `GameState` with sanitize/hydration and wire `applyWeeklyCoverStoryTick` into `advanceWeek` mirroring truth-layer and coercive-protocol weekly snapshot patterns.
+
+## Prerequisite (on `main` @ `18579682`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/coverStoryLifecycleRegistry.ts` (SPE-1347 slice 1 / PR #2799) |
+| Truth-layer persistence pattern | `planning/truth-layer-record-registry-slice-2.md` (SPE-2448)   |
+| Weekly hook pattern  | `planning/truth-layer-record-registry-slice-3.md` (SPE-2449)           |
+| Coercive snapshot pattern | `src/domain/coerciveContainedPersonProtocolWeeklyOrchestration.ts` |
+
+## Orchestration contract (slice 2)
+
+- **Lifecycle projection** — `projectCoverStoryLifecycleView(record)` derives stress/collapse/repair signals without revealing hidden operational truth.
+- **Weekly tick** — `applyWeeklyCoverStoryTick(records, week, snapshots)` preserves source records byte-stable; persists `coverStoryWeeklyProjectionSnapshots` keyed by record id.
+- **No-op** — empty `coverStoryRecords` map; re-tick same week is idempotent.
+- **Does not** — implement full contradiction engine, extend disclosure UI, or mutate cover-story record fields.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coverStoryRecords` on `GameState`                                  | Full contradiction engine          |
+| `coverStoryWeeklyProjectionSnapshots` on `GameState` + hydrate wire | SPE-861 disclosure UI                         |
+| `sanitizeCoverStoryRecords` + snapshot sanitize in `runTransfer`     | Mission triage expansion                      |
+| `applyWeeklyCoverStoryTick` in `coverStoryWeeklyOrchestration.ts`  | SPE-1309 unified engine                       |
+| Call from `advanceWeek` after week increment (`result.week`)         | Coercive protocol mirror changes              |
+| Default `{}` in `createStartingState`                                | SPE-1347 parent Done                          |
+| Save/import round-trip + advanceWeek integration tests               | Witness normalization (SPE-899)               |
+| Slice doc (this file) + backlog handoff                              |                                               |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] Fixture records byte-stable through `advanceWeek` tick
+- [x] Empty `coverStoryRecords` map is a no-op without throw
+- [x] Weekly lifecycle snapshots persist stress/collapse signals without hidden truth
+- [x] Re-applying tick for same post-advance week is idempotent
+- [x] Invalid phase transitions rejected at sanitize (from slice 1)
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coverStoryLifecycleRegistry.ts`, `src/domain/coverStoryWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/coverStoryLifecycleRegistry.test.ts`, `src/test/coverStoryWeeklyOrchestration.test.ts`, `src/test/advanceWeek.coverStoryRecords.integration.test.ts` |
+| Plan   | `planning/cover-story-lifecycle-slice-2.md`, `planning/backlog.md`    |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full contradiction accumulation engine across channels | SPE-1347 follow-up | Requires trigger sources beyond projection snapshots |
+| Disclosure campaign player UI | SPE-861 | Out of domain wire-up boundary |
+| Planning mirror UI for cover-story lifecycle review | SPE-1347 slice 3+ | Mirror follows orchestration pattern |
+| Witness normalization wire-up | SPE-899 | Sibling deferred work |
+
+## See also
+
+- `planning/cover-story-lifecycle-slice-1.md`
+- `planning/truth-layer-record-registry-slice-2.md` — persistence pattern (SPE-2448)
+- `planning/truth-layer-record-registry-slice-3.md` — weekly hook pattern (SPE-2449)

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -207,6 +207,10 @@ import {
   sanitizeTruthLayerRecords,
   sanitizeTruthLayerWeeklyProjectionSnapshots,
 } from '../../domain/truthLayerRecordRegistry'
+import {
+  sanitizeCoverStoryRecords,
+  sanitizeCoverStoryWeeklyProjectionSnapshots,
+} from '../../domain/coverStoryLifecycleRegistry'
 import { sanitizePatternSourceSeriesRecords } from '../../domain/patternSourceSeriesRegistry'
 import { sanitizeMassAnomalousPopulationEmergenceRecords } from '../../domain/massAnomalousPopulationEmergenceRegistry'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
@@ -8513,6 +8517,15 @@ export function hydrateGame(
     fallback.truthLayerWeeklyProjectionSnapshots ?? {},
     new Set(Object.keys(truthLayerRecords))
   )
+  const coverStoryRecords = sanitizeCoverStoryRecords(
+    game.coverStoryRecords,
+    fallback.coverStoryRecords ?? {}
+  )
+  const coverStoryWeeklyProjectionSnapshots = sanitizeCoverStoryWeeklyProjectionSnapshots(
+    game.coverStoryWeeklyProjectionSnapshots,
+    fallback.coverStoryWeeklyProjectionSnapshots ?? {},
+    new Set(Object.keys(coverStoryRecords))
+  )
   const patternSourceSeriesRecords = sanitizePatternSourceSeriesRecords(
     game.patternSourceSeriesRecords,
     fallback.patternSourceSeriesRecords ?? {}
@@ -8706,6 +8719,8 @@ export function hydrateGame(
       publicDisclosureRecords,
       truthLayerRecords,
       truthLayerWeeklyProjectionSnapshots,
+      coverStoryRecords,
+      coverStoryWeeklyProjectionSnapshots,
       patternSourceSeriesRecords,
       massAnomalousPopulationEmergenceRecords,
       visualTriggerHazardRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -52,6 +52,8 @@ const startingStateTemplate: GameState = {
   publicDisclosureRecords: {},
   truthLayerRecords: {},
   truthLayerWeeklyProjectionSnapshots: {},
+  coverStoryRecords: {},
+  coverStoryWeeklyProjectionSnapshots: {},
   patternSourceSeriesRecords: {},
   massAnomalousPopulationEmergenceRecords: {},
   visualTriggerHazardRecords: {},

--- a/src/domain/coverStoryLifecycleRegistry.ts
+++ b/src/domain/coverStoryLifecycleRegistry.ts
@@ -301,8 +301,23 @@ export interface CoverStoryLifecycleProjection {
 
 export type CoverStoryRecordsMap = Record<CoverStoryRecordId, CoverStoryRecord>
 
+/** SPE-1347 slice 2: persisted weekly lifecycle projection snapshot for one cover-story record. */
+export interface CoverStoryWeeklyProjectionSnapshot {
+  readonly recordId: CoverStoryRecordId
+  readonly week: number
+  readonly lifecycle: CoverStoryLifecycleProjection
+}
+
+export type CoverStoryWeeklyProjectionSnapshotsMap = Record<
+  CoverStoryRecordId,
+  CoverStoryWeeklyProjectionSnapshot
+>
+
 /** Upper bound on persisted cover-story record entries (byte-stable record-id keys). */
 export const MAX_COVER_STORY_RECORDS = 128
+
+/** Upper bound on persisted weekly projection snapshot entries (byte-stable record-id keys). */
+export const MAX_COVER_STORY_WEEKLY_PROJECTION_SNAPSHOTS = 128
 
 const DEFAULT_COVER_STRESS_THRESHOLD = 0.45
 
@@ -1250,6 +1265,199 @@ export function sanitizeCoverStoryRecords(
 
     seenIds.add(record.id)
     next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
+function sanitizeCoverStoryLifecycleProjection(
+  value: unknown,
+  recordId: string
+): CoverStoryLifecycleProjection | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const normalizedRecordId = normalizeToken(value.recordId ?? recordId)
+  if (!normalizedRecordId || normalizedRecordId !== normalizeToken(recordId)) {
+    return null
+  }
+
+  const label = normalizeToken(value.label)
+  if (!label) {
+    return null
+  }
+
+  const lifecyclePhaseRaw = value.lifecyclePhase
+  if (typeof lifecyclePhaseRaw !== 'string' || !isLifecyclePhase(lifecyclePhaseRaw)) {
+    return null
+  }
+
+  const subjectRef = normalizeToken(value.subjectRef)
+  if (!subjectRef) {
+    return null
+  }
+
+  const subjectKindRaw = value.subjectKind
+  if (typeof subjectKindRaw !== 'string' || !isSubjectKind(subjectKindRaw)) {
+    return null
+  }
+
+  const summary =
+    value.summary === null
+      ? null
+      : typeof value.summary === 'string' && value.summary.trim().length > 0
+        ? value.summary.trim()
+        : null
+
+  const coverMotivation =
+    value.coverMotivation === null || value.coverMotivation === undefined
+      ? null
+      : typeof value.coverMotivation === 'string' && isCoverMotivation(value.coverMotivation)
+        ? value.coverMotivation
+        : null
+
+  const exposureKind =
+    value.exposureKind === null || value.exposureKind === undefined
+      ? null
+      : typeof value.exposureKind === 'string' && isExposureKind(value.exposureKind)
+        ? value.exposureKind
+        : null
+
+  const contradictionPressure =
+    value.contradictionPressure === null || value.contradictionPressure === undefined
+      ? null
+      : isValidUnitScore(value.contradictionPressure)
+        ? value.contradictionPressure
+        : null
+
+  const coverCapacityScore =
+    value.coverCapacityScore === null || value.coverCapacityScore === undefined
+      ? null
+      : isValidUnitScore(value.coverCapacityScore)
+        ? value.coverCapacityScore
+        : null
+
+  const activeContradictionChannelCountRaw = value.activeContradictionChannelCount
+  const activeContradictionChannelCount =
+    typeof activeContradictionChannelCountRaw === 'number' &&
+    Number.isFinite(activeContradictionChannelCountRaw) &&
+    activeContradictionChannelCountRaw >= 0 &&
+    activeContradictionChannelCountRaw === Math.trunc(activeContradictionChannelCountRaw)
+      ? activeContradictionChannelCountRaw
+      : null
+  if (activeContradictionChannelCount === null) {
+    return null
+  }
+
+  const contradictionChannelHints = parseStringList(value.contradictionChannelHints).filter(
+    (channel): channel is CoverStoryContradictionChannelKind => isContradictionChannelKind(channel)
+  )
+
+  const latestRepairAction =
+    value.latestRepairAction === null || value.latestRepairAction === undefined
+      ? null
+      : typeof value.latestRepairAction === 'string' && isStagedResponse(value.latestRepairAction)
+        ? value.latestRepairAction
+        : null
+
+  const confidence =
+    value.confidence === null || value.confidence === undefined
+      ? null
+      : isValidUnitScore(value.confidence)
+        ? value.confidence
+        : null
+
+  return Object.freeze({
+    recordId: normalizedRecordId,
+    label,
+    summary,
+    lifecyclePhase: lifecyclePhaseRaw,
+    subjectRef,
+    subjectKind: subjectKindRaw,
+    coverMotivation,
+    exposureKind,
+    contradictionPressure,
+    coverCapacityScore,
+    activeContradictionChannelCount,
+    contradictionChannelHints: Object.freeze(
+      [...new Set(contradictionChannelHints)].sort((left, right) => left.localeCompare(right))
+    ),
+    latestRepairAction,
+    coverStressActive: value.coverStressActive === true,
+    coverCollapsed: value.coverCollapsed === true,
+    repairInProgress: value.repairInProgress === true,
+    confidence,
+    redacted: value.redacted === true,
+    unknownFields: sortedStringArray(value.unknownFields),
+  })
+}
+
+function sanitizeCoverStoryWeeklyProjectionSnapshotEntry(
+  key: string,
+  value: unknown
+): CoverStoryWeeklyProjectionSnapshot | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const recordId = normalizeToken(value.recordId ?? key)
+  if (!recordId || recordId !== normalizeToken(key)) {
+    return null
+  }
+
+  const weekRaw = value.week
+  if (typeof weekRaw !== 'number' || !Number.isFinite(weekRaw)) {
+    return null
+  }
+
+  const week = Math.max(1, Math.trunc(weekRaw))
+  const lifecycle = sanitizeCoverStoryLifecycleProjection(value.lifecycle, recordId)
+  if (!lifecycle || lifecycle.recordId !== recordId) {
+    return null
+  }
+
+  return Object.freeze({
+    recordId,
+    week,
+    lifecycle,
+  })
+}
+
+/** Hydration: canonical weekly projection snapshot map keyed by record id; drops invalid entries. */
+export function sanitizeCoverStoryWeeklyProjectionSnapshots(
+  value: unknown,
+  fallback: CoverStoryWeeklyProjectionSnapshotsMap = {},
+  knownRecordIds?: ReadonlySet<string>
+): CoverStoryWeeklyProjectionSnapshotsMap {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const candidates: CoverStoryWeeklyProjectionSnapshot[] = []
+
+  for (const [key, entry] of Object.entries(value)) {
+    const snapshot = sanitizeCoverStoryWeeklyProjectionSnapshotEntry(key, entry)
+    if (!snapshot) {
+      continue
+    }
+
+    if (knownRecordIds && !knownRecordIds.has(snapshot.recordId)) {
+      continue
+    }
+
+    candidates.push(snapshot)
+  }
+
+  if (candidates.length === 0) {
+    return fallback
+  }
+
+  candidates.sort((left, right) => left.recordId.localeCompare(right.recordId))
+
+  const next: CoverStoryWeeklyProjectionSnapshotsMap = {}
+  for (const snapshot of candidates.slice(0, MAX_COVER_STORY_WEEKLY_PROJECTION_SNAPSHOTS)) {
+    next[snapshot.recordId] = snapshot
   }
 
   return Object.keys(next).length > 0 ? next : fallback

--- a/src/domain/coverStoryWeeklyOrchestration.ts
+++ b/src/domain/coverStoryWeeklyOrchestration.ts
@@ -1,0 +1,179 @@
+/**
+ * SPE-1347 slice 2: weekly orchestration for persisted cover-story records.
+ *
+ * Pure deterministic tick: runs lifecycle projections each week, persists bounded
+ * weekly projection snapshots, and preserves source records byte-stable.
+ * Does not implement a full contradiction engine or mutate cover-story record fields.
+ */
+
+import {
+  projectCoverStoryLifecycleView,
+  type CoverStoryLifecycleProjection,
+  type CoverStoryRecord,
+  type CoverStoryRecordsMap,
+  type CoverStoryWeeklyProjectionSnapshot,
+  type CoverStoryWeeklyProjectionSnapshotsMap,
+} from './coverStoryLifecycleRegistry'
+
+export interface CoverStoryWeeklyProjectionBundle {
+  readonly recordId: string
+  readonly week: number
+  readonly lifecycle: CoverStoryLifecycleProjection
+}
+
+export interface CoverStoryWeeklyTickResult {
+  readonly records: CoverStoryRecordsMap
+  readonly snapshots: CoverStoryWeeklyProjectionSnapshotsMap
+}
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function freezeSnapshot(
+  bundle: CoverStoryWeeklyProjectionBundle
+): CoverStoryWeeklyProjectionSnapshot {
+  return Object.freeze({
+    recordId: bundle.recordId,
+    week: bundle.week,
+    lifecycle: bundle.lifecycle,
+  })
+}
+
+function weeklyProjectionSnapshotsEqual(
+  left: CoverStoryWeeklyProjectionSnapshot,
+  right: CoverStoryWeeklyProjectionSnapshot
+): boolean {
+  if (left.recordId !== right.recordId || left.week !== right.week) {
+    return false
+  }
+
+  return JSON.stringify(left.lifecycle) === JSON.stringify(right.lifecycle)
+}
+
+/**
+ * Builds the deterministic weekly lifecycle projection bundle for one cover-story record.
+ */
+export function buildCoverStoryWeeklyProjectionBundle(
+  record: CoverStoryRecord,
+  week: number
+): CoverStoryWeeklyProjectionBundle {
+  return Object.freeze({
+    recordId: record.id,
+    week: normalizeWeek(week),
+    lifecycle: projectCoverStoryLifecycleView(record),
+  })
+}
+
+/**
+ * Projects all persisted cover-story records for the simulation week in stable id order.
+ * Returns an empty frozen array when the map is empty.
+ */
+export function projectCoverStoryRecordsForWeek(
+  records: CoverStoryRecordsMap | null | undefined,
+  week: number
+): readonly CoverStoryWeeklyProjectionBundle[] {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return Object.freeze([])
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const bundles: CoverStoryWeeklyProjectionBundle[] = []
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    bundles.push(buildCoverStoryWeeklyProjectionBundle(record, normalizedWeek))
+  }
+
+  return Object.freeze(bundles)
+}
+
+function persistWeeklyProjectionSnapshots(
+  records: CoverStoryRecordsMap,
+  snapshots: CoverStoryWeeklyProjectionSnapshotsMap,
+  week: number
+): CoverStoryWeeklyProjectionSnapshotsMap {
+  const normalizedWeek = normalizeWeek(week)
+  const recordIds = Object.keys(records).sort((left, right) => left.localeCompare(right))
+  let nextSnapshots: CoverStoryWeeklyProjectionSnapshotsMap | null = null
+
+  for (const recordId of recordIds) {
+    const record = records[recordId]
+    if (!record) {
+      continue
+    }
+
+    const bundle = buildCoverStoryWeeklyProjectionBundle(record, normalizedWeek)
+    const candidate = freezeSnapshot(bundle)
+    const existing = (nextSnapshots ?? snapshots)[recordId]
+
+    if (existing && weeklyProjectionSnapshotsEqual(existing, candidate)) {
+      continue
+    }
+
+    if (!nextSnapshots) {
+      nextSnapshots = { ...snapshots }
+    }
+
+    nextSnapshots[recordId] = candidate
+  }
+
+  const activeRecordIds = new Set(recordIds)
+  const sourceSnapshots = nextSnapshots ?? snapshots
+  for (const snapshotId of Object.keys(sourceSnapshots)) {
+    if (activeRecordIds.has(snapshotId)) {
+      continue
+    }
+
+    if (!nextSnapshots) {
+      nextSnapshots = { ...snapshots }
+    }
+
+    delete nextSnapshots[snapshotId]
+  }
+
+  if (!nextSnapshots) {
+    return snapshots
+  }
+
+  return Object.keys(nextSnapshots).length > 0 ? nextSnapshots : {}
+}
+
+/**
+ * Applies one weekly orchestration pass over persisted cover-story records.
+ * Runs deterministic lifecycle projections, persists bounded weekly snapshots, and preserves
+ * source records byte-stable. Empty map is a no-op. Re-applying after advance is
+ * idempotent for the same week.
+ */
+export function applyWeeklyCoverStoryTick(
+  records: CoverStoryRecordsMap | null | undefined,
+  week: number,
+  snapshots: CoverStoryWeeklyProjectionSnapshotsMap | null | undefined = {}
+): CoverStoryWeeklyTickResult {
+  const safeRecords = records ?? {}
+  const safeSnapshots = snapshots ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return {
+      records: safeRecords,
+      snapshots: safeSnapshots,
+    }
+  }
+
+  const nextSnapshots = persistWeeklyProjectionSnapshots(safeRecords, safeSnapshots, week)
+
+  return {
+    records: safeRecords,
+    snapshots: nextSnapshots,
+  }
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -259,6 +259,10 @@ import type {
   TruthLayerRecord,
   TruthLayerWeeklyProjectionSnapshot,
 } from './truthLayerRecordRegistry'
+import type {
+  CoverStoryRecord,
+  CoverStoryWeeklyProjectionSnapshot,
+} from './coverStoryLifecycleRegistry'
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
@@ -2671,6 +2675,18 @@ export interface GameState {
    * Hydration drops invalid entries and orphans not present in truth-layer records.
    */
   truthLayerWeeklyProjectionSnapshots?: Record<string, TruthLayerWeeklyProjectionSnapshot>
+
+  /**
+   * SPE-1347 slice 2: persisted cover-story records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  coverStoryRecords?: Record<string, CoverStoryRecord>
+
+  /**
+   * SPE-1347 slice 2: persisted weekly lifecycle projection snapshots (keyed by record id).
+   * Hydration drops invalid entries and orphans not present in cover-story records.
+   */
+  coverStoryWeeklyProjectionSnapshots?: Record<string, CoverStoryWeeklyProjectionSnapshot>
 
   /**
    * SPE-2110 slice 2: persisted pattern source series records (keyed by record id).

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -270,6 +270,7 @@ import { applyWeeklyVisualTriggerHazardTick } from '../visualTriggerHazardWeekly
 import { applyWeeklyNamingHazardDescriptorTick } from '../namingHazardDescriptorWeeklyOrchestration'
 import { applyWeeklyTherapeuticCareTick } from '../containedPersonTherapeuticCareWeeklyOrchestration'
 import { applyWeeklyCoerciveProtocolTick } from '../coerciveContainedPersonProtocolWeeklyOrchestration'
+import { applyWeeklyCoverStoryTick } from '../coverStoryWeeklyOrchestration'
 import { applyWeeklyTruthLayerTick } from '../truthLayerWeeklyOrchestration'
 import { applyWeeklySurveillanceInterventionTuningTick } from '../surveillanceInterventionTuningWeeklyOrchestration'
 import { applyWeeklyPsychologicalResilienceDepletionTick } from '../psychologicalResilienceWeeklyOrchestration'
@@ -4651,6 +4652,18 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     )
     outputWeeklyState.truthLayerRecords = truthLayerTick.records
     outputWeeklyState.truthLayerWeeklyProjectionSnapshots = truthLayerTick.snapshots
+  }
+
+  // SPE-1347 slice 2: lifecycle projection on persisted cover-story records.
+  const currentCoverStoryRecords = outputWeeklyState.coverStoryRecords ?? {}
+  if (Object.keys(currentCoverStoryRecords).length > 0) {
+    const coverStoryTick = applyWeeklyCoverStoryTick(
+      currentCoverStoryRecords,
+      result.week,
+      outputWeeklyState.coverStoryWeeklyProjectionSnapshots
+    )
+    outputWeeklyState.coverStoryRecords = coverStoryTick.records
+    outputWeeklyState.coverStoryWeeklyProjectionSnapshots = coverStoryTick.snapshots
   }
 
   // SPE-2110 slice 3: advance readiness-gated pattern-source intake processing pipeline.

--- a/src/test/advanceWeek.coverStoryRecords.integration.test.ts
+++ b/src/test/advanceWeek.coverStoryRecords.integration.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+  COVER_STORY_STRESSED_FIXTURE,
+  projectCoverStoryLifecycleView,
+} from '../domain/coverStoryLifecycleRegistry'
+import { applyWeeklyCoverStoryTick } from '../domain/coverStoryWeeklyOrchestration'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek cover-story records integration (SPE-1347 slice 2)', () => {
+  it('is a no-op for an empty cover-story map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.coverStoryRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.coverStoryRecords).toEqual({})
+    expect(nextState.coverStoryWeeklyProjectionSnapshots).toEqual({})
+  })
+
+  it('preserves fixture record references byte-stable after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.coverStoryRecords = {
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.week).toBe(5)
+    expect(nextState.coverStoryRecords?.[COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]).toBe(
+      COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE
+    )
+    expect(nextState.coverStoryRecords?.[COVER_STORY_STRESSED_FIXTURE.id]).toBe(
+      COVER_STORY_STRESSED_FIXTURE
+    )
+  })
+
+  it('persists weekly lifecycle projection snapshots through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const snapshot =
+      nextState.coverStoryWeeklyProjectionSnapshots?.[COVER_STORY_STRESSED_FIXTURE.id]
+
+    expect(snapshot?.week).toBe(5)
+    expect(snapshot?.lifecycle).toEqual(projectCoverStoryLifecycleView(COVER_STORY_STRESSED_FIXTURE))
+    expect(snapshot?.lifecycle.coverStressActive).toBe(true)
+    expect(snapshot?.lifecycle.repairInProgress).toBe(false)
+  })
+
+  it('is idempotent when cover-story tick is re-applied at the post-advance week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+
+    const once = advanceWeek(state)
+    const recordsAfterAdvance = once.coverStoryRecords ?? {}
+    const reticked = applyWeeklyCoverStoryTick(
+      recordsAfterAdvance,
+      once.week,
+      once.coverStoryWeeklyProjectionSnapshots
+    )
+
+    expect(reticked.records).toBe(recordsAfterAdvance)
+    expect(reticked.snapshots).toBe(once.coverStoryWeeklyProjectionSnapshots)
+    expect(reticked.records[COVER_STORY_STRESSED_FIXTURE.id]).toBe(COVER_STORY_STRESSED_FIXTURE)
+  })
+
+  it('preserves validation fixture byte-stable through advanceWeek tick', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 30
+    state.coverStoryRecords = {
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.coverStoryRecords?.[COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]).toEqual(
+      COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE
+    )
+    expect(nextState.coverStoryRecords?.[COVER_STORY_STRESSED_FIXTURE.id]).toEqual(
+      COVER_STORY_STRESSED_FIXTURE
+    )
+  })
+})

--- a/src/test/coverStoryLifecycleRegistry.test.ts
+++ b/src/test/coverStoryLifecycleRegistry.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { createStartingState } from '../data/startingState'
 import {
   COASTAL_CAMPUS_COVER_STORY_FIXTURES,
   COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
@@ -15,6 +18,7 @@ import {
   isValidCoverStoryLifecycleTransition,
   projectCoverStoryLifecycleView,
   sanitizeCoverStoryRecords,
+  sanitizeCoverStoryWeeklyProjectionSnapshots,
   transitionCoverStoryLifecyclePhase,
   validateCoverStoryRecord,
   type CoverStoryRecord,
@@ -293,5 +297,141 @@ describe('coverStoryLifecycleTruthLayerAnchor (SPE-1347 slice 1)', () => {
 
     expect(anchor.linkedTruthLayerRecord).toBeNull()
     expect(anchor.dualIncidentPairing).toBeNull()
+  })
+})
+
+describe('coverStoryLifecycleRegistry persistence (SPE-1347 slice 2)', () => {
+  it('defaults starting state to empty cover-story maps', () => {
+    expect(createStartingState().coverStoryRecords).toEqual({})
+    expect(createStartingState().coverStoryWeeklyProjectionSnapshots).toEqual({})
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.coverStoryRecords = {
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.coverStoryRecords).toEqual(state.coverStoryRecords)
+    expect(
+      loaded.coverStoryRecords?.[COVER_STORY_STRESSED_FIXTURE.id]?.contradictionChannels
+    ).toEqual(COVER_STORY_STRESSED_FIXTURE.contradictionChannels)
+    expect(
+      loaded.coverStoryRecords?.[COVER_STORY_COLLAPSED_FIXTURE.id]
+    ).toBeUndefined()
+  })
+
+  it('hydrates persisted cover-story records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        coverStoryRecords: {
+          [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]:
+            COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+          invalid: {
+            id: 'cover:invalid',
+            label: 'Foundation cover narrative review',
+            lifecyclePhase: 'not-a-phase',
+            subjectRef: 'event:test',
+            subjectKind: 'event',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.coverStoryRecords).toEqual({
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]:
+        COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    })
+  })
+
+  it('round-trips weekly lifecycle projection snapshots through save/load', () => {
+    const state = createStartingState()
+    state.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+    state.coverStoryWeeklyProjectionSnapshots = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: {
+        recordId: COVER_STORY_STRESSED_FIXTURE.id,
+        week: 23,
+        lifecycle: projectCoverStoryLifecycleView(COVER_STORY_STRESSED_FIXTURE),
+      },
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.coverStoryWeeklyProjectionSnapshots).toEqual(
+      state.coverStoryWeeklyProjectionSnapshots
+    )
+    expect(
+      loaded.coverStoryWeeklyProjectionSnapshots?.[COVER_STORY_STRESSED_FIXTURE.id]?.lifecycle
+        .coverStressActive
+    ).toBe(true)
+  })
+
+  it('drops orphan weekly snapshots not present in hydrated cover-story records', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        coverStoryRecords: {
+          [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]:
+            COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+        },
+        coverStoryWeeklyProjectionSnapshots: {
+          [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: {
+            recordId: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id,
+            week: 22,
+            lifecycle: projectCoverStoryLifecycleView(COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE),
+          },
+          [COVER_STORY_COLLAPSED_FIXTURE.id]: {
+            recordId: COVER_STORY_COLLAPSED_FIXTURE.id,
+            week: 24,
+            lifecycle: projectCoverStoryLifecycleView(COVER_STORY_COLLAPSED_FIXTURE),
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.coverStoryWeeklyProjectionSnapshots).toEqual({
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: {
+        recordId: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id,
+        week: 22,
+        lifecycle: projectCoverStoryLifecycleView(COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE),
+      },
+    })
+  })
+
+  it('sanitizes weekly snapshots through sanitizeCoverStoryWeeklyProjectionSnapshots', () => {
+    const knownRecordIds = new Set([COVER_STORY_STRESSED_FIXTURE.id])
+    const sanitized = sanitizeCoverStoryWeeklyProjectionSnapshots(
+      {
+        [COVER_STORY_STRESSED_FIXTURE.id]: {
+          recordId: COVER_STORY_STRESSED_FIXTURE.id,
+          week: 23,
+          lifecycle: projectCoverStoryLifecycleView(COVER_STORY_STRESSED_FIXTURE),
+        },
+        orphan: {
+          recordId: COVER_STORY_COLLAPSED_FIXTURE.id,
+          week: 24,
+          lifecycle: projectCoverStoryLifecycleView(COVER_STORY_COLLAPSED_FIXTURE),
+        },
+        invalid: {
+          recordId: 'cover:invalid',
+          week: 'bad',
+          lifecycle: null,
+        },
+      },
+      {},
+      knownRecordIds
+    )
+
+    expect(Object.keys(sanitized)).toEqual([COVER_STORY_STRESSED_FIXTURE.id])
   })
 })

--- a/src/test/coverStoryWeeklyOrchestration.test.ts
+++ b/src/test/coverStoryWeeklyOrchestration.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+  COVER_STORY_COLLAPSED_FIXTURE,
+  COVER_STORY_STRESSED_FIXTURE,
+  projectCoverStoryLifecycleView,
+} from '../domain/coverStoryLifecycleRegistry'
+import {
+  applyWeeklyCoverStoryTick,
+  buildCoverStoryWeeklyProjectionBundle,
+  projectCoverStoryRecordsForWeek,
+} from '../domain/coverStoryWeeklyOrchestration'
+
+describe('coverStoryWeeklyOrchestration (SPE-1347 slice 2)', () => {
+  it('is a no-op for an empty cover-story map without throwing', () => {
+    const records = {}
+    const snapshots = {}
+
+    expect(applyWeeklyCoverStoryTick(records, 4, snapshots)).toEqual({
+      records,
+      snapshots,
+    })
+    expect(projectCoverStoryRecordsForWeek(records, 4)).toEqual([])
+  })
+
+  it('is a no-op for null or undefined maps', () => {
+    expect(applyWeeklyCoverStoryTick(null, 2)).toEqual({ records: {}, snapshots: {} })
+    expect(applyWeeklyCoverStoryTick(undefined, 2)).toEqual({ records: {}, snapshots: {} })
+    expect(projectCoverStoryRecordsForWeek(null, 2)).toEqual([])
+  })
+
+  it('builds projection bundles matching registry lifecycle helper', () => {
+    const bundle = buildCoverStoryWeeklyProjectionBundle(COVER_STORY_STRESSED_FIXTURE, 7)
+
+    expect(bundle.recordId).toBe(COVER_STORY_STRESSED_FIXTURE.id)
+    expect(bundle.week).toBe(7)
+    expect(bundle.lifecycle).toEqual(projectCoverStoryLifecycleView(COVER_STORY_STRESSED_FIXTURE))
+    expect(bundle.lifecycle.coverStressActive).toBe(true)
+    expect(bundle.lifecycle.repairInProgress).toBe(false)
+    expect(bundle.lifecycle.contradictionPressure).toBe(0.67)
+  })
+
+  it('projects records in stable sorted id order', () => {
+    const records = {
+      [COVER_STORY_COLLAPSED_FIXTURE.id]: COVER_STORY_COLLAPSED_FIXTURE,
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    }
+
+    const bundles = projectCoverStoryRecordsForWeek(records, 3)
+
+    expect(bundles.map((bundle) => bundle.recordId)).toEqual([
+      COVER_STORY_COLLAPSED_FIXTURE.id,
+      COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id,
+    ])
+    expect(bundles.every((bundle) => bundle.week === 3)).toBe(true)
+  })
+
+  it('preserves source records when tick runs projections', () => {
+    const records = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    }
+
+    const next = applyWeeklyCoverStoryTick(records, 5)
+
+    expect(next.records).toBe(records)
+    expect(next.records[COVER_STORY_STRESSED_FIXTURE.id]).toBe(COVER_STORY_STRESSED_FIXTURE)
+    expect(next.records[COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]).toBe(
+      COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE
+    )
+  })
+
+  it('is idempotent when re-applied at the same week', () => {
+    const records = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+
+    const once = applyWeeklyCoverStoryTick(records, 4)
+    const twice = applyWeeklyCoverStoryTick(once.records, 4, once.snapshots)
+
+    expect(twice.records).toBe(once.records)
+    expect(twice.snapshots).toBe(once.snapshots)
+    expect(twice.records).toBe(records)
+  })
+
+  it('normalizes non-finite week values to week 1 for projection bundles', () => {
+    const bundle = buildCoverStoryWeeklyProjectionBundle(
+      COVER_STORY_STRESSED_FIXTURE,
+      Number.NaN
+    )
+
+    expect(bundle.week).toBe(1)
+  })
+
+  it('persists weekly lifecycle projection snapshots keyed by record id', () => {
+    const records = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+      [COVER_STORY_COLLAPSED_FIXTURE.id]: COVER_STORY_COLLAPSED_FIXTURE,
+    }
+
+    const tick = applyWeeklyCoverStoryTick(records, 6)
+
+    expect(Object.keys(tick.snapshots).sort()).toEqual([
+      COVER_STORY_COLLAPSED_FIXTURE.id,
+      COVER_STORY_STRESSED_FIXTURE.id,
+    ])
+    expect(tick.snapshots[COVER_STORY_STRESSED_FIXTURE.id]?.week).toBe(6)
+    expect(tick.snapshots[COVER_STORY_STRESSED_FIXTURE.id]?.lifecycle).toEqual(
+      projectCoverStoryLifecycleView(COVER_STORY_STRESSED_FIXTURE)
+    )
+    expect(tick.snapshots[COVER_STORY_COLLAPSED_FIXTURE.id]?.lifecycle.coverCollapsed).toBe(true)
+  })
+
+  it('updates snapshots when week advances and prunes removed record ids', () => {
+    const records = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+      [COVER_STORY_COLLAPSED_FIXTURE.id]: COVER_STORY_COLLAPSED_FIXTURE,
+    }
+
+    const weekFour = applyWeeklyCoverStoryTick(records, 4)
+    const weekFiveRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+    const weekFive = applyWeeklyCoverStoryTick(
+      weekFiveRecords,
+      5,
+      weekFour.snapshots
+    )
+
+    expect(weekFive.snapshots[COVER_STORY_STRESSED_FIXTURE.id]?.week).toBe(5)
+    expect(weekFive.snapshots[COVER_STORY_COLLAPSED_FIXTURE.id]).toBeUndefined()
+  })
+
+  it('does not reveal hidden operational truth in lifecycle projections', () => {
+    const bundle = buildCoverStoryWeeklyProjectionBundle(COVER_STORY_STRESSED_FIXTURE, 23)
+
+    expect(bundle.lifecycle.contradictionChannelHints).toEqual([
+      'digital_traces',
+      'witness_testimony',
+    ])
+    expect(bundle.lifecycle.contradictionPressure).toBe(0.67)
+    expect(bundle.lifecycle.summary).toBe(COVER_STORY_STRESSED_FIXTURE.summary ?? null)
+  })
+})


### PR DESCRIPTION
## Summary

- Persist `coverStoryRecords` and `coverStoryWeeklyProjectionSnapshots` on `GameState` with sanitize/hydrate wire-up in `runTransfer.ts` and default `{}` in `createStartingState`.
- Add `applyWeeklyCoverStoryTick` in `coverStoryWeeklyOrchestration.ts`, mirroring truth-layer and coercive-protocol weekly snapshot patterns; call from `advanceWeek` after week increment.
- Source records remain byte-stable; empty map is a no-op; re-tick same week is idempotent.

## Linear

- **Slice:** [SPE-2457](https://linear.app/spectranoir/issue/SPE-2457) — Cover-story lifecycle GameState persistence + weekly orchestration hook (slice 2)
- **Parent:** [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347) — stays **Backlog** (slice 2 only; full contradiction engine deferred)

## What shipped

- `coverStoryRecords` + `coverStoryWeeklyProjectionSnapshots` on `GameState`
- `sanitizeCoverStoryWeeklyProjectionSnapshots` + runTransfer hydrate
- `coverStoryWeeklyOrchestration.ts` weekly tick
- `advanceWeek` hook after truth-layer tick
- Persistence + orchestration + integration tests

## Validation

- `npm run test:run -- src/test/coverStoryLifecycleRegistry.test.ts src/test/coverStoryWeeklyOrchestration.test.ts src/test/advanceWeek.coverStoryRecords.integration.test.ts`
- `npm run lint`

## Docs updated

- `planning/cover-story-lifecycle-slice-2.md`
- `planning/backlog.md` handoff row

## Parent remains open

SPE-1347 parent acceptance requires full contradiction engine, mirror UI, and additional slices — not satisfied by slice 2 alone.