### PR TITLE
SPE-1888 slice 12: welfare-debt mirror matrix projection labels

### DIFF
--- a/planning/welfare-debt-accounting-registry-slice-12.md
+++ b/planning/welfare-debt-accounting-registry-slice-12.md
@@ -1,0 +1,75 @@
+# SPE-1888 — Welfare-debt mirror matrix projection labels (slice 12)
+
+One-page implementation plan. Linear: child under [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) (create on start). Follows shipped slice 11 (`planning/welfare-debt-accounting-registry-slice-11.md`).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | SPE-1888 slice 12 — Welfare-debt mirror matrix projection labels (create on start)                         |
+| **Parent** | [SPE-1888](https://linear.app/spectranoir/issue/SPE-1888) — parent stays **Backlog** until full SPE-1047/1131 scope closes |
+| **Branch** | `spe-1888-welfare-debt-mirror-matrix-projection-labels-slice-12`                                         |
+| **Status** | **In progress**                                                                                            |
+| **Base `main` SHA** | `45c14223`                                                                                          |
+
+## Goal
+
+Surface SPE-1047 permissibility verdict and SPE-1131 moral/legal outcome projection labels on `getWelfareDebtAccountingMirrorView` when faction ethics and accountability matrix records are hydrated — read-only display labels derived from slice 9 cross-link compose, reusing slice 17 projection formatters, without policy engines or compose changes.
+
+## Prerequisite (on `main` @ `45c14223`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Cross-link compose   | `composeWelfareDebtAccountingCrossLinksForRecord` (slice 9)          |
+| Matrix projection formatters | `formatFactionEthicsPermissibilityProjectionLabel`, `formatAccountabilityOutcomeProjectionLabel` (slice 17 / SPE-1882) |
+| Matrix persistence   | `factionEthicsRecords` / `accountabilityMatrixRecords` on GameState (slice 10) |
+| Mirror cross-links   | slice 2 mirror wired-ref surfacing                                     |
+
+## Mirror contract
+
+- **Read-only** — projection labels derive from hydrated matrix records at mirror build time only; no GameState mutation.
+- **Matrix-gated** — labels populate only when `factionEthicsLinks` / `accountabilityMatrixLinks` are non-empty (matrix maps hydrated); opaque `review_owner:` / `mitigation_path:` refs alone yield empty projection labels.
+- **Deterministic sort** — multiple matrix matches per ledger record follow cross-link wired-ref sort order.
+- **Display-only** — labels do not gate ledger creation or authorization.
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Welfare-debt projection label formatters in `welfareDebtAccountingCrossLinks.ts` | Full SPE-1047 policy engine |
+| Mirror view per-record projection label fields                      | Full SPE-1131 matrix engine                   |
+| Mirror page review-column projection display                        | Inverse compose match kind changes            |
+| Targeted cross-link, mirror view, page tests                        | Coercive protocol mirror changes              |
+| Slice doc (this file) + backlog handoff on merge                    | Mission triage expansion                      |
+|                                                                    | SPE-1908 cross-reconciliation reopen          |
+
+## Acceptance
+
+- [x] Matrix maps absent → permissibility and outcome projection labels empty (opaque wired refs unchanged)
+- [x] Matrix hydration surfaces deterministic sorted permissibility verdict labels (e.g. Escalation Required)
+- [x] Matrix hydration surfaces deterministic sorted moral/legal outcome summary labels
+- [x] Projection labels remain display-only (no creation gates)
+- [x] Slice 1–11 mirror regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/welfareDebtAccountingCrossLinks.ts`                       |
+| View   | `src/features/operations/welfareDebtAccountingMirrorView.ts`        |
+| UI     | `src/features/operations/WelfareDebtAccountingMirrorPage.tsx`         |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/welfareDebtAccountingCrossLinks.test.ts`, `src/features/operations/welfareDebtAccountingMirrorView.test.ts`, `src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx` |
+| Plan   | `planning/welfare-debt-accounting-registry-slice-12.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Full faction ethics policy engine | SPE-1047 | Parent AC remainder beyond registry-wave mirror surfacing |
+| Full accountability matrix engine | SPE-1131 | Parent AC remainder beyond registry-wave mirror surfacing |
+| Broader SPE-1908 cross-system reconciliation | SPE-1889 / SPE-848 / SPE-1615 | Out of mirror surfacing boundary |
+
+## See also
+
+- `planning/welfare-debt-accounting-registry-slice-9.md` — cross-link compose origin
+- `planning/coercive-contained-person-protocol-model-slice-17.md` — projection formatter pattern

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1565,6 +1565,8 @@ export const WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT: Record<string, string> = {
   containmentBenefitPrefix: 'Containment benefit:',
   reviewOwnerPrefix: 'Review owner:',
   mitigationPathPrefix: 'Mitigation path:',
+  factionEthicsProjectionPrefix: 'Permissibility verdict:',
+  accountabilityMatrixProjectionPrefix: 'Outcome summary:',
   validationWarningPrefix: 'Validation warnings:',
   redactedSuffix: 'Partial redaction',
 }

--- a/src/domain/welfareDebtAccountingCrossLinks.ts
+++ b/src/domain/welfareDebtAccountingCrossLinks.ts
@@ -872,3 +872,55 @@ export function formatCoerciveProtocolAccountabilityMatrixProjectionLabels(
 
   return Object.freeze(labels)
 }
+
+/** Matrix-gated permissibility verdict labels for welfare-debt mirror (SPE-1888 slice 12). */
+export function formatWelfareDebtFactionEthicsProjectionLabels(
+  summary: WelfareDebtAccountingCrossLinkSummary,
+  factionEthicsRecords: FactionEthicsMatrixRecordsMap | null | undefined
+): readonly string[] {
+  if (!factionEthicsRecords || summary.factionEthicsLinks.length === 0) {
+    return Object.freeze([])
+  }
+
+  const labels: string[] = []
+
+  for (const link of summary.factionEthicsLinks) {
+    const record = factionEthicsRecords[link.factionEthicsRecordId]
+    if (!record) {
+      continue
+    }
+
+    const label = formatFactionEthicsPermissibilityProjectionLabel(record)
+    if (label) {
+      labels.push(label)
+    }
+  }
+
+  return Object.freeze(labels)
+}
+
+/** Matrix-gated moral/legal outcome summary labels for welfare-debt mirror (SPE-1888 slice 12). */
+export function formatWelfareDebtAccountabilityMatrixProjectionLabels(
+  summary: WelfareDebtAccountingCrossLinkSummary,
+  accountabilityMatrixRecords: MoralLegalAccountabilityMatrixRecordsMap | null | undefined
+): readonly string[] {
+  if (!accountabilityMatrixRecords || summary.accountabilityMatrixLinks.length === 0) {
+    return Object.freeze([])
+  }
+
+  const labels: string[] = []
+
+  for (const link of summary.accountabilityMatrixLinks) {
+    const record = accountabilityMatrixRecords[link.accountabilityMatrixRecordId]
+    if (!record) {
+      continue
+    }
+
+    const label = formatAccountabilityOutcomeProjectionLabel(record)
+    if (label) {
+      labels.push(label)
+    }
+  }
+
+  return Object.freeze(labels)
+}

--- a/src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx
+++ b/src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx
@@ -4,6 +4,8 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createStartingState } from '../../data/startingState'
+import { ETHICS_REVIEW_BOARD_MATRIX_FIXTURE } from '../../domain/factionEthicsMatrixRegistry'
+import { INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE } from '../../domain/moralLegalAccountabilityMatrixRegistry'
 import {
   COERCIVE_RESTRAINT_LEDGER_FIXTURE,
   FORCED_SEDATION_CYCLE_FIXTURE,
@@ -63,5 +65,30 @@ describe('WelfareDebtAccountingMirrorPage (SPE-1888 slice 2)', () => {
       'href',
       '/'
     )
+  })
+
+  it('renders matrix projection labels in the review column when maps are hydrated', () => {
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+    game.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    game.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted welfare debt accounting records/i,
+    })
+
+    expect(recordsRegion).toHaveTextContent('Permissibility verdict:')
+    expect(recordsRegion).toHaveTextContent('Escalation Required')
+    expect(recordsRegion).toHaveTextContent('Outcome summary:')
+    expect(recordsRegion).toHaveTextContent('Moral Blamed')
   })
 })

--- a/src/features/operations/WelfareDebtAccountingMirrorPage.tsx
+++ b/src/features/operations/WelfareDebtAccountingMirrorPage.tsx
@@ -154,6 +154,20 @@ export default function WelfareDebtAccountingMirrorPage() {
                         {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.mitigationPathPrefix}{' '}
                         {record.mitigationPathLabel}
                       </p>
+                      {record.factionEthicsProjectionLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.factionEthicsProjectionPrefix}{' '}
+                          {record.factionEthicsProjectionLabels.join('; ')}
+                        </p>
+                      ) : null}
+                      {record.accountabilityMatrixProjectionLabels.length > 0 ? (
+                        <p className="text-xs opacity-45">
+                          {
+                            WELFARE_DEBT_ACCOUNTING_MIRROR_UI_TEXT.accountabilityMatrixProjectionPrefix
+                          }{' '}
+                          {record.accountabilityMatrixProjectionLabels.join('; ')}
+                        </p>
+                      ) : null}
                     </td>
                     <td className="px-2 py-2">
                       {record.crossLinkLabels.length > 0 ? (

--- a/src/features/operations/welfareDebtAccountingMirrorView.test.ts
+++ b/src/features/operations/welfareDebtAccountingMirrorView.test.ts
@@ -201,3 +201,37 @@ describe('welfareDebtAccountingMirrorView (SPE-1888 slice 2)', () => {
     )
   })
 })
+
+describe('welfareDebtAccountingMirrorView (SPE-1888 slice 12)', () => {
+  it('omits projection labels when matrix maps are absent', () => {
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+
+    const record = getWelfareDebtAccountingMirrorView(game).records[0]
+
+    expect(record?.factionEthicsProjectionLabels).toEqual([])
+    expect(record?.accountabilityMatrixProjectionLabels).toEqual([])
+  })
+
+  it('surfaces permissibility verdict and outcome projection labels when matrix maps are hydrated', () => {
+    const game = createStartingState()
+    game.welfareDebtAccountingRecords = {
+      [COERCIVE_RESTRAINT_LEDGER_FIXTURE.id]: COERCIVE_RESTRAINT_LEDGER_FIXTURE,
+    }
+    game.factionEthicsRecords = {
+      [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+    }
+    game.accountabilityMatrixRecords = {
+      [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+    }
+
+    const record = getWelfareDebtAccountingMirrorView(game).records[0]
+
+    expect(record?.factionEthicsProjectionLabels).toEqual(['Escalation Required'])
+    expect(record?.accountabilityMatrixProjectionLabels).toEqual([
+      'Moral Blamed · Legal Deferred · Institutional Blamed · Public Deferred',
+    ])
+  })
+})

--- a/src/features/operations/welfareDebtAccountingMirrorView.ts
+++ b/src/features/operations/welfareDebtAccountingMirrorView.ts
@@ -1,7 +1,9 @@
 import type { GameState } from '../../domain/models'
 import {
   composeWelfareDebtAccountingCrossLinksForRecord,
+  formatWelfareDebtAccountabilityMatrixProjectionLabels,
   formatWelfareDebtAccountingCrossLinkLabels,
+  formatWelfareDebtFactionEthicsProjectionLabels,
 } from '../../domain/welfareDebtAccountingCrossLinks'
 import {
   projectWelfareDebtAccounting,
@@ -23,6 +25,8 @@ export interface WelfareDebtAccountingMirrorRecordView {
   mitigationPathLabel: string
   containmentBenefitScoreLabel: string
   crossLinkLabels: readonly string[]
+  factionEthicsProjectionLabels: readonly string[]
+  accountabilityMatrixProjectionLabels: readonly string[]
   validationWarningLabels: readonly string[]
   confidenceLabel: string
   redacted: boolean
@@ -98,6 +102,18 @@ function toRecordView(
   const crossLinkLabels = crossLinkSummary
     ? formatWelfareDebtAccountingCrossLinkLabels(crossLinkSummary)
     : Object.freeze([] as readonly string[])
+  const factionEthicsProjectionLabels = crossLinkSummary
+    ? formatWelfareDebtFactionEthicsProjectionLabels(
+        crossLinkSummary,
+        game.factionEthicsRecords
+      )
+    : Object.freeze([] as readonly string[])
+  const accountabilityMatrixProjectionLabels = crossLinkSummary
+    ? formatWelfareDebtAccountabilityMatrixProjectionLabels(
+        crossLinkSummary,
+        game.accountabilityMatrixRecords
+      )
+    : Object.freeze([] as readonly string[])
 
   return Object.freeze({
     id: record.id,
@@ -112,6 +128,8 @@ function toRecordView(
     mitigationPathLabel,
     containmentBenefitScoreLabel: formatUnitScore(projection.containmentBenefitScore),
     crossLinkLabels,
+    factionEthicsProjectionLabels,
+    accountabilityMatrixProjectionLabels,
     validationWarningLabels,
     confidenceLabel: formatConfidence(projection.confidence),
     redacted: projection.redacted,

--- a/src/test/welfareDebtAccountingCrossLinks.test.ts
+++ b/src/test/welfareDebtAccountingCrossLinks.test.ts
@@ -23,7 +23,9 @@ import {
   formatCoerciveProtocolFactionEthicsCrossLinkLabels,
   formatCoerciveProtocolFactionEthicsProjectionLabels,
   formatCoerciveProtocolWelfareDebtCrossLinkLabels,
+  formatWelfareDebtAccountabilityMatrixProjectionLabels,
   formatWelfareDebtAccountingCrossLinkLabels,
+  formatWelfareDebtFactionEthicsProjectionLabels,
   resolveProcedureRefFromWelfareDebtRecordId,
   resolveSubjectRefFromWelfareDebtRecordId,
 } from '../domain/welfareDebtAccountingCrossLinks'
@@ -542,5 +544,47 @@ describe('welfareDebtAccountingCrossLinks ethics/accountability projection label
       [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
       [PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE.id]: PSYCHIATRIC_REVIEW_PANEL_MATRIX_FIXTURE,
     })).toEqual(['Escalation Required', 'Restricted'])
+  })
+})
+
+describe('welfareDebtAccountingCrossLinks welfare-debt projection labels (SPE-1888 slice 12)', () => {
+  it('returns empty projection labels when matrix maps are absent', () => {
+    const summary = composeWelfareDebtAccountingCrossLinksForRecord(COERCIVE_RESTRAINT_LEDGER_FIXTURE)
+
+    expect(summary).not.toBeNull()
+    expect(formatWelfareDebtFactionEthicsProjectionLabels(summary!, undefined)).toEqual([])
+    expect(formatWelfareDebtAccountabilityMatrixProjectionLabels(summary!, undefined)).toEqual([])
+  })
+
+  it('surfaces permissibility verdict labels when faction ethics matrix is hydrated', () => {
+    const summary = composeWelfareDebtAccountingCrossLinksForRecord(COERCIVE_RESTRAINT_LEDGER_FIXTURE, {
+      factionEthicsRecords: {
+        [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+      },
+    })
+
+    expect(summary).not.toBeNull()
+    expect(formatWelfareDebtFactionEthicsProjectionLabels(summary!, {})).toEqual([])
+    expect(
+      formatWelfareDebtFactionEthicsProjectionLabels(summary!, {
+        [ETHICS_REVIEW_BOARD_MATRIX_FIXTURE.id]: ETHICS_REVIEW_BOARD_MATRIX_FIXTURE,
+      })
+    ).toEqual(['Escalation Required'])
+  })
+
+  it('surfaces moral/legal outcome summary labels when accountability matrix is hydrated', () => {
+    const summary = composeWelfareDebtAccountingCrossLinksForRecord(COERCIVE_RESTRAINT_LEDGER_FIXTURE, {
+      accountabilityMatrixRecords: {
+        [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+      },
+    })
+
+    expect(summary).not.toBeNull()
+    expect(formatWelfareDebtAccountabilityMatrixProjectionLabels(summary!, {})).toEqual([])
+    expect(
+      formatWelfareDebtAccountabilityMatrixProjectionLabels(summary!, {
+        [INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE.id]: INDEPENDENT_WELFARE_AUDIT_MATRIX_FIXTURE,
+      })
+    ).toEqual(['Moral Blamed · Legal Deferred · Institutional Blamed · Public Deferred'])
   })
 })


### PR DESCRIPTION
## Summary

- Add matrix-gated permissibility verdict and moral/legal outcome projection labels to `getWelfareDebtAccountingMirrorView` when `factionEthicsLinks` / `accountabilityMatrixLinks` are non-empty
- Reuse slice 17 projection formatters via new `formatWelfareDebtFactionEthicsProjectionLabels` and `formatWelfareDebtAccountabilityMatrixProjectionLabels` helpers
- Display projection labels in the welfare-debt mirror page review column

## Linear

- **Slice:** SPE-1888 slice 12 (child — create/link on merge if not yet filed)
- **Parent:** SPE-1888 (remains Backlog)

## Validation

- `npm run lint`
- `npm run test:run -- src/features/operations/welfareDebtAccountingMirrorView.test.ts src/features/operations/WelfareDebtAccountingMirrorPage.test.tsx src/test/welfareDebtAccountingCrossLinks.test.ts`

## Docs

- `planning/welfare-debt-accounting-registry-slice-12.md`
- `planning/backlog.md` handoff on merge

## Parent status

Parent SPE-1888 remains open — full SPE-1047/1131 scope not satisfied by this mirror-only slice.

Made with [Cursor](https://cursor.com)