### PR TITLE
SPE-861 slice 1: disclosure campaign player UI

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-861 disclosure UI or SPE-1309 unified engine owner slice if prioritized over remaining SPE-1347 siblings.
+**Next step:** SPE-861 disclosure campaign player UI slice 2 (trust outcomes) or SPE-1309 unified engine owner slice if prioritized over remaining SPE-1347 siblings.
 
-**Base `main` SHA:** `511642a8` — shipped: SPE-1347 cover-story lifecycle slice 4 @ `planning/cover-story-lifecycle-slice-4.md` (PR #2804)
+**Base `main` SHA:** `5aed7be3` — in progress: SPE-861 disclosure campaign player UI slice 1 @ `planning/disclosure-campaign-player-ui-slice-1.md` (branch `spe-861-disclosure-campaign-player-ui-slice-1`)
 
-**Recently shipped:** SPE-1347 cover-story lifecycle contradiction accumulation engine slice 4 (PR #2804); SPE-1347 cover-story lifecycle planning mirror UI slice 3 (PR #2803).
+**Recently shipped:** SPE-1347 cover-story lifecycle slice 4 (PR #2804); SPE-1347 cover-story lifecycle planning mirror UI slice 3 (PR #2803).
 
 **Recently shipped:** SPE-1882 coercive protocol mirror snapshot read slice 11 (PR #2798); SPE-1309 parent acceptance review grooming slice 4 (PR #2796); SPE-1888 parent acceptance review grooming slice 6 (PR #2793).
 
@@ -161,6 +161,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `public-disclosure-state-registry-slice-2.md`             | **Shipped**    | SPE-2325 / PR #2517; `publicDisclosureRecords` GameState persistence.                                                                                |
 | `public-disclosure-state-registry-slice-3.md`             | **Shipped**    | SPE-2326 / PR #2519; weekly scheduled awareness/fallout progression hook.                                                                          |
 | `public-disclosure-state-registry-slice-4.md`             | **Shipped**    | SPE-2331 / PR #2529; planning mirror UI over `publicDisclosureRecords` @ `6fa361b3`.                                                                |
+| `disclosure-campaign-player-ui-slice-1.md`                | **In progress** | SPE-861 child — player-facing disclosure campaign briefing UI @ `5aed7be3`.                                                                       |
 | `pattern-source-series-registry-slice-1.md`               | **Shipped**    | SPE-2110 / PR #2431; series-hub intake metadata and processing queue projection.                                                                      |
 | `pattern-source-series-registry-slice-2.md`               | **Shipped**    | SPE-2327 / PR #2521; `patternSourceSeriesRecords` GameState persistence @ `0f67c210`.                                                               |
 | `pattern-source-series-registry-slice-3.md`               | **Shipped**    | SPE-2328 / PR #2523; readiness-gated processing-pipeline weekly hook @ `37619b71`.                                                                    |

--- a/planning/disclosure-campaign-player-ui-slice-1.md
+++ b/planning/disclosure-campaign-player-ui-slice-1.md
@@ -1,0 +1,80 @@
+# SPE-861 — Disclosure campaign player UI (slice 1)
+
+One-page implementation plan. Linear: child under [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — **Disclosure campaign player UI (slice 1)** (create/claim on start). Parent [SPE-861](https://linear.app/spectranoir/issue/SPE-861) stays **Backlog** — full trust-to-compliance engine not in scope.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-861 child — Disclosure campaign player UI (slice 1)                                                    |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — public trust and compliance engine (umbrella)    |
+| **Branch** | `spe-861-disclosure-campaign-player-ui-slice-1`                                                            |
+| **Base `main` SHA** | `5aed7be3`                                                                                          |
+
+## Goal
+
+Player-facing disclosure progression UI wired to existing `publicDisclosureRecords` and `projectDisclosureRegionalView` projections — institutional briefing tone, read-only, no weekly tick or cover-story orchestration changes.
+
+## Prerequisite (on `main` @ `5aed7be3`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109)               |
+| Persistence          | `publicDisclosureRecords` on `GameState` (SPE-2325)                   |
+| Weekly progression   | `applyWeeklyPublicDisclosureProgressionTick` in `advanceWeek` (SPE-2326) |
+| Planning mirror UI   | `getPublicDisclosureMirrorView` + `/public-disclosure-state` (SPE-2331) |
+| Cover-narrative pairing | `resolveTruthLayerDualIncidentPairing` (SPE-1343)                   |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `getPublicDisclosureCampaignView` player projection              | Weekly tick / sanitize contract changes       |
+| `PublicDisclosureCampaignPage` + route `/campaign/public-disclosure` | SPE-1347 registry / contradiction engine   |
+| Front Desk attention segment + conditional quick link              | Planning mirror route / copy changes        |
+| `PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT` in `copy.ts`                  | SPE-861 parent Done                           |
+| View + component tests (no store mutation)                         | Trust-to-compliance outcomes engine         |
+| Slice doc (this file) + backlog handoff                            | Segmented population scores / choice mechanics |
+
+## Player contract
+
+- **Read-only** — no mutations to GameState from the campaign surface.
+- **Hydrated truth only** — display persisted records; do not re-validate dropped entries.
+- **Redaction policy** — respect `redactedFields`, confidence suppression, and unknown fields; no raw internal refs or operational truth-layer slots.
+- **Cover context** — optional linked cover-narrative label via `linkedDisclosureRecord`; omit operational record text and contradiction channel scores.
+- **Empty state** — institutional empty copy when `publicDisclosureRecords` map is empty.
+- **Mirror separation** — `/public-disclosure-state` planning mirror unchanged; player route uses campaign/briefing copy.
+
+## Acceptance
+
+- [ ] Empty `publicDisclosureRecords` map renders empty state without throw
+- [ ] Progression fixture displays institutional awareness/fallout and regional trust bands
+- [ ] Redacted summary/confidence suppressed in player copy
+- [ ] Front Desk attention item + quick link when records non-empty
+- [ ] `publicDisclosureMirrorView.test.ts` unchanged / regression green
+- [ ] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| View   | `src/features/operations/publicDisclosureCampaignView.ts`             |
+| UI     | `src/features/operations/PublicDisclosureCampaignPage.tsx`            |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`, `src/app/appShellRoutePaths.ts` |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/publicDisclosureCampaignView.test.ts`, `src/features/operations/PublicDisclosureCampaignPage.test.tsx` |
+| Plan   | `planning/disclosure-campaign-player-ui-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Public-trust / compliance outcomes engine | SPE-861 | Parent umbrella; out of player UI slice 1 |
+| Segmented population trust scores | SPE-861 | Deferred to later SPE-861 children |
+| Disclosure choice mechanics | SPE-861 | Out of read-only surfacing boundary |
+| Mass-anomalous population wire-up | SPE-2122 | Deferred governance integration |
+
+## See also
+
+- `planning/public-disclosure-state-registry-slice-4.md` — planning mirror template (SPE-2331)
+- `planning/truth-layer-cover-narrative-pairing-slice-1.md` — optional cover-narrative context

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -87,6 +87,9 @@ const SelfCensoringInformationMirrorRoute = createRouteComponent(
 const PublicDisclosureMirrorRoute = createRouteComponent(
   () => import('../features/operations/PublicDisclosureMirrorPage')
 )
+const PublicDisclosureCampaignRoute = createRouteComponent(
+  () => import('../features/operations/PublicDisclosureCampaignPage')
+)
 const TruthLayerMirrorRoute = createRouteComponent(
   () => import('../features/operations/TruthLayerMirrorPage')
 )
@@ -196,6 +199,10 @@ export default function App() {
         <Route
           path="public-disclosure-state"
           element={renderLazyRoute(PublicDisclosureMirrorRoute)}
+        />
+        <Route
+          path="campaign/public-disclosure"
+          element={renderLazyRoute(PublicDisclosureCampaignRoute)}
         />
         <Route path="truth-layer-records" element={renderLazyRoute(TruthLayerMirrorRoute)} />
         <Route path="cover-story-records" element={renderLazyRoute(CoverStoryMirrorRoute)} />

--- a/src/app/appShellRoutePaths.ts
+++ b/src/app/appShellRoutePaths.ts
@@ -25,6 +25,7 @@ export const APP_SHELL_STATIC_ROUTE_PATHS = [
   'pattern-source-series',
   'self-censoring-information',
   'public-disclosure-state',
+  'campaign/public-disclosure',
   'truth-layer-records',
   'cover-story-records',
   'mass-anomalous-population-emergence',

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -28,6 +28,7 @@ export const APP_ROUTES = {
   patternSourceSeries: '/pattern-source-series',
   selfCensoringInformation: '/self-censoring-information',
   publicDisclosureState: '/public-disclosure-state',
+  publicDisclosureCampaign: '/campaign/public-disclosure',
   truthLayerRecords: '/truth-layer-records',
   coverStoryRecords: '/cover-story-records',
   massAnomalousPopulationEmergence: '/mass-anomalous-population-emergence',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -978,6 +978,32 @@ export const TRUTH_LAYER_MIRROR_UI_TEXT: Record<string, string> = {
   redactedSuffix: 'Partial redaction',
 }
 
+export const PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Public affairs briefing',
+  pageHeading: 'Disclosure campaign posture',
+  pageSubtitle:
+    'Institutional readout of post-secrecy disclosure progression and regional public-trust bands.',
+  backToDeskLabel: 'Back to Operations Desk',
+  activeDisclosureLabel: 'Active disclosures',
+  dominantAwarenessLabel: 'Dominant awareness band',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Awareness and regional trust reflect the latest weekly progression. This briefing does not change campaign state.',
+  emptyTitle: 'No active disclosure campaigns',
+  emptyBody:
+    'When disclosure records enter play, campaign posture and regional trust bands will appear here.',
+  campaignsHeading: 'Active campaigns',
+  campaignsSubtitle:
+    'Each card summarizes public-awareness posture without operational or verification-layer detail.',
+  awarenessPrefix: 'Awareness:',
+  falloutPrefix: 'Fallout:',
+  objectivePrefix: 'Objective:',
+  regionalTrustHeading: 'Regional public trust',
+  coverNarrativePrefix: 'Linked cover narrative:',
+  confidencePrefix: 'Assessment:',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const PUBLIC_DISCLOSURE_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Public disclosure state registry',

--- a/src/features/operations/PublicDisclosureCampaignPage.test.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import { DISCLOSURE_PROGRESSION_FIXTURE } from '../../domain/publicDisclosureStateRegistry'
+import { useGameStore } from '../../app/store/gameStore'
+import PublicDisclosureCampaignPage from './PublicDisclosureCampaignPage'
+
+function renderCampaignPage() {
+  return render(
+    <MemoryRouter initialEntries={['/campaign/public-disclosure']}>
+      <Routes>
+        <Route path="/campaign/public-disclosure" element={<PublicDisclosureCampaignPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('PublicDisclosureCampaignPage (SPE-861 slice 1)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderCampaignPage()
+
+    expect(
+      screen.getByRole('region', { name: /public disclosure campaign briefing/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty campaign state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no active disclosure campaigns/i)).toBeInTheDocument()
+  })
+
+  it('renders populated campaign cards when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderCampaignPage()
+
+    const campaignsRegion = screen.getByRole('region', { name: /active disclosure campaigns/i })
+
+    expect(campaignsRegion).toBeInTheDocument()
+    expect(campaignsRegion).toHaveTextContent(DISCLOSURE_PROGRESSION_FIXTURE.label)
+    expect(campaignsRegion).toHaveTextContent('Official Disclosure')
+    expect(campaignsRegion).toHaveTextContent('Coastal Metro')
+    expect(campaignsRegion).not.toHaveTextContent(DISCLOSURE_PROGRESSION_FIXTURE.id)
+    expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+
+  it('does not mutate GameState after render', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    const before = JSON.stringify(useGameStore.getState().game)
+
+    renderCampaignPage()
+
+    expect(JSON.stringify(useGameStore.getState().game)).toBe(before)
+  })
+})

--- a/src/features/operations/PublicDisclosureCampaignPage.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT } from '../../data/copy'
+import { getPublicDisclosureCampaignView } from './publicDisclosureCampaignView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function PublicDisclosureCampaignPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getPublicDisclosureCampaignView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Public disclosure campaign briefing">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Campaign summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">
+              {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.pageHeading}
+            </h2>
+            <p className="text-sm opacity-60">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.pageSubtitle}</p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          <StatCard
+            label={PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.activeDisclosureLabel}
+            value={String(view.summary.activeDisclosureCount)}
+          />
+          <StatCard
+            label={PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.dominantAwarenessLabel}
+            value={view.summary.dominantAwarenessBandLabel}
+          />
+          <StatCard
+            label={PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.readOnlyNote}</p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty campaign state">
+          <h3 className="text-lg font-semibold">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.emptyTitle}</h3>
+          <p className="text-sm opacity-70">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Active disclosure campaigns"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">
+              {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.campaignsHeading}
+            </h3>
+            <p className="text-sm opacity-60">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.campaignsSubtitle}</p>
+          </div>
+
+          <ul className="space-y-3">
+            {view.records.map((record) => (
+              <li
+                key={record.label}
+                className="rounded border border-white/10 bg-white/5 px-3 py-3 space-y-2"
+              >
+                <div className="space-y-1">
+                  <p className="font-medium">{record.label}</p>
+                  <p className="text-sm opacity-70">{record.summaryLabel}</p>
+                </div>
+
+                <div className="flex flex-wrap gap-2 text-xs">
+                  <span className="rounded-full border border-white/15 px-2 py-0.5 opacity-80">
+                    {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.awarenessPrefix}{' '}
+                    {record.awarenessLevelLabel}
+                  </span>
+                  <span className="rounded-full border border-white/15 px-2 py-0.5 opacity-80">
+                    {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.falloutPrefix} {record.falloutPhaseLabel}
+                  </span>
+                  {record.campaignObjectivePivotLabel ? (
+                    <span className="rounded-full border border-white/15 px-2 py-0.5 opacity-80">
+                      {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.objectivePrefix}{' '}
+                      {record.campaignObjectivePivotLabel}
+                    </span>
+                  ) : null}
+                </div>
+
+                {record.regionalBandViews.length > 0 ? (
+                  <div className="space-y-1">
+                    <p className="text-xs uppercase tracking-[0.18em] opacity-50">
+                      {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.regionalTrustHeading}
+                    </p>
+                    <ul className="space-y-1 text-sm">
+                      {record.regionalBandViews.map((entry) => (
+                        <li key={`${record.label}:${entry.regionLabel}`}>
+                          {entry.regionLabel}: {entry.trustBandLabel}
+                          {entry.redacted ? (
+                            <span className="opacity-55">
+                              {' '}
+                              {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.redactedSuffix}
+                            </span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {record.coverNarrativeContextLabel ? (
+                  <p className="text-xs opacity-65">
+                    {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.coverNarrativePrefix}{' '}
+                    {record.coverNarrativeContextLabel}
+                  </p>
+                ) : null}
+
+                {record.coverCapacityStressLabel ? (
+                  <p className="text-xs opacity-65">{record.coverCapacityStressLabel}</p>
+                ) : null}
+
+                {record.confidenceBandLabel ? (
+                  <p className="text-xs opacity-55">
+                    {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.confidencePrefix}{' '}
+                    {record.confidenceBandLabel}
+                  </p>
+                ) : null}
+
+                {record.redacted ? (
+                  <p className="text-xs opacity-55">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.redactedSuffix}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -46,6 +46,7 @@ import {
   buildWeeklyReportTutorialChoices,
 } from './frontDeskChoices'
 import { FRONT_DESK_TRIGGER_IDS, getEligibleFrontDeskSceneTriggerIdSet } from './frontDeskTriggers'
+import { getPublicDisclosureCampaignView } from './publicDisclosureCampaignView'
 
 export type FrontDeskNoticeTone = 'info' | 'warning' | 'danger' | 'success'
 export type FrontDeskNoticeActionTarget = 'report' | 'cases' | 'recruitment' | 'factions'
@@ -736,8 +737,9 @@ function getAttentionPriority(tone: FrontDeskNoticeTone) {
 
 function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
   const shell = buildShellStatusBarView(game)
+  const disclosureCampaign = getPublicDisclosureCampaignView(game)
 
-  return [
+  const links: FrontDeskQuickLinkView[] = [
     {
       label: 'Open contracts',
       href: APP_ROUTES.contracts,
@@ -768,6 +770,17 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
       href: shell.weeklyReportHref,
       description: 'Open the current or latest weekly report.',
     },
+  ]
+
+  if (!disclosureCampaign.isEmpty) {
+    links.push({
+      label: 'Open disclosure campaign briefing',
+      href: APP_ROUTES.publicDisclosureCampaign,
+      description: 'Review post-secrecy awareness posture and regional public-trust bands.',
+    })
+  }
+
+  links.push(
     {
       label: 'Open series intake mirror',
       href: APP_ROUTES.patternSourceSeries,
@@ -884,8 +897,10 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
       href: APP_ROUTES.postIncidentReviewRecommendationActions,
       description:
         'Review follow-on action stubs linked to persisted recommendation and qualifying review records.',
-    },
-  ]
+    }
+  )
+
+  return links
 }
 
 function buildStatCards(game: GameState): FrontDeskStatCardView[] {
@@ -1179,7 +1194,30 @@ function buildAttentionItems(
       href: APP_ROUTES.teamDetail(entry.teamId),
     }))
 
-  return [...noticeItems, ...debriefAttention, ...signalItems, ...routingItems, ...readinessItems]
+  const disclosureCampaign = getPublicDisclosureCampaignView(game)
+  const disclosureAttention =
+    !disclosureCampaign.isEmpty && disclosureCampaign.summary.activeDisclosureCount > 0
+      ? [
+          {
+            id: 'disclosure:campaign-briefing',
+            title: 'Disclosure campaign posture requires review',
+            summary: `${disclosureCampaign.summary.activeDisclosureCount} active disclosure campaign(s); dominant awareness band: ${disclosureCampaign.summary.dominantAwarenessBandLabel}.`,
+            tone: ((): FrontDeskNoticeTone => {
+              const band = disclosureCampaign.summary.dominantAwarenessBandLabel
+              if (band === 'Public Scandal' || band === 'Official Disclosure') {
+                return 'warning'
+              }
+              if (band === 'Normalization') {
+                return 'info'
+              }
+              return 'warning'
+            })(),
+            href: APP_ROUTES.publicDisclosureCampaign,
+          } as const,
+        ]
+      : []
+
+  return [...noticeItems, ...debriefAttention, ...disclosureAttention, ...signalItems, ...routingItems, ...readinessItems]
     .sort((left, right) => {
       const priorityDelta = getAttentionPriority(right.tone) - getAttentionPriority(left.tone)
 

--- a/src/features/operations/publicDisclosureCampaignView.ts
+++ b/src/features/operations/publicDisclosureCampaignView.ts
@@ -1,0 +1,192 @@
+import type { GameState } from '../../domain/models'
+import {
+  projectDisclosureRegionalView,
+  type AwarenessLevel,
+  type PublicDisclosureRecord,
+} from '../../domain/publicDisclosureStateRegistry'
+import { resolveTruthLayerDualIncidentPairing } from '../../domain/truthLayerCoverNarrativePairing'
+import { formatPublicDisclosureEnumLabel } from './publicDisclosureMirrorView'
+
+const AWARENESS_SEVERITY_ORDER: readonly AwarenessLevel[] = [
+  'secrecy_intact',
+  'local_rumor',
+  'credible_leak',
+  'public_scandal',
+  'official_disclosure',
+  'normalization',
+] as const
+
+export interface PublicDisclosureCampaignRegionalBandView {
+  regionLabel: string
+  trustBandLabel: string
+  redacted: boolean
+}
+
+export interface PublicDisclosureCampaignRecordView {
+  label: string
+  summaryLabel: string
+  awarenessLevelLabel: string
+  falloutPhaseLabel: string
+  regionalBandViews: readonly PublicDisclosureCampaignRegionalBandView[]
+  campaignObjectivePivotLabel: string | null
+  coverCapacityStressLabel: string | null
+  coverNarrativeContextLabel: string | null
+  confidenceBandLabel: string | null
+  redacted: boolean
+}
+
+export interface PublicDisclosureCampaignSummaryView {
+  activeDisclosureCount: number
+  dominantAwarenessBandLabel: string
+  week: number
+}
+
+export interface PublicDisclosureCampaignView {
+  isEmpty: boolean
+  summary: PublicDisclosureCampaignSummaryView
+  records: readonly PublicDisclosureCampaignRecordView[]
+}
+
+function listPersistedRecords(game: GameState): PublicDisclosureRecord[] {
+  const map = game.publicDisclosureRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatRegionDisplayLabel(regionRef: string): string {
+  const token = regionRef.startsWith('region:') ? regionRef.slice('region:'.length) : regionRef
+  return formatPublicDisclosureEnumLabel(token.replace(/-/g, '_'))
+}
+
+function formatTrustBand(score: number): string {
+  if (score < 0.34) {
+    return 'Low'
+  }
+
+  if (score < 0.67) {
+    return 'Moderate'
+  }
+
+  return 'High'
+}
+
+function formatConfidenceBand(value: number): string {
+  if (value < 0.4) {
+    return 'Low confidence'
+  }
+
+  if (value < 0.7) {
+    return 'Moderate confidence'
+  }
+
+  return 'High confidence'
+}
+
+function awarenessSeverityIndex(level: AwarenessLevel): number {
+  return AWARENESS_SEVERITY_ORDER.indexOf(level)
+}
+
+function resolveDominantAwarenessBand(records: readonly PublicDisclosureRecord[]): string {
+  if (records.length === 0) {
+    return 'No active disclosure posture'
+  }
+
+  let dominant: AwarenessLevel = 'secrecy_intact'
+
+  for (const record of records) {
+    const level = record.awarenessLevel
+    if (awarenessSeverityIndex(level) > awarenessSeverityIndex(dominant)) {
+      dominant = level
+    }
+  }
+
+  return formatPublicDisclosureEnumLabel(dominant)
+}
+
+function resolveCoverNarrativeContextLabel(
+  game: GameState,
+  disclosureRecordId: string
+): string | null {
+  const truthLayerRecords = game.truthLayerRecords ?? {}
+
+  for (const incident of Object.values(truthLayerRecords)) {
+    const linkedRef = typeof incident.linkedDisclosureRef === 'string'
+      ? incident.linkedDisclosureRef.trim()
+      : ''
+
+    if (linkedRef !== disclosureRecordId) {
+      continue
+    }
+
+    const pairing = resolveTruthLayerDualIncidentPairing(
+      incident,
+      truthLayerRecords,
+      game.publicDisclosureRecords
+    )
+
+    return pairing.coverNarrativeRecord?.label ?? null
+  }
+
+  return null
+}
+
+function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDisclosureCampaignRecordView {
+  const projection = projectDisclosureRegionalView(record, { redactUnknown: true })
+
+  const summaryLabel =
+    projection.summary ??
+    (projection.redacted && record.summary ? 'Briefing summary withheld pending review.' : '—')
+
+  const regionalBandViews = Object.freeze(
+    projection.regionalTrust.map((entry) =>
+      Object.freeze({
+        regionLabel: formatRegionDisplayLabel(entry.regionRef),
+        trustBandLabel:
+          entry.redacted || entry.trustScore === null
+            ? '—'
+            : formatTrustBand(entry.trustScore),
+        redacted: entry.redacted,
+      })
+    )
+  )
+
+  const confidenceBandLabel =
+    projection.confidence === null
+      ? projection.redacted && record.confidence !== undefined
+        ? 'Withheld'
+        : null
+      : formatConfidenceBand(projection.confidence)
+
+  return Object.freeze({
+    label: record.label,
+    summaryLabel,
+    awarenessLevelLabel: formatPublicDisclosureEnumLabel(projection.publicAwarenessHint),
+    falloutPhaseLabel: formatPublicDisclosureEnumLabel(projection.falloutPhase),
+    regionalBandViews,
+    campaignObjectivePivotLabel: projection.campaignObjectivePivot
+      ? formatPublicDisclosureEnumLabel(projection.campaignObjectivePivot)
+      : null,
+    coverCapacityStressLabel: record.coverCapacityFailure === true ? 'Cover capacity under strain' : null,
+    coverNarrativeContextLabel: resolveCoverNarrativeContextLabel(game, record.id),
+    confidenceBandLabel,
+    redacted: projection.redacted,
+  })
+}
+
+/** Read-only player briefing over hydrated `publicDisclosureRecords`; does not mutate GameState. */
+export function getPublicDisclosureCampaignView(game: GameState): PublicDisclosureCampaignView {
+  const records = listPersistedRecords(game)
+
+  const activeDisclosureCount = records.filter(
+    (record) => record.awarenessLevel !== 'secrecy_intact'
+  ).length
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      activeDisclosureCount,
+      dominantAwarenessBandLabel: resolveDominantAwarenessBand(records),
+      week: game.week,
+    }),
+    records: Object.freeze(records.map((record) => toRecordView(game, record))),
+  })
+}

--- a/src/test/publicDisclosureCampaignView.test.ts
+++ b/src/test/publicDisclosureCampaignView.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  NORMALIZATION_INPUT_FIXTURE,
+  type PublicDisclosureRecord,
+} from '../domain/publicDisclosureStateRegistry'
+import { COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES } from '../domain/truthLayerCoverNarrativePairing'
+import { COVER_NARRATIVE_TRUTH_LAYER_FIXTURE } from '../domain/truthLayerRecordRegistry'
+import { getPublicDisclosureCampaignView } from '../features/operations/publicDisclosureCampaignView'
+
+describe('publicDisclosureCampaignView (SPE-861 slice 1)', () => {
+  it('returns empty campaign view when publicDisclosureRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.publicDisclosureRecords).toEqual({})
+
+    const view = getPublicDisclosureCampaignView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.activeDisclosureCount).toBe(0)
+    expect(view.summary.dominantAwarenessBandLabel).toBe('No active disclosure posture')
+    expect(view.records).toEqual([])
+  })
+
+  it('projects progression fixture with institutional labels and regional trust bands', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const view = getPublicDisclosureCampaignView(game)
+    const record = view.records[0]
+
+    expect(view.isEmpty).toBe(false)
+    expect(view.summary.activeDisclosureCount).toBe(1)
+    expect(view.summary.dominantAwarenessBandLabel).toBe('Official Disclosure')
+    expect(record?.label).toBe(DISCLOSURE_PROGRESSION_FIXTURE.label)
+    expect(record?.awarenessLevelLabel).toBe('Official Disclosure')
+    expect(record?.falloutPhaseLabel).toBe('Disclosure')
+    expect(record?.regionalBandViews).toHaveLength(2)
+    expect(record?.regionalBandViews[0]?.regionLabel).toBe('Coastal Metro')
+    expect(record?.regionalBandViews[0]?.trustBandLabel).toBe('Low')
+    expect(record?.confidenceBandLabel).toBe('Moderate confidence')
+  })
+
+  it('suppresses redacted summary and confidence for player copy', () => {
+    const game = createStartingState()
+    const redactedRecord: PublicDisclosureRecord = {
+      ...DISCLOSURE_PROGRESSION_FIXTURE,
+      summary: 'Internal escalation memo with restricted detail.',
+      redactedFields: ['summary', 'confidence'],
+    }
+
+    game.publicDisclosureRecords = {
+      [redactedRecord.id]: redactedRecord,
+    }
+
+    const record = getPublicDisclosureCampaignView(game).records[0]
+
+    expect(record?.summaryLabel).toBe('Briefing summary withheld pending review.')
+    expect(record?.confidenceBandLabel).toBe('Withheld')
+    expect(record?.redacted).toBe(true)
+  })
+
+  it('resolves optional cover-narrative context label without operational record text', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+    game.truthLayerRecords = { ...COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES }
+
+    const record = getPublicDisclosureCampaignView(game).records[0]
+
+    expect(record?.coverNarrativeContextLabel).toBe(COVER_NARRATIVE_TRUTH_LAYER_FIXTURE.label)
+  })
+
+  it('derives dominant awareness band across multiple records', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    }
+
+    const view = getPublicDisclosureCampaignView(game)
+
+    expect(view.summary.activeDisclosureCount).toBe(2)
+    expect(view.summary.dominantAwarenessBandLabel).toBe('Normalization')
+  })
+
+  it('is byte-stable for repeated campaign builds', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    }
+
+    const first = JSON.stringify(getPublicDisclosureCampaignView(game))
+    const second = JSON.stringify(getPublicDisclosureCampaignView(game))
+
+    expect(first).toBe(second)
+  })
+})


### PR DESCRIPTION
## Summary

- Add read-only player-facing disclosure campaign briefing at /campaign/public-disclosure via getPublicDisclosureCampaignView — institutional labels, redaction policy, regional trust bands, optional cover-narrative context.
- Wire Front Desk attention item and conditional quick link when publicDisclosureRecords is non-empty.
- Add PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT (briefing tone; planning mirror unchanged).

## Linear

- **Slice:** SPE-861 child — Disclosure campaign player UI (slice 1) *(create/claim on Linear; MCP create/update unavailable this session)*
- **Parent:** [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — stays **Backlog** (full trust-to-compliance engine deferred)

## What shipped

- publicDisclosureCampaignView.ts + PublicDisclosureCampaignPage.tsx
- Route + shell registration; Front Desk attention + quick link
- Slice doc: planning/disclosure-campaign-player-ui-slice-1.md
- Backlog handoff row updated

## Validation

- 
pm run test:run -- src/test/publicDisclosureCampaignView.test.ts src/features/operations/PublicDisclosureCampaignPage.test.tsx src/features/operations/publicDisclosureMirrorView.test.ts — 14 passed
- 
pm run lint — clean

## Docs updated

- planning/disclosure-campaign-player-ui-slice-1.md
- planning/backlog.md

## Parent remains open

SPE-861 parent acceptance bar not satisfied — player surfacing only; trust outcomes / compliance engine deferred to later children.

Made with [Cursor](https://cursor.com)