### PR TITLE
SPE-1309 slice 7: cognitive hazard simulation trigger vitals side-effects

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-1309 agent vitals / scoring side-effects from simulation triggers (row 3 **Partial** closure), or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
+**Next step:** SPE-1309 parent acceptance review grooming slice 6 (AC row 3 re-check after vitals ship), or next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics).
 
-**Base `main` SHA:** `62ddbc93` — shipped: SPE-1309 parent acceptance review grooming slice 5 @ `planning/spe-1309-parent-acceptance-review-slice-5.md` (PR #2813)
+**Base `main` SHA:** `195369f3` — in progress: SPE-1309 unified cognitive hazard engine slice 7 (agent vitals side-effects) @ `planning/spe-1309-unified-engine-slice-7.md`
 
 **Recently shipped:** SPE-1309 parent acceptance review grooming slice 5 (PR #2813 @ `62ddbc93`); SPE-1309 unified cognitive hazard engine slice 6 (PR #2812 @ `621b2d74`).
 
@@ -230,6 +230,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1309-unified-engine-slice-4.md`                      | **Shipped**    | SPE-1309 child — sibling registry compose wire-up from SPE-2108 persisted maps / PR #2810 @ `9c41fcf6`.                                                  |
 | `spe-1309-unified-engine-slice-5.md`                      | **Shipped**    | SPE-1309 child — agent/knowledge/procedure simulation triggers / PR #2811 @ `8f5fde47`.                                                                  |
 | `spe-1309-unified-engine-slice-6.md`                      | **Shipped**    | SPE-1309 child — planning mirror UI / PR #2812 @ `621b2d74`.                                                                                              |
+| `spe-1309-unified-engine-slice-7.md`                      | In progress    | SPE-1309 child — agent vitals / scoring side-effects from simulation triggers @ `195369f3`.                                                                 |
 | `spe-1309-parent-acceptance-review-slice-5.md`            | **Shipped**    | SPE-1309 grooming slice 5 / PR #2813; SPE-1309 stays Backlog — AC rows 1–2 **Yes**, row 3 **Partial**; post-engine auto-close reconciliation @ `62ddbc93`. |
 | `welfare-debt-accounting-registry-slice-2.md`             | **Shipped**    | SPE-2351 / PR #2570; planning mirror UI over `welfareDebtAccountingRecords` @ `96ad05ba`.                                                               |
 | `welfare-debt-accounting-registry-slice-3.md`             | **Shipped**    | SPE-2352 / PR #2572; weekly orchestration hook in `advanceWeek` @ `5673423c`.                                                                          |

--- a/planning/spe-1309-unified-engine-slice-7.md
+++ b/planning/spe-1309-unified-engine-slice-7.md
@@ -1,0 +1,78 @@
+# SPE-1309 — Unified cognitive hazard engine (slice 7)
+
+One-page implementation plan. Linear: child under [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — **agent vitals / scoring side-effects from simulation triggers (slice 7)** (create/claim on start). Parent [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) stays **Backlog** until grooming slice 6 reconciles AC row 3 after vitals ship.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1309 child — agent vitals / scoring side-effects from simulation triggers (slice 7)                    |
+| **Status** | In progress                                                                                                |
+| **Parent** | [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — Unified cognitive hazard engine (umbrella)    |
+| **Branch** | `spe-1309-unified-engine-slice-7`                                                                          |
+| **Base `main` SHA** | `195369f3`                                                                                          |
+
+## Goal
+
+Wire slice 5 simulation trigger kinds (`agent_duty_degraded`, `knowledge_integrity_degraded`, `procedure_restriction_active`) into agent vitals status flags and bounded stress/morale deltas during `advanceWeek`, plus team-score penalties in `computeTeamScore` — without mutating slice 1–6 compose/tick/trigger contracts or SPE-2108 / SPE-2116 weekly hooks.
+
+## Prerequisite (on `main` @ `195369f3`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Simulation triggers  | `cognitiveHazardSimulationTriggers.ts` + weekly report notes (slice 5 / PR #2811) |
+| Planning mirror UI   | `cognitiveHazardExposureMirrorView.ts` (slice 6 / PR #2812)            |
+| Parent grooming      | `planning/spe-1309-parent-acceptance-review-slice-5.md` — AC row 3 **Partial** @ `62ddbc93` |
+| Vitals flag pattern  | `recoveryImpairments.ts` (`exposure:residue`), `downtimeSideWork.ts` (`impaired:alcohol`) |
+
+## Vitals side-effect contract (slice 7)
+
+- **Inputs** — post-tick `cognitiveHazardExposureRecords` + prior-week map (terminal erased guard inherited from slice 5 summaries).
+- **Agent resolution** — `resolveAgentIdsForCognitiveHazardSubjectRef` via `resolveCognitiveHazardSiblingRefKeys` overlap on `agent:${agentId}`.
+- **Status flags** — `cognitive_hazard:duty_degraded`, `cognitive_hazard:knowledge_degraded`, `cognitive_hazard:procedure_restricted`.
+- **Vitals deltas** — bounded stress/morale from `COGNITIVE_HAZARD_CALIBRATION` by exposure review band.
+- **Flag sync** — strip cognitive-hazard flags each week; re-apply only for active trigger summaries.
+- **Scoring** — `computeTeamScore` duty/knowledge strain penalties when flags present.
+- **No new persistence fields** — vitals on `GameState.agents` only.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `cognitiveHazardSimulationTriggerVitals.ts` + `advanceWeek` wire   | Slice 1–6 domain compose/tick/trigger edits |
+| `COGNITIVE_HAZARD_CALIBRATION` + scoring penalties                 | SPE-2108 / SPE-2116 weekly hook changes       |
+| Targeted domain + `advanceWeek` integration tests                    | Full SPE-1309 parent Done (grooming slice 6) |
+| Slice doc (this file) + backlog handoff                            | Mirror UI changes                             |
+
+## Acceptance
+
+- [x] Empty exposure map is a no-op without throw
+- [x] Active triggers apply deterministic status flags + stress/morale deltas to linked agents
+- [x] Terminal erased records do not re-apply vitals on subsequent weeks
+- [x] Flags strip when triggers stop emitting
+- [x] `advanceWeek` integration matches direct vitals helper output
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/cognitiveHazardSimulationTriggerVitals.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/sim/calibration.ts`, `src/domain/sim/scoring.ts` |
+| Tests  | `src/test/cognitiveHazardSimulationTriggerVitals.test.ts`, `src/test/advanceWeek.cognitiveHazardSimulationTriggerVitals.integration.test.ts` |
+| Plan   | `planning/spe-1309-unified-engine-slice-7.md`, `planning/backlog.md`  |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| SPE-1309 parent acceptance / AC row 3 closure | grooming slice 6 follow-up | Vitals slice may satisfy row 3 **Yes** — grooming reconciles |
+| SPE-2116 naming-hazard compose into exposure records | SPE-1309 follow-up | Out of slice 7 boundary |
+| Segmented population trust / disclosure choice mechanics | [SPE-861](https://linear.app/spectranoir/issue/SPE-861) follow-up | Alternate next step per backlog |
+
+## Validation
+
+- `npm run lint`
+- `npm run test:run src/test/cognitiveHazardSimulationTriggerVitals.test.ts src/test/advanceWeek.cognitiveHazardSimulationTriggerVitals.integration.test.ts src/test/advanceWeek.cognitiveHazardSimulationTriggers.integration.test.ts`
+
+## See also
+
+- `planning/spe-1309-unified-engine-slice-5.md` — simulation triggers (shipped)
+- `planning/spe-1309-parent-acceptance-review-slice-5.md` — AC row 3 **Partial** grooming

--- a/src/domain/cognitiveHazardSimulationTriggerVitals.ts
+++ b/src/domain/cognitiveHazardSimulationTriggerVitals.ts
@@ -1,0 +1,294 @@
+/**
+ * SPE-1309 slice 7: agent vitals / scoring side-effects from cognitive hazard simulation triggers.
+ *
+ * Syncs status flags and bounded stress/morale deltas from post-tick trigger summaries —
+ * without mutating slice 1–6 compose/tick/trigger contracts or SPE-2108 / SPE-2116 hooks.
+ */
+
+import type { CognitiveHazardExposureRecordsMap, CognitiveHazardExposureReviewBand } from './cognitiveHazardEngine'
+import { resolveCognitiveHazardSiblingRefKeys } from './cognitiveHazardSiblingCompose'
+import {
+  composeCognitiveHazardSimulationTriggerSubjectSummaries,
+  type CognitiveHazardSimulationTriggerKind,
+  type CognitiveHazardSimulationTriggerSubjectSummary,
+} from './cognitiveHazardSimulationTriggers'
+import type { Agent, AgentVitals, GameState } from './models'
+import { COGNITIVE_HAZARD_CALIBRATION } from './sim/calibration'
+
+export const COGNITIVE_HAZARD_DUTY_DEGRADED_STATUS_FLAG =
+  'cognitive_hazard:duty_degraded' as const
+export const COGNITIVE_HAZARD_KNOWLEDGE_DEGRADED_STATUS_FLAG =
+  'cognitive_hazard:knowledge_degraded' as const
+export const COGNITIVE_HAZARD_PROCEDURE_RESTRICTED_STATUS_FLAG =
+  'cognitive_hazard:procedure_restricted' as const
+
+export const COGNITIVE_HAZARD_SIMULATION_TRIGGER_STATUS_FLAGS = Object.freeze([
+  COGNITIVE_HAZARD_DUTY_DEGRADED_STATUS_FLAG,
+  COGNITIVE_HAZARD_KNOWLEDGE_DEGRADED_STATUS_FLAG,
+  COGNITIVE_HAZARD_PROCEDURE_RESTRICTED_STATUS_FLAG,
+] as const)
+
+const TRIGGER_KIND_TO_STATUS_FLAG: Record<
+  CognitiveHazardSimulationTriggerKind,
+  (typeof COGNITIVE_HAZARD_SIMULATION_TRIGGER_STATUS_FLAGS)[number]
+> = {
+  agent_duty_degraded: COGNITIVE_HAZARD_DUTY_DEGRADED_STATUS_FLAG,
+  knowledge_integrity_degraded: COGNITIVE_HAZARD_KNOWLEDGE_DEGRADED_STATUS_FLAG,
+  procedure_restriction_active: COGNITIVE_HAZARD_PROCEDURE_RESTRICTED_STATUS_FLAG,
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  return Math.min(100, Math.max(0, value))
+}
+
+function resolveExposureReviewBandPriority(band: CognitiveHazardExposureReviewBand): number {
+  switch (band) {
+    case 'critical':
+      return 3
+    case 'elevated':
+      return 2
+    case 'stable':
+      return 1
+  }
+}
+
+function maxExposureReviewBand(
+  left: CognitiveHazardExposureReviewBand,
+  right: CognitiveHazardExposureReviewBand
+): CognitiveHazardExposureReviewBand {
+  return resolveExposureReviewBandPriority(left) >= resolveExposureReviewBandPriority(right)
+    ? left
+    : right
+}
+
+export function stripCognitiveHazardSimulationTriggerStatusFlags(
+  flags: readonly string[] | undefined
+): string[] {
+  const cognitiveHazardFlagSet = new Set<string>(COGNITIVE_HAZARD_SIMULATION_TRIGGER_STATUS_FLAGS)
+  return (flags ?? []).filter((flag) => !cognitiveHazardFlagSet.has(flag))
+}
+
+export function vitalsHasCognitiveHazardDutyDegraded(vitals: AgentVitals | undefined): boolean {
+  return (vitals?.statusFlags ?? []).includes(COGNITIVE_HAZARD_DUTY_DEGRADED_STATUS_FLAG)
+}
+
+export function vitalsHasCognitiveHazardKnowledgeDegraded(vitals: AgentVitals | undefined): boolean {
+  return (vitals?.statusFlags ?? []).includes(COGNITIVE_HAZARD_KNOWLEDGE_DEGRADED_STATUS_FLAG)
+}
+
+export function vitalsHasCognitiveHazardProcedureRestricted(vitals: AgentVitals | undefined): boolean {
+  return (vitals?.statusFlags ?? []).includes(COGNITIVE_HAZARD_PROCEDURE_RESTRICTED_STATUS_FLAG)
+}
+
+function statusFlagsForTriggerKinds(
+  kinds: readonly CognitiveHazardSimulationTriggerKind[]
+): readonly string[] {
+  return Object.freeze(
+    kinds
+      .map((kind) => TRIGGER_KIND_TO_STATUS_FLAG[kind])
+      .sort((left, right) => left.localeCompare(right))
+  )
+}
+
+/** Resolve roster agent ids linked to a cognitive hazard subject ref via normalized key overlap. */
+export function resolveAgentIdsForCognitiveHazardSubjectRef(
+  agents: GameState['agents'],
+  subjectRef: string
+): readonly string[] {
+  const subjectKeys = new Set(resolveCognitiveHazardSiblingRefKeys(subjectRef))
+  if (subjectKeys.size === 0) {
+    return Object.freeze([] as string[])
+  }
+
+  const matches: string[] = []
+
+  for (const agentId of Object.keys(agents).sort((left, right) => left.localeCompare(right))) {
+    const agent = agents[agentId]
+    if (!agent) {
+      continue
+    }
+
+    const agentKeys = resolveCognitiveHazardSiblingRefKeys(`agent:${agentId}`)
+    if (agentKeys.some((key) => subjectKeys.has(key))) {
+      matches.push(agentId)
+    }
+  }
+
+  return Object.freeze(matches)
+}
+
+export interface CognitiveHazardSimulationTriggerAgentVitalsEffect {
+  readonly agentId: string
+  readonly triggerKinds: readonly CognitiveHazardSimulationTriggerKind[]
+  readonly exposureReviewBand: CognitiveHazardExposureReviewBand
+  readonly statusFlags: readonly string[]
+  readonly stressDelta: number
+  readonly moraleDelta: number
+}
+
+function buildAgentVitalsEffectsByAgentId(input: {
+  agents: GameState['agents']
+  summaries: readonly CognitiveHazardSimulationTriggerSubjectSummary[]
+}): Map<string, CognitiveHazardSimulationTriggerAgentVitalsEffect> {
+  const effects = new Map<string, CognitiveHazardSimulationTriggerAgentVitalsEffect>()
+
+  for (const summary of input.summaries) {
+    const agentIds = resolveAgentIdsForCognitiveHazardSubjectRef(input.agents, summary.subjectRef)
+    const statusFlags = statusFlagsForTriggerKinds(summary.triggerKinds)
+    const stressDelta = COGNITIVE_HAZARD_CALIBRATION.stressDeltaByReviewBand[summary.exposureReviewBand]
+    const moraleDelta = COGNITIVE_HAZARD_CALIBRATION.moraleDeltaByReviewBand[summary.exposureReviewBand]
+
+    for (const agentId of agentIds) {
+      const existing = effects.get(agentId)
+      if (!existing) {
+        effects.set(
+          agentId,
+          Object.freeze({
+            agentId,
+            triggerKinds: summary.triggerKinds,
+            exposureReviewBand: summary.exposureReviewBand,
+            statusFlags,
+            stressDelta,
+            moraleDelta,
+          })
+        )
+        continue
+      }
+
+      const mergedKinds = Object.freeze(
+        [...new Set([...existing.triggerKinds, ...summary.triggerKinds])].sort((left, right) =>
+          left.localeCompare(right)
+        )
+      )
+      const mergedBand = maxExposureReviewBand(existing.exposureReviewBand, summary.exposureReviewBand)
+
+      effects.set(
+        agentId,
+        Object.freeze({
+          agentId,
+          triggerKinds: mergedKinds,
+          exposureReviewBand: mergedBand,
+          statusFlags: statusFlagsForTriggerKinds(mergedKinds),
+          stressDelta:
+            existing.stressDelta +
+            COGNITIVE_HAZARD_CALIBRATION.stressDeltaByReviewBand[summary.exposureReviewBand],
+          moraleDelta:
+            existing.moraleDelta +
+            COGNITIVE_HAZARD_CALIBRATION.moraleDeltaByReviewBand[summary.exposureReviewBand],
+        })
+      )
+    }
+  }
+
+  return effects
+}
+
+function withCognitiveHazardVitalsEffect(
+  agent: Agent,
+  effect: CognitiveHazardSimulationTriggerAgentVitalsEffect | undefined
+): Agent {
+  const baseVitals = agent.vitals ?? {
+    health: 100,
+    stress: agent.fatigue ?? 0,
+    wounds: 0,
+    morale: Math.max(0, 100 - (agent.fatigue ?? 0)),
+  }
+  const strippedFlags = stripCognitiveHazardSimulationTriggerStatusFlags(baseVitals.statusFlags)
+
+  if (!effect) {
+    if (strippedFlags.length === (baseVitals.statusFlags ?? []).length) {
+      return agent
+    }
+
+    return {
+      ...agent,
+      vitals: {
+        ...baseVitals,
+        statusFlags: strippedFlags.length > 0 ? strippedFlags : undefined,
+      },
+    }
+  }
+
+  return {
+    ...agent,
+    vitals: {
+      ...baseVitals,
+      stress: clampPercent((baseVitals.stress ?? 0) + effect.stressDelta),
+      morale: clampPercent((baseVitals.morale ?? 50) + effect.moraleDelta),
+      statusFlags: [...strippedFlags, ...effect.statusFlags],
+    },
+  }
+}
+
+/** Apply weekly vitals side-effects from active cognitive hazard simulation trigger summaries. */
+export function applyCognitiveHazardSimulationTriggerVitalsToAgents(input: {
+  agents: GameState['agents']
+  nextRecords: CognitiveHazardExposureRecordsMap | null | undefined
+  priorRecords?: CognitiveHazardExposureRecordsMap | null | undefined
+}): GameState['agents'] {
+  const summaries = composeCognitiveHazardSimulationTriggerSubjectSummaries(
+    input.nextRecords,
+    input.priorRecords
+  )
+  const effectsByAgentId = buildAgentVitalsEffectsByAgentId({
+    agents: input.agents,
+    summaries,
+  })
+
+  if (summaries.length === 0 && effectsByAgentId.size === 0) {
+    let changed = false
+    const nextAgents: GameState['agents'] = { ...input.agents }
+
+    for (const agentId of Object.keys(input.agents).sort((left, right) => left.localeCompare(right))) {
+      const agent = input.agents[agentId]
+      if (!agent) {
+        continue
+      }
+
+      const strippedFlags = stripCognitiveHazardSimulationTriggerStatusFlags(agent.vitals?.statusFlags)
+      if (strippedFlags.length !== (agent.vitals?.statusFlags ?? []).length) {
+        changed = true
+        nextAgents[agentId] = withCognitiveHazardVitalsEffect(agent, undefined)
+      }
+    }
+
+    return changed ? nextAgents : input.agents
+  }
+
+  const nextAgents: GameState['agents'] = { ...input.agents }
+
+  for (const agentId of Object.keys(input.agents).sort((left, right) => left.localeCompare(right))) {
+    const agent = input.agents[agentId]
+    if (!agent) {
+      continue
+    }
+
+    nextAgents[agentId] = withCognitiveHazardVitalsEffect(
+      agent,
+      effectsByAgentId.get(agentId)
+    )
+  }
+
+  return nextAgents
+}
+
+export function resolveCognitiveHazardSimulationTriggerAgentVitalsEffects(input: {
+  agents: GameState['agents']
+  nextRecords: CognitiveHazardExposureRecordsMap | null | undefined
+  priorRecords?: CognitiveHazardExposureRecordsMap | null | undefined
+}): readonly CognitiveHazardSimulationTriggerAgentVitalsEffect[] {
+  const summaries = composeCognitiveHazardSimulationTriggerSubjectSummaries(
+    input.nextRecords,
+    input.priorRecords
+  )
+
+  return Object.freeze(
+    [...buildAgentVitalsEffectsByAgentId({ agents: input.agents, summaries }).values()].sort(
+      (left, right) => left.agentId.localeCompare(right.agentId)
+    )
+  )
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -277,6 +277,7 @@ import { applyWeeklyPsychologicalResilienceDepletionTick } from '../psychologica
 import { composeSelfCensoringPropagationIntoCognitiveHazardExposureRecords } from '../cognitiveHazardSiblingCompose'
 import { applyWeeklyCognitiveHazardExposureTick } from '../cognitiveHazardWeeklyOrchestration'
 import { buildWeeklyCognitiveHazardSimulationTriggerReportNotes } from '../cognitiveHazardSimulationTriggerWeeklyReportNotes'
+import { applyCognitiveHazardSimulationTriggerVitalsToAgents } from '../cognitiveHazardSimulationTriggerVitals'
 import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   resolveCoerciveProcedureExecutionDrafts,
@@ -4893,6 +4894,15 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       }
       result.reports = reports
     }
+  }
+
+  // SPE-1309 slice 7: agent vitals side-effects from active simulation trigger summaries.
+  if (Object.keys(nextCognitiveHazardExposureRecordsForTriggers).length > 0) {
+    outputWeeklyState.agents = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: outputWeeklyState.agents ?? sourceState.agents,
+      nextRecords: nextCognitiveHazardExposureRecordsForTriggers,
+      priorRecords: priorCognitiveHazardExposureRecords,
+    })
   }
 
   // SPE-1888 slice 5: welfare-debt creation when coercive procedures execute with containment improvement.

