### PR TITLE
SPE-1309: unified cognitive hazard engine exposure state anchor (slice 1)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1309 unified engine owner slice if prioritized, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
+**Next step:** SPE-1309 unified engine slice 2 (persistence + hydrate) if prioritized, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
 
-**Base `main` SHA:** `47e3e652` — shipped: SPE-861 disclosure campaign trust outcomes slice 2 @ `planning/disclosure-campaign-player-ui-slice-2.md` (PR #2806)
+**Base `main` SHA:** `0db414af` — in progress: SPE-1309 unified cognitive hazard engine slice 1 @ `planning/spe-1309-unified-engine-slice-1.md`
 
-**Recently shipped:** SPE-861 disclosure campaign trust outcomes slice 2 (PR #2806); SPE-861 disclosure campaign player UI slice 1 (PR #2805 @ `517b1824`).
+**Recently shipped:** SPE-861 disclosure campaign trust outcomes slice 2 (PR #2806 @ `47e3e652`); SPE-861 disclosure campaign player UI slice 1 (PR #2805 @ `517b1824`).
 
 **Recently shipped:** SPE-1882 coercive protocol mirror snapshot read slice 11 (PR #2798); SPE-1309 parent acceptance review grooming slice 4 (PR #2796); SPE-1888 parent acceptance review grooming slice 6 (PR #2793).
 
@@ -224,6 +224,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1309-parent-acceptance-review-slice-2.md`            | **Shipped**    | SPE-2445 / PR #2766; SPE-1309 stays Backlog — SPE-2108 + SPE-2116 follow-on groomed; unified engine AC not met @ `1c8d2d74`.                            |
 | `spe-1309-parent-acceptance-review-slice-3.md`            | **Shipped**    | SPE-2451 / PR #2783; SPE-1309 stays Backlog — post SPE-1343 grooming; doc vs Linear auto-close reconciliation @ `a8b26733`.                            |
 | `spe-1309-parent-acceptance-review-slice-4.md`            | **Shipped**    | SPE-2456 / PR #2796; SPE-1309 stays Backlog — post SPE-1888 grooming slice 6; slice 4 auto-close reconciliation @ `25f10aff`.                    |
+| `spe-1309-unified-engine-slice-1.md`                      | **In Progress**| SPE-1309 child — unified cognitive hazard engine exposure state anchor @ `0db414af`.                                                                   |
 | `welfare-debt-accounting-registry-slice-2.md`             | **Shipped**    | SPE-2351 / PR #2570; planning mirror UI over `welfareDebtAccountingRecords` @ `96ad05ba`.                                                               |
 | `welfare-debt-accounting-registry-slice-3.md`             | **Shipped**    | SPE-2352 / PR #2572; weekly orchestration hook in `advanceWeek` @ `5673423c`.                                                                          |
 | `welfare-debt-accounting-registry-slice-4.md`             | **Shipped**    | SPE-2353 / PR #2574; ledger summary audit output @ `1ec3ca12`.                                                                                         |

--- a/planning/spe-1309-unified-engine-slice-1.md
+++ b/planning/spe-1309-unified-engine-slice-1.md
@@ -1,0 +1,95 @@
+# SPE-1309 — Unified cognitive hazard engine (slice 1)
+
+One-page implementation plan. Linear: child under [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — **Unified cognitive hazard engine — exposure state anchor (slice 1)** (create/claim on start). Parent [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays **Backlog** — unified engine AC rows 1–3 not fully met until persistence + wire-up slices.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1309 child — Unified cognitive hazard engine — exposure state anchor (slice 1)                       |
+| **Parent** | [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — Unified cognitive hazard engine (umbrella)    |
+| **Branch** | `spe-1309-unified-engine-slice-1`                                                                          |
+| **Base `main` SHA** | `0db414af`                                                                                          |
+
+## Goal
+
+Smallest deterministic unified cognitive hazard engine domain anchor: shared exposure state model with explicit trigger channels, fear/memetic/memory impairment dimensions, countermeasure posture, and read-side exposure review projection.
+
+## Prerequisite (on `main` @ `0db414af`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Self-censoring info registry | `src/domain/selfCensoringInformationRegistry.ts` (SPE-2108)      |
+| Naming-hazard registry | `src/domain/namingHazardDescriptorRegistry.ts` (SPE-2116)          |
+| Psychological resilience registry | `src/domain/psychologicalResilienceRegistry.ts` (SPE-1615) |
+| Parent grooming      | [SPE-2456](https://linear.app/spectranoir/issue/SPE-2456) / PR #2796 — AC gap table in `planning/spe-1309-parent-acceptance-review-slice-4.md` |
+
+## Gap (pre-slice)
+
+- No shared cross-hazard exposure state model — sibling registries attach independently.
+- No engine-level trigger-channel taxonomy (direct perception, recording-mediated, reference/description, memory interaction).
+- No unified projection describing agent duty, knowledge integrity, and procedure restriction effects.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `CognitiveHazardExposureRecord` + trigger channel taxonomy in `src/domain/cognitiveHazardEngine.ts` | GameState persistence                         |
+| `validateCognitiveHazardExposureRecord` — franchise token scan, failed-countermeasure warning | `advanceWeek` orchestration hook              |
+| `projectCognitiveHazardExposureReview` — fear/memetic/memory/countermeasure review bands | Full SPE-1309 parent Done                     |
+| `inferTriggerChannelsFromPropagationResistance` sibling attach helper | Sibling registry compose wire-up              |
+| Focused tests in `src/test/cognitiveHazardEngine.test.ts`          | UI surfacing                                  |
+| Slice doc (this file) + backlog handoff                            | SPE-2108 / SPE-2116 weekly hook changes       |
+
+## Exposure contract (deterministic)
+
+- **Trigger channels** — `direct_perception`, `recording_mediated`, `reference_description`, `memory_interaction`.
+- **Pressure dimensions** — `fearPressure` and `memeticExposure` as 0..1 unit scores; `memoryImpairmentBand` as `intact` → `erased`.
+- **Countermeasure posture** — `none`, `amnestic_protocol`, `mnestic_reinforcement`, `shielding_active`, `procedure_restricted`, `failed`.
+- **Effect flags** — `agentDutyDegraded`, `knowledgeIntegrityDegraded`, `procedureRestrictionActive` on projection (derived + explicit record flags).
+- **Sibling attach** — `inferTriggerChannelsFromPropagationResistance` maps SPE-2108 tags without replacing sibling registries.
+
+## SPE-1309 parent AC gaps addressed
+
+| Parent AC | This slice | Met? |
+| --- | --- | --- |
+| Unified model covering fear pressure, memetic/infohazard exposure, memory impairment, countermeasure interaction | `CognitiveHazardExposureRecord` + `projectCognitiveHazardExposureReview` | **Partial** — domain anchor exists; not persisted or wired |
+| Trigger channels explicit | Four-channel taxonomy + sorted projection labels | **Partial** — taxonomy defined; no routing/orchestration |
+| Cognitive hazard states affect agents, knowledge, and procedures | Projection flags `agentDutyDegraded`, `knowledgeIntegrityDegraded`, `procedureRestrictionActive` | **Partial** — read-side only; no simulation triggers |
+| Narrower cognitive-hazard issues attach without replacing parent | `inferTriggerChannelsFromPropagationResistance` helper | **Partial** — attach helper only |
+
+## Acceptance
+
+- [x] Stable subject fixture validates and projects `stable` review band
+- [x] Memetic escalation fixture projects `elevated` band with knowledge degradation
+- [x] Failed countermeasure fixture projects `critical` band with duty/procedure flags
+- [x] Failed countermeasure without refs yields warning
+- [x] Franchise token in label → validation error
+- [x] Propagation-resistance attach helper maps SPE-2108 tags to trigger channels
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/cognitiveHazardEngine.ts`                                 |
+| Tests  | `src/test/cognitiveHazardEngine.test.ts`                              |
+| Plan   | `planning/spe-1309-unified-engine-slice-1.md`, `planning/backlog.md`  |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| GameState persistence + hydrate | SPE-1309 slice 2 | Slice 1 is pure domain anchor only |
+| `advanceWeek` exposure tick / sibling compose wire-up | SPE-1309 follow-up | Requires persisted exposure records |
+| Agent/knowledge/procedure simulation triggers | SPE-1309 follow-up | Parent AC row 3 runtime effects deferred |
+| Full SPE-1309 parent Done | SPE-1309 | Slice 1 satisfies partial parent AC only |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/cognitiveHazardEngine.test.ts`
+
+## See also
+
+- `planning/spe-1309-parent-acceptance-review-slice-4.md`
+- `planning/self-censoring-information-registry-slice-1.md` — sibling attach surface (SPE-2108)
+- `src/domain/caseLifecycleStateMachine.ts` — pure domain graph slice-1 pattern (SPE-1310)

--- a/src/domain/cognitiveHazardEngine.ts
+++ b/src/domain/cognitiveHazardEngine.ts
@@ -1,0 +1,765 @@
+/**
+ * SPE-1309 slice 1: unified cognitive hazard engine domain anchor.
+ *
+ * Pure deterministic exposure state model with explicit trigger channels,
+ * fear/memetic/memory impairment dimensions, and countermeasure posture —
+ * distinct from sibling antimemetic (SPE-2108), naming-hazard (SPE-2116), and
+ * psychological-resilience (SPE-1615) registries.
+ */
+
+import {
+  BRANDED_OBJECT_NUMBER_PATTERN,
+  FRANCHISE_TOKEN_PATTERN,
+} from './containedPersonTherapeuticCareRegistry'
+import type { PropagationResistanceTag } from './selfCensoringInformationRegistry'
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type CognitiveHazardExposureId = string
+
+export type CognitiveHazardTriggerChannel =
+  | 'direct_perception'
+  | 'recording_mediated'
+  | 'reference_description'
+  | 'memory_interaction'
+
+export const COGNITIVE_HAZARD_TRIGGER_CHANNELS: readonly CognitiveHazardTriggerChannel[] = [
+  'direct_perception',
+  'recording_mediated',
+  'reference_description',
+  'memory_interaction',
+] as const
+
+export type CognitiveHazardMemoryImpairmentBand =
+  | 'intact'
+  | 'fragmented'
+  | 'compromised'
+  | 'erased'
+
+export const COGNITIVE_HAZARD_MEMORY_IMPAIRMENT_BANDS: readonly CognitiveHazardMemoryImpairmentBand[] =
+  [
+    'intact',
+    'fragmented',
+    'compromised',
+    'erased',
+  ] as const
+
+export type CognitiveHazardCountermeasurePosture =
+  | 'none'
+  | 'amnestic_protocol'
+  | 'mnestic_reinforcement'
+  | 'shielding_active'
+  | 'procedure_restricted'
+  | 'failed'
+
+export const COGNITIVE_HAZARD_COUNTERMEASURE_POSTURES: readonly CognitiveHazardCountermeasurePosture[] =
+  [
+    'none',
+    'amnestic_protocol',
+    'mnestic_reinforcement',
+    'shielding_active',
+    'procedure_restricted',
+    'failed',
+  ] as const
+
+export type CognitiveHazardExposureReviewBand = 'stable' | 'elevated' | 'critical'
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+export interface CognitiveHazardExposureRecord {
+  readonly id: CognitiveHazardExposureId
+  readonly label: string
+  readonly summary?: string
+  readonly subjectRef: string
+  readonly activeTriggerChannels: readonly CognitiveHazardTriggerChannel[]
+  readonly fearPressure: number
+  readonly memeticExposure: number
+  readonly memoryImpairmentBand: CognitiveHazardMemoryImpairmentBand
+  readonly countermeasurePosture: CognitiveHazardCountermeasurePosture
+  readonly countermeasureRefs?: readonly string[]
+  readonly knowledgeIntegrityDegraded?: boolean
+  readonly procedureRestrictionActive?: boolean
+  readonly agentDutyDegraded?: boolean
+  readonly confidence?: number
+  readonly unknownFields?: readonly string[]
+  readonly redactedFields?: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export type CognitiveHazardValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_subject_ref'
+  | 'invalid_trigger_channel'
+  | 'invalid_fear_pressure'
+  | 'invalid_memetic_exposure'
+  | 'invalid_memory_impairment_band'
+  | 'invalid_countermeasure_posture'
+  | 'invalid_confidence'
+  | 'failed_countermeasure_without_refs'
+  | 'erased_memory_without_knowledge_degradation'
+  | 'franchise_token_in_id'
+  | 'franchise_token_in_label'
+  | 'franchise_token_in_field'
+  | 'branded_object_number_in_id'
+  | 'branded_object_number_in_label'
+  | 'branded_object_number_in_field'
+
+export interface CognitiveHazardValidationIssue {
+  readonly code: CognitiveHazardValidationCode
+  readonly detail: string
+  readonly severity: 'error' | 'warning'
+  readonly relatedIds?: readonly string[]
+}
+
+export interface CognitiveHazardValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly CognitiveHazardValidationIssue[]
+}
+
+// ---------------------------------------------------------------------------
+// Projection
+// ---------------------------------------------------------------------------
+
+export interface CognitiveHazardProjectionPolicy {
+  readonly minimumConfidence?: number
+  readonly redactUnknown?: boolean
+  readonly elevatedExposureThreshold?: number
+  readonly criticalExposureThreshold?: number
+}
+
+export interface CognitiveHazardExposureReview {
+  readonly recordId: CognitiveHazardExposureId
+  readonly label: string
+  readonly subjectRef: string
+  readonly activeTriggerChannels: readonly CognitiveHazardTriggerChannel[]
+  readonly triggerChannelLabels: readonly string[]
+  readonly fearPressure: number | null
+  readonly memeticExposure: number | null
+  readonly aggregateExposurePressure: number | null
+  readonly memoryImpairmentBand: CognitiveHazardMemoryImpairmentBand
+  readonly memoryImpairmentAdvanced: boolean
+  readonly countermeasurePosture: CognitiveHazardCountermeasurePosture
+  readonly countermeasureFailed: boolean
+  readonly countermeasureShieldingActive: boolean
+  readonly exposureReviewBand: CognitiveHazardExposureReviewBand
+  readonly agentDutyDegraded: boolean
+  readonly knowledgeIntegrityDegraded: boolean
+  readonly procedureRestrictionActive: boolean
+  readonly confidence: number | null
+  readonly redacted: boolean
+  readonly unknownFields: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal constants
+// ---------------------------------------------------------------------------
+
+const TRIGGER_CHANNEL_SET = new Set<string>(COGNITIVE_HAZARD_TRIGGER_CHANNELS)
+const MEMORY_IMPAIRMENT_BAND_SET = new Set<string>(COGNITIVE_HAZARD_MEMORY_IMPAIRMENT_BANDS)
+const COUNTERMEASURE_POSTURE_SET = new Set<string>(COGNITIVE_HAZARD_COUNTERMEASURE_POSTURES)
+
+const DEFAULT_ELEVATED_EXPOSURE_THRESHOLD = 0.45
+const DEFAULT_CRITICAL_EXPOSURE_THRESHOLD = 0.75
+
+const ADVANCED_MEMORY_IMPAIRMENT_BANDS: ReadonlySet<CognitiveHazardMemoryImpairmentBand> = new Set([
+  'compromised',
+  'erased',
+])
+
+const PROPAGATION_TO_TRIGGER_CHANNEL: Readonly<
+  Partial<Record<PropagationResistanceTag, CognitiveHazardTriggerChannel>>
+> = {
+  forgetting: 'memory_interaction',
+  aversion: 'direct_perception',
+  record_decay: 'recording_mediated',
+  cognition_fail: 'memory_interaction',
+  transmission_block: 'recording_mediated',
+  retrieval_block: 'reference_description',
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is string => typeof item === 'string')
+}
+
+function sortedStringArray(value: unknown): readonly string[] {
+  return Object.freeze(
+    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function pushIssue(
+  issues: CognitiveHazardValidationIssue[],
+  issue: CognitiveHazardValidationIssue
+) {
+  issues.push(issue)
+}
+
+function sortValidationIssues(issues: CognitiveHazardValidationIssue[]) {
+  return [...issues].sort((left, right) => {
+    const codeCompare = left.code.localeCompare(right.code)
+    if (codeCompare !== 0) {
+      return codeCompare
+    }
+
+    const severityCompare = left.severity.localeCompare(right.severity)
+    if (severityCompare !== 0) {
+      return severityCompare
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function isValidUnitScore(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function clampUnit(value: number): number {
+  return Math.max(0, Math.min(1, value))
+}
+
+function roundUnit(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.round(clampUnit(value) * 1000) / 1000
+}
+
+function containsFranchiseToken(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && FRANCHISE_TOKEN_PATTERN.test(token)
+}
+
+function containsBrandedObjectNumber(value: string): boolean {
+  const token = normalizeToken(value)
+  return token.length > 0 && BRANDED_OBJECT_NUMBER_PATTERN.test(token)
+}
+
+function freezeValidationResult(
+  issues: CognitiveHazardValidationIssue[]
+): CognitiveHazardValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+  const hasError = sortedIssues.some((issue) => issue.severity === 'error')
+
+  return Object.freeze({
+    valid: !hasError,
+    issues: Object.freeze(
+      sortedIssues.map((issue) =>
+        Object.freeze({
+          ...issue,
+          ...(issue.relatedIds ? { relatedIds: Object.freeze([...issue.relatedIds]) } : {}),
+        })
+      )
+    ),
+  })
+}
+
+function scanForbiddenTokens(
+  issues: CognitiveHazardValidationIssue[],
+  id: string,
+  label: string,
+  record: CognitiveHazardExposureRecord
+) {
+  if (containsFranchiseToken(id)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_id',
+      severity: 'error',
+      detail: `Cognitive hazard exposure record id ${id || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(id)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_id',
+      severity: 'error',
+      detail: `Cognitive hazard exposure record id ${id || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsFranchiseToken(label)) {
+    pushIssue(issues, {
+      code: 'franchise_token_in_label',
+      severity: 'error',
+      detail: `Cognitive hazard exposure record label ${label || '(unknown)'} contains a franchise or source-literal token.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (containsBrandedObjectNumber(label)) {
+    pushIssue(issues, {
+      code: 'branded_object_number_in_label',
+      severity: 'error',
+      detail: `Cognitive hazard exposure record label ${label || '(unknown)'} contains a branded object number.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  const stringFields: Array<[string, string | undefined]> = [
+    ['summary', record.summary],
+    ['subjectRef', record.subjectRef],
+  ]
+
+  for (const [fieldName, fieldValue] of stringFields) {
+    const token = normalizeToken(fieldValue)
+    if (token.length === 0) {
+      continue
+    }
+
+    if (containsFranchiseToken(token)) {
+      pushIssue(issues, {
+        code: 'franchise_token_in_field',
+        severity: 'error',
+        detail: `Cognitive hazard exposure record field ${fieldName} contains a franchise or source-literal token.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (containsBrandedObjectNumber(token)) {
+      pushIssue(issues, {
+        code: 'branded_object_number_in_field',
+        severity: 'error',
+        detail: `Cognitive hazard exposure record field ${fieldName} contains a branded object number.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  for (const ref of asStringArray(record.countermeasureRefs)) {
+    if (containsFranchiseToken(ref)) {
+      pushIssue(issues, {
+        code: 'franchise_token_in_field',
+        severity: 'error',
+        detail: 'Cognitive hazard exposure record countermeasureRefs contains a franchise or source-literal token.',
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+
+    if (containsBrandedObjectNumber(ref)) {
+      pushIssue(issues, {
+        code: 'branded_object_number_in_field',
+        severity: 'error',
+        detail: 'Cognitive hazard exposure record countermeasureRefs contains a branded object number.',
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+}
+
+function sortedTriggerChannels(
+  channels: readonly CognitiveHazardTriggerChannel[] | undefined
+): readonly CognitiveHazardTriggerChannel[] {
+  return Object.freeze(
+    [...(channels ?? [])]
+      .filter((channel): channel is CognitiveHazardTriggerChannel =>
+        TRIGGER_CHANNEL_SET.has(channel)
+      )
+      .sort((left, right) => left.localeCompare(right))
+  )
+}
+
+function formatTriggerChannelLabel(channel: CognitiveHazardTriggerChannel): string {
+  return channel
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function resolveOptionalUnitScore(
+  record: CognitiveHazardExposureRecord,
+  field: 'fearPressure' | 'memeticExposure' | 'confidence',
+  policy: CognitiveHazardProjectionPolicy
+): number | null {
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = asStringArray(record.unknownFields)
+
+  if (
+    redactedFields.has(field) ||
+    (policy.redactUnknown === true && unknownFields.includes(field))
+  ) {
+    return null
+  }
+
+  const value = record[field]
+  return isValidUnitScore(value) ? roundUnit(value) : null
+}
+
+function resolveConfidence(
+  record: CognitiveHazardExposureRecord,
+  policy: CognitiveHazardProjectionPolicy
+): number | null {
+  const confidence = resolveOptionalUnitScore(record, 'confidence', policy)
+  if (confidence === null) {
+    return null
+  }
+
+  if (
+    typeof policy.minimumConfidence === 'number' &&
+    Number.isFinite(policy.minimumConfidence) &&
+    confidence < clampUnit(policy.minimumConfidence)
+  ) {
+    return null
+  }
+
+  return confidence
+}
+
+function resolveAggregateExposurePressure(
+  fearPressure: number | null,
+  memeticExposure: number | null
+): number | null {
+  if (fearPressure === null && memeticExposure === null) {
+    return null
+  }
+
+  const fear = fearPressure ?? 0
+  const memetic = memeticExposure ?? 0
+  return roundUnit(Math.max(fear, memetic))
+}
+
+function resolveExposureReviewBand(
+  aggregateExposurePressure: number | null,
+  memoryImpairmentBand: CognitiveHazardMemoryImpairmentBand,
+  countermeasureFailed: boolean,
+  policy: CognitiveHazardProjectionPolicy
+): CognitiveHazardExposureReviewBand {
+  const elevatedThreshold =
+    typeof policy.elevatedExposureThreshold === 'number' &&
+    Number.isFinite(policy.elevatedExposureThreshold)
+      ? clampUnit(policy.elevatedExposureThreshold)
+      : DEFAULT_ELEVATED_EXPOSURE_THRESHOLD
+
+  const criticalThreshold =
+    typeof policy.criticalExposureThreshold === 'number' &&
+    Number.isFinite(policy.criticalExposureThreshold)
+      ? clampUnit(policy.criticalExposureThreshold)
+      : DEFAULT_CRITICAL_EXPOSURE_THRESHOLD
+
+  if (
+    memoryImpairmentBand === 'erased' ||
+    countermeasureFailed ||
+    (aggregateExposurePressure !== null && aggregateExposurePressure >= criticalThreshold)
+  ) {
+    return 'critical'
+  }
+
+  if (
+    ADVANCED_MEMORY_IMPAIRMENT_BANDS.has(memoryImpairmentBand) ||
+    (aggregateExposurePressure !== null && aggregateExposurePressure >= elevatedThreshold)
+  ) {
+    return 'elevated'
+  }
+
+  return 'stable'
+}
+
+function resolveKnowledgeIntegrityDegraded(
+  record: CognitiveHazardExposureRecord
+): boolean {
+  if (record.knowledgeIntegrityDegraded === true) {
+    return true
+  }
+
+  return (
+    record.memoryImpairmentBand === 'fragmented' ||
+    record.memoryImpairmentBand === 'compromised' ||
+    record.memoryImpairmentBand === 'erased'
+  )
+}
+
+function resolveAgentDutyDegraded(record: CognitiveHazardExposureRecord): boolean {
+  if (record.agentDutyDegraded === true) {
+    return true
+  }
+
+  return (
+    record.memoryImpairmentBand === 'compromised' ||
+    record.memoryImpairmentBand === 'erased' ||
+    record.countermeasurePosture === 'failed'
+  )
+}
+
+function resolveProcedureRestrictionActive(record: CognitiveHazardExposureRecord): boolean {
+  if (record.procedureRestrictionActive === true) {
+    return true
+  }
+
+  return (
+    record.countermeasurePosture === 'procedure_restricted' ||
+    record.countermeasurePosture === 'shielding_active'
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sibling attach helper
+// ---------------------------------------------------------------------------
+
+/** Maps SPE-2108 propagation resistance tags onto engine trigger channels. */
+export function inferTriggerChannelsFromPropagationResistance(
+  tags: readonly PropagationResistanceTag[] | undefined
+): readonly CognitiveHazardTriggerChannel[] {
+  const channels = new Set<CognitiveHazardTriggerChannel>()
+
+  for (const tag of tags ?? []) {
+    const mapped = PROPAGATION_TO_TRIGGER_CHANNEL[tag]
+    if (mapped) {
+      channels.add(mapped)
+    }
+  }
+
+  return Object.freeze(
+    [...channels].sort((left, right) => left.localeCompare(right))
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Validation + projection API
+// ---------------------------------------------------------------------------
+
+export function validateCognitiveHazardExposureRecord(
+  record: CognitiveHazardExposureRecord
+): CognitiveHazardValidationResult {
+  const issues: CognitiveHazardValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const subjectRef = normalizeToken(record.subjectRef)
+
+  if (id.length === 0) {
+    pushIssue(issues, {
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Cognitive hazard exposure record is missing id.',
+    })
+  }
+
+  if (label.length === 0) {
+    pushIssue(issues, {
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Cognitive hazard exposure record is missing label.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (subjectRef.length === 0) {
+    pushIssue(issues, {
+      code: 'missing_subject_ref',
+      severity: 'error',
+      detail: 'Cognitive hazard exposure record is missing subjectRef.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  for (const channel of record.activeTriggerChannels ?? []) {
+    if (!TRIGGER_CHANNEL_SET.has(channel)) {
+      pushIssue(issues, {
+        code: 'invalid_trigger_channel',
+        severity: 'error',
+        detail: `Cognitive hazard exposure record has invalid trigger channel ${String(channel)}.`,
+        relatedIds: id ? [id] : undefined,
+      })
+    }
+  }
+
+  if (!isValidUnitScore(record.fearPressure)) {
+    pushIssue(issues, {
+      code: 'invalid_fear_pressure',
+      severity: 'error',
+      detail: 'Cognitive hazard exposure record fearPressure must be a finite unit score in 0..1.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!isValidUnitScore(record.memeticExposure)) {
+    pushIssue(issues, {
+      code: 'invalid_memetic_exposure',
+      severity: 'error',
+      detail: 'Cognitive hazard exposure record memeticExposure must be a finite unit score in 0..1.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!MEMORY_IMPAIRMENT_BAND_SET.has(record.memoryImpairmentBand)) {
+    pushIssue(issues, {
+      code: 'invalid_memory_impairment_band',
+      severity: 'error',
+      detail: `Cognitive hazard exposure record has invalid memoryImpairmentBand ${String(record.memoryImpairmentBand)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (!COUNTERMEASURE_POSTURE_SET.has(record.countermeasurePosture)) {
+    pushIssue(issues, {
+      code: 'invalid_countermeasure_posture',
+      severity: 'error',
+      detail: `Cognitive hazard exposure record has invalid countermeasurePosture ${String(record.countermeasurePosture)}.`,
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (record.confidence !== undefined && !isValidUnitScore(record.confidence)) {
+    pushIssue(issues, {
+      code: 'invalid_confidence',
+      severity: 'error',
+      detail: 'Cognitive hazard exposure record confidence must be a finite unit score in 0..1.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.countermeasurePosture === 'failed' &&
+    asStringArray(record.countermeasureRefs).length === 0
+  ) {
+    pushIssue(issues, {
+      code: 'failed_countermeasure_without_refs',
+      severity: 'warning',
+      detail:
+        'Cognitive hazard exposure record countermeasurePosture is failed without countermeasureRefs.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  if (
+    record.memoryImpairmentBand === 'erased' &&
+    record.knowledgeIntegrityDegraded !== true
+  ) {
+    pushIssue(issues, {
+      code: 'erased_memory_without_knowledge_degradation',
+      severity: 'warning',
+      detail:
+        'Cognitive hazard exposure record memoryImpairmentBand is erased without knowledgeIntegrityDegraded flag.',
+      relatedIds: id ? [id] : undefined,
+    })
+  }
+
+  scanForbiddenTokens(issues, id, label, record)
+
+  return freezeValidationResult(issues)
+}
+
+/** Projects unified cognitive hazard exposure review from a validated record shape. */
+export function projectCognitiveHazardExposureReview(
+  record: CognitiveHazardExposureRecord,
+  policy: CognitiveHazardProjectionPolicy = {}
+): CognitiveHazardExposureReview {
+  const activeTriggerChannels = sortedTriggerChannels(record.activeTriggerChannels)
+  const fearPressure = resolveOptionalUnitScore(record, 'fearPressure', policy)
+  const memeticExposure = resolveOptionalUnitScore(record, 'memeticExposure', policy)
+  const aggregateExposurePressure = resolveAggregateExposurePressure(fearPressure, memeticExposure)
+  const countermeasureFailed = record.countermeasurePosture === 'failed'
+  const countermeasureShieldingActive =
+    record.countermeasurePosture === 'shielding_active' ||
+    record.countermeasurePosture === 'procedure_restricted'
+  const memoryImpairmentAdvanced = ADVANCED_MEMORY_IMPAIRMENT_BANDS.has(
+    record.memoryImpairmentBand
+  )
+  const redactedFields = new Set(asStringArray(record.redactedFields))
+  const unknownFields = sortedStringArray(record.unknownFields)
+
+  return Object.freeze({
+    recordId: record.id,
+    label: record.label,
+    subjectRef: record.subjectRef,
+    activeTriggerChannels,
+    triggerChannelLabels: Object.freeze(
+      activeTriggerChannels.map((channel) => formatTriggerChannelLabel(channel))
+    ),
+    fearPressure,
+    memeticExposure,
+    aggregateExposurePressure,
+    memoryImpairmentBand: record.memoryImpairmentBand,
+    memoryImpairmentAdvanced,
+    countermeasurePosture: record.countermeasurePosture,
+    countermeasureFailed,
+    countermeasureShieldingActive,
+    exposureReviewBand: resolveExposureReviewBand(
+      aggregateExposurePressure,
+      record.memoryImpairmentBand,
+      countermeasureFailed,
+      policy
+    ),
+    agentDutyDegraded: resolveAgentDutyDegraded(record),
+    knowledgeIntegrityDegraded: resolveKnowledgeIntegrityDegraded(record),
+    procedureRestrictionActive: resolveProcedureRestrictionActive(record),
+    confidence: resolveConfidence(record, policy),
+    redacted: redactedFields.size > 0,
+    unknownFields,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE: CognitiveHazardExposureRecord =
+  Object.freeze({
+    id: 'cognitive-hazard:stable-subject-1',
+    label: 'Stable briefing-room exposure profile',
+    subjectRef: 'agent:field-analyst-7',
+    activeTriggerChannels: Object.freeze(['reference_description'] as const),
+    fearPressure: 0.12,
+    memeticExposure: 0.08,
+    memoryImpairmentBand: 'intact',
+    countermeasurePosture: 'none',
+    confidence: 0.82,
+  })
+
+export const COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE: CognitiveHazardExposureRecord =
+  Object.freeze({
+    id: 'cognitive-hazard:memetic-escalation-1',
+    label: 'Elevated memetic contact profile',
+    summary: 'Repeated direct and descriptive exposure without shielding.',
+    subjectRef: 'agent:containment-liaison-3',
+    activeTriggerChannels: Object.freeze([
+      'direct_perception',
+      'reference_description',
+    ] as const),
+    fearPressure: 0.58,
+    memeticExposure: 0.71,
+    memoryImpairmentBand: 'fragmented',
+    countermeasurePosture: 'mnestic_reinforcement',
+    countermeasureRefs: Object.freeze(['procedure:mnestic-reinforcement-cycle-2'] as const),
+    knowledgeIntegrityDegraded: true,
+    confidence: 0.64,
+  })
+
+export const COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE: CognitiveHazardExposureRecord =
+  Object.freeze({
+    id: 'cognitive-hazard:failed-countermeasure-1',
+    label: 'Failed amnestic protocol exposure profile',
+    subjectRef: 'agent:archive-clerk-11',
+    activeTriggerChannels: Object.freeze([
+      'memory_interaction',
+      'recording_mediated',
+    ] as const),
+    fearPressure: 0.41,
+    memeticExposure: 0.86,
+    memoryImpairmentBand: 'erased',
+    countermeasurePosture: 'failed',
+    knowledgeIntegrityDegraded: true,
+    agentDutyDegraded: true,
+    procedureRestrictionActive: true,
+    confidence: 0.39,
+  })

--- a/src/test/cognitiveHazardEngine.test.ts
+++ b/src/test/cognitiveHazardEngine.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+  inferTriggerChannelsFromPropagationResistance,
+  projectCognitiveHazardExposureReview,
+  validateCognitiveHazardExposureRecord,
+  type CognitiveHazardExposureRecord,
+} from '../domain/cognitiveHazardEngine'
+
+function baseRecord(
+  overrides: Partial<CognitiveHazardExposureRecord> = {}
+): CognitiveHazardExposureRecord {
+  return {
+    id: 'cognitive-hazard:test-base',
+    label: 'Test base exposure profile',
+    subjectRef: 'agent:test-subject-1',
+    activeTriggerChannels: ['direct_perception'],
+    fearPressure: 0.2,
+    memeticExposure: 0.15,
+    memoryImpairmentBand: 'intact',
+    countermeasurePosture: 'none',
+    ...overrides,
+  }
+}
+
+describe('cognitiveHazardEngine (SPE-1309 slice 1)', () => {
+  it('validates stable subject fixture and projects stable review band', () => {
+    const first = validateCognitiveHazardExposureRecord(
+      COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE
+    )
+    const second = validateCognitiveHazardExposureRecord(
+      COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE
+    )
+
+    expect(first.valid).toBe(true)
+    expect(first).toEqual(second)
+
+    const projection = projectCognitiveHazardExposureReview(
+      COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE
+    )
+
+    expect(projection.exposureReviewBand).toBe('stable')
+    expect(projection.activeTriggerChannels).toEqual(['reference_description'])
+    expect(projection.agentDutyDegraded).toBe(false)
+    expect(projection.knowledgeIntegrityDegraded).toBe(false)
+    expect(projection.procedureRestrictionActive).toBe(false)
+  })
+
+  it('projects memetic escalation with elevated review band and knowledge degradation', () => {
+    const validation = validateCognitiveHazardExposureRecord(
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE
+    )
+    const projection = projectCognitiveHazardExposureReview(
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE
+    )
+
+    expect(validation.valid).toBe(true)
+    expect(projection.exposureReviewBand).toBe('elevated')
+    expect(projection.aggregateExposurePressure).toBe(0.71)
+    expect(projection.knowledgeIntegrityDegraded).toBe(true)
+    expect(projection.countermeasureShieldingActive).toBe(false)
+    expect(projection.triggerChannelLabels).toEqual([
+      'Direct Perception',
+      'Reference Description',
+    ])
+  })
+
+  it('projects failed countermeasure with critical review band and duty/procedure flags', () => {
+    const validation = validateCognitiveHazardExposureRecord(
+      COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE
+    )
+    const projection = projectCognitiveHazardExposureReview(
+      COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE
+    )
+
+    expect(validation.valid).toBe(true)
+    expect(
+      validation.issues.some((issue) => issue.code === 'failed_countermeasure_without_refs')
+    ).toBe(true)
+    expect(projection.exposureReviewBand).toBe('critical')
+    expect(projection.countermeasureFailed).toBe(true)
+    expect(projection.agentDutyDegraded).toBe(true)
+    expect(projection.knowledgeIntegrityDegraded).toBe(true)
+    expect(projection.procedureRestrictionActive).toBe(true)
+  })
+
+  it('warns when erased memory band lacks explicit knowledge degradation flag', () => {
+    const result = validateCognitiveHazardExposureRecord(
+      baseRecord({
+        memoryImpairmentBand: 'erased',
+        countermeasurePosture: 'amnestic_protocol',
+        countermeasureRefs: ['procedure:amnestic-cycle-1'],
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(
+      result.issues.some((issue) => issue.code === 'erased_memory_without_knowledge_degradation')
+    ).toBe(true)
+  })
+
+  it('rejects franchise tokens in label', () => {
+    const result = validateCognitiveHazardExposureRecord(
+      baseRecord({
+        label: 'Foundation exposure profile',
+      })
+    )
+
+    expect(result.valid).toBe(false)
+    expect(result.issues.some((issue) => issue.code === 'franchise_token_in_label')).toBe(true)
+  })
+
+  it('maps SPE-2108 propagation resistance tags onto trigger channels', () => {
+    const channels = inferTriggerChannelsFromPropagationResistance([
+      'forgetting',
+      'retrieval_block',
+      'record_decay',
+    ])
+
+    expect(channels).toEqual([
+      'memory_interaction',
+      'recording_mediated',
+      'reference_description',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/domain/cognitiveHazardEngine.ts` — shared exposure state model with explicit trigger channels (`direct_perception`, `recording_mediated`, `reference_description`, `memory_interaction`), fear/memetic pressure dimensions, memory impairment bands, and countermeasure posture.
- Add `projectCognitiveHazardExposureReview` read-side projection with agent duty, knowledge integrity, and procedure restriction flags.
- Add `inferTriggerChannelsFromPropagationResistance` sibling attach helper mapping SPE-2108 propagation tags.
- Slice doc: `planning/spe-1309-unified-engine-slice-1.md`; backlog handoff updated.

## Linear mapping

- **Slice issue:** SPE-1309 child — Unified cognitive hazard engine — exposure state anchor (slice 1) (create/claim on merge)
- **Parent:** [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — stays **Backlog** (partial AC only; persistence/wire-up deferred)

## What shipped

Smallest deterministic domain anchor toward parent AC rows 1–3. No GameState persistence, `advanceWeek` hook, or UI surfacing.

## Validation

- `npm run lint`
- `npm run test:run src/test/cognitiveHazardEngine.test.ts` (6 tests green)

## Docs updated

- `planning/spe-1309-unified-engine-slice-1.md`
- `planning/backlog.md` (handoff + slice index row)

## Parent remains open

SPE-1309 stays **Backlog** — slice 2+ needed for persistence, orchestration, and full AC closure.