### PR TITLE
feat(SPE-2473): add intake cross-link bundle compose chain

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,7 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** Bundle compose chain integration (SPE-854 follow-up); mission triage full refresh remains **blocked**.
+**Next implementation (unblocked):** [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) intake cross-link bundle compose chain integration (slice 1) on branch `spe-854-intake-cross-link-bundle-compose-slice-1`; mission triage full refresh remains **blocked**.
 
 **Recently shipped:** [SPE-2472](https://linear.app/spectranoir/issue/SPE-2472) intake ↔ unexplained-location cross-link surfacing — triage chip + weekly report notes; mirror SPE-2471; branch `spe-854-intake-unexplained-location-cross-link-surfacing-slice-1` (PR #2863 @ `278ad57c`).
 
@@ -26,9 +26,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Bundle compose chain integration (SPE-854 follow-up) — out of surfacing boundary; see `planning/information-intake-unexplained-location-cross-link-surfacing-slice-1.md` deferred table.
+**Next step:** [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) intake cross-link bundle compose chain integration (slice 1) — compose-only orchestrator boundary documented in `planning/information-intake-cross-link-bundle-compose-slice-1.md`.
 
-**Base `main` SHA:** `278ad57c` — post SPE-2472 unexplained-location surfacing merge (PR #2863).
+**Base `main` SHA:** `3bdff620` — post SPE-2472 unexplained-location surfacing merge (PR #2863) and SPE-31 follow-up sync.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -155,6 +155,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-extranormal-cross-link-surfacing-slice-1.md` | **Shipped** | [SPE-2470](https://linear.app/spectranoir/issue/SPE-2470) — surface SPE-2354 compose in triage/report notes; PR #2859 @ `69b3bd99`. |
 | `information-intake-minor-anomaly-cross-link-surfacing-slice-1.md` | **Shipped** | [SPE-2471](https://linear.app/spectranoir/issue/SPE-2471) — surface SPE-2355 compose in triage/report notes; PR #2861 @ `b2a537d3`. |
 | `information-intake-unexplained-location-cross-link-surfacing-slice-1.md` | **Shipped** | [SPE-2472](https://linear.app/spectranoir/issue/SPE-2472) — surface SPE-2356 compose in triage/report notes; PR #2863 @ `278ad57c`. |
+| `information-intake-cross-link-bundle-compose-slice-1.md` | **In progress** | [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) — deterministic intake cross-link bundle orchestrator over SPE-2354/2355/2356/2358 compose modules. |
 | `investigation-question-case-prep-slice.md`               | **Shipped**    | SPE-626 UI; links forward to concealment prep.                                                                                                      |
 | `mission-triage-covert-prep-slice.md`                     | **Shipped**    | SPE-2255 slice 1.                                                                                                                                   |
 | `mission-triage-deferral-compare-slice.md`                | **Shipped**    | SPE-2256 slice 2.                                                                                                                                   |

--- a/planning/information-intake-cross-link-bundle-compose-slice-1.md
+++ b/planning/information-intake-cross-link-bundle-compose-slice-1.md
@@ -1,0 +1,70 @@
+# SPE-854 — Intake cross-link bundle compose chain integration (slice 1)
+
+One-page implementation plan. Follow-on from shipped cross-link compose slices [SPE-2354](https://linear.app/spectranoir/issue/SPE-2354), [SPE-2355](https://linear.app/spectranoir/issue/SPE-2355), [SPE-2356](https://linear.app/spectranoir/issue/SPE-2356), and [SPE-2358](https://linear.app/spectranoir/issue/SPE-2358), plus surfacing slices [SPE-2406](https://linear.app/spectranoir/issue/SPE-2406), [SPE-2470](https://linear.app/spectranoir/issue/SPE-2470), [SPE-2471](https://linear.app/spectranoir/issue/SPE-2471), and [SPE-2472](https://linear.app/spectranoir/issue/SPE-2472).
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2473 — Intake cross-link bundle compose chain integration (slice 1)](https://linear.app/spectranoir/issue/SPE-2473) |
+| **Parent** | [SPE-854](https://linear.app/spectranoir/issue/SPE-854) — parent remains **Done**; this is a follow-up child |
+| **Branch** | `spe-854-intake-cross-link-bundle-compose-slice-1` |
+| **Status** | **Ready for PR** |
+| **Base `main` SHA** | `3bdff620` |
+
+## Goal
+
+Implement a single deterministic orchestrator that composes all information-intake cross-link summaries across naming-hazard, extranormal, minor-anomaly, and unexplained-location registries from one chain call.
+
+## Prerequisite (on `main` @ `3bdff620`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Intake ↔ naming-hazard compose | `informationIntakeNamingHazardCrossLink.ts` (SPE-2358) |
+| Intake ↔ extranormal compose | `informationIntakeExtranormalCrossLink.ts` (SPE-2354) |
+| Intake ↔ minor-anomaly compose | `informationIntakeMinorAnomalyCrossLink.ts` (SPE-2355) |
+| Intake ↔ unexplained-location compose | `informationIntakeUnexplainedLocationCrossLink.ts` (SPE-2356) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New bundle chain compose module reusing per-registry `composeAll*` helpers | Any per-registry compose logic changes (SPE-2354/SPE-2355/SPE-2356/SPE-2358) |
+| Deterministic grouped ordering across all four registry bundles | Surfacing module changes (SPE-2406/SPE-2470/SPE-2471/SPE-2472) |
+| Bundle-focused unit tests including canal-bridge integration | Persistence changes |
+| Slice doc + backlog handoff update | Mission triage full refresh |
+
+## Bundle compose contract
+
+- **Read-only compose chain** — no persistence writes, no surfacing side effects.
+- **Registry-complete** — include naming-hazard, extranormal, minor-anomaly, unexplained-location groups.
+- **Deterministic ordering** — byte-stable grouped output with each group using existing deterministic `composeAll*` behavior.
+- **Empty maps** — no-op grouped empty arrays without throw.
+- **Topic overlap reuse** — preserve existing topic-key overlap logic via shared per-registry compose modules.
+
+## Acceptance
+
+- [x] One orchestrator call returns all four grouped cross-link summary arrays.
+- [x] Empty-map input returns grouped empty arrays without throw.
+- [x] Canal-bridge fixture integration proves all four cross-link groups in one call.
+- [x] Deterministic repeated calls return byte-identical output.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/informationIntakeCrossLinkBundle.ts` |
+| Tests  | `src/test/informationIntakeCrossLinkBundle.test.ts` |
+| Plan   | `planning/information-intake-cross-link-bundle-compose-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Mission triage full refresh | SPE-16 umbrella | Out of this compose-only boundary |
+
+## See also
+
+- `planning/information-intake-unexplained-location-cross-link-surfacing-slice-1.md`
+- `planning/information-intake-minor-anomaly-cross-link-surfacing-slice-1.md`
+- `planning/information-intake-extranormal-cross-link-surfacing-slice-1.md`
+- `planning/naming-hazard-cross-link-surfacing-slice-1.md`

--- a/src/domain/informationIntakeCrossLinkBundle.ts
+++ b/src/domain/informationIntakeCrossLinkBundle.ts
@@ -1,0 +1,80 @@
+import type { ExtranormalEventRecordsMap } from './extranormalEventRegistry'
+import {
+  composeAllIntakeExtranormalCrossLinks,
+  type IntakeExtranormalCrossLinkSummary,
+} from './informationIntakeExtranormalCrossLink'
+import {
+  composeAllIntakeMinorAnomalyCrossLinks,
+  type IntakeMinorAnomalyCrossLinkSummary,
+} from './informationIntakeMinorAnomalyCrossLink'
+import {
+  composeAllIntakeNamingHazardCrossLinks,
+  type IntakeNamingHazardCrossLinkSummary,
+} from './informationIntakeNamingHazardCrossLink'
+import type { InformationIntakeReportsMap } from './informationIntakeReport'
+import {
+  composeAllIntakeUnexplainedLocationCrossLinks,
+  type IntakeUnexplainedLocationCrossLinkSummary,
+} from './informationIntakeUnexplainedLocationCrossLink'
+import type { MinorAnomalyItemRecordsMap } from './minorAnomalyItemRegistry'
+import type { NamingHazardDescriptorRecordsMap } from './namingHazardDescriptorRegistry'
+import type { UnexplainedLocationRecordsMap } from './unexplainedLocationRegistry'
+
+export interface ComposeInformationIntakeCrossLinkBundleInput {
+  readonly reports?: InformationIntakeReportsMap | null | undefined
+  readonly namingHazardDescriptors?: NamingHazardDescriptorRecordsMap | null | undefined
+  readonly extranormalEvents?: ExtranormalEventRecordsMap | null | undefined
+  readonly minorAnomalyItems?: MinorAnomalyItemRecordsMap | null | undefined
+  readonly unexplainedLocations?: UnexplainedLocationRecordsMap | null | undefined
+}
+
+export interface InformationIntakeCrossLinkBundleSummary {
+  readonly namingHazard: readonly IntakeNamingHazardCrossLinkSummary[]
+  readonly extranormal: readonly IntakeExtranormalCrossLinkSummary[]
+  readonly minorAnomaly: readonly IntakeMinorAnomalyCrossLinkSummary[]
+  readonly unexplainedLocation: readonly IntakeUnexplainedLocationCrossLinkSummary[]
+}
+
+const EMPTY_BUNDLE_SUMMARY: InformationIntakeCrossLinkBundleSummary = Object.freeze({
+  namingHazard: Object.freeze([]),
+  extranormal: Object.freeze([]),
+  minorAnomaly: Object.freeze([]),
+  unexplainedLocation: Object.freeze([]),
+})
+
+/**
+ * SPE-854 follow-up: deterministic bundle compose chain that reuses existing
+ * per-registry composeAll helpers without mutating persisted state.
+ */
+export function composeInformationIntakeCrossLinkBundle(
+  input: ComposeInformationIntakeCrossLinkBundleInput
+): InformationIntakeCrossLinkBundleSummary {
+  const reports = input.reports ?? undefined
+  const namingHazardDescriptors = input.namingHazardDescriptors ?? undefined
+  const extranormalEvents = input.extranormalEvents ?? undefined
+  const minorAnomalyItems = input.minorAnomalyItems ?? undefined
+  const unexplainedLocations = input.unexplainedLocations ?? undefined
+
+  if (
+    Object.keys(reports ?? {}).length === 0 &&
+    Object.keys(namingHazardDescriptors ?? {}).length === 0 &&
+    Object.keys(extranormalEvents ?? {}).length === 0 &&
+    Object.keys(minorAnomalyItems ?? {}).length === 0 &&
+    Object.keys(unexplainedLocations ?? {}).length === 0
+  ) {
+    return EMPTY_BUNDLE_SUMMARY
+  }
+
+  return Object.freeze({
+    namingHazard: Object.freeze(
+      composeAllIntakeNamingHazardCrossLinks(reports, namingHazardDescriptors)
+    ),
+    extranormal: Object.freeze(composeAllIntakeExtranormalCrossLinks(reports, extranormalEvents)),
+    minorAnomaly: Object.freeze(
+      composeAllIntakeMinorAnomalyCrossLinks(reports, minorAnomalyItems)
+    ),
+    unexplainedLocation: Object.freeze(
+      composeAllIntakeUnexplainedLocationCrossLinks(reports, unexplainedLocations)
+    ),
+  })
+}

--- a/src/test/informationIntakeCrossLinkBundle.test.ts
+++ b/src/test/informationIntakeCrossLinkBundle.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import { BRIEF_COVER_UP_EVENT_WITH_CLUSTER } from '../domain/extranormalEventRegistry'
+import { composeInformationIntakeCrossLinkBundle } from '../domain/informationIntakeCrossLinkBundle'
+import {
+  FORMAL_ALERT_PARTIAL_FIXTURE,
+  IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  PUBLIC_RUMOR_CONFLICT_FIXTURE,
+} from '../domain/informationIntakeReport'
+import { CANAL_BRIDGE_MINOR_ITEM_FIXTURE } from '../domain/minorAnomalyItemRegistry'
+import { CANAL_BRIDGE_NAMING_HAZARD_FIXTURE } from '../domain/namingHazardDescriptorRegistry'
+import { CANAL_BRIDGE_LOCATION_FIXTURE } from '../domain/unexplainedLocationRegistry'
+
+const CANAL_BRIDGE_TOPIC = 'topic:canal-bridge-incident'
+
+const CANAL_BRIDGE_REPORTS = {
+  [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE,
+  [PUBLIC_RUMOR_CONFLICT_FIXTURE.id]: PUBLIC_RUMOR_CONFLICT_FIXTURE,
+  [FORMAL_ALERT_PARTIAL_FIXTURE.id]: FORMAL_ALERT_PARTIAL_FIXTURE,
+}
+
+describe('informationIntakeCrossLinkBundle (SPE-2473 slice 1)', () => {
+  it('returns empty grouped links for empty maps without throw', () => {
+    const summary = composeInformationIntakeCrossLinkBundle({
+      reports: undefined,
+      namingHazardDescriptors: undefined,
+      extranormalEvents: undefined,
+      minorAnomalyItems: undefined,
+      unexplainedLocations: undefined,
+    })
+
+    expect(summary.namingHazard).toEqual([])
+    expect(summary.extranormal).toEqual([])
+    expect(summary.minorAnomaly).toEqual([])
+    expect(summary.unexplainedLocation).toEqual([])
+  })
+
+  it('composes all four intake cross-link groups in one canal-bridge chain call', () => {
+    const summary = composeInformationIntakeCrossLinkBundle({
+      reports: CANAL_BRIDGE_REPORTS,
+      namingHazardDescriptors: {
+        [CANAL_BRIDGE_NAMING_HAZARD_FIXTURE.id]: CANAL_BRIDGE_NAMING_HAZARD_FIXTURE,
+      },
+      extranormalEvents: {
+        [BRIEF_COVER_UP_EVENT_WITH_CLUSTER.id]: BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+      },
+      minorAnomalyItems: {
+        [CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]: CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+      },
+      unexplainedLocations: {
+        [CANAL_BRIDGE_LOCATION_FIXTURE.id]: CANAL_BRIDGE_LOCATION_FIXTURE,
+      },
+    })
+
+    expect(summary.namingHazard).toHaveLength(1)
+    expect(summary.extranormal).toHaveLength(1)
+    expect(summary.minorAnomaly).toHaveLength(1)
+    expect(summary.unexplainedLocation).toHaveLength(1)
+
+    expect(summary.namingHazard[0]?.topicRef).toBe(CANAL_BRIDGE_TOPIC)
+    expect(summary.extranormal[0]?.topicRef).toBe(CANAL_BRIDGE_TOPIC)
+    expect(summary.minorAnomaly[0]?.topicRef).toBe(CANAL_BRIDGE_TOPIC)
+    expect(summary.unexplainedLocation[0]?.topicRef).toBe(CANAL_BRIDGE_TOPIC)
+
+    expect(summary.namingHazard[0]?.links).toHaveLength(3)
+    expect(summary.extranormal[0]?.links).toHaveLength(3)
+    expect(summary.minorAnomaly[0]?.links).toHaveLength(3)
+    expect(summary.unexplainedLocation[0]?.links).toHaveLength(3)
+  })
+
+  it('returns byte-stable output on repeated compose calls', () => {
+    const input = {
+      reports: CANAL_BRIDGE_REPORTS,
+      namingHazardDescriptors: {
+        [CANAL_BRIDGE_NAMING_HAZARD_FIXTURE.id]: CANAL_BRIDGE_NAMING_HAZARD_FIXTURE,
+      },
+      extranormalEvents: {
+        [BRIEF_COVER_UP_EVENT_WITH_CLUSTER.id]: BRIEF_COVER_UP_EVENT_WITH_CLUSTER,
+      },
+      minorAnomalyItems: {
+        [CANAL_BRIDGE_MINOR_ITEM_FIXTURE.id]: CANAL_BRIDGE_MINOR_ITEM_FIXTURE,
+      },
+      unexplainedLocations: {
+        [CANAL_BRIDGE_LOCATION_FIXTURE.id]: CANAL_BRIDGE_LOCATION_FIXTURE,
+      },
+    } as const
+
+    const first = composeInformationIntakeCrossLinkBundle(input)
+    const second = composeInformationIntakeCrossLinkBundle(input)
+
+    expect(first).toEqual(second)
+  })
+})


### PR DESCRIPTION
## Summary
- Add composeInformationIntakeCrossLinkBundle as a single deterministic orchestrator over existing intake cross-link compose modules for naming-hazard, extranormal, minor-anomaly, and unexplained-location registries.
- Add focused unit coverage for empty-map no-op, canal-bridge all-registry chain integration, and byte-stable repeated compose output.
- Add slice doc planning/information-intake-cross-link-bundle-compose-slice-1.md and update planning/backlog.md active queue/handoff + slice index row.

## Issue mapping
- Canonical issue: SPE-2473
- Parent issue: SPE-854
- Child issues covered by this branch: SPE-2473 only
- Parent status after this PR: remains Done (follow-up child slice only)

## Validation
- 
pm run test:run -- src/test/informationIntakeCrossLinkBundle.test.ts
- 
pm run lint

## Docs updated
- planning/information-intake-cross-link-bundle-compose-slice-1.md
- planning/backlog.md

Made with [Cursor](https://cursor.com)