### PR TITLE
SPE-70: concealment case prep activation preview notes

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Next open umbrella per active queue (SPE-70 concealment stack if prioritizing core loop).
+**Next step:** SPE-70 concealment case prep activation preview notes (in progress on `spe-70-concealment-case-prep-activation-preview`).
 
-**Base `main` SHA:** `da5b8fbf` — shipped: SPE-861 Front Desk posture choice notice slice 5 @ `planning/disclosure-campaign-player-ui-slice-5.md` (PR #2820)
+**Base `main` SHA:** `4eb49c26` — in progress: SPE-70 concealment prep activation preview @ `planning/concealment-case-prep-activation-preview-slice.md`
 
 **Recently shipped:** SPE-861 Front Desk posture choice notice slice 5 (PR #2820 @ `da5b8fbf`); SPE-861 disclosure choice mechanics slice 4 (PR #2819 @ `24b794d7`).
 
@@ -117,6 +117,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | File                                                      | Classification | Notes                                                                                                                                               |
 | --------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `concealment-case-prep-slice.md`                          | **Shipped**    | SPE-70 concealment case prep panel; PR #2326.                                                                                                       |
+| `concealment-case-prep-activation-preview-slice.md`       | **In progress** | SPE-70 concealment prep activation preview notes; branch `spe-70-concealment-case-prep-activation-preview`.                                        |
 | `concealment-activation-event-feed-slice.md`              | **Shipped**    | Event feed + report notes; see Shipped table (batch-4 stack).                                                                                       |
 | `concealment-triggers-migration-batch-4-slice.md`         | **Shipped**    | SPE-2249 batch-4 templates.                                                                                                                         |
 | `infiltration-case-prep-slice.md`                         | **Shipped**    | SPE-521 prep panel; keep for patterns.                                                                                                              |

--- a/planning/concealment-case-prep-activation-preview-slice.md
+++ b/planning/concealment-case-prep-activation-preview-slice.md
@@ -1,0 +1,63 @@
+# SPE-70 — Concealment case prep activation preview notes
+
+One-page implementation plan. Linear: SPE-70 child — **Concealment case prep activation preview notes** (create/claim on start). Follows shipped [SPE-2306](https://linear.app/spectranoir/issue/SPE-2306) triage chips and mirrors [SPE-2308](https://linear.app/spectranoir/issue/SPE-2308) infiltration encounter preview.
+
+| Field      | Value                                                                 |
+| ---------- | --------------------------------------------------------------------- |
+| **Linear** | SPE-70 child — Concealment case prep activation preview notes         |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70)               |
+| **Branch** | `spe-70-concealment-case-prep-activation-preview`                     |
+| **Status** | In progress                                                           |
+| **Base `main` SHA** | `4eb49c26`                                                   |
+
+## Goal
+
+Show **deterministic activation + modality preview bullets** on the concealment case-prep panel so players see operational flavor (activation path, tell readouts, illusion posture) before `advanceWeek` — without duplicating full weekly report sentences or adding modality mechanics.
+
+## Prerequisite (on `main` @ `4eb49c26`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Concealment case prep | `concealmentCasePrepView.ts`, `ConcealmentCasePrepPanel.tsx` (PR #2326) |
+| Activation summaries | `concealmentActivationFeed.ts` |
+| Modality tells / illusion | `hiddenStateModalityTells.ts`, `hiddenStateIllusionLifecycle.ts` |
+| Infiltration preview pattern | `buildInfiltrationPrepEncounterNotes` (SPE-2308 / PR #2479) |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `formatConcealmentActivationPreviewNote` (future-tense) in `concealmentActivationFeed.ts` | Mission triage full refresh |
+| `buildConcealmentPrepActivationPreviewNotes` domain helper | New modality families |
+| `activationPreviewNotes` on prep view + panel section | Front Desk choice mechanics |
+| Unit tests for note composition | SPE-70 parent Done closure |
+
+## Acceptance
+
+- [x] Eligible in-progress case shows activation preview note when `resolveConcealmentActivation` applies
+- [x] Authored tell tags show preview readout without assigned teams; assigned teams use live tell evaluation
+- [x] Authored illusion tags show bounded illusion preview on open posture cases
+- [x] `npm run lint` + targeted `npm run test:run` green
+
+## File touch list
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/concealmentActivationFeed.ts`, `src/domain/concealmentPrepActivationPreviewNotes.ts` |
+| View / UI | `src/features/cases/concealmentCasePrepView.ts`, `ConcealmentCasePrepPanel.tsx` |
+| Tests | `src/test/concealmentPrepActivationPreviewNotes.test.ts`, `src/test/concealmentCasePrepView.test.ts` |
+| Plan | `planning/concealment-case-prep-activation-preview-slice.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| ---- | ----- | --- |
+| Front Desk pending-activation attention | SPE-70 follow-up | Separate surfacing slice; out of case-prep boundary |
+| Full SPE-70 parent Done | SPE-70 | Grooming after stack complete |
+| Mission triage compare-top-2 / bulk actions | SPE-16 | Blocked per backlog |
+
+## See also
+
+- `planning/concealment-case-prep-slice.md`
+- `planning/infiltration-case-prep-encounter-preview-slice.md`
+- `planning/mission-triage-modality-signal-slice.md`

--- a/src/domain/concealmentActivationFeed.ts
+++ b/src/domain/concealmentActivationFeed.ts
@@ -39,3 +39,42 @@ export function formatConcealmentActivationSummary(
     ? `Displaced cover activated (${reason}).`
     : `Hidden presence activated (${reason}).`
 }
+
+/**
+ * Future-tense prep preview — same reason codes as `formatConcealmentActivationSummary`.
+ */
+export function formatConcealmentActivationPreviewNote(
+  mode: ConcealmentActivationMode,
+  reason: string
+): string {
+  if (reason.startsWith('authored-trigger:')) {
+    const triggerId = reason.slice('authored-trigger:'.length)
+    return mode === 'displaced'
+      ? `Next weekly tick will apply displaced cover (${triggerId}).`
+      : `Next weekly tick will apply hidden presence (${triggerId}).`
+  }
+
+  if (reason.startsWith('global-flag:conceal.displace.')) {
+    return 'Next weekly tick will apply displaced cover from the displacement flag.'
+  }
+
+  if (reason.startsWith('global-flag:conceal.case.')) {
+    return 'Next weekly tick will apply hidden presence from the covert posture flag.'
+  }
+
+  if (reason.startsWith('global-flag-prefix:')) {
+    return 'Next weekly tick will apply hidden presence from a shared conceal directive.'
+  }
+
+  if (reason === 'case-tag') {
+    return 'Next weekly tick will apply hidden presence from concealment activation tags.'
+  }
+
+  if (reason === 'recon-hidden-modifiers') {
+    return 'Next weekly tick will apply hidden presence when recon hidden-modifier threshold is met.'
+  }
+
+  return mode === 'displaced'
+    ? `Next weekly tick will apply displaced cover (${reason}).`
+    : `Next weekly tick will apply hidden presence (${reason}).`
+}

--- a/src/domain/concealmentPrepActivationPreviewNotes.ts
+++ b/src/domain/concealmentPrepActivationPreviewNotes.ts
@@ -1,0 +1,218 @@
+/**
+ * SPE-70 follow-up: deterministic concealment prep preview bullets (mirrors infiltration encounter preview).
+ */
+
+import { canShowConcealmentCasePrepOnCase } from './concealmentCasePrep'
+import { formatConcealmentActivationPreviewNote } from './concealmentActivationFeed'
+import { evaluateBehaviorWeightedDisguiseValidation } from './disguiseValidation'
+import { readGameStateManager } from './gameStateManager'
+import {
+  evaluateHiddenStateModalityTell,
+  formatModalityTellReadout,
+  TELL_METADATA_SPOOF_TAG,
+  TELL_ROUTE_TIMING_TAG,
+  TELL_SIGNATURE_DRIFT_TAG,
+  TELL_SPEECH_CADENCE_TAG,
+  TELL_THERMAL_RESIDUAL_TAG,
+  tellReadoutPrefixForModality,
+  type HiddenStateTellKind,
+} from './hiddenStateModalityTells'
+import { resolveConcealmentActivation } from './hiddenStateActivation'
+import {
+  resolveIllusionKindFromCase,
+  type HiddenStateIllusionKind,
+  type HiddenStateIllusionPhase,
+} from './hiddenStateIllusionLifecycle'
+import { resolveHiddenStateModality } from './hiddenStateModality'
+import type { Agent, CaseInstance, GameState } from './models'
+import { countCaseHiddenModifiers } from './recon'
+import { getUniqueTeamMembers } from './teamSimulation'
+
+function caseTagSet(caseData: CaseInstance): Set<string> {
+  return new Set([
+    ...(caseData.tags ?? []),
+    ...(caseData.requiredTags ?? []),
+    ...(caseData.preferredTags ?? []),
+  ])
+}
+
+function tellModalityForKind(kind: HiddenStateTellKind): HiddenStateModalityKind {
+  switch (kind) {
+    case 'thermal_residual':
+      return 'concealed_presence'
+    case 'route_timing':
+      return 'false_position'
+    case 'speech_cadence':
+    case 'metadata_spoof':
+      return 'disguised_identity'
+    case 'signature_drift':
+      return 'signature_masking'
+    default: {
+      const _exhaustive: never = kind
+      return _exhaustive
+    }
+  }
+}
+
+function tellKindForAuthoredTags(caseData: CaseInstance): HiddenStateTellKind | null {
+  const modality = resolveHiddenStateModality(caseData)
+  const tags = caseTagSet(caseData)
+
+  if (modality === 'disguised_identity') {
+    if (tags.has(TELL_SPEECH_CADENCE_TAG)) {
+      return 'speech_cadence'
+    }
+
+    if (tags.has(TELL_METADATA_SPOOF_TAG)) {
+      return 'metadata_spoof'
+    }
+  }
+
+  if (modality === 'false_position' && tags.has(TELL_ROUTE_TIMING_TAG)) {
+    return 'route_timing'
+  }
+
+  if (modality === 'signature_masking' && tags.has(TELL_SIGNATURE_DRIFT_TAG)) {
+    return 'signature_drift'
+  }
+
+  if (modality === 'concealed_presence' && tags.has(TELL_THERMAL_RESIDUAL_TAG)) {
+    return 'thermal_residual'
+  }
+
+  if (modality !== 'none') {
+    return null
+  }
+
+  if (tags.has(TELL_SPEECH_CADENCE_TAG)) {
+    return 'speech_cadence'
+  }
+
+  if (tags.has(TELL_METADATA_SPOOF_TAG)) {
+    return 'metadata_spoof'
+  }
+
+  if (tags.has(TELL_ROUTE_TIMING_TAG)) {
+    return 'route_timing'
+  }
+
+  if (tags.has(TELL_SIGNATURE_DRIFT_TAG)) {
+    return 'signature_drift'
+  }
+
+  if (tags.has(TELL_THERMAL_RESIDUAL_TAG)) {
+    return 'thermal_residual'
+  }
+
+  return null
+}
+
+function agentsForCase(game: GameState, caseData: CaseInstance): Agent[] {
+  const teamIds = caseData.assignedTeamIds ?? []
+  if (teamIds.length === 0) {
+    return []
+  }
+
+  return getUniqueTeamMembers(teamIds, game.teams, game.agents)
+}
+
+function illusionKindForPreview(caseData: CaseInstance): HiddenStateIllusionKind | null {
+  const resolved = resolveIllusionKindFromCase(caseData)
+  if (resolved !== null) {
+    return resolved
+  }
+
+  const tags = caseTagSet(caseData)
+  if (tags.has('false-entity')) {
+    return 'false_entity'
+  }
+
+  if (tags.has('structural-illusion')) {
+    return 'structural_illusion'
+  }
+
+  return null
+}
+
+function illusionPreviewNote(
+  kind: HiddenStateIllusionKind,
+  phase: HiddenStateIllusionPhase,
+  caseData: CaseInstance
+): string {
+  if (phase === 'disproved') {
+    const reason = caseData.hiddenStateIllusionState?.disproofReason?.trim()
+    return reason !== undefined && reason.length > 0
+      ? `Illusion disproved: ${reason}`
+      : 'Illusion overlay disproved; fabricated readouts should collapse on the next pass.'
+  }
+
+  return kind === 'false_entity'
+    ? 'False-entity overlay may project fabricated contact readouts while active.'
+    : 'Structural illusion may mislocate terrain or route anchors while active.'
+}
+
+function appendTellPreviewNotes(notes: string[], caseData: CaseInstance, agents: readonly Agent[]) {
+  const disguiseValidation = evaluateBehaviorWeightedDisguiseValidation(caseData, [...agents])
+
+  if (agents.length > 0) {
+    const tell = evaluateHiddenStateModalityTell({
+      caseData,
+      agents,
+      disguiseValidationActive: disguiseValidation.active,
+    })
+
+    if (tell.active && tell.readoutLine !== undefined) {
+      notes.push(tell.readoutLine)
+    }
+
+    return
+  }
+
+  const previewKind = tellKindForAuthoredTags(caseData)
+  if (previewKind === null) {
+    return
+  }
+
+  const modality = resolveHiddenStateModality(caseData)
+  const prefix = tellReadoutPrefixForModality(
+    modality === 'none' ? tellModalityForKind(previewKind) : modality
+  )
+  const sentence = formatModalityTellReadout(previewKind, caseData)
+
+  if (prefix !== null && sentence.length > 0) {
+    notes.push(`${prefix} ${sentence}`)
+  }
+}
+
+export function buildConcealmentPrepActivationPreviewNotes(
+  caseData: CaseInstance,
+  game: GameState
+): readonly string[] {
+  if (!canShowConcealmentCasePrepOnCase(caseData)) {
+    return []
+  }
+
+  const notes: string[] = []
+  const globalFlags = readGameStateManager(game).globalFlags
+  const hiddenModifierCount = countCaseHiddenModifiers(caseData, caseData.mapLayer)
+  const preview = resolveConcealmentActivation(caseData, {
+    globalFlags,
+    hiddenModifierCount,
+  })
+
+  if (preview.applied && preview.mode !== undefined && preview.reason !== undefined) {
+    notes.push(formatConcealmentActivationPreviewNote(preview.mode, preview.reason))
+  }
+
+  appendTellPreviewNotes(notes, caseData, agentsForCase(game, caseData))
+
+  const illusionKind = illusionKindForPreview(caseData)
+  if (illusionKind !== null) {
+    const phase = caseData.hiddenStateIllusionState?.phase ?? 'active'
+    if (phase !== 'collapsed') {
+      notes.push(illusionPreviewNote(illusionKind, phase, caseData))
+    }
+  }
+
+  return notes
+}

--- a/src/features/cases/ConcealmentCasePrepPanel.tsx
+++ b/src/features/cases/ConcealmentCasePrepPanel.tsx
@@ -38,6 +38,8 @@ export function ConcealmentCasePrepPanel({
 
       <PreviewSection view={view} />
 
+      {view.activationPreviewNotes.length > 0 ? <ActivationPreview view={view} /> : null}
+
       {view.activationTags.length > 0 ? (
         <section className="space-y-1" aria-label="Concealment activation tags">
           <p className="text-xs uppercase tracking-wide opacity-50">Activation tags</p>
@@ -108,6 +110,19 @@ function PanelHeader() {
       <h3 className="text-lg font-semibold">Concealment prep</h3>
       <p className="text-xs uppercase tracking-wide opacity-50">Covert activation</p>
     </div>
+  )
+}
+
+function ActivationPreview({ view }: { view: ConcealmentCasePrepView }) {
+  return (
+    <section className="space-y-1" aria-label="Activation preview">
+      <p className="text-xs uppercase tracking-wide opacity-50">Activation preview</p>
+      <ul className="list-disc space-y-1 pl-5 text-xs opacity-70">
+        {view.activationPreviewNotes.map((note) => (
+          <li key={note}>{note}</li>
+        ))}
+      </ul>
+    </section>
   )
 }
 

--- a/src/features/cases/concealmentCasePrepView.ts
+++ b/src/features/cases/concealmentCasePrepView.ts
@@ -5,6 +5,7 @@ import {
   listConcealmentActivationTagsOnCase,
   summarizeConcealmentTriggerWhen,
 } from '../../domain/concealmentCasePrep'
+import { buildConcealmentPrepActivationPreviewNotes } from '../../domain/concealmentPrepActivationPreviewNotes'
 import { isPersistentFlagSet } from '../../domain/flagSystem'
 import { readGameStateManager } from '../../domain/gameStateManager'
 import {
@@ -32,6 +33,7 @@ export interface ConcealmentCasePrepView {
   readonly playerConcealFlagActive: boolean
   readonly canToggleConcealFlag: boolean
   readonly hiddenModifierCount?: number
+  readonly activationPreviewNotes: readonly string[]
 }
 
 const MODE_LABELS: Record<ConcealmentActivationMode, string> = {
@@ -96,6 +98,7 @@ export function buildConcealmentCasePrepView(
     previewStatusLabel: 'Open posture — no covert activation on the next weekly tick',
     playerConcealFlagActive: false,
     canToggleConcealFlag: false,
+    activationPreviewNotes: [],
   }
 
   if (!canShowConcealmentCasePrepOnCase(caseData)) {
@@ -128,5 +131,6 @@ export function buildConcealmentCasePrepView(
     playerConcealFlagActive,
     canToggleConcealFlag: canPlayerSetConcealCaseFlag(caseData),
     hiddenModifierCount,
+    activationPreviewNotes: buildConcealmentPrepActivationPreviewNotes(caseData, game),
   }
 }

--- a/src/test/concealmentCasePrepView.test.ts
+++ b/src/test/concealmentCasePrepView.test.ts
@@ -75,4 +75,11 @@ describe('concealmentCasePrepView', () => {
     expect(view.triggerRows[0]?.id).toBe('trigger:test-cover')
     expect(view.canToggleConcealFlag).toBe(true)
   })
+
+  it('surfaces activation preview notes on the prep view', () => {
+    const view = buildConcealmentCasePrepView(createOpenCase(), createStartingState())
+
+    expect(view.activationPreviewNotes.length).toBeGreaterThan(0)
+    expect(view.activationPreviewNotes[0]).toContain('Next weekly tick')
+  })
 })

--- a/src/test/concealmentPrepActivationPreviewNotes.test.ts
+++ b/src/test/concealmentPrepActivationPreviewNotes.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { buildConcealCaseFlagId } from '../domain/concealmentCasePrep'
+import { buildConcealmentPrepActivationPreviewNotes } from '../domain/concealmentPrepActivationPreviewNotes'
+import { setPersistentFlag } from '../domain/flagSystem'
+import { TELL_THERMAL_RESIDUAL_TAG } from '../domain/hiddenStateModalityTells'
+import { createStarterCase } from '../domain/templates/startingCases'
+
+function createOpenCase(overrides: Record<string, unknown> = {}) {
+  return {
+    ...createStarterCase({ id: 'case-conceal-prep', templateId: 'ops-003' }),
+    status: 'in_progress' as const,
+    tags: ['infiltration'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+describe('buildConcealmentPrepActivationPreviewNotes', () => {
+  it('returns empty notes for resolved or concealed cases', () => {
+    const open = createOpenCase()
+    const game = createStartingState()
+
+    expect(
+      buildConcealmentPrepActivationPreviewNotes({ ...open, status: 'resolved' }, game)
+    ).toEqual([])
+    expect(
+      buildConcealmentPrepActivationPreviewNotes({ ...open, hiddenState: 'hidden' }, game)
+    ).toEqual([])
+  })
+
+  it('includes future-tense activation preview for case-tag eligibility', () => {
+    const notes = buildConcealmentPrepActivationPreviewNotes(
+      createOpenCase(),
+      createStartingState()
+    )
+
+    expect(notes[0]).toContain('Next weekly tick will apply hidden presence')
+    expect(notes[0]).toContain('concealment activation tags')
+  })
+
+  it('includes covert-flag activation preview', () => {
+    let state = createStartingState()
+    state.cases['case-conceal-prep'] = createOpenCase({ tags: [] })
+    state = setPersistentFlag(state, buildConcealCaseFlagId('case-conceal-prep'), true)
+
+    const notes = buildConcealmentPrepActivationPreviewNotes(
+      state.cases['case-conceal-prep']!,
+      state
+    )
+
+    expect(notes.some((note) => note.includes('covert posture flag'))).toBe(true)
+  })
+
+  it('includes authored tell preview when tell tags are present without assigned teams', () => {
+    const notes = buildConcealmentPrepActivationPreviewNotes(
+      createOpenCase({
+        tags: ['concealment', TELL_THERMAL_RESIDUAL_TAG],
+      }),
+      createStartingState()
+    )
+
+    expect(notes.some((note) => note.includes('Concealment tell readout:'))).toBe(true)
+  })
+
+  it('includes illusion preview for false-entity cases', () => {
+    const notes = buildConcealmentPrepActivationPreviewNotes(
+      createOpenCase({
+        tags: ['false-entity'],
+      }),
+      createStartingState()
+    )
+
+    expect(notes.some((note) => note.includes('False-entity overlay'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Add deterministic activation preview bullets on the concealment case-prep panel (mirrors SPE-2308 infiltration encounter preview).
- `buildConcealmentPrepActivationPreviewNotes` composes future-tense activation path, modality tell readouts (live or authored-tag preview), and illusion posture from existing domain helpers.
- `ConcealmentCasePrepPanel` surfaces an Activation preview section when notes exist.

## Linear

- **Parent:** [SPE-70](https://linear.app/spectranoir/issue/SPE-70) — Hidden-State, Displacement, & Counter-Detection Layer (stays **Backlog**)
- **Slice:** SPE-70 child — Concealment case prep activation preview notes (create/claim on Linear if not yet filed)

## What shipped

- `formatConcealmentActivationPreviewNote` in `concealmentActivationFeed.ts`
- `concealmentPrepActivationPreviewNotes.ts` + `activationPreviewNotes` on prep view/panel
- Slice doc: `planning/concealment-case-prep-activation-preview-slice.md`
- `planning/backlog.md` handoff update

## Validation

- `npm run test:run -- src/test/concealmentPrepActivationPreviewNotes.test.ts src/test/concealmentCasePrepView.test.ts` — 10 passed
- `npm run lint` — clean

## Docs updated

- `planning/concealment-case-prep-activation-preview-slice.md`
- `planning/backlog.md`

## Parent remains open

SPE-70 umbrella stays open; this slice does not close parent acceptance (Front Desk surfacing and parent grooming deferred).

## Test plan

- [x] Targeted concealment prep view + preview notes tests
- [x] Lint