### PR TITLE
SPE-1347 slice 4: cover-story contradiction accumulation engine

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1347 cover-story lifecycle follow-up (contradiction engine) or SPE-861 disclosure UI if truth-layer follow-on is prioritized; SPE-1309 unified engine owner slice if cognitive-hazard engine is prioritized.
+**Next step:** SPE-861 disclosure UI or SPE-1309 unified engine owner slice if prioritized over remaining SPE-1347 siblings.
 
-**Base `main` SHA:** `747b06f3` — shipped: SPE-1347 cover-story lifecycle slice 3 @ `planning/cover-story-lifecycle-slice-3.md` (PR #2803)
+**Base `main` SHA:** `6cfdc83c` — in progress: SPE-1347 cover-story lifecycle slice 4 @ `planning/cover-story-lifecycle-slice-4.md`
 
 **Recently shipped:** SPE-1347 cover-story lifecycle planning mirror UI slice 3 (PR #2803); SPE-1347 cover-story lifecycle persistence + weekly hook slice 2 (PR #2801).
 

--- a/planning/cover-story-lifecycle-slice-4.md
+++ b/planning/cover-story-lifecycle-slice-4.md
@@ -1,0 +1,74 @@
+# SPE-1347 — Cover-story lifecycle contradiction accumulation engine (slice 4)
+
+One-page implementation plan. Linear: child under [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347). Follows shipped slice 3 (`planning/cover-story-lifecycle-slice-3.md`, PR #2803).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | Cover-story lifecycle contradiction accumulation engine (slice 4) — child under SPE-1347                  |
+| **Status** | **Shipped** — PR pending @ slice 4 branch                                                                 |
+| **Parent** | [SPE-1347](https://linear.app/spectranoir/issue/SPE-1347) — Cover-story lifecycle state machine; stays **Backlog** |
+| **Branch** | `spe-1347-cover-story-lifecycle-slice-4`                                                                   |
+| **Base `main` SHA** | `6cfdc83c`                                                                                          |
+
+## Goal
+
+Wire contradiction channel accumulation from trigger sources (witness testimony, institutional records, digital traces, etc.) into weekly tick projection updates. Extend orchestration only — no mirror UI, no SPE-861 disclosure UI, no record mutation beyond deterministic channel score updates driven by defined trigger contracts.
+
+## Prerequisite (on `main` @ `6cfdc83c`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/coverStoryLifecycleRegistry.ts` (SPE-1347 slice 1 / PR #2799) |
+| Persistence + weekly hook | `planning/cover-story-lifecycle-slice-2.md` (SPE-2457 / PR #2801) |
+| Planning mirror UI   | `planning/cover-story-lifecycle-slice-3.md` (SPE-2458 / PR #2803)     |
+
+## Orchestration contract (slice 4)
+
+- **Trigger contracts** — `resolveWeeklyCoverStoryContradictionTriggers` maps intake contradiction events, truth-layer divergence, compliance breach, and extranormal witness monitoring onto channel kinds.
+- **Accumulation** — `applyCoverStoryContradictionTriggers` upserts channel scores (0..1 clamp), idempotent on `sourceRef`.
+- **Lifecycle transitions** — maintained → stressed at `0.45`; stressed → collapsed at `0.85`; invalid transitions still rejected at sanitize.
+- **Weekly tick** — `applyWeeklyCoverStoryTick(records, week, snapshots, { contradictionInput })` runs accumulation then projections; orphan snapshot pruning unchanged.
+- **Does not** — mirror UI changes, SPE-861 disclosure UI, SPE-899 witness normalization wire-up, SPE-1309 unified engine.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `coverStoryContradictionAccumulation.ts` trigger + tick logic      | Mirror UI changes                             |
+| Extended `applyWeeklyCoverStoryTick` with `contradictionInput`     | SPE-861 disclosure UI                         |
+| `advanceWeek` trigger context wire-up                              | SPE-1309 unified engine                       |
+| `deriveCoverStoryContradictionPressure` export on registry         | SPE-899 witness normalization                 |
+| Unit + orchestration + advanceWeek integration tests               | Record mutation beyond channel scores / lifecycle transitions |
+| Slice doc (this file) + backlog handoff                            |                                               |
+
+## Acceptance
+
+- [x] Channel accumulation from fixture triggers with 0..1 clamping
+- [x] Orchestration idempotent on same-week re-tick
+- [x] advanceWeek stressed → collapsed path via linked truth-layer divergence trigger
+- [x] Empty channel list / no triggers preserve byte-stable records
+- [x] Projections surface channel hints and aggregate pressure only (no hidden truth leakage)
+- [x] Invalid phase transitions rejected at sanitize (from slice 1)
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coverStoryContradictionAccumulation.ts`, `src/domain/coverStoryWeeklyOrchestration.ts`, `src/domain/coverStoryLifecycleRegistry.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/coverStoryContradictionAccumulation.test.ts`, `src/test/coverStoryWeeklyOrchestration.test.ts`, `src/test/advanceWeek.coverStoryRecords.integration.test.ts` |
+| Plan   | `planning/cover-story-lifecycle-slice-4.md`, `planning/backlog.md`    |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Disclosure campaign player UI | SPE-861 | Out of domain wire-up |
+| Witness normalization wire-up | SPE-899 | Sibling work |
+| Full SPE-1347 parent closure | SPE-1347 | Parent stays open until disclosure + witness siblings land or are explicitly deferred on parent |
+
+## See also
+
+- `planning/cover-story-lifecycle-slice-3.md`
+- `src/domain/informationIntakeWeeklyCorroboration.ts` — intake contradiction trigger pattern
+- `src/domain/caseLifecycleWeeklyOrchestration.ts` — weekly trigger input pattern

--- a/src/domain/coverStoryContradictionAccumulation.ts
+++ b/src/domain/coverStoryContradictionAccumulation.ts
@@ -1,0 +1,721 @@
+/**
+ * SPE-1347 slice 4: weekly contradiction channel accumulation from trigger sources.
+ *
+ * Maps deterministic weekly trigger contracts (intake contradiction events, truth-layer
+ * divergence, compliance breach, extranormal witness monitoring) onto cover-story
+ * contradiction channels and bounded lifecycle transitions — without revealing hidden
+ * operational truth in projections.
+ */
+
+import {
+  deriveCoverStoryContradictionPressure,
+  isValidCoverStoryLifecycleTransition,
+  transitionCoverStoryLifecyclePhase,
+  validateCoverStoryRecord,
+  type CoverStoryContradictionChannel,
+  type CoverStoryContradictionChannelKind,
+  type CoverStoryLifecycleEvent,
+  type CoverStoryLifecyclePhase,
+  type CoverStoryRecord,
+  type CoverStoryTransitionHistoryEntry,
+} from './coverStoryLifecycleRegistry'
+import type { ExtranormalEventRecord, ExtranormalEventRecordsMap } from './extranormalEventRegistry'
+import type {
+  InformationIntakeReportRecord,
+  InformationIntakeReportsMap,
+} from './informationIntakeReport'
+import type { CaseInstance } from './models'
+import {
+  projectTruthLayerOpsView,
+  type TruthLayerRecordsMap,
+} from './truthLayerRecordRegistry'
+import type { RuleDocumentComplianceRecordsMap } from './ruleDocumentComplianceContainmentRegistry'
+
+export type CoverStoryContradictionTriggerKind =
+  | 'intake_witness_contradiction'
+  | 'intake_digital_trace'
+  | 'intake_community_suspicion'
+  | 'truth_layer_divergence'
+  | 'compliance_breach'
+  | 'extranormal_witness_monitoring'
+
+export interface CoverStoryContradictionTrigger {
+  readonly kind: CoverStoryContradictionTriggerKind
+  readonly channel: CoverStoryContradictionChannelKind
+  readonly delta: number
+  readonly sourceRef: string
+}
+
+export interface CoverStoryContradictionTickInput {
+  readonly week: number
+  readonly priorIntakeReports?: InformationIntakeReportsMap | null
+  readonly nextIntakeReports?: InformationIntakeReportsMap | null
+  readonly truthLayerRecords?: TruthLayerRecordsMap | null
+  readonly ruleDocumentComplianceRecords?: RuleDocumentComplianceRecordsMap | null
+  readonly extranormalEventRecords?: ExtranormalEventRecordsMap | null
+  readonly cases?: Record<string, CaseInstance> | null
+}
+
+export const COVER_STORY_CONTRADICTION_STRESS_THRESHOLD = 0.45
+export const COVER_STORY_CONTRADICTION_COLLAPSE_THRESHOLD = 0.85
+
+const MINOR_INTAKE_CONTRADICTION_DELTA = 0.12
+const MAJOR_INTAKE_CONTRADICTION_DELTA = 0.22
+const TRUTH_LAYER_DIVERGENCE_DELTA = 0.15
+const COMPLIANCE_BREACH_DELTA = 0.18
+const EXTRANORMAL_MONITORING_DELTA = 0.1
+const COMMUNITY_SUSPICION_DELTA = 0.11
+
+const ACCUMULATING_PHASES: ReadonlySet<CoverStoryLifecyclePhase> = new Set([
+  'maintained',
+  'stressed',
+])
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function normalizeToken(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function splitTopicTokens(value: string): string[] {
+  return value
+    .split(/[^a-z0-9]+/i)
+    .map((token) => token.toLowerCase().trim())
+    .filter((token) => token.length >= 4)
+}
+
+function clampUnitScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.min(1, Math.max(0, value))
+}
+
+function freezeRecord(record: CoverStoryRecord): CoverStoryRecord {
+  return Object.freeze({ ...record })
+}
+
+function collectCaseTopicTokens(currentCase: CaseInstance): Set<string> {
+  const tokens = new Set<string>()
+  const addTokens = (value: string) => {
+    for (const token of splitTopicTokens(value)) {
+      tokens.add(token)
+    }
+  }
+
+  addTokens(currentCase.id)
+  addTokens(currentCase.templateId)
+  addTokens(currentCase.title)
+  for (const tag of currentCase.tags) addTokens(tag)
+  for (const tag of currentCase.requiredTags) addTokens(tag)
+  for (const tag of currentCase.preferredTags) addTokens(tag)
+
+  return tokens
+}
+
+function collectCoverStoryLinkTokens(record: CoverStoryRecord): Set<string> {
+  const tokens = new Set<string>()
+  const addTokens = (value: string | undefined) => {
+    if (!value) {
+      return
+    }
+
+    for (const token of splitTopicTokens(value)) {
+      tokens.add(token)
+    }
+
+    tokens.add(normalizeToken(value))
+  }
+
+  addTokens(record.subjectRef)
+  addTokens(record.parentCaseRef)
+  addTokens(record.linkedTruthLayerRef)
+  addTokens(record.linkedDisclosureRef)
+
+  return tokens
+}
+
+function topicRefsOverlap(leftRef: string, rightRef: string): boolean {
+  const left = normalizeToken(leftRef)
+  const right = normalizeToken(rightRef)
+  if (!left || !right) {
+    return false
+  }
+
+  if (left === right) {
+    return true
+  }
+
+  const leftTokens = new Set(splitTopicTokens(leftRef))
+  for (const token of splitTopicTokens(rightRef)) {
+    if (leftTokens.has(token)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function coverStoryLinksToCase(record: CoverStoryRecord, currentCase: CaseInstance): boolean {
+  const parentCaseRef = normalizeToken(record.parentCaseRef ?? '')
+  if (parentCaseRef && parentCaseRef === normalizeToken(currentCase.id)) {
+    return true
+  }
+
+  const coverTokens = collectCoverStoryLinkTokens(record)
+  const caseTokens = collectCaseTopicTokens(currentCase)
+  for (const token of coverTokens) {
+    if (caseTokens.has(token)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function coverStoryLinksToIntakeReport(
+  record: CoverStoryRecord,
+  report: InformationIntakeReportRecord,
+  cases: readonly CaseInstance[]
+): boolean {
+  if (topicRefsOverlap(record.subjectRef, report.topicRef)) {
+    return true
+  }
+
+  const normalizedTopic = normalizeToken(report.topicRef)
+  for (const currentCase of cases) {
+    if (currentCase.status === 'resolved') {
+      continue
+    }
+
+    if (
+      normalizeToken(currentCase.id) === normalizedTopic ||
+      normalizeToken(currentCase.templateId) === normalizedTopic
+    ) {
+      if (coverStoryLinksToCase(record, currentCase)) {
+        return true
+      }
+    }
+  }
+
+  const reportTokens = new Set(splitTopicTokens(report.topicRef))
+  const coverTokens = collectCoverStoryLinkTokens(record)
+  for (const token of coverTokens) {
+    if (reportTokens.has(token)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function resolveIntakeContradictionChannel(
+  report: InformationIntakeReportRecord
+): CoverStoryContradictionChannelKind {
+  if (
+    report.initialSourceClass === 'rumor_chain' ||
+    report.initialSourceClass === 'public_signal' ||
+    report.initialSourceClass === 'off_channel'
+  ) {
+    return 'family_suspicion'
+  }
+
+  if (
+    report.initialSourceClass === 'technical_trace' ||
+    report.initialSourceClass === 'media_trace' ||
+    report.initialSourceClass === 'archive_signature'
+  ) {
+    return 'digital_traces'
+  }
+
+  return 'witness_testimony'
+}
+
+function resolveIntakeContradictionTriggerKind(
+  channel: CoverStoryContradictionChannelKind
+): CoverStoryContradictionTriggerKind {
+  if (channel === 'digital_traces') {
+    return 'intake_digital_trace'
+  }
+
+  if (channel === 'family_suspicion') {
+    return 'intake_community_suspicion'
+  }
+
+  return 'intake_witness_contradiction'
+}
+
+function resolveWeeklyIntakeContradictionTriggers(
+  record: CoverStoryRecord,
+  input: CoverStoryContradictionTickInput
+): readonly CoverStoryContradictionTrigger[] {
+  const priorReports = input.priorIntakeReports ?? {}
+  const nextReports = input.nextIntakeReports ?? {}
+  const cases = Object.values(input.cases ?? {})
+  const normalizedWeek = normalizeWeek(input.week)
+  const triggers: CoverStoryContradictionTrigger[] = []
+
+  for (const reportId of Object.keys(nextReports).sort((left, right) => left.localeCompare(right))) {
+    const nextReport = nextReports[reportId]
+    if (!nextReport || !coverStoryLinksToIntakeReport(record, nextReport, cases)) {
+      continue
+    }
+
+    const priorHistory = priorReports[reportId]?.contradictionHistory ?? []
+    const priorEventIds = new Set(priorHistory.map((event) => event.eventId))
+
+    for (const event of nextReport.contradictionHistory) {
+      if (priorEventIds.has(event.eventId)) {
+        continue
+      }
+
+      if (event.week !== normalizedWeek) {
+        continue
+      }
+
+      const channel = resolveIntakeContradictionChannel(nextReport)
+      const kind = resolveIntakeContradictionTriggerKind(channel)
+      const delta =
+        kind === 'intake_community_suspicion'
+          ? COMMUNITY_SUSPICION_DELTA
+          : event.severity === 'major'
+            ? MAJOR_INTAKE_CONTRADICTION_DELTA
+            : MINOR_INTAKE_CONTRADICTION_DELTA
+      triggers.push({
+        kind,
+        channel,
+        delta,
+        sourceRef: event.sourceRef,
+      })
+    }
+  }
+
+  return triggers
+}
+
+function resolveWeeklyTruthLayerContradictionTriggers(
+  record: CoverStoryRecord,
+  input: CoverStoryContradictionTickInput
+): readonly CoverStoryContradictionTrigger[] {
+  const linkedRef = normalizeToken(record.linkedTruthLayerRef ?? '')
+  if (!linkedRef) {
+    return []
+  }
+
+  const truthLayerRecord = input.truthLayerRecords?.[linkedRef]
+  if (!truthLayerRecord) {
+    return []
+  }
+
+  const ops = projectTruthLayerOpsView(truthLayerRecord)
+  if (!ops.layerDivergence && (ops.correctionPressure ?? 0) < 0.5) {
+    return []
+  }
+
+  const normalizedWeek = normalizeWeek(input.week)
+  return [
+    {
+      kind: 'truth_layer_divergence',
+      channel: 'institutional_records',
+      delta: TRUTH_LAYER_DIVERGENCE_DELTA,
+      sourceRef: `truth-layer:divergence:${linkedRef}:w${normalizedWeek}`,
+    },
+  ]
+}
+
+function resolveWeeklyComplianceContradictionTriggers(
+  record: CoverStoryRecord,
+  input: CoverStoryContradictionTickInput
+): readonly CoverStoryContradictionTrigger[] {
+  const complianceRecords = Object.values(input.ruleDocumentComplianceRecords ?? {})
+  if (complianceRecords.length === 0) {
+    return []
+  }
+
+  const normalizedWeek = normalizeWeek(input.week)
+  const coverTokens = collectCoverStoryLinkTokens(record)
+  const triggers: CoverStoryContradictionTrigger[] = []
+
+  for (const complianceRecord of complianceRecords.sort((left, right) =>
+    left.id.localeCompare(right.id)
+  )) {
+    if (complianceRecord.complianceState !== 'breach') {
+      continue
+    }
+
+    const complianceTokens = new Set<string>()
+    for (const token of splitTopicTokens(complianceRecord.id)) {
+      complianceTokens.add(token)
+    }
+    for (const token of splitTopicTokens(complianceRecord.label)) {
+      complianceTokens.add(token)
+    }
+    for (const token of splitTopicTokens(complianceRecord.documentRef)) {
+      complianceTokens.add(token)
+    }
+
+    const linked = [...coverTokens].some((token) => complianceTokens.has(token))
+    if (!linked) {
+      continue
+    }
+
+    triggers.push({
+      kind: 'compliance_breach',
+      channel: 'institutional_records',
+      delta: COMPLIANCE_BREACH_DELTA,
+      sourceRef: `compliance:breach:${complianceRecord.id}:w${normalizedWeek}`,
+    })
+  }
+
+  return triggers
+}
+
+function extranormalEventLinksToCoverStory(
+  record: CoverStoryRecord,
+  event: ExtranormalEventRecord
+): boolean {
+  const coverTokens = collectCoverStoryLinkTokens(record)
+
+  const candidateRefs = [
+    event.intakeTopicRef,
+    event.escalatedCaseRef,
+    event.coverStoryCode,
+    event.locationTag,
+    event.themeRef,
+    event.id,
+    event.label,
+  ]
+
+  for (const ref of candidateRefs) {
+    if (!ref) {
+      continue
+    }
+
+    if (topicRefsOverlap(record.subjectRef, ref)) {
+      return true
+    }
+
+    if (record.parentCaseRef && topicRefsOverlap(record.parentCaseRef, ref)) {
+      return true
+    }
+
+    const refTokens = splitTopicTokens(ref)
+    if (refTokens.some((token) => coverTokens.has(token))) {
+      return true
+    }
+  }
+
+  for (const selector of event.populationSelectors) {
+    if (selector.kind !== 'location') {
+      continue
+    }
+
+    if (topicRefsOverlap(record.subjectRef, selector.value)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function resolveWeeklyExtranormalContradictionTriggers(
+  record: CoverStoryRecord,
+  input: CoverStoryContradictionTickInput
+): readonly CoverStoryContradictionTrigger[] {
+  const events = Object.values(input.extranormalEventRecords ?? {})
+  if (events.length === 0) {
+    return []
+  }
+
+  const normalizedWeek = normalizeWeek(input.week)
+  const triggers: CoverStoryContradictionTrigger[] = []
+
+  for (const event of events.sort((left, right) => left.id.localeCompare(right.id))) {
+    const witnessPlan = normalizeToken(event.witnessPlan ?? '')
+    if (!witnessPlan) {
+      continue
+    }
+
+    const monitoringUntilWeek = event.monitoringUntilWeek
+    if (
+      monitoringUntilWeek === undefined ||
+      !Number.isFinite(monitoringUntilWeek) ||
+      monitoringUntilWeek < normalizedWeek
+    ) {
+      continue
+    }
+
+    if (!extranormalEventLinksToCoverStory(record, event)) {
+      continue
+    }
+
+    triggers.push({
+      kind: 'extranormal_witness_monitoring',
+      channel: 'active_surveillance',
+      delta: EXTRANORMAL_MONITORING_DELTA,
+      sourceRef: `extranormal:witness-monitoring:${event.id}:w${normalizedWeek}`,
+    })
+  }
+
+  return triggers
+}
+
+/**
+ * Resolves deterministic weekly contradiction triggers for one cover-story record.
+ */
+export function resolveWeeklyCoverStoryContradictionTriggers(
+  record: CoverStoryRecord,
+  input: CoverStoryContradictionTickInput
+): readonly CoverStoryContradictionTrigger[] {
+  if (!ACCUMULATING_PHASES.has(record.lifecyclePhase)) {
+    return []
+  }
+
+  return Object.freeze([
+    ...resolveWeeklyIntakeContradictionTriggers(record, input),
+    ...resolveWeeklyTruthLayerContradictionTriggers(record, input),
+    ...resolveWeeklyComplianceContradictionTriggers(record, input),
+    ...resolveWeeklyExtranormalContradictionTriggers(record, input),
+  ])
+}
+
+function channelAlreadyHasSourceRef(
+  channels: readonly CoverStoryContradictionChannel[],
+  sourceRef: string
+): boolean {
+  const normalizedRef = normalizeToken(sourceRef)
+  return channels.some((channel) => normalizeToken(channel.sourceRef ?? '') === normalizedRef)
+}
+
+function upsertContradictionChannel(
+  channels: readonly CoverStoryContradictionChannel[],
+  trigger: CoverStoryContradictionTrigger,
+  week: number
+): readonly CoverStoryContradictionChannel[] {
+  if (channelAlreadyHasSourceRef(channels, trigger.sourceRef)) {
+    return channels
+  }
+
+  const existingIndex = channels.findIndex((channel) => channel.channel === trigger.channel)
+  if (existingIndex >= 0) {
+    const existing = channels[existingIndex]!
+    const nextScore = clampUnitScore(existing.accumulationScore + trigger.delta)
+    const updated: CoverStoryContradictionChannel = {
+      channel: trigger.channel,
+      accumulationScore: nextScore,
+      lastUpdatedWeek: week,
+      sourceRef: trigger.sourceRef,
+    }
+
+    const next = [...channels]
+    next[existingIndex] = updated
+    return next
+  }
+
+  return [
+    ...channels,
+    {
+      channel: trigger.channel,
+      accumulationScore: clampUnitScore(trigger.delta),
+      lastUpdatedWeek: week,
+      sourceRef: trigger.sourceRef,
+    },
+  ]
+}
+
+function seedChannelsFromExistingPressure(
+  record: CoverStoryRecord
+): readonly CoverStoryContradictionChannel[] {
+  const channels = record.contradictionChannels ?? []
+  if (channels.length > 0) {
+    return channels
+  }
+
+  if (record.contradictionPressure === undefined) {
+    return channels
+  }
+
+  return [
+    {
+      channel: 'institutional_records',
+      accumulationScore: clampUnitScore(record.contradictionPressure),
+      sourceRef: `seed:baseline-pressure:${record.id}`,
+    },
+  ]
+}
+
+/**
+ * Applies weekly contradiction triggers onto channel scores. Idempotent when the same
+ * sourceRef was already recorded on a channel.
+ */
+export function applyCoverStoryContradictionTriggers(
+  record: CoverStoryRecord,
+  triggers: readonly CoverStoryContradictionTrigger[],
+  week: number
+): CoverStoryRecord {
+  if (triggers.length === 0) {
+    return record
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  let channels = seedChannelsFromExistingPressure(record)
+  let changed = channels !== (record.contradictionChannels ?? [])
+
+  for (const trigger of triggers) {
+    const nextChannels = upsertContradictionChannel(channels, trigger, normalizedWeek)
+    if (nextChannels !== channels) {
+      channels = nextChannels
+      changed = true
+    }
+  }
+
+  if (!changed) {
+    return record
+  }
+
+  const contradictionPressure = deriveCoverStoryContradictionPressure({
+    ...record,
+    contradictionChannels: channels,
+    contradictionPressure: undefined,
+  })
+
+  return {
+    ...record,
+    contradictionChannels: channels,
+    ...(contradictionPressure !== null ? { contradictionPressure } : {}),
+  }
+}
+
+function appendLifecycleTransition(
+  record: CoverStoryRecord,
+  event: CoverStoryLifecycleEvent,
+  week: number,
+  note: string
+): CoverStoryRecord | null {
+  const fromPhase = record.lifecyclePhase
+  const toPhase = transitionCoverStoryLifecyclePhase(fromPhase, event)
+  if (toPhase === fromPhase || !isValidCoverStoryLifecycleTransition(fromPhase, event)) {
+    return null
+  }
+
+  const entry: CoverStoryTransitionHistoryEntry = {
+    fromPhase,
+    toPhase,
+    week,
+    event,
+    note,
+  }
+
+  return {
+    ...record,
+    lifecyclePhase: toPhase,
+    transitionHistory: [...(record.transitionHistory ?? []), entry],
+  }
+}
+
+function resolveLifecycleTransitionFromPressure(
+  record: CoverStoryRecord,
+  week: number
+): CoverStoryRecord {
+  const pressure =
+    record.contradictionPressure ?? deriveCoverStoryContradictionPressure(record) ?? 0
+
+  if (
+    record.lifecyclePhase === 'maintained' &&
+    pressure >= COVER_STORY_CONTRADICTION_STRESS_THRESHOLD
+  ) {
+    const transitioned = appendLifecycleTransition(
+      record,
+      'contradiction_accumulated',
+      week,
+      'Weekly contradiction channel accumulation crossed stress threshold.'
+    )
+    if (transitioned) {
+      record = transitioned
+    }
+  }
+
+  const postStressPressure =
+    record.contradictionPressure ?? deriveCoverStoryContradictionPressure(record) ?? 0
+
+  if (
+    record.lifecyclePhase === 'stressed' &&
+    postStressPressure >= COVER_STORY_CONTRADICTION_COLLAPSE_THRESHOLD
+  ) {
+    const transitioned = appendLifecycleTransition(
+      record,
+      'cover_collapsed',
+      week,
+      'Weekly contradiction pressure crossed collapse threshold.'
+    )
+    if (transitioned) {
+      record = transitioned
+    }
+  }
+
+  return record
+}
+
+/**
+ * Advances one cover-story record for the simulation week using weekly trigger contracts.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceCoverStoryRecordContradictionForWeek(
+  record: CoverStoryRecord,
+  input: CoverStoryContradictionTickInput
+): CoverStoryRecord {
+  const normalizedWeek = normalizeWeek(input.week)
+  const triggers = resolveWeeklyCoverStoryContradictionTriggers(record, input)
+  let next = applyCoverStoryContradictionTriggers(record, triggers, normalizedWeek)
+  next = resolveLifecycleTransitionFromPressure(next, normalizedWeek)
+
+  if (next === record) {
+    return record
+  }
+
+  if (!validateCoverStoryRecord(next).valid) {
+    return record
+  }
+
+  return freezeRecord(next)
+}
+
+/**
+ * Applies weekly contradiction accumulation across persisted cover-story records.
+ * Empty map is a no-op. Re-applying for the same week is idempotent.
+ */
+export function applyWeeklyCoverStoryContradictionAccumulationTick(
+  records: Record<string, CoverStoryRecord> | null | undefined,
+  input: CoverStoryContradictionTickInput
+): Record<string, CoverStoryRecord> {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const next: Record<string, CoverStoryRecord> = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceCoverStoryRecordContradictionForWeek(record, input)
+    if (advanced !== record) {
+      next[recordId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/coverStoryLifecycleRegistry.ts
+++ b/src/domain/coverStoryLifecycleRegistry.ts
@@ -522,7 +522,8 @@ function scanFranchiseTokens(
   }
 }
 
-function deriveContradictionPressure(record: CoverStoryRecord): number | null {
+/** Derives aggregate contradiction pressure from channel scores or explicit scalar. */
+export function deriveCoverStoryContradictionPressure(record: CoverStoryRecord): number | null {
   if (record.contradictionPressure !== undefined) {
     return record.contradictionPressure
   }
@@ -929,7 +930,7 @@ export function projectCoverStoryLifecycleView(
     redactedFields.has('exposureKind') ||
     (policy.redactUnknown === true && unknownFields.includes('exposureKind'))
 
-  const derivedPressure = deriveContradictionPressure(record)
+  const derivedPressure = deriveCoverStoryContradictionPressure(record)
   const contradictionPressure =
     contradictionRedacted || derivedPressure === null ? null : derivedPressure
 

--- a/src/domain/coverStoryWeeklyOrchestration.ts
+++ b/src/domain/coverStoryWeeklyOrchestration.ts
@@ -1,11 +1,13 @@
 /**
- * SPE-1347 slice 2: weekly orchestration for persisted cover-story records.
+ * SPE-1347 slice 4: weekly orchestration for persisted cover-story records.
  *
- * Pure deterministic tick: runs lifecycle projections each week, persists bounded
- * weekly projection snapshots, and preserves source records byte-stable.
- * Does not implement a full contradiction engine or mutate cover-story record fields.
+ * Pure deterministic tick: applies contradiction channel accumulation from trigger
+ * sources, runs lifecycle projections each week, persists bounded weekly projection
+ * snapshots, and preserves source records byte-stable when unchanged.
  */
 
+import type { CoverStoryContradictionTickInput } from './coverStoryContradictionAccumulation'
+import { applyWeeklyCoverStoryContradictionAccumulationTick } from './coverStoryContradictionAccumulation'
 import {
   projectCoverStoryLifecycleView,
   type CoverStoryLifecycleProjection,
@@ -14,6 +16,8 @@ import {
   type CoverStoryWeeklyProjectionSnapshot,
   type CoverStoryWeeklyProjectionSnapshotsMap,
 } from './coverStoryLifecycleRegistry'
+
+export type { CoverStoryContradictionTickInput } from './coverStoryContradictionAccumulation'
 
 export interface CoverStoryWeeklyProjectionBundle {
   readonly recordId: string
@@ -24,6 +28,10 @@ export interface CoverStoryWeeklyProjectionBundle {
 export interface CoverStoryWeeklyTickResult {
   readonly records: CoverStoryRecordsMap
   readonly snapshots: CoverStoryWeeklyProjectionSnapshotsMap
+}
+
+export interface CoverStoryWeeklyTickOptions {
+  readonly contradictionInput?: Omit<CoverStoryContradictionTickInput, 'week'> | null
 }
 
 function normalizeWeek(week: number): number {
@@ -151,14 +159,15 @@ function persistWeeklyProjectionSnapshots(
 
 /**
  * Applies one weekly orchestration pass over persisted cover-story records.
- * Runs deterministic lifecycle projections, persists bounded weekly snapshots, and preserves
- * source records byte-stable. Empty map is a no-op. Re-applying after advance is
- * idempotent for the same week.
+ * Runs deterministic contradiction accumulation when trigger input is provided,
+ * lifecycle projections, and bounded weekly snapshots. Empty map is a no-op.
+ * Re-applying after advance is idempotent for the same week.
  */
 export function applyWeeklyCoverStoryTick(
   records: CoverStoryRecordsMap | null | undefined,
   week: number,
-  snapshots: CoverStoryWeeklyProjectionSnapshotsMap | null | undefined = {}
+  snapshots: CoverStoryWeeklyProjectionSnapshotsMap | null | undefined = {},
+  options: CoverStoryWeeklyTickOptions = {}
 ): CoverStoryWeeklyTickResult {
   const safeRecords = records ?? {}
   const safeSnapshots = snapshots ?? {}
@@ -170,10 +179,24 @@ export function applyWeeklyCoverStoryTick(
     }
   }
 
-  const nextSnapshots = persistWeeklyProjectionSnapshots(safeRecords, safeSnapshots, week)
+  const normalizedWeek = normalizeWeek(week)
+  const contradictionInput = options.contradictionInput
+  const tickRecords =
+    contradictionInput === undefined || contradictionInput === null
+      ? safeRecords
+      : applyWeeklyCoverStoryContradictionAccumulationTick(safeRecords, {
+          week: normalizedWeek,
+          ...contradictionInput,
+        })
+
+  const nextSnapshots = persistWeeklyProjectionSnapshots(
+    tickRecords,
+    safeSnapshots,
+    normalizedWeek
+  )
 
   return {
-    records: safeRecords,
+    records: tickRecords,
     snapshots: nextSnapshots,
   }
 }

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4654,13 +4654,23 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     outputWeeklyState.truthLayerWeeklyProjectionSnapshots = truthLayerTick.snapshots
   }
 
-  // SPE-1347 slice 2: lifecycle projection on persisted cover-story records.
+  // SPE-1347 slice 4: lifecycle projection + contradiction accumulation on persisted cover-story records.
   const currentCoverStoryRecords = outputWeeklyState.coverStoryRecords ?? {}
   if (Object.keys(currentCoverStoryRecords).length > 0) {
     const coverStoryTick = applyWeeklyCoverStoryTick(
       currentCoverStoryRecords,
       result.week,
-      outputWeeklyState.coverStoryWeeklyProjectionSnapshots
+      outputWeeklyState.coverStoryWeeklyProjectionSnapshots,
+      {
+        contradictionInput: {
+          priorIntakeReports,
+          nextIntakeReports: outputWeeklyState.informationIntakeReports ?? priorIntakeReports,
+          truthLayerRecords: outputWeeklyState.truthLayerRecords,
+          ruleDocumentComplianceRecords: outputWeeklyState.ruleDocumentComplianceRecords,
+          extranormalEventRecords: outputWeeklyState.extranormalEventRecords,
+          cases: outputWeeklyState.cases,
+        },
+      }
     )
     outputWeeklyState.coverStoryRecords = coverStoryTick.records
     outputWeeklyState.coverStoryWeeklyProjectionSnapshots = coverStoryTick.snapshots

--- a/src/test/advanceWeek.coverStoryRecords.integration.test.ts
+++ b/src/test/advanceWeek.coverStoryRecords.integration.test.ts
@@ -5,6 +5,7 @@ import {
   COVER_STORY_STRESSED_FIXTURE,
   projectCoverStoryLifecycleView,
 } from '../domain/coverStoryLifecycleRegistry'
+import { COVER_NARRATIVE_TRUTH_LAYER_FIXTURE } from '../domain/truthLayerRecordRegistry'
 import { applyWeeklyCoverStoryTick } from '../domain/coverStoryWeeklyOrchestration'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 
@@ -81,12 +82,61 @@ describe('advanceWeek cover-story records integration (SPE-1347 slice 2)', () =>
     const reticked = applyWeeklyCoverStoryTick(
       recordsAfterAdvance,
       once.week,
-      once.coverStoryWeeklyProjectionSnapshots
+      once.coverStoryWeeklyProjectionSnapshots,
+      {
+        contradictionInput: {
+          priorIntakeReports: state.informationIntakeReports,
+          nextIntakeReports: once.informationIntakeReports,
+          truthLayerRecords: once.truthLayerRecords,
+          ruleDocumentComplianceRecords: once.ruleDocumentComplianceRecords,
+          extranormalEventRecords: once.extranormalEventRecords,
+          cases: once.cases,
+        },
+      }
     )
 
     expect(reticked.records).toBe(recordsAfterAdvance)
     expect(reticked.snapshots).toBe(once.coverStoryWeeklyProjectionSnapshots)
     expect(reticked.records[COVER_STORY_STRESSED_FIXTURE.id]).toBe(COVER_STORY_STRESSED_FIXTURE)
+  })
+
+  it('advances a stressed cover story toward collapsed through weekly accumulation triggers', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 20
+    state.truthLayerRecords = {
+      [COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.id]: COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+    }
+    state.coverStoryRecords = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: {
+        ...COVER_STORY_STRESSED_FIXTURE,
+        contradictionChannels: [
+          {
+            channel: 'witness_testimony',
+            accumulationScore: 0.86,
+            lastUpdatedWeek: 19,
+            sourceRef: 'witness:contractor-shift-log',
+          },
+          {
+            channel: 'institutional_records',
+            accumulationScore: 0.86,
+            lastUpdatedWeek: 19,
+            sourceRef: 'record:seal-inspection-summary',
+          },
+        ],
+        contradictionPressure: 0.86,
+      },
+    }
+
+    const nextState = advanceWeek(state)
+    const record = nextState.coverStoryRecords?.[COVER_STORY_STRESSED_FIXTURE.id]
+
+    expect(record?.lifecyclePhase).toBe('collapsed')
+    expect(record?.transitionHistory?.at(-1)?.event).toBe('cover_collapsed')
+    expect(
+      nextState.coverStoryWeeklyProjectionSnapshots?.[COVER_STORY_STRESSED_FIXTURE.id]?.lifecycle
+        .coverCollapsed
+    ).toBe(true)
   })
 
   it('preserves validation fixture byte-stable through advanceWeek tick', () => {

--- a/src/test/coverStoryContradictionAccumulation.test.ts
+++ b/src/test/coverStoryContradictionAccumulation.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+  COVER_STORY_STRESSED_FIXTURE,
+  projectCoverStoryLifecycleView,
+  type CoverStoryRecord,
+} from '../domain/coverStoryLifecycleRegistry'
+import {
+  applyCoverStoryContradictionTriggers,
+  applyWeeklyCoverStoryContradictionAccumulationTick,
+  advanceCoverStoryRecordContradictionForWeek,
+  COVER_STORY_CONTRADICTION_COLLAPSE_THRESHOLD,
+  COVER_STORY_CONTRADICTION_STRESS_THRESHOLD,
+  resolveWeeklyCoverStoryContradictionTriggers,
+  type CoverStoryContradictionTrigger,
+} from '../domain/coverStoryContradictionAccumulation'
+import { applyWeeklyCoverStoryTick } from '../domain/coverStoryWeeklyOrchestration'
+import {
+  COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+  type TruthLayerRecordsMap,
+} from '../domain/truthLayerRecordRegistry'
+import {
+  createInformationIntakeReport,
+  type InformationIntakeReportsMap,
+} from '../domain/informationIntakeReport'
+
+function baseRecord(overrides: Partial<CoverStoryRecord> = {}): CoverStoryRecord {
+  return {
+    id: 'cover:test-accumulation',
+    label: 'Test accumulation cover story',
+    lifecyclePhase: 'maintained',
+    subjectRef: 'site:coastal-research-campus',
+    subjectKind: 'site',
+    parentCaseRef: 'case:containment-response-24',
+    linkedTruthLayerRef: 'truth:regional-press-cover-24',
+    ...overrides,
+  }
+}
+
+describe('coverStoryContradictionAccumulation (SPE-1347 slice 4)', () => {
+  it('clamps channel accumulation scores to the unit interval', () => {
+    const triggers: CoverStoryContradictionTrigger[] = [
+      {
+        kind: 'intake_witness_contradiction',
+        channel: 'witness_testimony',
+        delta: 0.9,
+        sourceRef: 'witness:test-a',
+      },
+      {
+        kind: 'intake_witness_contradiction',
+        channel: 'witness_testimony',
+        delta: 0.9,
+        sourceRef: 'witness:test-b',
+      },
+    ]
+
+    const next = applyCoverStoryContradictionTriggers(baseRecord(), triggers, 4)
+
+    expect(next.contradictionChannels).toHaveLength(1)
+    expect(next.contradictionChannels?.[0]?.accumulationScore).toBe(1)
+  })
+
+  it('is idempotent when the same trigger sourceRef is re-applied', () => {
+    const trigger: CoverStoryContradictionTrigger = {
+      kind: 'truth_layer_divergence',
+      channel: 'institutional_records',
+      delta: 0.15,
+      sourceRef: 'truth-layer:divergence:truth:regional-press-cover-24:w5',
+    }
+    const record = baseRecord()
+
+    const once = applyCoverStoryContradictionTriggers(record, [trigger], 5)
+    const twice = applyCoverStoryContradictionTriggers(once, [trigger], 5)
+
+    expect(twice).toBe(once)
+  })
+
+  it('resolves truth-layer divergence triggers for linked cover stories', () => {
+    const truthLayerRecords: TruthLayerRecordsMap = {
+      [COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.id]: COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+    }
+
+    const triggers = resolveWeeklyCoverStoryContradictionTriggers(baseRecord(), {
+      week: 6,
+      truthLayerRecords,
+    })
+
+    expect(triggers).toEqual([
+      {
+        kind: 'truth_layer_divergence',
+        channel: 'institutional_records',
+        delta: 0.15,
+        sourceRef: 'truth-layer:divergence:truth:regional-press-cover-24:w6',
+      },
+    ])
+  })
+
+  it('resolves intake contradiction triggers from newly added weekly events', () => {
+    const report = createInformationIntakeReport({
+      id: 'intake:coastal-campus-witness',
+      label: 'Coastal campus witness intake',
+      topicRef: 'site:coastal-research-campus',
+      initialSourceClass: 'field_witness',
+      credibility: 'plausible',
+      plausibility: 'plausible',
+      rumorRisk: 'low',
+    })
+    const priorReports: InformationIntakeReportsMap = {
+      [report.id]: report,
+    }
+    const nextReports: InformationIntakeReportsMap = {
+      [report.id]: {
+        ...report,
+        contradictionHistory: [
+          {
+            eventId: 'weekly-intake:contradiction:intake:coastal-campus-witness:w7',
+            week: 7,
+            sourceRef: 'audit:weekly-intake:witness-mismatch',
+            severity: 'major',
+          },
+        ],
+      },
+    }
+
+    const triggers = resolveWeeklyCoverStoryContradictionTriggers(baseRecord(), {
+      week: 7,
+      priorIntakeReports: priorReports,
+      nextIntakeReports: nextReports,
+    })
+
+    expect(triggers).toEqual([
+      {
+        kind: 'intake_witness_contradiction',
+        channel: 'witness_testimony',
+        delta: 0.22,
+        sourceRef: 'audit:weekly-intake:witness-mismatch',
+      },
+    ])
+  })
+
+  it('returns no triggers for terminal lifecycle phases', () => {
+    const triggers = resolveWeeklyCoverStoryContradictionTriggers(
+      baseRecord({ lifecyclePhase: 'collapsed' }),
+      {
+        week: 3,
+        truthLayerRecords: {
+          [COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.id]: COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+        },
+      }
+    )
+
+    expect(triggers).toEqual([])
+  })
+
+  it('transitions maintained cover stories to stressed at the stress threshold', () => {
+    const record = baseRecord({
+      contradictionChannels: [
+        {
+          channel: 'witness_testimony',
+          accumulationScore: COVER_STORY_CONTRADICTION_STRESS_THRESHOLD,
+          sourceRef: 'witness:threshold',
+        },
+      ],
+      contradictionPressure: COVER_STORY_CONTRADICTION_STRESS_THRESHOLD,
+    })
+
+    const next = advanceCoverStoryRecordContradictionForWeek(record, { week: 8 })
+
+    expect(next.lifecyclePhase).toBe('stressed')
+    expect(next.transitionHistory?.at(-1)?.event).toBe('contradiction_accumulated')
+  })
+
+  it('transitions stressed cover stories to collapsed at the collapse threshold', () => {
+    const record = baseRecord({
+      lifecyclePhase: 'stressed',
+      contradictionChannels: [
+        {
+          channel: 'witness_testimony',
+          accumulationScore: 0.9,
+          sourceRef: 'witness:heavy',
+        },
+        {
+          channel: 'institutional_records',
+          accumulationScore: 0.82,
+          sourceRef: 'record:heavy',
+        },
+      ],
+      contradictionPressure: COVER_STORY_CONTRADICTION_COLLAPSE_THRESHOLD,
+      transitionHistory: [
+        {
+          fromPhase: 'drafted',
+          toPhase: 'maintained',
+          week: 1,
+          event: 'cover_deployed',
+        },
+        {
+          fromPhase: 'maintained',
+          toPhase: 'stressed',
+          week: 2,
+          event: 'contradiction_accumulated',
+        },
+      ],
+    })
+
+    const next = advanceCoverStoryRecordContradictionForWeek(record, { week: 9 })
+
+    expect(next.lifecyclePhase).toBe('collapsed')
+    expect(next.transitionHistory?.at(-1)?.event).toBe('cover_collapsed')
+  })
+
+  it('does not reveal hidden operational truth in post-accumulation projections', () => {
+    const trigger: CoverStoryContradictionTrigger = {
+      kind: 'intake_digital_trace',
+      channel: 'digital_traces',
+      delta: 0.14,
+      sourceRef: 'trace:forum-post-metadata',
+    }
+    const next = applyCoverStoryContradictionTriggers(COVER_STORY_STRESSED_FIXTURE, [trigger], 24)
+    const projection = projectCoverStoryLifecycleView(next)
+
+    expect(projection.contradictionChannelHints).toContain('digital_traces')
+    expect(projection.summary).toBe(COVER_STORY_STRESSED_FIXTURE.summary ?? null)
+    expect(JSON.stringify(projection)).not.toMatch(/foundation|scp|masquerade/i)
+  })
+
+  it('applies weekly accumulation across records in stable id order', () => {
+    const records = {
+      [COVER_STORY_STRESSED_FIXTURE.id]: COVER_STORY_STRESSED_FIXTURE,
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    }
+
+    const next = applyWeeklyCoverStoryContradictionAccumulationTick(records, {
+      week: 10,
+      truthLayerRecords: {
+        [COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.id]: COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+      },
+    })
+
+    expect(next[COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]).not.toBe(
+      COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE
+    )
+    expect(
+      next[COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]?.contradictionChannels?.length
+    ).toBeGreaterThan(0)
+  })
+
+  it('keeps orchestration idempotent when contradiction accumulation re-ticks the same week', () => {
+    const records = {
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    }
+    const contradictionInput = {
+      truthLayerRecords: {
+        [COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.id]: COVER_NARRATIVE_TRUTH_LAYER_FIXTURE,
+      },
+    }
+
+    const once = applyWeeklyCoverStoryTick(records, 11, {}, { contradictionInput })
+    const twice = applyWeeklyCoverStoryTick(once.records, 11, once.snapshots, {
+      contradictionInput,
+    })
+
+    expect(twice.records).toBe(once.records)
+    expect(twice.snapshots).toBe(once.snapshots)
+  })
+
+  it('preserves records byte-stable when no contradiction triggers resolve', () => {
+    const records = {
+      [COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE.id]: COASTAL_CAMPUS_COVER_STORY_MAINTAINED_FIXTURE,
+    }
+
+    const next = applyWeeklyCoverStoryTick(records, 4, {}, { contradictionInput: {} })
+
+    expect(next.records).toBe(records)
+  })
+})


### PR DESCRIPTION
## Summary
- Add \coverStoryContradictionAccumulation.ts\ with weekly trigger contracts (intake contradiction events, truth-layer divergence, compliance breach, extranormal witness monitoring) and bounded channel score / lifecycle transitions.
- Extend \pplyWeeklyCoverStoryTick\ with optional \contradictionInput\ and wire trigger context from \dvanceWeek\.
- Export \deriveCoverStoryContradictionPressure\ on the registry; add slice doc + backlog handoff.

## Linear
- **Slice:** SPE-1347 cover-story lifecycle contradiction accumulation engine (slice 4) — child under SPE-1347
- **Parent:** SPE-1347 — stays **Backlog**

## Validation
- \
pm run test:run -- src/test/coverStoryContradictionAccumulation.test.ts src/test/coverStoryWeeklyOrchestration.test.ts src/test/advanceWeek.coverStoryRecords.integration.test.ts\
- \
pm run lint\

## Docs updated
- \planning/cover-story-lifecycle-slice-4.md\
- \planning/backlog.md\

## Parent remains open
SPE-861 disclosure UI and SPE-899 witness normalization are still deferred siblings.

Made with [Cursor](https://cursor.com)