### PR TITLE
SPE-1309: cognitive hazard exposure weekly tick (slice 3)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1309 unified engine slice 3 (`advanceWeek` exposure tick / sibling compose wire-up) if prioritized, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
+**Next step:** SPE-1309 unified engine slice 4 (sibling registry compose wire-up from SPE-2108 persisted maps, or planning mirror UI) if prioritized, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
 
-**Base `main` SHA:** `9b22d0ca` — shipped: SPE-1309 unified cognitive hazard engine slice 2 @ `planning/spe-1309-unified-engine-slice-2.md` (PR #2808)
+**Base `main` SHA:** `9c8837ac` — in progress: SPE-1309 unified cognitive hazard engine slice 3 @ `planning/spe-1309-unified-engine-slice-3.md`
 
 **Recently shipped:** SPE-1309 unified cognitive hazard engine slice 2 (PR #2808 @ `9b22d0ca`); SPE-1309 unified cognitive hazard engine slice 1 (PR #2807 @ `0e803263`).
 
@@ -226,6 +226,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1309-parent-acceptance-review-slice-4.md`            | **Shipped**    | SPE-2456 / PR #2796; SPE-1309 stays Backlog — post SPE-1888 grooming slice 6; slice 4 auto-close reconciliation @ `25f10aff`.                    |
 | `spe-1309-unified-engine-slice-1.md`                      | **Shipped**    | SPE-1309 child — unified cognitive hazard engine exposure state anchor / PR #2807 @ `0e803263`.                                                        |
 | `spe-1309-unified-engine-slice-2.md`                      | **Shipped**    | SPE-1309 child — cognitive hazard exposure persistence + hydrate / PR #2808 @ `9b22d0ca`.                                                               |
+| `spe-1309-unified-engine-slice-3.md`                      | **In progress**| SPE-1309 child — `advanceWeek` exposure tick + sibling compose helper @ `9c8837ac`.                                                                      |
 | `welfare-debt-accounting-registry-slice-2.md`             | **Shipped**    | SPE-2351 / PR #2570; planning mirror UI over `welfareDebtAccountingRecords` @ `96ad05ba`.                                                               |
 | `welfare-debt-accounting-registry-slice-3.md`             | **Shipped**    | SPE-2352 / PR #2572; weekly orchestration hook in `advanceWeek` @ `5673423c`.                                                                          |
 | `welfare-debt-accounting-registry-slice-4.md`             | **Shipped**    | SPE-2353 / PR #2574; ledger summary audit output @ `1ec3ca12`.                                                                                         |

--- a/planning/spe-1309-unified-engine-slice-3.md
+++ b/planning/spe-1309-unified-engine-slice-3.md
@@ -1,0 +1,81 @@
+# SPE-1309 — Unified cognitive hazard engine (slice 3)
+
+One-page implementation plan. Linear: child under [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — **unified cognitive hazard engine advanceWeek exposure tick (slice 3)** (create/claim on start). Parent [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays **Backlog** — unified engine AC rows 1–3 not fully met until runtime effect slices.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1309 child — unified cognitive hazard engine advanceWeek exposure tick (slice 3)                       |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — Unified cognitive hazard engine (umbrella)    |
+| **Branch** | `spe-1309-unified-engine-slice-3`                                                                          |
+| **Base `main` SHA** | `9c8837ac`                                                                                          |
+
+## Goal
+
+Wire persisted `cognitiveHazardExposureRecords` into `advanceWeek` with a pure domain weekly exposure tick: one-step memory-impairment-band transitions from projected exposure review signals while preserving terminal erased posture and sibling trigger-channel compose via slice 1 helpers.
+
+## Prerequisite (on `main` @ `9c8837ac`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Engine anchor        | `src/domain/cognitiveHazardEngine.ts` (SPE-1309 slice 1 / PR #2807)    |
+| Persistence          | `cognitiveHazardExposureRecords` on `GameState` (slice 2 / PR #2808)   |
+| Sibling weekly hook  | `src/domain/psychologicalResilienceWeeklyOrchestration.ts` (SPE-2435)  |
+| Fixtures             | `COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE`, stable/failed countermeasure |
+
+## Orchestration tick contract (slice 3)
+
+- **intact → fragmented** — `exposureReviewBand` is `elevated` or `critical`.
+- **fragmented → compromised** — `exposureReviewBand` is `elevated` or `critical` and `aggregateExposurePressure` ≥ 0.55.
+- **compromised → erased** — `exposureReviewBand` is `critical` and (`countermeasureFailed` or `aggregateExposurePressure` ≥ 0.75).
+- **Terminal** — `erased` records do not advance further; duty/procedure flags preserved.
+- **Sibling compose** — `mergePropagationResistanceTriggerChannels` merges `inferTriggerChannelsFromPropagationResistance` output into `activeTriggerChannels` when tags supplied (optional compose step; no SPE-2108 / SPE-2116 hook changes).
+- **Validation gate** — invalid post-tick candidates preserve the source record.
+- **One composite step per week** — at most one memory-band step per record per tick; re-tick same week is idempotent.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `applyWeeklyCognitiveHazardExposureTick` in domain module          | Planning mirror UI                            |
+| Call from `advanceWeek` after week increment (`result.week`)       | SPE-2108 / SPE-2116 weekly hook changes       |
+| Sibling trigger-channel compose helper (slice 1 attach surface)    | Agent/knowledge/procedure simulation triggers |
+| Targeted domain + `advanceWeek` integration tests                    | Full SPE-1309 parent Done                     |
+| Slice doc (this file) + backlog handoff                            | Slice 1–2 validation/projection contract edits |
+
+## Acceptance
+
+- [x] Empty `cognitiveHazardExposureRecords` map is a no-op without throw
+- [x] Memetic escalation fixture escalates to `compromised` while preserving subject ref
+- [x] Failed countermeasure fixture remains idempotent at `erased`
+- [x] Stable subject fixture unchanged on low exposure
+- [x] Re-tick after advance is idempotent
+- [x] `advanceWeek` integration matches direct weekly tick output
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/cognitiveHazardWeeklyOrchestration.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/cognitiveHazardWeeklyOrchestration.test.ts`, `src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts` |
+| Plan   | `planning/spe-1309-unified-engine-slice-3.md`, `planning/backlog.md`  |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Sibling registry compose wire-up from SPE-2108 persisted maps | SPE-1309 follow-up | Compose helper lands; sibling hook reads deferred |
+| Agent/knowledge/procedure simulation triggers | SPE-1309 follow-up | Parent AC row 3 runtime effects deferred |
+| Planning mirror UI | SPE-1309 follow-up | Mirror follows orchestration pattern |
+| Full SPE-1309 parent Done | SPE-1309 | Multiple slices remain |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/cognitiveHazardWeeklyOrchestration.test.ts src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts src/test/cognitiveHazardEngine.test.ts`
+
+## See also
+
+- `planning/spe-1309-unified-engine-slice-2.md` — persistence slice
+- `planning/spe-1615-psychological-resilience-registry-slice-3.md` — sibling weekly-hook pattern

--- a/src/domain/cognitiveHazardWeeklyOrchestration.ts
+++ b/src/domain/cognitiveHazardWeeklyOrchestration.ts
@@ -1,0 +1,207 @@
+/**
+ * SPE-1309 slice 3: weekly orchestration for persisted cognitive hazard exposure records.
+ *
+ * Pure deterministic tick: project exposure review signals and advance memoryImpairmentBand
+ * one bounded step when fear/memetic/countermeasure thresholds warrant. Sibling trigger-channel
+ * compose uses slice 1 `inferTriggerChannelsFromPropagationResistance` without mutating
+ * SPE-2108 / SPE-2116 weekly hooks.
+ */
+
+import {
+  inferTriggerChannelsFromPropagationResistance,
+  projectCognitiveHazardExposureReview,
+  validateCognitiveHazardExposureRecord,
+  type CognitiveHazardExposureRecord,
+  type CognitiveHazardExposureRecordsMap,
+  type CognitiveHazardExposureReview,
+  type CognitiveHazardMemoryImpairmentBand,
+  type CognitiveHazardTriggerChannel,
+} from './cognitiveHazardEngine'
+import type { PropagationResistanceTag } from './selfCensoringInformationRegistry'
+
+const FRAGMENTED_ESCALATION_PRESSURE_THRESHOLD = 0.55
+const ERASED_ESCALATION_PRESSURE_THRESHOLD = 0.75
+
+function normalizeWeek(week: number): number {
+  if (!Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function freezeRecord(record: CognitiveHazardExposureRecord): CognitiveHazardExposureRecord {
+  return Object.freeze({ ...record })
+}
+
+function sortedUniqueTriggerChannels(
+  channels: readonly CognitiveHazardTriggerChannel[]
+): readonly CognitiveHazardTriggerChannel[] {
+  return Object.freeze([...new Set(channels)].sort((left, right) => left.localeCompare(right)))
+}
+
+/** Target memory impairment band from weekly projection signals; undefined when no transition applies. */
+export function resolveTargetMemoryImpairmentBandFromProjection(
+  record: CognitiveHazardExposureRecord,
+  projection: CognitiveHazardExposureReview
+): CognitiveHazardMemoryImpairmentBand | undefined {
+  const band = record.memoryImpairmentBand
+  const reviewBand = projection.exposureReviewBand
+  const aggregatePressure = projection.aggregateExposurePressure
+
+  if (band === 'erased') {
+    return undefined
+  }
+
+  if (reviewBand === 'stable') {
+    return undefined
+  }
+
+  if (band === 'intact') {
+    return 'fragmented'
+  }
+
+  if (band === 'fragmented') {
+    if (aggregatePressure !== null && aggregatePressure >= FRAGMENTED_ESCALATION_PRESSURE_THRESHOLD) {
+      return 'compromised'
+    }
+
+    return undefined
+  }
+
+  if (band === 'compromised') {
+    if (reviewBand !== 'critical') {
+      return undefined
+    }
+
+    if (
+      projection.countermeasureFailed ||
+      (aggregatePressure !== null && aggregatePressure >= ERASED_ESCALATION_PRESSURE_THRESHOLD)
+    ) {
+      return 'erased'
+    }
+
+    return undefined
+  }
+
+  return undefined
+}
+
+function applyMemoryBandEffectFlags(
+  record: CognitiveHazardExposureRecord,
+  targetBand: CognitiveHazardMemoryImpairmentBand
+): Pick<CognitiveHazardExposureRecord, 'knowledgeIntegrityDegraded' | 'agentDutyDegraded'> {
+  if (targetBand === 'fragmented' || targetBand === 'compromised' || targetBand === 'erased') {
+    return {
+      knowledgeIntegrityDegraded: true,
+      ...(targetBand === 'compromised' || targetBand === 'erased' ? { agentDutyDegraded: true } : {}),
+    }
+  }
+
+  return {}
+}
+
+/**
+ * Merges sibling propagation-resistance tags into active trigger channels via slice 1 attach helper.
+ * Returns undefined when no new channels would be added.
+ */
+export function mergePropagationResistanceTriggerChannels(
+  record: CognitiveHazardExposureRecord,
+  propagationResistance: readonly PropagationResistanceTag[] | undefined
+): CognitiveHazardExposureRecord | undefined {
+  const inferred = inferTriggerChannelsFromPropagationResistance(propagationResistance)
+  if (inferred.length === 0) {
+    return undefined
+  }
+
+  const merged = sortedUniqueTriggerChannels([
+    ...record.activeTriggerChannels,
+    ...inferred,
+  ])
+
+  if (
+    merged.length === record.activeTriggerChannels.length &&
+    merged.every((channel, index) => channel === record.activeTriggerChannels[index])
+  ) {
+    return undefined
+  }
+
+  return {
+    ...record,
+    activeTriggerChannels: merged,
+  }
+}
+
+function buildWeeklyAdvanceCandidate(
+  record: CognitiveHazardExposureRecord
+): CognitiveHazardExposureRecord | undefined {
+  const projection = projectCognitiveHazardExposureReview(record)
+  const targetBand = resolveTargetMemoryImpairmentBandFromProjection(record, projection)
+
+  if (!targetBand || targetBand === record.memoryImpairmentBand) {
+    return undefined
+  }
+
+  const effectFlags = applyMemoryBandEffectFlags(record, targetBand)
+
+  return {
+    ...record,
+    memoryImpairmentBand: targetBand,
+    ...effectFlags,
+  }
+}
+
+/**
+ * Advances one cognitive hazard exposure record for the simulation week using projected exposure semantics.
+ * Returns the same reference when no bounded field changes.
+ */
+export function advanceCognitiveHazardExposureRecordForWeek(
+  record: CognitiveHazardExposureRecord,
+  week: number
+): CognitiveHazardExposureRecord {
+  normalizeWeek(week)
+  const candidate = buildWeeklyAdvanceCandidate(record)
+  if (!candidate) {
+    return record
+  }
+
+  if (!validateCognitiveHazardExposureRecord(candidate).valid) {
+    return record
+  }
+
+  return freezeRecord(candidate)
+}
+
+/**
+ * Applies one weekly cognitive-hazard exposure pass over persisted records.
+ * Empty map is a no-op. Re-applying after advance is idempotent for the same week.
+ */
+export function applyWeeklyCognitiveHazardExposureTick(
+  records: CognitiveHazardExposureRecordsMap | null | undefined,
+  week: number
+): CognitiveHazardExposureRecordsMap {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords)
+  if (recordIds.length === 0) {
+    return safeRecords
+  }
+
+  const normalizedWeek = normalizeWeek(week)
+  const next: CognitiveHazardExposureRecordsMap = { ...safeRecords }
+  let changed = false
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const advanced = advanceCognitiveHazardExposureRecordForWeek(record, normalizedWeek)
+    if (advanced !== record) {
+      next[recordId] = advanced
+      changed = true
+    }
+  }
+
+  return changed ? next : safeRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -274,6 +274,7 @@ import { applyWeeklyCoverStoryTick } from '../coverStoryWeeklyOrchestration'
 import { applyWeeklyTruthLayerTick } from '../truthLayerWeeklyOrchestration'
 import { applyWeeklySurveillanceInterventionTuningTick } from '../surveillanceInterventionTuningWeeklyOrchestration'
 import { applyWeeklyPsychologicalResilienceDepletionTick } from '../psychologicalResilienceWeeklyOrchestration'
+import { applyWeeklyCognitiveHazardExposureTick } from '../cognitiveHazardWeeklyOrchestration'
 import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   resolveCoerciveProcedureExecutionDrafts,
@@ -4835,6 +4836,16 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
         currentPsychologicalResilienceRecords,
         result.week
       )
+  }
+
+  // SPE-1309 slice 3: memory-impairment-band advance on cognitive hazard exposure records.
+  const currentCognitiveHazardExposureRecords =
+    outputWeeklyState.cognitiveHazardExposureRecords ?? {}
+  if (Object.keys(currentCognitiveHazardExposureRecords).length > 0) {
+    outputWeeklyState.cognitiveHazardExposureRecords = applyWeeklyCognitiveHazardExposureTick(
+      currentCognitiveHazardExposureRecords,
+      result.week
+    )
   }
 
   // SPE-1888 slice 5: welfare-debt creation when coercive procedures execute with containment improvement.

--- a/src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts
+++ b/src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+} from '../domain/cognitiveHazardEngine'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import { applyWeeklyCognitiveHazardExposureTick } from '../domain/cognitiveHazardWeeklyOrchestration'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek cognitive hazard exposure records integration (SPE-1309 slice 3)', () => {
+  it('is a no-op for an empty exposure map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.cognitiveHazardExposureRecords).toEqual({})
+  })
+
+  it('advances memetic escalation fixture to compromised through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const advanced =
+      nextState.cognitiveHazardExposureRecords?.[COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]
+
+    expect(nextState.week).toBe(2)
+    expect(advanced?.memoryImpairmentBand).toBe('compromised')
+    expect(advanced?.knowledgeIntegrityDegraded).toBe(true)
+    expect(advanced?.agentDutyDegraded).toBe(true)
+    expect(advanced?.subjectRef).toBe(COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.subjectRef)
+  })
+
+  it('preserves failed countermeasure fixture at erased with unchanged gating flags', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE.id]:
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.cognitiveHazardExposureRecords).toEqual(state.cognitiveHazardExposureRecords)
+    expect(
+      nextState.cognitiveHazardExposureRecords?.[COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE.id]
+        ?.agentDutyDegraded
+    ).toBe(true)
+    expect(
+      nextState.cognitiveHazardExposureRecords?.[COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE.id]
+        ?.procedureRestrictionActive
+    ).toBe(true)
+  })
+
+  it('keeps stable subject fixture unchanged through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.cognitiveHazardExposureRecords).toEqual(state.cognitiveHazardExposureRecords)
+    expect(
+      nextState.cognitiveHazardExposureRecords?.[COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]
+        ?.memoryImpairmentBand
+    ).toBe('intact')
+  })
+
+  it('matches direct weekly tick output inside advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      [COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE.id]:
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const direct = applyWeeklyCognitiveHazardExposureTick(
+      state.cognitiveHazardExposureRecords,
+      nextState.week
+    )
+
+    expect(nextState.cognitiveHazardExposureRecords).toEqual(direct)
+  })
+})

--- a/src/test/cognitiveHazardWeeklyOrchestration.test.ts
+++ b/src/test/cognitiveHazardWeeklyOrchestration.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+  projectCognitiveHazardExposureReview,
+  type CognitiveHazardExposureRecord,
+} from '../domain/cognitiveHazardEngine'
+import {
+  advanceCognitiveHazardExposureRecordForWeek,
+  applyWeeklyCognitiveHazardExposureTick,
+  mergePropagationResistanceTriggerChannels,
+  resolveTargetMemoryImpairmentBandFromProjection,
+} from '../domain/cognitiveHazardWeeklyOrchestration'
+
+function baseRecord(
+  overrides: Partial<CognitiveHazardExposureRecord> = {}
+): CognitiveHazardExposureRecord {
+  return {
+    id: 'cognitive-hazard:weekly-orchestration-test',
+    label: 'Weekly orchestration test exposure profile',
+    subjectRef: 'agent:weekly-orchestration-test',
+    activeTriggerChannels: ['direct_perception'],
+    fearPressure: 0.2,
+    memeticExposure: 0.15,
+    memoryImpairmentBand: 'intact',
+    countermeasurePosture: 'none',
+    ...overrides,
+  }
+}
+
+describe('cognitiveHazardWeeklyOrchestration (SPE-1309 slice 3)', () => {
+  it('is a no-op for an empty map without throwing', () => {
+    expect(applyWeeklyCognitiveHazardExposureTick({}, 4)).toEqual({})
+    expect(applyWeeklyCognitiveHazardExposureTick(undefined, 4)).toEqual({})
+  })
+
+  it('keeps stable subject fixture unchanged when exposure remains low', () => {
+    const advanced = advanceCognitiveHazardExposureRecordForWeek(
+      COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+      2
+    )
+
+    expect(advanced).toBe(COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE)
+    expect(advanced.memoryImpairmentBand).toBe('intact')
+    expect(advanced.knowledgeIntegrityDegraded).toBeUndefined()
+    expect(advanced.agentDutyDegraded).toBeUndefined()
+  })
+
+  it('escalates memetic escalation fixture from fragmented to compromised while preserving subject ref', () => {
+    const projection = projectCognitiveHazardExposureReview(
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE
+    )
+
+    expect(
+      resolveTargetMemoryImpairmentBandFromProjection(
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+        projection
+      )
+    ).toBe('compromised')
+
+    const advanced = advanceCognitiveHazardExposureRecordForWeek(
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      2
+    )
+
+    expect(advanced).not.toBe(COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE)
+    expect(advanced.memoryImpairmentBand).toBe('compromised')
+    expect(advanced.knowledgeIntegrityDegraded).toBe(true)
+    expect(advanced.agentDutyDegraded).toBe(true)
+    expect(advanced.subjectRef).toBe(COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.subjectRef)
+    expect(advanced.countermeasurePosture).toBe('mnestic_reinforcement')
+  })
+
+  it('keeps failed countermeasure fixture idempotent at erased', () => {
+    const advanced = advanceCognitiveHazardExposureRecordForWeek(
+      COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+      2
+    )
+
+    expect(advanced).toBe(COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE)
+    expect(advanced.memoryImpairmentBand).toBe('erased')
+    expect(advanced.agentDutyDegraded).toBe(true)
+    expect(advanced.procedureRestrictionActive).toBe(true)
+  })
+
+  it('escalates intact records when exposure review band is elevated', () => {
+    const record = baseRecord({
+      id: 'cognitive-hazard:fragmented-escalation',
+      fearPressure: 0.62,
+      memeticExposure: 0.48,
+    })
+    const projection = projectCognitiveHazardExposureReview(record)
+
+    expect(resolveTargetMemoryImpairmentBandFromProjection(record, projection)).toBe('fragmented')
+
+    const advanced = advanceCognitiveHazardExposureRecordForWeek(record, 2)
+
+    expect(advanced.memoryImpairmentBand).toBe('fragmented')
+    expect(advanced.knowledgeIntegrityDegraded).toBe(true)
+    expect(advanced.agentDutyDegraded).toBeUndefined()
+  })
+
+  it('merges sibling propagation-resistance tags into active trigger channels', () => {
+    const record = baseRecord({
+      activeTriggerChannels: ['reference_description'],
+    })
+
+    const merged = mergePropagationResistanceTriggerChannels(record, [
+      'forgetting',
+      'record_decay',
+    ])
+
+    expect(merged).toBeDefined()
+    expect(merged?.activeTriggerChannels).toEqual([
+      'memory_interaction',
+      'recording_mediated',
+      'reference_description',
+    ])
+  })
+
+  it('is idempotent when re-applied after advance', () => {
+    const first = advanceCognitiveHazardExposureRecordForWeek(
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      2
+    )
+    const second = advanceCognitiveHazardExposureRecordForWeek(first, 2)
+
+    expect(second).toBe(first)
+    expect(
+      applyWeeklyCognitiveHazardExposureTick(
+        { [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]: first },
+        2
+      )
+    ).toEqual({
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]: first,
+    })
+  })
+
+  it('preserves source record when post-tick candidate fails validation', () => {
+    const record = baseRecord({
+      id: '',
+      fearPressure: 0.72,
+      memeticExposure: 0.61,
+    })
+
+    const advanced = advanceCognitiveHazardExposureRecordForWeek(record, 2)
+
+    expect(advanced).toBe(record)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `applyWeeklyCognitiveHazardExposureTick` with one-step memory-impairment-band transitions from projected exposure review signals.
- Export `mergePropagationResistanceTriggerChannels` sibling compose helper via slice 1 `inferTriggerChannelsFromPropagationResistance`.
- Wire tick into `advanceWeek` after psychological resilience depletion pass.
- Add domain + integration tests mirroring SPE-1615 slice 3 pattern.

## Linear

- **Slice:** SPE-1309 child — unified cognitive hazard engine advanceWeek exposure tick (slice 3)
- **Parent:** SPE-1309 — Unified cognitive hazard engine (stays Backlog)

## Validation

- `npm run lint`
- `npm run test:run src/test/cognitiveHazardWeeklyOrchestration.test.ts src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts src/test/cognitiveHazardEngine.test.ts`

## Docs

- `planning/spe-1309-unified-engine-slice-3.md`
- `planning/backlog.md`

## Parent status

Parent SPE-1309 remains **Backlog** — orchestration lands; sibling registry compose wire-up and runtime effects deferred.

Made with [Cursor](https://cursor.com)