### PR TITLE
SPE-1309 slice 5: cognitive hazard simulation triggers

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1309 unified engine follow-up (agent/knowledge/procedure simulation triggers, or planning mirror UI), or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
+**Next step:** SPE-1309 unified engine follow-up (planning mirror UI), or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
 
-**Base `main` SHA:** `289fa998` — shipped: SPE-1309 unified cognitive hazard engine slice 4 @ `planning/spe-1309-unified-engine-slice-4.md` (PR #2810)
+**Base `main` SHA:** `a51d784d` — in progress: SPE-1309 unified cognitive hazard engine slice 5 @ `planning/spe-1309-unified-engine-slice-5.md` (simulation triggers)
 
 **Recently shipped:** SPE-1309 unified cognitive hazard engine slice 4 (PR #2810 @ `9c41fcf6`); SPE-1309 unified cognitive hazard engine slice 3 (PR #2809 @ `0b56a272`).
 
@@ -228,6 +228,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1309-unified-engine-slice-2.md`                      | **Shipped**    | SPE-1309 child — cognitive hazard exposure persistence + hydrate / PR #2808 @ `9b22d0ca`.                                                               |
 | `spe-1309-unified-engine-slice-3.md`                      | **Shipped**    | SPE-1309 child — `advanceWeek` exposure tick + sibling compose helper / PR #2809 @ `0b56a272`.                                                          |
 | `spe-1309-unified-engine-slice-4.md`                      | **Shipped**    | SPE-1309 child — sibling registry compose wire-up from SPE-2108 persisted maps / PR #2810 @ `9c41fcf6`.                                                  |
+| `spe-1309-unified-engine-slice-5.md`                      | **In progress**| SPE-1309 child — agent/knowledge/procedure simulation triggers @ `a51d784d`.                                                                             |
 | `welfare-debt-accounting-registry-slice-2.md`             | **Shipped**    | SPE-2351 / PR #2570; planning mirror UI over `welfareDebtAccountingRecords` @ `96ad05ba`.                                                               |
 | `welfare-debt-accounting-registry-slice-3.md`             | **Shipped**    | SPE-2352 / PR #2572; weekly orchestration hook in `advanceWeek` @ `5673423c`.                                                                          |
 | `welfare-debt-accounting-registry-slice-4.md`             | **Shipped**    | SPE-2353 / PR #2574; ledger summary audit output @ `1ec3ca12`.                                                                                         |

--- a/planning/spe-1309-unified-engine-slice-5.md
+++ b/planning/spe-1309-unified-engine-slice-5.md
@@ -1,0 +1,81 @@
+# SPE-1309 — Unified cognitive hazard engine (slice 5)
+
+One-page implementation plan. Linear: child under [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — **agent/knowledge/procedure simulation triggers (slice 5)** (create/claim on start). Parent [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays **Backlog** — unified engine AC rows 1–3 not fully met until planning mirror UI slice.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1309 child — agent/knowledge/procedure simulation triggers (slice 5)                                   |
+| **Status** | **In progress** — PR pending                                                                               |
+| **Parent** | [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — Unified cognitive hazard engine (umbrella)    |
+| **Branch** | `spe-1309-unified-engine-slice-5`                                                                          |
+| **Base `main` SHA** | `a51d784d`                                                                                          |
+
+## Goal
+
+Consume composed `activeTriggerChannels` and projected effect flags (`agentDutyDegraded`, `knowledgeIntegrityDegraded`, `procedureRestrictionActive`) to drive deterministic simulation side-effects during `advanceWeek` weekly report surfacing and read-side subject routing — without mutating SPE-2108 / SPE-2116 weekly hooks or slice 1–4 compose/tick contracts.
+
+## Prerequisite (on `main` @ `a51d784d`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Engine anchor        | `src/domain/cognitiveHazardEngine.ts` (SPE-1309 slice 1 / PR #2807)    |
+| Persistence          | `cognitiveHazardExposureRecords` on `GameState` (slice 2 / PR #2808)   |
+| Weekly exposure tick | `applyWeeklyCognitiveHazardExposureTick` (slice 3 / PR #2809)          |
+| Sibling compose      | `composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords` (slice 4 / PR #2810) |
+| Surfacing pattern    | `welfareDebtAccountingCrossLinkWeeklyReportNotes`, coercive reconciliation notes |
+
+## Simulation trigger contract (slice 5)
+
+- **Inputs** — post-compose + post-tick `cognitiveHazardExposureRecords`; optional prior-week map for terminal guard.
+- **Resolution** — `projectCognitiveHazardExposureReview`; require non-empty `activeTriggerChannels` and at least one effect flag.
+- **Kinds** — `agent_duty_degraded`, `knowledge_integrity_degraded`, `procedure_restriction_active`.
+- **Terminal guard** — `memoryImpairmentBand === 'erased'` with prior also `erased` does not re-trigger.
+- **Subject grouping** — multiple records for one `subjectRef` merge with deterministic sorted record ids and channel/kind unions.
+- **Read-side routing** — `listCognitiveHazardSimulationTriggersForSubjectRef` uses slice 4 normalized ref keys.
+- **Weekly surfacing** — deterministic report notes after exposure tick; no new persistence fields.
+- **Redaction** — note content uses safe projection labels only; no hidden truth beyond registry projections.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `cognitiveHazardSimulationTriggers.ts` resolve + subject grouping  | Planning mirror UI                            |
+| Surfacing + weekly report note builder                             | SPE-2108 / SPE-2116 weekly hook changes       |
+| Call from `advanceWeek` after exposure tick                        | Slice 1–4 validation/projection/compose edits |
+| Targeted domain + `advanceWeek` integration tests                  | Full SPE-1309 parent Done                     |
+| Slice doc (this file) + backlog handoff                            | Agent vitals mutation                         |
+
+## Acceptance
+
+- [x] Empty exposure map is a no-op without throw
+- [x] Post-tick records with effect flags + channels resolve deterministic trigger kinds
+- [x] Terminal erased records do not re-trigger on subsequent weeks
+- [x] Multiple records for one subject merge with deterministic ordering
+- [x] `advanceWeek` integration matches direct trigger note builder output
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/cognitiveHazardSimulationTriggers.ts`, `src/domain/cognitiveHazardSimulationTriggerSurfacing.ts`, `src/domain/cognitiveHazardSimulationTriggerWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| Tests  | `src/test/cognitiveHazardSimulationTriggers.test.ts`, `src/test/advanceWeek.cognitiveHazardSimulationTriggers.integration.test.ts`, `src/test/reportNoteTypeAudit.test.ts` |
+| Plan   | `planning/spe-1309-unified-engine-slice-5.md`, `planning/backlog.md`  |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Planning mirror UI | SPE-1309 follow-up | Mirror follows orchestration + trigger surfacing |
+| Agent vitals / scoring side-effects from triggers | SPE-1309 follow-up | Slice 5 surfaces via report notes only |
+| Full SPE-1309 parent Done | SPE-1309 | Mirror slice may remain |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/cognitiveHazardSimulationTriggers.test.ts src/test/advanceWeek.cognitiveHazardSimulationTriggers.integration.test.ts src/test/advanceWeek.cognitiveHazardExposureRecords.integration.test.ts src/test/advanceWeek.cognitiveHazardSiblingCompose.integration.test.ts src/test/reportNoteTypeAudit.test.ts`
+
+## See also
+
+- `planning/spe-1309-unified-engine-slice-4.md` — sibling compose (shipped)
+- `planning/self-censoring-information-registry-slice-4.md` — mirror UI template (SPE-2330)

--- a/src/domain/cognitiveHazardSimulationTriggerSurfacing.ts
+++ b/src/domain/cognitiveHazardSimulationTriggerSurfacing.ts
@@ -1,0 +1,84 @@
+/**
+ * SPE-1309 slice 5: read-only surfacing for cognitive hazard simulation triggers.
+ *
+ * Formats trigger resolution output for weekly report notes and read-side routing —
+ * safe labels only; no hidden truth beyond registry projections.
+ */
+
+import type {
+  CognitiveHazardExposureRecordsMap,
+  CognitiveHazardTriggerChannel,
+} from './cognitiveHazardEngine'
+import {
+  composeCognitiveHazardSimulationTriggerSubjectSummaries,
+  type CognitiveHazardSimulationTriggerKind,
+  type CognitiveHazardSimulationTriggerSubjectSummary,
+} from './cognitiveHazardSimulationTriggers'
+
+function formatTriggerChannelLabel(channel: CognitiveHazardTriggerChannel): string {
+  return channel
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+export function formatCognitiveHazardSimulationTriggerKindLabel(
+  kind: CognitiveHazardSimulationTriggerKind
+): string {
+  switch (kind) {
+    case 'agent_duty_degraded':
+      return 'Agent duty degraded'
+    case 'knowledge_integrity_degraded':
+      return 'Knowledge integrity degraded'
+    case 'procedure_restriction_active':
+      return 'Procedure restriction active'
+  }
+}
+
+export function formatCognitiveHazardSimulationTriggerSummaryLabels(
+  summary: CognitiveHazardSimulationTriggerSubjectSummary
+): {
+  readonly triggerKindLabels: readonly string[]
+  readonly triggerChannelLabels: readonly string[]
+} {
+  return Object.freeze({
+    triggerKindLabels: Object.freeze(
+      summary.triggerKinds.map((kind) => formatCognitiveHazardSimulationTriggerKindLabel(kind))
+    ),
+    triggerChannelLabels: Object.freeze(
+      summary.activeTriggerChannels.map((channel) => formatTriggerChannelLabel(channel))
+    ),
+  })
+}
+
+export function formatCognitiveHazardSimulationTriggerNoteContent(
+  summary: CognitiveHazardSimulationTriggerSubjectSummary
+): string {
+  const { triggerKindLabels, triggerChannelLabels } =
+    formatCognitiveHazardSimulationTriggerSummaryLabels(summary)
+  const kindSegment =
+    triggerKindLabels.length > 0 ? triggerKindLabels.join('; ') : 'no active effect flags'
+  const channelSegment =
+    triggerChannelLabels.length > 0 ? triggerChannelLabels.join('; ') : 'no active trigger channels'
+
+  return `Cognitive hazard simulation trigger — ${summary.subjectRef}: ${summary.recordIds.length} exposure record(s), review band ${summary.exposureReviewBand}. Effects: ${kindSegment}. Channels: ${channelSegment}.`
+}
+
+export function composeAllCognitiveHazardSimulationTriggerSubjectSummaries(input: {
+  records: CognitiveHazardExposureRecordsMap | null | undefined
+  priorRecords?: CognitiveHazardExposureRecordsMap | null | undefined
+}): readonly CognitiveHazardSimulationTriggerSubjectSummary[] {
+  return composeCognitiveHazardSimulationTriggerSubjectSummaries(
+    input.records,
+    input.priorRecords
+  )
+}
+
+export function summarizeCognitiveHazardSimulationTriggerFingerprint(
+  summaries: readonly CognitiveHazardSimulationTriggerSubjectSummary[]
+): string {
+  return summaries
+    .map((summary) => summary.structuredReasons.join('|'))
+    .sort((left, right) => left.localeCompare(right))
+    .join(';;')
+}

--- a/src/domain/cognitiveHazardSimulationTriggerWeeklyReportNotes.ts
+++ b/src/domain/cognitiveHazardSimulationTriggerWeeklyReportNotes.ts
@@ -1,0 +1,61 @@
+/**
+ * SPE-1309 slice 5: weekly report notes for cognitive hazard simulation triggers.
+ *
+ * Emits deterministic notes when post-tick exposure records resolve active triggers —
+ * no new persistence.
+ */
+
+import type { CognitiveHazardExposureRecordsMap } from './cognitiveHazardEngine'
+import {
+  composeAllCognitiveHazardSimulationTriggerSubjectSummaries,
+  formatCognitiveHazardSimulationTriggerNoteContent,
+} from './cognitiveHazardSimulationTriggerSurfacing'
+import type { ReportNote } from './models'
+import { createDeterministicReportNote } from './reportNotes'
+
+/**
+ * Builds weekly report notes when cognitive hazard exposure records resolve simulation triggers.
+ */
+export function buildWeeklyCognitiveHazardSimulationTriggerReportNotes(input: {
+  nextRecords: CognitiveHazardExposureRecordsMap | null | undefined
+  priorRecords?: CognitiveHazardExposureRecordsMap | null | undefined
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const nextSummaries = composeAllCognitiveHazardSimulationTriggerSubjectSummaries({
+    records: input.nextRecords,
+    priorRecords: input.priorRecords,
+  })
+
+  if (nextSummaries.length === 0) {
+    return []
+  }
+
+  const notes: ReportNote[] = []
+  let sequence = input.sequenceStart
+
+  for (const summary of nextSummaries) {
+    notes.push(
+      createDeterministicReportNote(
+        formatCognitiveHazardSimulationTriggerNoteContent(summary),
+        input.week,
+        sequence,
+        input.baseTimestamp,
+        'cognitive_hazard.simulation_trigger',
+        {
+          subjectRef: summary.subjectRef,
+          linkedRecordCount: summary.recordIds.length,
+          exposureReviewBand: summary.exposureReviewBand,
+          triggerKinds: [...summary.triggerKinds],
+          activeTriggerChannels: [...summary.activeTriggerChannels],
+          structuredReasons: [...summary.structuredReasons],
+          week: input.week,
+        }
+      )
+    )
+    sequence += 1
+  }
+
+  return notes
+}

--- a/src/domain/cognitiveHazardSimulationTriggers.ts
+++ b/src/domain/cognitiveHazardSimulationTriggers.ts
@@ -1,0 +1,285 @@
+/**
+ * SPE-1309 slice 5: simulation trigger resolution from composed exposure records.
+ *
+ * Consumes post-compose `activeTriggerChannels` and projected effect flags without
+ * mutating SPE-2108 / SPE-2116 weekly hooks or slice 1–4 compose/tick contracts.
+ */
+
+import {
+  projectCognitiveHazardExposureReview,
+  type CognitiveHazardExposureRecord,
+  type CognitiveHazardExposureRecordsMap,
+  type CognitiveHazardExposureReviewBand,
+  type CognitiveHazardTriggerChannel,
+} from './cognitiveHazardEngine'
+import { resolveCognitiveHazardSiblingRefKeys } from './cognitiveHazardSiblingCompose'
+
+export type CognitiveHazardSimulationTriggerKind =
+  | 'agent_duty_degraded'
+  | 'knowledge_integrity_degraded'
+  | 'procedure_restriction_active'
+
+export const COGNITIVE_HAZARD_SIMULATION_TRIGGER_KINDS: readonly CognitiveHazardSimulationTriggerKind[] =
+  Object.freeze([
+    'agent_duty_degraded',
+    'knowledge_integrity_degraded',
+    'procedure_restriction_active',
+  ] as const)
+
+export interface CognitiveHazardSimulationTrigger {
+  readonly recordId: string
+  readonly subjectRef: string
+  readonly label: string
+  readonly activeTriggerChannels: readonly CognitiveHazardTriggerChannel[]
+  readonly triggerKinds: readonly CognitiveHazardSimulationTriggerKind[]
+  readonly exposureReviewBand: CognitiveHazardExposureReviewBand
+}
+
+export interface CognitiveHazardSimulationTriggerSubjectSummary {
+  readonly subjectRef: string
+  readonly recordIds: readonly string[]
+  readonly triggerKinds: readonly CognitiveHazardSimulationTriggerKind[]
+  readonly activeTriggerChannels: readonly CognitiveHazardTriggerChannel[]
+  readonly exposureReviewBand: CognitiveHazardExposureReviewBand
+  readonly structuredReasons: readonly string[]
+}
+
+function sortedUniqueTriggerKinds(
+  kinds: readonly CognitiveHazardSimulationTriggerKind[]
+): readonly CognitiveHazardSimulationTriggerKind[] {
+  return Object.freeze([...new Set(kinds)].sort((left, right) => left.localeCompare(right)))
+}
+
+function sortedUniqueTriggerChannels(
+  channels: readonly CognitiveHazardTriggerChannel[]
+): readonly CognitiveHazardTriggerChannel[] {
+  return Object.freeze([...new Set(channels)].sort((left, right) => left.localeCompare(right)))
+}
+
+function resolveActiveSimulationTriggerKinds(input: {
+  agentDutyDegraded: boolean
+  knowledgeIntegrityDegraded: boolean
+  procedureRestrictionActive: boolean
+  activeTriggerChannels: readonly CognitiveHazardTriggerChannel[]
+}): readonly CognitiveHazardSimulationTriggerKind[] {
+  if (input.activeTriggerChannels.length === 0) {
+    return Object.freeze([] as CognitiveHazardSimulationTriggerKind[])
+  }
+
+  const kinds: CognitiveHazardSimulationTriggerKind[] = []
+
+  if (input.agentDutyDegraded) {
+    kinds.push('agent_duty_degraded')
+  }
+
+  if (input.knowledgeIntegrityDegraded) {
+    kinds.push('knowledge_integrity_degraded')
+  }
+
+  if (input.procedureRestrictionActive) {
+    kinds.push('procedure_restriction_active')
+  }
+
+  return sortedUniqueTriggerKinds(kinds)
+}
+
+function resolveExposureReviewBandPriority(
+  band: CognitiveHazardExposureReviewBand
+): number {
+  switch (band) {
+    case 'critical':
+      return 3
+    case 'elevated':
+      return 2
+    case 'stable':
+      return 1
+  }
+}
+
+function maxExposureReviewBand(
+  left: CognitiveHazardExposureReviewBand,
+  right: CognitiveHazardExposureReviewBand
+): CognitiveHazardExposureReviewBand {
+  return resolveExposureReviewBandPriority(left) >= resolveExposureReviewBandPriority(right)
+    ? left
+    : right
+}
+
+/** Terminal erased posture must not re-fire triggers when unchanged week-over-week. */
+export function shouldEmitCognitiveHazardSimulationTrigger(
+  record: CognitiveHazardExposureRecord,
+  priorRecord: CognitiveHazardExposureRecord | undefined,
+  triggerKinds: readonly CognitiveHazardSimulationTriggerKind[]
+): boolean {
+  if (triggerKinds.length === 0) {
+    return false
+  }
+
+  if (
+    record.memoryImpairmentBand === 'erased' &&
+    priorRecord?.memoryImpairmentBand === 'erased'
+  ) {
+    return false
+  }
+
+  return true
+}
+
+export function resolveCognitiveHazardSimulationTriggerForRecord(
+  record: CognitiveHazardExposureRecord,
+  priorRecord: CognitiveHazardExposureRecord | undefined
+): CognitiveHazardSimulationTrigger | null {
+  const projection = projectCognitiveHazardExposureReview(record)
+  const triggerKinds = resolveActiveSimulationTriggerKinds({
+    agentDutyDegraded: projection.agentDutyDegraded,
+    knowledgeIntegrityDegraded: projection.knowledgeIntegrityDegraded,
+    procedureRestrictionActive: projection.procedureRestrictionActive,
+    activeTriggerChannels: projection.activeTriggerChannels,
+  })
+
+  if (!shouldEmitCognitiveHazardSimulationTrigger(record, priorRecord, triggerKinds)) {
+    return null
+  }
+
+  return Object.freeze({
+    recordId: record.id,
+    subjectRef: record.subjectRef,
+    label: record.label,
+    activeTriggerChannels: projection.activeTriggerChannels,
+    triggerKinds,
+    exposureReviewBand: projection.exposureReviewBand,
+  })
+}
+
+/** Resolve simulation triggers for all exposure records with deterministic record-id ordering. */
+export function resolveCognitiveHazardSimulationTriggers(
+  records: CognitiveHazardExposureRecordsMap | null | undefined,
+  priorRecords: CognitiveHazardExposureRecordsMap | null | undefined = undefined
+): readonly CognitiveHazardSimulationTrigger[] {
+  const safeRecords = records ?? {}
+  const safePriorRecords = priorRecords ?? {}
+  const recordIds = Object.keys(safeRecords)
+
+  if (recordIds.length === 0) {
+    return Object.freeze([] as CognitiveHazardSimulationTrigger[])
+  }
+
+  const triggers: CognitiveHazardSimulationTrigger[] = []
+
+  for (const recordId of recordIds.sort((left, right) => left.localeCompare(right))) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const trigger = resolveCognitiveHazardSimulationTriggerForRecord(
+      record,
+      safePriorRecords[recordId]
+    )
+    if (trigger) {
+      triggers.push(trigger)
+    }
+  }
+
+  return Object.freeze(triggers)
+}
+
+function subjectRefsOverlap(leftRef: string, rightRef: string): boolean {
+  const leftKeys = new Set(resolveCognitiveHazardSiblingRefKeys(leftRef))
+  if (leftKeys.size === 0) {
+    return false
+  }
+
+  for (const key of resolveCognitiveHazardSiblingRefKeys(rightRef)) {
+    if (leftKeys.has(key)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function buildStructuredReason(trigger: CognitiveHazardSimulationTrigger): string {
+  return [
+    trigger.recordId,
+    trigger.exposureReviewBand,
+    trigger.triggerKinds.join('+'),
+    trigger.activeTriggerChannels.join('+'),
+  ].join('|')
+}
+
+/** Group resolved triggers by subject ref for deterministic weekly surfacing and routing. */
+export function composeCognitiveHazardSimulationTriggerSubjectSummaries(
+  records: CognitiveHazardExposureRecordsMap | null | undefined,
+  priorRecords: CognitiveHazardExposureRecordsMap | null | undefined = undefined
+): readonly CognitiveHazardSimulationTriggerSubjectSummary[] {
+  const triggers = resolveCognitiveHazardSimulationTriggers(records, priorRecords)
+  if (triggers.length === 0) {
+    return Object.freeze([] as CognitiveHazardSimulationTriggerSubjectSummary[])
+  }
+
+  const grouped = new Map<string, CognitiveHazardSimulationTrigger[]>()
+
+  for (const trigger of triggers) {
+    const existing = grouped.get(trigger.subjectRef) ?? []
+    existing.push(trigger)
+    grouped.set(trigger.subjectRef, existing)
+  }
+
+  const summaries: CognitiveHazardSimulationTriggerSubjectSummary[] = []
+
+  for (const subjectRef of [...grouped.keys()].sort((left, right) => left.localeCompare(right))) {
+    const subjectTriggers = grouped.get(subjectRef) ?? []
+    const allRecordIds = Object.freeze(
+      [...new Set(subjectTriggers.map((trigger) => trigger.recordId))].sort((left, right) =>
+        left.localeCompare(right)
+      )
+    )
+    const allKinds = sortedUniqueTriggerKinds(
+      subjectTriggers.flatMap((trigger) => trigger.triggerKinds)
+    )
+    const allChannels = sortedUniqueTriggerChannels(
+      subjectTriggers.flatMap((trigger) => trigger.activeTriggerChannels)
+    )
+    const exposureReviewBand = subjectTriggers.reduce(
+      (current, trigger) => maxExposureReviewBand(current, trigger.exposureReviewBand),
+      'stable' as CognitiveHazardExposureReviewBand
+    )
+    const structuredReasons = Object.freeze(
+      subjectTriggers
+        .map((trigger) => buildStructuredReason(trigger))
+        .sort((left, right) => left.localeCompare(right))
+    )
+
+    summaries.push(
+      Object.freeze({
+        subjectRef,
+        recordIds: allRecordIds,
+        triggerKinds: allKinds,
+        activeTriggerChannels: allChannels,
+        exposureReviewBand,
+        structuredReasons,
+      })
+    )
+  }
+
+  return Object.freeze(summaries)
+}
+
+/** Read-side routing helper: triggers linked to one subject ref via normalized key overlap. */
+export function listCognitiveHazardSimulationTriggersForSubjectRef(
+  records: CognitiveHazardExposureRecordsMap | null | undefined,
+  subjectRef: string,
+  priorRecords: CognitiveHazardExposureRecordsMap | null | undefined = undefined
+): readonly CognitiveHazardSimulationTrigger[] {
+  const normalizedSubjectRef = subjectRef.trim()
+  if (!normalizedSubjectRef) {
+    return Object.freeze([] as CognitiveHazardSimulationTrigger[])
+  }
+
+  return Object.freeze(
+    resolveCognitiveHazardSimulationTriggers(records, priorRecords).filter((trigger) =>
+      subjectRefsOverlap(trigger.subjectRef, normalizedSubjectRef)
+    )
+  )
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1545,6 +1545,7 @@ export type ReportNoteType =
   | 'post_incident_review.follow_on'
   | 'post_incident_review.closeout_reward_payout'
   | 'public_disclosure.trust_outcome'
+  | 'cognitive_hazard.simulation_trigger'
 
 export type ReportNoteMetadataValue =
   | string

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -276,6 +276,7 @@ import { applyWeeklySurveillanceInterventionTuningTick } from '../surveillanceIn
 import { applyWeeklyPsychologicalResilienceDepletionTick } from '../psychologicalResilienceWeeklyOrchestration'
 import { composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords } from '../cognitiveHazardSiblingCompose'
 import { applyWeeklyCognitiveHazardExposureTick } from '../cognitiveHazardWeeklyOrchestration'
+import { buildWeeklyCognitiveHazardSimulationTriggerReportNotes } from '../cognitiveHazardSimulationTriggerWeeklyReportNotes'
 import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   resolveCoerciveProcedureExecutionDrafts,
@@ -4862,6 +4863,36 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       currentCognitiveHazardExposureRecords,
       result.week
     )
+  }
+
+  // SPE-1309 slice 5: surface agent/knowledge/procedure simulation triggers from post-tick projections.
+  const priorCognitiveHazardExposureRecords = sourceState.cognitiveHazardExposureRecords ?? {}
+  const nextCognitiveHazardExposureRecordsForTriggers =
+    outputWeeklyState.cognitiveHazardExposureRecords ?? {}
+  if (
+    Object.keys(nextCognitiveHazardExposureRecordsForTriggers).length > 0 &&
+    result.reports.length > 0
+  ) {
+    const lastWeeklyReport = result.reports[result.reports.length - 1]
+    const cognitiveHazardSimulationTriggerNotes =
+      buildWeeklyCognitiveHazardSimulationTriggerReportNotes({
+        nextRecords: nextCognitiveHazardExposureRecordsForTriggers,
+        priorRecords: priorCognitiveHazardExposureRecords,
+        week: result.week,
+        sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
+        baseTimestamp: noteBaseTimestamp,
+      })
+
+    if (cognitiveHazardSimulationTriggerNotes.length > 0) {
+      const reports = [...result.reports]
+      const lastReportIndex = reports.length - 1
+      const lastReport = reports[lastReportIndex]
+      reports[lastReportIndex] = {
+        ...lastReport,
+        notes: [...(lastReport.notes ?? []), ...cognitiveHazardSimulationTriggerNotes],
+      }
+      result.reports = reports
+    }
   }
 
   // SPE-1888 slice 5: welfare-debt creation when coercive procedures execute with containment improvement.

--- a/src/test/advanceWeek.cognitiveHazardSimulationTriggers.integration.test.ts
+++ b/src/test/advanceWeek.cognitiveHazardSimulationTriggers.integration.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+} from '../domain/cognitiveHazardEngine'
+import { buildWeeklyCognitiveHazardSimulationTriggerReportNotes } from '../domain/cognitiveHazardSimulationTriggerWeeklyReportNotes'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek cognitive hazard simulation triggers integration (SPE-1309 slice 5)', () => {
+  it('is a no-op for an empty exposure map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.cognitiveHazardExposureRecords).toEqual({})
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    expect(
+      lastReport?.notes?.filter((note) => note.type === 'cognitive_hazard.simulation_trigger') ?? []
+    ).toEqual([])
+  })
+
+  it('surfaces simulation trigger notes for memetic escalation fixture on first week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const triggerNotes =
+      nextState.reports[nextState.reports.length - 1]?.notes?.filter(
+        (note) => note.type === 'cognitive_hazard.simulation_trigger'
+      ) ?? []
+
+    expect(triggerNotes.length).toBeGreaterThan(0)
+    expect(triggerNotes[0]?.content).toContain(COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.subjectRef)
+    expect(triggerNotes[0]?.content).toContain('Knowledge integrity degraded')
+  })
+
+  it('does not re-trigger terminal erased failed countermeasure fixture on subsequent weeks', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE.id]:
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+    }
+
+    const firstWeek = advanceWeek(state)
+    const secondWeek = advanceWeek(firstWeek)
+    const triggerNotes =
+      secondWeek.reports[secondWeek.reports.length - 1]?.notes?.filter(
+        (note) => note.type === 'cognitive_hazard.simulation_trigger'
+      ) ?? []
+
+    expect(triggerNotes).toEqual([])
+  })
+
+  it('does not surface trigger notes for stable subject fixture', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const triggerNotes =
+      nextState.reports[nextState.reports.length - 1]?.notes?.filter(
+        (note) => note.type === 'cognitive_hazard.simulation_trigger'
+      ) ?? []
+
+    expect(triggerNotes).toEqual([])
+  })
+
+  it('matches direct trigger note builder output inside advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const directNotes = buildWeeklyCognitiveHazardSimulationTriggerReportNotes({
+      nextRecords: nextState.cognitiveHazardExposureRecords,
+      priorRecords: state.cognitiveHazardExposureRecords,
+      week: nextState.week,
+      sequenceStart: 1,
+    })
+    const triggerNotes =
+      lastReport?.notes?.filter((note) => note.type === 'cognitive_hazard.simulation_trigger') ??
+      []
+
+    expect(triggerNotes.map((note) => note.content)).toEqual(
+      directNotes.map((note) => note.content)
+    )
+  })
+})

