### PR TITLE
feat(SPE-1047/SPE-1131): coercive protocol mirror ethics + accountability cross-links (slice 16)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -22,9 +22,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Next step:** Pick next active queue item per `planning/backlog.md` (mission triage full refresh remains blocked).
 
-**Base `main` SHA:** `416f9260` — shipped: SPE-1882 canonical abusive-surveillance fixture compromised-care realignment slice 15 @ `planning/coercive-contained-person-protocol-model-slice-15.md` (PR #2841)
+**Base `main` SHA:** `23dd59b1` — in progress: SPE-1047 / SPE-1131 coercive protocol mirror ethics + accountability cross-links slice 16 @ `planning/coercive-contained-person-protocol-model-slice-16.md` (branch `spe-1047-coercive-protocol-mirror-ethics-accountability-slice-16`)
 
-**Recently shipped:** SPE-1882 canonical abusive-surveillance fixture compromised-care realignment slice 15 (PR #2841 @ `2cb289a3`); SPE-1882 forced-isolation / staff-exclusion procedure anchors slice 14 (PR #2840 @ `df379681`); SPE-1882 compromised-care procedural debt creation wire-up slice 13 (PR #2839 @ `6225a6e5`).
+**Recently shipped:** SPE-1882 canonical abusive-surveillance fixture compromised-care realignment slice 15 (PR #2841 @ `416f9260`); SPE-1882 forced-isolation / staff-exclusion procedure anchors slice 14 (PR #2840 @ `df379681`); SPE-1882 compromised-care procedural debt creation wire-up slice 13 (PR #2839 @ `6225a6e5`).
 
 **Recently shipped:** SPE-1309 parent acceptance review grooming slice 6 (PR #2815 @ `0ec51d86`); SPE-1309 unified cognitive hazard engine slice 7 (PR #2814 @ `a0f8e9ec`).
 

--- a/planning/coercive-contained-person-protocol-model-slice-16.md
+++ b/planning/coercive-contained-person-protocol-model-slice-16.md
@@ -1,0 +1,79 @@
+# SPE-1047 / SPE-1131 — Coercive protocol mirror faction ethics + accountability cross-links (slice 16)
+
+One-page implementation plan. Linear: SPE-1882 slice 16 child (create on merge) under SPE-1047 / SPE-1131 deferred scope. Follows shipped slice 15 (`planning/coercive-contained-person-protocol-model-slice-15.md`, PR #2841).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1882 slice 16 — Mirror faction ethics + accountability cross-links (create on merge)                   |
+| **Status** | **In Progress** — branch `spe-1047-coercive-protocol-mirror-ethics-accountability-slice-16` |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–15 shipped)           |
+| **Related**| [SPE-1047](https://linear.app/spectranoir/issue/SPE-1047), [SPE-1131](https://linear.app/spectranoir/issue/SPE-1131) — registry-wave compose deferred; mirror surfacing only |
+| **Branch** | `spe-1047-coercive-protocol-mirror-ethics-accountability-slice-16`                                       |
+| **Base `main` SHA** | `23dd59b1`                                                                                          |
+
+## Goal
+
+Surface SPE-1047 faction ethics and SPE-1131 accountability matrix cross-links on `getCoerciveContainedPersonProtocolMirrorView` by reusing welfare-debt-mediated inverse compose — read-only agent-routing labels without registry reopen, policy engines, or creation gates.
+
+## Prerequisite (on `main` @ `23dd59b1`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Welfare-debt inverse compose | `composeWelfareDebtCrossLinksForCoerciveProtocolRecord` (slice 12) |
+| Matrix cross-link compose | `composeWelfareDebtAccountingCrossLinksForRecord` + matrix maps (SPE-1888 slice 9) |
+| Matrix persistence | `factionEthicsRecords` / `accountabilityMatrixRecords` on GameState (SPE-2454) |
+| Canonical fixture posture | slice 15 compromised-care realignment (PR #2841)                |
+
+## Mirror contract
+
+- **Read-only** — mirror calls inverse compose at build time only; no GameState mutation.
+- **Welfare-debt mediated** — ethics/accountability links derive from linked welfare-debt ledger entries' `reviewOwnerLabel` / `mitigationPathLabel`; match kinds stay byte-stable with welfare-debt mirror compose.
+- **Opaque fallback** — when matrix maps absent, surface `review-owner:` / `mitigation-path:` wired refs from linked debt labels (display-only; not authorization gates).
+- **Summary** — `factionEthicsLinkedRecordCount` and `accountabilityMatrixLinkedRecordCount` count records with ≥1 linked label.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Inverse ethics/accountability compose in `welfareDebtAccountingCrossLinks.ts` | Full SPE-1047 policy engine |
+| Mirror view per-record cross-link labels + summary counts           | Full SPE-1131 matrix engine                   |
+| Mirror page stat cards + owner-ref column display                   | Registry reopen / handling-mode rewrite       |
+| Targeted cross-link, mirror view, page, advanceWeek tests           | Procedure anchors / merge precedence          |
+| Slice doc (this file) + backlog handoff on merge                    | Mission triage expansion                      |
+|                                                                    | SPE-1908 cross-reconciliation reopen          |
+
+## Acceptance
+
+- [x] Missing welfare-debt or matrix maps yield empty ethics/accountability labels and zero summary counts
+- [x] Matrix hydration surfaces deterministic sorted `faction-ethics:` / `accountability-matrix:` wired refs
+- [x] Opaque `review_owner:` / `mitigation_path:` labels surface when matrix maps absent but linked debt carries labels
+- [x] `advanceWeek`-hydrated GameState mirror reads persisted cross-links
+- [x] Ethics labels remain display-only (no creation gates)
+- [x] Slice 1–15 mirror regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/welfareDebtAccountingCrossLinks.ts`                       |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` |
+| UI     | `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx` |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/welfareDebtAccountingCrossLinks.test.ts`, `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx`, `src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-16.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full faction ethics policy engine | SPE-1047 | Parent AC remainder beyond registry-wave mirror surfacing |
+| Full accountability matrix engine | SPE-1131 | Parent AC remainder beyond registry-wave mirror surfacing |
+| Permissibility verdict / outcome projection label columns | SPE-1047 / SPE-1131 follow-up | Cross-link wired refs sufficient for agent routing this slice |
+| Broader SPE-1908 cross-system reconciliation | SPE-1889 / SPE-848 / SPE-1615 | Out of mirror surfacing boundary |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-12.md` — welfare-debt inverse compose origin
+- `planning/coercive-contained-person-protocol-model-slice-15.md` — deferred row origin
+- `planning/welfare-debt-accounting-registry-slice-9.md` — matrix cross-link compose origin

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1376,7 +1376,11 @@ export const COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT: Record<string, s
   crossSystemTensionSubjectsLabel: 'Cross-system tension subjects',
   weeklySnapshotCountLabel: 'Weekly snapshots',
   welfareDebtLinkedRecordsLabel: 'Welfare-debt links',
+  factionEthicsLinkedRecordsLabel: 'Faction ethics links',
+  accountabilityMatrixLinkedRecordsLabel: 'Accountability matrix links',
   welfareDebtCrossLinkPrefix: 'Welfare-debt cross-links:',
+  factionEthicsCrossLinkPrefix: 'Faction ethics cross-links:',
+  accountabilityMatrixCrossLinkPrefix: 'Accountability matrix cross-links:',
   validationWarningPrefix: 'Validation warnings:',
   redactedSuffix: 'Partial redaction',
 }

--- a/src/domain/welfareDebtAccountingCrossLinks.ts
+++ b/src/domain/welfareDebtAccountingCrossLinks.ts
@@ -596,3 +596,189 @@ export function formatCoerciveProtocolWelfareDebtCrossLinkLabels(
       .sort((left, right) => left.localeCompare(right))
   )
 }
+
+export interface CoerciveProtocolEthicsAccountabilityCrossLinkSummary {
+  readonly factionEthicsLinks: readonly WelfareDebtFactionEthicsCrossLink[]
+  readonly accountabilityMatrixLinks: readonly WelfareDebtAccountabilityMatrixCrossLink[]
+  readonly accountabilityLinkRefs: readonly WelfareDebtAccountabilityLinkRef[]
+}
+
+const EMPTY_COERCIVE_PROTOCOL_ETHICS_ACCOUNTABILITY_SUMMARY: CoerciveProtocolEthicsAccountabilityCrossLinkSummary =
+  Object.freeze({
+    factionEthicsLinks: Object.freeze([]),
+    accountabilityMatrixLinks: Object.freeze([]),
+    accountabilityLinkRefs: Object.freeze([]),
+  })
+
+function mergeFactionEthicsCrossLinks(
+  target: Map<string, WelfareDebtFactionEthicsCrossLink>,
+  links: readonly WelfareDebtFactionEthicsCrossLink[]
+): void {
+  for (const link of links) {
+    const key = `${link.factionEthicsRecordId}:${link.wiredRef}:${link.matchKind}`
+    if (!target.has(key)) {
+      target.set(key, link)
+    }
+  }
+}
+
+function mergeAccountabilityMatrixCrossLinks(
+  target: Map<string, WelfareDebtAccountabilityMatrixCrossLink>,
+  links: readonly WelfareDebtAccountabilityMatrixCrossLink[]
+): void {
+  for (const link of links) {
+    const key = `${link.accountabilityMatrixRecordId}:${link.wiredRef}:${link.matchKind}`
+    if (!target.has(key)) {
+      target.set(key, link)
+    }
+  }
+}
+
+function mergeAccountabilityLinkRefs(
+  target: Map<string, WelfareDebtAccountabilityLinkRef>,
+  refs: readonly WelfareDebtAccountabilityLinkRef[]
+): void {
+  for (const ref of refs) {
+    const key = `${ref.kind}:${ref.wiredRef}`
+    if (!target.has(key)) {
+      target.set(key, ref)
+    }
+  }
+}
+
+function sortFactionEthicsCrossLinks(
+  links: readonly WelfareDebtFactionEthicsCrossLink[]
+): readonly WelfareDebtFactionEthicsCrossLink[] {
+  return Object.freeze(
+    [...links].sort((left, right) => {
+      const wiredCompare = left.wiredRef.localeCompare(right.wiredRef)
+      if (wiredCompare !== 0) {
+        return wiredCompare
+      }
+
+      return left.matchKind.localeCompare(right.matchKind)
+    })
+  )
+}
+
+function sortAccountabilityMatrixCrossLinks(
+  links: readonly WelfareDebtAccountabilityMatrixCrossLink[]
+): readonly WelfareDebtAccountabilityMatrixCrossLink[] {
+  return Object.freeze(
+    [...links].sort((left, right) => {
+      const wiredCompare = left.wiredRef.localeCompare(right.wiredRef)
+      if (wiredCompare !== 0) {
+        return wiredCompare
+      }
+
+      return left.matchKind.localeCompare(right.matchKind)
+    })
+  )
+}
+
+/** Inverse compose: SPE-1047 / SPE-1131 cross-links for one coercive protocol via linked welfare-debt ledger entries (SPE-1882 slice 16). */
+export function composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+  record: CoerciveProtocolRecord,
+  input?: {
+    readonly welfareDebtRecords?: WelfareDebtAccountingRecordsMap | null | undefined
+    readonly factionEthicsRecords?: FactionEthicsMatrixRecordsMap | null | undefined
+    readonly accountabilityMatrixRecords?: MoralLegalAccountabilityMatrixRecordsMap | null | undefined
+  }
+): CoerciveProtocolEthicsAccountabilityCrossLinkSummary {
+  if (!validateCoerciveProtocolRecord(record).valid) {
+    return EMPTY_COERCIVE_PROTOCOL_ETHICS_ACCOUNTABILITY_SUMMARY
+  }
+
+  const protocolId = normalizeToken(record.id)
+  if (!protocolId) {
+    return EMPTY_COERCIVE_PROTOCOL_ETHICS_ACCOUNTABILITY_SUMMARY
+  }
+
+  const welfareDebtLinks = composeWelfareDebtCrossLinksForCoerciveProtocolRecord(record, {
+    welfareDebtRecords: input?.welfareDebtRecords,
+  })
+  if (welfareDebtLinks.length === 0) {
+    return EMPTY_COERCIVE_PROTOCOL_ETHICS_ACCOUNTABILITY_SUMMARY
+  }
+
+  const safeRecords = input?.welfareDebtRecords ?? {}
+  const factionEthicsByKey = new Map<string, WelfareDebtFactionEthicsCrossLink>()
+  const accountabilityMatrixByKey = new Map<string, WelfareDebtAccountabilityMatrixCrossLink>()
+  const accountabilityLinkRefsByKey = new Map<string, WelfareDebtAccountabilityLinkRef>()
+
+  for (const welfareDebtLink of welfareDebtLinks) {
+    const debtRecord = safeRecords[welfareDebtLink.debtRef]
+    if (!debtRecord) {
+      continue
+    }
+
+    const summary = composeWelfareDebtAccountingCrossLinksForRecord(debtRecord, {
+      coerciveProtocolRecords: { [protocolId]: record },
+      factionEthicsRecords: input?.factionEthicsRecords,
+      accountabilityMatrixRecords: input?.accountabilityMatrixRecords,
+    })
+    if (!summary) {
+      continue
+    }
+
+    mergeFactionEthicsCrossLinks(factionEthicsByKey, summary.factionEthicsLinks)
+    mergeAccountabilityMatrixCrossLinks(
+      accountabilityMatrixByKey,
+      summary.accountabilityMatrixLinks
+    )
+    mergeAccountabilityLinkRefs(accountabilityLinkRefsByKey, summary.accountabilityLinkRefs)
+  }
+
+  return Object.freeze({
+    factionEthicsLinks: sortFactionEthicsCrossLinks([...factionEthicsByKey.values()]),
+    accountabilityMatrixLinks: sortAccountabilityMatrixCrossLinks([
+      ...accountabilityMatrixByKey.values(),
+    ]),
+    accountabilityLinkRefs: Object.freeze(
+      [...accountabilityLinkRefsByKey.values()].sort((left, right) => {
+        const byKind = left.kind.localeCompare(right.kind)
+        if (byKind !== 0) {
+          return byKind
+        }
+
+        return left.wiredRef.localeCompare(right.wiredRef)
+      })
+    ),
+  })
+}
+
+export function formatCoerciveProtocolFactionEthicsCrossLinkLabels(
+  summary: CoerciveProtocolEthicsAccountabilityCrossLinkSummary
+): readonly string[] {
+  const labels: string[] = []
+
+  for (const link of summary.factionEthicsLinks) {
+    labels.push(link.wiredRef)
+  }
+
+  for (const ref of summary.accountabilityLinkRefs) {
+    if (ref.kind === 'review_owner') {
+      labels.push(`${ref.kind}:${ref.wiredRef}`)
+    }
+  }
+
+  return Object.freeze([...labels].sort((left, right) => left.localeCompare(right)))
+}
+
+export function formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels(
+  summary: CoerciveProtocolEthicsAccountabilityCrossLinkSummary
+): readonly string[] {
+  const labels: string[] = []
+
+  for (const link of summary.accountabilityMatrixLinks) {
+    labels.push(link.wiredRef)
+  }
+
+  for (const ref of summary.accountabilityLinkRefs) {
+    if (ref.kind === 'mitigation_path') {
+      labels.push(`${ref.kind}:${ref.wiredRef}`)
+    }
+  }
+
+  return Object.freeze([...labels].sort((left, right) => left.localeCompare(right)))
+}

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
@@ -12,6 +12,12 @@ import {
 import { INTEGRATED_HEALTH_BUNDLE_SURVEILLANCE_TENSION_FIXTURE } from '../../domain/containedPersonIntegratedHealthBundleRegistry'
 import { useGameStore } from '../../app/store/gameStore'
 import CoerciveContainedPersonProtocolMirrorPage from './CoerciveContainedPersonProtocolMirrorPage'
+import {
+  ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+} from '../../domain/coerciveContainedPersonProtocolRegistry'
+import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../../domain/welfareDebtAccountingRegistry'
+import { ETHICS_REVIEW_BOARD_MATRIX_FIXTURE } from '../../domain/factionEthicsMatrixRegistry'
+import { INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE } from '../../domain/moralLegalAccountabilityMatrixRegistry'
 
 function renderMirrorPage() {
   return render(
@@ -116,5 +122,44 @@ describe('CoerciveContainedPersonProtocolMirrorPage (SPE-2429 slice 2)', () => {
     expect(recordsRegion).toHaveTextContent(/cross-system tension:/i)
     expect(recordsRegion).toHaveTextContent(/surveillance burden stable mental state/i)
     expect(screen.getByText(/cross-system tension subjects/i)).toBeInTheDocument()
+  })
+})
+
+describe('CoerciveContainedPersonProtocolMirrorPage (SPE-1047 / SPE-1131 slice 16)', () => {
+  it('renders faction ethics and accountability cross-link labels when matrix maps are hydrated', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    game.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    game.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted coercive contained person protocol records/i,
+    })
+
+    expect(screen.getByText(/faction ethics links/i)).toBeInTheDocument()
+    expect(screen.getByText(/accountability matrix links/i)).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(/faction ethics cross-links:/i)
+    expect(recordsRegion).toHaveTextContent(/accountability matrix cross-links:/i)
+    expect(recordsRegion).toHaveTextContent(
+      'faction-ethics:faction-ethics:ethics-review-board-routing'
+    )
+    expect(recordsRegion).toHaveTextContent(
+      'accountability-matrix:accountability-matrix:independent-welfare-audit'
+    )
   })
 })

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
@@ -70,6 +70,18 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
             value={String(view.summary.welfareDebtLinkedRecordCount)}
           />
           <StatCard
+            label={
+              COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.factionEthicsLinkedRecordsLabel
+            }
+            value={String(view.summary.factionEthicsLinkedRecordCount)}
+          />
+          <StatCard
+            label={
+              COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.accountabilityMatrixLinkedRecordsLabel
+            }
+            value={String(view.summary.accountabilityMatrixLinkedRecordCount)}
+          />
+          <StatCard
             label={COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.weekLabel}
             value={`W${view.summary.week}`}
           />
@@ -241,11 +253,29 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
                           {record.welfareDebtCrossLinkLabels.join('; ')}
                         </p>
                       ) : null}
+                      {record.factionEthicsCrossLinkLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {
+                            COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.factionEthicsCrossLinkPrefix
+                          }{' '}
+                          {record.factionEthicsCrossLinkLabels.join('; ')}
+                        </p>
+                      ) : null}
+                      {record.accountabilityMatrixCrossLinkLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {
+                            COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.accountabilityMatrixCrossLinkPrefix
+                          }{' '}
+                          {record.accountabilityMatrixCrossLinkLabels.join('; ')}
+                        </p>
+                      ) : null}
                       {record.medicationRegimenRefLabel === '—' &&
                       record.custodyStatusRefLabel === '—' &&
                       record.procedureRefLabel === '—' &&
                       record.subjectFitValidationRefLabel === '—' &&
-                      record.welfareDebtCrossLinkLabels.length === 0 ? (
+                      record.welfareDebtCrossLinkLabels.length === 0 &&
+                      record.factionEthicsCrossLinkLabels.length === 0 &&
+                      record.accountabilityMatrixCrossLinkLabels.length === 0 ? (
                         <p className="text-xs opacity-45">—</p>
                       ) : null}
                     </td>

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -19,6 +19,8 @@ import { applyWeeklyCoerciveProtocolTick } from '../../domain/coerciveContainedP
 import { PSYCHOLOGICAL_RESILIENCE_STAGED_DEPLETION_FIXTURE } from '../../domain/psychologicalResilienceRegistry'
 import { SURVEILLANCE_TUNING_SUBJECT_22_FIXTURE } from '../../domain/surveillanceCapacityInterventionTuningRegistry'
 import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../../domain/welfareDebtAccountingRegistry'
+import { ETHICS_REVIEW_BOARD_MATRIX_FIXTURE } from '../../domain/factionEthicsMatrixRegistry'
+import { INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE } from '../../domain/moralLegalAccountabilityMatrixRegistry'
 import {
   formatCoerciveProtocolEnumLabel,
   getCoerciveContainedPersonProtocolMirrorView,
@@ -535,5 +537,73 @@ describe('coerciveContainedPersonProtocolMirrorView (SPE-1882 slice 12)', () => 
 
     expect(view.summary.welfareDebtLinkedRecordCount).toBe(1)
     expect(view.records[0]?.welfareDebtCrossLinkLabels).toEqual([`welfare-debt:${debtId}`])
+  })
+})
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-1047 / SPE-1131 slice 16)', () => {
+  it('omits faction ethics and accountability labels when welfare-debt ledger is absent', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.summary.factionEthicsLinkedRecordCount).toBe(0)
+    expect(view.summary.accountabilityMatrixLinkedRecordCount).toBe(0)
+    expect(view.records[0]?.factionEthicsCrossLinkLabels).toEqual([])
+    expect(view.records[0]?.accountabilityMatrixCrossLinkLabels).toEqual([])
+  })
+
+  it('surfaces opaque ethics/accountability labels from linked welfare-debt entries', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.summary.factionEthicsLinkedRecordCount).toBe(1)
+    expect(view.summary.accountabilityMatrixLinkedRecordCount).toBe(1)
+    expect(view.records[0]?.factionEthicsCrossLinkLabels).toEqual([
+      'review_owner:review-owner:ethics-review-board',
+    ])
+    expect(view.records[0]?.accountabilityMatrixCrossLinkLabels).toEqual([
+      'mitigation_path:mitigation-path:independent-welfare-audit',
+    ])
+  })
+
+  it('surfaces matrix wired refs when faction ethics and accountability maps are hydrated', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    game.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    game.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.records[0]?.factionEthicsCrossLinkLabels).toEqual([
+      'faction-ethics:faction-ethics:ethics-review-board-routing',
+    ])
+    expect(view.records[0]?.accountabilityMatrixCrossLinkLabels).toEqual([
+      'accountability-matrix:accountability-matrix:independent-welfare-audit',
+    ])
   })
 })

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -17,7 +17,10 @@ import {
   formatCrossSystemTensionFlagLabel,
 } from '../../domain/coerciveProtocolIntegratedHealthCrossReconciliationSurfacing'
 import {
+  composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord,
   composeWelfareDebtCrossLinksForCoerciveProtocolRecord,
+  formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels,
+  formatCoerciveProtocolFactionEthicsCrossLinkLabels,
   formatCoerciveProtocolWelfareDebtCrossLinkLabels,
 } from '../../domain/welfareDebtAccountingCrossLinks'
 
@@ -52,6 +55,8 @@ export interface CoerciveContainedPersonProtocolMirrorRecordView {
   contradictionCheckViews: readonly CoerciveProtocolContradictionCheckMirrorView[]
   crossSystemTensionFlagLabels: readonly string[]
   welfareDebtCrossLinkLabels: readonly string[]
+  factionEthicsCrossLinkLabels: readonly string[]
+  accountabilityMatrixCrossLinkLabels: readonly string[]
   medicationRegimenRefLabel: string
   custodyStatusRefLabel: string
   procedureRefLabel: string
@@ -70,6 +75,8 @@ export interface CoerciveContainedPersonProtocolMirrorSummaryView {
   integratedHealthLinkedSubjectCount: number
   crossSystemTensionSubjectCount: number
   welfareDebtLinkedRecordCount: number
+  factionEthicsLinkedRecordCount: number
+  accountabilityMatrixLinkedRecordCount: number
   weeklySnapshotCount: number
   week: number
 }
@@ -178,6 +185,8 @@ function toRecordView(
   record: CoerciveProtocolRecord,
   crossSystemTensionFlagLabels: readonly string[],
   welfareDebtCrossLinkLabels: readonly string[],
+  factionEthicsCrossLinkLabels: readonly string[],
+  accountabilityMatrixCrossLinkLabels: readonly string[],
   tradeoff: ContainmentCareTradeoffProjection,
   riskReview: CoerciveProtocolRiskReviewProjection
 ): CoerciveContainedPersonProtocolMirrorRecordView {
@@ -217,6 +226,8 @@ function toRecordView(
     contradictionCheckViews: Object.freeze(contradictionChecks.map(toContradictionCheckView)),
     crossSystemTensionFlagLabels: Object.freeze([...crossSystemTensionFlagLabels]),
     welfareDebtCrossLinkLabels: Object.freeze([...welfareDebtCrossLinkLabels]),
+    factionEthicsCrossLinkLabels: Object.freeze([...factionEthicsCrossLinkLabels]),
+    accountabilityMatrixCrossLinkLabels: Object.freeze([...accountabilityMatrixCrossLinkLabels]),
     medicationRegimenRefLabel: formatOptionalRef(record.medicationRegimenRef),
     custodyStatusRefLabel: formatOptionalRef(record.custodyStatusRef),
     procedureRefLabel: formatOptionalRef(record.procedureRef),
@@ -257,6 +268,8 @@ export function getCoerciveContainedPersonProtocolMirrorView(
 
   let weeklySnapshotCount = 0
   let welfareDebtLinkedRecordCount = 0
+  let factionEthicsLinkedRecordCount = 0
+  let accountabilityMatrixLinkedRecordCount = 0
 
   const recordViews = records.map((record) => {
     const { tradeoff, riskReview } = resolveCoerciveProtocolWeeklyProjections(record, snapshots)
@@ -265,6 +278,19 @@ export function getCoerciveContainedPersonProtocolMirrorView(
         welfareDebtRecords: game.welfareDebtAccountingRecords,
       })
     )
+    const ethicsAccountabilitySummary = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      record,
+      {
+        welfareDebtRecords: game.welfareDebtAccountingRecords,
+        factionEthicsRecords: game.factionEthicsRecords,
+        accountabilityMatrixRecords: game.accountabilityMatrixRecords,
+      }
+    )
+    const factionEthicsCrossLinkLabels = formatCoerciveProtocolFactionEthicsCrossLinkLabels(
+      ethicsAccountabilitySummary
+    )
+    const accountabilityMatrixCrossLinkLabels =
+      formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels(ethicsAccountabilitySummary)
 
     if (snapshots[record.id]?.recordId === record.id) {
       weeklySnapshotCount += 1
@@ -272,6 +298,14 @@ export function getCoerciveContainedPersonProtocolMirrorView(
 
     if (welfareDebtCrossLinkLabels.length > 0) {
       welfareDebtLinkedRecordCount += 1
+    }
+
+    if (factionEthicsCrossLinkLabels.length > 0) {
+      factionEthicsLinkedRecordCount += 1
+    }
+
+    if (accountabilityMatrixCrossLinkLabels.length > 0) {
+      accountabilityMatrixLinkedRecordCount += 1
     }
 
     if (tradeoff.stableContainmentDominatesCare) {
@@ -290,6 +324,8 @@ export function getCoerciveContainedPersonProtocolMirrorView(
       record,
       tensionLabelsBySubject.get(record.subjectRef) ?? [],
       welfareDebtCrossLinkLabels,
+      factionEthicsCrossLinkLabels,
+      accountabilityMatrixCrossLinkLabels,
       tradeoff,
       riskReview
     )
@@ -305,6 +341,8 @@ export function getCoerciveContainedPersonProtocolMirrorView(
       integratedHealthLinkedSubjectCount,
       crossSystemTensionSubjectCount,
       welfareDebtLinkedRecordCount,
+      factionEthicsLinkedRecordCount,
+      accountabilityMatrixLinkedRecordCount,
       weeklySnapshotCount,
       week,
     }),

--- a/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
+++ b/src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts
@@ -14,7 +14,12 @@ import {
 import { applyWeeklyCoerciveProtocolTick } from '../domain/coerciveContainedPersonProtocolWeeklyOrchestration'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { COERCIVE_RESTRAINT_LEDGER_FIXTURE } from '../domain/welfareDebtAccountingRegistry'
-import { composeWelfareDebtCrossLinksForCoerciveProtocolRecord } from '../domain/welfareDebtAccountingCrossLinks'
+import {
+  composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord,
+  composeWelfareDebtCrossLinksForCoerciveProtocolRecord,
+} from '../domain/welfareDebtAccountingCrossLinks'
+import { ETHICS_REVIEW_BOARD_MATRIX_FIXTURE } from '../domain/factionEthicsMatrixRegistry'
+import { INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE } from '../domain/moralLegalAccountabilityMatrixRegistry'
 import { getCoerciveContainedPersonProtocolMirrorView } from '../features/operations/coerciveContainedPersonProtocolMirrorView'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
@@ -313,6 +318,47 @@ describe('advanceWeek coercive protocol records integration (SPE-1882 slice 14)'
     const view = getCoerciveContainedPersonProtocolMirrorView(nextState)
 
     expect(view.summary.welfareDebtLinkedRecordCount).toBe(1)
+    expect(view.records[0]?.welfareDebtCrossLinkLabels).toEqual([`welfare-debt:${debtId}`])
+  })
+})
+
+describe('advanceWeek coercive protocol records integration (SPE-1047 / SPE-1131 slice 16)', () => {
+  it('mirror reads faction ethics and accountability cross-links after advanceWeek when matrix maps are hydrated', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 2
+    state.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    state.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    state.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+
+    const nextState = advanceWeek(state)
+    const debtId = `welfare-debt:${ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.procedureRef}:${ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef}`
+    const view = getCoerciveContainedPersonProtocolMirrorView(nextState)
+
+    expect(
+      composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+        ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+        {
+          welfareDebtRecords: nextState.welfareDebtAccountingRecords,
+          factionEthicsRecords: nextState.factionEthicsRecords,
+          accountabilityMatrixRecords: nextState.accountabilityMatrixRecords,
+        }
+      ).factionEthicsLinks
+    ).toHaveLength(1)
+    expect(view.summary.factionEthicsLinkedRecordCount).toBe(1)
+    expect(view.summary.accountabilityMatrixLinkedRecordCount).toBe(1)
+    expect(view.records[0]?.factionEthicsCrossLinkLabels).toEqual([
+      'faction-ethics:faction-ethics:ethics-review-board-routing',
+    ])
+    expect(view.records[0]?.accountabilityMatrixCrossLinkLabels).toEqual([
+      'accountability-matrix:accountability-matrix:independent-welfare-audit',
+    ])
     expect(view.records[0]?.welfareDebtCrossLinkLabels).toEqual([`welfare-debt:${debtId}`])
   })
 })

--- a/src/test/welfareDebtAccountingCrossLinks.test.ts
+++ b/src/test/welfareDebtAccountingCrossLinks.test.ts
@@ -15,8 +15,11 @@ import {
 } from '../domain/moralLegalAccountabilityMatrixRegistry'
 import {
   composeAllWelfareDebtAccountingCrossLinks,
+  composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord,
   composeWelfareDebtAccountingCrossLinksForRecord,
   composeWelfareDebtCrossLinksForCoerciveProtocolRecord,
+  formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels,
+  formatCoerciveProtocolFactionEthicsCrossLinkLabels,
   formatCoerciveProtocolWelfareDebtCrossLinkLabels,
   formatWelfareDebtAccountingCrossLinkLabels,
   resolveProcedureRefFromWelfareDebtRecordId,
@@ -342,6 +345,98 @@ describe('welfareDebtAccountingCrossLinks inverse compose (SPE-1882 slice 12)', 
     const second = composeWelfareDebtCrossLinksForCoerciveProtocolRecord(
       ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
       { welfareDebtRecords }
+    )
+
+    expect(first).toEqual(second)
+  })
+})
+
+describe('welfareDebtAccountingCrossLinks ethics/accountability inverse compose (SPE-1882 slice 16)', () => {
+  it('returns empty ethics/accountability links when welfare-debt records map is empty', () => {
+    expect(
+      composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+        ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE
+      )
+    ).toEqual({
+      factionEthicsLinks: [],
+      accountabilityMatrixLinks: [],
+      accountabilityLinkRefs: [],
+    })
+  })
+
+  it('surfaces opaque review-owner and mitigation-path labels when matrix maps are absent', () => {
+    const welfareDebtRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    const summary = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      { welfareDebtRecords }
+    )
+
+    expect(formatCoerciveProtocolFactionEthicsCrossLinkLabels(summary)).toEqual([
+      'review_owner:review-owner:ethics-review-board',
+    ])
+    expect(formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels(summary)).toEqual([
+      'mitigation_path:mitigation-path:independent-welfare-audit',
+    ])
+  })
+
+  it('wires SPE-1047 and SPE-1131 matrix projections when maps are provided', () => {
+    const welfareDebtRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    const summary = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      {
+        welfareDebtRecords,
+        factionEthicsRecords: {
+          [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+        },
+        accountabilityMatrixRecords: {
+          [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+        },
+      }
+    )
+
+    expect(summary.factionEthicsLinks).toHaveLength(1)
+    expect(summary.accountabilityMatrixLinks).toHaveLength(1)
+    expect(formatCoerciveProtocolFactionEthicsCrossLinkLabels(summary)).toEqual([
+      'faction-ethics:faction-ethics:ethics-review-board-routing',
+    ])
+    expect(formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels(summary)).toEqual([
+      'accountability-matrix:accountability-matrix:independent-welfare-audit',
+    ])
+  })
+
+  it('ethics/accountability inverse compose is byte-stable across repeated calls', () => {
+    const input = {
+      welfareDebtRecords: {
+        [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+          ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+          subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+        },
+      },
+      factionEthicsRecords: {
+        [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+      },
+      accountabilityMatrixRecords: {
+        [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+      },
+    }
+
+    const first = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      input
+    )
+    const second = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      input
     )
 
     expect(first).toEqual(second)


### PR DESCRIPTION
## Summary
- Add welfare-debt-mediated inverse compose for SPE-1047 faction ethics and SPE-1131 accountability matrix cross-links on coercive protocol records.
- Surface per-record cross-link labels and summary counts on the coercive protocol mirror view and page (display-only; no policy engines or creation gates).
- Deferred from SPE-1882 slices 13-15; closes the slice 12/15 deferred row for ethics/accountability mirror surfacing.

## Linear
- **Slice:** SPE-1882 slice 16 (create child on merge) — related SPE-1047 / SPE-1131 mirror surfacing
- **Parent:** SPE-1882 (Done — runtime follow-up)

## What shipped
- `composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord` + label formatters in `welfareDebtAccountingCrossLinks.ts`
- Mirror view fields: `factionEthicsCrossLinkLabels`, `accountabilityMatrixCrossLinkLabels`, summary counts
- Mirror page stat cards + owner-ref column display
- Slice doc: `planning/coercive-contained-person-protocol-model-slice-16.md`

## Validation
- `npm run lint`
- `npm run test:run -- src/test/welfareDebtAccountingCrossLinks.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx src/test/advanceWeek.coerciveProtocolRecords.integration.test.ts` (67 tests)

## Docs updated
- `planning/coercive-contained-person-protocol-model-slice-16.md`
- `planning/backlog.md` handoff

## Parent remains open
- SPE-1047 / SPE-1131 full policy engines remain deferred; SPE-1882 parent stays Done.

Made with [Cursor](https://cursor.com)