--- a/src/domain/sim/calibration.ts
+++ b/src/domain/sim/calibration.ts
@@ -84,6 +84,22 @@ export const RECOVERY_CALIBRATION = {
   exposureResidueMedicalClearThreshold: 2,
 } as const
 
+/** SPE-1309 slice 7: bounded vitals/scoring side-effects from cognitive hazard simulation triggers. */
+export const COGNITIVE_HAZARD_CALIBRATION = {
+  dutyDegradedTeamPenaltyMultiplier: 0.92,
+  knowledgeDegradedTeamPenaltyMultiplier: 0.95,
+  stressDeltaByReviewBand: {
+    stable: 0,
+    elevated: 6,
+    critical: 12,
+  },
+  moraleDeltaByReviewBand: {
+    stable: 0,
+    elevated: 0,
+    critical: -4,
+  },
+} as const
+
 export const RESPONDER_ENERGY_CALIBRATION = {
   defaultReserve: 100,
   reserveBands: {

--- a/src/domain/sim/scoring.ts
+++ b/src/domain/sim/scoring.ts
@@ -14,7 +14,11 @@ import {
   type WeeklyReport,
 } from '../models'
 import { clamp, sigmoid } from '../math'
-import { RECOVERY_CALIBRATION } from './calibration'
+import { COGNITIVE_HAZARD_CALIBRATION, RECOVERY_CALIBRATION } from './calibration'
+import {
+  vitalsHasCognitiveHazardDutyDegraded,
+  vitalsHasCognitiveHazardKnowledgeDegraded,
+} from '../cognitiveHazardSimulationTriggerVitals'
 import {
   buildAgentSquadCompositionProfile,
   dotResolutionProfile,
@@ -823,6 +827,36 @@ export function computeTeamScore(agents: Agent[], c: CaseInstance, context: Team
     reasons.push(`Impaired: ${impairedPenalty.toFixed(1)}`)
   }
 
+  const cognitiveHazardDutyCount = agents.filter((a) =>
+    vitalsHasCognitiveHazardDutyDegraded(a.vitals)
+  ).length
+  const cognitiveHazardDutyPenalty =
+    cognitiveHazardDutyCount > 0
+      ? -(
+          base *
+          (1 - COGNITIVE_HAZARD_CALIBRATION.dutyDegradedTeamPenaltyMultiplier) *
+          (cognitiveHazardDutyCount / Math.max(1, agents.length))
+        )
+      : 0
+  if (cognitiveHazardDutyPenalty !== 0) {
+    reasons.push(`Cognitive hazard duty strain: ${cognitiveHazardDutyPenalty.toFixed(1)}`)
+  }
+
+  const cognitiveHazardKnowledgeCount = agents.filter((a) =>
+    vitalsHasCognitiveHazardKnowledgeDegraded(a.vitals)
+  ).length
+  const cognitiveHazardKnowledgePenalty =
+    cognitiveHazardKnowledgeCount > 0
+      ? -(
+          base *
+          (1 - COGNITIVE_HAZARD_CALIBRATION.knowledgeDegradedTeamPenaltyMultiplier) *
+          (cognitiveHazardKnowledgeCount / Math.max(1, agents.length))
+        )
+      : 0
+  if (cognitiveHazardKnowledgePenalty !== 0) {
+    reasons.push(`Cognitive hazard knowledge strain: ${cognitiveHazardKnowledgePenalty.toFixed(1)}`)
+  }
+
   const nonAxisModifierTotal = computeNonAxisModifierTotal({
     leaderBonus,
     synergyBonus,
@@ -831,7 +865,7 @@ export function computeTeamScore(agents: Agent[], c: CaseInstance, context: Team
     preferredBonus,
     equipmentScore: equipment.score,
     partyCardScore: partyCardBonus,
-    contextAdjustment: contextAdjustment + impairedPenalty,
+    contextAdjustment: contextAdjustment + impairedPenalty + cognitiveHazardDutyPenalty + cognitiveHazardKnowledgePenalty,
   })
   const comparison = compareResolutionAgainstCase(
     profile.resolutionProfile,
@@ -875,7 +909,7 @@ export function computeTeamScore(agents: Agent[], c: CaseInstance, context: Team
       { id: 'preferred-tags', label: 'Preferred tags', delta: preferredBonus },
       { id: 'equipment', label: 'Equipment', delta: equipment.score },
       { id: 'party-cards', label: 'Party cards', delta: partyCardBonus },
-      { id: 'context-adjustment', label: 'Context adjustment', delta: contextAdjustment + impairedPenalty },
+      { id: 'context-adjustment', label: 'Context adjustment', delta: contextAdjustment + impairedPenalty + cognitiveHazardDutyPenalty + cognitiveHazardKnowledgePenalty },
     ],
   }
 
@@ -911,7 +945,7 @@ export function computeTeamScore(agents: Agent[], c: CaseInstance, context: Team
       preferredTagBonus: preferredBonus,
       equipmentBonus: equipment.score,
       partyCardBonus,
-      contextAdjustment: contextAdjustment + impairedPenalty,
+      contextAdjustment: contextAdjustment + impairedPenalty + cognitiveHazardDutyPenalty + cognitiveHazardKnowledgePenalty,
     }),
     layerBreakdown,
     comparison,

--- a/src/test/advanceWeek.cognitiveHazardSimulationTriggerVitals.integration.test.ts
+++ b/src/test/advanceWeek.cognitiveHazardSimulationTriggerVitals.integration.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import {
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+  type CognitiveHazardExposureRecord,
+} from '../domain/cognitiveHazardEngine'
+import {
+  vitalsHasCognitiveHazardKnowledgeDegraded,
+} from '../domain/cognitiveHazardSimulationTriggerVitals'
+import { applyCognitiveHazardSimulationTriggerVitalsToAgents } from '../domain/cognitiveHazardSimulationTriggerVitals'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+function memeticFixtureForAgent(agentId: string): CognitiveHazardExposureRecord {
+  return {
+    ...COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+    subjectRef: `agent:${agentId}`,
+  }
+}
+
+describe('advanceWeek cognitive hazard simulation trigger vitals integration (SPE-1309 slice 7)', () => {
+  it('is a no-op for an empty exposure map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.cognitiveHazardExposureRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.cognitiveHazardExposureRecords).toEqual({})
+    expect(
+      nextState.agents.a_mina?.vitals?.statusFlags?.some((flag) =>
+        flag.startsWith('cognitive_hazard:')
+      )
+    ).toBeFalsy()
+  })
+
+  it('applies knowledge-degraded vitals for memetic escalation fixture on first week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    const record = memeticFixtureForAgent('a_mina')
+    state.cognitiveHazardExposureRecords = { [record.id]: record }
+
+    const nextState = advanceWeek(state)
+    const directAgents = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: nextState.agents,
+      nextRecords: nextState.cognitiveHazardExposureRecords ?? {},
+      priorRecords: state.cognitiveHazardExposureRecords,
+    })
+
+    expect(vitalsHasCognitiveHazardKnowledgeDegraded(nextState.agents.a_mina?.vitals)).toBe(true)
+    expect(nextState.agents.a_mina?.vitals?.statusFlags).toEqual(
+      directAgents.a_mina?.vitals?.statusFlags
+    )
+  })
+
+  it('clears cognitive hazard vitals flags when triggers stop after stable week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    const record = memeticFixtureForAgent('a_mina')
+    state.cognitiveHazardExposureRecords = { [record.id]: record }
+
+    const firstWeek = advanceWeek(state)
+    expect(vitalsHasCognitiveHazardKnowledgeDegraded(firstWeek.agents.a_mina?.vitals)).toBe(true)
+
+    firstWeek.cognitiveHazardExposureRecords = {
+      [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+    }
+    const secondWeek = advanceWeek(firstWeek)
+    expect(vitalsHasCognitiveHazardKnowledgeDegraded(secondWeek.agents.a_mina?.vitals)).toBe(
+      false
+    )
+  })
+})

