### PR TITLE
feat(SPE-2474): contribution intake curation pipeline (slice 1)

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,11 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) intake cross-link bundle compose chain integration (slice 1) on branch `spe-854-intake-cross-link-bundle-compose-slice-1`; mission triage full refresh remains **blocked**.
+**Next implementation (unblocked):** mission triage full refresh remains **blocked**; pick next SPE-75 follow-up child or backlog grooming when unblocked work is identified.
+
+**Recently shipped:** [SPE-2474](https://linear.app/spectranoir/issue/SPE-2474) contribution intake curation pipeline (slice 1) — deterministic submission validation + curation decision envelope (`accepted` / `needs_revision` / `rejected`); branch `spe-75-contribution-intake-curation-pipeline-slice-1` (PR pending).
+
+**Recently shipped:** [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) intake cross-link bundle compose chain integration — deterministic four-registry orchestrator over SPE-2354/2355/2356/2358 compose modules; branch `spe-854-intake-cross-link-bundle-compose-slice-1` (PR #2865 @ `3f92bb49`).
 
 **Recently shipped:** [SPE-2472](https://linear.app/spectranoir/issue/SPE-2472) intake ↔ unexplained-location cross-link surfacing — triage chip + weekly report notes; mirror SPE-2471; branch `spe-854-intake-unexplained-location-cross-link-surfacing-slice-1` (PR #2863 @ `278ad57c`).
 
@@ -26,9 +30,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) intake cross-link bundle compose chain integration (slice 1) — compose-only orchestrator boundary documented in `planning/information-intake-cross-link-bundle-compose-slice-1.md`.
+**Next step:** mission triage full refresh remains **blocked**; SPE-75 follow-up children (release packaging, segmented feedback, playbook variants) remain deferred per `planning/contribution-intake-curation-pipeline-slice-1.md`.
 
-**Base `main` SHA:** `3bdff620` — post SPE-2472 unexplained-location surfacing merge (PR #2863) and SPE-31 follow-up sync.
+**Base `main` SHA:** `3f92bb49` — post SPE-2473 intake cross-link bundle compose merge (PR #2865); SPE-2474 branch targets this base.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -126,6 +130,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 
 | File                                                      | Classification | Notes                                                                                                                                               |
 | --------------------------------------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `contribution-intake-curation-pipeline-slice-1.md`          | **Shipped**    | [SPE-2474](https://linear.app/spectranoir/issue/SPE-2474) — deterministic contribution submission validation + curation decision baseline under SPE-75; PR pending. |
 | `concealment-case-prep-slice.md`                          | **Shipped**    | SPE-70 concealment case prep panel; PR #2326.                                                                                                       |
 | `concealment-case-prep-activation-preview-slice.md`       | **Shipped**    | SPE-70 concealment prep activation preview notes; PR #2821 @ `17db4ab2`.                                                                            |
 | `concealment-front-desk-pending-activation-slice.md`      | **Shipped**    | SPE-70 follow-up — Front Desk pending-activation attention; PR #2822 @ `c09addaf`.                                                                  |
@@ -155,7 +160,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `information-intake-extranormal-cross-link-surfacing-slice-1.md` | **Shipped** | [SPE-2470](https://linear.app/spectranoir/issue/SPE-2470) — surface SPE-2354 compose in triage/report notes; PR #2859 @ `69b3bd99`. |
 | `information-intake-minor-anomaly-cross-link-surfacing-slice-1.md` | **Shipped** | [SPE-2471](https://linear.app/spectranoir/issue/SPE-2471) — surface SPE-2355 compose in triage/report notes; PR #2861 @ `b2a537d3`. |
 | `information-intake-unexplained-location-cross-link-surfacing-slice-1.md` | **Shipped** | [SPE-2472](https://linear.app/spectranoir/issue/SPE-2472) — surface SPE-2356 compose in triage/report notes; PR #2863 @ `278ad57c`. |
-| `information-intake-cross-link-bundle-compose-slice-1.md` | **In progress** | [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) — deterministic intake cross-link bundle orchestrator over SPE-2354/2355/2356/2358 compose modules. |
+| `information-intake-cross-link-bundle-compose-slice-1.md` | **Shipped**    | [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) — deterministic intake cross-link bundle orchestrator; PR #2865 @ `3f92bb49`. |
 | `investigation-question-case-prep-slice.md`               | **Shipped**    | SPE-626 UI; links forward to concealment prep.                                                                                                      |
 | `mission-triage-covert-prep-slice.md`                     | **Shipped**    | SPE-2255 slice 1.                                                                                                                                   |
 | `mission-triage-deferral-compare-slice.md`                | **Shipped**    | SPE-2256 slice 2.                                                                                                                                   |

--- a/planning/contribution-intake-curation-pipeline-slice-1.md
+++ b/planning/contribution-intake-curation-pipeline-slice-1.md
@@ -1,0 +1,71 @@
+# SPE-75 — Contribution intake curation pipeline (slice 1)
+
+One-page implementation plan. Linear: [SPE-2474](https://linear.app/spectranoir/issue/SPE-2474) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). This slice establishes the deterministic submission-to-curation-decision baseline before release packaging, segmented feedback, and playbook variants.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2474 — Contribution intake curation pipeline (slice 1)](https://linear.app/spectranoir/issue/SPE-2474) |
+| **Status** | **Shipped** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent remains open |
+| **Branch** | `spe-75-contribution-intake-curation-pipeline-slice-1` |
+| **Base `main` SHA** | `3f92bb49` |
+
+## Goal
+
+Implement a deterministic contribution-intake curation pipeline that evaluates structured submission payloads, validates schema conformance, and emits bounded curation decisions (`accepted`, `needs_revision`, `rejected`) without persistence writes or publishing side effects.
+
+## Prerequisite (on `main`)
+
+| Existing surface | Anchor |
+| ---------------- | ------ |
+| Pattern intake registry lineage | `src/domain/patternSourceSeriesRegistry.ts` and related SPE-2110 slices |
+| Existing deterministic domain helper style | `src/domain/*` pure compose/project helpers |
+| Existing projection test style | `src/test/*` domain-focused deterministic fixtures |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New pure domain module for submission validation + curation decisioning | External submission platform integration |
+| Deterministic schema validation errors for malformed payloads | Rights/licensing governance automation |
+| Curation decision output envelope (reason codes + notes) | Modular release packaging and compatibility matrix |
+| Targeted unit tests for valid/invalid and deterministic ordering behavior | Segmented tester feedback weighting |
+| Slice doc + backlog handoff update | Disaster playbook wrong-document failure mechanics |
+
+## Curation contract
+
+- **Pure deterministic evaluation** — same payload + policy input yields byte-identical decision output.
+- **Safe-fail validation** — malformed submissions return structured validation errors, never throw during normal evaluation.
+- **Bounded decisions** — only `accepted`, `needs_revision`, `rejected` statuses in this slice.
+- **Reason-coded output** — each non-accept path includes deterministic reason codes for downstream routing.
+- **No side effects** — no persistence changes, no route/UI requirements, no publish actions.
+
+## Acceptance
+
+- [x] Valid canonical submission fixture returns `accepted` with stable normalized metadata.
+- [x] Missing/invalid required fields return `rejected` with deterministic validation reason codes.
+- [x] Borderline fixture returns `needs_revision` with bounded remediation notes.
+- [x] Repeated evaluations are byte-identical for the same input set.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/contributionIntakeCuration.ts` |
+| Tests  | `src/test/contributionIntakeCuration.test.ts` |
+| Plan   | `planning/contribution-intake-curation-pipeline-slice-1.md`, `planning/backlog.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Modular release packaging and compatibility declarations | SPE-75 follow-up child | Requires post-curation artifact pipeline beyond this intake baseline |
+| Segmented/weighted feedback workflow | SPE-75 follow-up child | Needs dedicated scoring/ranking model and policy shape |
+| Playbook variant mismatch deterministic failure | SPE-75 follow-up child | Separate mechanic with its own fixtures and acceptance |
+| Submission governance and rights policy enforcement | SPE-75 follow-up child | Requires policy artifact model not needed for intake baseline |
+
+## See also
+
+- `planning/pattern-source-series-registry-slice-4.md`
+- `planning/backlog.md`

--- a/src/domain/contributionIntakeCuration.ts
+++ b/src/domain/contributionIntakeCuration.ts
@@ -1,0 +1,487 @@
+/**
+ * SPE-2474 slice 1: contribution intake curation pipeline.
+ *
+ * Pure deterministic submission validation and curation decisioning for
+ * contribution/release operations — distinct from in-world information intake
+ * (SPE-854) and pattern-source series registries (SPE-2110).
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type ContributionArtifactKind = 'code' | 'docs' | 'content' | 'mixed'
+
+export const CONTRIBUTION_ARTIFACT_KINDS: readonly ContributionArtifactKind[] = [
+  'code',
+  'docs',
+  'content',
+  'mixed',
+] as const
+
+export type ContributionCurationStatus = 'accepted' | 'needs_revision' | 'rejected'
+
+export const CONTRIBUTION_CURATION_STATUSES: readonly ContributionCurationStatus[] = [
+  'accepted',
+  'needs_revision',
+  'rejected',
+] as const
+
+export type ContributionSubmissionValidationCode =
+  | 'invalid_payload'
+  | 'missing_submission_id'
+  | 'missing_contributor_ref'
+  | 'missing_issue_link'
+  | 'invalid_issue_link'
+  | 'missing_title'
+  | 'missing_scope_statement'
+  | 'scope_statement_too_short'
+  | 'invalid_artifact_kind'
+  | 'missing_test_evidence'
+  | 'invalid_test_evidence_ref'
+
+export type ContributionRemediationCode =
+  | 'summary_too_short'
+  | 'license_declaration_missing'
+  | 'scope_statement_borderline'
+
+export type ContributionCurationReasonCode =
+  | ContributionSubmissionValidationCode
+  | ContributionRemediationCode
+
+// ---------------------------------------------------------------------------
+// Payload, policy, and envelopes
+// ---------------------------------------------------------------------------
+
+export interface ContributionSubmissionPayload {
+  readonly submissionId?: string
+  readonly contributorRef?: string
+  readonly issueLink?: string
+  readonly title?: string
+  readonly scopeStatement?: string
+  readonly artifactKind?: string
+  readonly summary?: string
+  readonly testEvidenceRefs?: readonly string[]
+  readonly licenseDeclaration?: string
+}
+
+export interface ContributionCurationPolicy {
+  readonly minimumScopeLength?: number
+  readonly minimumSummaryLength?: number
+  readonly borderlineScopeLength?: number
+  readonly requireTestEvidenceForCode?: boolean
+  readonly requireLicenseDeclaration?: boolean
+}
+
+export interface ContributionSubmissionValidationIssue {
+  readonly code: ContributionSubmissionValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface ContributionRemediationNote {
+  readonly code: ContributionRemediationCode
+  readonly note: string
+}
+
+export interface ContributionNormalizedMetadata {
+  readonly submissionId: string
+  readonly contributorRef: string
+  readonly issueLink: string
+  readonly title: string
+  readonly artifactKind: ContributionArtifactKind
+  readonly scopeStatement: string
+  readonly summary: string
+  readonly testEvidenceRefs: readonly string[]
+  readonly licenseDeclaration: string
+}
+
+export interface ContributionSubmissionValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly ContributionSubmissionValidationIssue[]
+}
+
+export interface ContributionCurationDecision {
+  readonly status: ContributionCurationStatus
+  readonly validationIssues: readonly ContributionSubmissionValidationIssue[]
+  readonly reasonCodes: readonly ContributionCurationReasonCode[]
+  readonly remediationNotes: readonly ContributionRemediationNote[]
+  readonly normalizedMetadata?: ContributionNormalizedMetadata
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const ARTIFACT_KIND_SET = new Set<string>(CONTRIBUTION_ARTIFACT_KINDS)
+
+const DEFAULT_POLICY: Required<ContributionCurationPolicy> = {
+  minimumScopeLength: 24,
+  minimumSummaryLength: 48,
+  borderlineScopeLength: 40,
+  requireTestEvidenceForCode: true,
+  requireLicenseDeclaration: false,
+}
+
+const ISSUE_LINK_PATTERN =
+  /^(SPE-\d+|https:\/\/linear\.app\/[^\s/]+\/issue\/SPE-\d+[^\s]*|https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/issues\/\d+[^\s]*)$/i
+
+const CODE_ARTIFACT_KINDS = new Set<ContributionArtifactKind>(['code', 'mixed'])
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE: ContributionSubmissionPayload = Object.freeze({
+  submissionId: 'submission:domain-template-canonical',
+  contributorRef: 'contributor:agent-maintainer',
+  issueLink: 'SPE-2474',
+  title: 'Contribution intake curation baseline',
+  scopeStatement:
+    'Add deterministic submission validation and curation decision envelope for SPE-75 intake baseline.',
+  artifactKind: 'code',
+  summary:
+    'Pure domain helper that validates structured contribution payloads and emits accepted, needs_revision, or rejected decisions without persistence side effects.',
+  testEvidenceRefs: Object.freeze(['src/test/contributionIntakeCuration.test.ts']),
+  licenseDeclaration: 'MIT',
+})
+
+export const INVALID_CONTRIBUTION_SUBMISSION_FIXTURE: ContributionSubmissionPayload = Object.freeze({
+  submissionId: '',
+  contributorRef: 'contributor:anonymous',
+  issueLink: 'not-a-valid-link',
+  title: '',
+  scopeStatement: 'too short',
+  artifactKind: 'unknown_kind',
+  testEvidenceRefs: Object.freeze(['']),
+})
+
+export const BORDERLINE_CONTRIBUTION_SUBMISSION_FIXTURE: ContributionSubmissionPayload = Object.freeze({
+  submissionId: 'submission:borderline-scope-only',
+  contributorRef: 'contributor:external-author',
+  issueLink: 'https://linear.app/spectranoir/issue/SPE-75/contribution-intake',
+  title: 'Docs-only clarification packet',
+  scopeStatement: 'Clarify docs-only submission metadata.',
+  artifactKind: 'docs',
+  summary: 'Short summary.',
+})
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isContributionArtifactKind(value: string): value is ContributionArtifactKind {
+  return ARTIFACT_KIND_SET.has(value)
+}
+
+export function isContributionCurationStatus(value: string): value is ContributionCurationStatus {
+  return CONTRIBUTION_CURATION_STATUSES.includes(value as ContributionCurationStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => entry.length > 0)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function resolvePolicy(policy?: ContributionCurationPolicy): Required<ContributionCurationPolicy> {
+  return {
+    minimumScopeLength: policy?.minimumScopeLength ?? DEFAULT_POLICY.minimumScopeLength,
+    minimumSummaryLength: policy?.minimumSummaryLength ?? DEFAULT_POLICY.minimumSummaryLength,
+    borderlineScopeLength: policy?.borderlineScopeLength ?? DEFAULT_POLICY.borderlineScopeLength,
+    requireTestEvidenceForCode:
+      policy?.requireTestEvidenceForCode ?? DEFAULT_POLICY.requireTestEvidenceForCode,
+    requireLicenseDeclaration:
+      policy?.requireLicenseDeclaration ?? DEFAULT_POLICY.requireLicenseDeclaration,
+  }
+}
+
+function sortValidationIssues(
+  issues: ContributionSubmissionValidationIssue[]
+): ContributionSubmissionValidationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortRemediationNotes(notes: ContributionRemediationNote[]): ContributionRemediationNote[] {
+  return [...notes].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.note.localeCompare(right.note)
+  })
+}
+
+function freezeValidationResult(
+  issues: ContributionSubmissionValidationIssue[]
+): ContributionSubmissionValidationResult {
+  const sortedIssues = sortValidationIssues(issues)
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function freezeDecision(decision: ContributionCurationDecision): ContributionCurationDecision {
+  return Object.freeze({
+    status: decision.status,
+    validationIssues: Object.freeze(decision.validationIssues),
+    reasonCodes: Object.freeze([...decision.reasonCodes]),
+    remediationNotes: Object.freeze(decision.remediationNotes),
+    normalizedMetadata: decision.normalizedMetadata
+      ? Object.freeze({
+          ...decision.normalizedMetadata,
+          testEvidenceRefs: Object.freeze([...decision.normalizedMetadata.testEvidenceRefs]),
+        })
+      : undefined,
+  })
+}
+
+function buildNormalizedMetadata(
+  payload: ContributionSubmissionPayload,
+  artifactKind: ContributionArtifactKind
+): ContributionNormalizedMetadata {
+  return Object.freeze({
+    submissionId: normalizeToken(payload.submissionId),
+    contributorRef: normalizeToken(payload.contributorRef),
+    issueLink: normalizeToken(payload.issueLink),
+    title: normalizeToken(payload.title),
+    artifactKind,
+    scopeStatement: normalizeToken(payload.scopeStatement),
+    summary: normalizeToken(payload.summary),
+    testEvidenceRefs: Object.freeze(asStringArray(payload.testEvidenceRefs)),
+    licenseDeclaration: normalizeToken(payload.licenseDeclaration),
+  })
+}
+
+function collectRemediationNotes(
+  payload: ContributionSubmissionPayload,
+  policy: Required<ContributionCurationPolicy>
+): ContributionRemediationNote[] {
+  const notes: ContributionRemediationNote[] = []
+  const scopeStatement = normalizeToken(payload.scopeStatement)
+  const summary = normalizeToken(payload.summary)
+  const licenseDeclaration = normalizeToken(payload.licenseDeclaration)
+
+  if (
+    scopeStatement.length >= policy.minimumScopeLength &&
+    scopeStatement.length < policy.borderlineScopeLength
+  ) {
+    notes.push({
+      code: 'scope_statement_borderline',
+      note: 'Expand the scope statement with acceptance criteria and explicit out-of-scope boundaries.',
+    })
+  }
+
+  if (summary.length > 0 && summary.length < policy.minimumSummaryLength) {
+    notes.push({
+      code: 'summary_too_short',
+      note: 'Provide a fuller summary describing artifact type, validation evidence, and downstream consumers.',
+    })
+  }
+
+  if (policy.requireLicenseDeclaration && licenseDeclaration.length === 0) {
+    notes.push({
+      code: 'license_declaration_missing',
+      note: 'Declare the contribution license or rights assumption before curation can accept the submission.',
+    })
+  }
+
+  return sortRemediationNotes(notes)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateContributionSubmission(
+  payload: ContributionSubmissionPayload,
+  policy?: ContributionCurationPolicy
+): ContributionSubmissionValidationResult {
+  const resolvedPolicy = resolvePolicy(policy)
+
+  if (!payload || typeof payload !== 'object') {
+    return freezeValidationResult([
+      {
+        code: 'invalid_payload',
+        severity: 'error',
+        detail: 'Contribution submission payload must be an object.',
+      },
+    ])
+  }
+
+  const issues: ContributionSubmissionValidationIssue[] = []
+  const submissionId = normalizeToken(payload.submissionId)
+  const contributorRef = normalizeToken(payload.contributorRef)
+  const issueLink = normalizeToken(payload.issueLink)
+  const title = normalizeToken(payload.title)
+  const scopeStatement = normalizeToken(payload.scopeStatement)
+  const artifactKindToken = normalizeToken(payload.artifactKind)
+  const testEvidenceRefs = asStringArray(payload.testEvidenceRefs)
+
+  if (!submissionId) {
+    issues.push({
+      code: 'missing_submission_id',
+      severity: 'error',
+      detail: 'Contribution submission is missing submissionId.',
+    })
+  }
+
+  if (!contributorRef) {
+    issues.push({
+      code: 'missing_contributor_ref',
+      severity: 'error',
+      detail: 'Contribution submission is missing contributorRef.',
+    })
+  }
+
+  if (!issueLink) {
+    issues.push({
+      code: 'missing_issue_link',
+      severity: 'error',
+      detail: 'Contribution submission is missing issueLink.',
+    })
+  } else if (!ISSUE_LINK_PATTERN.test(issueLink)) {
+    issues.push({
+      code: 'invalid_issue_link',
+      severity: 'error',
+      detail: `Contribution submission issueLink "${issueLink}" is not a recognized SPE or tracker URL.`,
+    })
+  }
+
+  if (!title) {
+    issues.push({
+      code: 'missing_title',
+      severity: 'error',
+      detail: 'Contribution submission is missing title.',
+    })
+  }
+
+  if (!scopeStatement) {
+    issues.push({
+      code: 'missing_scope_statement',
+      severity: 'error',
+      detail: 'Contribution submission is missing scopeStatement.',
+    })
+  } else if (scopeStatement.length < resolvedPolicy.minimumScopeLength) {
+    issues.push({
+      code: 'scope_statement_too_short',
+      severity: 'error',
+      detail: `Contribution submission scopeStatement must be at least ${resolvedPolicy.minimumScopeLength} characters.`,
+    })
+  }
+
+  let artifactKind: ContributionArtifactKind | null = null
+  if (!artifactKindToken) {
+    issues.push({
+      code: 'invalid_artifact_kind',
+      severity: 'error',
+      detail: 'Contribution submission is missing artifactKind.',
+    })
+  } else if (!isContributionArtifactKind(artifactKindToken)) {
+    issues.push({
+      code: 'invalid_artifact_kind',
+      severity: 'error',
+      detail: `Contribution submission has invalid artifactKind "${artifactKindToken}".`,
+    })
+  } else {
+    artifactKind = artifactKindToken
+  }
+
+  if (
+    resolvedPolicy.requireTestEvidenceForCode &&
+    artifactKind &&
+    CODE_ARTIFACT_KINDS.has(artifactKind) &&
+    testEvidenceRefs.length === 0
+  ) {
+    issues.push({
+      code: 'missing_test_evidence',
+      severity: 'error',
+      detail: `Contribution submission with artifactKind "${artifactKind}" requires testEvidenceRefs.`,
+    })
+  }
+
+  if (Array.isArray(payload.testEvidenceRefs)) {
+    const hasBlankRef = payload.testEvidenceRefs.some((entry) => normalizeToken(entry).length === 0)
+    if (hasBlankRef) {
+      issues.push({
+        code: 'invalid_test_evidence_ref',
+        severity: 'error',
+        detail: 'Contribution submission testEvidenceRefs must not include blank entries.',
+      })
+    }
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * SPE-75 follow-up baseline: deterministic submission-to-curation decisioning with
+ * safe-fail validation and bounded remediation notes — no persistence or publish side effects.
+ */
+export function evaluateContributionIntakeCuration(
+  payload: ContributionSubmissionPayload,
+  policy?: ContributionCurationPolicy
+): ContributionCurationDecision {
+  const resolvedPolicy = resolvePolicy(policy)
+  const validation = validateContributionSubmission(payload, resolvedPolicy)
+
+  if (!validation.valid) {
+    const reasonCodes = [
+      ...new Set(validation.issues.map((issue) => issue.code)),
+    ].sort((left, right) => left.localeCompare(right))
+
+    return freezeDecision({
+      status: 'rejected',
+      validationIssues: validation.issues,
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const artifactKind = normalizeToken(payload.artifactKind) as ContributionArtifactKind
+  const remediationNotes = sortRemediationNotes(collectRemediationNotes(payload, resolvedPolicy))
+
+  if (remediationNotes.length > 0) {
+    const reasonCodes = remediationNotes
+      .map((note) => note.code)
+      .sort((left, right) => left.localeCompare(right))
+
+    return freezeDecision({
+      status: 'needs_revision',
+      validationIssues: Object.freeze([]),
+      reasonCodes,
+      remediationNotes: Object.freeze(remediationNotes.map((note) => Object.freeze({ ...note }))),
+    })
+  }
+
+  return freezeDecision({
+    status: 'accepted',
+    validationIssues: Object.freeze([]),
+    reasonCodes: Object.freeze([]),
+    remediationNotes: Object.freeze([]),
+    normalizedMetadata: buildNormalizedMetadata(payload, artifactKind),
+  })
+}

--- a/src/test/contributionIntakeCuration.test.ts
+++ b/src/test/contributionIntakeCuration.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BORDERLINE_CONTRIBUTION_SUBMISSION_FIXTURE,
+  CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+  evaluateContributionIntakeCuration,
+  INVALID_CONTRIBUTION_SUBMISSION_FIXTURE,
+  validateContributionSubmission,
+} from '../domain/contributionIntakeCuration'
+
+describe('contributionIntakeCuration (SPE-2474 slice 1)', () => {
+  it('accepts the canonical submission fixture with stable normalized metadata', () => {
+    const decision = evaluateContributionIntakeCuration(CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE)
+
+    expect(decision.status).toBe('accepted')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual([])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.normalizedMetadata).toEqual({
+      submissionId: 'submission:domain-template-canonical',
+      contributorRef: 'contributor:agent-maintainer',
+      issueLink: 'SPE-2474',
+      title: 'Contribution intake curation baseline',
+      artifactKind: 'code',
+      scopeStatement:
+        'Add deterministic submission validation and curation decision envelope for SPE-75 intake baseline.',
+      summary:
+        'Pure domain helper that validates structured contribution payloads and emits accepted, needs_revision, or rejected decisions without persistence side effects.',
+      testEvidenceRefs: ['src/test/contributionIntakeCuration.test.ts'],
+      licenseDeclaration: 'MIT',
+    })
+  })
+
+  it('rejects missing and invalid required fields with deterministic validation reason codes', () => {
+    const decision = evaluateContributionIntakeCuration(INVALID_CONTRIBUTION_SUBMISSION_FIXTURE)
+
+    expect(decision.status).toBe('rejected')
+    expect(decision.normalizedMetadata).toBeUndefined()
+    expect(decision.reasonCodes).toEqual([
+      'invalid_artifact_kind',
+      'invalid_issue_link',
+      'invalid_test_evidence_ref',
+      'missing_submission_id',
+      'missing_title',
+      'scope_statement_too_short',
+    ])
+    expect(decision.validationIssues.map((issue) => issue.code)).toEqual(decision.reasonCodes)
+    expect(decision.remediationNotes).toEqual([])
+  })
+
+  it('returns needs_revision for the borderline fixture with bounded remediation notes', () => {
+    const decision = evaluateContributionIntakeCuration(BORDERLINE_CONTRIBUTION_SUBMISSION_FIXTURE)
+
+    expect(decision.status).toBe('needs_revision')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.normalizedMetadata).toBeUndefined()
+    expect(decision.reasonCodes).toEqual(['scope_statement_borderline', 'summary_too_short'])
+    expect(decision.remediationNotes).toHaveLength(2)
+    expect(decision.remediationNotes[0]?.code).toBe('scope_statement_borderline')
+    expect(decision.remediationNotes[1]?.code).toBe('summary_too_short')
+  })
+
+  it('safe-fails malformed payloads without throw', () => {
+    const validation = validateContributionSubmission(null as unknown as never)
+    const decision = evaluateContributionIntakeCuration(undefined as unknown as never)
+
+    expect(validation.valid).toBe(false)
+    expect(validation.issues[0]?.code).toBe('invalid_payload')
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['invalid_payload'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const payloads = [
+      CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+      INVALID_CONTRIBUTION_SUBMISSION_FIXTURE,
+      BORDERLINE_CONTRIBUTION_SUBMISSION_FIXTURE,
+    ] as const
+
+    for (const payload of payloads) {
+      const first = evaluateContributionIntakeCuration(payload)
+      const second = evaluateContributionIntakeCuration(payload)
+
+      expect(first).toEqual(second)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/domain/contributionIntakeCuration.ts` — pure deterministic submission validation and curation decisioning (`accepted` / `needs_revision` / `rejected`) with reason codes and remediation notes; no persistence or publish side effects.
- Add targeted tests covering canonical accept, invalid reject, borderline needs_revision, safe-fail malformed payloads, and byte-stable repeat evaluation.
- Add slice doc and update `planning/backlog.md` handoff.

## Linear

- **Slice:** [SPE-2474](https://linear.app/spectranoir/issue/SPE-2474) — Contribution intake curation pipeline (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — remains open (intake baseline only; release packaging / feedback / playbook variants deferred)

## Validation

- `npm run test:run -- src/test/contributionIntakeCuration.test.ts`
- `npm run lint`

## Docs updated

- `planning/contribution-intake-curation-pipeline-slice-1.md`
- `planning/backlog.md`

## Parent status

SPE-75 parent remains **open** — this slice ships intake curation baseline only; deferred follow-ups documented in slice doc `## Deferred`.