### PR TITLE
SPE-861 slice 2: public-disclosure trust outcome projection

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-861 disclosure campaign player UI slice 2 (trust outcomes) or SPE-1309 unified engine owner slice if prioritized over remaining SPE-1347 siblings.
+**Next step:** SPE-1309 unified engine owner slice if prioritized, or next SPE-861 follow-up child after trust-outcome slice 2 ships.
 
-**Base `main` SHA:** `517b1824` — shipped: SPE-861 disclosure campaign player UI slice 1 @ `planning/disclosure-campaign-player-ui-slice-1.md` (PR #2805)
+**Base `main` SHA:** `256a156e` — in progress: SPE-861 disclosure campaign trust outcomes slice 2 @ `planning/disclosure-campaign-player-ui-slice-2.md`
 
-**Recently shipped:** SPE-861 disclosure campaign player UI slice 1 (PR #2805); SPE-1347 cover-story lifecycle slice 4 (PR #2804).
+**Recently shipped:** SPE-861 disclosure campaign player UI slice 1 (PR #2805 @ `517b1824`); SPE-1347 cover-story lifecycle slice 4 (PR #2804).
 
 **Recently shipped:** SPE-1882 coercive protocol mirror snapshot read slice 11 (PR #2798); SPE-1309 parent acceptance review grooming slice 4 (PR #2796); SPE-1888 parent acceptance review grooming slice 6 (PR #2793).
 
@@ -162,6 +162,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `public-disclosure-state-registry-slice-3.md`             | **Shipped**    | SPE-2326 / PR #2519; weekly scheduled awareness/fallout progression hook.                                                                          |
 | `public-disclosure-state-registry-slice-4.md`             | **Shipped**    | SPE-2331 / PR #2529; planning mirror UI over `publicDisclosureRecords` @ `6fa361b3`.                                                                |
 | `disclosure-campaign-player-ui-slice-1.md`                | **Shipped**    | SPE-861 child — player-facing disclosure campaign briefing UI / PR #2805 @ `517b1824`.                                                             |
+| `disclosure-campaign-player-ui-slice-2.md`                | **In Progress** | SPE-861 child — public-trust outcome projection + weekly note + Front Desk signal / branch `spe-861-disclosure-campaign-trust-outcomes-slice-2` @ `256a156e`. |
 | `pattern-source-series-registry-slice-1.md`               | **Shipped**    | SPE-2110 / PR #2431; series-hub intake metadata and processing queue projection.                                                                      |
 | `pattern-source-series-registry-slice-2.md`               | **Shipped**    | SPE-2327 / PR #2521; `patternSourceSeriesRecords` GameState persistence @ `0f67c210`.                                                               |
 | `pattern-source-series-registry-slice-3.md`               | **Shipped**    | SPE-2328 / PR #2523; readiness-gated processing-pipeline weekly hook @ `37619b71`.                                                                    |

--- a/planning/disclosure-campaign-player-ui-slice-2.md
+++ b/planning/disclosure-campaign-player-ui-slice-2.md
@@ -1,0 +1,80 @@
+# SPE-861 — Disclosure campaign public-trust outcome projection (slice 2)
+
+One-page implementation plan. Linear: child under [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — **Disclosure campaign public-trust outcome projection (slice 2)** (create/claim on start). Parent [SPE-861](https://linear.app/spectranoir/issue/SPE-861) stays **Done** on Linear — full trust-to-compliance engine not in scope.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-861 child — Disclosure campaign public-trust outcome projection (slice 2)                            |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — public trust and compliance engine (umbrella)    |
+| **Branch** | `spe-861-disclosure-campaign-trust-outcomes-slice-2`                                                       |
+| **Base `main` SHA** | `256a156e`                                                                                          |
+
+## Goal
+
+Smallest deterministic trust-outcome hook reading post-tick `publicDisclosureRecords` — compliance/cooperation band projection, weekly report note, and Front Desk signal wired from a single domain read-side module.
+
+## Prerequisite (on `main` @ `256a156e`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109)               |
+| Weekly progression   | `applyWeeklyPublicDisclosureProgressionTick` in `advanceWeek` (SPE-2326) |
+| Player campaign UI   | `getPublicDisclosureCampaignView` + `/campaign/public-disclosure` (SPE-861 slice 1 / PR #2805) |
+| Planning mirror UI   | `getPublicDisclosureMirrorView` + `/public-disclosure-state` (SPE-2331) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `projectPublicDisclosureTrustOutcome` domain projection            | Full SPE-861 compliance engine              |
+| `buildWeeklyPublicDisclosureTrustOutcomeReportNotes` + `advanceWeek` hook | Weekly tick / sanitize contract changes |
+| Front Desk attention from domain projection                        | SPE-1347 contradiction engine changes       |
+| Campaign summary `cooperationBandLabel` surfacing                  | Disclosure choice mechanics                   |
+| `public_disclosure.trust_outcome` report note type                 | Planning mirror route changes               |
+| Domain + `advanceWeek` integration tests                           | Segmented population trust scores           |
+| Slice doc (this file) + backlog handoff                            | SPE-861 parent scope expansion              |
+
+## Outcome contract
+
+- **Read-only** — project hydrated `publicDisclosureRecords`; no GameState mutation from projection.
+- **Post-tick** — weekly notes emit after disclosure progression tick and normalization compose in `advanceWeek`.
+- **Bands** — dominant awareness level, aggregate regional trust band (minimum non-redacted score), cooperation band (`aligned` / `watchful` / `opposed` / `inactive`).
+- **Redaction** — respect `projectDisclosureRegionalView` redaction; omit redacted trust scores from aggregate band.
+- **Front Desk** — attention item tone/summary from domain projection; no duplicate campaign-view band logic.
+- **Empty maps** — inactive cooperation band; no weekly note; no Front Desk attention item.
+
+## Acceptance
+
+- [x] Empty `publicDisclosureRecords` map yields inactive projection without throw
+- [x] `DISCLOSURE_PROGRESSION_FIXTURE` projects opposed cooperation + low regional trust
+- [x] `NORMALIZATION_INPUT_FIXTURE` projects aligned cooperation + moderate regional trust
+- [x] `advanceWeek` appends `public_disclosure.trust_outcome` note when active campaigns exist
+- [x] Front Desk attention uses domain projection summary/tone
+- [x] Campaign summary surfaces cooperation band label
+- [x] `publicDisclosureMirrorView.test.ts` unchanged / regression green
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publicDisclosureTrustOutcomeProjection.ts`, `src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| View   | `src/features/operations/publicDisclosureCampaignView.ts`, `src/features/operations/frontDeskView.ts`, `src/features/operations/PublicDisclosureCampaignPage.tsx`, `src/features/report/reportNoteView.ts` |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/publicDisclosureTrustOutcomeProjection.test.ts`, `src/test/advanceWeek.publicDisclosureTrustOutcome.integration.test.ts`, `src/test/publicDisclosureCampaignView.test.ts`, `src/features/operations/PublicDisclosureCampaignPage.test.tsx`, `src/test/reportNoteTypeAudit.test.ts`, `src/features/report/reportNoteView.test.ts` |
+| Plan   | `planning/disclosure-campaign-player-ui-slice-2.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full public-trust / compliance outcomes engine | SPE-861 follow-up | Parent umbrella; out of smallest hook boundary |
+| Segmented population trust scores | SPE-861 | Deferred to later SPE-861 children |
+| Disclosure choice mechanics | SPE-861 | Out of read-side projection boundary |
+| Mass-anomalous population wire-up | SPE-2122 | Deferred governance integration |
+
+## See also
+
+- `planning/disclosure-campaign-player-ui-slice-1.md` — player briefing UI (slice 1)
+- `planning/public-disclosure-state-registry-slice-3.md` — weekly progression hook

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -986,6 +986,7 @@ export const PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT: Record<string, string> = {
   backToDeskLabel: 'Back to Operations Desk',
   activeDisclosureLabel: 'Active disclosures',
   dominantAwarenessLabel: 'Dominant awareness band',
+  cooperationBandLabel: 'Public cooperation band',
   weekLabel: 'Campaign week',
   readOnlyNote:
     'Awareness and regional trust reflect the latest weekly progression. This briefing does not change campaign state.',

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1543,6 +1543,7 @@ export type ReportNoteType =
   | 'coercive_protocol.integrated_health_reconciliation'
   | 'post_incident_review.follow_on'
   | 'post_incident_review.closeout_reward_payout'
+  | 'public_disclosure.trust_outcome'
 
 export type ReportNoteMetadataValue =
   | string

--- a/src/domain/publicDisclosureTrustOutcomeProjection.ts
+++ b/src/domain/publicDisclosureTrustOutcomeProjection.ts
@@ -1,0 +1,270 @@
+/**
+ * SPE-861 slice 2: read-side public-trust outcome projection from persisted disclosure records.
+ *
+ * Pure deterministic projection over post-tick `publicDisclosureRecords` — no GameState
+ * mutation and no weekly progression duplication.
+ */
+
+import type { GameState } from './models'
+import {
+  projectDisclosureRegionalView,
+  type AwarenessLevel,
+  type PublicDisclosureRecord,
+  type PublicDisclosureRecordsMap,
+} from './publicDisclosureStateRegistry'
+
+const AWARENESS_SEVERITY_ORDER: readonly AwarenessLevel[] = [
+  'secrecy_intact',
+  'local_rumor',
+  'credible_leak',
+  'public_scandal',
+  'official_disclosure',
+  'normalization',
+] as const
+
+export type PublicDisclosureRegionalTrustBand = 'low' | 'moderate' | 'high'
+
+export type PublicDisclosureCooperationBand = 'aligned' | 'watchful' | 'opposed' | 'inactive'
+
+export type PublicDisclosureTrustOutcomeAttentionTone = 'info' | 'warning' | 'danger'
+
+export interface PublicDisclosureTrustOutcomeProjection {
+  readonly isEmpty: boolean
+  readonly activeCampaignCount: number
+  readonly dominantAwarenessLevel: AwarenessLevel | null
+  readonly dominantAwarenessBandLabel: string
+  readonly aggregateRegionalTrustBand: PublicDisclosureRegionalTrustBand | null
+  readonly cooperationBand: PublicDisclosureCooperationBand
+  readonly cooperationBandLabel: string
+  readonly frontDeskAttentionTone: PublicDisclosureTrustOutcomeAttentionTone
+  readonly frontDeskAttentionSummary: string
+}
+
+const COOPERATION_BAND_LABELS: Record<PublicDisclosureCooperationBand, string> = {
+  aligned: 'Aligned cooperation',
+  watchful: 'Watchful compliance',
+  opposed: 'Opposed posture',
+  inactive: 'No active disclosure posture',
+}
+
+function formatDisclosureEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function awarenessSeverityIndex(level: AwarenessLevel): number {
+  return AWARENESS_SEVERITY_ORDER.indexOf(level)
+}
+
+function listPersistedRecords(
+  records: PublicDisclosureRecordsMap | null | undefined
+): PublicDisclosureRecord[] {
+  const map = records ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function resolveDominantAwarenessLevel(
+  records: readonly PublicDisclosureRecord[]
+): AwarenessLevel | null {
+  if (records.length === 0) {
+    return null
+  }
+
+  let dominant: AwarenessLevel = 'secrecy_intact'
+
+  for (const record of records) {
+    const level = record.awarenessLevel
+    if (awarenessSeverityIndex(level) > awarenessSeverityIndex(dominant)) {
+      dominant = level
+    }
+  }
+
+  return dominant
+}
+
+function resolveTrustBandFromScore(score: number): PublicDisclosureRegionalTrustBand {
+  if (score < 0.34) {
+    return 'low'
+  }
+
+  if (score < 0.67) {
+    return 'moderate'
+  }
+
+  return 'high'
+}
+
+function resolveAggregateRegionalTrustBand(
+  records: readonly PublicDisclosureRecord[]
+): PublicDisclosureRegionalTrustBand | null {
+  let minimumScore: number | null = null
+
+  for (const record of records) {
+    const projection = projectDisclosureRegionalView(record, { redactUnknown: true })
+
+    for (const entry of projection.regionalTrust) {
+      if (entry.redacted || entry.trustScore === null) {
+        continue
+      }
+
+      minimumScore =
+        minimumScore === null ? entry.trustScore : Math.min(minimumScore, entry.trustScore)
+    }
+  }
+
+  if (minimumScore === null) {
+    return null
+  }
+
+  return resolveTrustBandFromScore(minimumScore)
+}
+
+function resolveCooperationBand(input: {
+  dominantAwarenessLevel: AwarenessLevel | null
+  aggregateRegionalTrustBand: PublicDisclosureRegionalTrustBand | null
+  activeCampaignCount: number
+}): PublicDisclosureCooperationBand {
+  const { dominantAwarenessLevel, aggregateRegionalTrustBand, activeCampaignCount } = input
+
+  if (activeCampaignCount === 0 || dominantAwarenessLevel === null) {
+    return 'inactive'
+  }
+
+  if (dominantAwarenessLevel === 'secrecy_intact') {
+    return 'inactive'
+  }
+
+  if (
+    dominantAwarenessLevel === 'normalization' &&
+    (aggregateRegionalTrustBand === 'moderate' || aggregateRegionalTrustBand === 'high')
+  ) {
+    return 'aligned'
+  }
+
+  if (dominantAwarenessLevel === 'official_disclosure' && aggregateRegionalTrustBand === 'high') {
+    return 'aligned'
+  }
+
+  if (
+    (dominantAwarenessLevel === 'public_scandal' || dominantAwarenessLevel === 'official_disclosure') &&
+    aggregateRegionalTrustBand === 'low'
+  ) {
+    return 'opposed'
+  }
+
+  if (
+    aggregateRegionalTrustBand === 'low' &&
+    (dominantAwarenessLevel === 'credible_leak' || dominantAwarenessLevel === 'local_rumor')
+  ) {
+    return 'opposed'
+  }
+
+  return 'watchful'
+}
+
+function resolveFrontDeskAttentionTone(
+  cooperationBand: PublicDisclosureCooperationBand,
+  dominantAwarenessLevel: AwarenessLevel | null
+): PublicDisclosureTrustOutcomeAttentionTone {
+  if (cooperationBand === 'opposed') {
+    return 'danger'
+  }
+
+  if (cooperationBand === 'watchful') {
+    return 'warning'
+  }
+
+  if (cooperationBand === 'aligned') {
+    return 'info'
+  }
+
+  if (
+    dominantAwarenessLevel === 'public_scandal' ||
+    dominantAwarenessLevel === 'official_disclosure'
+  ) {
+    return 'warning'
+  }
+
+  return 'info'
+}
+
+function formatRegionalTrustBandLabel(
+  band: PublicDisclosureRegionalTrustBand | null
+): string {
+  if (band === null) {
+    return 'Regional trust unavailable'
+  }
+
+  return `${band.charAt(0).toUpperCase()}${band.slice(1)} regional trust`
+}
+
+function buildFrontDeskAttentionSummary(input: {
+  activeCampaignCount: number
+  dominantAwarenessBandLabel: string
+  cooperationBandLabel: string
+  aggregateRegionalTrustBand: PublicDisclosureRegionalTrustBand | null
+}): string {
+  const trustLabel = formatRegionalTrustBandLabel(input.aggregateRegionalTrustBand)
+
+  return `${input.activeCampaignCount} active disclosure campaign(s); dominant awareness band: ${input.dominantAwarenessBandLabel}; ${input.cooperationBandLabel.toLowerCase()}; ${trustLabel.toLowerCase()}.`
+}
+
+/** Projects compliance/cooperation bands from hydrated disclosure records. */
+export function projectPublicDisclosureTrustOutcome(
+  records: PublicDisclosureRecordsMap | null | undefined
+): PublicDisclosureTrustOutcomeProjection {
+  const persistedRecords = listPersistedRecords(records)
+  const activeCampaignCount = persistedRecords.filter(
+    (record) => record.awarenessLevel !== 'secrecy_intact'
+  ).length
+  const dominantAwarenessLevel = resolveDominantAwarenessLevel(persistedRecords)
+  const dominantAwarenessBandLabel =
+    dominantAwarenessLevel === null
+      ? 'No active disclosure posture'
+      : formatDisclosureEnumLabel(dominantAwarenessLevel)
+  const aggregateRegionalTrustBand = resolveAggregateRegionalTrustBand(persistedRecords)
+  const cooperationBand = resolveCooperationBand({
+    dominantAwarenessLevel,
+    aggregateRegionalTrustBand,
+    activeCampaignCount,
+  })
+  const cooperationBandLabel = COOPERATION_BAND_LABELS[cooperationBand]
+
+  return Object.freeze({
+    isEmpty: persistedRecords.length === 0,
+    activeCampaignCount,
+    dominantAwarenessLevel,
+    dominantAwarenessBandLabel,
+    aggregateRegionalTrustBand,
+    cooperationBand,
+    cooperationBandLabel,
+    frontDeskAttentionTone: resolveFrontDeskAttentionTone(cooperationBand, dominantAwarenessLevel),
+    frontDeskAttentionSummary: buildFrontDeskAttentionSummary({
+      activeCampaignCount,
+      dominantAwarenessBandLabel,
+      cooperationBandLabel,
+      aggregateRegionalTrustBand,
+    }),
+  })
+}
+
+export function projectPublicDisclosureTrustOutcomeFromGame(
+  game: Pick<GameState, 'publicDisclosureRecords'>
+): PublicDisclosureTrustOutcomeProjection {
+  return projectPublicDisclosureTrustOutcome(game.publicDisclosureRecords)
+}
+
+export function formatPublicDisclosureTrustOutcomeNoteContent(
+  projection: PublicDisclosureTrustOutcomeProjection,
+  week: number
+): string {
+  if (projection.activeCampaignCount === 0) {
+    return `Public disclosure trust outcome — W${week}: no active disclosure campaigns.`
+  }
+
+  const trustLabel = formatRegionalTrustBandLabel(projection.aggregateRegionalTrustBand)
+
+  return `Public disclosure trust outcome — W${week}: ${projection.activeCampaignCount} active campaign(s); dominant awareness ${projection.dominantAwarenessBandLabel}; ${projection.cooperationBandLabel}; ${trustLabel}.`
+}

--- a/src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts
+++ b/src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts
@@ -1,0 +1,44 @@
+/**
+ * SPE-861 slice 2: weekly report notes for public-disclosure trust outcomes.
+ *
+ * Emits deterministic notes from post-tick disclosure records — no new persistence.
+ */
+
+import {
+  formatPublicDisclosureTrustOutcomeNoteContent,
+  projectPublicDisclosureTrustOutcome,
+} from './publicDisclosureTrustOutcomeProjection'
+import type { ReportNote } from './models'
+import type { PublicDisclosureRecordsMap } from './publicDisclosureStateRegistry'
+import { createDeterministicReportNote } from './reportNotes'
+
+/** Builds weekly report notes when active disclosure campaigns project a trust outcome. */
+export function buildWeeklyPublicDisclosureTrustOutcomeReportNotes(input: {
+  nextRecords: PublicDisclosureRecordsMap | null | undefined
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const projection = projectPublicDisclosureTrustOutcome(input.nextRecords)
+
+  if (projection.activeCampaignCount === 0) {
+    return []
+  }
+
+  return [
+    createDeterministicReportNote(
+      formatPublicDisclosureTrustOutcomeNoteContent(projection, input.week),
+      input.week,
+      input.sequenceStart,
+      input.baseTimestamp,
+      'public_disclosure.trust_outcome',
+      {
+        activeCampaignCount: projection.activeCampaignCount,
+        dominantAwarenessLevel: projection.dominantAwarenessLevel,
+        aggregateRegionalTrustBand: projection.aggregateRegionalTrustBand,
+        cooperationBand: projection.cooperationBand,
+        week: input.week,
+      }
+    ),
+  ]
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -292,6 +292,7 @@ import {
 import { applyWeeklyPatternSourceSeriesIntakeTick } from '../patternSourceSeriesWeeklyIntake'
 import { composePopulationEmergenceNormalizationIntoDisclosureRecords } from '../publicDisclosureNormalizationCompose'
 import { applyWeeklyPublicDisclosureProgressionTick } from '../publicDisclosureWeeklyProgression'
+import { buildWeeklyPublicDisclosureTrustOutcomeReportNotes } from '../publicDisclosureTrustOutcomeWeeklyReportNotes'
 import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInformationWeeklyRetention'
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
@@ -5126,6 +5127,30 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
         currentDisclosureRecordsForCompose,
         derivedPopulationEmergenceNormalizationInputs
       )
+  }
+
+  // SPE-861 slice 2: surface post-tick public-disclosure trust outcomes in weekly report notes.
+  const nextPublicDisclosureRecordsForTrustOutcome =
+    outputWeeklyState.publicDisclosureRecords ?? {}
+  if (Object.keys(nextPublicDisclosureRecordsForTrustOutcome).length > 0 && result.reports.length > 0) {
+    const lastWeeklyReport = result.reports[result.reports.length - 1]
+    const trustOutcomeNotes = buildWeeklyPublicDisclosureTrustOutcomeReportNotes({
+      nextRecords: nextPublicDisclosureRecordsForTrustOutcome,
+      week: result.week,
+      sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
+      baseTimestamp: noteBaseTimestamp,
+    })
+
+    if (trustOutcomeNotes.length > 0) {
+      const reports = [...result.reports]
+      const lastReportIndex = reports.length - 1
+      const lastReport = reports[lastReportIndex]
+      reports[lastReportIndex] = {
+        ...lastReport,
+        notes: [...(lastReport.notes ?? []), ...trustOutcomeNotes],
+      }
+      result.reports = reports
+    }
   }
 
   // SPE-1265: Decay rumor packets each week; drop packets below the 0.05 signal threshold.

--- a/src/features/operations/PublicDisclosureCampaignPage.test.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.test.tsx
@@ -43,6 +43,8 @@ describe('PublicDisclosureCampaignPage (SPE-861 slice 1)', () => {
 
     renderCampaignPage()
 
+    expect(screen.getByText('Opposed posture')).toBeInTheDocument()
+
     const campaignsRegion = screen.getByRole('region', { name: /active disclosure campaigns/i })
 
     expect(campaignsRegion).toBeInTheDocument()

--- a/src/features/operations/PublicDisclosureCampaignPage.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.tsx
@@ -46,6 +46,10 @@ export default function PublicDisclosureCampaignPage() {
             value={view.summary.dominantAwarenessBandLabel}
           />
           <StatCard
+            label={PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.cooperationBandLabel}
+            value={view.summary.cooperationBandLabel ?? '—'}
+          />
+          <StatCard
             label={PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.weekLabel}
             value={`W${view.summary.week}`}
           />

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -47,6 +47,7 @@ import {
 } from './frontDeskChoices'
 import { FRONT_DESK_TRIGGER_IDS, getEligibleFrontDeskSceneTriggerIdSet } from './frontDeskTriggers'
 import { getPublicDisclosureCampaignView } from './publicDisclosureCampaignView'
+import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
 
 export type FrontDeskNoticeTone = 'info' | 'warning' | 'danger' | 'success'
 export type FrontDeskNoticeActionTarget = 'report' | 'cases' | 'recruitment' | 'factions'
@@ -1194,24 +1195,15 @@ function buildAttentionItems(
       href: APP_ROUTES.teamDetail(entry.teamId),
     }))
 
-  const disclosureCampaign = getPublicDisclosureCampaignView(game)
+  const disclosureTrustOutcome = projectPublicDisclosureTrustOutcomeFromGame(game)
   const disclosureAttention =
-    !disclosureCampaign.isEmpty && disclosureCampaign.summary.activeDisclosureCount > 0
+    disclosureTrustOutcome.activeCampaignCount > 0
       ? [
           {
             id: 'disclosure:campaign-briefing',
             title: 'Disclosure campaign posture requires review',
-            summary: `${disclosureCampaign.summary.activeDisclosureCount} active disclosure campaign(s); dominant awareness band: ${disclosureCampaign.summary.dominantAwarenessBandLabel}.`,
-            tone: ((): FrontDeskNoticeTone => {
-              const band = disclosureCampaign.summary.dominantAwarenessBandLabel
-              if (band === 'Public Scandal' || band === 'Official Disclosure') {
-                return 'warning'
-              }
-              if (band === 'Normalization') {
-                return 'info'
-              }
-              return 'warning'
-            })(),
+            summary: disclosureTrustOutcome.frontDeskAttentionSummary,
+            tone: disclosureTrustOutcome.frontDeskAttentionTone,
             href: APP_ROUTES.publicDisclosureCampaign,
           } as const,
         ]

--- a/src/features/operations/publicDisclosureCampaignView.ts
+++ b/src/features/operations/publicDisclosureCampaignView.ts
@@ -5,6 +5,7 @@ import {
   type PublicDisclosureRecord,
 } from '../../domain/publicDisclosureStateRegistry'
 import { resolveTruthLayerDualIncidentPairing } from '../../domain/truthLayerCoverNarrativePairing'
+import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
 import { formatPublicDisclosureEnumLabel } from './publicDisclosureMirrorView'
 
 const AWARENESS_SEVERITY_ORDER: readonly AwarenessLevel[] = [
@@ -38,6 +39,7 @@ export interface PublicDisclosureCampaignRecordView {
 export interface PublicDisclosureCampaignSummaryView {
   activeDisclosureCount: number
   dominantAwarenessBandLabel: string
+  cooperationBandLabel: string | null
   week: number
 }
 
@@ -175,6 +177,7 @@ function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDi
 /** Read-only player briefing over hydrated `publicDisclosureRecords`; does not mutate GameState. */
 export function getPublicDisclosureCampaignView(game: GameState): PublicDisclosureCampaignView {
   const records = listPersistedRecords(game)
+  const trustOutcome = projectPublicDisclosureTrustOutcomeFromGame(game)
 
   const activeDisclosureCount = records.filter(
     (record) => record.awarenessLevel !== 'secrecy_intact'
@@ -185,6 +188,8 @@ export function getPublicDisclosureCampaignView(game: GameState): PublicDisclosu
     summary: Object.freeze({
       activeDisclosureCount,
       dominantAwarenessBandLabel: resolveDominantAwarenessBand(records),
+      cooperationBandLabel:
+        trustOutcome.cooperationBand === 'inactive' ? null : trustOutcome.cooperationBandLabel,
       week: game.week,
     }),
     records: Object.freeze(records.map((record) => toRecordView(game, record))),

--- a/src/features/report/reportNoteView.test.ts
+++ b/src/features/report/reportNoteView.test.ts
@@ -62,6 +62,7 @@ const EXPECTED_CATEGORY_BY_TYPE = {
   'coercive_protocol.integrated_health_reconciliation': 'system',
   'post_incident_review.follow_on': 'post_incident_review',
   'post_incident_review.closeout_reward_payout': 'post_incident_review',
+  'public_disclosure.trust_outcome': 'system',
 } satisfies Record<ReportNoteType, ReportNoteCategory>
 
 describe('reportNoteView', () => {

--- a/src/features/report/reportNoteView.ts
+++ b/src/features/report/reportNoteView.ts
@@ -48,6 +48,7 @@ const RECRUITMENT_NOTE_TYPES: ReportNoteType[] = [
 const SYSTEM_NOTE_TYPES: ReportNoteType[] = [
   'welfare_debt.accounting_cross_link',
   'coercive_protocol.integrated_health_reconciliation',
+  'public_disclosure.trust_outcome',
   'system.week_delta',
   'system.party_cards_drawn',
   'system.equipment_recovered',

--- a/src/test/advanceWeek.publicDisclosureTrustOutcome.integration.test.ts
+++ b/src/test/advanceWeek.publicDisclosureTrustOutcome.integration.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  NORMALIZATION_INPUT_FIXTURE,
+} from '../domain/publicDisclosureStateRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek public disclosure trust outcome integration (SPE-861 slice 2)', () => {
+  it('is a no-op for an empty public disclosure map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {}
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const trustOutcomeNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'public_disclosure.trust_outcome') ?? []
+
+    expect(trustOutcomeNotes).toEqual([])
+  })
+
+  it('surfaces trust-outcome notes after post-tick disclosure records', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const trustOutcomeNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'public_disclosure.trust_outcome') ?? []
+
+    expect(trustOutcomeNotes).toHaveLength(1)
+    expect(trustOutcomeNotes[0]?.content).toContain('Public disclosure trust outcome')
+    expect(trustOutcomeNotes[0]?.content).toContain('Opposed posture')
+    expect(trustOutcomeNotes[0]?.metadata?.cooperationBand).toBe('opposed')
+    expect(trustOutcomeNotes[0]?.metadata?.dominantAwarenessLevel).toBe('official_disclosure')
+  })
+
+  it('preserves progression fixture and still emits aligned trust outcome for normalization fixture', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 30
+    state.publicDisclosureRecords = {
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const record = nextState.publicDisclosureRecords?.[NORMALIZATION_INPUT_FIXTURE.id]
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const trustOutcomeNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'public_disclosure.trust_outcome') ?? []
+
+    expect(record).toEqual(NORMALIZATION_INPUT_FIXTURE)
+    expect(trustOutcomeNotes).toHaveLength(1)
+    expect(trustOutcomeNotes[0]?.metadata?.cooperationBand).toBe('aligned')
+  })
+})

--- a/src/test/publicDisclosureCampaignView.test.ts
+++ b/src/test/publicDisclosureCampaignView.test.ts
@@ -35,6 +35,7 @@ describe('publicDisclosureCampaignView (SPE-861 slice 1)', () => {
     expect(view.isEmpty).toBe(false)
     expect(view.summary.activeDisclosureCount).toBe(1)
     expect(view.summary.dominantAwarenessBandLabel).toBe('Official Disclosure')
+    expect(view.summary.cooperationBandLabel).toBe('Opposed posture')
     expect(record?.label).toBe(DISCLOSURE_PROGRESSION_FIXTURE.label)
     expect(record?.awarenessLevelLabel).toBe('Official Disclosure')
     expect(record?.falloutPhaseLabel).toBe('Disclosure')

--- a/src/test/publicDisclosureTrustOutcomeProjection.test.ts
+++ b/src/test/publicDisclosureTrustOutcomeProjection.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  NORMALIZATION_INPUT_FIXTURE,
+  type PublicDisclosureRecord,
+} from '../domain/publicDisclosureStateRegistry'
+import {
+  formatPublicDisclosureTrustOutcomeNoteContent,
+  projectPublicDisclosureTrustOutcome,
+} from '../domain/publicDisclosureTrustOutcomeProjection'
+
+describe('publicDisclosureTrustOutcomeProjection (SPE-861 slice 2)', () => {
+  it('returns inactive projection for an empty disclosure map', () => {
+    const projection = projectPublicDisclosureTrustOutcome({})
+
+    expect(projection.isEmpty).toBe(true)
+    expect(projection.activeCampaignCount).toBe(0)
+    expect(projection.cooperationBand).toBe('inactive')
+    expect(projection.aggregateRegionalTrustBand).toBeNull()
+    expect(projection.frontDeskAttentionTone).toBe('info')
+  })
+
+  it('projects opposed cooperation for official disclosure with low regional trust', () => {
+    const projection = projectPublicDisclosureTrustOutcome({
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    })
+
+    expect(projection.activeCampaignCount).toBe(1)
+    expect(projection.dominantAwarenessLevel).toBe('official_disclosure')
+    expect(projection.aggregateRegionalTrustBand).toBe('low')
+    expect(projection.cooperationBand).toBe('opposed')
+    expect(projection.cooperationBandLabel).toBe('Opposed posture')
+    expect(projection.frontDeskAttentionTone).toBe('danger')
+    expect(projection.frontDeskAttentionSummary).toContain('opposed posture')
+  })
+
+  it('projects aligned cooperation for normalization with moderate regional trust', () => {
+    const projection = projectPublicDisclosureTrustOutcome({
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    })
+
+    expect(projection.activeCampaignCount).toBe(1)
+    expect(projection.dominantAwarenessLevel).toBe('normalization')
+    expect(projection.aggregateRegionalTrustBand).toBe('moderate')
+    expect(projection.cooperationBand).toBe('aligned')
+    expect(projection.frontDeskAttentionTone).toBe('info')
+  })
+
+  it('derives dominant awareness and watchful cooperation across mixed records', () => {
+    const projection = projectPublicDisclosureTrustOutcome({
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    })
+
+    expect(projection.activeCampaignCount).toBe(2)
+    expect(projection.dominantAwarenessLevel).toBe('normalization')
+    expect(projection.aggregateRegionalTrustBand).toBe('low')
+    expect(projection.cooperationBand).toBe('watchful')
+    expect(projection.frontDeskAttentionTone).toBe('warning')
+  })
+
+  it('ignores redacted regional trust scores when aggregating trust band', () => {
+    const redactedRecord: PublicDisclosureRecord = {
+      ...DISCLOSURE_PROGRESSION_FIXTURE,
+      trustByRegion: [{ regionRef: 'region:coastal-metro', trustScore: 0.12 }],
+      redactedFields: ['trustByRegion'],
+    }
+
+    const projection = projectPublicDisclosureTrustOutcome({
+      [redactedRecord.id]: redactedRecord,
+    })
+
+    expect(projection.aggregateRegionalTrustBand).toBeNull()
+    expect(projection.cooperationBand).toBe('watchful')
+  })
+
+  it('formats weekly trust-outcome note content deterministically', () => {
+    const projection = projectPublicDisclosureTrustOutcome({
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    })
+
+    expect(formatPublicDisclosureTrustOutcomeNoteContent(projection, 24)).toBe(
+      'Public disclosure trust outcome — W24: 1 active campaign(s); dominant awareness Official Disclosure; Opposed posture; Low regional trust.'
+    )
+  })
+
+  it('is byte-stable for repeated projections', () => {
+    const records = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    }
+
+    const first = JSON.stringify(projectPublicDisclosureTrustOutcome(records))
+    const second = JSON.stringify(projectPublicDisclosureTrustOutcome(records))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -78,6 +78,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
     producer: 'postIncidentReviewCloseoutRewardPayoutSurfacing',
     category: 'post_incident_review',
   },
+  'public_disclosure.trust_outcome': {
+    status: 'active',
+    producer: 'publicDisclosureTrustOutcomeWeeklyReportNotes',
+    category: 'system',
+  },
 } as const satisfies Record<
   ReportNoteType,
   { status: 'active' | 'future-reserved' | 'stale'; producer: string; category: string }
@@ -89,7 +94,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(44)
+    expect(entries).toHaveLength(45)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Add read-side domain projection over post-tick `publicDisclosureRecords` (dominant awareness, aggregate regional trust band, cooperation band).
- Wire `advanceWeek` to append `public_disclosure.trust_outcome` weekly report notes after disclosure progression + normalization compose.
- Route Front Desk attention and campaign summary cooperation band from the domain projection (no duplicate tick logic).

## Linear mapping

- **Slice issue:** SPE-861 child — Disclosure campaign public-trust outcome projection (slice 2) *(create/claim on Linear; parent SPE-861 stays Done)*
- **Parent:** [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — public trust and compliance engine
- **Parent remains open:** No — parent already Done; this is a follow-up child slice

## What shipped

- `publicDisclosureTrustOutcomeProjection.ts` + weekly report note builder
- Front Desk attention + campaign summary cooperation band surfacing
- Domain + `advanceWeek` integration tests with `DISCLOSURE_PROGRESSION_FIXTURE`

## Validation

- `npm run lint`
- `npm run test:run -- src/test/publicDisclosureTrustOutcomeProjection.test.ts src/test/advanceWeek.publicDisclosureTrustOutcome.integration.test.ts src/test/publicDisclosureCampaignView.test.ts src/features/operations/PublicDisclosureCampaignPage.test.tsx src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts src/features/operations/publicDisclosureMirrorView.test.ts`

## Docs updated

- `planning/disclosure-campaign-player-ui-slice-2.md`
- `planning/backlog.md` handoff row

Made with [Cursor](https://cursor.com)