--- a/src/test/cognitiveHazardSimulationTriggers.test.ts
+++ b/src/test/cognitiveHazardSimulationTriggers.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+  type CognitiveHazardExposureRecord,
+} from '../domain/cognitiveHazardEngine'
+import {
+  composeCognitiveHazardSimulationTriggerSubjectSummaries,
+  listCognitiveHazardSimulationTriggersForSubjectRef,
+  resolveCognitiveHazardSimulationTriggerForRecord,
+  resolveCognitiveHazardSimulationTriggers,
+  shouldEmitCognitiveHazardSimulationTrigger,
+} from '../domain/cognitiveHazardSimulationTriggers'
+import { buildWeeklyCognitiveHazardSimulationTriggerReportNotes } from '../domain/cognitiveHazardSimulationTriggerWeeklyReportNotes'
+
+function baseRecord(
+  overrides: Partial<CognitiveHazardExposureRecord> = {}
+): CognitiveHazardExposureRecord {
+  return {
+    id: 'cognitive-hazard:simulation-trigger-test',
+    label: 'Simulation trigger test exposure profile',
+    subjectRef: 'agent:simulation-trigger-test',
+    activeTriggerChannels: ['direct_perception'],
+    fearPressure: 0.2,
+    memeticExposure: 0.15,
+    memoryImpairmentBand: 'intact',
+    countermeasurePosture: 'none',
+    ...overrides,
+  }
+}
+
+describe('cognitiveHazardSimulationTriggers (SPE-1309 slice 5)', () => {
+  it('is a no-op for an empty exposure map without throwing', () => {
+    expect(resolveCognitiveHazardSimulationTriggers({})).toEqual([])
+    expect(resolveCognitiveHazardSimulationTriggers(undefined)).toEqual([])
+    expect(composeCognitiveHazardSimulationTriggerSubjectSummaries({})).toEqual([])
+  })
+
+  it('does not trigger stable subject fixture without effect flags', () => {
+    expect(
+      resolveCognitiveHazardSimulationTriggerForRecord(
+        COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+        undefined
+      )
+    ).toBeNull()
+  })
+
+  it('resolves knowledge triggers for memetic escalation fixture before weekly band advance', () => {
+    const trigger = resolveCognitiveHazardSimulationTriggerForRecord(
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      undefined
+    )
+
+    expect(trigger).not.toBeNull()
+    expect(trigger?.triggerKinds).toEqual(['knowledge_integrity_degraded'])
+    expect(trigger?.activeTriggerChannels).toEqual([
+      'direct_perception',
+      'reference_description',
+    ])
+  })
+
+  it('does not re-trigger terminal erased records when prior posture was already erased', () => {
+    expect(
+      shouldEmitCognitiveHazardSimulationTrigger(
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+        ['agent_duty_degraded', 'knowledge_integrity_degraded', 'procedure_restriction_active']
+      )
+    ).toBe(false)
+
+    expect(
+      resolveCognitiveHazardSimulationTriggerForRecord(
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE
+      )
+    ).toBeNull()
+  })
+
+  it('emits failed countermeasure triggers on first week when prior record is absent', () => {
+    const trigger = resolveCognitiveHazardSimulationTriggerForRecord(
+      COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+      undefined
+    )
+
+    expect(trigger?.triggerKinds).toEqual([
+      'agent_duty_degraded',
+      'knowledge_integrity_degraded',
+      'procedure_restriction_active',
+    ])
+  })
+
+  it('groups multiple records for one subject with deterministic ordering', () => {
+    const sharedSubjectRef = 'agent:shared-subject-1'
+    const first = baseRecord({
+      id: 'cognitive-hazard:shared-b',
+      subjectRef: sharedSubjectRef,
+      memoryImpairmentBand: 'fragmented',
+      knowledgeIntegrityDegraded: true,
+      activeTriggerChannels: ['reference_description'],
+      fearPressure: 0.62,
+      memeticExposure: 0.48,
+    })
+    const second = baseRecord({
+      id: 'cognitive-hazard:shared-a',
+      subjectRef: sharedSubjectRef,
+      memoryImpairmentBand: 'compromised',
+      knowledgeIntegrityDegraded: true,
+      agentDutyDegraded: true,
+      activeTriggerChannels: ['direct_perception', 'memory_interaction'],
+      countermeasurePosture: 'procedure_restricted',
+      procedureRestrictionActive: true,
+      fearPressure: 0.72,
+      memeticExposure: 0.81,
+    })
+
+    const summaries = composeCognitiveHazardSimulationTriggerSubjectSummaries({
+      [first.id]: first,
+      [second.id]: second,
+    })
+
+    expect(summaries).toHaveLength(1)
+    expect(summaries[0]?.subjectRef).toBe(sharedSubjectRef)
+    expect(summaries[0]?.recordIds).toEqual([
+      'cognitive-hazard:shared-a',
+      'cognitive-hazard:shared-b',
+    ])
+    expect(summaries[0]?.triggerKinds).toEqual([
+      'agent_duty_degraded',
+      'knowledge_integrity_degraded',
+      'procedure_restriction_active',
+    ])
+  })
+
+  it('lists triggers for subject refs with namespace overlap', () => {
+    const record = baseRecord({
+      subjectRef: 'agent:field-analyst-7',
+      memoryImpairmentBand: 'fragmented',
+      knowledgeIntegrityDegraded: true,
+      activeTriggerChannels: ['reference_description'],
+      fearPressure: 0.62,
+      memeticExposure: 0.48,
+    })
+
+    const triggers = listCognitiveHazardSimulationTriggersForSubjectRef(
+      { [record.id]: record },
+      'field-analyst-7'
+    )
+
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0]?.recordId).toBe(record.id)
+  })
+
+  it('builds deterministic weekly report notes from trigger summaries', () => {
+    const notes = buildWeeklyCognitiveHazardSimulationTriggerReportNotes({
+      nextRecords: {
+        [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+          COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      },
+      week: 2,
+      sequenceStart: 1,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.type).toBe('cognitive_hazard.simulation_trigger')
+    expect(notes[0]?.content).toContain('Cognitive hazard simulation trigger')
+    expect(notes[0]?.content).toContain('Knowledge integrity degraded')
+  })
+
+  it('skips records with effect flags but no active trigger channels', () => {
+    const record = baseRecord({
+      knowledgeIntegrityDegraded: true,
+      activeTriggerChannels: [],
+    })
+
+    expect(resolveCognitiveHazardSimulationTriggerForRecord(record, undefined)).toBeNull()
+  })
+})

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -83,6 +83,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
     producer: 'publicDisclosureTrustOutcomeWeeklyReportNotes',
     category: 'system',
   },
