### PR TITLE
SPE-1882 slice 12: coercive protocol mirror welfare-debt cross-link surfacing

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-12.md
+++ b/planning/coercive-contained-person-protocol-model-slice-12.md
@@ -1,0 +1,75 @@
+# SPE-1882 — Coercive protocol mirror welfare-debt cross-link surfacing (slice 12)
+
+One-page implementation plan. Linear: SPE-1882 slice 12 child (create on merge). Follows shipped slice 11 (`planning/coercive-contained-person-protocol-model-slice-11.md`, PR #2798).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1882 slice 12 — Mirror welfare-debt cross-link surfacing (create on merge)                             |
+| **Status** | **In progress**                                                                                            |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–11 shipped)           |
+| **Branch** | `spe-1882-coercive-protocol-slice-12`                                                                      |
+| **Base `main` SHA** | `049ff7e4`                                                                                          |
+
+## Goal
+
+Surface inverse welfare-debt ledger cross-links on `getCoerciveContainedPersonProtocolMirrorView` by reusing `welfareDebtAccountingCrossLinks.ts` compose contracts — agent-routing visibility for SPE-1888 ↔ SPE-1882 linkage without duplicating welfare-debt math or faction ethics matrix scope.
+
+## Prerequisite (on `main` @ `049ff7e4`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Welfare-debt cross-link compose | `src/domain/welfareDebtAccountingCrossLinks.ts` (SPE-1888 slice 7–9) |
+| Mirror snapshot read | `coerciveContainedPersonProtocolMirrorView.ts` (slice 11 / PR #2798)   |
+| Welfare-debt mirror cross-links | `welfareDebtAccountingMirrorView.ts` (inverse direction model)   |
+
+## Mirror contract
+
+- **Read-only** — mirror calls inverse compose at build time only; no GameState mutation.
+- **Reuse forward compose** — `composeWelfareDebtCrossLinksForCoerciveProtocolRecord` delegates per-debt `composeWelfareDebtAccountingCrossLinksForRecord` with a single-protocol map; match kinds (`procedure_ref` / `subject_ref`) stay byte-stable with welfare-debt mirror.
+- **Label format** — `welfare-debt:${debtRef}` mirrors welfare-debt mirror `coercive-protocol:${id}` prefix pattern.
+- **Summary** — `welfareDebtLinkedRecordCount` counts records with ≥1 linked debt; `weeklySnapshotCount` stat card on mirror page (slice 11 deferred row).
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Inverse compose + label format in `welfareDebtAccountingCrossLinks.ts` | Welfare-debt accounting math                |
+| Mirror view per-record `welfareDebtCrossLinkLabels` + summary count | Faction ethics links (SPE-1047)               |
+| Mirror page welfare-debt cross-link display + weekly snapshot stat  | Accountability matrix engine (SPE-1131)     |
+| Targeted cross-link, mirror view, advanceWeek integration tests     | SPE-1888 registry reopens                     |
+| Slice doc (this file) + backlog handoff                            | Contradiction-check evaluator changes         |
+
+## Acceptance
+
+- [x] Missing welfare-debt records yield empty cross-link labels and zero summary count
+- [x] Procedure-ref and subject-ref matches surface deterministic sorted labels
+- [x] `advanceWeek`-hydrated GameState mirror reads persisted welfare-debt cross-links
+- [x] Mirror page shows weekly snapshot count stat card
+- [x] Slice 1–11 mirror regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/welfareDebtAccountingCrossLinks.ts`                       |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` |
+| UI     | `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx` |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/welfareDebtAccountingCrossLinks.test.ts`, `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-12.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Broader SPE-1908 cross-system reconciliation | SPE-1889 / SPE-848 / SPE-1615 | Out of welfare-debt cross-link boundary |
+| Faction ethics + accountability matrix links on protocol mirror | SPE-1047 / SPE-1131 | Out of slice 12 boundary per parent constraints |
+| Compromised-care procedural debt creation wire-up | SPE-1882 follow-up | Parent goal breadth; not registry-wave pattern |
+| SPE-1882 parent grooming if auto-closed drift | SPE-1882 | Parent **Done** on Linear; slice 12 is runtime follow-up |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-11.md` — weekly snapshot read origin
+- `planning/welfare-debt-accounting-registry-slice-7.md` — forward cross-link compose origin

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1374,6 +1374,9 @@ export const COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT: Record<string, s
   crossSystemTensionPrefix: 'Cross-system tension:',
   integratedHealthLinkedSubjectsLabel: 'Integrated health links',
   crossSystemTensionSubjectsLabel: 'Cross-system tension subjects',
+  weeklySnapshotCountLabel: 'Weekly snapshots',
+  welfareDebtLinkedRecordsLabel: 'Welfare-debt links',
+  welfareDebtCrossLinkPrefix: 'Welfare-debt cross-links:',
   validationWarningPrefix: 'Validation warnings:',
   redactedSuffix: 'Partial redaction',
 }

--- a/src/domain/welfareDebtAccountingCrossLinks.ts
+++ b/src/domain/welfareDebtAccountingCrossLinks.ts
@@ -536,3 +536,63 @@ export function formatWelfareDebtAccountingCrossLinkAuditLine(
   const linkText = labels.length > 0 ? labels.join('; ') : 'none'
   return `Cross-links (${summary.debtRef}): ${linkText}`
 }
+
+/** Inverse compose: welfare-debt ledger links for one coercive protocol record (SPE-1882 slice 12). */
+export function composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
+  record: CoerciveProtocolRecord,
+  input?: {
+    readonly welfareDebtRecords?: WelfareDebtAccountingRecordsMap | null | undefined
+  }
+): readonly WelfareDebtCoerciveProtocolCrossLink[] {
+  if (!validateCoerciveProtocolRecord(record).valid) {
+    return Object.freeze([])
+  }
+
+  const protocolId = normalizeToken(record.id)
+  if (!protocolId) {
+    return Object.freeze([])
+  }
+
+  const safeRecords = input?.welfareDebtRecords ?? {}
+  if (Object.keys(safeRecords).length === 0) {
+    return Object.freeze([])
+  }
+
+  const links: WelfareDebtCoerciveProtocolCrossLink[] = []
+
+  for (const debtRecord of Object.values(safeRecords)) {
+    const summary = composeWelfareDebtAccountingCrossLinksForRecord(debtRecord, {
+      coerciveProtocolRecords: { [protocolId]: record },
+    })
+    if (!summary) {
+      continue
+    }
+
+    for (const link of summary.coerciveProtocolLinks) {
+      if (link.coerciveProtocolId === protocolId) {
+        links.push(link)
+      }
+    }
+  }
+
+  return Object.freeze(
+    [...links].sort((left, right) => {
+      const debtCompare = left.debtRef.localeCompare(right.debtRef)
+      if (debtCompare !== 0) {
+        return debtCompare
+      }
+
+      return left.matchKind.localeCompare(right.matchKind)
+    })
+  )
+}
+
+export function formatCoerciveProtocolWelfareDebtCrossLinkLabels(
+  links: readonly WelfareDebtCoerciveProtocolCrossLink[]
+): readonly string[] {
+  return Object.freeze(
+    [...links]
+      .map((link) => `welfare-debt:${link.debtRef}`)
+      .sort((left, right) => left.localeCompare(right))
+  )
+}

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
@@ -62,6 +62,14 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
             value={String(view.summary.crossSystemTensionSubjectCount)}
           />
           <StatCard
+            label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.weeklySnapshotCountLabel}
+            value={String(view.summary.weeklySnapshotCount)}
+          />
+          <StatCard
+            label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.welfareDebtLinkedRecordsLabel}
+            value={String(view.summary.welfareDebtLinkedRecordCount)}
+          />
+          <StatCard
             label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.weekLabel}
             value={`W${view.summary.week}`}
           />
@@ -227,10 +235,17 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
                       {record.subjectFitValidationRefLabel !== '—' ? (
                         <p className="text-xs opacity-45">{record.subjectFitValidationRefLabel}</p>
                       ) : null}
+                      {record.welfareDebtCrossLinkLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.welfareDebtCrossLinkPrefix}{' '}
+                          {record.welfareDebtCrossLinkLabels.join('; ')}
+                        </p>
+                      ) : null}
                       {record.medicationRegimenRefLabel === '—' &&
                       record.custodyStatusRefLabel === '—' &&
                       record.procedureRefLabel === '—' &&
-                      record.subjectFitValidationRefLabel === '—' ? (
+                      record.subjectFitValidationRefLabel === '—' &&
+                      record.welfareDebtCrossLinkLabels.length === 0 ? (
                         <p className="text-xs opacity-45">—</p>
                       ) : null}
                     </td>

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -18,6 +18,7 @@ import {
 import { applyWeeklyCoerciveProtocolTick } from '../../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
 import { PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE } from '../../domain/psychologicalResilienceRegistry'
 import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
+import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../../domain/welfareDebtAccountingRegistry'
 import {
   formatCoerciveProtocolEnumLabel,
   getCoerciveContainedPersonProtocolMirrorView,
@@ -500,5 +501,39 @@ describe('coerciveContainedPersonProtocolMirrorView (SPE-1882 slice 11)', () => 
     expect(view.summary.stableContainmentDominatesCareCount).toBe(1)
     expect(view.summary.abusivePostureCount).toBe(1)
     expect(view.summary.contradictionFlaggedCount).toBe(1)
+  })
+})
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-1882 slice 12)', () => {
+  it('omits welfare-debt cross-link labels when ledger records are absent', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.summary.welfareDebtLinkedRecordCount).toBe(0)
+    expect(view.records[0]?.welfareDebtCrossLinkLabels).toEqual([])
+  })
+
+  it('surfaces welfare-debt cross-link labels by procedureRef match', () => {
+    const game = createStartingState()
+    const debtId = `welfare-debt:${ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.procedureRef}:subject:cooperative-field-asset-31`
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    game.welfareDebtAccountingRecords = {
+      [debtId]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        id: debtId,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.summary.welfareDebtLinkedRecordCount).toBe(1)
+    expect(view.records[0]?.welfareDebtCrossLinkLabels).toEqual([`welfare-debt:${debtId}`])
   })
 })

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -16,6 +16,10 @@ import {
   composeAllCoerciveProtocolIntegratedHealthReconciliationSummaries,
   formatCrossSystemTensionFlagLabel,
 } from '../../domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing'
+import {
+  composeWelfareDebtCrossLinksForCoerciveProtocolRecord,
+  formatCoerciveProtocolWelfareDebtCrossLinkLabels,
+} from '../../domain/welfareDebtAccountingCrossLinks'
 
 export interface CoerciveProtocolContradictionCheckMirrorView {
   flagLabel: string
@@ -47,6 +51,7 @@ export interface CoerciveContainedPersonProtocolMirrorRecordView {
   contradictionRiskFlagLabels: readonly string[]
   contradictionCheckViews: readonly CoerciveProtocolContradictionCheckMirrorView[]
   crossSystemTensionFlagLabels: readonly string[]
+  welfareDebtCrossLinkLabels: readonly string[]
   medicationRegimenRefLabel: string
   custodyStatusRefLabel: string
   procedureRefLabel: string
@@ -64,6 +69,7 @@ export interface CoerciveContainedPersonProtocolMirrorSummaryView {
   contradictionFlaggedCount: number
   integratedHealthLinkedSubjectCount: number
   crossSystemTensionSubjectCount: number
+  welfareDebtLinkedRecordCount: number
   weeklySnapshotCount: number
   week: number
 }
@@ -171,6 +177,7 @@ function buildCrossSystemTensionFlagLabelsBySubject(
 function toRecordView(
   record: CoerciveProtocolRecord,
   crossSystemTensionFlagLabels: readonly string[],
+  welfareDebtCrossLinkLabels: readonly string[],
   tradeoff: ContainmentCareTradeoffProjection,
   riskReview: CoerciveProtocolRiskReviewProjection
 ): CoerciveContainedPersonProtocolMirrorRecordView {
@@ -209,6 +216,7 @@ function toRecordView(
     ),
     contradictionCheckViews: Object.freeze(contradictionChecks.map(toContradictionCheckView)),
     crossSystemTensionFlagLabels: Object.freeze([...crossSystemTensionFlagLabels]),
+    welfareDebtCrossLinkLabels: Object.freeze([...welfareDebtCrossLinkLabels]),
     medicationRegimenRefLabel: formatOptionalRef(record.medicationRegimenRef),
     custodyStatusRefLabel: formatOptionalRef(record.custodyStatusRef),
     procedureRefLabel: formatOptionalRef(record.procedureRef),
@@ -248,12 +256,22 @@ export function getCoerciveContainedPersonProtocolMirrorView(
   }
 
   let weeklySnapshotCount = 0
+  let welfareDebtLinkedRecordCount = 0
 
   const recordViews = records.map((record) => {
     const { tradeoff, riskReview } = resolveCoerciveProtocolWeeklyProjections(record, snapshots)
+    const welfareDebtCrossLinkLabels = formatCoerciveProtocolWelfareDebtCrossLinkLabels(
+      composeWelfareDebtCrossLinksForCoerciveProtocolRecord(record, {
+        welfareDebtRecords: game.welfareDebtAccountingRecords,
+      })
+    )
 
     if (snapshots[record.id]?.recordId === record.id) {
       weeklySnapshotCount += 1
+    }
+
+    if (welfareDebtCrossLinkLabels.length > 0) {
+      welfareDebtLinkedRecordCount += 1
     }
 
     if (tradeoff.stableContainmentDominatesCare) {
@@ -271,6 +289,7 @@ export function getCoerciveContainedPersonProtocolMirrorView(
     return toRecordView(
       record,
       tensionLabelsBySubject.get(record.subjectRef) ?? [],
+      welfareDebtCrossLinkLabels,
       tradeoff,
       riskReview
     )
@@ -285,6 +304,7 @@ export function getCoerciveContainedPersonProtocolMirrorView(
       contradictionFlaggedCount,
       integratedHealthLinkedSubjectCount,
       crossSystemTensionSubjectCount,
+      welfareDebtLinkedRecordCount,
       weeklySnapshotCount,
       week,
     }),

--- a/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../domain/coerciveContainedPersonProtocolRegistry'
 import { applyWeeklyCoerciveProtocolTick } from '../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../domain/welfareDebtAccountingRegistry'
 import { getCoerciveContainedPersonProtocolMirrorView } from '../features/operations/coerciveContainedPersonProtocolMirrorView'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -185,5 +186,29 @@ describe('advanceWeek coercive protocol records integration (SPE-1882 slice 11)'
       snapshot?.riskReview.coercionRiskScore?.toFixed(2)
     )
     expect(view.records[0]?.welfareDebtImpactLabel).toBe(snapshot?.tradeoff.welfareDebtImpactLabel)
+  })
+})
+
+describe('advanceWeek coercive protocol records integration (SPE-1882 slice 12)', () => {
+  it('mirror reads welfare-debt cross-links from persisted ledger records after advanceWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    const debtId = `welfare-debt:${ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.procedureRef}:subject:cooperative-field-asset-31`
+    state.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    state.welfareDebtAccountingRecords = {
+      [debtId]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        id: debtId,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+
+    const nextState = advanceWeek(state)
+    const view = getCoerciveContainedPersonProtocolMirrorView(nextState)
+
+    expect(view.summary.welfareDebtLinkedRecordCount).toBe(1)
+    expect(view.records[0]?.welfareDebtCrossLinkLabels).toEqual([`welfare-debt:${debtId}`])
   })
 })

--- a/src/test/welfareDebtAccountingCrossLinks.test.ts
+++ b/src/test/welfareDebtAccountingCrossLinks.test.ts
@@ -16,6 +16,8 @@ import {
 import {
   composeAllWelfareDebtAccountingCrossLinks,
   composeWelfareDebtAccountingCrossLinksForRecord,
+  composeWelfareDebtCrossLinksForCoerciveProtocolRecord,
+  formatCoerciveProtocolWelfareDebtCrossLinkLabels,
   formatWelfareDebtAccountingCrossLinkLabels,
   resolveProcedureRefFromWelfareDebtRecordId,
   resolveSubjectRefFromWelfareDebtRecordId,
@@ -272,5 +274,76 @@ describe('welfareDebtAccountingCrossLinks (SPE-1888 slice 7 + slice 9)', () => {
       COERCIVE_RESTRAINT_LEDGER_FIXTURE.id,
       'welfare-debt:zzz-second',
     ])
+  })
+})
+
+describe('welfareDebtAccountingCrossLinks inverse compose (SPE-1882 slice 12)', () => {
+  it('returns empty links when welfare-debt records map is empty', () => {
+    expect(
+      composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
+        ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+      )
+    ).toEqual([])
+  })
+
+  it('links welfare-debt ledger entries by procedureRef when creation-tick id matches', () => {
+    const creationTickRecord: WelfareDebtAccountingRecord = {
+      ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+      id: `welfare-debt:${ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.procedureRef}:subject:cooperative-field-asset-31`,
+      subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+    }
+
+    const links = composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      {
+        welfareDebtRecords: {
+          [creationTickRecord.id]: creationTickRecord,
+        },
+      }
+    )
+
+    expect(links).toHaveLength(1)
+    expect(links[0]?.debtRef).toBe(creationTickRecord.id)
+    expect(links[0]?.matchKind).toBe('procedure_ref')
+    expect(formatCoerciveProtocolWelfareDebtCrossLinkLabels(links)).toEqual([
+      `welfare-debt:${creationTickRecord.id}`,
+    ])
+  })
+
+  it('falls back to subject-only welfare-debt matches for authored fixture ids', () => {
+    const links = composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      {
+        welfareDebtRecords: {
+          [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+            ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+            subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+          },
+        },
+      }
+    )
+
+    expect(links).toHaveLength(1)
+    expect(links[0]?.matchKind).toBe('subject_ref')
+  })
+
+  it('inverse compose is byte-stable across repeated calls', () => {
+    const welfareDebtRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+
+    const first = composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      { welfareDebtRecords }
+    )
+    const second = composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      { welfareDebtRecords }
+    )
+
+    expect(first).toEqual(second)
   })
 })


### PR DESCRIPTION
## Summary

- Add inverse compose \composeWelfareDebtCrossLinksForCoerciveProtocolRecord\ reusing SPE-1888 forward cross-link contracts (\procedure_ref\ / \subject_ref\ match kinds).
- Surface \welfareDebtCrossLinkLabels\ and \welfareDebtLinkedRecordCount\ on coercive protocol mirror view; display links on mirror page owner-ref column.
- Add weekly snapshot count stat card (slice 11 deferred row).

## Linear

- Parent: [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — Coercive contained-person protocol model
- Slice: SPE-1882 slice 12 (child to create on merge)

## What shipped

- \welfareDebtAccountingCrossLinks.ts\ inverse compose + label formatter
- \coerciveContainedPersonProtocolMirrorView.ts\ + mirror page UI
- Slice doc: \planning/coercive-contained-person-protocol-model-slice-12.md\

## Validation

- \
pm run test:run -- src/test/welfareDebtAccountingCrossLinks.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts\
- \
pm run lint\

## Docs updated

- \planning/coercive-contained-person-protocol-model-slice-12.md\
- \planning/backlog.md\ handoff on merge

## Parent remains open?

SPE-1882 parent is **Done** on Linear; slice 12 is runtime follow-up (welfare-debt cross-link mirror surfacing). No parent reopen.

Made with [Cursor](https://cursor.com)