### PR TITLE
SPE-70: Front Desk pending concealment activation attention

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -8,7 +8,7 @@ This file is the **canonical ordered queue** for concrete engineering and design
 
 From `README.md` **Current design notes**:
 
-- Concealment activation stack and hidden-modality matrix slices 1–11 shipped (SPE-2281–SPE-2303 / PR #2403–#2469); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) umbrella remains open — mission-triage tell/illusion chips shipped in SPE-2306; see Shipped table and active queue below.
+- Concealment activation stack and hidden-modality matrix slices 1–11 shipped (SPE-2281–SPE-2303 / PR #2403–#2469); [SPE-70](https://linear.app/spectranoir/issue/SPE-70) parent **Done** on Linear (prep activation preview PR #2821); mission-triage tell/illusion chips shipped in SPE-2306; Front Desk pending-activation follow-up in progress — see active queue.
 - Intake registry wave and [SPE-854](https://linear.app/spectranoir/issue/SPE-854) parent integration slices 1–2 shipped (SPE-2292–SPE-2304 / PR #2444–#2471); parent [SPE-854](https://linear.app/spectranoir/issue/SPE-854) **Done** on Linear. [SPE-848](https://linear.app/spectranoir/issue/SPE-848) surveillance-tuning and [SPE-1615](https://linear.app/spectranoir/issue/SPE-1615) psychological-resilience registry parents **Done** (registry slices 2–4 / 1–5 + SPE-1908 cross-reconciliation surfacing). [SPE-1310](https://linear.app/spectranoir/issue/SPE-1310) parent **Done** (lifecycle slices 1–6). [SPE-1343](https://linear.app/spectranoir/issue/SPE-1343) parent **Done** on Linear (truth-layer registry slices 1–4 + cover pairing + historical-icon fixtures; groomed [SPE-2401](https://linear.app/spectranoir/issue/SPE-2401), [SPE-2446](https://linear.app/spectranoir/issue/SPE-2446), [SPE-2450](https://linear.app/spectranoir/issue/SPE-2450) — sibling deferred SPE-1347 / SPE-899 / SPE-861 / SPE-677 / SPE-58). [SPE-1309](https://linear.app/spectranoir/issue/SPE-1309) parent **Done** on Linear (unified engine slices 1–7 + grooming slices 1–6; groomed [SPE-2399](https://linear.app/spectranoir/issue/SPE-2399), [SPE-2445](https://linear.app/spectranoir/issue/SPE-2445), [SPE-2451](https://linear.app/spectranoir/issue/SPE-2451), [SPE-2456](https://linear.app/spectranoir/issue/SPE-2456), grooming slice 6 — AC rows 1–3 **Yes** after vitals slice 7). [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) parent **Backlog** on Linear (groomed [SPE-2400](https://linear.app/spectranoir/issue/SPE-2400), [SPE-2419](https://linear.app/spectranoir/issue/SPE-2419), [SPE-2452](https://linear.app/spectranoir/issue/SPE-2452), [SPE-2453](https://linear.app/spectranoir/issue/SPE-2453), [SPE-2455](https://linear.app/spectranoir/issue/SPE-2455) — registry slices 1–11 + cross-link compose + matrix persistence + weekly surfacing shipped; slice 6 reconciles slice 11 auto-close drift; SPE-1882 + full SPE-1047/1131 deferred). [SPE-1889](https://linear.app/spectranoir/issue/SPE-1889) parent **Done** on Linear.
 - Shared explanatory ownership stays in the domain wherever possible.
 - Prefer compact reusable rules vocabularies over bespoke subsystem logic.
@@ -20,9 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Next open umbrella per active queue ([SPE-70](https://linear.app/spectranoir/issue/SPE-70) concealment stack if prioritizing core loop).
+**Next step:** SPE-70 follow-up — Front Desk pending-activation attention @ `planning/concealment-front-desk-pending-activation-slice.md` (branch `spe-70-concealment-front-desk-pending-activation`).
 
-**Base `main` SHA:** `17db4ab2` — shipped: SPE-70 concealment prep activation preview @ `planning/concealment-case-prep-activation-preview-slice.md` (PR #2821)
+**Base `main` SHA:** `5a06b0a2` — shipped: SPE-70 concealment prep activation preview @ `planning/concealment-case-prep-activation-preview-slice.md` (PR #2821 @ `17db4ab2`)
 
 **Recently shipped:** SPE-70 concealment case prep activation preview notes (PR #2821 @ `17db4ab2`); SPE-861 Front Desk posture choice notice slice 5 (PR #2820 @ `da5b8fbf`).
 
@@ -118,6 +118,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | --------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `concealment-case-prep-slice.md`                          | **Shipped**    | SPE-70 concealment case prep panel; PR #2326.                                                                                                       |
 | `concealment-case-prep-activation-preview-slice.md`       | **Shipped**    | SPE-70 concealment prep activation preview notes; PR #2821 @ `17db4ab2`.                                                                            |
+| `concealment-front-desk-pending-activation-slice.md`      | **In Progress** | SPE-70 follow-up — Front Desk pending-activation attention.                                                                                         |
 | `concealment-activation-event-feed-slice.md`              | **Shipped**    | Event feed + report notes; see Shipped table (batch-4 stack).                                                                                       |
 | `concealment-triggers-migration-batch-4-slice.md`         | **Shipped**    | SPE-2249 batch-4 templates.                                                                                                                         |
 | `infiltration-case-prep-slice.md`                         | **Shipped**    | SPE-521 prep panel; keep for patterns.                                                                                                              |

--- a/planning/concealment-front-desk-pending-activation-slice.md
+++ b/planning/concealment-front-desk-pending-activation-slice.md
@@ -1,0 +1,61 @@
+# SPE-70 — Concealment Front Desk pending-activation attention
+
+One-page implementation plan. Linear: SPE-70 follow-up — **Concealment Front Desk pending-activation attention** (create/claim on start). Follows shipped [concealment case prep activation preview](planning/concealment-case-prep-activation-preview-slice.md) (PR #2821).
+
+| Field      | Value                                                                 |
+| ---------- | --------------------------------------------------------------------- |
+| **Linear** | SPE-70 follow-up — Concealment Front Desk pending-activation attention |
+| **Parent** | [SPE-70](https://linear.app/spectranoir/issue/SPE-70) (Done)        |
+| **Branch** | `spe-70-concealment-front-desk-pending-activation`                    |
+| **Status** | **In Progress**                                                     |
+| **Base `main` SHA** | `17db4ab2`                                                   |
+
+## Goal
+
+Surface **deterministic pending concealment activation** on the Front Desk attention rail when in-progress open-posture cases will enter hidden or displaced presence on the next weekly tick — reusing `resolveConcealmentActivation` and prep preview copy without opening each case detail.
+
+## Prerequisite (on `main` @ `17db4ab2`)
+
+| Shipped | Anchor |
+| ------- | ------ |
+| Activation resolver | `hiddenStateActivation.ts` |
+| Prep preview notes | `concealmentPrepActivationPreviewNotes.ts` (PR #2821) |
+| Front Desk attention pattern | `publicDisclosureTrustOutcomeProjection.ts`, `frontDeskView.ts` |
+
+## Scope (this slice)
+
+| In | Out |
+| -- | --- |
+| `projectConcealmentPendingActivationAttention` domain projection | New modality families |
+| Front Desk attention item wired from projection | Case prep panel changes |
+| Unit tests for projection + hub view | Mission triage full refresh |
+| Slice doc + backlog handoff | SPE-70 parent reopen |
+
+## Acceptance
+
+- [x] No pending activations → no Front Desk attention item
+- [x] Single pending case → attention item links to case detail with preview summary
+- [x] Multiple pending cases → aggregated summary links to `/cases`
+- [x] Displaced activation uses `warning` tone; hidden-only uses `info`
+- [x] `npm run lint` + targeted `npm run test:run` green
+
+## File touch list
+
+| Area | Files |
+| ---- | ----- |
+| Domain | `src/domain/concealmentPendingActivationAttention.ts` |
+| View | `src/features/operations/frontDeskView.ts` |
+| Tests | `src/test/concealmentPendingActivationAttention.test.ts` |
+| Plan | `planning/concealment-front-desk-pending-activation-slice.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| ---- | ----- | --- |
+| Per-case attention rows on Front Desk | SPE-70 follow-up | Aggregated item sufficient for slice boundary |
+| Mission triage compare-top-2 / bulk actions | SPE-16 | Blocked per backlog |
+
+## See also
+
+- `planning/concealment-case-prep-activation-preview-slice.md`
+- `planning/disclosure-campaign-player-ui-slice-2.md`

--- a/src/domain/concealmentPendingActivationAttention.ts
+++ b/src/domain/concealmentPendingActivationAttention.ts
@@ -1,0 +1,114 @@
+/**
+ * SPE-70 follow-up: Front Desk attention for pending concealment activation on open-posture cases.
+ */
+
+import { canShowConcealmentCasePrepOnCase } from './concealmentCasePrep'
+import { formatConcealmentActivationPreviewNote } from './concealmentActivationFeed'
+import { readGameStateManager } from './gameStateManager'
+import { resolveConcealmentActivation, type ConcealmentActivationMode } from './hiddenStateActivation'
+import type { CaseInstance, GameState } from './models'
+import { countCaseHiddenModifiers } from './recon'
+
+export type ConcealmentPendingActivationAttentionTone = 'info' | 'warning'
+
+export interface ConcealmentPendingActivationCaseRow {
+  readonly caseId: string
+  readonly caseTitle: string
+  readonly mode: ConcealmentActivationMode
+  readonly previewNote: string
+}
+
+export interface ConcealmentPendingActivationAttentionProjection {
+  readonly isEmpty: boolean
+  readonly pendingCount: number
+  readonly displacedCount: number
+  readonly hiddenCount: number
+  readonly cases: readonly ConcealmentPendingActivationCaseRow[]
+  readonly frontDeskAttentionTone: ConcealmentPendingActivationAttentionTone
+  readonly frontDeskAttentionSummary: string
+  readonly frontDeskAttentionCaseId: string | null
+}
+
+function listOpenPostureCases(game: GameState): CaseInstance[] {
+  return Object.values(game.cases)
+    .filter((caseData) => canShowConcealmentCasePrepOnCase(caseData))
+    .sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function resolvePendingActivationRow(
+  caseData: CaseInstance,
+  game: GameState
+): ConcealmentPendingActivationCaseRow | null {
+  const globalFlags = readGameStateManager(game).globalFlags
+  const hiddenModifierCount = countCaseHiddenModifiers(caseData, caseData.mapLayer)
+  const preview = resolveConcealmentActivation(caseData, {
+    globalFlags,
+    hiddenModifierCount,
+  })
+
+  if (!preview.applied || preview.mode === undefined || preview.reason === undefined) {
+    return null
+  }
+
+  return {
+    caseId: caseData.id,
+    caseTitle: caseData.title,
+    mode: preview.mode,
+    previewNote: formatConcealmentActivationPreviewNote(preview.mode, preview.reason),
+  }
+}
+
+function resolveFrontDeskAttentionTone(
+  rows: readonly ConcealmentPendingActivationCaseRow[]
+): ConcealmentPendingActivationAttentionTone {
+  return rows.some((row) => row.mode === 'displaced') ? 'warning' : 'info'
+}
+
+function formatCaseLabel(title: string): string {
+  const trimmed = title.trim()
+  return trimmed.length > 0 ? trimmed : 'Untitled operation'
+}
+
+function buildFrontDeskAttentionSummary(
+  rows: readonly ConcealmentPendingActivationCaseRow[]
+): string {
+  if (rows.length === 0) {
+    return 'No covert activation is queued on the next weekly tick.'
+  }
+
+  if (rows.length === 1) {
+    const row = rows[0]!
+    return `${formatCaseLabel(row.caseTitle)} — ${row.previewNote}`
+  }
+
+  const leadTitles = rows
+    .slice(0, 2)
+    .map((row) => formatCaseLabel(row.caseTitle))
+    .join('; ')
+  const remainder = rows.length > 2 ? ` (+${rows.length - 2} more)` : ''
+
+  return `${rows.length} in-progress operations will enter covert activation on the next weekly tick: ${leadTitles}${remainder}.`
+}
+
+/** Projects pending concealment activation rows from hydrated in-progress open-posture cases. */
+export function projectConcealmentPendingActivationAttention(
+  game: GameState
+): ConcealmentPendingActivationAttentionProjection {
+  const rows = listOpenPostureCases(game)
+    .map((caseData) => resolvePendingActivationRow(caseData, game))
+    .filter((row): row is ConcealmentPendingActivationCaseRow => row !== null)
+
+  const displacedCount = rows.filter((row) => row.mode === 'displaced').length
+  const hiddenCount = rows.filter((row) => row.mode === 'hidden').length
+
+  return Object.freeze({
+    isEmpty: rows.length === 0,
+    pendingCount: rows.length,
+    displacedCount,
+    hiddenCount,
+    cases: rows,
+    frontDeskAttentionTone: resolveFrontDeskAttentionTone(rows),
+    frontDeskAttentionSummary: buildFrontDeskAttentionSummary(rows),
+    frontDeskAttentionCaseId: rows.length === 1 ? rows[0]!.caseId : null,
+  })
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -51,6 +51,7 @@ import { getPublicDisclosureCampaignView } from './publicDisclosureCampaignView'
 import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
 import { projectPublicDisclosureSegmentedTrustOutcomeFromGame } from '../../domain/publicDisclosureSegmentedTrustOutcomeProjection'
 import { listPendingPublicDisclosurePostureDecisions } from '../../domain/publicDisclosurePostureChoice'
+import { projectConcealmentPendingActivationAttention } from '../../domain/concealmentPendingActivationAttention'
 
 export type FrontDeskNoticeTone = 'info' | 'warning' | 'danger' | 'success'
 export type FrontDeskNoticeActionTarget = 'report' | 'cases' | 'recruitment' | 'factions' | 'disclosure'
@@ -1235,7 +1236,35 @@ function buildAttentionItems(
         ]
       : []
 
-  return [...noticeItems, ...debriefAttention, ...disclosureAttention, ...signalItems, ...routingItems, ...readinessItems]
+  const concealmentPendingActivation = projectConcealmentPendingActivationAttention(game)
+  const concealmentAttention =
+    concealmentPendingActivation.pendingCount > 0
+      ? [
+          {
+            id: 'concealment:pending-activation',
+            title:
+              concealmentPendingActivation.pendingCount === 1
+                ? 'Covert activation pending on next weekly tick'
+                : `${concealmentPendingActivation.pendingCount} covert activations pending on next weekly tick`,
+            summary: concealmentPendingActivation.frontDeskAttentionSummary,
+            tone: concealmentPendingActivation.frontDeskAttentionTone,
+            href:
+              concealmentPendingActivation.frontDeskAttentionCaseId !== null
+                ? APP_ROUTES.caseDetail(concealmentPendingActivation.frontDeskAttentionCaseId)
+                : APP_ROUTES.cases,
+          } as const,
+        ]
+      : []
+
+  return [
+    ...noticeItems,
+    ...debriefAttention,
+    ...disclosureAttention,
+    ...concealmentAttention,
+    ...signalItems,
+    ...routingItems,
+    ...readinessItems,
+  ]
     .sort((left, right) => {
       const priorityDelta = getAttentionPriority(right.tone) - getAttentionPriority(left.tone)
 

--- a/src/test/concealmentPendingActivationAttention.test.ts
+++ b/src/test/concealmentPendingActivationAttention.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { buildConcealCaseFlagId } from '../domain/concealmentCasePrep'
+import { projectConcealmentPendingActivationAttention } from '../domain/concealmentPendingActivationAttention'
+import { setPersistentFlag } from '../domain/flagSystem'
+import { createStarterCase } from '../domain/templates/startingCases'
+import { getFrontDeskHubView } from '../features/operations/frontDeskView'
+import { APP_ROUTES } from '../app/routes'
+
+function createOpenCase(overrides: Record<string, unknown> = {}) {
+  return {
+    ...createStarterCase({ id: 'case-conceal-desk', templateId: 'ops-003' }),
+    status: 'in_progress' as const,
+    tags: ['infiltration'],
+    requiredTags: [],
+    preferredTags: [],
+    assignedTeamIds: [],
+    ...overrides,
+  }
+}
+
+describe('projectConcealmentPendingActivationAttention', () => {
+  it('returns empty projection when no cases qualify', () => {
+    const projection = projectConcealmentPendingActivationAttention(createStartingState())
+
+    expect(projection.isEmpty).toBe(true)
+    expect(projection.pendingCount).toBe(0)
+    expect(projection.frontDeskAttentionCaseId).toBeNull()
+  })
+
+  it('projects pending hidden activation for concealment-tagged open cases', () => {
+    const state = createStartingState()
+    state.cases['case-conceal-desk'] = createOpenCase()
+
+    const projection = projectConcealmentPendingActivationAttention(state)
+
+    expect(projection.isEmpty).toBe(false)
+    expect(projection.pendingCount).toBe(1)
+    expect(projection.hiddenCount).toBe(1)
+    expect(projection.frontDeskAttentionTone).toBe('info')
+    expect(projection.frontDeskAttentionSummary).toContain('Next weekly tick will apply hidden presence')
+    expect(projection.frontDeskAttentionCaseId).toBe('case-conceal-desk')
+  })
+
+  it('projects warning tone for displaced activation', () => {
+    let state = createStartingState()
+    state.cases['case-conceal-desk'] = createOpenCase()
+    state = setPersistentFlag(state, 'conceal.displace.case-conceal-desk', 'site-b')
+
+    const projection = projectConcealmentPendingActivationAttention(state)
+
+    expect(projection.displacedCount).toBe(1)
+    expect(projection.frontDeskAttentionTone).toBe('warning')
+    expect(projection.frontDeskAttentionSummary).toContain('displaced cover')
+  })
+
+  it('aggregates multiple pending cases in the summary', () => {
+    let state = createStartingState()
+    state.cases['case-conceal-desk'] = createOpenCase({ id: 'case-conceal-desk' })
+    state.cases['case-conceal-desk-2'] = createOpenCase({
+      id: 'case-conceal-desk-2',
+      title: 'Second covert op',
+    })
+    state = setPersistentFlag(state, buildConcealCaseFlagId('case-conceal-desk-2'), true)
+
+    const projection = projectConcealmentPendingActivationAttention(state)
+
+    expect(projection.pendingCount).toBe(2)
+    expect(projection.frontDeskAttentionCaseId).toBeNull()
+    expect(projection.frontDeskAttentionSummary).toContain('2 in-progress operations')
+    expect(projection.frontDeskAttentionSummary).toContain('Second covert op')
+  })
+
+  it('ignores cases that already entered hidden posture', () => {
+    const state = createStartingState()
+    state.cases['case-conceal-desk'] = createOpenCase({ hiddenState: 'hidden' })
+
+    const projection = projectConcealmentPendingActivationAttention(state)
+
+    expect(projection.isEmpty).toBe(true)
+  })
+})
+
+describe('getFrontDeskHubView concealment pending activation', () => {
+  it('surfaces attention item for a single pending activation case', () => {
+    const state = createStartingState()
+    state.cases['case-conceal-desk'] = createOpenCase()
+
+    const hub = getFrontDeskHubView(state)
+    const item = hub.attentionItems.find((entry) => entry.id === 'concealment:pending-activation')
+
+    expect(item).toBeDefined()
+    expect(item?.title).toContain('Covert activation pending')
+    expect(item?.summary).toContain('Next weekly tick will apply hidden presence')
+    expect(item?.href).toBe(APP_ROUTES.caseDetail('case-conceal-desk'))
+    expect(item?.tone).toBe('info')
+  })
+
+  it('links to cases list when multiple pending activations exist', () => {
+    const state = createStartingState()
+    state.cases['case-conceal-desk'] = createOpenCase({ id: 'case-conceal-desk' })
+    state.cases['case-conceal-desk-2'] = createOpenCase({ id: 'case-conceal-desk-2' })
+
+    const hub = getFrontDeskHubView(state)
+    const item = hub.attentionItems.find((entry) => entry.id === 'concealment:pending-activation')
+
+    expect(item?.href).toBe(APP_ROUTES.cases)
+  })
+
+  it('omits attention item when no pending activations exist', () => {
+    const hub = getFrontDeskHubView(createStartingState())
+    const item = hub.attentionItems.find((entry) => entry.id === 'concealment:pending-activation')
+
+    expect(item).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Add \projectConcealmentPendingActivationAttention\ domain projection over in-progress open-posture cases using \esolveConcealmentActivation\ and prep preview copy.
- Wire a Front Desk attention item (single case → case detail link; multiple → \/cases\) with \info\ vs \warning\ tone for hidden vs displaced activation.
- Slice doc: \planning/concealment-front-desk-pending-activation-slice.md\.

## Linear
- Parent: [SPE-70](https://linear.app/spectranoir/issue/SPE-70) (Done) — follow-up slice; create child **Concealment Front Desk pending-activation attention** on merge if not already filed.

## Test plan
- [x] \
pm run test:run -- src/test/concealmentPendingActivationAttention.test.ts\
- [x] \
pm run lint\ on touched files

## Docs
- \planning/concealment-front-desk-pending-activation-slice.md\
- \planning/backlog.md\ handoff updated

Parent SPE-70 remains **Done**; this is a bounded surfacing follow-up only.

Made with [Cursor](https://cursor.com)