--- a/src/test/cognitiveHazardSimulationTriggerVitals.test.ts
+++ b/src/test/cognitiveHazardSimulationTriggerVitals.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import {
+  COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+  COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+  COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+  type CognitiveHazardExposureRecord,
+} from '../domain/cognitiveHazardEngine'
+import {
+  applyCognitiveHazardSimulationTriggerVitalsToAgents,
+  COGNITIVE_HAZARD_KNOWLEDGE_DEGRADED_STATUS_FLAG,
+  COGNITIVE_HAZARD_PROCEDURE_RESTRICTED_STATUS_FLAG,
+  resolveAgentIdsForCognitiveHazardSubjectRef,
+  vitalsHasCognitiveHazardDutyDegraded,
+  vitalsHasCognitiveHazardKnowledgeDegraded,
+} from '../domain/cognitiveHazardSimulationTriggerVitals'
+
+function memeticFixtureForAgent(agentId: string): CognitiveHazardExposureRecord {
+  return {
+    ...COGNITIVE_HAZARD_MEMETIC_ESCALATION_FIXTURE,
+    subjectRef: `agent:${agentId}`,
+  }
+}
+
+describe('cognitiveHazardSimulationTriggerVitals (SPE-1309 slice 7)', () => {
+  it('resolves roster agent ids from agent-prefixed subject refs', () => {
+    const state = createStartingState()
+
+    expect(resolveAgentIdsForCognitiveHazardSubjectRef(state.agents, 'agent:a_mina')).toEqual([
+      'a_mina',
+    ])
+    expect(resolveAgentIdsForCognitiveHazardSubjectRef(state.agents, 'agent:missing-id')).toEqual(
+      []
+    )
+  })
+
+  it('is a no-op for empty exposure maps without throwing', () => {
+    const state = createStartingState()
+
+    expect(
+      applyCognitiveHazardSimulationTriggerVitalsToAgents({
+        agents: state.agents,
+        nextRecords: {},
+      })
+    ).toBe(state.agents)
+  })
+
+  it('applies knowledge-degraded status flag and stress delta for memetic escalation fixture', () => {
+    const state = createStartingState()
+    const record = memeticFixtureForAgent('a_mina')
+    const priorStress = state.agents.a_mina?.vitals?.stress ?? 0
+
+    const nextAgents = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: state.agents,
+      nextRecords: { [record.id]: record },
+    })
+
+    expect(vitalsHasCognitiveHazardKnowledgeDegraded(nextAgents.a_mina?.vitals)).toBe(true)
+    expect(nextAgents.a_mina?.vitals?.statusFlags).toContain(
+      COGNITIVE_HAZARD_KNOWLEDGE_DEGRADED_STATUS_FLAG
+    )
+    expect((nextAgents.a_mina?.vitals?.stress ?? 0) - priorStress).toBe(6)
+  })
+
+  it('applies duty, knowledge, and procedure flags for failed countermeasure fixture on first week', () => {
+    const state = createStartingState()
+    const record: CognitiveHazardExposureRecord = {
+      ...COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+      subjectRef: 'agent:a_sato',
+    }
+
+    const nextAgents = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: state.agents,
+      nextRecords: { [record.id]: record },
+    })
+
+    const vitals = nextAgents.a_sato?.vitals
+    expect(vitalsHasCognitiveHazardDutyDegraded(vitals)).toBe(true)
+    expect(vitalsHasCognitiveHazardKnowledgeDegraded(vitals)).toBe(true)
+    expect(vitals?.statusFlags).toContain(COGNITIVE_HAZARD_PROCEDURE_RESTRICTED_STATUS_FLAG)
+    expect((vitals?.morale ?? 0)).toBeLessThan(state.agents.a_sato?.vitals?.morale ?? 50)
+  })
+
+  it('strips cognitive hazard flags when triggers stop emitting', () => {
+    const state = createStartingState()
+    const flaggedAgents = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: state.agents,
+      nextRecords: { [memeticFixtureForAgent('a_mina').id]: memeticFixtureForAgent('a_mina') },
+    })
+
+    expect(vitalsHasCognitiveHazardKnowledgeDegraded(flaggedAgents.a_mina?.vitals)).toBe(true)
+
+    const clearedAgents = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: flaggedAgents,
+      nextRecords: {
+        [COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE.id]: COGNITIVE_HAZARD_STABLE_SUBJECT_FIXTURE,
+      },
+    })
+
+    expect(
+      vitalsHasCognitiveHazardKnowledgeDegraded(clearedAgents.a_mina?.vitals)
+    ).toBe(false)
+  })
+
+  it('does not re-apply vitals for terminal erased records on subsequent weeks', () => {
+    const state = createStartingState()
+    const record: CognitiveHazardExposureRecord = {
+      ...COGNITIVE_HAZARD_FAILED_COUNTERMEASURE_FIXTURE,
+      subjectRef: 'agent:a_sato',
+    }
+    const firstWeek = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: state.agents,
+      nextRecords: { [record.id]: record },
+    })
+
+    const secondWeek = applyCognitiveHazardSimulationTriggerVitalsToAgents({
+      agents: firstWeek,
+      nextRecords: { [record.id]: record },
+      priorRecords: { [record.id]: record },
+    })
+
+    expect(vitalsHasCognitiveHazardDutyDegraded(secondWeek.a_sato?.vitals)).toBe(false)
+    expect(vitalsHasCognitiveHazardKnowledgeDegraded(secondWeek.a_sato?.vitals)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add cognitiveHazardSimulationTriggerVitals.ts — sync cognitive_hazard:* status flags and bounded stress/morale deltas from slice 5 trigger summaries.
- Wire vitals application in dvanceWeek after simulation trigger notes; add COGNITIVE_HAZARD_CALIBRATION team-score penalties in computeTeamScore.
- Slice doc + backlog handoff for grooming slice 6 follow-up.

## Linear mapping

- **Slice issue:** SPE-1309 child — agent vitals / scoring side-effects from simulation triggers (slice 7) — create/claim on start
- **Parent:** [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) — stays **Backlog** until grooming slice 6 reconciles AC row 3
- **Prior:** grooming slice 5 @ 62ddbc93 — AC row 3 **Partial**

## What shipped

Agent vitals side-effects from gent_duty_degraded / knowledge_integrity_degraded / procedure_restriction_active triggers — no changes to slice 1–6 compose/tick/trigger contracts or SPE-2108/SPE-2116 hooks.

## Validation

- 
pm run lint
- 
pm run test:run src/test/cognitiveHazardSimulationTriggerVitals.test.ts src/test/advanceWeek.cognitiveHazardSimulationTriggerVitals.integration.test.ts src/test/advanceWeek.cognitiveHazardSimulationTriggers.integration.test.ts (14 passed)

## Docs updated

- planning/spe-1309-unified-engine-slice-7.md
- planning/backlog.md

## Parent remains open

Yes — parent **Backlog** until grooming slice 6 confirms AC row 3 **Yes**.

Made with [Cursor](https://cursor.com)