### PR TITLE
SPE-1309 slice 6: cognitive hazard exposure planning mirror UI

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,11 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1309 unified engine follow-up (planning mirror UI), or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
+**Next step:** SPE-1309 parent acceptance / AC reconciliation after mirror UI ships, or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
 
-**Base `main` SHA:** `95f353e4` — shipped: SPE-1309 unified cognitive hazard engine slice 5 @ `planning/spe-1309-unified-engine-slice-5.md` (PR #2811)
+**Base `main` SHA:** `68f5fc2e` — in progress: SPE-1309 unified cognitive hazard engine slice 6 (planning mirror UI) @ `planning/spe-1309-unified-engine-slice-6.md` on branch `spe-1309-unified-engine-slice-6`
 
-**Recently shipped:** SPE-1309 unified cognitive hazard engine slice 4 (PR #2810 @ `9c41fcf6`); SPE-1309 unified cognitive hazard engine slice 3 (PR #2809 @ `0b56a272`).
+**Recently shipped:** SPE-1309 unified cognitive hazard engine slice 5 (PR #2811 @ `8f5fde47`); SPE-1309 unified cognitive hazard engine slice 4 (PR #2810 @ `9c41fcf6`).
 
 **Recently shipped:** SPE-1882 coercive protocol mirror snapshot read slice 11 (PR #2798); SPE-1309 parent acceptance review grooming slice 4 (PR #2796); SPE-1888 parent acceptance review grooming slice 6 (PR #2793).
 
@@ -229,6 +229,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1309-unified-engine-slice-3.md`                      | **Shipped**    | SPE-1309 child — `advanceWeek` exposure tick + sibling compose helper / PR #2809 @ `0b56a272`.                                                          |
 | `spe-1309-unified-engine-slice-4.md`                      | **Shipped**    | SPE-1309 child — sibling registry compose wire-up from SPE-2108 persisted maps / PR #2810 @ `9c41fcf6`.                                                  |
 | `spe-1309-unified-engine-slice-5.md`                      | **Shipped**    | SPE-1309 child — agent/knowledge/procedure simulation triggers / PR #2811 @ `8f5fde47`.                                                                  |
+| `spe-1309-unified-engine-slice-6.md`                      | **In progress** | SPE-1309 child — planning mirror UI / branch `spe-1309-unified-engine-slice-6` @ `68f5fc2e`.                                                              |
 | `welfare-debt-accounting-registry-slice-2.md`             | **Shipped**    | SPE-2351 / PR #2570; planning mirror UI over `welfareDebtAccountingRecords` @ `96ad05ba`.                                                               |
 | `welfare-debt-accounting-registry-slice-3.md`             | **Shipped**    | SPE-2352 / PR #2572; weekly orchestration hook in `advanceWeek` @ `5673423c`.                                                                          |
 | `welfare-debt-accounting-registry-slice-4.md`             | **Shipped**    | SPE-2353 / PR #2574; ledger summary audit output @ `1ec3ca12`.                                                                                         |

--- a/planning/spe-1309-unified-engine-slice-6.md
+++ b/planning/spe-1309-unified-engine-slice-6.md
@@ -1,0 +1,69 @@
+# SPE-1309 — Unified cognitive hazard engine (slice 6)
+
+One-page implementation plan. Linear: child under [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — **planning mirror UI (slice 6)** (create/claim on start). Parent [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays **Backlog** until unified engine AC rows 1–3 are reconciled after mirror ships.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1309 child — planning mirror UI (slice 6)                                                            |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — Unified cognitive hazard engine (umbrella)    |
+| **Branch** | `spe-1309-unified-engine-slice-6`                                                                          |
+| **Base `main` SHA** | `68f5fc2e`                                                                                          |
+
+## Goal
+
+Read-only planning mirror over persisted `cognitiveHazardExposureRecords` projecting safe labels from `projectCognitiveHazardExposureReview` and slice 5 trigger subject summaries — no re-validation surfacing, no hidden truth, no changes to compose/tick/trigger contracts.
+
+## Prerequisite (on `main` @ `68f5fc2e`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Engine anchor        | `src/domain/cognitiveHazardEngine.ts` (slice 1 / PR #2807)             |
+| Persistence          | `cognitiveHazardExposureRecords` on `GameState` (slice 2 / PR #2808) |
+| Weekly exposure tick | `applyWeeklyCognitiveHazardExposureTick` (slice 3 / PR #2809)          |
+| Sibling compose      | `composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords` (slice 4 / PR #2810) |
+| Simulation triggers  | `cognitiveHazardSimulationTriggers.ts` + surfacing (slice 5 / PR #2811) |
+| Mirror template      | `selfCensoringInformationMirrorView.ts` (SPE-2330), `publicDisclosureMirrorView.ts` (SPE-2331) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `cognitiveHazardExposureMirrorView.ts` + page + route              | SPE-2108 / SPE-2116 weekly hook changes       |
+| UI copy in `src/data/copy.ts`                                      | Slice 1–5 domain compose/tick/trigger edits   |
+| Mirror view unit tests + route smoke                               | Agent vitals / scoring side-effects           |
+| Slice doc (this file) + backlog handoff                            | Full SPE-1309 parent Done (grooming may follow) |
+
+## Acceptance
+
+- [ ] Empty exposure map renders empty state
+- [ ] Fixture rows mirror projection labels deterministically (sorted by record id)
+- [ ] Redacted unit scores show `—`; summary shows `[Redacted]` only when summary field is redacted — never raw pre-projection values
+- [ ] Trigger chip labels come from `composeCognitiveHazardSimulationTriggerSubjectSummaries` + `formatCognitiveHazardSimulationTriggerSummaryLabels`
+- [ ] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Mirror | `src/features/operations/cognitiveHazardExposureMirrorView.ts`, `CognitiveHazardExposureMirrorPage.tsx` |
+| App    | `src/app/routes.ts`, `src/app/App.tsx`, `src/data/copy.ts`            |
+| Tests  | `src/features/operations/cognitiveHazardExposureMirrorView.test.ts`, `CognitiveHazardExposureMirrorPage.test.tsx` |
+| Plan   | `planning/spe-1309-unified-engine-slice-6.md`, `planning/backlog.md`  |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1309 parent acceptance / AC reconciliation | SPE-1309 follow-up | Mirror slice does not alone satisfy parent AC rows 1–3 |
+| Agent vitals from simulation triggers | SPE-1309 follow-up | Slice 5 surfaces via report notes only |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/features/operations/cognitiveHazardExposureMirrorView.test.ts src/features/operations/CognitiveHazardExposureMirrorPage.test.tsx`
+
+## See also
+
+- `planning/spe-1309-unified-engine-slice-5.md` — simulation triggers (shipped)
+- `planning/self-censoring-information-registry-slice-4.md` — mirror UI template (SPE-2330)

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -114,6 +114,9 @@ const CoerciveContainedPersonProtocolMirrorRoute = createRouteComponent(
 const PsychologicalResilienceMirrorRoute = createRouteComponent(
   () => import('../features/operations/PsychologicalResilienceMirrorPage')
 )
+const CognitiveHazardExposureMirrorRoute = createRouteComponent(
+  () => import('../features/operations/CognitiveHazardExposureMirrorPage')
+)
 const SurveillanceInterventionTuningMirrorRoute = createRouteComponent(
   () => import('../features/operations/SurveillanceInterventionTuningMirrorPage')
 )
@@ -229,6 +232,10 @@ export default function App() {
         <Route
           path="psychological-resilience"
           element={renderLazyRoute(PsychologicalResilienceMirrorRoute)}
+        />
+        <Route
+          path="cognitive-hazard-exposure"
+          element={renderLazyRoute(CognitiveHazardExposureMirrorRoute)}
         />
         <Route
           path="surveillance-intervention-tuning"

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -37,6 +37,7 @@ export const APP_ROUTES = {
   containedPersonTherapeuticCare: '/contained-person-therapeutic-care',
   coerciveContainedPersonProtocol: '/coercive-contained-person-protocol',
   psychologicalResilience: '/psychological-resilience',
+  cognitiveHazardExposure: '/cognitive-hazard-exposure',
   surveillanceInterventionTuning: '/surveillance-intervention-tuning',
   namingHazardDescriptor: '/naming-hazard-descriptor',
   containedPersonIntegratedHealthBundle: '/contained-person-integrated-health-bundle',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1408,6 +1408,45 @@ export const PSYCHOLOGICAL_RESILIENCE_MIRROR_UI_TEXT: Record<string, string> = {
   redactedSuffix: 'Partial redaction',
 }
 
+export const COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Cognitive hazard exposure registry',
+  pageSubtitle:
+    'Read-only operations view over persisted unified cognitive hazard exposure records, review-band projections, and simulation trigger summaries.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Persisted records',
+  elevatedExposureLabel: 'Elevated exposure',
+  simulationTriggerSubjectsLabel: 'Simulation trigger subjects',
+  countermeasureFailedLabel: 'Countermeasure failed',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Exposure pressures, review bands, and trigger chips mirror hydrated GameState only. Invalid records dropped on hydrate are not shown here.',
+  emptyTitle: 'No cognitive hazard exposure records',
+  emptyBody:
+    'Persisted cognitive hazard exposure records will appear here after hydration. This mirror does not re-validate hidden truth.',
+  recordsHeading: 'Persisted records',
+  recordsSubtitle:
+    'Review projections and simulation trigger labels are read-time only; pre-projection field values are not surfaced.',
+  labelColumn: 'Label',
+  subjectColumn: 'Subject / channels',
+  exposureColumn: 'Exposure pressures',
+  memoryColumn: 'Memory / countermeasure',
+  reviewColumn: 'Review band / effects',
+  triggerColumn: 'Simulation triggers',
+  confidenceColumn: 'Confidence',
+  subjectRefPrefix: 'Subject:',
+  fearPressurePrefix: 'Fear:',
+  memeticExposurePrefix: 'Memetic:',
+  aggregateExposurePrefix: 'Aggregate:',
+  agentDutySuffix: 'Agent duty degraded',
+  knowledgeIntegritySuffix: 'Knowledge integrity degraded',
+  procedureRestrictionSuffix: 'Procedure restriction active',
+  countermeasureFailedSuffix: 'Countermeasure failed',
+  countermeasureShieldingSuffix: 'Shielding active',
+  memoryImpairmentAdvancedSuffix: 'Memory impairment advanced',
+  redactedSuffix: 'Partial redaction',
+}
+
 export const SURVEILLANCE_INTERVENTION_TUNING_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Surveillance intervention tuning registry',

--- a/src/features/operations/CognitiveHazardExposureMirrorPage.test.tsx
+++ b/src/features/operations/CognitiveHazardExposureMirrorPage.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+} from '../../domain/cognitiveHazardEngine'
+import { useGameStore } from '../../app/store/gameStore'
+import CognitiveHazardExposureMirrorPage from './CognitiveHazardExposureMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/cognitive-hazard-exposure']}>
+      <Routes>
+        <Route path="/cognitive-hazard-exposure" element={<CognitiveHazardExposureMirrorPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('CognitiveHazardExposureMirrorPage (SPE-1309 slice 6)', () => {
+  it('renders empty state when no persisted records exist', () => {
+    renderMirrorPage()
+
+    expect(
+      screen.getByRole('region', { name: /cognitive hazard exposure registry mirror/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty registry state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no cognitive hazard exposure records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted records when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted cognitive hazard exposure records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent(COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent('Knowledge integrity degraded')
+    expect(recordsRegion).toHaveTextContent('Fear: 0.58')
+    expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/features/operations/CognitiveHazardExposureMirrorPage.tsx
+++ b/src/features/operations/CognitiveHazardExposureMirrorPage.tsx
@@ -1,0 +1,197 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT } from '../../data/copy'
+import { getCognitiveHazardExposureMirrorView } from './cognitiveHazardExposureMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function CognitiveHazardExposureMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getCognitiveHazardExposureMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Cognitive hazard exposure registry mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Registry summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">
+              {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.pageHeading}
+            </h2>
+            <p className="text-sm opacity-60">
+              {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.pageSubtitle}
+            </p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.elevatedExposureLabel}
+            value={String(view.summary.elevatedExposureCount)}
+          />
+          <StatCard
+            label={COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.simulationTriggerSubjectsLabel}
+            value={String(view.summary.simulationTriggerSubjectCount)}
+          />
+          <StatCard
+            label={COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">
+          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.readOnlyNote}
+        </p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty registry state">
+          <h3 className="text-lg font-semibold">
+            {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.emptyTitle}
+          </h3>
+          <p className="text-sm opacity-70">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted cognitive hazard exposure records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">
+              {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.recordsHeading}
+            </h3>
+            <p className="text-sm opacity-60">
+              {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.recordsSubtitle}
+            </p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.labelColumn}</th>
+                  <th className="px-2 py-2">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.subjectColumn}</th>
+                  <th className="px-2 py-2">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.exposureColumn}</th>
+                  <th className="px-2 py-2">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.memoryColumn}</th>
+                  <th className="px-2 py-2">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.reviewColumn}</th>
+                  <th className="px-2 py-2">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.triggerColumn}</th>
+                  <th className="px-2 py-2">{COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.confidenceColumn}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                    </td>
+                    <td className="px-2 py-2">
+                      <p className="text-xs opacity-55">
+                        {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.subjectRefPrefix}{' '}
+                        {record.subjectRefLabel}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {record.triggerChannelLabels.length > 0
+                          ? record.triggerChannelLabels.join('; ')
+                          : '—'}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      <p className="text-xs opacity-55">
+                        {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.fearPressurePrefix}{' '}
+                        {record.fearPressureLabel}
+                      </p>
+                      <p className="text-xs opacity-55">
+                        {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.memeticExposurePrefix}{' '}
+                        {record.memeticExposureLabel}
+                      </p>
+                      <p className="text-xs opacity-45">
+                        {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.aggregateExposurePrefix}{' '}
+                        {record.aggregateExposurePressureLabel}
+                      </p>
+                    </td>
+                    <td className="px-2 py-2">
+                      <p>{record.memoryImpairmentBandLabel}</p>
+                      <p className="text-xs opacity-55">{record.countermeasurePostureLabel}</p>
+                      {record.countermeasureFailedLabel === 'Yes' ? (
+                        <p className="text-xs opacity-45">
+                          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.countermeasureFailedSuffix}
+                        </p>
+                      ) : null}
+                      {record.countermeasureShieldingActiveLabel === 'Yes' ? (
+                        <p className="text-xs opacity-45">
+                          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.countermeasureShieldingSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      <p>{record.exposureReviewBandLabel}</p>
+                      {record.agentDutyDegradedLabel === 'Yes' ? (
+                        <p className="text-xs opacity-55">
+                          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.agentDutySuffix}
+                        </p>
+                      ) : null}
+                      {record.knowledgeIntegrityDegradedLabel === 'Yes' ? (
+                        <p className="text-xs opacity-55">
+                          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.knowledgeIntegritySuffix}
+                        </p>
+                      ) : null}
+                      {record.procedureRestrictionActiveLabel === 'Yes' ? (
+                        <p className="text-xs opacity-55">
+                          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.procedureRestrictionSuffix}
+                        </p>
+                      ) : null}
+                      {record.memoryImpairmentAdvancedLabel === 'Yes' ? (
+                        <p className="text-xs opacity-45">
+                          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.memoryImpairmentAdvancedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.simulationTriggerKindLabels.length > 0
+                        ? record.simulationTriggerKindLabels.join('; ')
+                        : '—'}
+                      {record.simulationTriggerChannelLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {record.simulationTriggerChannelLabels.join('; ')}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">
+                      {record.confidenceLabel}
+                      {record.redacted ? (
+                        <p className="text-xs opacity-55">
+                          {COGNITIVE_HAZARD_EXPOSURE_MIRROR_UI_TEXT.redactedSuffix}
+                        </p>
+                      ) : null}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/cognitiveHazardExposureMirrorView.test.ts
+++ b/src/features/operations/cognitiveHazardExposureMirrorView.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+  type CognitiveHazardExposureRecord,
+} from '../../domain/cognitiveHazardEngine'
+import {
+  formatCognitiveHazardEnumLabel,
+  getCognitiveHazardExposureMirrorView,
+} from './cognitiveHazardExposureMirrorView'
+
+describe('cognitiveHazardExposureMirrorView (SPE-1309 slice 6)', () => {
+  it('returns empty mirror when cognitiveHazardExposureRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.cognitiveHazardExposureRecords).toEqual({})
+
+    const view = getCognitiveHazardExposureMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.summary.simulationTriggerSubjectCount).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('mirrors projection labels and simulation trigger chips without raw record fields', () => {
+    const game = createStartingState()
+    game.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+    }
+
+    const view = getCognitiveHazardExposureMirrorView(game)
+    const escalation = view.records.find(
+      (record) => record.id === COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id
+    )
+    const stable = view.records.find(
+      (record) => record.id === COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id
+    )
+
+    expect(view.isEmpty).toBe(false)
+    expect(view.summary.totalRecords).toBe(2)
+    expect(view.summary.elevatedExposureCount).toBe(1)
+    expect(view.summary.simulationTriggerSubjectCount).toBe(1)
+    expect(view.records.map((record) => record.id)).toEqual([
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id,
+      COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id,
+    ])
+    expect(escalation?.subjectRefLabel).toBe(
+      COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.subjectRef
+    )
+    expect(escalation?.triggerChannelLabels).toEqual(['Direct Perception', 'Reference Description'])
+    expect(escalation?.fearPressureLabel).toBe('0.58')
+    expect(escalation?.memeticExposureLabel).toBe('0.71')
+    expect(escalation?.exposureReviewBandLabel).toBe('Elevated')
+    expect(escalation?.knowledgeIntegrityDegradedLabel).toBe('Yes')
+    expect(escalation?.simulationTriggerKindLabels).toEqual(['Knowledge integrity degraded'])
+    expect(escalation?.summaryLabel).toBe('—')
+    expect(stable?.simulationTriggerKindLabels).toEqual([])
+    expect(stable?.exposureReviewBandLabel).toBe('Stable')
+  })
+
+  it('shows safe placeholders for redacted unit scores and summary', () => {
+    const redactedRecord: CognitiveHazardExposureRecord = Object.freeze({
+      ...COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+      summary: 'Hidden narrative that must not surface in mirror.',
+      redactedFields: Object.freeze([
+        'summary',
+        'fearPressure',
+        'memeticExposure',
+        'confidence',
+      ] as const),
+    })
+    const game = createStartingState()
+    game.cognitiveHazardExposureRecords = {
+      [redactedRecord.id]: redactedRecord,
+    }
+
+    const view = getCognitiveHazardExposureMirrorView(game)
+    const record = view.records[0]
+
+    expect(record?.summaryLabel).toBe('[Redacted]')
+    expect(record?.fearPressureLabel).toBe('—')
+    expect(record?.memeticExposureLabel).toBe('—')
+    expect(record?.confidenceLabel).toBe('—')
+    expect(record?.redacted).toBe(true)
+    expect(JSON.stringify(record)).not.toContain('Hidden narrative')
+  })
+
+  it('mirrors failed countermeasure effect flags and trigger kinds', () => {
+    const game = createStartingState()
+    game.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE.id]:
+        COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+    }
+
+    const view = getCognitiveHazardExposureMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.countermeasureFailedCount).toBe(1)
+    expect(record?.countermeasureFailedLabel).toBe('Yes')
+    expect(record?.agentDutyDegradedLabel).toBe('Yes')
+    expect(record?.procedureRestrictionActiveLabel).toBe('Yes')
+    expect(record?.simulationTriggerKindLabels).toEqual([
+      'Agent duty degraded',
+      'Knowledge integrity degraded',
+      'Procedure restriction active',
+    ])
+    expect(record?.exposureReviewBandLabel).toBe('Critical')
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatCognitiveHazardEnumLabel('memory_interaction')).toBe('Memory Interaction')
+    expect(formatCognitiveHazardEnumLabel('procedure_restricted')).toBe('Procedure Restricted')
+  })
+
+  it('is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE.id]:
+        COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+    }
+
+    const first = JSON.stringify(getCognitiveHazardExposureMirrorView(game))
+    const second = JSON.stringify(getCognitiveHazardExposureMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/features/operations/cognitiveHazardExposureMirrorView.ts
+++ b/src/features/operations/cognitiveHazardExposureMirrorView.ts
@@ -1,0 +1,181 @@
+import type { GameState } from '../../domain/models'
+import {
+  projectCognitiveHazardExposureReview,
+  type CognitiveHazardExposureRecord,
+} from '../../domain/cognitiveHazardEngine'
+import {
+  composeCognitiveHazardSimulationTriggerSubjectSummaries,
+  type CognitiveHazardSimulationTriggerSubjectSummary,
+} from '../../domain/cognitiveHazardSimulationTriggers'
+import { formatCognitiveHazardSimulationTriggerSummaryLabels } from '../../domain/cognitiveHazardSimulationTriggerSurfacing'
+
+export interface CognitiveHazardExposureMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  subjectRefLabel: string
+  triggerChannelLabels: readonly string[]
+  fearPressureLabel: string
+  memeticExposureLabel: string
+  aggregateExposurePressureLabel: string
+  memoryImpairmentBandLabel: string
+  countermeasurePostureLabel: string
+  exposureReviewBandLabel: string
+  agentDutyDegradedLabel: string
+  knowledgeIntegrityDegradedLabel: string
+  procedureRestrictionActiveLabel: string
+  countermeasureFailedLabel: string
+  countermeasureShieldingActiveLabel: string
+  memoryImpairmentAdvancedLabel: string
+  simulationTriggerKindLabels: readonly string[]
+  simulationTriggerChannelLabels: readonly string[]
+  unknownFieldLabels: readonly string[]
+  confidenceLabel: string
+  redacted: boolean
+}
+
+export interface CognitiveHazardExposureMirrorSummaryView {
+  totalRecords: number
+  elevatedExposureCount: number
+  simulationTriggerSubjectCount: number
+  countermeasureFailedCount: number
+  week: number
+}
+
+export interface CognitiveHazardExposureMirrorView {
+  isEmpty: boolean
+  summary: CognitiveHazardExposureMirrorSummaryView
+  records: readonly CognitiveHazardExposureMirrorRecordView[]
+}
+
+export function formatCognitiveHazardEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(game: GameState): CognitiveHazardExposureRecord[] {
+  const map = game.cognitiveHazardExposureRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function formatUnitScore(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return '—'
+  }
+
+  return value.toFixed(2)
+}
+
+function formatYesNo(value: boolean): string {
+  return value ? 'Yes' : '—'
+}
+
+function resolveSummaryLabel(record: CognitiveHazardExposureRecord, redacted: boolean): string {
+  const summary = record.summary?.trim()
+  if (!summary) {
+    return '—'
+  }
+
+  const redactedFields = new Set(record.redactedFields ?? [])
+  if (redacted && redactedFields.has('summary')) {
+    return '[Redacted]'
+  }
+
+  return '—'
+}
+
+function findSubjectSummaryForRecord(
+  recordId: string,
+  subjectRef: string,
+  summaries: readonly CognitiveHazardSimulationTriggerSubjectSummary[]
+): CognitiveHazardSimulationTriggerSubjectSummary | undefined {
+  return summaries.find(
+    (summary) =>
+      summary.recordIds.includes(recordId) ||
+      summary.subjectRef.localeCompare(subjectRef) === 0
+  )
+}
+
+function toRecordView(
+  record: CognitiveHazardExposureRecord,
+  subjectSummaries: readonly CognitiveHazardSimulationTriggerSubjectSummary[]
+): CognitiveHazardExposureMirrorRecordView {
+  const projection = projectCognitiveHazardExposureReview(record)
+  const subjectSummary = findSubjectSummaryForRecord(
+    record.id,
+    projection.subjectRef,
+    subjectSummaries
+  )
+  const triggerLabels = subjectSummary
+    ? formatCognitiveHazardSimulationTriggerSummaryLabels(subjectSummary)
+    : Object.freeze({
+        triggerKindLabels: Object.freeze([] as string[]),
+        triggerChannelLabels: Object.freeze([] as string[]),
+      })
+
+  return Object.freeze({
+    id: projection.recordId,
+    label: projection.label,
+    summaryLabel: resolveSummaryLabel(record, projection.redacted),
+    subjectRefLabel: projection.subjectRef,
+    triggerChannelLabels: Object.freeze([...projection.triggerChannelLabels]),
+    fearPressureLabel: formatUnitScore(projection.fearPressure),
+    memeticExposureLabel: formatUnitScore(projection.memeticExposure),
+    aggregateExposurePressureLabel: formatUnitScore(projection.aggregateExposurePressure),
+    memoryImpairmentBandLabel: formatCognitiveHazardEnumLabel(projection.memoryImpairmentBand),
+    countermeasurePostureLabel: formatCognitiveHazardEnumLabel(projection.countermeasurePosture),
+    exposureReviewBandLabel: formatCognitiveHazardEnumLabel(projection.exposureReviewBand),
+    agentDutyDegradedLabel: formatYesNo(projection.agentDutyDegraded),
+    knowledgeIntegrityDegradedLabel: formatYesNo(projection.knowledgeIntegrityDegraded),
+    procedureRestrictionActiveLabel: formatYesNo(projection.procedureRestrictionActive),
+    countermeasureFailedLabel: formatYesNo(projection.countermeasureFailed),
+    countermeasureShieldingActiveLabel: formatYesNo(projection.countermeasureShieldingActive),
+    memoryImpairmentAdvancedLabel: formatYesNo(projection.memoryImpairmentAdvanced),
+    simulationTriggerKindLabels: Object.freeze([...triggerLabels.triggerKindLabels]),
+    simulationTriggerChannelLabels: Object.freeze([...triggerLabels.triggerChannelLabels]),
+    unknownFieldLabels: Object.freeze([...projection.unknownFields]),
+    confidenceLabel: formatUnitScore(projection.confidence),
+    redacted: projection.redacted,
+  })
+}
+
+/** Read-only mirror over hydrated `cognitiveHazardExposureRecords`; does not re-validate hidden truth. */
+export function getCognitiveHazardExposureMirrorView(
+  game: GameState
+): CognitiveHazardExposureMirrorView {
+  const records = listPersistedRecords(game)
+  const subjectSummaries = composeCognitiveHazardSimulationTriggerSubjectSummaries(
+    game.cognitiveHazardExposureRecords
+  )
+
+  let elevatedExposureCount = 0
+  let countermeasureFailedCount = 0
+
+  const recordViews = records.map((record) => {
+    const projection = projectCognitiveHazardExposureReview(record)
+
+    if (projection.exposureReviewBand === 'elevated' || projection.exposureReviewBand === 'critical') {
+      elevatedExposureCount += 1
+    }
+
+    if (projection.countermeasureFailed) {
+      countermeasureFailedCount += 1
+    }
+
+    return toRecordView(record, subjectSummaries)
+  })
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      totalRecords: records.length,
+      elevatedExposureCount,
+      simulationTriggerSubjectCount: subjectSummaries.length,
+      countermeasureFailedCount,
+      week: game.week,
+    }),
+    records: Object.freeze(recordViews),
+  })
+}


### PR DESCRIPTION
## Summary

- Add read-only planning mirror over persisted `cognitiveHazardExposureRecords` via `getCognitiveHazardExposureMirrorView`, projecting safe labels from `projectCognitiveHazardExposureReview` and slice 5 simulation trigger subject summaries.
- Wire `/cognitive-hazard-exposure` route, page, and UI copy following sibling mirror patterns (SPE-2330 / SPE-2331).
- No changes to compose/tick/trigger domain contracts or SPE-2108/SPE-2116 hooks.

## Linear

- **Slice:** SPE-1309 child — planning mirror UI (slice 6) — create/link on merge
- **Parent:** [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — stays open for AC reconciliation after mirror ships

## Docs updated

- `planning/spe-1309-unified-engine-slice-6.md`
- `planning/backlog.md` (handoff)

## Validation

- `npm run lint`
- `npm run test:run src/features/operations/cognitiveHazardExposureMirrorView.test.ts src/features/operations/CognitiveHazardExposureMirrorPage.test.tsx`

## Parent status

Parent SPE-1309 remains open — mirror slice alone does not satisfy unified engine AC rows 1–3.