### PR TITLE
SPE-1309: cognitive hazard exposure persistence (slice 2)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1309 unified engine slice 2 (persistence + hydrate) if prioritized, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
+**Next step:** SPE-1309 unified engine slice 3 (`advanceWeek` exposure tick / sibling compose wire-up) if prioritized, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
 
-**Base `main` SHA:** `0e803263` — shipped: SPE-1309 unified cognitive hazard engine slice 1 @ `planning/spe-1309-unified-engine-slice-1.md` (PR #2807)
+**Base `main` SHA:** `aa6c6d90` — in progress: SPE-1309 unified cognitive hazard engine slice 2 @ `planning/spe-1309-unified-engine-slice-2.md`
 
-**Recently shipped:** SPE-1309 unified cognitive hazard engine slice 1 (PR #2807); SPE-861 disclosure campaign trust outcomes slice 2 (PR #2806 @ `47e3e652`).
+**Recently shipped:** SPE-1309 unified cognitive hazard engine slice 1 (PR #2807 @ `0e803263`); SPE-861 disclosure campaign trust outcomes slice 2 (PR #2806 @ `47e3e652`).
 
 **Recently shipped:** SPE-1882 coercive protocol mirror snapshot read slice 11 (PR #2798); SPE-1309 parent acceptance review grooming slice 4 (PR #2796); SPE-1888 parent acceptance review grooming slice 6 (PR #2793).
 
@@ -225,6 +225,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1309-parent-acceptance-review-slice-3.md`            | **Shipped**    | SPE-2451 / PR #2783; SPE-1309 stays Backlog — post SPE-1343 grooming; doc vs Linear auto-close reconciliation @ `a8b26733`.                            |
 | `spe-1309-parent-acceptance-review-slice-4.md`            | **Shipped**    | SPE-2456 / PR #2796; SPE-1309 stays Backlog — post SPE-1888 grooming slice 6; slice 4 auto-close reconciliation @ `25f10aff`.                    |
 | `spe-1309-unified-engine-slice-1.md`                      | **Shipped**    | SPE-1309 child — unified cognitive hazard engine exposure state anchor / PR #2807 @ `0e803263`.                                                        |
+| `spe-1309-unified-engine-slice-2.md`                      | **In Progress** | SPE-1309 child — cognitive hazard exposure persistence + hydrate @ `aa6c6d90`.                                                                        |
 | `welfare-debt-accounting-registry-slice-2.md`             | **Shipped**    | SPE-2351 / PR #2570; planning mirror UI over `welfareDebtAccountingRecords` @ `96ad05ba`.                                                               |
 | `welfare-debt-accounting-registry-slice-3.md`             | **Shipped**    | SPE-2352 / PR #2572; weekly orchestration hook in `advanceWeek` @ `5673423c`.                                                                          |
 | `welfare-debt-accounting-registry-slice-4.md`             | **Shipped**    | SPE-2353 / PR #2574; ledger summary audit output @ `1ec3ca12`.                                                                                         |

--- a/planning/spe-1309-unified-engine-slice-2.md
+++ b/planning/spe-1309-unified-engine-slice-2.md
@@ -1,0 +1,79 @@
+# SPE-1309 — Unified cognitive hazard engine (slice 2)
+
+One-page implementation plan. Linear: child under [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — **cognitive hazard exposure persistence (slice 2)** (create/claim on start). Parent [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays **Backlog** — unified engine AC rows 1–3 not fully met until advanceWeek wire-up slices.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1309 child — cognitive hazard exposure persistence (slice 2)                                           |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — Unified cognitive hazard engine (umbrella)    |
+| **Branch** | `spe-1309-unified-engine-slice-2`                                                                          |
+| **Base `main` SHA** | `aa6c6d90`                                                                                          |
+
+## Goal
+
+Persist validated `CognitiveHazardExposureRecord` entries on `GameState` with sanitize/hydration and save round-trip tests. Mirror SPE-2434 / SPE-1615 slice 2 persistence pattern. Weekly exposure orchestration deferred to a later slice.
+
+## Prerequisite (on `main` @ `aa6c6d90`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Engine anchor        | `src/domain/cognitiveHazardEngine.ts` (SPE-1309 slice 1 / PR #2807)    |
+| Fixtures             | `COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE`, memetic escalation, failed countermeasure |
+| Persistence pattern  | `sanitizePsychologicalResilienceRecords` (SPE-2434 slice 2)            |
+
+## Gap (pre-slice)
+
+- Slice 1 domain anchor exists but exposure records are not on `GameState`.
+- Save/load and hydrate paths do not sanitize cognitive hazard exposure maps.
+- No byte-stable round-trip regression for fixture records.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `cognitiveHazardExposureRecords` on `GameState`                    | Weekly `advanceWeek` exposure orchestration   |
+| `sanitizeCognitiveHazardExposureRecords` + `runTransfer` hydrate wire | Sibling registry compose wire-up           |
+| `validateCognitiveHazardExposureRecord` on hydrate; drop invalid, no throw | Planning mirror UI                    |
+| Default `{}` in `createStartingState`                              | Full SPE-1309 parent Done                     |
+| Persistence tests (sanitize round-trip, invalid drop, save/load)   | UI surfacing                                  |
+| Slice doc (this file) + backlog handoff                            | SPE-2108 / SPE-2116 weekly hook changes       |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through `sanitizeCognitiveHazardExposureRecords`
+- [x] Invalid/duplicate-id entries dropped safely on hydrate without throw
+- [x] Subject refs byte-stable after save/load round-trip
+- [x] Warning-only records (e.g. failed countermeasure without refs) persist when valid
+- [x] Repeated sanitize is byte-stable for fixture records
+- [x] Slice 1 engine tests unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/cognitiveHazardEngine.ts`, `src/domain/models.ts`         |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/cognitiveHazardEnginePersistence.test.ts`                   |
+| Plan   | `planning/spe-1309-unified-engine-slice-2.md`, `planning/backlog.md`  |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| `advanceWeek` exposure tick / sibling compose wire-up | SPE-1309 follow-up | Persistence must land before orchestration |
+| Agent/knowledge/procedure simulation triggers | SPE-1309 follow-up | Parent AC row 3 runtime effects deferred |
+| Planning mirror UI | SPE-1309 follow-up | Mirror follows persistence pattern |
+| Full SPE-1309 parent Done | SPE-1309 | Multiple slices remain |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/cognitiveHazardEnginePersistence.test.ts src/test/cognitiveHazardEngine.test.ts`
+
+## See also
+
+- `planning/spe-1309-unified-engine-slice-1.md` — domain anchor (shipped)
+- `planning/spe-1615-psychological-resilience-registry-slice-2.md` — persistence-only slice pattern

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -224,6 +224,7 @@ import { sanitizeMedicationRegimenRecords } from '../../domain/containedPersonMe
 import { sanitizeContainedPersonIntegratedHealthBundles } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
 import { sanitizeSurveillanceInterventionTuningRecords } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
 import { sanitizePsychologicalResilienceRecords } from '../../domain/psychologicalResilienceRegistry'
+import { sanitizeCognitiveHazardExposureRecords } from '../../domain/cognitiveHazardEngine'
 import { sanitizeVisualTriggerHazardRecords } from '../../domain/visualTriggerHazardRegistry'
 import {
   buildCandidateEvaluation,
@@ -8589,6 +8590,10 @@ export function hydrateGame(
     game.psychologicalResilienceRecords,
     fallback.psychologicalResilienceRecords ?? {}
   )
+  const cognitiveHazardExposureRecords = sanitizeCognitiveHazardExposureRecords(
+    game.cognitiveHazardExposureRecords,
+    fallback.cognitiveHazardExposureRecords ?? {}
+  )
   const factions = hasPersistedFactions
     ? sanitizeFactionsMap(game.factions, fallback.factions)
     : fallback.factions
@@ -8736,6 +8741,7 @@ export function hydrateGame(
       containedPersonIntegratedHealthBundles,
       surveillanceInterventionTuningRecords,
       psychologicalResilienceRecords,
+      cognitiveHazardExposureRecords,
       candidates,
       recruitmentPool,
       teams,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -69,6 +69,7 @@ const startingStateTemplate: GameState = {
   containedPersonIntegratedHealthBundles: {},
   surveillanceInterventionTuningRecords: {},
   psychologicalResilienceRecords: {},
+  cognitiveHazardExposureRecords: {},
   factions: createInitialFactionState(),
 
   agency: {

--- a/src/domain/cognitiveHazardEngine.ts
+++ b/src/domain/cognitiveHazardEngine.ts
@@ -70,6 +70,11 @@ export type CognitiveHazardExposureReviewBand = 'stable' | 'elevated' | 'critica
 // Records
 // ---------------------------------------------------------------------------
 
+export type CognitiveHazardExposureRecordsMap = Record<
+  CognitiveHazardExposureId,
+  CognitiveHazardExposureRecord
+>
+
 export interface CognitiveHazardExposureRecord {
   readonly id: CognitiveHazardExposureId
   readonly label: string
@@ -707,6 +712,120 @@ export function projectCognitiveHazardExposureReview(
     redacted: redactedFields.size > 0,
     unknownFields,
   })
+}
+
+// ---------------------------------------------------------------------------
+// Persistence / hydration
+// ---------------------------------------------------------------------------
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function sanitizeTriggerChannelList(value: unknown): readonly CognitiveHazardTriggerChannel[] {
+  if (!Array.isArray(value)) {
+    return Object.freeze([] as CognitiveHazardTriggerChannel[])
+  }
+
+  return sortedTriggerChannels(
+    value.filter(
+      (entry): entry is CognitiveHazardTriggerChannel =>
+        typeof entry === 'string' && TRIGGER_CHANNEL_SET.has(entry)
+    )
+  )
+}
+
+function sanitizeCountermeasureRefs(value: unknown): readonly string[] | undefined {
+  const refs = sortedStringArray(value).filter((ref) => ref.length > 0)
+  return refs.length > 0 ? refs : undefined
+}
+
+function sanitizeCognitiveHazardExposureRecordEntry(
+  value: unknown
+): CognitiveHazardExposureRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const subjectRef = normalizeToken(value.subjectRef)
+  const memoryImpairmentBand = value.memoryImpairmentBand
+  const countermeasurePosture = value.countermeasurePosture
+  const fearPressure = value.fearPressure
+  const memeticExposure = value.memeticExposure
+  const activeTriggerChannels = sanitizeTriggerChannelList(value.activeTriggerChannels)
+
+  if (
+    !id ||
+    !label ||
+    !subjectRef ||
+    !MEMORY_IMPAIRMENT_BAND_SET.has(String(memoryImpairmentBand)) ||
+    !COUNTERMEASURE_POSTURE_SET.has(String(countermeasurePosture)) ||
+    !isValidUnitScore(fearPressure) ||
+    !isValidUnitScore(memeticExposure)
+  ) {
+    return null
+  }
+
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const countermeasureRefs = sanitizeCountermeasureRefs(value.countermeasureRefs)
+  const confidence = value.confidence
+  const unknownFields = sortedStringArray(value.unknownFields)
+  const redactedFields = sortedStringArray(value.redactedFields)
+
+  const record: CognitiveHazardExposureRecord = {
+    id,
+    label,
+    subjectRef,
+    activeTriggerChannels,
+    fearPressure,
+    memeticExposure,
+    memoryImpairmentBand: memoryImpairmentBand as CognitiveHazardMemoryImpairmentBand,
+    countermeasurePosture: countermeasurePosture as CognitiveHazardCountermeasurePosture,
+    ...(summary ? { summary } : {}),
+    ...(countermeasureRefs ? { countermeasureRefs } : {}),
+    ...(value.knowledgeIntegrityDegraded === true ? { knowledgeIntegrityDegraded: true } : {}),
+    ...(value.procedureRestrictionActive === true ? { procedureRestrictionActive: true } : {}),
+    ...(value.agentDutyDegraded === true ? { agentDutyDegraded: true } : {}),
+    ...(isValidUnitScore(confidence) ? { confidence } : {}),
+    ...(unknownFields.length > 0 ? { unknownFields } : {}),
+    ...(redactedFields.length > 0 ? { redactedFields } : {}),
+  }
+
+  if (!validateCognitiveHazardExposureRecord(record).valid) {
+    return null
+  }
+
+  return record
+}
+
+/** Hydration: canonical exposure map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizeCognitiveHazardExposureRecords(
+  value: unknown,
+  fallback: CognitiveHazardExposureRecordsMap = {}
+): CognitiveHazardExposureRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: CognitiveHazardExposureRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeCognitiveHazardExposureRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
 }
 
 // ---------------------------------------------------------------------------

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -279,6 +279,7 @@ import type { WelfareDebtAccountingRecord } from './welfareDebtAccountingRegistr
 import type { ContainedPersonIntegratedHealthBundle } from './containedPersonIntegratedHealthBundleRegistry'
 import type { SurveillanceInterventionTuningRecord } from './surveillanceCapacityInterventionTuningRegistry'
 import type { PsychologicalResilienceRecord } from './psychologicalResilienceRegistry'
+import type { CognitiveHazardExposureRecord } from './cognitiveHazardEngine'
 import type { VisualTriggerHazardRecord } from './visualTriggerHazardRegistry'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
@@ -2781,6 +2782,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   psychologicalResilienceRecords?: Record<string, PsychologicalResilienceRecord>
+
+  /**
+   * SPE-1309 slice 2: persisted cognitive hazard exposure records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  cognitiveHazardExposureRecords?: Record<string, CognitiveHazardExposureRecord>
 
   /** Optional active compromised-authority runtime packet (SPE-746). */
   compromisedAuthority?: CompromisedAuthorityState

--- a/src/test/cognitiveHazardEnginePersistence.test.ts
+++ b/src/test/cognitiveHazardEnginePersistence.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+  sanitizeCognitiveHazardExposureRecords,
+  validateCognitiveHazardExposureRecord,
+} from '../domain/cognitiveHazardEngine'
+
+describe('cognitiveHazardEngine persistence (SPE-1309 slice 2)', () => {
+  it('defaults starting state to an empty cognitive hazard exposure map', () => {
+    expect(createStartingState().cognitiveHazardExposureRecords).toEqual({})
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const altRecord = {
+      ...COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      id: 'cognitive-hazard:alt-subject',
+      subjectRef: 'agent:alt-subject',
+    }
+    const fallback = {}
+    const sanitized = sanitizeCognitiveHazardExposureRecords(
+      {
+        valid: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+        alt: altRecord,
+        'wrong-key': {
+          ...altRecord,
+          label: 'wrong map key should lose to canonical id entry',
+        },
+        duplicate: {
+          ...COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        invalid: {
+          id: '',
+          label: 'bad',
+          subjectRef: 'agent:test',
+          activeTriggerChannels: ['direct_perception'],
+          fearPressure: 0.5,
+          memeticExposure: 0.5,
+          memoryImpairmentBand: 'unknown',
+          countermeasurePosture: 'none',
+        },
+        franchiseLabel: {
+          ...COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+          id: 'cognitive-hazard:franchise',
+          label: 'SCP division exposure profile',
+        },
+        brandedObjectId: {
+          ...COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+          id: 'cognitive-hazard:scp-049',
+          label: 'Archive exposure profile',
+        },
+        outOfRangeScore: {
+          ...COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+          id: 'cognitive-hazard:out-of-range',
+          fearPressure: 1.5,
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized[COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]).toEqual(
+      COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE
+    )
+    expect(sanitized[altRecord.id]).toEqual(altRecord)
+    expect(sanitized.invalid).toBeUndefined()
+    expect(sanitized.franchiseLabel).toBeUndefined()
+    expect(sanitized.brandedObjectId).toBeUndefined()
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['wrong-key']).toBeUndefined()
+    expect(sanitized.outOfRangeScore).toBeUndefined()
+    expect(Object.keys(sanitized).sort()).toEqual(
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id, altRecord.id].sort()
+    )
+  })
+
+  it('persists warning-only records that remain valid on hydrate', () => {
+    const warningOnly = {
+      ...COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+      id: 'cognitive-hazard:failed-warning-only',
+      countermeasureRefs: undefined,
+    }
+
+    expect(validateCognitiveHazardExposureRecord(warningOnly).valid).toBe(true)
+
+    const sanitized = sanitizeCognitiveHazardExposureRecords({ [warningOnly.id]: warningOnly }, {})
+
+    expect(sanitized[warningOnly.id]).toEqual(warningOnly)
+    expect(sanitized[warningOnly.id]?.countermeasurePosture).toBe('failed')
+    expect(sanitized[warningOnly.id]?.countermeasureRefs).toBeUndefined()
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.cognitiveHazardExposureRecords).toEqual(state.cognitiveHazardExposureRecords)
+    expect(
+      loaded.cognitiveHazardExposureRecords?.[COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]
+        ?.subjectRef
+    ).toBe(COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.subjectRef)
+    expect(
+      loaded.cognitiveHazardExposureRecords?.[COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]
+        ?.knowledgeIntegrityDegraded
+    ).toBe(true)
+    expect(
+      loaded.cognitiveHazardExposureRecords?.[COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]
+        ?.activeTriggerChannels
+    ).toEqual(['direct_perception', 'reference_description'])
+  })
+
+  it('hydrates persisted cognitive hazard exposure records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        cognitiveHazardExposureRecords: {
+          [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+          invalid: {
+            ...COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+            id: 'cognitive-hazard:invalid',
+            label: 'SCP division exposure profile',
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.cognitiveHazardExposureRecords).toEqual({
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+    })
+  })
+
+  it('repeated sanitize is byte-stable for fixture records', () => {
+    const first = sanitizeCognitiveHazardExposureRecords(
+      {
+        [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+      },
+      {}
+    )
+    const second = sanitizeCognitiveHazardExposureRecords(first, {})
+
+    expect(second).toEqual(first)
+    expect(
+      validateCognitiveHazardExposureRecord(COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE)
+    ).toEqual(
+      validateCognitiveHazardExposureRecord(second[COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]!)
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Add \cognitiveHazardExposureRecords\ to \GameState\ with \sanitizeCognitiveHazardExposureRecords\ hydrate helper mirroring SPE-2434.
- Wire sanitize through \unTransfer\ and default \{}\ in \createStartingState\.
- Add persistence tests: invalid/duplicate drop, warning-only retain, save/load round-trip, byte-stable re-sanitize.

## Linear

- **Slice:** SPE-1309 child — cognitive hazard exposure persistence (slice 2)
- **Parent:** SPE-1309 — Unified cognitive hazard engine (stays Backlog)

## Validation

- \
pm run lint\
- \
pm run test:run src/test/cognitiveHazardEnginePersistence.test.ts src/test/cognitiveHazardEngine.test.ts\

## Docs

- \planning/spe-1309-unified-engine-slice-2.md\
- \planning/backlog.md\ handoff updated

## Parent status

Parent SPE-1309 remains open — \dvanceWeek\ exposure tick and sibling compose wire-up deferred to slice 3+.

Made with [Cursor](https://cursor.com)