### PR TITLE
feat(SPE-31): surface tag-conflict value-stream hub opportunity

### DIFF
--- a/planning/spe-31-frontdesk-tag-conflict-value-stream-opportunity-slice.md
+++ b/planning/spe-31-frontdesk-tag-conflict-value-stream-opportunity-slice.md
@@ -1,0 +1,39 @@
+# SPE-31 — Front Desk town-tag conflict/value-stream opportunity slice
+
+One-page implementation plan. Linear: [SPE-2465](https://linear.app/spectranoir/issue/SPE-2465).
+
+| Field | Value |
+| --- | --- |
+| **Linear** | [SPE-2465](https://linear.app/spectranoir/issue/SPE-2465) — Front Desk town-tag conflict/value-stream lead opportunity card |
+| **Parent** | [SPE-31](https://linear.app/spectranoir/issue/SPE-31) |
+| **Branch** | `spe-31-frontdesk-tag-conflict-value-stream-opportunity-slice` |
+| **Status** | In progress |
+| **Base `main` SHA** | `bac4dfc9` |
+
+## Goal
+
+Surface one deterministic Front Desk opportunity card that highlights a shared-region tag conflict and classifies it into a value-stream lead using existing case tags and existing hub card patterns.
+
+## Scope
+
+| In | Out |
+| --- | --- |
+| Read-only projection from existing `cases`, `regionTag`, and `tags` | New simulation subsystem |
+| Front Desk opportunity card rendering + links to existing routes | Mission triage expansion |
+| Focused Front Desk tests for show/hide behavior | New persistence fields |
+
+## Acceptance
+
+- [ ] Card appears when at least two non-resolved cases share a region tag and carry conflicting tag groups
+- [ ] Card stays hidden when conflict conditions are absent
+- [ ] Card exposes one value-stream lane and links to existing routes
+- [ ] Existing courier/procurement/staffing opportunity cards are unaffected
+- [ ] `npm run test:run -- src/features/operations/FrontDeskPage.test.tsx` passes
+- [ ] `npm run lint` passes
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Multi-card ranking across all region conflicts | SPE-31 follow-up child | Keep slice deterministic and bounded to one opportunity card |
+| Rich town/actor packet ingestion from generation systems | SPE-31 follow-up child | Reuse current case tags first; avoid parallel modeling |

--- a/src/features/operations/FrontDeskPage.test.tsx
+++ b/src/features/operations/FrontDeskPage.test.tsx
@@ -71,6 +71,34 @@ function withLostAgents(game: GameState, count: number): GameState {
   })
 }
 
+function withTagConflictRegionCases(game: GameState): GameState {
+  const normalized = normalizeGameState({ ...game })
+  const caseIds = Object.keys(normalized.cases).slice(0, 2)
+  if (caseIds.length < 2) {
+    throw new Error('Expected at least two cases in starting state for tag conflict fixture.')
+  }
+  const first = caseIds[0]!
+  const second = caseIds[1]!
+  return normalizeGameState({
+    ...normalized,
+    cases: {
+      ...normalized.cases,
+      [first]: {
+        ...normalized.cases[first]!,
+        status: 'open',
+        regionTag: 'district:river-ward',
+        tags: [...new Set([...(normalized.cases[first]!.tags ?? []), 'authority', 'public'])],
+      },
+      [second]: {
+        ...normalized.cases[second]!,
+        status: 'in_progress',
+        regionTag: 'district:river-ward',
+        tags: [...new Set([...(normalized.cases[second]!.tags ?? []), 'criminal', 'smuggling'])],
+      },
+    },
+  })
+}
+
 describe('FrontDeskPage', () => {
   beforeEach(() => {
     useGameStore.persist.clearStorage()
@@ -213,6 +241,27 @@ describe('FrontDeskPage', () => {
 
     await user.click(within(opportunity).getByRole('link', { name: /open teams/i }))
     expect(screen.getByText(/teams home/i)).toBeInTheDocument()
+  })
+
+  it('renders tag-conflict value-stream opportunity when region-tag conflict signals are present', () => {
+    const game = withTagConflictRegionCases(createStartingState())
+    act(() => {
+      useGameStore.setState({ game })
+    })
+    renderFrontDesk()
+
+    const opportunity = screen.getByRole('region', { name: /tag conflict value stream opportunity/i })
+    expect(within(opportunity).getByText(/town-tag conflict lead requires routing/i)).toBeInTheDocument()
+    expect(within(opportunity).getByText(/^value stream:/i)).toBeInTheDocument()
+    expect(within(opportunity).getByRole('link', { name: /open cases/i })).toBeInTheDocument()
+    expect(within(opportunity).getByRole('link', { name: /open report/i })).toBeInTheDocument()
+  })
+
+  it('hides tag-conflict value-stream opportunity when no shared region-tag conflict exists', () => {
+    renderFrontDesk()
+    expect(
+      screen.queryByRole('region', { name: /tag conflict value stream opportunity/i })
+    ).not.toBeInTheDocument()
   })
 
   it('logs the selected front-desk routes once per route signature', async () => {

--- a/src/features/operations/FrontDeskPage.tsx
+++ b/src/features/operations/FrontDeskPage.tsx
@@ -577,6 +577,54 @@ export default function FrontDeskPage() {
             </section>
           ) : null}
 
+          {view.tagConflictValueStreamOpportunity ? (
+            <section className="panel space-y-3" aria-label="Tag conflict value stream opportunity">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <h2 className="text-lg font-semibold">Tag-conflict opportunity</h2>
+                  <p className="text-xs opacity-60">
+                    Region-tag conflict lead derived from active case tags.
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[11px] ${toneChipClass(view.tagConflictValueStreamOpportunity.tone)}`}
+                >
+                  {view.tagConflictValueStreamOpportunity.conflictLabel}
+                </span>
+              </div>
+              <div
+                className={`rounded border px-3 py-3 space-y-2 ${toneSurfaceClass(view.tagConflictValueStreamOpportunity.tone)}`}
+              >
+                <p className="text-sm font-medium">{view.tagConflictValueStreamOpportunity.title}</p>
+                <p className="text-sm opacity-80">{view.tagConflictValueStreamOpportunity.summary}</p>
+                <p className="text-xs uppercase tracking-[0.12em] opacity-70">
+                  Value stream: {view.tagConflictValueStreamOpportunity.valueStreamLabel}
+                </p>
+                {view.tagConflictValueStreamOpportunity.details.length > 0 ? (
+                  <ul className="space-y-1 text-sm opacity-70">
+                    {view.tagConflictValueStreamOpportunity.details.map((detail) => (
+                      <li key={detail}>{detail}</li>
+                    ))}
+                  </ul>
+                ) : null}
+                <div className="flex flex-wrap gap-3 pt-1 text-[11px] uppercase tracking-[0.14em]">
+                  <Link
+                    to={view.tagConflictValueStreamOpportunity.primaryHref}
+                    className="opacity-70 hover:opacity-100"
+                  >
+                    {view.tagConflictValueStreamOpportunity.primaryLinkLabel}
+                  </Link>
+                  <Link
+                    to={view.tagConflictValueStreamOpportunity.secondaryHref}
+                    className="opacity-70 hover:opacity-100"
+                  >
+                    {view.tagConflictValueStreamOpportunity.secondaryLinkLabel}
+                  </Link>
+                </div>
+              </div>
+            </section>
+          ) : null}
+
           <section className="panel space-y-3" aria-label="Active pressures">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="space-y-1">

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -201,6 +201,21 @@ export interface FrontDeskStaffingReadinessOpportunityView {
   secondaryLinkLabel?: string
 }
 
+/** SPE-31: deterministic hub opportunity derived from existing case region tags and value-stream hints. */
+export interface FrontDeskTagConflictValueStreamOpportunityView {
+  id: 'tag-conflict-value-stream'
+  title: string
+  summary: string
+  tone: FrontDeskNoticeTone
+  conflictLabel: string
+  valueStreamLabel: string
+  details: string[]
+  primaryHref: string
+  primaryLinkLabel: string
+  secondaryHref: string
+  secondaryLinkLabel: string
+}
+
 /** SPE-1734: Bounded player-facing readout of the canonical campaign ledger. */
 export interface FrontDeskCampaignRulesSummaryView {
   title: string
@@ -233,6 +248,7 @@ export interface FrontDeskHubView {
   courierCapacityOpportunity: FrontDeskCourierCapacityOpportunityView | null
   procurementPressureOpportunity: FrontDeskProcurementPressureOpportunityView | null
   staffingReadinessOpportunity: FrontDeskStaffingReadinessOpportunityView | null
+  tagConflictValueStreamOpportunity: FrontDeskTagConflictValueStreamOpportunityView | null
   campaignRulesSummary: FrontDeskCampaignRulesSummaryView
 }
 
@@ -1687,6 +1703,83 @@ export function buildStaffingReadinessOpportunityCard(
   }
 }
 
+const TAG_CONFLICT_GROUPS: ReadonlyArray<{
+  id: 'authority' | 'criminal' | 'occult' | 'civilian'
+  label: string
+  tags: readonly string[]
+}> = [
+  { id: 'authority', label: 'Authority', tags: ['authority', 'police', 'government', 'institution'] },
+  { id: 'criminal', label: 'Criminal', tags: ['criminal', 'smuggling', 'gang', 'blackmarket'] },
+  { id: 'occult', label: 'Occult', tags: ['occult', 'cult', 'ritual', 'esoteric'] },
+  { id: 'civilian', label: 'Civilian', tags: ['civilian', 'public', 'community', 'witness'] },
+]
+
+const VALUE_STREAM_GROUPS: ReadonlyArray<{ label: string; tags: readonly string[] }> = [
+  { label: 'Public legitimacy', tags: ['public', 'civilian', 'authority', 'community'] },
+  { label: 'Cover integrity', tags: ['covert', 'cover', 'infiltration', 'smuggling'] },
+  { label: 'Funding', tags: ['funding', 'procurement', 'resource', 'supply'] },
+  { label: 'Evidence quality', tags: ['evidence', 'intel', 'signal', 'verification'] },
+  { label: 'Doctrine risk', tags: ['occult', 'cult', 'ritual', 'classified'] },
+]
+
+function hasAnyTag(haystack: readonly string[], needles: readonly string[]) {
+  return needles.some((needle) => haystack.includes(needle))
+}
+
+export function buildTagConflictValueStreamOpportunityCard(
+  game: GameState
+): FrontDeskTagConflictValueStreamOpportunityView | null {
+  const openCases = Object.values(game.cases).filter((currentCase) => currentCase.status !== 'resolved')
+  const casesByRegion = new Map<string, typeof openCases>()
+  for (const currentCase of openCases) {
+    if (!currentCase.regionTag) continue
+    const existing = casesByRegion.get(currentCase.regionTag) ?? []
+    existing.push(currentCase)
+    casesByRegion.set(currentCase.regionTag, existing)
+  }
+
+  const sortedRegions = [...casesByRegion.entries()].sort((left, right) => left[0].localeCompare(right[0]))
+  for (const [regionTag, regionCases] of sortedRegions) {
+    if (regionCases.length < 2) continue
+
+    const mergedTags = [...new Set(regionCases.flatMap((currentCase) => currentCase.tags))].sort((a, b) =>
+      a.localeCompare(b)
+    )
+    const presentGroups = TAG_CONFLICT_GROUPS.filter((group) => hasAnyTag(mergedTags, group.tags))
+    if (presentGroups.length < 2) continue
+
+    const conflictLabel = `${presentGroups[0]!.label} vs ${presentGroups[1]!.label}`
+    const scoredStreams = VALUE_STREAM_GROUPS.map((stream) => ({
+      label: stream.label,
+      score: stream.tags.filter((tag) => mergedTags.includes(tag)).length,
+    })).sort((left, right) => right.score - left.score || left.label.localeCompare(right.label))
+    const valueStreamLabel = scoredStreams[0]!.score > 0 ? scoredStreams[0]!.label : 'Evidence quality'
+
+    return {
+      id: 'tag-conflict-value-stream',
+      title: 'Town-tag conflict lead requires routing',
+      summary: `${regionTag} carries a deterministic ${conflictLabel.toLowerCase()} tag conflict. Surface it as a ${valueStreamLabel.toLowerCase()} lead before it diffuses into low-signal queue noise.`,
+      tone: presentGroups.length >= 3 ? 'danger' : 'warning',
+      conflictLabel,
+      valueStreamLabel,
+      details: uniqueBounded(
+        [
+          `${pluralize(regionCases.length, 'open case')} share the ${regionTag} region tag.`,
+          `Conflict lane: ${conflictLabel}.`,
+          `Lead value stream: ${valueStreamLabel}.`,
+        ],
+        MAX_PRESSURE_DETAILS
+      ),
+      primaryHref: APP_ROUTES.cases,
+      primaryLinkLabel: 'Open cases',
+      secondaryHref: APP_ROUTES.report,
+      secondaryLinkLabel: 'Open report',
+    }
+  }
+
+  return null
+}
+
 export function getFrontDeskHubView(game: GameState): FrontDeskHubView {
   const shell = buildShellStatusBarView(game)
   const agency = buildAgencySummary(game)
@@ -1745,6 +1838,7 @@ export function getFrontDeskHubView(game: GameState): FrontDeskHubView {
     ),
     procurementPressureOpportunity: buildProcurementPressureOpportunityCard(game),
     staffingReadinessOpportunity: buildStaffingReadinessOpportunityCard(game, operationsReport),
+    tagConflictValueStreamOpportunity: buildTagConflictValueStreamOpportunityCard(game),
     campaignRulesSummary: {
       title: 'Campaign profile & rules ledger',
       headline: rulesSummary.headline,


### PR DESCRIPTION
## Summary
- Add a bounded Front Desk tag-conflict/value-stream opportunity card for SPE-31 by projecting shared-region case tag conflicts from existing case data.
- Reuse existing Front Desk card patterns and routes (read-only presentation only, no new simulation or persistence).
- Add focused Front Desk tests for visible/hidden behavior of the new opportunity card.

## Linear
- Child issue: SPE-2465
- Parent issue: SPE-31

## Validation
- npm run test:run -- src/features/operations/FrontDeskPage.test.tsx
- npm run lint

## Docs
- Added planning/spe-31-frontdesk-tag-conflict-value-stream-opportunity-slice.md