### PR TITLE
SPE-861 slice 4: disclosure posture choice mechanics

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** SPE-861 slice 4 candidate (disclosure choice mechanics) or next open umbrella per active queue.
+**Next step:** Next open umbrella per active queue (SPE-861 slice 4 in progress).
 
-**Base `main` SHA:** `86d0956f` — shipped: SPE-861 segmented population trust slice 3 @ `planning/disclosure-campaign-player-ui-slice-3.md` (PR #2818 / [SPE-2459](https://linear.app/spectranoir/issue/SPE-2459))
+**Base `main` SHA:** `ad173090` — in progress: SPE-861 disclosure choice mechanics slice 4 @ `planning/disclosure-campaign-player-ui-slice-4.md` (branch `spe-861-disclosure-choice-mechanics-slice-4`)
 
 **Recently shipped:** SPE-861 segmented population trust slice 3 (PR #2818 @ `86d0956f`); SPE-1309 parent acceptance review grooming slice 6 (PR #2815 @ `0ec51d86`).
 

--- a/planning/disclosure-campaign-player-ui-slice-4.md
+++ b/planning/disclosure-campaign-player-ui-slice-4.md
@@ -1,0 +1,82 @@
+# SPE-861 — Disclosure choice mechanics (slice 4)
+
+One-page implementation plan. Linear: child under [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — **Disclosure choice mechanics (slice 4)** (create/claim on start). Parent [SPE-861](https://linear.app/spectranoir/issue/SPE-861) stays **Done** — full trust-to-compliance engine not in scope.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-861 child — Disclosure choice mechanics (slice 4)                                                    |
+| **Status** | Ready for PR                                                                                               |
+| **Parent** | [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — public trust and compliance engine (umbrella)    |
+| **Branch** | `spe-861-disclosure-choice-mechanics-slice-4`                                                            |
+| **Base `main` SHA** | `ad173090`                                                                                          |
+
+## Goal
+
+Smallest deterministic write-side hook that lets the player set disclosure posture choices on active campaigns and see downstream cooperation / segment-trust effects through existing trust-outcome projections — no full SPE-861 compliance engine.
+
+## Prerequisite (on `main` @ `ad173090`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Registry schema      | `src/domain/publicDisclosureStateRegistry.ts` (SPE-2109)               |
+| Weekly progression   | `applyWeeklyPublicDisclosureProgressionTick` in `advanceWeek` (SPE-2326) |
+| Trust outcome hook   | `projectPublicDisclosureTrustOutcome` + weekly note (SPE-861 slice 2) |
+| Segmented trust hook | `projectPublicDisclosureSegmentedTrustOutcome` (SPE-861 slice 3)     |
+| Player campaign UI   | `getPublicDisclosureCampaignView` + `/campaign/public-disclosure` (SPE-861 slice 1) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `publicDisclosurePostureChoices` on `GameState` + sanitize         | Full SPE-861 compliance engine              |
+| `applyPublicDisclosurePostureChoice` domain command                | SPE-2109 registry schema / sanitize changes |
+| Posture trust adjustment at projection time (no record mutation)   | Weekly tick contract changes                |
+| Campaign posture choice UI + store action                          | Planning mirror route changes               |
+| `advanceWeek` trust-outcome notes honor posture choices            | SPE-861 parent scope expansion              |
+| Domain + integration + campaign view/page tests                    | Raw trust score surfacing in choice UI      |
+| Slice doc (this file) + backlog handoff                            | Authored-choice flag orchestration          |
+
+## Outcome contract
+
+- **Write-side choice state** — `publicDisclosurePostureChoices` keyed by disclosure record id; hydrate drops orphan ids and invalid postures.
+- **Projection-only trust delta** — `transparent` (+0.10), `managed_secrecy` (0), `restrictive` (−0.10) applied when projecting cooperation/segment trust; persisted `trustByRegion` unchanged.
+- **Active campaigns only** — choices available when `awarenessLevel !== 'secrecy_intact'`; empty/no-active-campaign states stay inactive.
+- **Redaction** — choice UI shows band labels only; no raw trust scores or redacted score reveal.
+- **Determinism** — sort-stable record iteration; idempotent re-selection; slice 2–3 projection tests unchanged without posture input.
+- **Front Desk** — attention summary/tone continues via `projectPublicDisclosureTrustOutcomeFromGame` with posture choices.
+
+## Acceptance
+
+- [x] Empty `publicDisclosureRecords` map yields inactive posture UI without throw
+- [x] Active campaign exposes three posture options and persists selection
+- [x] Transparent posture shifts opposed fixture to watchful cooperation band
+- [x] Restrictive posture preserves or deepens opposed posture on low-trust fixture
+- [x] `advanceWeek` trust-outcome note metadata reflects posture-adjusted cooperation band
+- [x] Persisted registry records unchanged after posture selection
+- [x] Front Desk attention regression green
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publicDisclosurePostureChoice.ts`, `src/domain/publicDisclosureTrustOutcomeProjection.ts`, `src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts`, `src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts`, `src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/gameStore.ts`, `src/app/store/runTransfer.ts`          |
+| View   | `src/features/operations/publicDisclosureCampaignView.ts`, `src/features/operations/PublicDisclosureCampaignPage.tsx` |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/publicDisclosurePostureChoice.test.ts`, `src/test/advanceWeek.publicDisclosurePostureChoice.integration.test.ts`, `src/test/publicDisclosureCampaignView.test.ts`, `src/features/operations/PublicDisclosureCampaignPage.test.tsx` |
+| Plan   | `planning/disclosure-campaign-player-ui-slice-4.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full public-trust / compliance outcomes engine | SPE-861 follow-up | Parent umbrella; out of smallest hook boundary |
+| Authored-choice / Front Desk notice orchestration for posture | SPE-861 follow-up | Campaign surface sufficient for slice 4 |
+| Mass-anomalous population wire-up | SPE-2122 | Deferred governance integration |
+
+## See also
+
+- `planning/disclosure-campaign-player-ui-slice-3.md` — segmented trust projection (slice 3)
+- `planning/disclosure-campaign-player-ui-slice-2.md` — trust outcome projection (slice 2)
+- `planning/disclosure-campaign-player-ui-slice-1.md` — player briefing UI (slice 1)

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -97,6 +97,10 @@ import {
   applyInfiltrationWeeklyProbeActionOverride,
   canConfigureInfiltrationWeeklyProbeOnCase,
 } from '../../domain/infiltrationProbeOverride'
+import {
+  applyPublicDisclosurePostureChoice,
+  type PublicDisclosurePostureChoice,
+} from '../../domain/publicDisclosurePostureChoice'
 import { applyStealthLeaveBehindSelection } from '../../domain/stealthLeaveBehindSelection'
 import { queueFabrication } from '../../domain/sim/production'
 import { invokeEmergencyGrayMarketWaiver } from '../../domain/procurementEmergency'
@@ -252,6 +256,11 @@ interface GameStore {
   setInfiltrationWeeklyProbeAction: (
     caseId: Id,
     action: InfiltrationProbeAction | null
+  ) => void
+  /** SPE-861 slice 4: set disclosure posture choice on an active disclosure campaign record. */
+  setPublicDisclosurePostureChoice: (
+    recordId: Id,
+    posture: PublicDisclosurePostureChoice
   ) => void
   hireCandidate: (candidateId: Id) => void
   scoutCandidate: (candidateId: Id) => void
@@ -1201,6 +1210,20 @@ export const useGameStore = create<GameStore>()(
             caseId,
             action,
           })
+          if (!result.applied) {
+            return { game: s.game }
+          }
+
+          return { game: result.state }
+        }),
+
+      setPublicDisclosurePostureChoice: (recordId, posture) =>
+        set((s) => {
+          const result = applyPublicDisclosurePostureChoice(s.game, {
+            recordId,
+            posture,
+          })
+
           if (!result.applied) {
             return { game: s.game }
           }

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -203,6 +203,7 @@ import { sanitizeUnexplainedLocationRecords } from '../../domain/unexplainedLoca
 import { sanitizeMinorAnomalyItemRecords } from '../../domain/minorAnomalyItemRegistry'
 import { sanitizeSelfCensoringInformationRecords } from '../../domain/selfCensoringInformationRegistry'
 import { sanitizePublicDisclosureRecords } from '../../domain/publicDisclosureStateRegistry'
+import { sanitizePublicDisclosurePostureChoices } from '../../domain/publicDisclosurePostureChoice'
 import {
   sanitizeTruthLayerRecords,
   sanitizeTruthLayerWeeklyProjectionSnapshots,
@@ -8509,6 +8510,11 @@ export function hydrateGame(
     game.publicDisclosureRecords,
     fallback.publicDisclosureRecords ?? {}
   )
+  const publicDisclosurePostureChoices = sanitizePublicDisclosurePostureChoices(
+    game.publicDisclosurePostureChoices,
+    new Set(Object.keys(publicDisclosureRecords)),
+    fallback.publicDisclosurePostureChoices ?? {}
+  )
   const truthLayerRecords = sanitizeTruthLayerRecords(
     game.truthLayerRecords,
     fallback.truthLayerRecords ?? {}
@@ -8722,6 +8728,7 @@ export function hydrateGame(
       ruleDocumentComplianceRecords,
       selfCensoringInformationRecords,
       publicDisclosureRecords,
+      publicDisclosurePostureChoices,
       truthLayerRecords,
       truthLayerWeeklyProjectionSnapshots,
       coverStoryRecords,

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -991,7 +991,7 @@ export const PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT: Record<string, string> = {
   segmentTrustChipsHeading: 'Population and channel trust segments',
   weekLabel: 'Campaign week',
   readOnlyNote:
-    'Awareness and regional trust reflect the latest weekly progression. This briefing does not change campaign state.',
+    'Awareness and regional trust reflect the latest weekly progression. Posture choices adjust projected cooperation bands without revealing raw trust scores.',
   emptyTitle: 'No active disclosure campaigns',
   emptyBody:
     'When disclosure records enter play, campaign posture and regional trust bands will appear here.',
@@ -1005,6 +1005,13 @@ export const PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT: Record<string, string> = {
   coverNarrativePrefix: 'Linked cover narrative:',
   confidencePrefix: 'Assessment:',
   redactedSuffix: 'Partial redaction',
+  postureChoiceHeading: 'Disclosure posture choice',
+  postureChoiceSubtitle:
+    'Set institutional messaging posture for this campaign. Effects appear in cooperation bands and weekly trust outcomes.',
+  postureChoiceSelectedPrefix: 'Selected posture:',
+  postureChoiceUnselectedLabel: 'No posture selected',
+  postureChoiceEffectNote:
+    'Cooperation and segment-trust summaries above reflect your selected posture without exposing redacted trust scores.',
 }
 
 export const PUBLIC_DISCLOSURE_MIRROR_UI_TEXT: Record<string, string> = {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -255,6 +255,7 @@ import type { PostIncidentReviewRecommendationRecord } from './postIncidentRevie
 import type { RuleDocumentComplianceRecord } from './ruleDocumentComplianceContainmentRegistry'
 import type { SelfCensoringInformationRecord } from './selfCensoringInformationRegistry'
 import type { PublicDisclosureRecord } from './publicDisclosureStateRegistry'
+import type { PublicDisclosurePostureChoicesMap } from './publicDisclosurePostureChoice'
 import type {
   TruthLayerRecord,
   TruthLayerWeeklyProjectionSnapshot,
@@ -2667,6 +2668,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   publicDisclosureRecords?: Record<string, PublicDisclosureRecord>
+
+  /**
+   * SPE-861 slice 4: player disclosure posture choices keyed by disclosure record id.
+   * Hydration drops invalid record ids and unknown posture values.
+   */
+  publicDisclosurePostureChoices?: PublicDisclosurePostureChoicesMap
 
   /**
    * SPE-1343 slice 2: persisted truth-layer records (keyed by record id).

--- a/src/domain/publicDisclosurePostureChoice.ts
+++ b/src/domain/publicDisclosurePostureChoice.ts
@@ -1,0 +1,241 @@
+/**
+ * SPE-861 slice 4: player disclosure posture choices keyed by disclosure record id.
+ *
+ * Write-side choice state on GameState — trust modifiers apply at projection time only.
+ */
+
+import type { GameState } from './models'
+import type { PublicDisclosureRecord, PublicDisclosureRecordsMap } from './publicDisclosureStateRegistry'
+
+export type PublicDisclosurePostureChoice = 'transparent' | 'managed_secrecy' | 'restrictive'
+
+export type PublicDisclosurePostureChoicesMap = Record<string, PublicDisclosurePostureChoice>
+
+export type PublicDisclosurePostureChoiceFailureReason =
+  | 'invalid_record'
+  | 'inactive_campaign'
+  | 'invalid_posture'
+
+export interface ApplyPublicDisclosurePostureChoiceInput {
+  readonly recordId: string
+  readonly posture: PublicDisclosurePostureChoice
+}
+
+export interface ApplyPublicDisclosurePostureChoiceResult {
+  readonly state: GameState
+  readonly applied: boolean
+  readonly reason?: PublicDisclosurePostureChoiceFailureReason
+  readonly posture?: PublicDisclosurePostureChoice
+}
+
+export interface PublicDisclosurePostureChoiceOption {
+  readonly posture: PublicDisclosurePostureChoice
+  readonly label: string
+  readonly description: string
+}
+
+const POSTURE_CHOICE_ORDER: readonly PublicDisclosurePostureChoice[] = [
+  'transparent',
+  'managed_secrecy',
+  'restrictive',
+] as const
+
+const POSTURE_CHOICE_LABELS: Record<PublicDisclosurePostureChoice, string> = {
+  transparent: 'Transparent posture',
+  managed_secrecy: 'Managed secrecy',
+  restrictive: 'Restrictive posture',
+}
+
+const POSTURE_CHOICE_DESCRIPTIONS: Record<PublicDisclosurePostureChoice, string> = {
+  transparent:
+    'Prioritize openness and follow-through messaging; tends to improve public cooperation bands.',
+  managed_secrecy:
+    'Balance institutional messaging with operational discretion; neutral trust posture.',
+  restrictive:
+    'Clamp messaging and limit public detail; tends to reduce cooperation and deepen resistance.',
+}
+
+export const PUBLIC_DISCLOSURE_POSTURE_TRUST_DELTAS: Record<PublicDisclosurePostureChoice, number> =
+  {
+    transparent: 0.1,
+    managed_secrecy: 0,
+    restrictive: -0.1,
+  }
+
+function sanitizeRecordId(recordId: string) {
+  return recordId.trim()
+}
+
+export function isPublicDisclosurePostureChoice(
+  value: unknown
+): value is PublicDisclosurePostureChoice {
+  return (
+    value === 'transparent' || value === 'managed_secrecy' || value === 'restrictive'
+  )
+}
+
+export function listPublicDisclosurePostureChoiceOptions(): readonly PublicDisclosurePostureChoiceOption[] {
+  return Object.freeze(
+    POSTURE_CHOICE_ORDER.map((posture) =>
+      Object.freeze({
+        posture,
+        label: POSTURE_CHOICE_LABELS[posture],
+        description: POSTURE_CHOICE_DESCRIPTIONS[posture],
+      })
+    )
+  )
+}
+
+export function formatPublicDisclosurePostureChoiceLabel(
+  posture: PublicDisclosurePostureChoice | null | undefined
+): string | null {
+  if (posture === null || posture === undefined) {
+    return null
+  }
+
+  return POSTURE_CHOICE_LABELS[posture]
+}
+
+export function canApplyPublicDisclosurePostureChoiceOnRecord(
+  record: PublicDisclosureRecord | undefined
+): record is PublicDisclosureRecord {
+  return record !== undefined && record.awarenessLevel !== 'secrecy_intact'
+}
+
+export function readPublicDisclosurePostureChoice(
+  state: Pick<GameState, 'publicDisclosurePostureChoices'>,
+  recordId: string
+): PublicDisclosurePostureChoice | undefined {
+  const normalizedRecordId = sanitizeRecordId(recordId)
+
+  if (normalizedRecordId.length === 0) {
+    return undefined
+  }
+
+  const posture = state.publicDisclosurePostureChoices?.[normalizedRecordId]
+  return isPublicDisclosurePostureChoice(posture) ? posture : undefined
+}
+
+export function applyPublicDisclosurePostureChoice(
+  state: GameState,
+  input: ApplyPublicDisclosurePostureChoiceInput
+): ApplyPublicDisclosurePostureChoiceResult {
+  const normalizedRecordId = sanitizeRecordId(input.recordId)
+  const record =
+    normalizedRecordId.length > 0
+      ? state.publicDisclosureRecords?.[normalizedRecordId]
+      : undefined
+
+  if (!record) {
+    return { state, applied: false, reason: 'invalid_record' }
+  }
+
+  if (!canApplyPublicDisclosurePostureChoiceOnRecord(record)) {
+    return { state, applied: false, reason: 'inactive_campaign' }
+  }
+
+  if (!isPublicDisclosurePostureChoice(input.posture)) {
+    return { state, applied: false, reason: 'invalid_posture' }
+  }
+
+  const prior = readPublicDisclosurePostureChoice(state, normalizedRecordId)
+
+  if (prior === input.posture) {
+    return { state, applied: false, posture: input.posture }
+  }
+
+  return {
+    state: {
+      ...state,
+      publicDisclosurePostureChoices: {
+        ...(state.publicDisclosurePostureChoices ?? {}),
+        [normalizedRecordId]: input.posture,
+      },
+    },
+    applied: true,
+    posture: input.posture,
+  }
+}
+
+function clampTrustScore(score: number): number {
+  const clamped = Math.min(1, Math.max(0, score))
+  return Math.round(clamped * 100) / 100
+}
+
+/** Applies posture trust deltas for projection inputs without mutating persisted registry records. */
+export function applyPublicDisclosurePostureTrustAdjustment(
+  records: PublicDisclosureRecordsMap | null | undefined,
+  postureChoices: PublicDisclosurePostureChoicesMap | null | undefined
+): PublicDisclosureRecordsMap {
+  const sourceRecords = records ?? {}
+  const choices = postureChoices ?? {}
+
+  if (Object.keys(sourceRecords).length === 0 || Object.keys(choices).length === 0) {
+    return sourceRecords
+  }
+
+  let changed = false
+  const nextRecords: PublicDisclosureRecordsMap = {}
+
+  for (const [recordId, record] of Object.entries(sourceRecords).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    const posture = choices[recordId]
+    const delta =
+      posture !== undefined &&
+      isPublicDisclosurePostureChoice(posture) &&
+      record.awarenessLevel !== 'secrecy_intact'
+        ? PUBLIC_DISCLOSURE_POSTURE_TRUST_DELTAS[posture]
+        : 0
+
+    if (delta === 0 || !record.trustByRegion || record.trustByRegion.length === 0) {
+      nextRecords[recordId] = record
+      continue
+    }
+
+    changed = true
+    nextRecords[recordId] = Object.freeze({
+      ...record,
+      trustByRegion: Object.freeze(
+        record.trustByRegion.map((entry) =>
+          Object.freeze({
+            ...entry,
+            trustScore: clampTrustScore(entry.trustScore + delta),
+          })
+        )
+      ),
+    })
+  }
+
+  return changed ? nextRecords : sourceRecords
+}
+
+export function sanitizePublicDisclosurePostureChoices(
+  value: unknown,
+  validRecordIds: ReadonlySet<string>,
+  fallback: PublicDisclosurePostureChoicesMap = {}
+): PublicDisclosurePostureChoicesMap {
+  if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
+    return fallback
+  }
+
+  const next: PublicDisclosurePostureChoicesMap = {}
+
+  for (const [recordId, posture] of Object.entries(value as Record<string, unknown>).sort(
+    ([left], [right]) => left.localeCompare(right)
+  )) {
+    const normalizedRecordId = sanitizeRecordId(recordId)
+
+    if (normalizedRecordId.length === 0 || !validRecordIds.has(normalizedRecordId)) {
+      continue
+    }
+
+    if (!isPublicDisclosurePostureChoice(posture)) {
+      continue
+    }
+
+    next[normalizedRecordId] = posture
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}

--- a/src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts
+++ b/src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts
@@ -7,6 +7,10 @@
 
 import type { GameState } from './models'
 import {
+  applyPublicDisclosurePostureTrustAdjustment,
+  type PublicDisclosurePostureChoicesMap,
+} from './publicDisclosurePostureChoice'
+import {
   projectDisclosureRegionalView,
   type PublicDisclosureRecord,
   type PublicDisclosureRecordsMap,
@@ -269,9 +273,11 @@ function resolveFrontDeskDivergenceTone(
 
 /** Projects population / channel trust divergence from hydrated disclosure records. */
 export function projectPublicDisclosureSegmentedTrustOutcome(
-  records: PublicDisclosureRecordsMap | null | undefined
+  records: PublicDisclosureRecordsMap | null | undefined,
+  postureChoices?: PublicDisclosurePostureChoicesMap | null
 ): PublicDisclosureSegmentedTrustOutcomeProjection {
-  const persistedRecords = listPersistedRecords(records)
+  const effectiveRecords = applyPublicDisclosurePostureTrustAdjustment(records, postureChoices)
+  const persistedRecords = listPersistedRecords(effectiveRecords)
   const activeRecords = persistedRecords.filter((record) => record.awarenessLevel !== 'secrecy_intact')
   const aggregate = collectSegmentTrustScores(activeRecords)
   const segmentEntries = Object.freeze(buildSegmentEntries(aggregate))
@@ -300,9 +306,12 @@ export function projectPublicDisclosureSegmentedTrustOutcome(
 }
 
 export function projectPublicDisclosureSegmentedTrustOutcomeFromGame(
-  game: Pick<GameState, 'publicDisclosureRecords'>
+  game: Pick<GameState, 'publicDisclosureRecords' | 'publicDisclosurePostureChoices'>
 ): PublicDisclosureSegmentedTrustOutcomeProjection {
-  return projectPublicDisclosureSegmentedTrustOutcome(game.publicDisclosureRecords)
+  return projectPublicDisclosureSegmentedTrustOutcome(
+    game.publicDisclosureRecords,
+    game.publicDisclosurePostureChoices
+  )
 }
 
 export function formatPublicDisclosureSegmentedTrustOutcomeNoteContent(

--- a/src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts
+++ b/src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts
@@ -9,17 +9,22 @@ import {
   projectPublicDisclosureSegmentedTrustOutcome,
 } from './publicDisclosureSegmentedTrustOutcomeProjection'
 import type { ReportNote } from './models'
+import type { PublicDisclosurePostureChoicesMap } from './publicDisclosurePostureChoice'
 import type { PublicDisclosureRecordsMap } from './publicDisclosureStateRegistry'
 import { createDeterministicReportNote } from './reportNotes'
 
 /** Builds weekly report notes when active campaigns project divergent segment trust. */
 export function buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes(input: {
   nextRecords: PublicDisclosureRecordsMap | null | undefined
+  postureChoices?: PublicDisclosurePostureChoicesMap | null
   week: number
   sequenceStart: number
   baseTimestamp?: number
 }): ReportNote[] {
-  const projection = projectPublicDisclosureSegmentedTrustOutcome(input.nextRecords)
+  const projection = projectPublicDisclosureSegmentedTrustOutcome(
+    input.nextRecords,
+    input.postureChoices
+  )
 
   if (projection.isInactive || !projection.hasDivergence) {
     return []

--- a/src/domain/publicDisclosureTrustOutcomeProjection.ts
+++ b/src/domain/publicDisclosureTrustOutcomeProjection.ts
@@ -7,6 +7,10 @@
 
 import type { GameState } from './models'
 import {
+  applyPublicDisclosurePostureTrustAdjustment,
+  type PublicDisclosurePostureChoicesMap,
+} from './publicDisclosurePostureChoice'
+import {
   projectDisclosureRegionalView,
   type AwarenessLevel,
   type PublicDisclosureRecord,
@@ -213,9 +217,11 @@ function buildFrontDeskAttentionSummary(input: {
 
 /** Projects compliance/cooperation bands from hydrated disclosure records. */
 export function projectPublicDisclosureTrustOutcome(
-  records: PublicDisclosureRecordsMap | null | undefined
+  records: PublicDisclosureRecordsMap | null | undefined,
+  postureChoices?: PublicDisclosurePostureChoicesMap | null
 ): PublicDisclosureTrustOutcomeProjection {
-  const persistedRecords = listPersistedRecords(records)
+  const effectiveRecords = applyPublicDisclosurePostureTrustAdjustment(records, postureChoices)
+  const persistedRecords = listPersistedRecords(effectiveRecords)
   const activeCampaignCount = persistedRecords.filter(
     (record) => record.awarenessLevel !== 'secrecy_intact'
   ).length
@@ -251,9 +257,12 @@ export function projectPublicDisclosureTrustOutcome(
 }
 
 export function projectPublicDisclosureTrustOutcomeFromGame(
-  game: Pick<GameState, 'publicDisclosureRecords'>
+  game: Pick<GameState, 'publicDisclosureRecords' | 'publicDisclosurePostureChoices'>
 ): PublicDisclosureTrustOutcomeProjection {
-  return projectPublicDisclosureTrustOutcome(game.publicDisclosureRecords)
+  return projectPublicDisclosureTrustOutcome(
+    game.publicDisclosureRecords,
+    game.publicDisclosurePostureChoices
+  )
 }
 
 export function formatPublicDisclosureTrustOutcomeNoteContent(

--- a/src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts
+++ b/src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts
@@ -9,17 +9,22 @@ import {
   projectPublicDisclosureTrustOutcome,
 } from './publicDisclosureTrustOutcomeProjection'
 import type { ReportNote } from './models'
+import type { PublicDisclosurePostureChoicesMap } from './publicDisclosurePostureChoice'
 import type { PublicDisclosureRecordsMap } from './publicDisclosureStateRegistry'
 import { createDeterministicReportNote } from './reportNotes'
 
 /** Builds weekly report notes when active disclosure campaigns project a trust outcome. */
 export function buildWeeklyPublicDisclosureTrustOutcomeReportNotes(input: {
   nextRecords: PublicDisclosureRecordsMap | null | undefined
+  postureChoices?: PublicDisclosurePostureChoicesMap | null
   week: number
   sequenceStart: number
   baseTimestamp?: number
 }): ReportNote[] {
-  const projection = projectPublicDisclosureTrustOutcome(input.nextRecords)
+  const projection = projectPublicDisclosureTrustOutcome(
+    input.nextRecords,
+    input.postureChoices
+  )
 
   if (projection.activeCampaignCount === 0) {
     return []

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -5205,6 +5205,7 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     const lastWeeklyReport = result.reports[result.reports.length - 1]
     const trustOutcomeNotes = buildWeeklyPublicDisclosureTrustOutcomeReportNotes({
       nextRecords: nextPublicDisclosureRecordsForTrustOutcome,
+      postureChoices: inputWeeklyState.publicDisclosurePostureChoices,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,
@@ -5214,6 +5215,7 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
 
     const segmentedTrustNotes = buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes({
       nextRecords: nextPublicDisclosureRecordsForTrustOutcome,
+      postureChoices: inputWeeklyState.publicDisclosurePostureChoices,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + appendedDisclosureNotes.length + 1,
       baseTimestamp: noteBaseTimestamp,

--- a/src/features/operations/PublicDisclosureCampaignPage.test.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import '../../test/setup'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createStartingState } from '../../data/startingState'
@@ -90,5 +90,28 @@ describe('PublicDisclosureCampaignPage (SPE-861 slice 1)', () => {
     renderCampaignPage()
 
     expect(JSON.stringify(useGameStore.getState().game)).toBe(before)
+  })
+
+  it('applies disclosure posture choices and updates cooperation band copy', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderCampaignPage()
+
+    expect(screen.getByText('Opposed posture')).toBeInTheDocument()
+    expect(screen.getByText(/no posture selected/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /transparent posture/i }))
+
+    expect(
+      useGameStore.getState().game.publicDisclosurePostureChoices?.[
+        DISCLOSURE_PROGRESSION_FIXTURE.id
+      ]
+    ).toBe('transparent')
+    expect(screen.getByText('Watchful compliance')).toBeInTheDocument()
+    expect(screen.getByText(/selected posture:/i)).toHaveTextContent('Transparent posture')
   })
 })

--- a/src/features/operations/PublicDisclosureCampaignPage.tsx
+++ b/src/features/operations/PublicDisclosureCampaignPage.tsx
@@ -15,7 +15,7 @@ function StatCard({ label, value }: { label: string; value: string }) {
 }
 
 export default function PublicDisclosureCampaignPage() {
-  const { game } = useGameStore()
+  const { game, setPublicDisclosurePostureChoice } = useGameStore()
   const view = useMemo(() => getPublicDisclosureCampaignView(game), [game])
 
   return (
@@ -78,6 +78,12 @@ export default function PublicDisclosureCampaignPage() {
           </div>
         ) : null}
 
+        {view.records.some((record) => record.allowsPostureChoice) ? (
+          <p className="text-xs opacity-55">
+            {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.postureChoiceEffectNote}
+          </p>
+        ) : null}
+
         <p className="text-xs opacity-55">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.readOnlyNote}</p>
       </article>
 
@@ -102,7 +108,7 @@ export default function PublicDisclosureCampaignPage() {
           <ul className="space-y-3">
             {view.records.map((record) => (
               <li
-                key={record.label}
+                key={record.recordId}
                 className="rounded border border-white/10 bg-white/5 px-3 py-3 space-y-2"
               >
                 <div className="space-y-1">
@@ -167,6 +173,44 @@ export default function PublicDisclosureCampaignPage() {
 
                 {record.redacted ? (
                   <p className="text-xs opacity-55">{PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.redactedSuffix}</p>
+                ) : null}
+
+                {record.allowsPostureChoice ? (
+                  <div className="space-y-2 border-t border-white/10 pt-2">
+                    <div className="space-y-1">
+                      <p className="text-xs uppercase tracking-[0.18em] opacity-50">
+                        {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.postureChoiceHeading}
+                      </p>
+                      <p className="text-xs opacity-60">
+                        {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.postureChoiceSubtitle}
+                      </p>
+                      <p className="text-sm opacity-80">
+                        {PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.postureChoiceSelectedPrefix}{' '}
+                        {record.selectedPostureChoiceLabel ??
+                          PUBLIC_DISCLOSURE_CAMPAIGN_UI_TEXT.postureChoiceUnselectedLabel}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {record.postureChoiceOptions.map((option) => {
+                        const isSelected = record.selectedPostureChoice === option.posture
+
+                        return (
+                          <button
+                            key={`${record.recordId}:${option.posture}`}
+                            type="button"
+                            className={`btn btn-sm ${isSelected ? 'btn-primary' : 'btn-ghost'}`}
+                            aria-pressed={isSelected}
+                            title={option.description}
+                            onClick={() =>
+                              setPublicDisclosurePostureChoice(record.recordId, option.posture)
+                            }
+                          >
+                            {option.label}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
                 ) : null}
               </li>
             ))}

--- a/src/features/operations/publicDisclosureCampaignView.ts
+++ b/src/features/operations/publicDisclosureCampaignView.ts
@@ -7,6 +7,13 @@ import {
 import { resolveTruthLayerDualIncidentPairing } from '../../domain/truthLayerCoverNarrativePairing'
 import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
 import { projectPublicDisclosureSegmentedTrustOutcomeFromGame } from '../../domain/publicDisclosureSegmentedTrustOutcomeProjection'
+import {
+  canApplyPublicDisclosurePostureChoiceOnRecord,
+  listPublicDisclosurePostureChoiceOptions,
+  readPublicDisclosurePostureChoice,
+  formatPublicDisclosurePostureChoiceLabel,
+  type PublicDisclosurePostureChoice,
+} from '../../domain/publicDisclosurePostureChoice'
 import { formatPublicDisclosureEnumLabel } from './publicDisclosureMirrorView'
 
 const AWARENESS_SEVERITY_ORDER: readonly AwarenessLevel[] = [
@@ -24,7 +31,14 @@ export interface PublicDisclosureCampaignRegionalBandView {
   redacted: boolean
 }
 
+export interface PublicDisclosureCampaignPostureChoiceOptionView {
+  posture: PublicDisclosurePostureChoice
+  label: string
+  description: string
+}
+
 export interface PublicDisclosureCampaignRecordView {
+  recordId: string
   label: string
   summaryLabel: string
   awarenessLevelLabel: string
@@ -35,6 +49,10 @@ export interface PublicDisclosureCampaignRecordView {
   coverNarrativeContextLabel: string | null
   confidenceBandLabel: string | null
   redacted: boolean
+  allowsPostureChoice: boolean
+  selectedPostureChoice: PublicDisclosurePostureChoice | null
+  selectedPostureChoiceLabel: string | null
+  postureChoiceOptions: readonly PublicDisclosureCampaignPostureChoiceOptionView[]
 }
 
 export interface PublicDisclosureCampaignSegmentChipView {
@@ -143,6 +161,17 @@ function resolveCoverNarrativeContextLabel(
 
 function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDisclosureCampaignRecordView {
   const projection = projectDisclosureRegionalView(record, { redactUnknown: true })
+  const allowsPostureChoice = canApplyPublicDisclosurePostureChoiceOnRecord(record)
+  const selectedPostureChoice = readPublicDisclosurePostureChoice(game, record.id) ?? null
+  const postureChoiceOptions = allowsPostureChoice
+    ? listPublicDisclosurePostureChoiceOptions().map((option) =>
+        Object.freeze({
+          posture: option.posture,
+          label: option.label,
+          description: option.description,
+        })
+      )
+    : []
 
   const summaryLabel =
     projection.summary ??
@@ -169,6 +198,7 @@ function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDi
       : formatConfidenceBand(projection.confidence)
 
   return Object.freeze({
+    recordId: record.id,
     label: record.label,
     summaryLabel,
     awarenessLevelLabel: formatPublicDisclosureEnumLabel(projection.publicAwarenessHint),
@@ -181,6 +211,10 @@ function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDi
     coverNarrativeContextLabel: resolveCoverNarrativeContextLabel(game, record.id),
     confidenceBandLabel,
     redacted: projection.redacted,
+    allowsPostureChoice,
+    selectedPostureChoice,
+    selectedPostureChoiceLabel: formatPublicDisclosurePostureChoiceLabel(selectedPostureChoice),
+    postureChoiceOptions: Object.freeze(postureChoiceOptions),
   })
 }
 

--- a/src/test/advanceWeek.publicDisclosurePostureChoice.integration.test.ts
+++ b/src/test/advanceWeek.publicDisclosurePostureChoice.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { DISCLOSURE_PROGRESSION_FIXTURE } from '../domain/publicDisclosureStateRegistry'
+import { applyPublicDisclosurePostureChoice } from '../domain/publicDisclosurePostureChoice'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('advanceWeek public disclosure posture choice integration (SPE-861 slice 4)', () => {
+  it('uses posture choices when emitting trust-outcome notes after post-tick records', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const withTransparentPosture = applyPublicDisclosurePostureChoice(state, {
+      recordId: DISCLOSURE_PROGRESSION_FIXTURE.id,
+      posture: 'transparent',
+    }).state
+
+    const nextState = advanceWeek(withTransparentPosture)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const trustOutcomeNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'public_disclosure.trust_outcome') ?? []
+
+    expect(trustOutcomeNotes).toHaveLength(1)
+    expect(trustOutcomeNotes[0]?.metadata?.cooperationBand).toBe('watchful')
+    expect(trustOutcomeNotes[0]?.content).toContain('Watchful compliance')
+    expect(nextState.publicDisclosurePostureChoices?.[DISCLOSURE_PROGRESSION_FIXTURE.id]).toBe(
+      'transparent'
+    )
+  })
+
+  it('preserves opposed trust outcome when no posture choice is set', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const weeklyReport = nextState.reports[nextState.reports.length - 1]
+    const trustOutcomeNotes =
+      weeklyReport?.notes?.filter((note) => note.type === 'public_disclosure.trust_outcome') ?? []
+
+    expect(trustOutcomeNotes[0]?.metadata?.cooperationBand).toBe('opposed')
+  })
+})

--- a/src/test/publicDisclosureCampaignView.test.ts
+++ b/src/test/publicDisclosureCampaignView.test.ts
@@ -8,6 +8,7 @@ import {
 import { COASTAL_RESEARCH_CAMPUS_DUAL_INCIDENT_TRUTH_LAYER_FIXTURES } from '../domain/truthLayerCoverNarrativePairing'
 import { COVER_NARRATIVE_TRUTH_LAYER_FIXTURE } from '../domain/truthLayerRecordRegistry'
 import { getPublicDisclosureCampaignView } from '../features/operations/publicDisclosureCampaignView'
+import { applyPublicDisclosurePostureChoice } from '../domain/publicDisclosurePostureChoice'
 
 describe('publicDisclosureCampaignView (SPE-861 slice 1)', () => {
   it('returns empty campaign view when publicDisclosureRecords map is empty', () => {
@@ -114,5 +115,31 @@ describe('publicDisclosureCampaignView (SPE-861 slice 1)', () => {
     const second = JSON.stringify(getPublicDisclosureCampaignView(game))
 
     expect(first).toBe(second)
+  })
+
+  it('surfaces posture choice options and shifts cooperation band from selected posture', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const baseline = getPublicDisclosureCampaignView(game)
+    const record = baseline.records[0]
+
+    expect(record?.recordId).toBe(DISCLOSURE_PROGRESSION_FIXTURE.id)
+    expect(record?.allowsPostureChoice).toBe(true)
+    expect(record?.postureChoiceOptions).toHaveLength(3)
+    expect(record?.selectedPostureChoice).toBeNull()
+    expect(baseline.summary.cooperationBandLabel).toBe('Opposed posture')
+
+    const withTransparent = applyPublicDisclosurePostureChoice(game, {
+      recordId: DISCLOSURE_PROGRESSION_FIXTURE.id,
+      posture: 'transparent',
+    }).state
+    const adjusted = getPublicDisclosureCampaignView(withTransparent)
+
+    expect(adjusted.records[0]?.selectedPostureChoice).toBe('transparent')
+    expect(adjusted.records[0]?.selectedPostureChoiceLabel).toBe('Transparent posture')
+    expect(adjusted.summary.cooperationBandLabel).toBe('Watchful compliance')
   })
 })

--- a/src/test/publicDisclosurePostureChoice.test.ts
+++ b/src/test/publicDisclosurePostureChoice.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  DISCLOSURE_PROGRESSION_FIXTURE,
+  NORMALIZATION_INPUT_FIXTURE,
+} from '../domain/publicDisclosureStateRegistry'
+import {
+  applyPublicDisclosurePostureChoice,
+  applyPublicDisclosurePostureTrustAdjustment,
+  readPublicDisclosurePostureChoice,
+  sanitizePublicDisclosurePostureChoices,
+} from '../domain/publicDisclosurePostureChoice'
+import { projectPublicDisclosureTrustOutcome } from '../domain/publicDisclosureTrustOutcomeProjection'
+
+describe('publicDisclosurePostureChoice (SPE-861 slice 4)', () => {
+  it('rejects posture choice on missing or inactive disclosure records', () => {
+    const state = createStartingState()
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const missing = applyPublicDisclosurePostureChoice(state, {
+      recordId: 'disclosure:missing',
+      posture: 'transparent',
+    })
+
+    expect(missing.applied).toBe(false)
+    expect(missing.reason).toBe('invalid_record')
+
+    const inactiveRecord = {
+      ...DISCLOSURE_PROGRESSION_FIXTURE,
+      id: 'disclosure:secrecy-intact',
+      awarenessLevel: 'secrecy_intact' as const,
+    }
+    const inactiveState = {
+      ...state,
+      publicDisclosureRecords: {
+        [inactiveRecord.id]: inactiveRecord,
+      },
+    }
+
+    const inactive = applyPublicDisclosurePostureChoice(inactiveState, {
+      recordId: inactiveRecord.id,
+      posture: 'transparent',
+    })
+
+    expect(inactive.applied).toBe(false)
+    expect(inactive.reason).toBe('inactive_campaign')
+  })
+
+  it('persists posture choices deterministically without mutating registry records', () => {
+    const state = createStartingState()
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const applied = applyPublicDisclosurePostureChoice(state, {
+      recordId: DISCLOSURE_PROGRESSION_FIXTURE.id,
+      posture: 'transparent',
+    })
+
+    expect(applied.applied).toBe(true)
+    expect(readPublicDisclosurePostureChoice(applied.state, DISCLOSURE_PROGRESSION_FIXTURE.id)).toBe(
+      'transparent'
+    )
+    expect(applied.state.publicDisclosureRecords?.[DISCLOSURE_PROGRESSION_FIXTURE.id]).toEqual(
+      DISCLOSURE_PROGRESSION_FIXTURE
+    )
+
+    const repeated = applyPublicDisclosurePostureChoice(applied.state, {
+      recordId: DISCLOSURE_PROGRESSION_FIXTURE.id,
+      posture: 'transparent',
+    })
+
+    expect(repeated.applied).toBe(false)
+  })
+
+  it('adjusts projected trust bands from posture deltas without changing persisted scores', () => {
+    const records = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const baseline = projectPublicDisclosureTrustOutcome(records)
+    const transparent = projectPublicDisclosureTrustOutcome(records, {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: 'transparent',
+    })
+    const restrictive = projectPublicDisclosureTrustOutcome(records, {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: 'restrictive',
+    })
+
+    expect(baseline.cooperationBand).toBe('opposed')
+    expect(transparent.cooperationBand).toBe('watchful')
+    expect(restrictive.cooperationBand).toBe('opposed')
+
+    const adjustedRecords = applyPublicDisclosurePostureTrustAdjustment(records, {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: 'transparent',
+    })
+
+    expect(adjustedRecords[DISCLOSURE_PROGRESSION_FIXTURE.id]?.trustByRegion?.[0]?.trustScore).toBe(
+      0.41
+    )
+    expect(records[DISCLOSURE_PROGRESSION_FIXTURE.id]?.trustByRegion?.[0]?.trustScore).toBe(0.31)
+  })
+
+  it('sanitizes posture choices to valid disclosure record ids and known postures', () => {
+    const sanitized = sanitizePublicDisclosurePostureChoices(
+      {
+        [DISCLOSURE_PROGRESSION_FIXTURE.id]: 'transparent',
+        'disclosure:orphan': 'restrictive',
+        [NORMALIZATION_INPUT_FIXTURE.id]: 'invalid-posture',
+      },
+      new Set([DISCLOSURE_PROGRESSION_FIXTURE.id, NORMALIZATION_INPUT_FIXTURE.id])
+    )
+
+    expect(sanitized).toEqual({
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: 'transparent',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `publicDisclosurePostureChoices` on GameState with hydrate sanitize and `applyPublicDisclosurePostureChoice` domain command.
- Apply deterministic trust deltas at projection time (transparent +0.10, restrictive -0.10) without mutating SPE-2109 registry records.
- Surface posture choice UI on `/campaign/public-disclosure`; cooperation band and weekly trust-outcome notes honor selected posture.

## Linear
- Parent: SPE-861 (stays Done)
- Slice: create/claim **Disclosure choice mechanics (slice 4)** under SPE-861

## Validation
- `npm run lint`
- Targeted tests: posture choice unit, advanceWeek integration, campaign view/page, slice 2-3 regression

## Docs
- `planning/disclosure-campaign-player-ui-slice-4.md`
- `planning/backlog.md` handoff

## Parent status
SPE-861 parent remains Done; full compliance engine out of scope.

Made with [Cursor](https://cursor.com)