### PR TITLE
SPE-1882 slice 17: coercive protocol mirror ethics projection labels

### DIFF
--- a/planning/coercive-contained-person-protocol-model-slice-17.md
+++ b/planning/coercive-contained-person-protocol-model-slice-17.md
@@ -1,0 +1,76 @@
+# SPE-1047 / SPE-1131 — Coercive protocol mirror ethics + accountability projection labels (slice 17)
+
+One-page implementation plan. Linear: SPE-1882 slice 17 child (create on merge) under SPE-1047 / SPE-1131 deferred scope. Follows shipped slice 16 (`planning/coercive-contained-person-protocol-model-slice-16.md`, PR #2842).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1882 slice 17 — Mirror ethics + accountability projection labels (create on merge)                     |
+| **Status** | **In Progress**                                                                                            |
+| **Parent** | [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — registry anchor (slice 1–16 shipped)           |
+| **Related**| [SPE-1047](https://linear.app/spectranoir/issue/SPE-1047), [SPE-1131](https://linear.app/spectranoir/issue/SPE-1131) — registry-wave compose deferred; mirror surfacing only |
+| **Branch** | `spe-1047-coercive-protocol-mirror-ethics-projection-labels-slice-17`                                    |
+| **Base `main` SHA** | `269e6e89`                                                                                          |
+
+## Goal
+
+Surface SPE-1047 permissibility verdict and SPE-1131 moral/legal outcome projection labels on `getCoerciveContainedPersonProtocolMirrorView` when faction ethics and accountability matrix records are hydrated — read-only display labels derived from slice 16 cross-link compose, without policy engines or creation gates.
+
+## Prerequisite (on `main` @ `269e6e89`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Ethics/accountability inverse compose | `composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord` (slice 16) |
+| Matrix projection    | `projectFactionEthicsMatrixReview`, `projectMoralLegalAccountabilityMatrixReview` |
+| Matrix persistence   | `factionEthicsRecords` / `accountabilityMatrixRecords` on GameState (SPE-2454) |
+| Cross-link mirror    | slice 16 wired-ref surfacing (PR #2842)                                |
+
+## Mirror contract
+
+- **Read-only** — projection labels derive from hydrated matrix records at mirror build time only; no GameState mutation.
+- **Matrix-gated** — labels populate only when `factionEthicsLinks` / `accountabilityMatrixLinks` are non-empty (matrix maps hydrated); opaque `review_owner:` / `mitigation_path:` refs alone yield empty projection labels.
+- **Deterministic sort** — multiple matrix matches per protocol follow slice 16 cross-link wired-ref sort order.
+- **Display-only** — labels do not gate protocol creation or authorization.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Projection label formatters in `welfareDebtAccountingCrossLinks.ts` | Full SPE-1047 policy engine |
+| Mirror view per-record projection label fields                      | Full SPE-1131 matrix engine                   |
+| Mirror page owner-ref column projection display                     | Inverse compose match kind changes            |
+| Targeted cross-link, mirror view, page tests                        | Procedure anchors / debt category mapping     |
+| Slice doc (this file) + backlog handoff on merge                    | Mission triage expansion                      |
+|                                                                    | SPE-1908 cross-reconciliation reopen          |
+
+## Acceptance
+
+- [ ] Matrix maps absent → permissibility and outcome projection labels empty (opaque wired refs unchanged)
+- [ ] Matrix hydration surfaces deterministic sorted permissibility verdict labels (e.g. Escalation Required)
+- [ ] Matrix hydration surfaces deterministic sorted moral/legal outcome summary labels
+- [ ] Projection labels remain display-only (no creation gates)
+- [ ] Slice 1–16 mirror regression unchanged
+- [ ] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/welfareDebtAccountingCrossLinks.ts`                       |
+| View   | `src/features/operations/coerciveContainedPersonProtocolMirrorView.ts` |
+| UI     | `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx` |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/welfareDebtAccountingCrossLinks.test.ts`, `src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts`, `src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx` |
+| Plan   | `planning/coercive-contained-person-protocol-model-slice-17.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full faction ethics policy engine | SPE-1047 | Parent AC remainder beyond registry-wave mirror surfacing |
+| Full accountability matrix engine | SPE-1131 | Parent AC remainder beyond registry-wave mirror surfacing |
+| Broader SPE-1908 cross-system reconciliation | SPE-1889 / SPE-848 / SPE-1615 | Out of mirror surfacing boundary |
+
+## See also
+
+- `planning/coercive-contained-person-protocol-model-slice-16.md` — cross-link compose + deferred row origin
+- `planning/welfare-debt-accounting-registry-slice-9.md` — matrix cross-link compose origin

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1381,6 +1381,8 @@ export const COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT: Record<string, s
   welfareDebtCrossLinkPrefix: 'Welfare-debt cross-links:',
   factionEthicsCrossLinkPrefix: 'Faction ethics cross-links:',
   accountabilityMatrixCrossLinkPrefix: 'Accountability matrix cross-links:',
+  factionEthicsProjectionPrefix: 'Permissibility verdict:',
+  accountabilityMatrixProjectionPrefix: 'Accountability outcomes:',
   validationWarningPrefix: 'Validation warnings:',
   redactedSuffix: 'Partial redaction',
 }

--- a/src/domain/welfareDebtAccountingCrossLinks.ts
+++ b/src/domain/welfareDebtAccountingCrossLinks.ts
@@ -23,6 +23,8 @@ import {
   listHydratedFactionEthicsMatrixRecordsForSubjectRef,
   projectFactionEthicsMatrixReview,
   slugifyReviewOwnerLabel,
+  validateFactionEthicsMatrixRecord,
+  type FactionEthicsMatrixRecord,
   type FactionEthicsMatrixRecordsMap,
 } from './factionEthicsMatrixRegistry'
 import {
@@ -30,6 +32,8 @@ import {
   listHydratedAccountabilityMatrixRecordsForSubjectRef,
   projectMoralLegalAccountabilityMatrixReview,
   slugifyMitigationPathLabel,
+  validateMoralLegalAccountabilityMatrixRecord,
+  type MoralLegalAccountabilityMatrixRecord,
   type MoralLegalAccountabilityMatrixRecordsMap,
 } from './moralLegalAccountabilityMatrixRegistry'
 import {
@@ -781,4 +785,90 @@ export function formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels(
   }
 
   return Object.freeze([...labels].sort((left, right) => left.localeCompare(right)))
+}
+
+function formatMatrixRegistryEnumLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+function formatFactionEthicsPermissibilityProjectionLabel(
+  record: FactionEthicsMatrixRecord
+): string | null {
+  if (!validateFactionEthicsMatrixRecord(record).valid) {
+    return null
+  }
+
+  const projection = projectFactionEthicsMatrixReview(record)
+  return formatMatrixRegistryEnumLabel(projection.permissibilityVerdict)
+}
+
+function formatAccountabilityOutcomeProjectionLabel(
+  record: MoralLegalAccountabilityMatrixRecord
+): string | null {
+  if (!validateMoralLegalAccountabilityMatrixRecord(record).valid) {
+    return null
+  }
+
+  const projection = projectMoralLegalAccountabilityMatrixReview(record)
+  return [
+    `Moral ${formatMatrixRegistryEnumLabel(projection.moralOutcome)}`,
+    `Legal ${formatMatrixRegistryEnumLabel(projection.legalOutcome)}`,
+    `Institutional ${formatMatrixRegistryEnumLabel(projection.institutionalOutcome)}`,
+    `Public ${formatMatrixRegistryEnumLabel(projection.publicOutcome)}`,
+  ].join(' · ')
+}
+
+/** Matrix-gated permissibility verdict labels for coercive protocol mirror (SPE-1882 slice 17). */
+export function formatCoerciveProtocolFactionEthicsProjectionLabels(
+  summary: CoerciveProtocolEthicsAccountabilityCrossLinkSummary,
+  factionEthicsRecords: FactionEthicsMatrixRecordsMap | null | undefined
+): readonly string[] {
+  if (!factionEthicsRecords || summary.factionEthicsLinks.length === 0) {
+    return Object.freeze([])
+  }
+
+  const labels: string[] = []
+
+  for (const link of summary.factionEthicsLinks) {
+    const record = factionEthicsRecords[link.factionEthicsRecordId]
+    if (!record) {
+      continue
+    }
+
+    const label = formatFactionEthicsPermissibilityProjectionLabel(record)
+    if (label) {
+      labels.push(label)
+    }
+  }
+
+  return Object.freeze(labels)
+}
+
+/** Matrix-gated moral/legal outcome summary labels for coercive protocol mirror (SPE-1882 slice 17). */
+export function formatCoerciveProtocolAccountabilityMatrixProjectionLabels(
+  summary: CoerciveProtocolEthicsAccountabilityCrossLinkSummary,
+  accountabilityMatrixRecords: MoralLegalAccountabilityMatrixRecordsMap | null | undefined
+): readonly string[] {
+  if (!accountabilityMatrixRecords || summary.accountabilityMatrixLinks.length === 0) {
+    return Object.freeze([])
+  }
+
+  const labels: string[] = []
+
+  for (const link of summary.accountabilityMatrixLinks) {
+    const record = accountabilityMatrixRecords[link.accountabilityMatrixRecordId]
+    if (!record) {
+      continue
+    }
+
+    const label = formatAccountabilityOutcomeProjectionLabel(record)
+    if (label) {
+      labels.push(label)
+    }
+  }
+
+  return Object.freeze(labels)
 }

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx
@@ -163,3 +163,36 @@ describe('CoerciveContainedPersonProtocolMirrorPage (SPE-1047 / SPE-1131 slice 1
     )
   })
 })
+
+describe('CoerciveContainedPersonProtocolMirrorPage (SPE-1047 / SPE-1131 slice 17)', () => {
+  it('renders permissibility verdict and accountability outcome projection labels when matrix maps are hydrated', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    game.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    game.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted coercive contained person protocol records/i,
+    })
+
+    expect(recordsRegion).toHaveTextContent(/permissibility verdict:/i)
+    expect(recordsRegion).toHaveTextContent(/escalation required/i)
+    expect(recordsRegion).toHaveTextContent(/accountability outcomes:/i)
+    expect(recordsRegion).toHaveTextContent(/moral blamed · legal deferred/i)
+  })
+})

--- a/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
+++ b/src/features/operations/CoerciveContainedPersonProtocolMirrorPage.tsx
@@ -269,13 +269,31 @@ export default function CoerciveContainedPersonProtocolMirrorPage() {
                           {record.accountabilityMatrixCrossLinkLabels.join('; ')}
                         </p>
                       ) : null}
+                      {record.factionEthicsProjectionLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {
+                            COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.factionEthicsProjectionPrefix
+                          }{' '}
+                          {record.factionEthicsProjectionLabels.join('; ')}
+                        </p>
+                      ) : null}
+                      {record.accountabilityMatrixProjectionLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {
+                            COERCIVE_CONTAINED_PERSON_PROTOCOL_MIRROR_UI_TEXT.accountabilityMatrixProjectionPrefix
+                          }{' '}
+                          {record.accountabilityMatrixProjectionLabels.join('; ')}
+                        </p>
+                      ) : null}
                       {record.medicationRegimenRefLabel === '—' &&
                       record.custodyStatusRefLabel === '—' &&
                       record.procedureRefLabel === '—' &&
                       record.subjectFitValidationRefLabel === '—' &&
                       record.welfareDebtCrossLinkLabels.length === 0 &&
                       record.factionEthicsCrossLinkLabels.length === 0 &&
-                      record.accountabilityMatrixCrossLinkLabels.length === 0 ? (
+                      record.accountabilityMatrixCrossLinkLabels.length === 0 &&
+                      record.factionEthicsProjectionLabels.length === 0 &&
+                      record.accountabilityMatrixProjectionLabels.length === 0 ? (
                         <p className="text-xs opacity-45">—</p>
                       ) : null}
                     </td>

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts
@@ -607,3 +607,49 @@ describe('coerciveContainedPersonProtocolMirrorView (SPE-1047 / SPE-1131 slice 1
     ])
   })
 })
+
+describe('coerciveContainedPersonProtocolMirrorView (SPE-1047 / SPE-1131 slice 17)', () => {
+  it('omits projection labels when matrix maps are absent', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.records[0]?.factionEthicsProjectionLabels).toEqual([])
+    expect(view.records[0]?.accountabilityMatrixProjectionLabels).toEqual([])
+  })
+
+  it('surfaces permissibility verdict and outcome projection labels when matrix maps are hydrated', () => {
+    const game = createStartingState()
+    game.coerciveContainedPersonProtocolRecords = {
+      [ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.id]: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+    }
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    game.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    game.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+
+    const view = getCoerciveContainedPersonProtocolMirrorView(game)
+
+    expect(view.records[0]?.factionEthicsProjectionLabels).toEqual(['Escalation Required'])
+    expect(view.records[0]?.accountabilityMatrixProjectionLabels).toEqual([
+      'Moral Blamed · Legal Deferred · Institutional Blamed · Public Deferred',
+    ])
+  })
+})

--- a/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
+++ b/src/features/operations/coerciveContainedPersonProtocolMirrorView.ts
@@ -20,7 +20,9 @@ import {
   composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord,
   composeWelfareDebtCrossLinksForCoerciveProtocolRecord,
   formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels,
+  formatCoerciveProtocolAccountabilityMatrixProjectionLabels,
   formatCoerciveProtocolFactionEthicsCrossLinkLabels,
+  formatCoerciveProtocolFactionEthicsProjectionLabels,
   formatCoerciveProtocolWelfareDebtCrossLinkLabels,
 } from '../../domain/welfareDebtAccountingCrossLinks'
 
@@ -57,6 +59,8 @@ export interface CoerciveContainedPersonProtocolMirrorRecordView {
   welfareDebtCrossLinkLabels: readonly string[]
   factionEthicsCrossLinkLabels: readonly string[]
   accountabilityMatrixCrossLinkLabels: readonly string[]
+  factionEthicsProjectionLabels: readonly string[]
+  accountabilityMatrixProjectionLabels: readonly string[]
   medicationRegimenRefLabel: string
   custodyStatusRefLabel: string
   procedureRefLabel: string
@@ -187,6 +191,8 @@ function toRecordView(
   welfareDebtCrossLinkLabels: readonly string[],
   factionEthicsCrossLinkLabels: readonly string[],
   accountabilityMatrixCrossLinkLabels: readonly string[],
+  factionEthicsProjectionLabels: readonly string[],
+  accountabilityMatrixProjectionLabels: readonly string[],
   tradeoff: ContainmentCareTradeoffProjection,
   riskReview: CoerciveProtocolRiskReviewProjection
 ): CoerciveContainedPersonProtocolMirrorRecordView {
@@ -228,6 +234,8 @@ function toRecordView(
     welfareDebtCrossLinkLabels: Object.freeze([...welfareDebtCrossLinkLabels]),
     factionEthicsCrossLinkLabels: Object.freeze([...factionEthicsCrossLinkLabels]),
     accountabilityMatrixCrossLinkLabels: Object.freeze([...accountabilityMatrixCrossLinkLabels]),
+    factionEthicsProjectionLabels: Object.freeze([...factionEthicsProjectionLabels]),
+    accountabilityMatrixProjectionLabels: Object.freeze([...accountabilityMatrixProjectionLabels]),
     medicationRegimenRefLabel: formatOptionalRef(record.medicationRegimenRef),
     custodyStatusRefLabel: formatOptionalRef(record.custodyStatusRef),
     procedureRefLabel: formatOptionalRef(record.procedureRef),
@@ -291,6 +299,15 @@ export function getCoerciveContainedPersonProtocolMirrorView(
     )
     const accountabilityMatrixCrossLinkLabels =
       formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels(ethicsAccountabilitySummary)
+    const factionEthicsProjectionLabels = formatCoerciveProtocolFactionEthicsProjectionLabels(
+      ethicsAccountabilitySummary,
+      game.factionEthicsRecords
+    )
+    const accountabilityMatrixProjectionLabels =
+      formatCoerciveProtocolAccountabilityMatrixProjectionLabels(
+        ethicsAccountabilitySummary,
+        game.accountabilityMatrixRecords
+      )
 
     if (snapshots[record.id]?.recordId === record.id) {
       weeklySnapshotCount += 1
@@ -326,6 +343,8 @@ export function getCoerciveContainedPersonProtocolMirrorView(
       welfareDebtCrossLinkLabels,
       factionEthicsCrossLinkLabels,
       accountabilityMatrixCrossLinkLabels,
+      factionEthicsProjectionLabels,
+      accountabilityMatrixProjectionLabels,
       tradeoff,
       riskReview
     )

--- a/src/test/welfareDebtAccountingCrossLinks.test.ts
+++ b/src/test/welfareDebtAccountingCrossLinks.test.ts
@@ -19,7 +19,9 @@ import {
   composeWelfareDebtAccountingCrossLinksForRecord,
   composeWelfareDebtCrossLinksForCoerciveProtocolRecord,
   formatCoerciveProtocolAccountabilityMatrixCrossLinkLabels,
+  formatCoerciveProtocolAccountabilityMatrixProjectionLabels,
   formatCoerciveProtocolFactionEthicsCrossLinkLabels,
+  formatCoerciveProtocolFactionEthicsProjectionLabels,
   formatCoerciveProtocolWelfareDebtCrossLinkLabels,
   formatWelfareDebtAccountingCrossLinkLabels,
   resolveProcedureRefFromWelfareDebtRecordId,
@@ -440,5 +442,105 @@ describe('welfareDebtAccountingCrossLinks ethics/accountability inverse compose 
     )
 
     expect(first).toEqual(second)
+  })
+})
+
+describe('welfareDebtAccountingCrossLinks ethics/accountability projection labels (SPE-1882 slice 17)', () => {
+  it('returns empty projection labels when matrix maps are absent', () => {
+    const welfareDebtRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    const summary = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      { welfareDebtRecords }
+    )
+
+    expect(formatCoerciveProtocolFactionEthicsProjectionLabels(summary, undefined)).toEqual([])
+    expect(formatCoerciveProtocolAccountabilityMatrixProjectionLabels(summary, undefined)).toEqual(
+      []
+    )
+  })
+
+  it('surfaces permissibility verdict labels when faction ethics matrix is hydrated', () => {
+    const welfareDebtRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    const summary = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      {
+        welfareDebtRecords,
+        factionEthicsRecords: {
+          [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+        },
+      }
+    )
+
+    expect(formatCoerciveProtocolFactionEthicsProjectionLabels(summary, {})).toEqual([])
+    expect(
+      formatCoerciveProtocolFactionEthicsProjectionLabels(summary, {
+        [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+      })
+    ).toEqual(['Escalation Required'])
+  })
+
+  it('surfaces moral/legal outcome summary labels when accountability matrix is hydrated', () => {
+    const welfareDebtRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    const summary = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      {
+        welfareDebtRecords,
+        accountabilityMatrixRecords: {
+          [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+        },
+      }
+    )
+
+    expect(formatCoerciveProtocolAccountabilityMatrixProjectionLabels(summary, {})).toEqual([])
+    expect(
+      formatCoerciveProtocolAccountabilityMatrixProjectionLabels(summary, {
+        [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+      })
+    ).toEqual([
+      'Moral Blamed · Legal Deferred · Institutional Blamed · Public Deferred',
+    ])
+  })
+
+  it('sorts multiple matrix projection labels by cross-link wired-ref order', () => {
+    const welfareDebtRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: {
+        ...COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+      [FORCED_SEDATION_CYCLE_FIXTURE.id]: {
+        ...FORCED_SEDATION_CYCLE_FIXTURE,
+        subjectRef: ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE.subjectRef,
+      },
+    }
+    const summary = composeEthicsAccountabilityCrossLinksForCoerciveProtocolRecord(
+      ROUTINE_FORCE_GENERALIZED_PROTOCOL_FIXTURE,
+      {
+        welfareDebtRecords,
+        factionEthicsRecords: {
+          [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+          [PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE.id]: PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE,
+        },
+      }
+    )
+
+    expect(formatCoerciveProtocolFactionEthicsProjectionLabels(summary, {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+      [PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE.id]: PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE,
+    })).toEqual(['Escalation Required', 'Restricted'])
   })
 })


### PR DESCRIPTION
## Summary

- Add matrix-gated projection label formatters for SPE-1047 permissibility verdicts (e.g. Escalation Required) and SPE-1131 moral/legal outcome summaries on the coercive protocol mirror
- Surface labels in mirror view + owner-refs column; opaque wired refs alone still yield empty projection labels
- Slice doc: `planning/coercive-contained-person-protocol-model-slice-17.md`

## Linear mapping

- **Slice (create on merge):** SPE-1882 slice 17 — Coercive protocol mirror ethics + accountability projection labels
- **Parent:** [SPE-1882](https://linear.app/spectranoir/issue/SPE-1882) — stays Done (registry anchor complete)
- **Related deferred:** [SPE-1047](https://linear.app/spectranoir/issue/SPE-1047), [SPE-1131](https://linear.app/spectranoir/issue/SPE-1131) — full policy/matrix engines remain deferred

## What shipped

- `formatCoerciveProtocolFactionEthicsProjectionLabels` + `formatCoerciveProtocolAccountabilityMatrixProjectionLabels` in `welfareDebtAccountingCrossLinks.ts`
- Mirror record fields `factionEthicsProjectionLabels` / `accountabilityMatrixProjectionLabels`
- Page display with copy prefixes in owner-refs column

## Validation

- `npm run lint`
- `npm run test:run -- src/test/welfareDebtAccountingCrossLinks.test.ts src/features/operations/coerciveContainedPersonProtocolMirrorView.test.ts src/features/operations/CoerciveContainedPersonProtocolMirrorPage.test.tsx`

## Docs updated

- `planning/coercive-contained-person-protocol-model-slice-17.md` (new)
- `planning/backlog.md` handoff deferred to merge

## Parent remains open?

No — SPE-1882 parent stays Done; this is a deferred surfacing follow-up under SPE-1047/SPE-1131 registry-wave scope.