### PR TITLE
SPE-2458: cover-story lifecycle planning mirror UI (slice 3)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1347 cover-story lifecycle slice 3 (planning mirror UI) or SPE-861 disclosure UI if truth-layer follow-on is prioritized; SPE-1309 unified engine owner slice if cognitive-hazard engine is prioritized.
+**Next step:** SPE-1347 cover-story lifecycle follow-up (contradiction engine) or SPE-861 disclosure UI if truth-layer follow-on is prioritized; SPE-1309 unified engine owner slice if cognitive-hazard engine is prioritized.
 
-**Base `main` SHA:** `adcb571a` — shipped: SPE-1347 cover-story lifecycle slice 2 @ `planning/cover-story-lifecycle-slice-2.md` (PR #2801)
+**Base `main` SHA:** `8d6a746e` — in progress: SPE-1347 cover-story lifecycle slice 3 @ `planning/cover-story-lifecycle-slice-3.md` (branch `spe-1347-cover-story-lifecycle-slice-3`)
 
 **Recently shipped:** SPE-1347 cover-story lifecycle persistence + weekly hook slice 2 (PR #2801); SPE-1347 cover-story lifecycle registry slice 1 (PR #2799).
 

--- a/planning/cover-story-lifecycle-slice-3.md
+++ b/planning/cover-story-lifecycle-slice-3.md
@@ -1,0 +1,79 @@
+# SPE-1347 — Cover-story lifecycle planning mirror UI (slice 3)
+
+One-page implementation plan. Linear: child under [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347). Follows shipped slice 2 (`planning/cover-story-lifecycle-slice-2.md`, PR #2801).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2458 — Cover-story lifecycle planning mirror UI (slice 3)](https://linear.app/spectranoir/issue/SPE-2458) |
+| **Status** | **Ready for PR** — branch `spe-1347-cover-story-lifecycle-slice-3` @ `8d6a746e`                         |
+| **Parent** | [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347) — Cover-story lifecycle state machine; stays **Backlog** |
+| **Branch** | `spe-1347-cover-story-lifecycle-slice-3`                                                                   |
+| **Base `main` SHA** | `8d6a746e`                                                                                          |
+
+## Goal
+
+Read-only planning/operations mirror over persisted `coverStoryRecords` and `coverStoryWeeklyProjectionSnapshots` — for agent routing visibility, not player-facing canon.
+
+## Prerequisite (on `main` @ `8d6a746e`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/coverStoryLifecycleRegistry.ts` (SPE-1347 slice 1 / PR #2799) |
+| Persistence          | `coverStoryRecords` on `GameState` (SPE-2457 / PR #2801)               |
+| Weekly orchestration | `applyWeeklyCoverStoryTick` (SPE-2457 / PR #2801)                        |
+| Sibling mirror template | `TruthLayerMirrorPage` (SPE-1343 slice 4 / PR #2777)                  |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `getCoverStoryMirrorView` + `CoverStoryMirrorPage`               | New persistence fields                     |
+| Route `/cover-story-records` + Front Desk quick link               | Weekly tick / sanitize contract changes       |
+| Lifecycle projection + contradiction channel hints display         | SPE-1347 parent status changes               |
+| Ops flags + weekly snapshot column from persisted snapshots        | SPE-861 disclosure UI                         |
+| View + component tests                                             | Full contradiction engine                   |
+| Slice doc (this file) + backlog handoff                            | Mission triage expansion                      |
+|                                                                    | Record mutation from mirror surface           |
+
+## Mirror contract
+
+- **Read-only** — no mutations to GameState from the mirror surface.
+- **Hydrated truth only** — display persisted records as hydrated; do not re-run validation or surface dropped invalid entries.
+- **Lifecycle projection** — `projectCoverStoryLifecycleView` derives stress/collapse/repair signals without revealing hidden operational truth.
+- **Contradiction hints** — channel kinds and aggregate pressure only; no hidden truth leakage in mirror labels.
+- **Weekly snapshot** — column from persisted `coverStoryWeeklyProjectionSnapshots`; snapshot week vs game week displayed separately.
+- **Empty state** — when `coverStoryRecords` map is empty after hydrate.
+- **Copy** — CP-neutral labels; no franchise tokens in UI strings.
+
+## Acceptance
+
+- [x] Empty `coverStoryRecords` map renders empty state without throw
+- [x] Records table shows lifecycle projection from `projectCoverStoryLifecycleView`
+- [x] Ops flags and weekly snapshot display persisted projection without hidden truth leakage
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/coverStoryMirrorView.ts`                     |
+| UI     | `src/features/operations/CoverStoryMirrorPage.tsx`                    |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`, `src/app/appShellRoutePaths.ts` |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/features/operations/coverStoryMirrorView.test.ts`, `src/features/operations/CoverStoryMirrorPage.test.tsx` |
+| Plan   | `planning/cover-story-lifecycle-slice-3.md`, `planning/backlog.md`    |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full contradiction accumulation engine across channels | SPE-1347 follow-up | Requires trigger sources beyond projection snapshots |
+| Disclosure campaign player UI | SPE-861 | Out of domain wire-up boundary |
+| Witness normalization wire-up | SPE-899 | Sibling deferred work |
+
+## See also
+
+- `planning/cover-story-lifecycle-slice-2.md`
+- `planning/truth-layer-record-registry-slice-4.md` — mirror UI template (SPE-1343 slice 4)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -90,6 +90,9 @@ const PublicDisclosureMirrorRoute = createRouteComponent(
 const TruthLayerMirrorRoute = createRouteComponent(
   () => import('../features/operations/TruthLayerMirrorPage')
 )
+const CoverStoryMirrorRoute = createRouteComponent(
+  () => import('../features/operations/CoverStoryMirrorPage')
+)
 const MassAnomalousPopulationEmergenceMirrorRoute = createRouteComponent(
   () => import('../features/operations/MassAnomalousPopulationEmergenceMirrorPage')
 )
@@ -195,6 +198,7 @@ export default function App() {
           element={renderLazyRoute(PublicDisclosureMirrorRoute)}
         />
         <Route path="truth-layer-records" element={renderLazyRoute(TruthLayerMirrorRoute)} />
+        <Route path="cover-story-records" element={renderLazyRoute(CoverStoryMirrorRoute)} />
         <Route
           path="mass-anomalous-population-emergence"
           element={renderLazyRoute(MassAnomalousPopulationEmergenceMirrorRoute)}

--- a/src/app/appShellRoutePaths.ts
+++ b/src/app/appShellRoutePaths.ts
@@ -26,6 +26,7 @@ export const APP_SHELL_STATIC_ROUTE_PATHS = [
   'self-censoring-information',
   'public-disclosure-state',
   'truth-layer-records',
+  'cover-story-records',
   'mass-anomalous-population-emergence',
   'visual-trigger-hazard',
   'entity-welfare-reclassification',

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -29,6 +29,7 @@ export const APP_ROUTES = {
   selfCensoringInformation: '/self-censoring-information',
   publicDisclosureState: '/public-disclosure-state',
   truthLayerRecords: '/truth-layer-records',
+  coverStoryRecords: '/cover-story-records',
   massAnomalousPopulationEmergence: '/mass-anomalous-population-emergence',
   visualTriggerHazard: '/visual-trigger-hazard',
   entityWelfareReclassification: '/entity-welfare-reclassification',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -903,6 +903,42 @@ export const SELF_CENSORING_INFORMATION_MIRROR_UI_TEXT: Record<string, string> =
   redactedSuffix: 'Partial redaction',
 }
 
+export const COVER_STORY_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Cover-story lifecycle registry',
+  pageSubtitle:
+    'Read-only operations view over persisted cover-story records and weekly lifecycle projection snapshots.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Persisted records',
+  coverStressActiveLabel: 'Cover stress active',
+  coverCollapsedLabel: 'Cover collapsed',
+  repairInProgressLabel: 'Repair in progress',
+  weekLabel: 'Simulation week',
+  readOnlyNote:
+    'Lifecycle projections mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
+  emptyTitle: 'No cover-story records',
+  emptyBody:
+    'Persisted cover-story records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  recordsHeading: 'Persisted records',
+  recordsSubtitle:
+    'Contradiction channel hints show aggregate pressure only; weekly snapshot column displays persisted lifecycle projection when available.',
+  labelColumn: 'Label',
+  lifecycleColumn: 'Lifecycle',
+  contradictionColumn: 'Contradiction signals',
+  opsFlagsColumn: 'Ops flags',
+  weeklySnapshotColumn: 'Weekly snapshot',
+  contradictionPressureLabel: 'Contradiction pressure',
+  coverCapacityScoreLabel: 'Cover capacity score',
+  channelCountPrefix: 'Active channels:',
+  motivationPrefix: 'Motivation:',
+  exposurePrefix: 'Exposure:',
+  confidenceColumn: 'Confidence',
+  latestRepairPrefix: 'Latest repair:',
+  unknownFieldsPrefix: 'Unknown fields:',
+  snapshotWeekPrefix: 'Snapshot week',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const TRUTH_LAYER_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Truth-layer record registry',

--- a/src/features/operations/CoverStoryMirrorPage.test.tsx
+++ b/src/features/operations/CoverStoryMirrorPage.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+  COVER_STORY_STRESSED_FIXTURE,
+} from '../../domain/coverStoryLifecycleRegistry'
+import { applyWeeklyCoverStoryTick } from '../../domain/coverStoryWeeklyOrchestration'
+import { useGameStore } from '../../app/store/gameStore'
+import CoverStoryMirrorPage from './CoverStoryMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/cover-story-records']}>
+      <Routes>
+        <Route path="/cover-story-records" element={<CoverStoryMirrorPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('CoverStoryMirrorPage (SPE-1347 slice 3)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderMirrorPage()
+
+    expect(
+      screen.getByRole('region', { name: /cover-story lifecycle registry mirror/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty registry state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no cover-story records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted records with lifecycle projection and weekly snapshot', () => {
+    const game = createStartingState()
+    game.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    }
+    const tick = applyWeeklyCoverStoryTick(game.coverStoryRecords, 15)
+    game.coverStoryWeeklyProjectionSnapshots = tick.snapshots
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted cover-story records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(COVER_STORY_STRESSED_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent(COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent('Routine maintenance narrative stressed by witness timelines and forum metadata.')
+    expect(recordsRegion).toHaveTextContent('Cover stress active: Yes')
+    expect(recordsRegion).toHaveTextContent('Contradiction pressure: 0.67')
+    expect(recordsRegion).toHaveTextContent('Snapshot week W15')
+    expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/features/operations/CoverStoryMirrorPage.tsx
+++ b/src/features/operations/CoverStoryMirrorPage.tsx
@@ -1,0 +1,194 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { COVER_STORY_MIRROR_UI_TEXT } from '../../data/copy'
+import { getCoverStoryMirrorView } from './coverStoryMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function CoverStoryMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getCoverStoryMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Cover-story lifecycle registry mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Registry summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {COVER_STORY_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">{COVER_STORY_MIRROR_UI_TEXT.pageHeading}</h2>
+            <p className="text-sm opacity-60">{COVER_STORY_MIRROR_UI_TEXT.pageSubtitle}</p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {COVER_STORY_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+          <StatCard
+            label={COVER_STORY_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={COVER_STORY_MIRROR_UI_TEXT.coverStressActiveLabel}
+            value={String(view.summary.coverStressActiveCount)}
+          />
+          <StatCard
+            label={COVER_STORY_MIRROR_UI_TEXT.coverCollapsedLabel}
+            value={String(view.summary.coverCollapsedCount)}
+          />
+          <StatCard
+            label={COVER_STORY_MIRROR_UI_TEXT.repairInProgressLabel}
+            value={String(view.summary.repairInProgressCount)}
+          />
+          <StatCard
+            label={COVER_STORY_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">{COVER_STORY_MIRROR_UI_TEXT.readOnlyNote}</p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty registry state">
+          <h3 className="text-lg font-semibold">{COVER_STORY_MIRROR_UI_TEXT.emptyTitle}</h3>
+          <p className="text-sm opacity-70">{COVER_STORY_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted cover-story records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">{COVER_STORY_MIRROR_UI_TEXT.recordsHeading}</h3>
+            <p className="text-sm opacity-60">{COVER_STORY_MIRROR_UI_TEXT.recordsSubtitle}</p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">{COVER_STORY_MIRROR_UI_TEXT.labelColumn}</th>
+                  <th className="px-2 py-2">{COVER_STORY_MIRROR_UI_TEXT.lifecycleColumn}</th>
+                  <th className="px-2 py-2">{COVER_STORY_MIRROR_UI_TEXT.contradictionColumn}</th>
+                  <th className="px-2 py-2">{COVER_STORY_MIRROR_UI_TEXT.opsFlagsColumn}</th>
+                  <th className="px-2 py-2">{COVER_STORY_MIRROR_UI_TEXT.weeklySnapshotColumn}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {record.subjectKindLabel}: {record.subjectRef}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {COVER_STORY_MIRROR_UI_TEXT.motivationPrefix} {record.coverMotivationLabel}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {COVER_STORY_MIRROR_UI_TEXT.exposurePrefix} {record.exposureKindLabel}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {COVER_STORY_MIRROR_UI_TEXT.confidenceColumn}: {record.confidenceLabel}
+                      </p>
+                      {record.unknownFieldsLabel !== '—' ? (
+                        <p className="text-xs opacity-45">
+                          {COVER_STORY_MIRROR_UI_TEXT.unknownFieldsPrefix}{' '}
+                          {record.unknownFieldsLabel}
+                        </p>
+                      ) : null}
+                      {record.redacted ? (
+                        <p className="text-xs opacity-55">
+                          {COVER_STORY_MIRROR_UI_TEXT.redactedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2 align-top">
+                      <p className="font-medium">{record.lifecyclePhaseLabel}</p>
+                      <p className="text-xs opacity-45">
+                        {COVER_STORY_MIRROR_UI_TEXT.latestRepairPrefix}{' '}
+                        {record.latestRepairActionLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2 align-top">
+                      <p className="text-xs">
+                        {COVER_STORY_MIRROR_UI_TEXT.contradictionPressureLabel}:{' '}
+                        {record.contradictionPressureLabel}
+                      </p>
+                      <p className="text-xs">
+                        {COVER_STORY_MIRROR_UI_TEXT.coverCapacityScoreLabel}:{' '}
+                        {record.coverCapacityScoreLabel}
+                      </p>
+                      <p className="text-xs">
+                        {COVER_STORY_MIRROR_UI_TEXT.channelCountPrefix}{' '}
+                        {record.activeContradictionChannelCount}
+                      </p>
+                      <p className="text-xs opacity-45">{record.contradictionChannelHintsLabel}</p>
+                    </td>
+                    <td className="px-2 py-2 align-top">
+                      <p className="text-xs">
+                        {COVER_STORY_MIRROR_UI_TEXT.coverStressActiveLabel}:{' '}
+                        {record.coverStressActiveLabel}
+                      </p>
+                      <p className="text-xs">
+                        {COVER_STORY_MIRROR_UI_TEXT.coverCollapsedLabel}: {record.coverCollapsedLabel}
+                      </p>
+                      <p className="text-xs">
+                        {COVER_STORY_MIRROR_UI_TEXT.repairInProgressLabel}:{' '}
+                        {record.repairInProgressLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2 align-top">
+                      {record.weeklySnapshot ? (
+                        <>
+                          <p className="text-xs">
+                            {COVER_STORY_MIRROR_UI_TEXT.snapshotWeekPrefix} W
+                            {record.weeklySnapshot.week}
+                          </p>
+                          <p className="text-xs">
+                            {COVER_STORY_MIRROR_UI_TEXT.lifecycleColumn}:{' '}
+                            {record.weeklySnapshot.lifecyclePhaseLabel}
+                          </p>
+                          <p className="text-xs">
+                            {COVER_STORY_MIRROR_UI_TEXT.coverStressActiveLabel}:{' '}
+                            {record.weeklySnapshot.coverStressActiveLabel}
+                          </p>
+                          <p className="text-xs">
+                            {COVER_STORY_MIRROR_UI_TEXT.contradictionPressureLabel}:{' '}
+                            {record.weeklySnapshot.contradictionPressureLabel}
+                          </p>
+                          {record.weeklySnapshot.redacted ? (
+                            <p className="text-xs opacity-55">
+                              {COVER_STORY_MIRROR_UI_TEXT.redactedSuffix}
+                            </p>
+                          ) : null}
+                        </>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/coverStoryMirrorView.test.ts
+++ b/src/features/operations/coverStoryMirrorView.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+  COVER_STORY_COLLAPSED_FIXTURE,
+  COVER_STORY_STRESSED_FIXTURE,
+  projectCoverStoryLifecycleView,
+} from '../../domain/coverStoryLifecycleRegistry'
+import { applyWeeklyCoverStoryTick } from '../../domain/coverStoryWeeklyOrchestration'
+import {
+  formatCoverStoryEnumLabel,
+  getCoverStoryMirrorView,
+} from './coverStoryMirrorView'
+
+describe('coverStoryMirrorView (SPE-1347 slice 3)', () => {
+  it('returns empty mirror when coverStoryRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.coverStoryRecords).toEqual({})
+
+    const view = getCoverStoryMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.summary.weeklySnapshotCount).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('mirrors lifecycle projection fields without hidden operational truth leakage', () => {
+    const game = createStartingState()
+    game.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+
+    const view = getCoverStoryMirrorView(game)
+    const record = view.records[0]
+    const projection = projectCoverStoryLifecycleView(COVER_STORY_STRESSED_FIXTURE)
+
+    expect(view.isEmpty).toBe(false)
+    expect(view.summary.coverStressActiveCount).toBe(1)
+    expect(view.summary.coverCollapsedCount).toBe(0)
+    expect(record?.lifecyclePhaseLabel).toBe('Stressed')
+    expect(record?.coverStressActiveLabel).toBe('Yes')
+    expect(record?.contradictionPressureLabel).toBe('0.67')
+    expect(record?.coverCapacityScoreLabel).toBe('0.41')
+    expect(record?.contradictionChannelHintsLabel).toBe('Digital Traces, Witness Testimony')
+    expect(record?.latestRepairActionLabel).toBe('Reinforcement')
+    expect(record?.coverMotivationLabel).toBe('Reputation Protection')
+    expect(record?.label).not.toMatch(/foundation|scp|masquerade/i)
+    expect(record?.summaryLabel).toBe(projection.summary)
+  })
+
+  it('displays persisted weekly lifecycle snapshot round-trip', () => {
+    const game = createStartingState()
+    game.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+    }
+    const tick = applyWeeklyCoverStoryTick(game.coverStoryRecords, 12)
+    game.coverStoryWeeklyProjectionSnapshots = tick.snapshots
+
+    const view = getCoverStoryMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.weeklySnapshotCount).toBe(1)
+    expect(record?.weeklySnapshot?.week).toBe(12)
+    expect(record?.weeklySnapshot?.coverStressActiveLabel).toBe('Yes')
+    expect(record?.weeklySnapshot?.contradictionPressureLabel).toBe('0.67')
+    expect(record?.weeklySnapshot?.lifecyclePhaseLabel).toBe('Stressed')
+  })
+
+  it('mirrors collapsed and maintained fixtures with distinct lifecycle signals', () => {
+    const game = createStartingState()
+    game.coverStoryRecords = {
+      [COVER_STORY_COLLAPSED_FIXTURE.id]: COVER_STORY_COLLAPSED_FIXTURE,
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    }
+
+    const view = getCoverStoryMirrorView(game)
+    const collapsed = view.records.find((record) => record.id === COVER_STORY_COLLAPSED_FIXTURE.id)
+    const maintained = view.records.find(
+      (record) => record.id === COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id
+    )
+
+    expect(view.summary.coverCollapsedCount).toBe(1)
+    expect(collapsed?.coverCollapsedLabel).toBe('Yes')
+    expect(collapsed?.lifecyclePhaseLabel).toBe('Collapsed')
+    expect(maintained?.lifecyclePhaseLabel).toBe('Maintained')
+    expect(maintained?.coverStressActiveLabel).toBe('No')
+    expect(maintained?.weeklySnapshot).toBeNull()
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatCoverStoryEnumLabel('witness_testimony')).toBe('Witness Testimony')
+    expect(formatCoverStoryEnumLabel('institutional_face_saving')).toBe('Institutional Face Saving')
+  })
+
+  it('is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+      [COVER_STORY_COLLAPSED_FIXTURE.id]: COVER_STORY_COLLAPSED_FIXTURE,
+    }
+    const tick = applyWeeklyCoverStoryTick(game.coverStoryRecords, 8)
+    game.coverStoryWeeklyProjectionSnapshots = tick.snapshots
+
+    const first = JSON.stringify(getCoverStoryMirrorView(game))
+    const second = JSON.stringify(getCoverStoryMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/features/operations/coverStoryMirrorView.ts
+++ b/src/features/operations/coverStoryMirrorView.ts
@@ -1,0 +1,202 @@
+import type { GameState } from '../../domain/models'
+import {
+  projectCoverStoryLifecycleView,
+  type CoverStoryLifecycleProjection,
+  type CoverStoryRecord,
+  type CoverStoryWeeklyProjectionSnapshot,
+} from '../../domain/coverStoryLifecycleRegistry'
+
+export interface CoverStoryMirrorSnapshotView {
+  week: number
+  lifecyclePhaseLabel: string
+  coverStressActiveLabel: string
+  coverCollapsedLabel: string
+  repairInProgressLabel: string
+  contradictionPressureLabel: string
+  coverCapacityScoreLabel: string
+  activeContradictionChannelCount: number
+  contradictionChannelHintsLabel: string
+  latestRepairActionLabel: string
+  confidenceLabel: string
+  redacted: boolean
+}
+
+export interface CoverStoryMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  lifecyclePhaseLabel: string
+  subjectRef: string
+  subjectKindLabel: string
+  coverMotivationLabel: string
+  exposureKindLabel: string
+  contradictionPressureLabel: string
+  coverCapacityScoreLabel: string
+  activeContradictionChannelCount: number
+  contradictionChannelHintsLabel: string
+  latestRepairActionLabel: string
+  coverStressActiveLabel: string
+  coverCollapsedLabel: string
+  repairInProgressLabel: string
+  confidenceLabel: string
+  unknownFieldsLabel: string
+  redacted: boolean
+  weeklySnapshot: CoverStoryMirrorSnapshotView | null
+}
+
+export interface CoverStoryMirrorSummaryView {
+  totalRecords: number
+  coverStressActiveCount: number
+  coverCollapsedCount: number
+  repairInProgressCount: number
+  weeklySnapshotCount: number
+  week: number
+}
+
+export interface CoverStoryMirrorView {
+  isEmpty: boolean
+  summary: CoverStoryMirrorSummaryView
+  records: readonly CoverStoryMirrorRecordView[]
+}
+
+export function formatCoverStoryEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(game: GameState): CoverStoryRecord[] {
+  const map = game.coverStoryRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatConfidence(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatBoolean(value: boolean): string {
+  return value ? 'Yes' : 'No'
+}
+
+function formatNullableEnum(value: string | null | undefined): string {
+  if (!value) {
+    return '—'
+  }
+
+  return formatCoverStoryEnumLabel(value)
+}
+
+function formatSummary(projection: CoverStoryLifecycleProjection, summaryRedacted: boolean): string {
+  if (projection.redacted && summaryRedacted) {
+    return '[Redacted]'
+  }
+
+  return projection.summary ?? '—'
+}
+
+function formatChannelHints(hints: readonly string[]): string {
+  if (hints.length === 0) {
+    return '—'
+  }
+
+  return hints.map((hint) => formatCoverStoryEnumLabel(hint)).join(', ')
+}
+
+function toSnapshotView(
+  snapshot: CoverStoryWeeklyProjectionSnapshot
+): CoverStoryMirrorSnapshotView {
+  const lifecycle = snapshot.lifecycle
+
+  return Object.freeze({
+    week: snapshot.week,
+    lifecyclePhaseLabel: formatCoverStoryEnumLabel(lifecycle.lifecyclePhase),
+    coverStressActiveLabel: formatBoolean(lifecycle.coverStressActive),
+    coverCollapsedLabel: formatBoolean(lifecycle.coverCollapsed),
+    repairInProgressLabel: formatBoolean(lifecycle.repairInProgress),
+    contradictionPressureLabel: formatConfidence(lifecycle.contradictionPressure),
+    coverCapacityScoreLabel: formatConfidence(lifecycle.coverCapacityScore),
+    activeContradictionChannelCount: lifecycle.activeContradictionChannelCount,
+    contradictionChannelHintsLabel: formatChannelHints(lifecycle.contradictionChannelHints),
+    latestRepairActionLabel: formatNullableEnum(lifecycle.latestRepairAction),
+    confidenceLabel: formatConfidence(lifecycle.confidence),
+    redacted: lifecycle.redacted,
+  })
+}
+
+function toRecordView(
+  record: CoverStoryRecord,
+  projection: CoverStoryLifecycleProjection,
+  snapshot: CoverStoryWeeklyProjectionSnapshot | undefined
+): CoverStoryMirrorRecordView {
+  const summaryRedacted = (record.redactedFields ?? []).includes('summary')
+
+  return Object.freeze({
+    id: record.id,
+    label: projection.label,
+    summaryLabel: formatSummary(projection, summaryRedacted),
+    lifecyclePhaseLabel: formatCoverStoryEnumLabel(projection.lifecyclePhase),
+    subjectRef: projection.subjectRef,
+    subjectKindLabel: formatCoverStoryEnumLabel(projection.subjectKind),
+    coverMotivationLabel: formatNullableEnum(projection.coverMotivation),
+    exposureKindLabel: formatNullableEnum(projection.exposureKind),
+    contradictionPressureLabel: formatConfidence(projection.contradictionPressure),
+    coverCapacityScoreLabel: formatConfidence(projection.coverCapacityScore),
+    activeContradictionChannelCount: projection.activeContradictionChannelCount,
+    contradictionChannelHintsLabel: formatChannelHints(projection.contradictionChannelHints),
+    latestRepairActionLabel: formatNullableEnum(projection.latestRepairAction),
+    coverStressActiveLabel: formatBoolean(projection.coverStressActive),
+    coverCollapsedLabel: formatBoolean(projection.coverCollapsed),
+    repairInProgressLabel: formatBoolean(projection.repairInProgress),
+    confidenceLabel: formatConfidence(projection.confidence),
+    unknownFieldsLabel:
+      projection.unknownFields.length > 0 ? projection.unknownFields.join(', ') : '—',
+    redacted: projection.redacted,
+    weeklySnapshot: snapshot ? toSnapshotView(snapshot) : null,
+  })
+}
+
+/** Read-only mirror over hydrated `coverStoryRecords` and weekly projection snapshots. */
+export function getCoverStoryMirrorView(game: GameState): CoverStoryMirrorView {
+  const records = listPersistedRecords(game)
+  const snapshots = game.coverStoryWeeklyProjectionSnapshots ?? {}
+
+  const coverStressActiveCount = records.filter((record) => {
+    const projection = projectCoverStoryLifecycleView(record)
+    return projection.coverStressActive
+  }).length
+
+  const coverCollapsedCount = records.filter((record) => {
+    const projection = projectCoverStoryLifecycleView(record)
+    return projection.coverCollapsed
+  }).length
+
+  const repairInProgressCount = records.filter((record) => {
+    const projection = projectCoverStoryLifecycleView(record)
+    return projection.repairInProgress
+  }).length
+
+  const weeklySnapshotCount = records.filter((record) => snapshots[record.id] !== undefined).length
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      totalRecords: records.length,
+      coverStressActiveCount,
+      coverCollapsedCount,
+      repairInProgressCount,
+      weeklySnapshotCount,
+      week: game.week,
+    }),
+    records: Object.freeze(
+      records.map((record) => {
+        const projection = projectCoverStoryLifecycleView(record)
+        return toRecordView(record, projection, snapshots[record.id])
+      })
+    ),
+  })
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -790,6 +790,12 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
         'Review separate claim, doctrine, and verification layers plus myth infrastructure ops flags.',
     },
     {
+      label: 'Open cover-story mirror',
+      href: APP_ROUTES.coverStoryRecords,
+      description:
+        'Review cover-story lifecycle phases, contradiction pressure, and weekly projection snapshots.',
+    },
+    {
       label: 'Open population emergence mirror',
       href: APP_ROUTES.massAnomalousPopulationEmergence,
       description:


### PR DESCRIPTION
## Summary

- Add read-only getCoverStoryMirrorView over hydrated coverStoryRecords + coverStoryWeeklyProjectionSnapshots, mirroring the SPE-1343 truth-layer mirror pattern.
- Wire /cover-story-records route, CoverStoryMirrorPage, Front Desk quick link, and CP-neutral copy.
- Add view unit tests (empty map, fixture projection, snapshot read) and page smoke test.

## Linear

- **Slice:** [SPE-2458](https://linear.app/spectranoir/issue/SPE-2458) — Cover-story lifecycle planning mirror UI (slice 3)
- **Parent:** [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347) — stays **Backlog**

## What shipped

Planning mirror UI only — no persistence changes, no contradiction engine, no SPE-861 disclosure UI, no record mutation.

## Validation

- 
pm run test:run -- src/features/operations/coverStoryMirrorView.test.ts src/features/operations/CoverStoryMirrorPage.test.tsx (8 passed)
- 
pm run lint (clean)

## Docs updated

- planning/cover-story-lifecycle-slice-3.md
- planning/backlog.md (handoff row)

## Parent remains open

SPE-1347 parent acceptance not met — contradiction engine and sibling work deferred per slice doc.

Made with [Cursor](https://cursor.com)