### PR TITLE
SPE-1309: sibling registry compose wire-up from SPE-2108 maps (slice 4)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1309 unified engine slice 4 (sibling registry compose wire-up from SPE-2108 persisted maps, or planning mirror UI) if prioritized, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
+**Next step:** SPE-1309 unified engine follow-up (agent/knowledge/procedure simulation triggers, or planning mirror UI), or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
 
-**Base `main` SHA:** `0b56a272` — shipped: SPE-1309 unified cognitive hazard engine slice 3 @ `planning/spe-1309-unified-engine-slice-3.md` (PR #2809)
+**Base `main` SHA:** `16209ad8` — in progress: SPE-1309 unified cognitive hazard engine slice 4 @ `planning/spe-1309-unified-engine-slice-4.md` (branch `spe-1309-unified-engine-slice-4`)
 
 **Recently shipped:** SPE-1309 unified cognitive hazard engine slice 3 (PR #2809 @ `0b56a272`); SPE-1309 unified cognitive hazard engine slice 2 (PR #2808 @ `9b22d0ca`).
 
@@ -227,6 +227,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1309-unified-engine-slice-1.md`                      | **Shipped**    | SPE-1309 child — unified cognitive hazard engine exposure state anchor / PR #2807 @ `0e803263`.                                                        |
 | `spe-1309-unified-engine-slice-2.md`                      | **Shipped**    | SPE-1309 child — cognitive hazard exposure persistence + hydrate / PR #2808 @ `9b22d0ca`.                                                               |
 | `spe-1309-unified-engine-slice-3.md`                      | **Shipped**    | SPE-1309 child — `advanceWeek` exposure tick + sibling compose helper / PR #2809 @ `0b56a272`.                                                          |
+| `spe-1309-unified-engine-slice-4.md`                      | **In Progress** | SPE-1309 child — sibling registry compose wire-up from SPE-2108 persisted maps @ `16209ad8`.                                                             |
 | `welfare-debt-accounting-registry-slice-2.md`             | **Shipped**    | SPE-2351 / PR #2570; planning mirror UI over `welfareDebtAccountingRecords` @ `96ad05ba`.                                                               |
 | `welfare-debt-accounting-registry-slice-3.md`             | **Shipped**    | SPE-2352 / PR #2572; weekly orchestration hook in `advanceWeek` @ `5673423c`.                                                                          |
 | `welfare-debt-accounting-registry-slice-4.md`             | **Shipped**    | SPE-2353 / PR #2574; ledger summary audit output @ `1ec3ca12`.                                                                                         |

--- a/planning/spe-1309-unified-engine-slice-4.md
+++ b/planning/spe-1309-unified-engine-slice-4.md
@@ -1,0 +1,83 @@
+# SPE-1309 — Unified cognitive hazard engine (slice 4)
+
+One-page implementation plan. Linear: child under [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — **sibling registry compose wire-up from SPE-2108 persisted maps (slice 4)** (create/claim on start). Parent [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays **Backlog** — unified engine AC rows 1–3 not fully met until runtime effect slices.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1309 child — sibling registry compose wire-up from SPE-2108 persisted maps (slice 4)                   |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — Unified cognitive hazard engine (umbrella)    |
+| **Branch** | `spe-1309-unified-engine-slice-4`                                                                          |
+| **Base `main` SHA** | `16209ad8`                                                                                          |
+
+## Goal
+
+Wire persisted `selfCensoringInformationRecords` propagation-resistance tags into `cognitiveHazardExposureRecords.activeTriggerChannels` during `advanceWeek` via a pure domain compose pass. Reuses slice 1 `inferTriggerChannelsFromPropagationResistance` and slice 3 `mergePropagationResistanceTriggerChannels` without mutating SPE-2108 / SPE-2116 weekly hooks.
+
+## Prerequisite (on `main` @ `16209ad8`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Engine anchor        | `src/domain/cognitiveHazardEngine.ts` (SPE-1309 slice 1 / PR #2807)    |
+| Persistence          | `cognitiveHazardExposureRecords` on `GameState` (slice 2 / PR #2808)   |
+| Weekly exposure tick | `applyWeeklyCognitiveHazardExposureTick` (slice 3 / PR #2809)          |
+| Sibling registry     | `selfCensoringInformationRecords` (SPE-2108 / SPE-2318)                |
+| Compose helper       | `mergePropagationResistanceTriggerChannels` (slice 3)                  |
+
+## Sibling compose contract (slice 4)
+
+- **Hydrated truth only** — compose over persisted maps; no re-sanitize or invalid-drop surfacing.
+- **Linkage (explicit)** — exposure record links to self-censoring record when normalized refs match:
+  - **`parent_case_ref`** — `cognitiveHazardExposureRecord.subjectRef` equals `selfCensoringInformationRecord.parentCaseRef`.
+  - **`info_record_id`** — `cognitiveHazardExposureRecord.subjectRef` equals `selfCensoringInformationRecord.id`.
+- **Tag merge** — collect `propagationResistance` tags from all linked sibling records; dedupe and sort before channel inference.
+- **Channel merge** — `mergePropagationResistanceTriggerChannels`; deterministic sorted `activeTriggerChannels`.
+- **Validation gate** — invalid post-compose candidate preserves source exposure record.
+- **No-op** — empty exposure map, empty sibling map, no linked siblings, or no new channels: preserve records unchanged.
+- **Ordering** — compose runs after SPE-2108 weekly retention tick and before SPE-1309 slice 3 exposure tick.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `cognitiveHazardSiblingCompose.ts` derive + compose helpers        | Planning mirror UI                            |
+| Call compose from `advanceWeek` before exposure tick               | SPE-2108 / SPE-2116 weekly hook changes       |
+| Targeted compose unit + `advanceWeek` integration tests            | Full SPE-1309 parent Done                     |
+| Slice doc (this file) + backlog handoff                            | Slice 1–3 validation/projection contract edits |
+|                                                                    | UI surfacing                                  |
+
+## Acceptance
+
+- [x] Empty sibling map is a no-op without throw
+- [x] Linked sibling propagation tags merge into `activeTriggerChannels` with deterministic sort
+- [x] Unlinked exposure records unchanged when sibling map populated
+- [x] Records preserved when compose adds no new channels
+- [x] Invalid post-compose candidate preserves source record
+- [x] `advanceWeek` integration matches direct compose output
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/cognitiveHazardSiblingCompose.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/cognitiveHazardSiblingCompose.test.ts`, `src/test/advanceWeek.cognitiveHazardSiblingCompose.integration.test.ts` |
+| Plan   | `planning/spe-1309-unified-engine-slice-4.md`, `planning/backlog.md`  |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Agent/knowledge/procedure simulation triggers | SPE-1309 follow-up | Parent AC row 3 runtime effects deferred |
+| Planning mirror UI | SPE-1309 follow-up | Mirror follows orchestration pattern |
+| Full SPE-1309 parent Done | SPE-1309 | Multiple slices remain |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/cognitiveHazardSiblingCompose.test.ts src/test/advanceWeek.cognitiveHazardSiblingCompose.integration.test.ts src/test/cognitiveHazardWeeklyOrchestration.test.ts src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts`
+
+## See also
+
+- `planning/spe-1309-unified-engine-slice-3.md` — exposure tick (shipped)
+- `planning/mass-anomalous-population-emergence-registry-slice-5.md` — sibling compose wire-up pattern

--- a/src/domain/cognitiveHazardSiblingCompose.ts
+++ b/src/domain/cognitiveHazardSiblingCompose.ts
@@ -1,0 +1,251 @@
+/**
+ * SPE-1309 slice 4: compose SPE-2108 propagation-resistance tags into cognitive hazard
+ * exposure trigger channels.
+ *
+ * Pure deterministic merge — reads persisted self-censoring information records and merges
+ * inferred trigger channels into linked cognitive hazard exposure records without mutating
+ * SPE-2108 / SPE-2116 weekly hooks.
+ */
+
+import type {
+  CognitiveHazardExposureRecord,
+  CognitiveHazardExposureRecordsMap,
+} from './cognitiveHazardEngine'
+import { validateCognitiveHazardExposureRecord } from './cognitiveHazardEngine'
+import { mergePropagationResistanceTriggerChannels } from './cognitiveHazardWeeklyOrchestration'
+import type {
+  PropagationResistanceTag,
+  SelfCensoringInformationRecord,
+} from './selfCensoringInformationRegistry'
+
+export type CognitiveHazardSiblingLinkMatchKind = 'parent_case_ref' | 'info_record_id'
+
+export interface CognitiveHazardSiblingLink {
+  readonly exposureRecordId: string
+  readonly selfCensoringInformationId: string
+  readonly matchKind: CognitiveHazardSiblingLinkMatchKind
+  readonly linkedRef: string
+}
+
+function normalizeToken(value: unknown): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim().toLowerCase()
+}
+
+/** Expand a subject or case ref into normalized match keys (namespace prefix variants). */
+export function resolveCognitiveHazardSiblingRefKeys(ref: string): readonly string[] {
+  const normalized = normalizeToken(ref)
+  if (!normalized) {
+    return []
+  }
+
+  const keys = new Set<string>([normalized])
+  const prefixes = ['case:', 'agent:', 'topic:', 'info:'] as const
+
+  for (const prefix of prefixes) {
+    if (normalized.startsWith(prefix)) {
+      const stripped = normalized.slice(prefix.length)
+      if (stripped) {
+        keys.add(stripped)
+        keys.add(`${prefix}${stripped}`)
+      }
+    }
+  }
+
+  return Object.freeze([...keys].sort((left, right) => left.localeCompare(right)))
+}
+
+function siblingRefKeysOverlap(leftRef: string, rightRef: string): boolean {
+  const leftKeys = new Set(resolveCognitiveHazardSiblingRefKeys(leftRef))
+  if (leftKeys.size === 0) {
+    return false
+  }
+
+  for (const key of resolveCognitiveHazardSiblingRefKeys(rightRef)) {
+    if (leftKeys.has(key)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function resolveSiblingLinkMatch(
+  exposureRecord: CognitiveHazardExposureRecord,
+  infoRecord: SelfCensoringInformationRecord
+): CognitiveHazardSiblingLink | null {
+  const subjectRef = normalizeToken(exposureRecord.subjectRef)
+  if (!subjectRef) {
+    return null
+  }
+
+  const parentCaseRef = normalizeToken(infoRecord.parentCaseRef ?? '')
+  if (parentCaseRef && siblingRefKeysOverlap(subjectRef, parentCaseRef)) {
+    return {
+      exposureRecordId: exposureRecord.id,
+      selfCensoringInformationId: infoRecord.id,
+      matchKind: 'parent_case_ref',
+      linkedRef: parentCaseRef,
+    }
+  }
+
+  const infoRecordId = normalizeToken(infoRecord.id)
+  if (infoRecordId && siblingRefKeysOverlap(subjectRef, infoRecordId)) {
+    return {
+      exposureRecordId: exposureRecord.id,
+      selfCensoringInformationId: infoRecord.id,
+      matchKind: 'info_record_id',
+      linkedRef: infoRecordId,
+    }
+  }
+
+  return null
+}
+
+/** Whether persisted sibling records link via explicit subject/case ref contract. */
+export function refsLinkCognitiveHazardExposureToSelfCensoringInformation(
+  exposureRecord: CognitiveHazardExposureRecord,
+  infoRecord: SelfCensoringInformationRecord
+): boolean {
+  return resolveSiblingLinkMatch(exposureRecord, infoRecord) !== null
+}
+
+export function listSelfCensoringInformationRecordsForExposureRecord(
+  exposureRecord: CognitiveHazardExposureRecord,
+  selfCensoringRecords: Record<string, SelfCensoringInformationRecord> | null | undefined
+): SelfCensoringInformationRecord[] {
+  if (!selfCensoringRecords) {
+    return []
+  }
+
+  const linked: SelfCensoringInformationRecord[] = []
+
+  for (const recordId of Object.keys(selfCensoringRecords).sort((left, right) =>
+    left.localeCompare(right)
+  )) {
+    const record = selfCensoringRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    if (refsLinkCognitiveHazardExposureToSelfCensoringInformation(exposureRecord, record)) {
+      linked.push(record)
+    }
+  }
+
+  return linked
+}
+
+export function listCognitiveHazardSiblingLinks(
+  exposureRecords: CognitiveHazardExposureRecordsMap | null | undefined,
+  selfCensoringRecords: Record<string, SelfCensoringInformationRecord> | null | undefined
+): readonly CognitiveHazardSiblingLink[] {
+  const safeExposureRecords = exposureRecords ?? {}
+  const safeSelfCensoringRecords = selfCensoringRecords ?? {}
+  const links: CognitiveHazardSiblingLink[] = []
+
+  for (const exposureRecordId of Object.keys(safeExposureRecords).sort((left, right) =>
+    left.localeCompare(right)
+  )) {
+    const exposureRecord = safeExposureRecords[exposureRecordId]
+    if (!exposureRecord) {
+      continue
+    }
+
+    for (const infoRecordId of Object.keys(safeSelfCensoringRecords).sort((left, right) =>
+      left.localeCompare(right)
+    )) {
+      const infoRecord = safeSelfCensoringRecords[infoRecordId]
+      if (!infoRecord) {
+        continue
+      }
+
+      const link = resolveSiblingLinkMatch(exposureRecord, infoRecord)
+      if (link) {
+        links.push(link)
+      }
+    }
+  }
+
+  return Object.freeze(links)
+}
+
+function sortedUniquePropagationResistanceTags(
+  records: readonly SelfCensoringInformationRecord[]
+): readonly PropagationResistanceTag[] {
+  const tags = new Set<PropagationResistanceTag>()
+
+  for (const record of records) {
+    for (const tag of record.propagationResistance ?? []) {
+      tags.add(tag)
+    }
+  }
+
+  return Object.freeze([...tags].sort((left, right) => left.localeCompare(right)))
+}
+
+/** Collect propagation-resistance tags from sibling records linked to one exposure record. */
+export function derivePropagationResistanceTagsForExposureRecord(
+  exposureRecord: CognitiveHazardExposureRecord,
+  selfCensoringRecords: Record<string, SelfCensoringInformationRecord> | null | undefined
+): readonly PropagationResistanceTag[] {
+  return sortedUniquePropagationResistanceTags(
+    listSelfCensoringInformationRecordsForExposureRecord(exposureRecord, selfCensoringRecords)
+  )
+}
+
+function composeExposureRecordTriggerChannels(
+  record: CognitiveHazardExposureRecord,
+  selfCensoringRecords: Record<string, SelfCensoringInformationRecord> | null | undefined
+): CognitiveHazardExposureRecord {
+  const tags = derivePropagationResistanceTagsForExposureRecord(record, selfCensoringRecords)
+  const merged = mergePropagationResistanceTriggerChannels(record, tags)
+  if (!merged) {
+    return record
+  }
+
+  if (!validateCognitiveHazardExposureRecord(merged).valid) {
+    return record
+  }
+
+  return Object.freeze(merged)
+}
+
+/**
+ * Merges sibling propagation-resistance tags into linked cognitive hazard exposure records.
+ * Empty exposure map or empty sibling map is a no-op.
+ */
+export function composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+  exposureRecords: CognitiveHazardExposureRecordsMap | null | undefined,
+  selfCensoringRecords: Record<string, SelfCensoringInformationRecord> | null | undefined
+): CognitiveHazardExposureRecordsMap {
+  const safeExposureRecords = exposureRecords ?? {}
+  const safeSelfCensoringRecords = selfCensoringRecords ?? {}
+  const exposureRecordIds = Object.keys(safeExposureRecords)
+  const siblingRecordIds = Object.keys(safeSelfCensoringRecords)
+
+  if (exposureRecordIds.length === 0 || siblingRecordIds.length === 0) {
+    return safeExposureRecords
+  }
+
+  const next: CognitiveHazardExposureRecordsMap = { ...safeExposureRecords }
+  let changed = false
+
+  for (const recordId of exposureRecordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeExposureRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const composed = composeExposureRecordTriggerChannels(record, safeSelfCensoringRecords)
+    if (composed !== record) {
+      next[recordId] = composed
+      changed = true
+    }
+  }
+
+  return changed ? next : safeExposureRecords
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -274,6 +274,7 @@ import { applyWeeklyCoverStoryTick } from '../coverStoryWeeklyOrchestration'
 import { applyWeeklyTruthLayerTick } from '../truthLayerWeeklyOrchestration'
 import { applyWeeklySurveillanceInterventionTuningTick } from '../surveillanceInterventionTuningWeeklyOrchestration'
 import { applyWeeklyPsychologicalResilienceDepletionTick } from '../psychologicalResilienceWeeklyOrchestration'
+import { composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords } from '../cognitiveHazardSiblingCompose'
 import { applyWeeklyCognitiveHazardExposureTick } from '../cognitiveHazardWeeklyOrchestration'
 import {
   applyCoerciveProcedureWelfareDebtCreationTick,
@@ -4838,9 +4839,24 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       )
   }
 
-  // SPE-1309 slice 3: memory-impairment-band advance on cognitive hazard exposure records.
-  const currentCognitiveHazardExposureRecords =
+  // SPE-1309 slice 4: merge SPE-2108 propagation-resistance tags into linked exposure channels.
+  let currentCognitiveHazardExposureRecords =
     outputWeeklyState.cognitiveHazardExposureRecords ?? {}
+  const currentSelfCensoringForCognitiveHazardCompose =
+    outputWeeklyState.selfCensoringInformationRecords ?? {}
+  if (
+    Object.keys(currentCognitiveHazardExposureRecords).length > 0 &&
+    Object.keys(currentSelfCensoringForCognitiveHazardCompose).length > 0
+  ) {
+    currentCognitiveHazardExposureRecords =
+      composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+        currentCognitiveHazardExposureRecords,
+        currentSelfCensoringForCognitiveHazardCompose
+      )
+    outputWeeklyState.cognitiveHazardExposureRecords = currentCognitiveHazardExposureRecords
+  }
+
+  // SPE-1309 slice 3: memory-impairment-band advance on cognitive hazard exposure records.
   if (Object.keys(currentCognitiveHazardExposureRecords).length > 0) {
     outputWeeklyState.cognitiveHazardExposureRecords = applyWeeklyCognitiveHazardExposureTick(
       currentCognitiveHazardExposureRecords,

--- a/src/test/advanceWeek.cognitiveHazardSiblingCompose.integration.test.ts
+++ b/src/test/advanceWeek.cognitiveHazardSiblingCompose.integration.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import {
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  type CognitiveHazardExposureRecord,
+} from '../domain/cognitiveHazardEngine'
+import { composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords } from '../domain/cognitiveHazardSiblingCompose'
+import { applyWeeklyCognitiveHazardExposureTick } from '../domain/cognitiveHazardWeeklyOrchestration'
+import { REDISCOVERY_LOOP_RECORD_FIXTURE } from '../domain/selfCensoringInformationRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+const LINKED_EXPOSURE_FIXTURE: CognitiveHazardExposureRecord = Object.freeze({
+  ...COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  id: 'cognitive-hazard:linked-roster-audit-exposure',
+  subjectRef: 'case:facility-roster-audit-12',
+  activeTriggerChannels: Object.freeze(['reference_description'] as const),
+})
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek cognitive hazard sibling compose integration (SPE-1309 slice 4)', () => {
+  it('is a no-op when sibling map is empty without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [LINKED_EXPOSURE_FIXTURE.id]: LINKED_EXPOSURE_FIXTURE,
+    }
+    state.selfCensoringInformationRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.cognitiveHazardExposureRecords?.[LINKED_EXPOSURE_FIXTURE.id]).toEqual(
+      expect.objectContaining({
+        activeTriggerChannels: ['reference_description'],
+      })
+    )
+  })
+
+  it('merges sibling propagation tags into linked exposure channels through advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [LINKED_EXPOSURE_FIXTURE.id]: LINKED_EXPOSURE_FIXTURE,
+    }
+    state.selfCensoringInformationRecords = {
+      [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const advanced = nextState.cognitiveHazardExposureRecords?.[LINKED_EXPOSURE_FIXTURE.id]
+
+    expect(advanced?.activeTriggerChannels).toEqual([
+      'memory_interaction',
+      'recording_mediated',
+      'reference_description',
+    ])
+    expect(advanced?.memoryImpairmentBand).toBe('compromised')
+    expect(advanced?.subjectRef).toBe(LINKED_EXPOSURE_FIXTURE.subjectRef)
+  })
+
+  it('matches direct compose then weekly tick output inside advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [LINKED_EXPOSURE_FIXTURE.id]: LINKED_EXPOSURE_FIXTURE,
+    }
+    state.selfCensoringInformationRecords = {
+      [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const composed = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+      state.cognitiveHazardExposureRecords,
+      state.selfCensoringInformationRecords
+    )
+    const direct = applyWeeklyCognitiveHazardExposureTick(composed, nextState.week)
+
+    expect(nextState.cognitiveHazardExposureRecords).toEqual(direct)
+  })
+})

--- a/src/test/cognitiveHazardSiblingCompose.test.ts
+++ b/src/test/cognitiveHazardSiblingCompose.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CognitiveHazardExposureRecord } from '../domain/cognitiveHazardEngine'
+import {
+  composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords,
+  derivePropagationResistanceTagsForExposureRecord,
+  listCognitiveHazardSiblingLinks,
+  listSelfCensoringInformationRecordsForExposureRecord,
+  refsLinkCognitiveHazardExposureToSelfCensoringInformation,
+  resolveCognitiveHazardSiblingRefKeys,
+} from '../domain/cognitiveHazardSiblingCompose'
+import {
+  REDISCOVERY_LOOP_RECORD_FIXTURE,
+  STUDY_BLOCKED_ARCHIVE_FIXTURE,
+  type SelfCensoringInformationRecord,
+} from '../domain/selfCensoringInformationRegistry'
+
+function exposureRecord(
+  overrides: Partial<CognitiveHazardExposureRecord> = {}
+): CognitiveHazardExposureRecord {
+  return Object.freeze({
+    id: 'cognitive-hazard:sibling-compose-test',
+    label: 'Sibling compose test exposure profile',
+    subjectRef: 'case:facility-roster-audit-12',
+    activeTriggerChannels: Object.freeze(['reference_description'] as const),
+    fearPressure: 0.2,
+    memeticExposure: 0.15,
+    memoryImpairmentBand: 'intact',
+    countermeasurePosture: 'none',
+    ...overrides,
+  })
+}
+
+describe('cognitiveHazardSiblingCompose (SPE-1309 slice 4)', () => {
+  it('is a no-op for empty maps without throwing', () => {
+    expect(
+      composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords({}, {})
+    ).toEqual({})
+    expect(
+      composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(undefined, undefined)
+    ).toEqual({})
+    expect(
+      composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+        { [exposureRecord().id]: exposureRecord() },
+        {}
+      )
+    ).toEqual({
+      [exposureRecord().id]: exposureRecord(),
+    })
+    expect(
+      composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+        {},
+        { [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE }
+      )
+    ).toEqual({})
+  })
+
+  it('links exposure subjectRef to sibling parentCaseRef via parent_case_ref match kind', () => {
+    const record = exposureRecord()
+    const links = listCognitiveHazardSiblingLinks(
+      { [record.id]: record },
+      { [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE }
+    )
+
+    expect(links).toEqual([
+      {
+        exposureRecordId: record.id,
+        selfCensoringInformationId: REDISCOVERY_LOOP_RECORD_FIXTURE.id,
+        matchKind: 'parent_case_ref',
+        linkedRef: 'case:facility-roster-audit-12',
+      },
+    ])
+    expect(
+      refsLinkCognitiveHazardExposureToSelfCensoringInformation(
+        record,
+        REDISCOVERY_LOOP_RECORD_FIXTURE
+      )
+    ).toBe(true)
+  })
+
+  it('links exposure subjectRef to sibling info record id via info_record_id match kind', () => {
+    const record = exposureRecord({
+      id: 'cognitive-hazard:info-id-link',
+      subjectRef: REDISCOVERY_LOOP_RECORD_FIXTURE.id,
+    })
+
+    const links = listCognitiveHazardSiblingLinks(
+      { [record.id]: record },
+      { [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE }
+    )
+
+    expect(links).toEqual([
+      {
+        exposureRecordId: record.id,
+        selfCensoringInformationId: REDISCOVERY_LOOP_RECORD_FIXTURE.id,
+        matchKind: 'info_record_id',
+        linkedRef: REDISCOVERY_LOOP_RECORD_FIXTURE.id,
+      },
+    ])
+  })
+
+  it('merges sibling propagation-resistance tags into active trigger channels with deterministic sort', () => {
+    const record = exposureRecord()
+    const composed = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+      { [record.id]: record },
+      { [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE }
+    )
+
+    expect(composed[record.id]).not.toBe(record)
+    expect(composed[record.id]?.activeTriggerChannels).toEqual([
+      'memory_interaction',
+      'recording_mediated',
+      'reference_description',
+    ])
+    expect(derivePropagationResistanceTagsForExposureRecord(record, {
+      [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE,
+    })).toEqual(['cognition_fail', 'forgetting', 'record_decay'])
+  })
+
+  it('leaves unlinked exposure records unchanged when sibling map is populated', () => {
+    const record = exposureRecord({
+      subjectRef: 'case:unrelated-audit-99',
+    })
+
+    const composed = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+      { [record.id]: record },
+      {
+        [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE,
+        [STUDY_BLOCKED_ARCHIVE_FIXTURE.id]: STUDY_BLOCKED_ARCHIVE_FIXTURE,
+      }
+    )
+
+    expect(composed[record.id]).toBe(record)
+    expect(listSelfCensoringInformationRecordsForExposureRecord(record, {
+      [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE,
+    })).toEqual([])
+  })
+
+  it('preserves records when compose adds no new channels', () => {
+    const record = exposureRecord({
+      activeTriggerChannels: Object.freeze([
+        'direct_perception',
+        'memory_interaction',
+        'recording_mediated',
+        'reference_description',
+      ] as const),
+    })
+
+    const composed = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+      { [record.id]: record },
+      { [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE }
+    )
+
+    expect(composed[record.id]).toBe(record)
+  })
+
+  it('merges tags from multiple linked sibling records in sorted order', () => {
+    const siblingA: SelfCensoringInformationRecord = Object.freeze({
+      ...REDISCOVERY_LOOP_RECORD_FIXTURE,
+      id: 'info:linked-a',
+      propagationResistance: Object.freeze(['forgetting'] as const),
+    })
+    const siblingB: SelfCensoringInformationRecord = Object.freeze({
+      ...STUDY_BLOCKED_ARCHIVE_FIXTURE,
+      id: 'info:linked-b',
+      parentCaseRef: 'case:facility-roster-audit-12',
+    })
+    const record = exposureRecord()
+
+    const composed = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+      { [record.id]: record },
+      {
+        [siblingA.id]: siblingA,
+        [siblingB.id]: siblingB,
+      }
+    )
+
+    expect(composed[record.id]?.activeTriggerChannels).toEqual([
+      'memory_interaction',
+      'recording_mediated',
+      'reference_description',
+    ])
+  })
+
+  it('preserves source record when post-compose candidate fails validation', () => {
+    const record = exposureRecord({
+      id: '',
+      subjectRef: 'case:facility-roster-audit-12',
+    })
+
+    const composed = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+      { [record.id]: record },
+      { [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE }
+    )
+
+    expect(composed[record.id]).toBe(record)
+  })
+
+  it('is byte-stable when compose is repeated', () => {
+    const record = exposureRecord()
+    const siblings = { [REDISCOVERY_LOOP_RECORD_FIXTURE.id]: REDISCOVERY_LOOP_RECORD_FIXTURE }
+    const first = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(
+      { [record.id]: record },
+      siblings
+    )
+    const second = composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords(first, siblings)
+
+    expect(second).toEqual(first)
+  })
+
+  it('expands sibling ref keys for namespace prefix variants', () => {
+    expect(resolveCognitiveHazardSiblingRefKeys('case:facility-roster-audit-12')).toEqual([
+      'case:facility-roster-audit-12',
+      'facility-roster-audit-12',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Add \cognitiveHazardSiblingCompose.ts\ to merge SPE-2108 \propagationResistance\ tags into linked \cognitiveHazardExposureRecords.activeTriggerChannels\ via slice 1/3 helpers.
- Wire compose into \dvanceWeek\ after SPE-2108 weekly retention tick and before SPE-1309 exposure tick.
- Explicit linkage contract: \parent_case_ref\ (subjectRef ↔ parentCaseRef) and \info_record_id\ (subjectRef ↔ info record id).

## Linear
- **Slice:** SPE-1309 child — sibling registry compose wire-up (slice 4)
- **Parent:** SPE-1309 — Unified cognitive hazard engine (stays Backlog)

## What shipped
- Domain compose module + advanceWeek wire-up
- 10 compose unit tests + 3 advanceWeek integration tests
- Slice doc + backlog handoff

## Validation
- \
pm run lint\`n- \
pm run test:run src/test/cognitiveHazardSiblingCompose.test.ts src/test/advanceWeek.cognitiveHazardSiblingCompose.integration.test.ts src/test/cognitiveHazardWeeklyOrchestration.test.ts src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts\`n
## Docs updated
- \planning/spe-1309-unified-engine-slice-4.md\`n- \planning/backlog.md\`n
## Parent status
SPE-1309 parent remains **Backlog** — agent/knowledge/procedure simulation triggers and planning mirror UI deferred.

Made with [Cursor](https://cursor.com)