### PR TITLE
SPE-861 slice 5: Front Desk disclosure posture choice notices

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Next open umbrella per active queue.
+**Next step:** SPE-861 Front Desk posture choice notice orchestration (slice 5) @ `planning/disclosure-campaign-player-ui-slice-5.md`, or next open umbrella per active queue (SPE-70 concealment stack if prioritizing core loop).
 
-**Base `main` SHA:** `24b794d7` — shipped: SPE-861 disclosure choice mechanics slice 4 @ `planning/disclosure-campaign-player-ui-slice-4.md` (PR #2819)
+**Base `main` SHA:** `9e1f17bb` — shipped: SPE-861 disclosure choice mechanics slice 4 @ `planning/disclosure-campaign-player-ui-slice-4.md` (PR #2819 @ `24b794d7`)
+
+**In progress:** SPE-861 Front Desk posture choice notice slice 5 — branch `spe-861-front-desk-posture-choice-slice-5`
 
 **Recently shipped:** SPE-861 disclosure choice mechanics slice 4 (PR #2819 @ `24b794d7`); SPE-861 segmented population trust slice 3 (PR #2818 @ `86d0956f`).
 

--- a/planning/disclosure-campaign-player-ui-slice-5.md
+++ b/planning/disclosure-campaign-player-ui-slice-5.md
@@ -1,0 +1,74 @@
+# SPE-861 — Front Desk posture choice notice (slice 5)
+
+One-page implementation plan. Linear: child under [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — **Front Desk posture choice notice orchestration (slice 5)** (create/claim on start). Parent [SPE-861](https://linear.app/spectranoir/issue/SPE-861) stays **Done** — full trust-to-compliance engine not in scope.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-861 child — Front Desk posture choice notice orchestration (slice 5)                                 |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — public trust and compliance engine (umbrella)    |
+| **Branch** | `spe-861-front-desk-posture-choice-slice-5`                                                                |
+| **Base `main` SHA** | `9e1f17bb`                                                                                          |
+
+## Goal
+
+Smallest authored-choice hook that surfaces pending disclosure posture decisions on the Front Desk when active campaigns lack a selected posture — reusing slice 4 write-side state and the existing `applyAuthoredChoice` executor.
+
+## Prerequisite (on `main` @ `9e1f17bb`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Posture choice state | `publicDisclosurePostureChoices` + `applyPublicDisclosurePostureChoice` (SPE-861 slice 4) |
+| Campaign briefing UI | `getPublicDisclosureCampaignView` + `/campaign/public-disclosure` (SPE-861 slice 1) |
+| Trust outcome hook   | `projectPublicDisclosureTrustOutcomeFromGame` (SPE-861 slice 2)       |
+| Front Desk attention | `buildAttentionItems` disclosure summary (slice 2–4)                   |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `listPendingPublicDisclosurePostureDecisions` domain helper        | Full SPE-861 compliance engine              |
+| Front Desk briefing notices + authored posture choices               | SPE-2109 registry schema / sanitize changes |
+| `set_public_disclosure_posture` authored-choice consequence        | Weekly tick contract changes                |
+| `disclosure` Front Desk notice action target → campaign briefing     | Raw trust score surfacing in notice copy    |
+| Front Desk + choiceSystem regression tests                           | Slice 2–4 projection contract changes       |
+| Slice doc (this file) + backlog handoff                            | Campaign page posture UI changes            |
+
+## Outcome contract
+
+- **Pending detection** — active campaigns (`awarenessLevel !== 'secrecy_intact'`) without a stored posture appear as Front Desk briefing notices (sort-stable per record id).
+- **Authored execution** — posture buttons route through `buildPublicDisclosurePostureChoices` → `applyAuthoredChoice` → `applyPublicDisclosurePostureChoice`.
+- **Inactive when resolved** — notice and choices disappear once posture is set; idempotent re-selection stays unavailable.
+- **Redaction** — notice copy uses record label only; no raw trust scores or cooperation-band duplication in notice body.
+- **Attention item** — existing disclosure trust attention summary unchanged; posture prompt is the new briefing notice layer.
+
+## Acceptance
+
+- [x] Empty or secrecy-intact registry yields no disclosure posture notices
+- [x] Active campaign without posture exposes three Front Desk choice buttons
+- [x] Choosing a posture persists via authored-choice executor and clears the notice
+- [x] Already-set posture keeps notice inactive
+- [x] Notice copy does not surface numeric trust scores
+- [x] Front Desk attention regression green
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publicDisclosurePostureChoice.ts`, `src/domain/choiceSystem.ts` |
+| View   | `src/features/operations/frontDeskView.ts`, `src/features/operations/frontDeskChoices.ts` |
+| Tests  | `src/test/frontDeskView.test.ts`, `src/test/choiceSystem.test.ts`, `src/test/publicDisclosurePostureChoice.test.ts` |
+| Plan   | `planning/disclosure-campaign-player-ui-slice-5.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full public-trust / compliance outcomes engine | SPE-861 follow-up | Parent umbrella; out of smallest hook boundary |
+| Mass-anomalous population wire-up | SPE-2122 | Deferred governance integration |
+
+## See also
+
+- `planning/disclosure-campaign-player-ui-slice-4.md` — posture choice write-side (slice 4)
+- `planning/disclosure-campaign-player-ui-slice-1.md` — player briefing UI (slice 1)

--- a/src/domain/choiceSystem.ts
+++ b/src/domain/choiceSystem.ts
@@ -23,6 +23,10 @@ import {
   setDefinedProgressClock,
   type ProgressClockDefaults,
 } from './progressClocks'
+import {
+  applyPublicDisclosurePostureChoice,
+  type PublicDisclosurePostureChoice,
+} from './publicDisclosurePostureChoice'
 import type {
   GameFlagValue,
   GameLocationState,
@@ -74,6 +78,11 @@ export type AuthoredChoiceConsequence =
       type: 'emit_follow_up'
       /** Result-only follow-up identifier for UI/report orchestration. */
       followUpId: string
+    }
+  | {
+      type: 'set_public_disclosure_posture'
+      recordId: string
+      posture: PublicDisclosurePostureChoice
     }
 
 export interface AuthoredChoiceDefinition<
@@ -312,6 +321,26 @@ export function applyAuthoredChoice<
         type: consequence.type,
         key: encounterId,
         changed: true,
+      })
+      continue
+    }
+
+    if (consequence.type === 'set_public_disclosure_posture') {
+      const recordId = normalizeAuthorId(consequence.recordId)
+
+      if (recordId.length === 0) {
+        continue
+      }
+
+      const result = applyPublicDisclosurePostureChoice(nextState, {
+        recordId,
+        posture: consequence.posture,
+      })
+      nextState = result.state
+      appliedConsequences.push({
+        type: consequence.type,
+        key: `${recordId}:${consequence.posture}`,
+        changed: result.applied,
       })
       continue
     }

--- a/src/domain/publicDisclosurePostureChoice.ts
+++ b/src/domain/publicDisclosurePostureChoice.ts
@@ -102,6 +102,31 @@ export function canApplyPublicDisclosurePostureChoiceOnRecord(
   return record !== undefined && record.awarenessLevel !== 'secrecy_intact'
 }
 
+export interface PendingPublicDisclosurePostureDecision {
+  readonly recordId: string
+  readonly label: string
+}
+
+/** Active disclosure campaigns that still need a player posture choice, sort-stable by record id. */
+export function listPendingPublicDisclosurePostureDecisions(
+  state: Pick<GameState, 'publicDisclosureRecords' | 'publicDisclosurePostureChoices'>
+): readonly PendingPublicDisclosurePostureDecision[] {
+  const records = state.publicDisclosureRecords ?? {}
+
+  return Object.freeze(
+    Object.values(records)
+      .filter((record) => canApplyPublicDisclosurePostureChoiceOnRecord(record))
+      .filter((record) => readPublicDisclosurePostureChoice(state, record.id) === undefined)
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((record) =>
+        Object.freeze({
+          recordId: record.id,
+          label: record.label,
+        })
+      )
+  )
+}
+
 export function readPublicDisclosurePostureChoice(
   state: Pick<GameState, 'publicDisclosurePostureChoices'>,
   recordId: string

--- a/src/features/operations/frontDeskChoices.ts
+++ b/src/features/operations/frontDeskChoices.ts
@@ -2,6 +2,11 @@ import type { AuthoredChoiceDefinition } from '../../domain/choiceSystem'
 import type { FactionState } from '../../domain/factions'
 import { PROGRESS_CLOCK_IDS } from '../../domain/progressClocks'
 import type { Candidate } from '../../domain/recruitment/types'
+import {
+  listPublicDisclosurePostureChoiceOptions,
+  readPublicDisclosurePostureChoice,
+  type PublicDisclosurePostureChoice,
+} from '../../domain/publicDisclosurePostureChoice'
 
 export function buildWeeklyReportTutorialChoices(): AuthoredChoiceDefinition[] {
   return [
@@ -260,4 +265,40 @@ export function buildHostileFactionResponseChoices(
       ],
     },
   ]
+}
+
+const PUBLIC_DISCLOSURE_POSTURE_CHOICE_TONES: Record<
+  PublicDisclosurePostureChoice,
+  'success' | 'neutral' | 'warning'
+> = {
+  transparent: 'success',
+  managed_secrecy: 'neutral',
+  restrictive: 'warning',
+}
+
+export function buildPublicDisclosurePostureChoices(
+  recordId: string,
+  recordLabel: string
+): AuthoredChoiceDefinition[] {
+  return listPublicDisclosurePostureChoiceOptions().map((option) => ({
+    id: `frontdesk.notice.disclosure-posture.${recordId}.${option.posture}`,
+    label: option.label,
+    tone: PUBLIC_DISCLOSURE_POSTURE_CHOICE_TONES[option.posture],
+    description: `${option.description} Applies to ${recordLabel}.`,
+    when: {
+      predicates: [
+        {
+          id: `disclosure-posture-${recordId}-unset`,
+          test: ({ state }) => readPublicDisclosurePostureChoice(state, recordId) === undefined,
+        },
+      ],
+    },
+    consequences: [
+      {
+        type: 'set_public_disclosure_posture',
+        recordId,
+        posture: option.posture,
+      },
+    ],
+  }))
 }

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -42,6 +42,7 @@ import {
 import {
   buildBreachFollowUpChoices,
   buildHostileFactionResponseChoices,
+  buildPublicDisclosurePostureChoices,
   buildSpecialRecruitOpportunityChoices,
   buildWeeklyReportTutorialChoices,
 } from './frontDeskChoices'
@@ -49,9 +50,10 @@ import { FRONT_DESK_TRIGGER_IDS, getEligibleFrontDeskSceneTriggerIdSet } from '.
 import { getPublicDisclosureCampaignView } from './publicDisclosureCampaignView'
 import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
 import { projectPublicDisclosureSegmentedTrustOutcomeFromGame } from '../../domain/publicDisclosureSegmentedTrustOutcomeProjection'
+import { listPendingPublicDisclosurePostureDecisions } from '../../domain/publicDisclosurePostureChoice'
 
 export type FrontDeskNoticeTone = 'info' | 'warning' | 'danger' | 'success'
-export type FrontDeskNoticeActionTarget = 'report' | 'cases' | 'recruitment' | 'factions'
+export type FrontDeskNoticeActionTarget = 'report' | 'cases' | 'recruitment' | 'factions' | 'disclosure'
 
 const MAX_QUEUE_DETAILS = 3
 const MAX_RECENT_ITEMS = 3
@@ -633,6 +635,18 @@ function buildSpecialRecruitNotice(
   )
 }
 
+function buildPublicDisclosurePostureNotices(game: GameState): FrontDeskNoticeView[] {
+  return listPendingPublicDisclosurePostureDecisions(game).map((pending) => ({
+    id: `disclosure-posture-${pending.recordId}`,
+    title: 'Disclosure posture decision required',
+    body: `${pending.label} is active but has no command posture on file. Set messaging posture from the desk or open the campaign briefing for regional band context.`,
+    tone: 'warning',
+    actionTarget: 'disclosure',
+    actionLabel: 'Open campaign briefing',
+    choices: buildPublicDisclosurePostureChoices(pending.recordId, pending.label),
+  }))
+}
+
 /**
  * Author-facing front-desk example surface for conditional content selection.
  * Add new notices here instead of scattering one-off `if/else` branches across
@@ -652,6 +666,7 @@ export function getFrontDeskBriefingView(game: GameState): FrontDeskBriefingView
     buildBreachFollowUpNotice(game, eligibleTriggerIds, branchContext),
     buildHostileFactionNotice(game, hostileFaction, branchContext),
     buildSpecialRecruitNotice(game, eligibleTriggerIds, branchContext),
+    ...buildPublicDisclosurePostureNotices(game),
   ].filter((notice): notice is FrontDeskNoticeView => Boolean(notice))
 
   return {
@@ -676,6 +691,10 @@ export function getFrontDeskNoticeActionHref(target?: FrontDeskNoticeActionTarge
 
   if (target === 'factions') {
     return APP_ROUTES.factions
+  }
+
+  if (target === 'disclosure') {
+    return APP_ROUTES.publicDisclosureCampaign
   }
 
   return APP_ROUTES.report

--- a/src/test/choiceSystem.test.ts
+++ b/src/test/choiceSystem.test.ts
@@ -9,6 +9,7 @@ import type { Candidate } from '../domain/recruitment/types'
 import {
   buildBreachFollowUpChoices,
   buildHostileFactionResponseChoices,
+  buildPublicDisclosurePostureChoices,
   buildSpecialRecruitOpportunityChoices,
   buildWeeklyReportTutorialChoices,
 } from '../features/operations/frontDeskChoices'
@@ -17,6 +18,7 @@ import {
   getEligibleFrontDeskSceneTriggerIds,
 } from '../features/operations/frontDeskTriggers'
 import { getFrontDeskBriefingView } from '../features/operations/frontDeskView'
+import { DISCLOSURE_PROGRESSION_FIXTURE } from '../domain/publicDisclosureStateRegistry'
 
 function createSpecialRecruitCandidate(): Candidate {
   return {
@@ -239,5 +241,41 @@ describe('choiceSystem', () => {
       'followup.alpha',
       'followup.beta',
     ])
+  })
+
+  it('applies disclosure posture choices through the authored-choice executor', () => {
+    const state = createStartingState()
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const choice = buildPublicDisclosurePostureChoices(
+      DISCLOSURE_PROGRESSION_FIXTURE.id,
+      DISCLOSURE_PROGRESSION_FIXTURE.label
+    ).find((entry) => entry.id.endsWith('.managed_secrecy'))!
+
+    const first = applyAuthoredChoice(state, choice)
+    const second = applyAuthoredChoice(first.state, choice)
+
+    expect(first).toMatchObject({
+      applied: true,
+      choiceId: choice.id,
+      appliedConsequences: [
+        {
+          type: 'set_public_disclosure_posture',
+          key: `${DISCLOSURE_PROGRESSION_FIXTURE.id}:managed_secrecy`,
+          changed: true,
+        },
+      ],
+    })
+    expect(first.state.publicDisclosurePostureChoices?.[DISCLOSURE_PROGRESSION_FIXTURE.id]).toBe(
+      'managed_secrecy'
+    )
+    expect(second.applied).toBe(false)
+    expect(
+      getFrontDeskBriefingView(first.state).notices.some((notice) =>
+        notice.id.startsWith('disclosure-posture-')
+      )
+    ).toBe(false)
   })
 })

--- a/src/test/frontDeskView.test.ts
+++ b/src/test/frontDeskView.test.ts
@@ -12,6 +12,10 @@ import { OFF_BOOKS_COURIER_LOCKOUT_TAG } from '../domain/sim/downtimeSideWork'
 import { openCourierShellFront } from '../domain/sim/frontBusiness'
 import { normalizeGameState } from '../domain/teamSimulation'
 import { getProcurementListings } from '../domain/market'
+import { DISCLOSURE_PROGRESSION_FIXTURE } from '../domain/publicDisclosureStateRegistry'
+import {
+  buildPublicDisclosurePostureChoices,
+} from '../features/operations/frontDeskChoices'
 import {
   buildCourierNetworkCapacityOpportunityCard,
   buildProcurementPressureOpportunityCard,
@@ -272,6 +276,85 @@ describe('frontDeskView', () => {
     expect(getEligibleFrontDeskSceneTriggerIds(state)).not.toContain(
       FRONT_DESK_TRIGGER_IDS.specialRecruitOpportunity
     )
+  })
+
+  it('surfaces disclosure posture notices only for active campaigns without a selected posture', () => {
+    const inactive = createStartingState()
+    expect(
+      getFrontDeskBriefingView(inactive).notices.some((notice) =>
+        notice.id.startsWith('disclosure-posture-')
+      )
+    ).toBe(false)
+
+    const activeWithoutPosture = createStartingState()
+    activeWithoutPosture.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const notice = getFrontDeskBriefingView(activeWithoutPosture).notices.find(
+      (entry) => entry.id === `disclosure-posture-${DISCLOSURE_PROGRESSION_FIXTURE.id}`
+    )
+
+    expect(notice).toMatchObject({
+      title: 'Disclosure posture decision required',
+      tone: 'warning',
+      actionTarget: 'disclosure',
+    })
+    expect(notice?.choices?.map((choice) => choice.id)).toEqual(
+      buildPublicDisclosurePostureChoices(
+        DISCLOSURE_PROGRESSION_FIXTURE.id,
+        DISCLOSURE_PROGRESSION_FIXTURE.label
+      ).map((choice) => choice.id)
+    )
+    expect(notice?.body).toContain(DISCLOSURE_PROGRESSION_FIXTURE.label)
+    expect(notice?.body).not.toMatch(/\b0\.\d+\b/)
+  })
+
+  it('clears disclosure posture notices after an authored choice sets posture', () => {
+    let state = createStartingState()
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    const notice = getFrontDeskBriefingView(state).notices.find(
+      (entry) => entry.id === `disclosure-posture-${DISCLOSURE_PROGRESSION_FIXTURE.id}`
+    )
+    const transparentChoice = notice?.choices?.find((choice) =>
+      choice.id.endsWith('.transparent')
+    )
+
+    expect(transparentChoice?.id).toBe(
+      `frontdesk.notice.disclosure-posture.${DISCLOSURE_PROGRESSION_FIXTURE.id}.transparent`
+    )
+
+    state = applyAuthoredChoice(state, transparentChoice!, {
+      activeContextId: `frontdesk.notice.disclosure-posture-${DISCLOSURE_PROGRESSION_FIXTURE.id}`,
+    }).state
+
+    expect(
+      getFrontDeskBriefingView(state).notices.some((entry) =>
+        entry.id.startsWith('disclosure-posture-')
+      )
+    ).toBe(false)
+    expect(state.publicDisclosurePostureChoices?.[DISCLOSURE_PROGRESSION_FIXTURE.id]).toBe(
+      'transparent'
+    )
+  })
+
+  it('keeps disclosure posture notices hidden when posture is already set', () => {
+    const state = createStartingState()
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+    state.publicDisclosurePostureChoices = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: 'managed_secrecy',
+    }
+
+    expect(
+      getFrontDeskBriefingView(state).notices.some((notice) =>
+        notice.id.startsWith('disclosure-posture-')
+      )
+    ).toBe(false)
   })
 })
 

--- a/src/test/publicDisclosurePostureChoice.test.ts
+++ b/src/test/publicDisclosurePostureChoice.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   applyPublicDisclosurePostureChoice,
   applyPublicDisclosurePostureTrustAdjustment,
+  listPendingPublicDisclosurePostureDecisions,
   readPublicDisclosurePostureChoice,
   sanitizePublicDisclosurePostureChoices,
 } from '../domain/publicDisclosurePostureChoice'
@@ -115,5 +116,26 @@ describe('publicDisclosurePostureChoice (SPE-861 slice 4)', () => {
     expect(sanitized).toEqual({
       [DISCLOSURE_PROGRESSION_FIXTURE.id]: 'transparent',
     })
+  })
+
+  it('lists pending posture decisions for active campaigns without a stored choice', () => {
+    const state = createStartingState()
+    state.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+
+    expect(listPendingPublicDisclosurePostureDecisions(state)).toEqual([
+      {
+        recordId: DISCLOSURE_PROGRESSION_FIXTURE.id,
+        label: DISCLOSURE_PROGRESSION_FIXTURE.label,
+      },
+    ])
+
+    const withPosture = applyPublicDisclosurePostureChoice(state, {
+      recordId: DISCLOSURE_PROGRESSION_FIXTURE.id,
+      posture: 'restrictive',
+    }).state
+
+    expect(listPendingPublicDisclosurePostureDecisions(withPosture)).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Add `listPendingPublicDisclosurePostureDecisions` and Front Desk briefing notices with three authored posture choices per active campaign missing a stored posture.
- Extend `applyAuthoredChoice` with `set_public_disclosure_posture` consequence wiring into slice 4 `applyPublicDisclosurePostureChoice`.
- Add `disclosure` Front Desk notice action target linking to `/campaign/public-disclosure`.

## Linear mapping
- **Slice issue (create/claim):** SPE-861 child — Front Desk posture choice notice orchestration (slice 5)
- **Parent:** [SPE-861](https://linear.app/spectranoir/issue/SPE-861) — public trust and compliance engine (stays **Done**)
- **Slice doc:** `planning/disclosure-campaign-player-ui-slice-5.md`
- **Branch:** `spe-861-front-desk-posture-choice-slice-5`
- **Base `main` SHA:** `9e1f17bb`

## What shipped
Smallest authored-choice hook surfacing pending disclosure posture decisions on the Front Desk when active campaigns lack a selected posture — reuses slice 4 write-side state; no new trust math or registry changes.

## Validation
- `npm run test:run -- src/test/frontDeskView.test.ts src/test/choiceSystem.test.ts src/test/publicDisclosurePostureChoice.test.ts`
- `npm run lint`

## Docs updated
- `planning/disclosure-campaign-player-ui-slice-5.md`
- `planning/backlog.md`

## Parent remains open?
No — parent SPE-861 stays **Done**; this is a follow-up child slice only.