### PR TITLE
SPE-1882 slice 13: compromised-care procedural debt creation wire-up

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-13.md
+++ b/planning/coercive-contained-person-protocol-model-slice-13.md
@@ -1,0 +1,73 @@
+# SPE-1882 — Compromised-care procedural debt creation wire-up (slice 13)
+
+One-page implementation plan. Linear: SPE-1882 slice 13 child (create on merge). Deferred from SPE-1888 parent grooming slice 7 (`planning/spe-1888-parent-acceptance-review-slice-7.md`). Follows shipped slice 12 (`planning/coercive-contained-person-protocol-model-slice-12.md`, PR #2837).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1882 slice 13 — Compromised-care procedural debt creation wire-up (create on merge)                    |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–12 shipped)           |
+| **Branch** | `spe-1882-coercive-protocol-slice-13`                                                                      |
+| **Base `main` SHA** | `5464c6e2`                                                                                          |
+
+## Goal
+
+Smallest `advanceWeek` wire-up from coercive protocol records with compromised-care posture (`stableContainmentDominatesCare`) to welfare-debt creation — reuse `coerciveProcedureWelfareDebtCreation.ts` + `welfareDebtAccountingCrossLinks.ts` procedure-ref matching; no SPE-1888 registry reopen.
+
+## Prerequisite (on `main` @ `5464c6e2`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Protocol registry    | `src/domain/coerciveContainedPersonProtocolRegistry.ts` (SPE-2420)     |
+| Care-harm tradeoff   | `projectContainmentCareTradeoff` (slice 1 / slice 3 tick)              |
+| Welfare-debt creation | `coerciveProcedureWelfareDebtCreation.ts` (SPE-1888 slices 5–6)     |
+| Cross-link compose   | `welfareDebtAccountingCrossLinks.ts` (slice 7–9, slice 12 inverse)   |
+| Mirror cross-links   | `coerciveContainedPersonProtocolMirrorView.ts` (slice 12)              |
+
+## Trigger contract
+
+- **Compromised-care posture** — `projectContainmentCareTradeoff(record).stableContainmentDominatesCare === true`.
+- **Procedure anchor** — `record.procedureRef` resolves via `resolveCoerciveProcedureAnchor`; `welfareDebtImpactLabel` is display-only, not a creation gate.
+- **Containment improvement** — `containmentStabilityGain` > `BASELINE_INSECURITY_SCORE` (0.38).
+- **Merge precedence** — regimen/custody/combo drafts win on duplicate `executionKey`; protocol path fills gaps only.
+- **Idempotency** — `applyCoerciveProcedureWelfareDebtCreationTick` skips existing `welfare-debt:${executionKey}` ledger ids.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords` | SPE-1888 registry reopen                    |
+| Extend `resolveCoerciveProcedureExecutionDrafts` merge + `advanceWeek` | Faction ethics (SPE-1047)                 |
+| Unit + `advanceWeek` integration tests + cross-link procedure_ref assertion | Full taxonomy / handling-mode engine |
+| Slice doc (this file) + backlog handoff on merge                   | Mission triage expansion                      |
+
+## Acceptance
+
+- [x] Protocol-only compromised-care fixture creates welfare-debt ledger entry through `advanceWeek`
+- [x] Records without `stableContainmentDominatesCare` or without resolvable `procedureRef` are skipped
+- [x] Regimen/custody drafts take precedence on duplicate execution keys
+- [x] Quiet weeks and re-advance are no-op / idempotent for ledger creation
+- [x] Mirror cross-link `procedure_ref` matches creation-tick id for wired protocol fixture
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/coerciveProcedureWelfareDebtCreation.ts`                  |
+| Sim    | `src/domain/sim/advanceWeek.ts`                                       |
+| Tests  | `src/test/coerciveProcedureWelfareDebtCreation.test.ts`, `src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts`, `src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-13.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Forced-isolation / staff-exclusion procedure anchors for protocol-only debt | SPE-1882 follow-up | Fixtures lack `procedureRef`; out of smallest wire-up |
+| Broader SPE-1908 cross-system reconciliation | SPE-1889 / SPE-848 / SPE-1615 | Out of slice boundary |
+| Faction ethics + accountability matrix on protocol mirror | SPE-1047 / SPE-1131 | Out of slice boundary |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-12.md` — deferred row origin
+- `planning/spe-1888-parent-acceptance-review-slice-7.md` — compromised-care deferral comment

--- a/src/domain/coerciveProcedureWelfareDebtCreation.ts
+++ b/src/domain/coerciveProcedureWelfareDebtCreation.ts
@@ -9,6 +9,12 @@
 import type { CustodyStatusRecordsMap, CustodyStatusRecord } from './containedPersonCustodyStatusRegistry'
 import type { MedicationRegimenRecordsMap, MedicationRegimenRecord } from './containedPersonMedicationRegimenRegistry'
 import {
+  projectContainmentCareTradeoff,
+  validateCoerciveProtocolRecord,
+  type CoerciveProtocolRecord,
+  type CoerciveProtocolRecordsMap,
+} from './coerciveContainedPersonProtocolRegistry'
+import {
   COERCIVE_PROCEDURE_ANCHORS,
   resolveCoerciveProcedureAnchor,
   type CoerciveProcedureAnchor,
@@ -437,11 +443,73 @@ export function resolveCoerciveProcedureExecutionDraftsFromRegimenCustodyCombos(
   )
 }
 
-/** Merge medication-regimen, custody-status, and combo derived execution drafts. */
+function pushCompromisedCareProtocolDraft(
+  drafts: CoerciveProcedureExecutionDraft[],
+  record: CoerciveProtocolRecord,
+  week: number
+) {
+  if (!validateCoerciveProtocolRecord(record).valid) {
+    return
+  }
+
+  const tradeoff = projectContainmentCareTradeoff(record)
+  if (!tradeoff.stableContainmentDominatesCare) {
+    return
+  }
+
+  const procedureRef = normalizeToken(record.procedureRef ?? '')
+  if (!procedureRef || !resolveCoerciveProcedureAnchor(procedureRef)) {
+    return
+  }
+
+  const subjectRef = normalizeToken(record.subjectRef)
+  if (!subjectRef) {
+    return
+  }
+
+  const postContainmentScore = clampUnitScore(record.containmentStabilityGain)
+  const priorContainmentScore = BASELINE_INSECURITY_SCORE
+  if (postContainmentScore <= priorContainmentScore) {
+    return
+  }
+
+  drafts.push({
+    executionKey: buildExecutionKey(procedureRef, subjectRef),
+    subjectRef,
+    procedureRef,
+    priorContainmentScore,
+    postContainmentScore,
+    week,
+  })
+}
+
+/**
+ * Derive execution drafts from coercive protocol records in compromised-care posture.
+ * `welfareDebtImpactLabel` is not a creation gate — only stableContainmentDominatesCare + procedure anchor.
+ */
+export function resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords(
+  protocols: CoerciveProtocolRecordsMap | null | undefined,
+  week: number
+): readonly CoerciveProcedureExecutionDraft[] {
+  const safeProtocols = protocols ?? {}
+  const normalizedWeek = normalizeWeek(week)
+  const drafts: CoerciveProcedureExecutionDraft[] = []
+
+  for (const record of Object.values(safeProtocols)) {
+    pushCompromisedCareProtocolDraft(drafts, record, normalizedWeek)
+  }
+
+  return Object.freeze(
+    drafts.sort((left, right) => left.executionKey.localeCompare(right.executionKey))
+  )
+}
+
+/** Merge regimen, custody, combo, and compromised-care protocol derived execution drafts. */
 export function resolveCoerciveProcedureExecutionDrafts(
   regimens: MedicationRegimenRecordsMap | null | undefined,
   custodyRecords: CustodyStatusRecordsMap | null | undefined,
-  week: number
+  week: number,
+  protocols?: CoerciveProtocolRecordsMap | null | undefined
 ): readonly CoerciveProcedureExecutionDraft[] {
   const merged = new Map<string, CoerciveProcedureExecutionDraft>()
 
@@ -459,6 +527,15 @@ export function resolveCoerciveProcedureExecutionDrafts(
     week
   )) {
     merged.set(draft.executionKey, draft)
+  }
+
+  for (const draft of resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords(
+    protocols,
+    week
+  )) {
+    if (!merged.has(draft.executionKey)) {
+      merged.set(draft.executionKey, draft)
+    }
   }
 
   return Object.freeze(

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -4907,11 +4907,12 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     })
   }
 