+  'cognitive_hazard.simulation_trigger': {
+    status: 'active',
+    producer: 'cognitiveHazardSimulationTriggerWeeklyReportNotes',
+    category: 'system',
+  },
 } as const satisfies Record<
   ReportNoteType,
   { status: 'active' | 'future-reserved' | 'stale'; producer: string; category: string }
@@ -94,7 +99,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(45)
+    expect(entries).toHaveLength(46)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Add pure domain trigger resolution from post-tick `cognitiveHazardExposureRecords` using composed `activeTriggerChannels` and projected effect flags (`agentDutyDegraded`, `knowledgeIntegrityDegraded`, `procedureRestrictionActive`).
- Surface deterministic weekly report notes (`cognitive_hazard.simulation_trigger`) from `advanceWeek` after the slice 3 exposure tick; terminal erased records do not re-trigger on subsequent weeks.
- Add read-side routing helper `listCognitiveHazardSimulationTriggersForSubjectRef` with slice 4 ref-key overlap.

## Linear

- **Slice:** SPE-1309 child — agent/knowledge/procedure simulation triggers (slice 5)
- **Parent:** SPE-1309 — Unified cognitive hazard engine (stays Backlog)

## What shipped

- `cognitiveHazardSimulationTriggers.ts`, surfacing + weekly report note modules
- `advanceWeek` hook after exposure tick
- Domain unit + integration tests

## Validation

- `npm run lint`
- `npm run test:run src/test/cognitiveHazardSimulationTriggers.test.ts src/test/advanceWeek.cognitiveHazardSimulationTriggers.integration.test.ts src/test/reportNoteTypeAudit.test.ts`

## Docs

- `planning/spe-1309-unified-engine-slice-5.md`
- `planning/backlog.md` handoff

## Parent remains open

Planning mirror UI deferred to follow-up slice.

Made with [Cursor](https://cursor.com)