### PR TITLE
feat(SPE-2475): modular release packaging and compatibility declarations (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -21,6 +21,8 @@ Non-release **correction or clarification packets** (errata, hotfix docs, semver
 
 Releases declare **compatibility surfaces**: engine/runtime versions, save format expectations, schema versions (`SCHEMA_REGISTRY.md`), and breaking-change callouts.
 
+Domain packaging baseline: `src/domain/modularReleasePackaging.ts` (SPE-2475) consumes accepted curation output from `src/domain/contributionIntakeCuration.ts` and emits sorted compatibility declarations plus delivery assumptions — no publish side effects.
+
 ## Artifact-type packaging
 
 Different artifact types (domain templates, UX specs, tuning tables, binaries if any) use **distinct packaging rules** — do not mix incompatible consumers in one bundle without explicit manifests.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,9 +18,9 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** mission triage full refresh remains **blocked**; pick next SPE-75 follow-up child or backlog grooming when unblocked work is identified.
+**Next implementation (unblocked):** [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) modular release packaging and compatibility declarations (slice 1) — `planning/modular-release-packaging-slice-1.md`; branch `spe-75-modular-release-packaging-slice-1`. Mission triage full refresh remains **blocked**.
 
-**Recently shipped:** [SPE-2474](https://linear.app/spectranoir/issue/SPE-2474) contribution intake curation pipeline (slice 1) — deterministic submission validation + curation decision envelope (`accepted` / `needs_revision` / `rejected`); branch `spe-75-contribution-intake-curation-pipeline-slice-1` (PR #2867 @ `895fdc42`).
+**Recently shipped:** [SPE-2474](https://linear.app/spectranoir/issue/SPE-2474) contribution intake curation pipeline (slice 1) — deterministic submission validation + curation decision envelope (`accepted` / `needs_revision` / `rejected`); branch `spe-75-contribution-intake-curation-pipeline-slice-1` (PR #2867 @ `b44a3781`).
 
 **Recently shipped:** [SPE-2473](https://linear.app/spectranoir/issue/SPE-2473) intake cross-link bundle compose chain integration — deterministic four-registry orchestrator over SPE-2354/2355/2356/2358 compose modules; branch `spe-854-intake-cross-link-bundle-compose-slice-1` (PR #2865 @ `3f92bb49`).
 
@@ -30,9 +30,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** mission triage full refresh remains **blocked**; SPE-75 follow-up children (release packaging, segmented feedback, playbook variants) remain deferred per `planning/contribution-intake-curation-pipeline-slice-1.md`.
+**Next step:** [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) modular release packaging (slice 1) — `planning/modular-release-packaging-slice-1.md`; branch `spe-75-modular-release-packaging-slice-1`. Mission triage full refresh remains **blocked**; remaining SPE-75 follow-ups (segmented feedback, playbook variants) deferred per slice doc.
 
-**Base `main` SHA:** `895fdc42` — post SPE-2474 contribution intake curation merge (PR #2867).
+**Base `main` SHA:** `b44a3781` — post SPE-2474 backlog handoff finalize.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 

--- a/planning/modular-release-packaging-slice-1.md
+++ b/planning/modular-release-packaging-slice-1.md
@@ -1,0 +1,74 @@
+# SPE-75 — Modular release packaging and compatibility declarations (slice 1)
+
+One-page implementation plan. Linear: [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Natural continuation after [SPE-2474](https://linear.app/spectranoir/issue/SPE-2474) per `planning/contribution-intake-curation-pipeline-slice-1.md` ## Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2475 — Modular release packaging and compatibility declarations (slice 1)](https://linear.app/spectranoir/issue/SPE-2475) |
+| **Status** | **Shipped** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent remains open for deferred follow-ups |
+| **Branch** | `spe-75-modular-release-packaging-slice-1` |
+| **Base `main` SHA** | `b44a3781` |
+
+## Goal
+
+Implement a pure domain module that consumes accepted contribution-intake curation output plus artifact manifest metadata and emits a bounded release-package envelope (artifact type, compatibility surfaces, delivery assumptions) without publish actions, UI, or persistence writes.
+
+## Prerequisite (on `main`)
+
+| Existing surface | Anchor |
+| ---------------- | ------ |
+| Accepted curation envelope | `src/domain/contributionIntakeCuration.ts` (SPE-2474 / PR #2867) |
+| Registry validation/freeze idioms | `src/domain/patternSourceSeriesRegistry.ts` (SPE-2110) |
+| Projection test style | `src/test/contributionIntakeCuration.test.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New pure domain module for post-curation release packaging | Publish actions or release automation |
+| Accepted-only input gate on curation decision | Segmented/weighted feedback workflow |
+| Compatibility declaration envelope with deterministic ordering | Playbook wrong-document failure mechanics |
+| Artifact-kind branching (code/docs/content/mixed) | Rights governance automation |
+| Targeted unit tests + fixtures | Route/UI/persistence changes |
+
+## Packaging contract
+
+- **Accepted-only gate** — non-accepted curation decisions reject before manifest evaluation.
+- **Pure deterministic evaluation** — same curation decision + manifest yields byte-identical envelope.
+- **Safe-fail validation** — malformed manifests return structured validation errors, never throw during normal evaluation.
+- **Bounded statuses** — only `packaged`, `needs_revision`, `rejected` in this slice.
+- **Sorted compatibility declarations** — surface kind then declaration text, localeCompare.
+- **No side effects** — no persistence changes, no route/UI requirements, no publish actions.
+
+## Acceptance
+
+- [x] Canonical accepted curation + manifest fixture returns `packaged` with stable envelope.
+- [x] Non-accepted curation or missing required compatibility fields return `rejected` with deterministic reason codes.
+- [x] Borderline manifest returns `needs_revision` with bounded remediation notes.
+- [x] Repeated evaluations are byte-identical for the same input set.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/modularReleasePackaging.ts` |
+| Tests  | `src/test/modularReleasePackaging.test.ts` |
+| Plan   | `planning/modular-release-packaging-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Segmented/weighted feedback workflow | SPE-75 follow-up child | Needs dedicated scoring/ranking model and policy shape |
+| Playbook variant mismatch deterministic failure | SPE-75 follow-up child | Separate mechanic with its own fixtures and acceptance |
+| Submission governance and rights policy enforcement | SPE-75 follow-up child | Requires policy artifact model beyond packaging baseline |
+| Publish automation and crediting hooks | SPE-75 follow-up child | Out of slice 1 boundary — packaging envelope only |
+
+## See also
+
+- `planning/contribution-intake-curation-pipeline-slice-1.md`
+- `docs/contribution-and-release-operations.md`
+- `planning/backlog.md`

--- a/src/domain/modularReleasePackaging.ts
+++ b/src/domain/modularReleasePackaging.ts
@@ -1,0 +1,648 @@
+/**
+ * SPE-2475 slice 1: modular release packaging and compatibility declarations.
+ *
+ * Pure deterministic post-curation packaging that consumes accepted
+ * contribution-intake curation output and emits a bounded release-package
+ * envelope — no publish actions, UI, or persistence writes.
+ */
+
+import type {
+  ContributionArtifactKind,
+  ContributionCurationDecision,
+  ContributionNormalizedMetadata,
+} from './contributionIntakeCuration'
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type ReleasePackageStatus = 'packaged' | 'needs_revision' | 'rejected'
+
+export const RELEASE_PACKAGE_STATUSES: readonly ReleasePackageStatus[] = [
+  'packaged',
+  'needs_revision',
+  'rejected',
+] as const
+
+export type ReleaseArtifactType =
+  | 'domain_code_bundle'
+  | 'documentation_bundle'
+  | 'content_accessory'
+  | 'mixed_release_bundle'
+
+export const RELEASE_ARTIFACT_TYPES: readonly ReleaseArtifactType[] = [
+  'domain_code_bundle',
+  'documentation_bundle',
+  'content_accessory',
+  'mixed_release_bundle',
+] as const
+
+export type CompatibilitySurfaceKind =
+  | 'runtime_version'
+  | 'save_format'
+  | 'schema_registry'
+  | 'breaking_change_callout'
+
+export const COMPATIBILITY_SURFACE_KINDS: readonly CompatibilitySurfaceKind[] = [
+  'runtime_version',
+  'save_format',
+  'schema_registry',
+  'breaking_change_callout',
+] as const
+
+export type ReleaseManifestValidationCode =
+  | 'invalid_manifest'
+  | 'curation_not_accepted'
+  | 'missing_normalized_metadata'
+  | 'missing_artifact_paths'
+  | 'missing_runtime_version'
+  | 'missing_schema_registry_version'
+  | 'missing_save_format_version'
+  | 'missing_delivery_channel'
+  | 'missing_consumer_scopes'
+
+export type ReleaseManifestRemediationCode =
+  | 'save_format_version_recommended'
+  | 'delivery_channel_recommended'
+  | 'breaking_change_notes_recommended'
+
+export type ReleasePackageReasonCode =
+  | ReleaseManifestValidationCode
+  | ReleaseManifestRemediationCode
+
+// ---------------------------------------------------------------------------
+// Payload, policy, and envelopes
+// ---------------------------------------------------------------------------
+
+export interface ReleaseArtifactManifest {
+  readonly artifactPaths?: readonly string[]
+  readonly runtimeVersion?: string
+  readonly saveFormatVersion?: string
+  readonly schemaRegistryVersion?: string
+  readonly breakingChangeNotes?: readonly string[]
+  readonly deliveryChannel?: string
+  readonly consumerScopes?: readonly string[]
+}
+
+export interface CompatibilityDeclaration {
+  readonly surface: CompatibilitySurfaceKind
+  readonly declaration: string
+}
+
+export interface ReleaseManifestValidationIssue {
+  readonly code: ReleaseManifestValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface ReleaseManifestRemediationNote {
+  readonly code: ReleaseManifestRemediationCode
+  readonly note: string
+}
+
+export interface ReleasePackageEnvelope {
+  readonly status: ReleasePackageStatus
+  readonly artifactType?: ReleaseArtifactType
+  readonly compatibilityDeclarations: readonly CompatibilityDeclaration[]
+  readonly deliveryAssumptions: readonly string[]
+  readonly validationIssues: readonly ReleaseManifestValidationIssue[]
+  readonly reasonCodes: readonly ReleasePackageReasonCode[]
+  readonly remediationNotes: readonly ReleaseManifestRemediationNote[]
+  readonly sourceMetadata?: ContributionNormalizedMetadata
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const ARTIFACT_TYPE_BY_KIND: Record<ContributionArtifactKind, ReleaseArtifactType> = {
+  code: 'domain_code_bundle',
+  docs: 'documentation_bundle',
+  content: 'content_accessory',
+  mixed: 'mixed_release_bundle',
+}
+
+const COMPATIBILITY_SURFACE_SET = new Set<string>(COMPATIBILITY_SURFACE_KINDS)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE: ReleaseArtifactManifest = Object.freeze({
+  artifactPaths: Object.freeze([
+    'src/domain/modularReleasePackaging.ts',
+    'src/test/modularReleasePackaging.test.ts',
+  ]),
+  runtimeVersion: 'node-22',
+  saveFormatVersion: 'save-v1',
+  schemaRegistryVersion: 'SCHEMA_REGISTRY.md@main',
+  breakingChangeNotes: Object.freeze([
+    'No breaking compatibility surface changes in this baseline release.',
+  ]),
+  deliveryChannel: 'pr-merge',
+  consumerScopes: Object.freeze(['domain-maintainers', 'agent-packaging-pipeline']),
+})
+
+export const INVALID_RELEASE_ARTIFACT_MANIFEST_FIXTURE: ReleaseArtifactManifest = Object.freeze({
+  artifactPaths: Object.freeze([]),
+  runtimeVersion: '',
+  schemaRegistryVersion: '',
+})
+
+export const BORDERLINE_RELEASE_ARTIFACT_MANIFEST_FIXTURE: ReleaseArtifactManifest = Object.freeze({
+  artifactPaths: Object.freeze([
+    'src/domain/modularReleasePackaging.ts',
+    'src/test/modularReleasePackaging.test.ts',
+  ]),
+  runtimeVersion: 'node-22',
+  schemaRegistryVersion: 'SCHEMA_REGISTRY.md@main',
+  deliveryChannel: 'pr-merge',
+})
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isReleasePackageStatus(value: string): value is ReleasePackageStatus {
+  return RELEASE_PACKAGE_STATUSES.includes(value as ReleasePackageStatus)
+}
+
+export function isReleaseArtifactType(value: string): value is ReleaseArtifactType {
+  return RELEASE_ARTIFACT_TYPES.includes(value as ReleaseArtifactType)
+}
+
+export function isCompatibilitySurfaceKind(value: string): value is CompatibilitySurfaceKind {
+  return COMPATIBILITY_SURFACE_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => entry.length > 0)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function sortValidationIssues(
+  issues: ReleaseManifestValidationIssue[]
+): ReleaseManifestValidationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortRemediationNotes(
+  notes: ReleaseManifestRemediationNote[]
+): ReleaseManifestRemediationNote[] {
+  return [...notes].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.note.localeCompare(right.note)
+  })
+}
+
+function sortCompatibilityDeclarations(
+  declarations: CompatibilityDeclaration[]
+): CompatibilityDeclaration[] {
+  return [...declarations].sort((left, right) => {
+    const surfaceOrder = left.surface.localeCompare(right.surface)
+    if (surfaceOrder !== 0) {
+      return surfaceOrder
+    }
+
+    return left.declaration.localeCompare(right.declaration)
+  })
+}
+
+function freezeValidationResult(
+  issues: ReleaseManifestValidationIssue[]
+): { readonly valid: boolean; readonly issues: readonly ReleaseManifestValidationIssue[] } {
+  const sortedIssues = sortValidationIssues(issues)
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function freezeEnvelope(envelope: ReleasePackageEnvelope): ReleasePackageEnvelope {
+  return Object.freeze({
+    status: envelope.status,
+    artifactType: envelope.artifactType,
+    compatibilityDeclarations: Object.freeze(
+      envelope.compatibilityDeclarations.map((declaration) => Object.freeze({ ...declaration }))
+    ),
+    deliveryAssumptions: Object.freeze([...envelope.deliveryAssumptions]),
+    validationIssues: Object.freeze(envelope.validationIssues),
+    reasonCodes: Object.freeze([...envelope.reasonCodes]),
+    remediationNotes: Object.freeze(envelope.remediationNotes),
+    sourceMetadata: envelope.sourceMetadata
+      ? Object.freeze({
+          ...envelope.sourceMetadata,
+          testEvidenceRefs: Object.freeze([...envelope.sourceMetadata.testEvidenceRefs]),
+        })
+      : undefined,
+  })
+}
+
+function resolveArtifactType(artifactKind: ContributionArtifactKind): ReleaseArtifactType {
+  return ARTIFACT_TYPE_BY_KIND[artifactKind]
+}
+
+function buildCompatibilityDeclarations(
+  manifest: ReleaseArtifactManifest
+): CompatibilityDeclaration[] {
+  const declarations: CompatibilityDeclaration[] = []
+  const runtimeVersion = normalizeToken(manifest.runtimeVersion)
+  const saveFormatVersion = normalizeToken(manifest.saveFormatVersion)
+  const schemaRegistryVersion = normalizeToken(manifest.schemaRegistryVersion)
+  const breakingChangeNotes = asStringArray(manifest.breakingChangeNotes)
+
+  if (runtimeVersion) {
+    declarations.push({
+      surface: 'runtime_version',
+      declaration: runtimeVersion,
+    })
+  }
+
+  if (saveFormatVersion) {
+    declarations.push({
+      surface: 'save_format',
+      declaration: saveFormatVersion,
+    })
+  }
+
+  if (schemaRegistryVersion) {
+    declarations.push({
+      surface: 'schema_registry',
+      declaration: schemaRegistryVersion,
+    })
+  }
+
+  for (const note of breakingChangeNotes) {
+    declarations.push({
+      surface: 'breaking_change_callout',
+      declaration: note,
+    })
+  }
+
+  return sortCompatibilityDeclarations(declarations)
+}
+
+function buildDeliveryAssumptions(
+  manifest: ReleaseArtifactManifest,
+  artifactKind: ContributionArtifactKind
+): string[] {
+  const assumptions: string[] = []
+  const deliveryChannel = normalizeToken(manifest.deliveryChannel)
+  const consumerScopes = asStringArray(manifest.consumerScopes)
+  const artifactPaths = asStringArray(manifest.artifactPaths)
+
+  if (deliveryChannel) {
+    assumptions.push(`delivery_channel:${deliveryChannel}`)
+  }
+
+  for (const scope of consumerScopes) {
+    assumptions.push(`consumer_scope:${scope}`)
+  }
+
+  assumptions.push(`artifact_kind:${artifactKind}`)
+
+  if (artifactPaths.length > 0) {
+    assumptions.push(`artifact_path_count:${artifactPaths.length}`)
+  }
+
+  return assumptions.sort((left, right) => left.localeCompare(right))
+}
+
+function collectRequiredManifestIssues(
+  manifest: ReleaseArtifactManifest,
+  artifactKind: ContributionArtifactKind
+): ReleaseManifestValidationIssue[] {
+  const issues: ReleaseManifestValidationIssue[] = []
+  const artifactPaths = asStringArray(manifest.artifactPaths)
+  const runtimeVersion = normalizeToken(manifest.runtimeVersion)
+  const saveFormatVersion = normalizeToken(manifest.saveFormatVersion)
+  const schemaRegistryVersion = normalizeToken(manifest.schemaRegistryVersion)
+  const deliveryChannel = normalizeToken(manifest.deliveryChannel)
+  const consumerScopes = asStringArray(manifest.consumerScopes)
+
+  if (artifactPaths.length === 0) {
+    issues.push({
+      code: 'missing_artifact_paths',
+      severity: 'error',
+      detail: 'Release artifact manifest must declare at least one artifact path.',
+    })
+  }
+
+  switch (artifactKind) {
+    case 'code':
+      if (!runtimeVersion) {
+        issues.push({
+          code: 'missing_runtime_version',
+          severity: 'error',
+          detail: 'Code artifacts require runtimeVersion in the release manifest.',
+        })
+      }
+
+      if (!schemaRegistryVersion) {
+        issues.push({
+          code: 'missing_schema_registry_version',
+          severity: 'error',
+          detail: 'Code artifacts require schemaRegistryVersion in the release manifest.',
+        })
+      }
+      break
+    case 'docs':
+      if (!schemaRegistryVersion) {
+        issues.push({
+          code: 'missing_schema_registry_version',
+          severity: 'error',
+          detail: 'Documentation artifacts require schemaRegistryVersion in the release manifest.',
+        })
+      }
+
+      if (!deliveryChannel) {
+        issues.push({
+          code: 'missing_delivery_channel',
+          severity: 'error',
+          detail: 'Documentation artifacts require deliveryChannel in the release manifest.',
+        })
+      }
+      break
+    case 'content':
+      if (!deliveryChannel) {
+        issues.push({
+          code: 'missing_delivery_channel',
+          severity: 'error',
+          detail: 'Content artifacts require deliveryChannel in the release manifest.',
+        })
+      }
+
+      if (consumerScopes.length === 0) {
+        issues.push({
+          code: 'missing_consumer_scopes',
+          severity: 'error',
+          detail: 'Content artifacts require consumerScopes in the release manifest.',
+        })
+      }
+      break
+    case 'mixed':
+      if (!runtimeVersion) {
+        issues.push({
+          code: 'missing_runtime_version',
+          severity: 'error',
+          detail: 'Mixed artifacts require runtimeVersion in the release manifest.',
+        })
+      }
+
+      if (!saveFormatVersion) {
+        issues.push({
+          code: 'missing_save_format_version',
+          severity: 'error',
+          detail: 'Mixed artifacts require saveFormatVersion in the release manifest.',
+        })
+      }
+
+      if (!schemaRegistryVersion) {
+        issues.push({
+          code: 'missing_schema_registry_version',
+          severity: 'error',
+          detail: 'Mixed artifacts require schemaRegistryVersion in the release manifest.',
+        })
+      }
+
+      if (!deliveryChannel) {
+        issues.push({
+          code: 'missing_delivery_channel',
+          severity: 'error',
+          detail: 'Mixed artifacts require deliveryChannel in the release manifest.',
+        })
+      }
+      break
+    default: {
+      const _exhaustive: never = artifactKind
+      return _exhaustive
+    }
+  }
+
+  return issues
+}
+
+function collectRemediationNotes(
+  manifest: ReleaseArtifactManifest,
+  artifactKind: ContributionArtifactKind
+): ReleaseManifestRemediationNote[] {
+  const notes: ReleaseManifestRemediationNote[] = []
+  const saveFormatVersion = normalizeToken(manifest.saveFormatVersion)
+  const deliveryChannel = normalizeToken(manifest.deliveryChannel)
+  const breakingChangeNotes = asStringArray(manifest.breakingChangeNotes)
+
+  if (artifactKind === 'code' && !saveFormatVersion) {
+    notes.push({
+      code: 'save_format_version_recommended',
+      note: 'Declare saveFormatVersion so downstream consumers can evaluate save compatibility.',
+    })
+  }
+
+  if (artifactKind === 'content' && !deliveryChannel) {
+    notes.push({
+      code: 'delivery_channel_recommended',
+      note: 'Declare deliveryChannel so content accessories route to the correct publish surface.',
+    })
+  }
+
+  if (
+    (artifactKind === 'code' || artifactKind === 'mixed') &&
+    breakingChangeNotes.length === 0
+  ) {
+    notes.push({
+      code: 'breaking_change_notes_recommended',
+      note: 'Add breakingChangeNotes when the release changes compatibility surfaces.',
+    })
+  }
+
+  return sortRemediationNotes(notes)
+}
+
+function validateCurationGate(
+  curationDecision: ContributionCurationDecision
+): ReleaseManifestValidationIssue[] {
+  if (!curationDecision || typeof curationDecision !== 'object') {
+    return [
+      {
+        code: 'invalid_manifest',
+        severity: 'error',
+        detail: 'Release packaging requires a curation decision object.',
+      },
+    ]
+  }
+
+  if (curationDecision.status !== 'accepted') {
+    return [
+      {
+        code: 'curation_not_accepted',
+        severity: 'error',
+        detail: `Release packaging requires accepted curation status; received "${curationDecision.status}".`,
+      },
+    ]
+  }
+
+  if (!curationDecision.normalizedMetadata) {
+    return [
+      {
+        code: 'missing_normalized_metadata',
+        severity: 'error',
+        detail: 'Accepted curation decisions must include normalizedMetadata for packaging.',
+      },
+    ]
+  }
+
+  return []
+}
+
+function validateManifestShape(manifest: unknown): ReleaseManifestValidationIssue[] {
+  if (!manifest || typeof manifest !== 'object') {
+    return [
+      {
+        code: 'invalid_manifest',
+        severity: 'error',
+        detail: 'Release artifact manifest must be an object.',
+      },
+    ]
+  }
+
+  return []
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateReleaseArtifactManifest(
+  curationDecision: ContributionCurationDecision,
+  manifest?: ReleaseArtifactManifest
+): { readonly valid: boolean; readonly issues: readonly ReleaseManifestValidationIssue[] } {
+  const gateIssues = validateCurationGate(curationDecision)
+  if (gateIssues.length > 0) {
+    return freezeValidationResult(gateIssues)
+  }
+
+  const shapeIssues = validateManifestShape(manifest)
+  if (shapeIssues.length > 0) {
+    return freezeValidationResult(shapeIssues)
+  }
+
+  const artifactKind = curationDecision.normalizedMetadata!.artifactKind
+  const manifestIssues = collectRequiredManifestIssues(manifest!, artifactKind)
+
+  return freezeValidationResult(manifestIssues)
+}
+
+/**
+ * SPE-75 follow-up baseline: deterministic post-curation release packaging with
+ * bounded compatibility declarations and delivery assumptions — no publish side effects.
+ */
+export function evaluateModularReleasePackaging(
+  curationDecision: ContributionCurationDecision,
+  manifest?: ReleaseArtifactManifest
+): ReleasePackageEnvelope {
+  const gateIssues = validateCurationGate(curationDecision)
+  if (gateIssues.length > 0) {
+    const reasonCodes = [...new Set(gateIssues.map((issue) => issue.code))].sort((left, right) =>
+      left.localeCompare(right)
+    )
+
+    return freezeEnvelope({
+      status: 'rejected',
+      compatibilityDeclarations: Object.freeze([]),
+      deliveryAssumptions: Object.freeze([]),
+      validationIssues: Object.freeze(gateIssues),
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const shapeIssues = validateManifestShape(manifest)
+  if (shapeIssues.length > 0) {
+    const reasonCodes = [...new Set(shapeIssues.map((issue) => issue.code))].sort((left, right) =>
+      left.localeCompare(right)
+    )
+
+    return freezeEnvelope({
+      status: 'rejected',
+      compatibilityDeclarations: Object.freeze([]),
+      deliveryAssumptions: Object.freeze([]),
+      validationIssues: Object.freeze(shapeIssues),
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const normalizedMetadata = curationDecision.normalizedMetadata!
+  const artifactKind = normalizedMetadata.artifactKind
+  const manifestIssues = collectRequiredManifestIssues(manifest!, artifactKind)
+
+  if (manifestIssues.length > 0) {
+    const reasonCodes = [...new Set(manifestIssues.map((issue) => issue.code))].sort((left, right) =>
+      left.localeCompare(right)
+    )
+
+    return freezeEnvelope({
+      status: 'rejected',
+      compatibilityDeclarations: Object.freeze([]),
+      deliveryAssumptions: Object.freeze([]),
+      validationIssues: Object.freeze(sortValidationIssues(manifestIssues)),
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const remediationNotes = sortRemediationNotes(collectRemediationNotes(manifest!, artifactKind))
+
+  if (remediationNotes.length > 0) {
+    const reasonCodes = remediationNotes
+      .map((note) => note.code)
+      .sort((left, right) => left.localeCompare(right))
+
+    return freezeEnvelope({
+      status: 'needs_revision',
+      artifactType: resolveArtifactType(artifactKind),
+      compatibilityDeclarations: Object.freeze(buildCompatibilityDeclarations(manifest!)),
+      deliveryAssumptions: Object.freeze(buildDeliveryAssumptions(manifest!, artifactKind)),
+      validationIssues: Object.freeze([]),
+      reasonCodes,
+      remediationNotes: Object.freeze(remediationNotes.map((note) => Object.freeze({ ...note }))),
+    })
+  }
+
+  return freezeEnvelope({
+    status: 'packaged',
+    artifactType: resolveArtifactType(artifactKind),
+    compatibilityDeclarations: Object.freeze(buildCompatibilityDeclarations(manifest!)),
+    deliveryAssumptions: Object.freeze(buildDeliveryAssumptions(manifest!, artifactKind)),
+    validationIssues: Object.freeze([]),
+    reasonCodes: Object.freeze([]),
+    remediationNotes: Object.freeze([]),
+    sourceMetadata: normalizedMetadata,
+  })
+}

--- a/src/test/modularReleasePackaging.test.ts
+++ b/src/test/modularReleasePackaging.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BORDERLINE_CONTRIBUTION_SUBMISSION_FIXTURE,
+  CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+  evaluateContributionIntakeCuration,
+  INVALID_CONTRIBUTION_SUBMISSION_FIXTURE,
+} from '../domain/contributionIntakeCuration'
+import {
+  BORDERLINE_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+  INVALID_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  validateReleaseArtifactManifest,
+} from '../domain/modularReleasePackaging'
+
+describe('modularReleasePackaging (SPE-2475 slice 1)', () => {
+  const acceptedCuration = evaluateContributionIntakeCuration(
+    CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE
+  )
+
+  it('packages the canonical accepted curation + manifest fixture with stable envelope', () => {
+    const envelope = evaluateModularReleasePackaging(
+      acceptedCuration,
+      CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+
+    expect(envelope.status).toBe('packaged')
+    expect(envelope.validationIssues).toEqual([])
+    expect(envelope.reasonCodes).toEqual([])
+    expect(envelope.remediationNotes).toEqual([])
+    expect(envelope.artifactType).toBe('domain_code_bundle')
+    expect(envelope.compatibilityDeclarations).toEqual([
+      {
+        surface: 'breaking_change_callout',
+        declaration: 'No breaking compatibility surface changes in this baseline release.',
+      },
+      { surface: 'runtime_version', declaration: 'node-22' },
+      { surface: 'save_format', declaration: 'save-v1' },
+      { surface: 'schema_registry', declaration: 'SCHEMA_REGISTRY.md@main' },
+    ])
+    expect(envelope.deliveryAssumptions).toEqual([
+      'artifact_kind:code',
+      'artifact_path_count:2',
+      'consumer_scope:agent-packaging-pipeline',
+      'consumer_scope:domain-maintainers',
+      'delivery_channel:pr-merge',
+    ])
+    expect(envelope.sourceMetadata?.submissionId).toBe('submission:domain-template-canonical')
+  })
+
+  it('rejects non-accepted curation and missing compatibility fields with deterministic reason codes', () => {
+    const rejectedCuration = evaluateContributionIntakeCuration(
+      INVALID_CONTRIBUTION_SUBMISSION_FIXTURE
+    )
+    const rejectedEnvelope = evaluateModularReleasePackaging(
+      rejectedCuration,
+      CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+
+    expect(rejectedEnvelope.status).toBe('rejected')
+    expect(rejectedEnvelope.artifactType).toBeUndefined()
+    expect(rejectedEnvelope.reasonCodes).toEqual(['curation_not_accepted'])
+    expect(rejectedEnvelope.validationIssues[0]?.code).toBe('curation_not_accepted')
+
+    const missingCompatibilityEnvelope = evaluateModularReleasePackaging(
+      acceptedCuration,
+      INVALID_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+
+    expect(missingCompatibilityEnvelope.status).toBe('rejected')
+    expect(missingCompatibilityEnvelope.reasonCodes).toEqual([
+      'missing_artifact_paths',
+      'missing_runtime_version',
+      'missing_schema_registry_version',
+    ])
+    expect(missingCompatibilityEnvelope.validationIssues.map((issue) => issue.code)).toEqual(
+      missingCompatibilityEnvelope.reasonCodes
+    )
+  })
+
+  it('returns needs_revision for the borderline manifest fixture with bounded remediation notes', () => {
+    const borderlineCuration = evaluateContributionIntakeCuration(
+      BORDERLINE_CONTRIBUTION_SUBMISSION_FIXTURE
+    )
+
+    const envelope = evaluateModularReleasePackaging(
+      acceptedCuration,
+      BORDERLINE_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+
+    expect(envelope.status).toBe('needs_revision')
+    expect(envelope.validationIssues).toEqual([])
+    expect(envelope.artifactType).toBe('domain_code_bundle')
+    expect(envelope.reasonCodes).toEqual([
+      'breaking_change_notes_recommended',
+      'save_format_version_recommended',
+    ])
+    expect(envelope.remediationNotes).toHaveLength(2)
+    expect(envelope.remediationNotes[0]?.code).toBe('breaking_change_notes_recommended')
+    expect(envelope.remediationNotes[1]?.code).toBe('save_format_version_recommended')
+    expect(envelope.compatibilityDeclarations).toEqual([
+      { surface: 'runtime_version', declaration: 'node-22' },
+      { surface: 'schema_registry', declaration: 'SCHEMA_REGISTRY.md@main' },
+    ])
+
+    const notAccepted = evaluateModularReleasePackaging(
+      borderlineCuration,
+      BORDERLINE_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+    expect(notAccepted.status).toBe('rejected')
+    expect(notAccepted.reasonCodes).toEqual(['curation_not_accepted'])
+  })
+
+  it('safe-fails malformed post-curation payloads without throw', () => {
+    const validation = validateReleaseArtifactManifest(null as unknown as never)
+    const envelope = evaluateModularReleasePackaging(undefined as unknown as never)
+
+    expect(validation.valid).toBe(false)
+    expect(validation.issues[0]?.code).toBe('invalid_manifest')
+    expect(envelope.status).toBe('rejected')
+    expect(envelope.reasonCodes).toEqual(['invalid_manifest'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const curationDecisions = [
+      acceptedCuration,
+      evaluateContributionIntakeCuration(INVALID_CONTRIBUTION_SUBMISSION_FIXTURE),
+      acceptedCuration,
+    ] as const
+
+    const manifests = [
+      CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+      INVALID_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+      BORDERLINE_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+    ] as const
+
+    for (let index = 0; index < curationDecisions.length; index += 1) {
+      const curationDecision = curationDecisions[index]!
+      const manifest = manifests[index]!
+      const first = evaluateModularReleasePackaging(curationDecision, manifest)
+      const second = evaluateModularReleasePackaging(curationDecision, manifest)
+
+      expect(first).toEqual(second)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/domain/modularReleasePackaging.ts` — pure post-curation packaging module consuming accepted `ContributionCurationDecision` output plus artifact manifest metadata.
- Emit bounded release-package envelope: artifact type, sorted compatibility declarations, delivery assumptions (`packaged` / `needs_revision` / `rejected`).
- Artifact-kind branching for code, docs, content, and mixed manifests with accepted-only input gate and safe-fail validation.
- Targeted tests in `src/test/modularReleasePackaging.test.ts`; slice doc and backlog handoff.

## Linear

- **Slice:** [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — Modular release packaging and compatibility declarations (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — remains open for deferred follow-ups (segmented feedback, playbook variants, rights governance)

## What shipped

- `evaluateModularReleasePackaging` + `validateReleaseArtifactManifest`
- Canonical, invalid, and borderline manifest fixtures
- Cross-ref in `docs/contribution-and-release-operations.md`

## Validation

- `npm run test:run -- src/test/modularReleasePackaging.test.ts`
- `npm run lint`

## Docs updated

- `planning/modular-release-packaging-slice-1.md`
- `planning/backlog.md`
- `docs/contribution-and-release-operations.md` (packaging contract cross-ref)

## Parent remains open

SPE-75 deferred: segmented/weighted feedback, playbook wrong-document failure, submission governance/rights policy.