-  // SPE-1888 slice 5: welfare-debt creation when coercive procedures execute with containment improvement.
+  // SPE-1888 slice 5 + SPE-1882 slice 13: welfare-debt creation from regimen/custody anchors and compromised-care protocol records.
   const coerciveProcedureExecutionDrafts = resolveCoerciveProcedureExecutionDrafts(
     outputWeeklyState.containedPersonMedicationRegimenRecords,
     outputWeeklyState.containedPersonCustodyStatusRecords,
-    result.week
+    result.week,
+    outputWeeklyState.coerciveContainedPersonProtocolRecords
   )
   if (coerciveProcedureExecutionDrafts.length > 0) {
     outputWeeklyState.welfareDebtAccountingRecords = applyCoerciveProcedureWelfareDebtCreationTick(

--- a/src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts
@@ -11,6 +11,9 @@ import {
 } from '../domain/containedPersonMedicationRegimenRegistry'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import {
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   resolveCoerciveProcedureExecutionDrafts,
 } from '../domain/coerciveProcedureWelfareDebtCreation'
@@ -180,5 +183,68 @@ describe('advanceWeek privilege-deprivation and personnel-sourcing welfare-debt 
 
     expect(Object.keys(once.welfareDebtAccountingRecords ?? {})).toHaveLength(1)
     expect(twice.welfareDebtAccountingRecords).toEqual(once.welfareDebtAccountingRecords)
+  })
+})
+
+describe('advanceWeek compromised-care protocol welfare-debt integration (SPE-1882 slice 13)', () => {
+  it('creates welfare-debt records from compromised-care protocol records without regimen/custody anchors', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 2
+    state.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const recordId =
+      'welfare-debt:coercive-procedure:extended-mechanical-restraint:subject:cooperative-field-asset-31'
+    const record = nextState.welfareDebtAccountingRecords?.[recordId]
+
+    expect(record?.debtCategory).toBe('harmful_restraint')
+    expect(record?.severityBand).toBe('high')
+    expect(record?.containmentBenefitScore).toBe(0.71)
+  })
+
+  it('does not duplicate protocol-derived debt when advanceWeek runs again on a quiet week', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 1
+    state.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const once = advanceWeek(state)
+    const twice = advanceWeek(once)
+
+    expect(Object.keys(once.welfareDebtAccountingRecords ?? {})).toHaveLength(1)
+    expect(twice.welfareDebtAccountingRecords).toEqual(once.welfareDebtAccountingRecords)
+  })
+
+  it('matches standalone creation tick output for compromised-care protocol derived drafts', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 3
+    state.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const nextWeek = state.week + 1
+    const drafts = resolveCoerciveProcedureExecutionDrafts(
+      state.containedPersonMedicationRegimenRecords,
+      state.containedPersonCustodyStatusRecords,
+      nextWeek,
+      state.coerciveContainedPersonProtocolRecords
+    )
+    const createdOnly = applyCoerciveProcedureWelfareDebtCreationTick({}, drafts)
+    const viaAdvanceWeek = advanceWeek(state).welfareDebtAccountingRecords ?? {}
+
+    for (const recordId of Object.keys(createdOnly)) {
+      expect(viaAdvanceWeek[recordId]?.id).toBe(createdOnly[recordId]?.id)
+      expect(viaAdvanceWeek[recordId]?.debtCategory).toBe(createdOnly[recordId]?.debtCategory)
+      expect(viaAdvanceWeek[recordId]?.severityBand).toBe(createdOnly[recordId]?.severityBand)
+      expect(viaAdvanceWeek[recordId]?.containmentBenefitScore).toBe(
+        createdOnly[recordId]?.containmentBenefitScore
+      )
+    }
   })
 })

