### PR TITLE
SPE-2459: Disclosure segmented population trust (slice 3)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Next SPE-861 follow-up child (segmented population trust / disclosure choice mechanics), or next open umbrella per active queue.
+**Next step:** SPE-861 slice 4 candidate (disclosure choice mechanics) or next open umbrella per active queue.
 
-**Base `main` SHA:** `0ec51d86` — shipped: SPE-1309 parent acceptance review grooming slice 6 @ `planning/spe-1309-parent-acceptance-review-slice-6.md` (PR #2815)
+**Base `main` SHA:** `d45b250a` — in progress: SPE-861 segmented population trust slice 3 @ `planning/disclosure-campaign-player-ui-slice-3.md` (branch `spe-861-segmented-population-trust-slice-3`)
 
 **Recently shipped:** SPE-1309 parent acceptance review grooming slice 6 (PR #2815 @ `0ec51d86`); SPE-1309 unified cognitive hazard engine slice 7 (PR #2814 @ `a0f8e9ec`).
 

--- a/planning/disclosure-campaign-player-ui-slice-3.md
+++ b/planning/disclosure-campaign-player-ui-slice-3.md
@@ -1,0 +1,80 @@
+# SPE-861 — Disclosure segmented population trust (slice 3)
+
+One-page implementation plan. Linear: child under [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — **Disclosure segmented population trust (slice 3)**. Parent [SPE-861](https://linear.app/spectranoir/issue/SPE-861) stays **Done** on Linear — full trust-to-compliance engine not in scope.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2459](https://linear.app/spectranoir/issue/SPE-2459) — Disclosure segmented population trust (slice 3) |
+| **Status** | **In Progress** → ship on merge                                                                           |
+| **Parent** | [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — public trust and compliance engine (umbrella)    |
+| **Branch** | `spe-861-segmented-population-trust-slice-3`                                                               |
+| **Base `main` SHA** | `d45b250a`                                                                                          |
+
+## Goal
+
+Smallest deterministic read-side projection exposing per-population / per-channel trust divergence from existing `publicDisclosureRecords` + `projectDisclosureRegionalView` — weekly report note + Front Desk signal extension + campaign summary segment chips.
+
+## Prerequisite (on `main` @ `d45b250a`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109)               |
+| Weekly progression   | `applyWeeklyPublicDisclosureProgressionTick` in `advanceWeek` (SPE-2326) |
+| Trust outcome hook   | `projectPublicDisclosureTrustOutcome` + weekly note (SPE-861 slice 2 / PR #2806) |
+| Player campaign UI   | `getPublicDisclosureCampaignView` + `/campaign/public-disclosure` (SPE-861 slice 1) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `projectPublicDisclosureSegmentedTrustOutcome` domain projection   | Full SPE-861 compliance engine              |
+| `buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes` + `advanceWeek` hook | Weekly tick / sanitize contract changes |
+| Front Desk attention summary/tone extension from segmented projection | SPE-1347 contradiction engine changes |
+| Campaign summary segment chips + divergence label                  | Disclosure choice mechanics (slice 4)       |
+| `public_disclosure.segment_trust_divergence` report note type    | Planning mirror route changes               |
+| Domain + `advanceWeek` integration tests                           | SPE-2109 registry schema changes            |
+| Slice doc (this file) + backlog handoff                            | SPE-861 parent scope expansion              |
+
+## Outcome contract
+
+- **Read-only** — project hydrated `publicDisclosureRecords` via `projectDisclosureRegionalView`; no GameState mutation.
+- **Post-tick** — weekly notes emit after disclosure progression tick compose in `advanceWeek` (same hook block as slice 2).
+- **Segments** — classify `trustByRegion` refs: `population:*`, `region:*` → population; `channel:*` → channel; sort-stable by kind then ref.
+- **Divergence** — two or more visible non-redacted segments with different trust bands; uniform or single-segment posture does not emit weekly note.
+- **Redaction** — respect regional projection redaction; omit redacted scores from divergence math and note copy.
+- **Front Desk** — append divergence summary to existing disclosure attention item; elevate tone to `warning` when divergent.
+- **Empty maps** — inactive projection; no weekly note; no divergence Front Desk extension.
+
+## Acceptance
+
+- [x] Empty `publicDisclosureRecords` map yields inactive projection without throw
+- [x] Mixed population/channel fixture projects divergent bands deterministically
+- [x] Redacted `trustByRegion` excludes scores from divergence and chips
+- [x] `advanceWeek` appends `public_disclosure.segment_trust_divergence` note when segments diverge
+- [x] Uniform segment trust does not emit segment-divergence note
+- [x] Front Desk attention summary includes divergence copy when applicable
+- [x] Campaign summary surfaces segment chips + divergence label
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts`, `src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| View   | `src/features/operations/publicDisclosureCampaignView.ts`, `src/features/operations/frontDeskView.ts`, `src/features/operations/PublicDisclosureCampaignPage.tsx`, `src/features/report/reportNoteView.ts` |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/publicDisclosureSegmentedTrustOutcomeProjection.test.ts`, `src/test/advanceWeek.publicDisclosureSegmentedTrust.integration.test.ts`, `src/test/publicDisclosureCampaignView.test.ts`, `src/features/operations/PublicDisclosureCampaignPage.test.tsx`, `src/test/reportNoteTypeAudit.test.ts`, `src/features/report/reportNoteView.test.ts` |
+| Plan   | `planning/disclosure-campaign-player-ui-slice-3.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full public-trust / compliance outcomes engine | SPE-861 follow-up | Parent umbrella; out of smallest hook boundary |
+| Disclosure choice mechanics | SPE-861 slice 4 candidate | Out of read-side projection boundary |
+| Mass-anomalous population wire-up | SPE-2122 | Deferred governance integration |
+
+## See also
+
+- `planning/disclosure-campaign-player-ui-slice-2.md` — trust outcome projection (slice 2)
+- `planning/disclosure-campaign-player-ui-slice-1.md` — player briefing UI (slice 1)

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -987,6 +987,8 @@ export const PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT: Record<string, string> = {
   activeDisclosureLabel: 'Active disclosures',
   dominantAwarenessLabel: 'Dominant awareness band',
   cooperationBandLabel: 'Public cooperation band',
+  segmentDivergenceLabel: 'Audience segment trust',
+  segmentTrustChipsHeading: 'Population and channel trust segments',
   weekLabel: 'Campaign week',
   readOnlyNote:
     'Awareness and regional trust reflect the latest weekly progression. This briefing does not change campaign state.',

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1545,6 +1545,7 @@ export type ReportNoteType =
   | 'post_incident_review.follow_on'
   | 'post_incident_review.closeout_reward_payout'
   | 'public_disclosure.trust_outcome'
+  | 'public_disclosure.segment_trust_divergence'
   | 'cognitive_hazard.simulation_trigger'
 
 export type ReportNoteMetadataValue =

--- a/src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts
+++ b/src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts
@@ -1,0 +1,322 @@
+/**
+ * SPE-861 slice 3: read-side segmented population / channel trust divergence projection.
+ *
+ * Pure deterministic projection over post-tick `publicDisclosureRecords` via
+ * `projectDisclosureRegionalView` — no GameState mutation and no registry schema changes.
+ */
+
+import type { GameState } from './models'
+import {
+  projectDisclosureRegionalView,
+  type PublicDisclosureRecord,
+  type PublicDisclosureRecordsMap,
+} from './publicDisclosureStateRegistry'
+import type { PublicDisclosureTrustOutcomeAttentionTone } from './publicDisclosureTrustOutcomeProjection'
+
+export type PublicDisclosureTrustSegmentKind = 'population' | 'channel'
+
+export type PublicDisclosureSegmentTrustBand = 'low' | 'moderate' | 'high'
+
+export interface PublicDisclosureSegmentTrustEntry {
+  readonly segmentRef: string
+  readonly segmentKind: PublicDisclosureTrustSegmentKind
+  readonly segmentLabel: string
+  readonly segmentKindLabel: string
+  readonly trustBand: PublicDisclosureSegmentTrustBand | null
+  readonly trustBandLabel: string
+  readonly redacted: boolean
+}
+
+export interface PublicDisclosureSegmentedTrustOutcomeProjection {
+  readonly isEmpty: boolean
+  readonly isInactive: boolean
+  readonly activeCampaignCount: number
+  readonly visibleSegmentCount: number
+  readonly hasDivergence: boolean
+  readonly divergenceLabel: string | null
+  readonly segmentEntries: readonly PublicDisclosureSegmentTrustEntry[]
+  readonly frontDeskDivergenceSummary: string | null
+  readonly frontDeskDivergenceTone: PublicDisclosureTrustOutcomeAttentionTone | null
+}
+
+const SEGMENT_KIND_LABELS: Record<PublicDisclosureTrustSegmentKind, string> = {
+  population: 'Population',
+  channel: 'Channel',
+}
+
+const SEGMENT_KIND_ORDER: Record<PublicDisclosureTrustSegmentKind, number> = {
+  population: 0,
+  channel: 1,
+}
+
+function formatDisclosureEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function listPersistedRecords(
+  records: PublicDisclosureRecordsMap | null | undefined
+): PublicDisclosureRecord[] {
+  const map = records ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function resolveSegmentKind(segmentRef: string): PublicDisclosureTrustSegmentKind {
+  const normalized = segmentRef.trim().toLowerCase()
+
+  if (normalized.startsWith('channel:')) {
+    return 'channel'
+  }
+
+  return 'population'
+}
+
+function resolveSegmentDisplayToken(segmentRef: string, kind: PublicDisclosureTrustSegmentKind): string {
+  if (kind === 'channel' && segmentRef.startsWith('channel:')) {
+    return segmentRef.slice('channel:'.length)
+  }
+
+  if (segmentRef.startsWith('population:')) {
+    return segmentRef.slice('population:'.length)
+  }
+
+  if (segmentRef.startsWith('region:')) {
+    return segmentRef.slice('region:'.length)
+  }
+
+  return segmentRef
+}
+
+function formatSegmentDisplayLabel(segmentRef: string): string {
+  const kind = resolveSegmentKind(segmentRef)
+  const token = resolveSegmentDisplayToken(segmentRef, kind)
+  return formatDisclosureEnumLabel(token.replace(/-/g, '_'))
+}
+
+function resolveTrustBandFromScore(score: number): PublicDisclosureSegmentTrustBand {
+  if (score < 0.34) {
+    return 'low'
+  }
+
+  if (score < 0.67) {
+    return 'moderate'
+  }
+
+  return 'high'
+}
+
+function formatTrustBandLabel(band: PublicDisclosureSegmentTrustBand | null, redacted: boolean): string {
+  if (redacted || band === null) {
+    return '—'
+  }
+
+  return band.charAt(0).toUpperCase() + band.slice(1)
+}
+
+function compareSegmentEntries(
+  left: PublicDisclosureSegmentTrustEntry,
+  right: PublicDisclosureSegmentTrustEntry
+): number {
+  const kindDelta = SEGMENT_KIND_ORDER[left.segmentKind] - SEGMENT_KIND_ORDER[right.segmentKind]
+
+  if (kindDelta !== 0) {
+    return kindDelta
+  }
+
+  return left.segmentRef.localeCompare(right.segmentRef)
+}
+
+function collectSegmentTrustScores(
+  records: readonly PublicDisclosureRecord[]
+): Map<string, { minimumScore: number | null; redacted: boolean; kind: PublicDisclosureTrustSegmentKind }> {
+  const aggregate = new Map<
+    string,
+    { minimumScore: number | null; redacted: boolean; kind: PublicDisclosureTrustSegmentKind }
+  >()
+
+  for (const record of records) {
+    if (record.awarenessLevel === 'secrecy_intact') {
+      continue
+    }
+
+    const projection = projectDisclosureRegionalView(record, { redactUnknown: true })
+
+    for (const entry of projection.regionalTrust) {
+      const segmentRef = entry.regionRef
+      const kind = resolveSegmentKind(segmentRef)
+      const existing = aggregate.get(segmentRef)
+
+      if (entry.redacted || entry.trustScore === null) {
+        if (!existing) {
+          aggregate.set(segmentRef, { minimumScore: null, redacted: true, kind })
+        } else if (!existing.redacted) {
+          aggregate.set(segmentRef, { ...existing, redacted: true })
+        }
+
+        continue
+      }
+
+      const nextMinimum =
+        existing?.minimumScore === undefined || existing.minimumScore === null
+          ? entry.trustScore
+          : Math.min(existing.minimumScore, entry.trustScore)
+
+      aggregate.set(segmentRef, {
+        minimumScore: nextMinimum,
+        redacted: existing?.redacted === true,
+        kind,
+      })
+    }
+  }
+
+  return aggregate
+}
+
+function buildSegmentEntries(
+  aggregate: Map<string, { minimumScore: number | null; redacted: boolean; kind: PublicDisclosureTrustSegmentKind }>
+): PublicDisclosureSegmentTrustEntry[] {
+  const entries = [...aggregate.entries()]
+    .sort(([leftRef, leftMeta], [rightRef, rightMeta]) => {
+      const kindDelta = SEGMENT_KIND_ORDER[leftMeta.kind] - SEGMENT_KIND_ORDER[rightMeta.kind]
+
+      if (kindDelta !== 0) {
+        return kindDelta
+      }
+
+      return leftRef.localeCompare(rightRef)
+    })
+    .map(([segmentRef, meta]) => {
+      const trustBand =
+        meta.redacted || meta.minimumScore === null
+          ? null
+          : resolveTrustBandFromScore(meta.minimumScore)
+
+      return Object.freeze({
+        segmentRef,
+        segmentKind: meta.kind,
+        segmentLabel: formatSegmentDisplayLabel(segmentRef),
+        segmentKindLabel: SEGMENT_KIND_LABELS[meta.kind],
+        trustBand,
+        trustBandLabel: formatTrustBandLabel(trustBand, meta.redacted),
+        redacted: meta.redacted,
+      })
+    })
+
+  return entries.sort(compareSegmentEntries)
+}
+
+function resolveHasDivergence(entries: readonly PublicDisclosureSegmentTrustEntry[]): boolean {
+  const visibleBands = new Set<PublicDisclosureSegmentTrustBand>()
+
+  for (const entry of entries) {
+    if (entry.redacted || entry.trustBand === null) {
+      continue
+    }
+
+    visibleBands.add(entry.trustBand)
+  }
+
+  return visibleBands.size >= 2
+}
+
+function resolveDivergenceLabel(input: {
+  visibleSegmentCount: number
+  hasDivergence: boolean
+}): string | null {
+  if (input.visibleSegmentCount === 0) {
+    return null
+  }
+
+  if (input.visibleSegmentCount === 1) {
+    return 'Single visible audience segment'
+  }
+
+  if (input.hasDivergence) {
+    return 'Segment trust diverges'
+  }
+
+  return 'Uniform segment trust'
+}
+
+function buildFrontDeskDivergenceSummary(input: {
+  hasDivergence: boolean
+  visibleSegmentCount: number
+  segmentEntries: readonly PublicDisclosureSegmentTrustEntry[]
+}): string | null {
+  if (!input.hasDivergence || input.visibleSegmentCount < 2) {
+    return null
+  }
+
+  const divergentLabels = input.segmentEntries
+    .filter((entry) => !entry.redacted && entry.trustBand !== null)
+    .map((entry) => `${entry.segmentLabel} (${entry.trustBandLabel})`)
+    .join('; ')
+
+  return `Segment trust diverges across ${input.visibleSegmentCount} audience segment(s): ${divergentLabels}.`
+}
+
+function resolveFrontDeskDivergenceTone(
+  hasDivergence: boolean
+): PublicDisclosureTrustOutcomeAttentionTone | null {
+  if (!hasDivergence) {
+    return null
+  }
+
+  return 'warning'
+}
+
+/** Projects population / channel trust divergence from hydrated disclosure records. */
+export function projectPublicDisclosureSegmentedTrustOutcome(
+  records: PublicDisclosureRecordsMap | null | undefined
+): PublicDisclosureSegmentedTrustOutcomeProjection {
+  const persistedRecords = listPersistedRecords(records)
+  const activeRecords = persistedRecords.filter((record) => record.awarenessLevel !== 'secrecy_intact')
+  const aggregate = collectSegmentTrustScores(activeRecords)
+  const segmentEntries = Object.freeze(buildSegmentEntries(aggregate))
+  const visibleSegmentCount = segmentEntries.filter(
+    (entry) => !entry.redacted && entry.trustBand !== null
+  ).length
+  const hasDivergence = resolveHasDivergence(segmentEntries)
+  const isInactive =
+    persistedRecords.length === 0 || activeRecords.length === 0 || segmentEntries.length === 0
+
+  return Object.freeze({
+    isEmpty: persistedRecords.length === 0,
+    isInactive,
+    activeCampaignCount: activeRecords.length,
+    visibleSegmentCount,
+    hasDivergence,
+    divergenceLabel: resolveDivergenceLabel({ visibleSegmentCount, hasDivergence }),
+    segmentEntries,
+    frontDeskDivergenceSummary: buildFrontDeskDivergenceSummary({
+      hasDivergence,
+      visibleSegmentCount,
+      segmentEntries,
+    }),
+    frontDeskDivergenceTone: resolveFrontDeskDivergenceTone(hasDivergence),
+  })
+}
+
+export function projectPublicDisclosureSegmentedTrustOutcomeFromGame(
+  game: Pick<GameState, 'publicDisclosureRecords'>
+): PublicDisclosureSegmentedTrustOutcomeProjection {
+  return projectPublicDisclosureSegmentedTrustOutcome(game.publicDisclosureRecords)
+}
+
+export function formatPublicDisclosureSegmentedTrustOutcomeNoteContent(
+  projection: PublicDisclosureSegmentedTrustOutcomeProjection,
+  week: number
+): string {
+  if (projection.isInactive || !projection.hasDivergence) {
+    return `Public disclosure segment trust divergence — W${week}: no divergent audience segments.`
+  }
+
+  const segmentSummary = projection.segmentEntries
+    .filter((entry) => !entry.redacted && entry.trustBand !== null)
+    .map((entry) => `${entry.segmentLabel} (${entry.trustBandLabel})`)
+    .join('; ')
+
+  return `Public disclosure segment trust divergence — W${week}: ${projection.activeCampaignCount} active campaign(s); ${segmentSummary}.`
+}

--- a/src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts
+++ b/src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts
@@ -1,0 +1,43 @@
+/**
+ * SPE-861 slice 3: weekly report notes for segmented public-disclosure trust divergence.
+ *
+ * Emits deterministic notes from post-tick disclosure records — no new persistence.
+ */
+
+import {
+  formatPublicDisclosureSegmentedTrustOutcomeNoteContent,
+  projectPublicDisclosureSegmentedTrustOutcome,
+} from './publicDisclosureSegmentedTrustOutcomeProjection'
+import type { ReportNote } from './models'
+import type { PublicDisclosureRecordsMap } from './publicDisclosureStateRegistry'
+import { createDeterministicReportNote } from './reportNotes'
+
+/** Builds weekly report notes when active campaigns project divergent segment trust. */
+export function buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes(input: {
+  nextRecords: PublicDisclosureRecordsMap | null | undefined
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const projection = projectPublicDisclosureSegmentedTrustOutcome(input.nextRecords)
+
+  if (projection.isInactive || !projection.hasDivergence) {
+    return []
+  }
+
+  return [
+    createDeterministicReportNote(
+      formatPublicDisclosureSegmentedTrustOutcomeNoteContent(projection, input.week),
+      input.week,
+      input.sequenceStart,
+      input.baseTimestamp,
+      'public_disclosure.segment_trust_divergence',
+      {
+        activeCampaignCount: projection.activeCampaignCount,
+        visibleSegmentCount: projection.visibleSegmentCount,
+        hasDivergence: projection.hasDivergence,
+        week: input.week,
+      }
+    ),
+  ]
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -297,6 +297,7 @@ import { applyWeeklyPatternSourceSeriesIntakeTick } from '../patternSourceSeries
 import { composePopulationEmergenceNormalizationIntoDisclosureRecords } from '../publicDisclosureNormalizationCompose'
 import { applyWeeklyPublicDisclosureProgressionTick } from '../publicDisclosureWeeklyProgression'
 import { buildWeeklyPublicDisclosureTrustOutcomeReportNotes } from '../publicDisclosureTrustOutcomeWeeklyReportNotes'
+import { buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes } from '../publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes'
 import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInformationWeeklyRetention'
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
@@ -5209,13 +5210,24 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       baseTimestamp: noteBaseTimestamp,
     })
 
-    if (trustOutcomeNotes.length > 0) {
+    let appendedDisclosureNotes = trustOutcomeNotes
+
+    const segmentedTrustNotes = buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes({
+      nextRecords: nextPublicDisclosureRecordsForTrustOutcome,
+      week: result.week,
+      sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + appendedDisclosureNotes.length + 1,
+      baseTimestamp: noteBaseTimestamp,
+    })
+
+    appendedDisclosureNotes = [...appendedDisclosureNotes, ...segmentedTrustNotes]
+
+    if (appendedDisclosureNotes.length > 0) {
       const reports = [...result.reports]
       const lastReportIndex = reports.length - 1
       const lastReport = reports[lastReportIndex]
       reports[lastReportIndex] = {
         ...lastReport,
-        notes: [...(lastReport.notes ?? []), ...trustOutcomeNotes],
+        notes: [...(lastReport.notes ?? []), ...appendedDisclosureNotes],
       }
       result.reports = reports
     }

--- a/src/features/operations/PublicDisclosureCampaignPage.test.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.test.tsx
@@ -58,6 +58,26 @@ describe('PublicDisclosureCampaignPage (SPE-861 slice 1)', () => {
     )
   })
 
+  it('renders segment trust chips when population and channel segments diverge', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: {
+        ...DISCLOSURE_PROGRESSION_FIXTURE,
+        trustByRegion: [
+          { regionRef: 'population:general-public', trustScore: 0.72 },
+          { regionRef: 'channel:community-forums', trustScore: 0.18 },
+        ],
+      },
+    }
+    useGameStore.setState({ game })
+
+    renderCampaignPage()
+
+    expect(screen.getByText(/segment trust diverges/i)).toBeInTheDocument()
+    expect(screen.getByText(/Population: General Public — High/i)).toBeInTheDocument()
+    expect(screen.getByText(/Channel: Community Forums — Low/i)).toBeInTheDocument()
+  })
+
   it('does not mutate GameState after render', () => {
     const game = createStartingState()
     game.publicDisclosureRecords = {

--- a/src/features/operations/PublicDisclosureCampaignPage.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.tsx
@@ -50,10 +50,33 @@ export default function PublicDisclosureCampaignPage() {
             value={view.summary.cooperationBandLabel ?? '—'}
           />
           <StatCard
+            label={PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.segmentDivergenceLabel}
+            value={view.summary.segmentDivergenceLabel ?? '—'}
+          />
+          <StatCard
             label={PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.weekLabel}
             value={`W${view.summary.week}`}
           />
         </div>
+
+        {view.summary.segmentTrustChips.length > 0 ? (
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.18em] opacity-50">
+              {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.segmentTrustChipsHeading}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {view.summary.segmentTrustChips.map((chip) => (
+                <span
+                  key={`${chip.segmentKindLabel}:${chip.segmentLabel}`}
+                  className="rounded-full border border-white/15 px-2 py-0.5 text-xs opacity-80"
+                >
+                  {chip.segmentKindLabel}: {chip.segmentLabel} — {chip.trustBandLabel}
+                  {chip.redacted ? ` ${PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.redactedSuffix}` : ''}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         <p className="text-xs opacity-55">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.readOnlyNote}</p>
       </article>

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -48,6 +48,7 @@ import {
 import { FRONT_DESK_TRIGGER_IDS, getEligibleFrontDeskSceneTriggerIdSet } from './frontDeskTriggers'
 import { getPublicDisclosureCampaignView } from './publicDisclosureCampaignView'
 import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
+import { projectPublicDisclosureSegmentedTrustOutcomeFromGame } from '../../domain/publicDisclosureSegmentedTrustOutcomeProjection'
 
 export type FrontDeskNoticeTone = 'info' | 'warning' | 'danger' | 'success'
 export type FrontDeskNoticeActionTarget = 'report' | 'cases' | 'recruitment' | 'factions'
@@ -1196,14 +1197,20 @@ function buildAttentionItems(
     }))
 
   const disclosureTrustOutcome = projectPublicDisclosureTrustOutcomeFromGame(game)
+  const disclosureSegmentedTrust = projectPublicDisclosureSegmentedTrustOutcomeFromGame(game)
+  const disclosureAttentionSummary = disclosureSegmentedTrust.frontDeskDivergenceSummary
+    ? `${disclosureTrustOutcome.frontDeskAttentionSummary} ${disclosureSegmentedTrust.frontDeskDivergenceSummary}`
+    : disclosureTrustOutcome.frontDeskAttentionSummary
+  const disclosureAttentionTone =
+    disclosureSegmentedTrust.frontDeskDivergenceTone ?? disclosureTrustOutcome.frontDeskAttentionTone
   const disclosureAttention =
     disclosureTrustOutcome.activeCampaignCount > 0
       ? [
           {
             id: 'disclosure:campaign-briefing',
             title: 'Disclosure campaign posture requires review',
-            summary: disclosureTrustOutcome.frontDeskAttentionSummary,
-            tone: disclosureTrustOutcome.frontDeskAttentionTone,
+            summary: disclosureAttentionSummary,
+            tone: disclosureAttentionTone,
             href: APP_ROUTES.publicDisclosureCampaign,
           } as const,
         ]

--- a/src/features/operations/publicDisclosureCampaignView.ts
+++ b/src/features/operations/publicDisclosureCampaignView.ts
@@ -6,6 +6,7 @@ import {
 } from '../../domain/publicDisclosureStateRegistry'
 import { resolveTruthLayerDualIncidentPairing } from '../../domain/truthLayerCoverNarrativePairing'
 import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
+import { projectPublicDisclosureSegmentedTrustOutcomeFromGame } from '../../domain/publicDisclosureSegmentedTrustOutcomeProjection'
 import { formatPublicDisclosureEnumLabel } from './publicDisclosureMirrorView'
 
 const AWARENESS_SEVERITY_ORDER: readonly AwarenessLevel[] = [
@@ -36,10 +37,19 @@ export interface PublicDisclosureCampaignRecordView {
   redacted: boolean
 }
 
+export interface PublicDisclosureCampaignSegmentChipView {
+  segmentLabel: string
+  segmentKindLabel: string
+  trustBandLabel: string
+  redacted: boolean
+}
+
 export interface PublicDisclosureCampaignSummaryView {
   activeDisclosureCount: number
   dominantAwarenessBandLabel: string
   cooperationBandLabel: string | null
+  segmentDivergenceLabel: string | null
+  segmentTrustChips: readonly PublicDisclosureCampaignSegmentChipView[]
   week: number
 }
 
@@ -178,10 +188,22 @@ function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDi
 export function getPublicDisclosureCampaignView(game: GameState): PublicDisclosureCampaignView {
   const records = listPersistedRecords(game)
   const trustOutcome = projectPublicDisclosureTrustOutcomeFromGame(game)
+  const segmentedTrust = projectPublicDisclosureSegmentedTrustOutcomeFromGame(game)
 
   const activeDisclosureCount = records.filter(
     (record) => record.awarenessLevel !== 'secrecy_intact'
   ).length
+
+  const segmentTrustChips = Object.freeze(
+    segmentedTrust.segmentEntries.map((entry) =>
+      Object.freeze({
+        segmentLabel: entry.segmentLabel,
+        segmentKindLabel: entry.segmentKindLabel,
+        trustBandLabel: entry.trustBandLabel,
+        redacted: entry.redacted,
+      })
+    )
+  )
 
   return Object.freeze({
     isEmpty: records.length === 0,
@@ -190,6 +212,8 @@ export function getPublicDisclosureCampaignView(game: GameState): PublicDisclosu
       dominantAwarenessBandLabel: resolveDominantAwarenessBand(records),
       cooperationBandLabel:
         trustOutcome.cooperationBand === 'inactive' ? null : trustOutcome.cooperationBandLabel,
+      segmentDivergenceLabel: segmentedTrust.isInactive ? null : segmentedTrust.divergenceLabel,
+      segmentTrustChips,
       week: game.week,
     }),
     records: Object.freeze(records.map((record) => toRecordView(game, record))),

--- a/src/features/report/reportNoteView.test.ts
+++ b/src/features/report/reportNoteView.test.ts
@@ -63,6 +63,7 @@ const EXPECTED_CATEGORY_BY_TYPE = {
   'post_incident_review.follow_on': 'post_incident_review',
   'post_incident_review.closeout_reward_payout': 'post_incident_review',
   'public_disclosure.trust_outcome': 'system',
+  'public_disclosure.segment_trust_divergence': 'system',
 } satisfies Record<ReportNoteType, ReportNoteCategory>
 
 describe('reportNoteView', () => {

--- a/src/features/report/reportNoteView.ts
+++ b/src/features/report/reportNoteView.ts
@@ -49,6 +49,7 @@ const SYSTEM_NOTE_TYPES: ReportNoteType[] = [
   'welfare_debt.accounting_cross_link',
   'coercive_protocol.integrated_health_reconciliation',
   'public_disclosure.trust_outcome',
+  'public_disclosure.segment_trust_divergence',
   'system.week_delta',
   'system.party_cards_drawn',
   'system.equipment_recovered',

--- a/src/test/advanceWeek.publicDisclosureSegmentedTrust.integration.test.ts
+++ b/src/test/advanceWeek.publicDisclosureSegmentedTrust.integration.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  type PublicDisclosureRecord,
+} from '../domain/publicDisclosureStateRegistry'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+const SEGMENT_DIVERGENCE_FIXTURE: PublicDisclosureRecord = {
+  ...DISCLOSURE_PROGRESSION_FIXTURE,
+  id: 'disclosure:segment-divergence-test',
+  label: 'Segment trust divergence campaign',
+  trustByRegion: [
+    { regionRef: 'population:general-public', trustScore: 0.72 },
+    { regionRef: 'population:affected-residents', trustScore: 0.28 },
+    { regionRef: 'channel:institutional-press', trustScore: 0.55 },
+    { regionRef: 'channel:community-forums', trustScore: 0.18 },
+  ],
+}
+
+describe('advanceWeek public disclosure segmented trust integration (SPE-861 slice 3)', () => {
+  it('is a no-op for an empty public disclosure map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {}
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const segmentNotes =
+      weeklyReport?.notes?.filter(
+        (note) => note.type === 'public_disclosure.segment_trust_divergence'
+      ) ?? []
+
+    expect(segmentNotes).toEqual([])
+  })
+
+  it('surfaces segment-divergence notes after post-tick disclosure records diverge', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {
+      [SEGMENT_DIVERGENCE_FIXTURE.id]: SEGMENT_DIVERGENCE_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const segmentNotes =
+      weeklyReport?.notes?.filter(
+        (note) => note.type === 'public_disclosure.segment_trust_divergence'
+      ) ?? []
+
+    expect(segmentNotes).toHaveLength(1)
+    expect(segmentNotes[0]?.content).toContain('Public disclosure segment trust divergence')
+    expect(segmentNotes[0]?.content).toContain('Affected Residents (Low)')
+    expect(segmentNotes[0]?.content).toContain('General Public (High)')
+    expect(segmentNotes[0]?.metadata?.hasDivergence).toBe(true)
+    expect(segmentNotes[0]?.metadata?.visibleSegmentCount).toBe(4)
+  })
+
+  it('does not emit segment-divergence notes when segment trust is uniform', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: {
+        ...DISCLOSURE_PROGRESSION_FIXTURE,
+        trustByRegion: [
+          { regionRef: 'population:general-public', trustScore: 0.65 },
+          { regionRef: 'channel:institutional-press', trustScore: 0.62 },
+        ],
+      },
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const segmentNotes =
+      weeklyReport?.notes?.filter(
+        (note) => note.type === 'public_disclosure.segment_trust_divergence'
+      ) ?? []
+
+    expect(segmentNotes).toEqual([])
+  })
+})

--- a/src/test/publicDisclosureCampaignView.test.ts
+++ b/src/test/publicDisclosureCampaignView.test.ts
@@ -89,6 +89,20 @@ describe('publicDisclosureCampaignView (SPE-861 slice 1)', () => {
     expect(view.summary.dominantAwarenessBandLabel).toBe('Normalization')
   })
 
+  it('surfaces segment trust chips and divergence label in campaign summary', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const view = getPublicDisclosureCampaignView(game)
+
+    expect(view.summary.segmentDivergenceLabel).toBe('Segment trust diverges')
+    expect(view.summary.segmentTrustChips).toHaveLength(2)
+    expect(view.summary.segmentTrustChips[0]?.segmentLabel).toBe('Coastal Metro')
+    expect(view.summary.segmentTrustChips[0]?.segmentKindLabel).toBe('Population')
+  })
+
   it('is byte-stable for repeated campaign builds', () => {
     const game = createStartingState()
     game.publicDisclosureRecords = {

--- a/src/test/publicDisclosureSegmentedTrustOutcomeProjection.test.ts
+++ b/src/test/publicDisclosureSegmentedTrustOutcomeProjection.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  NORMALIZATION_INPUT_FIXTURE,
+  type PublicDisclosureRecord,
+} from '../domain/publicDisclosureStateRegistry'
+import {
+  formatPublicDisclosureSegmentedTrustOutcomeNoteContent,
+  projectPublicDisclosureSegmentedTrustOutcome,
+} from '../domain/publicDisclosureSegmentedTrustOutcomeProjection'
+
+const SEGMENT_DIVERGENCE_FIXTURE: PublicDisclosureRecord = {
+  ...DISCLOSURE_PROGRESSION_FIXTURE,
+  id: 'disclosure:segment-divergence-test',
+  label: 'Segment trust divergence campaign',
+  trustByRegion: [
+    { regionRef: 'population:general-public', trustScore: 0.72 },
+    { regionRef: 'population:affected-residents', trustScore: 0.28 },
+    { regionRef: 'channel:institutional-press', trustScore: 0.55 },
+    { regionRef: 'channel:community-forums', trustScore: 0.18 },
+  ],
+}
+
+const UNIFORM_SEGMENT_FIXTURE: PublicDisclosureRecord = {
+  ...DISCLOSURE_PROGRESSION_FIXTURE,
+  id: 'disclosure:uniform-segment-test',
+  label: 'Uniform segment trust campaign',
+  trustByRegion: [
+    { regionRef: 'population:general-public', trustScore: 0.65 },
+    { regionRef: 'channel:institutional-press', trustScore: 0.62 },
+  ],
+}
+
+describe('publicDisclosureSegmentedTrustOutcomeProjection (SPE-861 slice 3)', () => {
+  it('returns inactive projection for an empty disclosure map', () => {
+    const projection = projectPublicDisclosureSegmentedTrustOutcome({})
+
+    expect(projection.isEmpty).toBe(true)
+    expect(projection.isInactive).toBe(true)
+    expect(projection.activeCampaignCount).toBe(0)
+    expect(projection.visibleSegmentCount).toBe(0)
+    expect(projection.hasDivergence).toBe(false)
+    expect(projection.segmentEntries).toEqual([])
+    expect(projection.frontDeskDivergenceSummary).toBeNull()
+  })
+
+  it('classifies region refs as population segments and sorts deterministically', () => {
+    const projection = projectPublicDisclosureSegmentedTrustOutcome({
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    })
+
+    expect(projection.activeCampaignCount).toBe(1)
+    expect(projection.segmentEntries).toHaveLength(2)
+    expect(projection.segmentEntries[0]?.segmentKind).toBe('population')
+    expect(projection.segmentEntries[0]?.segmentLabel).toBe('Coastal Metro')
+    expect(projection.segmentEntries[0]?.trustBand).toBe('low')
+    expect(projection.segmentEntries[1]?.segmentLabel).toBe('Inland Corridor')
+    expect(projection.hasDivergence).toBe(true)
+    expect(projection.divergenceLabel).toBe('Segment trust diverges')
+  })
+
+  it('detects divergent population and channel segment trust bands', () => {
+    const projection = projectPublicDisclosureSegmentedTrustOutcome({
+      [SEGMENT_DIVERGENCE_FIXTURE.id]: SEGMENT_DIVERGENCE_FIXTURE,
+    })
+
+    expect(projection.visibleSegmentCount).toBe(4)
+    expect(projection.hasDivergence).toBe(true)
+    expect(projection.segmentEntries.map((entry) => entry.segmentKind)).toEqual([
+      'population',
+      'population',
+      'channel',
+      'channel',
+    ])
+    expect(projection.frontDeskDivergenceSummary).toContain('Segment trust diverges')
+    expect(projection.frontDeskDivergenceTone).toBe('warning')
+  })
+
+  it('reports uniform segment trust when visible bands align', () => {
+    const projection = projectPublicDisclosureSegmentedTrustOutcome({
+      [UNIFORM_SEGMENT_FIXTURE.id]: UNIFORM_SEGMENT_FIXTURE,
+    })
+
+    expect(projection.visibleSegmentCount).toBe(2)
+    expect(projection.hasDivergence).toBe(false)
+    expect(projection.divergenceLabel).toBe('Uniform segment trust')
+    expect(projection.frontDeskDivergenceSummary).toBeNull()
+  })
+
+  it('ignores redacted regional scores in divergence and segment breakdown', () => {
+    const redactedRecord: PublicDisclosureRecord = {
+      ...SEGMENT_DIVERGENCE_FIXTURE,
+      redactedFields: ['trustByRegion'],
+    }
+
+    const projection = projectPublicDisclosureSegmentedTrustOutcome({
+      [redactedRecord.id]: redactedRecord,
+    })
+
+    expect(projection.segmentEntries.every((entry) => entry.redacted)).toBe(true)
+    expect(projection.visibleSegmentCount).toBe(0)
+    expect(projection.hasDivergence).toBe(false)
+    expect(projection.segmentEntries[0]?.trustBandLabel).toBe('—')
+  })
+
+  it('aggregates minimum trust score for duplicate segment refs across records', () => {
+    const secondRecord: PublicDisclosureRecord = {
+      ...NORMALIZATION_INPUT_FIXTURE,
+      trustByRegion: [{ regionRef: 'region:coastal-metro', trustScore: 0.12 }],
+    }
+
+    const projection = projectPublicDisclosureSegmentedTrustOutcome({
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+      [secondRecord.id]: secondRecord,
+    })
+
+    const coastalEntry = projection.segmentEntries.find(
+      (entry) => entry.segmentRef === 'region:coastal-metro'
+    )
+
+    expect(coastalEntry?.trustBand).toBe('low')
+    expect(projection.activeCampaignCount).toBe(2)
+  })
+
+  it('formats weekly segment-divergence note content deterministically', () => {
+    const projection = projectPublicDisclosureSegmentedTrustOutcome({
+      [SEGMENT_DIVERGENCE_FIXTURE.id]: SEGMENT_DIVERGENCE_FIXTURE,
+    })
+
+    expect(formatPublicDisclosureSegmentedTrustOutcomeNoteContent(projection, 24)).toBe(
+      'Public disclosure segment trust divergence — W24: 1 active campaign(s); Affected Residents (Low); General Public (High); Community Forums (Low); Institutional Press (Moderate).'
+    )
+  })
+
+  it('is byte-stable for repeated projections', () => {
+    const records = {
+      [SEGMENT_DIVERGENCE_FIXTURE.id]: SEGMENT_DIVERGENCE_FIXTURE,
+      [NORMALIZATION_INPUT_FIXTURE.id]: NORMALIZATION_INPUT_FIXTURE,
+    }
+
+    const first = JSON.stringify(projectPublicDisclosureSegmentedTrustOutcome(records))
+    const second = JSON.stringify(projectPublicDisclosureSegmentedTrustOutcome(records))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -83,6 +83,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
     producer: 'publicDisclosureTrustOutcomeWeeklyReportNotes',
     category: 'system',
   },
+  'public_disclosure.segment_trust_divergence': {
+    status: 'active',
+    producer: 'publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes',
+    category: 'system',
+  },
   'cognitive_hazard.simulation_trigger': {
     status: 'active',
     producer: 'cognitiveHazardSimulationTriggerWeeklyReportNotes',
@@ -99,7 +104,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(46)
+    expect(entries).toHaveLength(47)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Adds `projectPublicDisclosureSegmentedTrustOutcome` — deterministic read-side projection classifying `trustByRegion` refs into population vs channel segments via `projectDisclosureRegionalView`, with sort-stable divergence detection and redaction-safe bands.
- Wires `public_disclosure.segment_trust_divergence` weekly report notes in `advanceWeek` (post-tick, alongside slice 2 trust-outcome notes) and extends Front Desk disclosure attention summary/tone when segments diverge.
- Surfaces campaign summary segment chips + divergence label on `/campaign/public-disclosure` (read-only).

## Linear mapping

- **Slice:** [SPE-2459](https://linear.app/spectranoir/issue/SPE-2459) — Disclosure segmented population trust (slice 3)
- **Parent:** [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — stays **Done** (full compliance engine out of scope)
- **Parent remains open:** No — parent scope not expanded; deferred disclosure choice mechanics to slice 4 candidate

## What shipped

- Domain: `publicDisclosureSegmentedTrustOutcomeProjection.ts`, `publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts`
- Integration: `advanceWeek.ts`, `models.ts` (`public_disclosure.segment_trust_divergence`)
- UI: `publicDisclosureCampaignView.ts`, `PublicDisclosureCampaignPage.tsx`, `frontDeskView.ts`, `copy.ts`, `reportNoteView.ts`
- Docs: `planning/disclosure-campaign-player-ui-slice-3.md`, `planning/backlog.md` handoff

## Validation

- `npm run lint`
- `npm run test:run -- src/test/publicDisclosureSegmentedTrustOutcomeProjection.test.ts src/test/advanceWeek.publicDisclosureSegmentedTrust.integration.test.ts src/test/publicDisclosureCampaignView.test.ts src/features/operations/PublicDisclosureCampaignPage.test.tsx src/test/reportNoteTypeAudit.test.ts src/features/report/reportNoteView.test.ts src/test/advanceWeek.publicDisclosureTrustOutcome.integration.test.ts`

## Docs updated

- `planning/disclosure-campaign-player-ui-slice-3.md`
- `planning/backlog.md`