--- a/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
@@ -13,6 +13,7 @@ import {
 import { applyWeeklyCoerciveProtocolTick } from '../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../domain/welfareDebtAccountingRegistry'
+import { composeWelfareDebtCrossLinksForCoerciveProtocolRecord } from '../domain/welfareDebtAccountingCrossLinks'
 import { getCoerciveContainedPersonProtocolMirrorView } from '../features/operations/coerciveContainedPersonProtocolMirrorView'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -206,6 +207,41 @@ describe('advanceWeek coercive protocol records integration (SPE-1882 slice 12)'
     }
 
     const nextState = advanceWeek(state)
+    const view = getCoerciveContainedPersonProtocolMirrorView(nextState)
+
+    expect(view.summary.welfareDebtLinkedRecordCount).toBe(1)
+    expect(view.records[0]?.welfareDebtCrossLinkLabels).toEqual([`welfare-debt:${debtId}`])
+  })
+})
+
+describe('advanceWeek coercive protocol records integration (SPE-1882 slice 13)', () => {
+  it('creates welfare-debt ledger entries from compromised-care protocol records and links by procedure_ref', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 2
+    state.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const debtId = `welfare-debt:${ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.procedureRef}:${ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef}`
+    const debtRecord = nextState.welfareDebtAccountingRecords?.[debtId]
+
+    expect(debtRecord?.debtCategory).toBe('harmful_restraint')
+    expect(
+      composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
+        ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+        { welfareDebtRecords: nextState.welfareDebtAccountingRecords }
+      )
+    ).toEqual([
+      expect.objectContaining({
+        debtRef: debtId,
+        coerciveProtocolId: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+        matchKind: 'procedure_ref',
+      }),
+    ])
+
     const view = getCoerciveContainedPersonProtocolMirrorView(nextState)
 
     expect(view.summary.welfareDebtLinkedRecordCount).toBe(1)

--- a/src/test/coerciveProcedureWelfareDebtCreation.test.ts
+++ b/src/test/coerciveProcedureWelfareDebtCreation.test.ts
@@ -15,10 +15,16 @@ import {
   PRIVILEGE_SUSPENSION_ENFORCEMENT_ANCHOR,
 } from '../domain/coerciveProcedureRegistry'
 import {
+  ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+  EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+} from '../domain/coerciveContainedPersonProtocolRegistry'
+import {
   applyCoerciveProcedureWelfareDebtCreationTick,
   buildWelfareDebtAccountingRecordForCoerciveProcedureExecution,
   hasContainmentOrSecurityImprovement,
   resolveCoerciveProcedureExecutionDrafts,
+  resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords,
   resolveCoerciveProcedureExecutionDraftsFromCustodyStatus,
   resolveCoerciveProcedureExecutionDraftsFromMedicationRegimens,
   resolveCoerciveProcedureExecutionDraftsFromRegimenCustodyCombos,
@@ -313,5 +319,74 @@ describe('coerciveProcedureWelfareDebtCreation (SPE-1888 slice 6)', () => {
       'coercive-procedure:forced-sedation-stabilization',
       'coercive-procedure:privilege-suspension-enforcement',
     ])
+  })
+})
+
+describe('coerciveProcedureWelfareDebtCreation (SPE-1882 slice 13)', () => {
+  it('derives compromised-care protocol drafts from stableContainmentDominatesCare fixtures', () => {
+    const drafts = resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords(
+      {
+        [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+        [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+      },
+      4
+    )
+
+    expect(drafts).toHaveLength(2)
+    expect(drafts.map((draft) => draft.executionKey)).toEqual([
+      'coercive-procedure:extended-mechanical-restraint:subject:cooperative-field-asset-31',
+      'coercive-procedure:forced-sedation-stabilization:subject:cooperative-field-asset-17',
+    ])
+    expect(drafts[0]?.postContainmentScore).toBe(0.71)
+    expect(drafts[1]?.postContainmentScore).toBe(0.78)
+  })
+
+  it('skips protocol records without compromised-care posture or resolvable procedureRef', () => {
+    const drafts = resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords(
+      {
+        [ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE.id]:
+          ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      },
+      2
+    )
+
+    expect(drafts).toHaveLength(0)
+  })
+
+  it('does not treat welfareDebtImpactLabel alone as a creation gate', () => {
+    const labelOnly = {
+      ...ABUSIVE_SURVEILLANCE_ISOLATION_PROTOCOL_FIXTURE,
+      procedureRef: 'coercive-procedure:forced-sedation-stabilization',
+    }
+    const drafts = resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords(
+      { [labelOnly.id]: labelOnly },
+      3
+    )
+
+    expect(drafts).toHaveLength(0)
+  })
+
+  it('prefers regimen/custody drafts over protocol drafts on duplicate execution keys', () => {
+    const drafts = resolveCoerciveProcedureExecutionDrafts(
+      {
+        [COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE.id]: COMPELLED_ADVERSE_REACTION_REGIMEN_FIXTURE,
+      },
+      {},
+      2,
+      {
+        [EMERGENCY_SEDATION_PROTOCOL_FIXTURE.id]: {
+          ...EMERGENCY_SEDATION_PROTOCOL_FIXTURE,
+          subjectRef: 'subject:cooperative-field-asset-22',
+          procedureRef: 'coercive-procedure:forced-sedation-stabilization',
+        },
+      }
+    )
+
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0]?.executionKey).toBe(
+      'coercive-procedure:forced-sedation-stabilization:subject:cooperative-field-asset-22'
+    )
+    expect(drafts[0]?.postContainmentScore).toBe(0.64)
+    expect(drafts[0]?.adverseReactionFlag).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Add `resolveCoerciveProcedureExecutionDraftsFromCoerciveProtocolRecords` to derive welfare-debt creation drafts from coercive protocol records in compromised-care posture (`stableContainmentDominatesCare`), gated on resolvable `procedureRef` anchors — not `welfareDebtImpactLabel` text.
- Extend `resolveCoerciveProcedureExecutionDrafts` merge so regimen/custody drafts take precedence on duplicate execution keys; wire `coerciveContainedPersonProtocolRecords` into `advanceWeek`.
- Add unit and integration tests including mirror `procedure_ref` cross-link assertion after creation-tick ledger hydration.

## Linear

- **Slice:** SPE-1882 slice 13 — Compromised-care procedural debt creation wire-up (child to create/claim on Linear)
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — remains **Done**; runtime follow-up only
- **Deferred from:** SPE-1888 parent grooming slice 7

## What shipped

- Compromised-care protocol → welfare-debt creation path in `advanceWeek`
- Slice doc: `planning/coercive-contained-person-protocol-model-slice-13.md`

## Validation

- `npm run test:run -- src/test/coerciveProcedureWelfareDebtCreation.test.ts src/test/advanceWeek.coerciveProcedureWelfareDebt.integration.test.ts src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` (40 passed)
- `npm run lint`

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-13.md`
- `planning/backlog.md` handoff deferred to merge closeout

## Parent remains open?

No — SPE-1882 parent stays **Done**; slice 13 is bounded runtime follow-up per slice 12 deferred table.