### PR TITLE
feat(SPE-2476): segmented/weighted feedback workflow (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -31,6 +31,8 @@ Different artifact types (domain templates, UX specs, tuning tables, binaries if
 
 Separate **bug reports**, **balance discussion**, **security disclosures**, and **RFC-style design feedback** so triage stays deterministic and low-noise.
 
+Domain feedback baseline: `src/domain/segmentedFeedbackWorkflow.ts` (SPE-2476) accepts structured channel payloads and emits weighted ranking decisions with channel-type discrimination and grouping policy — no publish side effects.
+
 ## Submission governance
 
 - **Required metadata** — issue link, scope statement, test evidence for code.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,7 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** mission triage full refresh remains **blocked**; pick next SPE-75 follow-up child (segmented feedback, playbook variants) or backlog grooming when unblocked work is identified.
+**Next implementation (in progress):** [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) segmented/weighted feedback workflow (slice 1) — deterministic channel scoring/ranking; branch `spe-75-segmented-feedback-workflow-slice-1` @ `7d72f39c`.
 
 **Recently shipped:** [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) modular release packaging and compatibility declarations (slice 1) — post-curation release envelope with compatibility surfaces + delivery assumptions; branch `spe-75-modular-release-packaging-slice-1` (PR #2869 @ `d43f07cb`).
 
@@ -30,9 +30,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** mission triage full refresh remains **blocked**; remaining SPE-75 follow-ups (segmented feedback, playbook variants, rights governance) deferred per `planning/modular-release-packaging-slice-1.md`.
+**Next step:** [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) segmented/weighted feedback workflow (slice 1) — `planning/segmented-feedback-workflow-slice-1.md`; branch `spe-75-segmented-feedback-workflow-slice-1`; base `main` @ `7d72f39c`.
 
-**Base `main` SHA:** `d43f07cb` — post SPE-2475 modular release packaging merge (PR #2869).
+**Remaining SPE-75 follow-ups:** playbook variants, rights governance per `planning/segmented-feedback-workflow-slice-1.md` ## Deferred.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -193,6 +193,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `minor-anomaly-item-registry-slice-1.md`                  | **Shipped**    | SPE-2104 / PR #2428; low-priority item intake schema.                                                                                               |
 | `minor-anomaly-item-registry-slice-2.md`                  | **Shipped**    | SPE-2314 / PR #2492; `minorAnomalyItemRecords` GameState persistence.                                                                               |
 | `minor-anomaly-item-registry-slice-3.md`                  | **Shipped**    | SPE-2316 / PR #2496 — weekly disposition/custody advance hook for SPE-2104.                                                                         |
+| `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
+| `segmented-feedback-workflow-slice-1.md`                  | **In Progress** | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; branch `spe-75-segmented-feedback-workflow-slice-1` @ `7d72f39c`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |
 | `self-censoring-information-registry-slice-2.md`          | **Shipped**    | SPE-2318 / PR #2500; `selfCensoringInformationRecords` GameState persistence.                                                                        |
 | `self-censoring-information-registry-slice-3.md`          | **Shipped**    | SPE-2324 / PR #2515; weekly retention-decay expiry + rediscovery due-week advance hook.                                                              |

--- a/planning/segmented-feedback-workflow-slice-1.md
+++ b/planning/segmented-feedback-workflow-slice-1.md
@@ -1,0 +1,73 @@
+# SPE-75 — Segmented/weighted feedback workflow (slice 1)
+
+One-page implementation plan. Linear: [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Natural continuation after [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) per `planning/modular-release-packaging-slice-1.md` ## Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2476 — Segmented/weighted feedback workflow (slice 1)](https://linear.app/spectranoir/issue/SPE-2476) |
+| **Status** | **In Progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent remains open for deferred follow-ups |
+| **Branch** | `spe-75-segmented-feedback-workflow-slice-1` |
+| **Base `main` SHA** | `7d72f39c` |
+
+## Goal
+
+Implement a pure domain module that accepts structured feedback channel payloads and emits bounded scoring/ranking decisions (channel type, weight, grouping policy) without UI, persistence writes, or publish actions.
+
+## Prerequisite (on `main`)
+
+| Existing surface | Anchor |
+| ---------------- | ------ |
+| Decision envelope patterns | `src/domain/contributionIntakeCuration.ts` (SPE-2474) |
+| Freeze/sort idioms | `src/domain/modularReleasePackaging.ts` (SPE-2475) |
+| Projection test style | `src/test/contributionIntakeCuration.test.ts`, `src/test/modularReleasePackaging.test.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New pure domain module for feedback channel scoring/ranking | Publish actions or release automation |
+| Channel-type discrimination (bug/balance/security/RFC) | Curation and packaging pipelines |
+| Weight policy and grouping policy envelope | Playbook wrong-document failure mechanics |
+| Targeted unit tests + fixtures | Route/UI/persistence changes |
+| Slice doc + backlog handoff | Rights governance automation |
+
+## Feedback contract
+
+- **Pure deterministic evaluation** — same batch + policy yields byte-identical ranking decision.
+- **Safe-fail validation** — malformed payloads return structured validation errors, never throw during normal evaluation.
+- **Bounded statuses** — only `ranked`, `needs_revision`, `rejected` in this slice.
+- **Channel weights** — security > bug > balance > RFC by default; partial policies fall back to defaults.
+- **Sorted ranked outputs** — weighted score descending, then feedbackId localeCompare.
+- **No side effects** — no persistence changes, no route/UI requirements, no publish actions.
+
+## Acceptance
+
+- [x] Canonical feedback fixture returns `ranked` with stable ranked entries.
+- [x] Invalid channel/weight returns `rejected` with deterministic reason codes.
+- [x] Borderline confidence returns `needs_revision` with bounded remediation notes.
+- [x] Repeated evaluations are byte-identical for the same input set.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/segmentedFeedbackWorkflow.ts` |
+| Tests  | `src/test/segmentedFeedbackWorkflow.test.ts` |
+| Plan   | `planning/segmented-feedback-workflow-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Playbook variant mismatch deterministic failure | SPE-75 follow-up child | Separate mechanic with its own fixtures and acceptance |
+| Submission governance and rights policy enforcement | SPE-75 follow-up child | Requires policy artifact model beyond feedback baseline |
+| Publish automation and crediting hooks | SPE-75 follow-up child | Out of slice 1 boundary — ranking envelope only |
+
+## See also
+
+- `planning/modular-release-packaging-slice-1.md`
+- `docs/contribution-and-release-operations.md`
+- `planning/backlog.md`

--- a/src/domain/segmentedFeedbackWorkflow.ts
+++ b/src/domain/segmentedFeedbackWorkflow.ts
@@ -1,0 +1,624 @@
+/**
+ * SPE-75 follow-up slice 1: segmented/weighted feedback workflow.
+ *
+ * Pure deterministic feedback channel scoring and ranking that accepts
+ * structured channel payloads and emits bounded ranking decisions —
+ * no UI, persistence writes, or publish actions.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type FeedbackChannelType = 'bug' | 'balance' | 'security' | 'rfc'
+
+export const FEEDBACK_CHANNEL_TYPES: readonly FeedbackChannelType[] = [
+  'bug',
+  'balance',
+  'security',
+  'rfc',
+] as const
+
+export type FeedbackGroupingPolicy = 'by_channel' | 'flat'
+
+export const FEEDBACK_GROUPING_POLICIES: readonly FeedbackGroupingPolicy[] = [
+  'by_channel',
+  'flat',
+] as const
+
+export type FeedbackWorkflowStatus = 'ranked' | 'needs_revision' | 'rejected'
+
+export const FEEDBACK_WORKFLOW_STATUSES: readonly FeedbackWorkflowStatus[] = [
+  'ranked',
+  'needs_revision',
+  'rejected',
+] as const
+
+export type FeedbackValidationCode =
+  | 'invalid_payload'
+  | 'missing_entries'
+  | 'missing_feedback_id'
+  | 'missing_channel_type'
+  | 'invalid_channel_type'
+  | 'missing_summary'
+  | 'summary_too_short'
+  | 'invalid_confidence_score'
+  | 'invalid_channel_weight'
+
+export type FeedbackRemediationCode = 'confidence_borderline' | 'channel_weight_partial'
+
+export type FeedbackReasonCode = FeedbackValidationCode | FeedbackRemediationCode
+
+// ---------------------------------------------------------------------------
+// Payload, policy, and envelopes
+// ---------------------------------------------------------------------------
+
+export interface FeedbackChannelPayload {
+  readonly feedbackId?: string
+  readonly channelType?: string
+  readonly reporterRef?: string
+  readonly summary?: string
+  readonly confidenceScore?: number
+  readonly relatedSubsystemRef?: string
+}
+
+export interface FeedbackChannelBatch {
+  readonly entries?: readonly FeedbackChannelPayload[]
+}
+
+export interface FeedbackChannelWeights {
+  readonly bug?: number
+  readonly balance?: number
+  readonly security?: number
+  readonly rfc?: number
+}
+
+export interface FeedbackWeightPolicy {
+  readonly channelWeights?: FeedbackChannelWeights
+  readonly minimumConfidence?: number
+  readonly borderlineConfidence?: number
+  readonly minimumSummaryLength?: number
+  readonly groupingPolicy?: FeedbackGroupingPolicy
+}
+
+export interface FeedbackValidationIssue {
+  readonly code: FeedbackValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface FeedbackRemediationNote {
+  readonly code: FeedbackRemediationCode
+  readonly note: string
+}
+
+export interface FeedbackRankingEntry {
+  readonly feedbackId: string
+  readonly channelType: FeedbackChannelType
+  readonly channelWeight: number
+  readonly confidenceScore: number
+  readonly weightedScore: number
+  readonly groupKey: string
+  readonly rank: number
+  readonly summary: string
+  readonly reporterRef: string
+  readonly relatedSubsystemRef: string
+}
+
+export interface FeedbackRankingDecision {
+  readonly status: FeedbackWorkflowStatus
+  readonly groupingPolicy: FeedbackGroupingPolicy
+  readonly rankedEntries: readonly FeedbackRankingEntry[]
+  readonly validationIssues: readonly FeedbackValidationIssue[]
+  readonly reasonCodes: readonly FeedbackReasonCode[]
+  readonly remediationNotes: readonly FeedbackRemediationNote[]
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const CHANNEL_TYPE_SET = new Set<string>(FEEDBACK_CHANNEL_TYPES)
+
+const DEFAULT_CHANNEL_WEIGHTS: Record<FeedbackChannelType, number> = {
+  security: 1,
+  bug: 0.8,
+  balance: 0.5,
+  rfc: 0.4,
+}
+
+const DEFAULT_POLICY: Required<
+  Omit<FeedbackWeightPolicy, 'channelWeights'> & { channelWeights: FeedbackChannelWeights }
+> = {
+  channelWeights: Object.freeze({ ...DEFAULT_CHANNEL_WEIGHTS }),
+  minimumConfidence: 0.4,
+  borderlineConfidence: 0.55,
+  minimumSummaryLength: 16,
+  groupingPolicy: 'by_channel',
+}
+
+const WEIGHT_PRECISION = 4
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_FEEDBACK_CHANNEL_BATCH_FIXTURE: FeedbackChannelBatch = Object.freeze({
+  entries: Object.freeze([
+    Object.freeze({
+      feedbackId: 'feedback:security-disclosure-canonical',
+      channelType: 'security',
+      reporterRef: 'tester:security-auditor',
+      summary:
+        'Deterministic privilege-escalation path in intake validation when malformed payloads bypass channel checks.',
+      confidenceScore: 0.92,
+      relatedSubsystemRef: 'subsystem:contribution-intake',
+    }),
+    Object.freeze({
+      feedbackId: 'feedback:bug-repro-canonical',
+      channelType: 'bug',
+      reporterRef: 'tester:qa-maintainer',
+      summary:
+        'Release packaging rejects valid manifests when saveFormatVersion is omitted on docs-only artifacts.',
+      confidenceScore: 0.78,
+      relatedSubsystemRef: 'subsystem:release-packaging',
+    }),
+    Object.freeze({
+      feedbackId: 'feedback:rfc-design-canonical',
+      channelType: 'rfc',
+      reporterRef: 'tester:design-contributor',
+      summary:
+        'Proposal to segment weighted feedback channels before roadmap prioritization consumes tester input.',
+      confidenceScore: 0.65,
+      relatedSubsystemRef: 'subsystem:roadmap-input',
+    }),
+  ]),
+})
+
+export const INVALID_FEEDBACK_CHANNEL_BATCH_FIXTURE: FeedbackChannelBatch = Object.freeze({
+  entries: Object.freeze([
+    Object.freeze({
+      feedbackId: '',
+      channelType: 'unknown_channel',
+      reporterRef: 'tester:anonymous',
+      summary: 'too short',
+      confidenceScore: 1.5,
+    }),
+    Object.freeze({
+      feedbackId: 'feedback:missing-channel',
+      channelType: '',
+      reporterRef: 'tester:anonymous',
+      summary: 'Missing channel type should fail validation deterministically.',
+      confidenceScore: 0.7,
+    }),
+  ]),
+})
+
+export const BORDERLINE_FEEDBACK_CHANNEL_BATCH_FIXTURE: FeedbackChannelBatch = Object.freeze({
+  entries: Object.freeze([
+    Object.freeze({
+      feedbackId: 'feedback:borderline-confidence',
+      channelType: 'balance',
+      reporterRef: 'tester:balance-cohort',
+      summary:
+        'Encounter pacing feels uneven in week-three infiltration templates but evidence is anecdotal.',
+      confidenceScore: 0.48,
+      relatedSubsystemRef: 'subsystem:encounter-pacing',
+    }),
+  ]),
+})
+
+export const INVALID_FEEDBACK_WEIGHT_POLICY_FIXTURE: FeedbackWeightPolicy = Object.freeze({
+  channelWeights: Object.freeze({
+    bug: -0.2,
+    security: 1.5,
+  }),
+})
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isFeedbackChannelType(value: string): value is FeedbackChannelType {
+  return CHANNEL_TYPE_SET.has(value)
+}
+
+export function isFeedbackGroupingPolicy(value: string): value is FeedbackGroupingPolicy {
+  return FEEDBACK_GROUPING_POLICIES.includes(value as FeedbackGroupingPolicy)
+}
+
+export function isFeedbackWorkflowStatus(value: string): value is FeedbackWorkflowStatus {
+  return FEEDBACK_WORKFLOW_STATUSES.includes(value as FeedbackWorkflowStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function roundWeight(value: number): number {
+  const factor = 10 ** WEIGHT_PRECISION
+  return Math.round(value * factor) / factor
+}
+
+function resolvePolicy(policy?: FeedbackWeightPolicy): Required<
+  Omit<FeedbackWeightPolicy, 'channelWeights'> & { channelWeights: Record<FeedbackChannelType, number> }
+> {
+  const customWeights = policy?.channelWeights ?? {}
+
+  return {
+    channelWeights: {
+      bug: customWeights.bug ?? DEFAULT_CHANNEL_WEIGHTS.bug,
+      balance: customWeights.balance ?? DEFAULT_CHANNEL_WEIGHTS.balance,
+      security: customWeights.security ?? DEFAULT_CHANNEL_WEIGHTS.security,
+      rfc: customWeights.rfc ?? DEFAULT_CHANNEL_WEIGHTS.rfc,
+    },
+    minimumConfidence: policy?.minimumConfidence ?? DEFAULT_POLICY.minimumConfidence,
+    borderlineConfidence: policy?.borderlineConfidence ?? DEFAULT_POLICY.borderlineConfidence,
+    minimumSummaryLength: policy?.minimumSummaryLength ?? DEFAULT_POLICY.minimumSummaryLength,
+    groupingPolicy: policy?.groupingPolicy ?? DEFAULT_POLICY.groupingPolicy,
+  }
+}
+
+function sortValidationIssues(issues: FeedbackValidationIssue[]): FeedbackValidationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortRemediationNotes(notes: FeedbackRemediationNote[]): FeedbackRemediationNote[] {
+  return [...notes].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.note.localeCompare(right.note)
+  })
+}
+
+function sortRankedEntries(entries: FeedbackRankingEntry[]): FeedbackRankingEntry[] {
+  return [...entries].sort((left, right) => {
+    const scoreOrder = right.weightedScore - left.weightedScore
+    if (scoreOrder !== 0) {
+      return scoreOrder
+    }
+
+    return left.feedbackId.localeCompare(right.feedbackId)
+  })
+}
+
+function freezeValidationResult(
+  issues: FeedbackValidationIssue[]
+): { readonly valid: boolean; readonly issues: readonly FeedbackValidationIssue[] } {
+  const sortedIssues = sortValidationIssues(issues)
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function freezeDecision(decision: FeedbackRankingDecision): FeedbackRankingDecision {
+  return Object.freeze({
+    status: decision.status,
+    groupingPolicy: decision.groupingPolicy,
+    rankedEntries: Object.freeze(
+      decision.rankedEntries.map((entry) => Object.freeze({ ...entry }))
+    ),
+    validationIssues: Object.freeze(decision.validationIssues),
+    reasonCodes: Object.freeze([...decision.reasonCodes]),
+    remediationNotes: Object.freeze(decision.remediationNotes),
+  })
+}
+
+function resolveGroupKey(
+  channelType: FeedbackChannelType,
+  groupingPolicy: FeedbackGroupingPolicy
+): string {
+  switch (groupingPolicy) {
+    case 'by_channel':
+      return `channel:${channelType}`
+    case 'flat':
+      return 'group:all'
+    default: {
+      const _exhaustive: never = groupingPolicy
+      return _exhaustive
+    }
+  }
+}
+
+function computeWeightedScore(channelWeight: number, confidenceScore: number): number {
+  return roundWeight(channelWeight * confidenceScore)
+}
+
+function validateChannelWeights(
+  policy: Required<
+    Omit<FeedbackWeightPolicy, 'channelWeights'> & { channelWeights: Record<FeedbackChannelType, number> }
+  >
+): FeedbackValidationIssue[] {
+  const issues: FeedbackValidationIssue[] = []
+
+  for (const channelType of FEEDBACK_CHANNEL_TYPES) {
+    const weight = policy.channelWeights[channelType]
+    if (weight < 0 || weight > 1) {
+      issues.push({
+        code: 'invalid_channel_weight',
+        severity: 'error',
+        detail: `Feedback channel weight for "${channelType}" must be between 0 and 1; received ${weight}.`,
+      })
+    }
+  }
+
+  return issues
+}
+
+function collectEntryValidationIssues(
+  entry: FeedbackChannelPayload,
+  index: number,
+  policy: Required<
+    Omit<FeedbackWeightPolicy, 'channelWeights'> & { channelWeights: Record<FeedbackChannelType, number> }
+  >
+): FeedbackValidationIssue[] {
+  const issues: FeedbackValidationIssue[] = []
+  const feedbackId = normalizeToken(entry.feedbackId)
+  const channelTypeToken = normalizeToken(entry.channelType)
+  const summary = normalizeToken(entry.summary)
+  const confidenceScore = entry.confidenceScore
+  const entryLabel = feedbackId || `entries[${index}]`
+
+  if (!feedbackId) {
+    issues.push({
+      code: 'missing_feedback_id',
+      severity: 'error',
+      detail: `Feedback entry ${entryLabel} is missing feedbackId.`,
+    })
+  }
+
+  if (!channelTypeToken) {
+    issues.push({
+      code: 'missing_channel_type',
+      severity: 'error',
+      detail: `Feedback entry ${entryLabel} is missing channelType.`,
+    })
+  } else if (!isFeedbackChannelType(channelTypeToken)) {
+    issues.push({
+      code: 'invalid_channel_type',
+      severity: 'error',
+      detail: `Feedback entry ${entryLabel} has invalid channelType "${channelTypeToken}".`,
+    })
+  }
+
+  if (!summary) {
+    issues.push({
+      code: 'missing_summary',
+      severity: 'error',
+      detail: `Feedback entry ${entryLabel} is missing summary.`,
+    })
+  } else if (summary.length < policy.minimumSummaryLength) {
+    issues.push({
+      code: 'summary_too_short',
+      severity: 'error',
+      detail: `Feedback entry ${entryLabel} summary must be at least ${policy.minimumSummaryLength} characters.`,
+    })
+  }
+
+  if (typeof confidenceScore !== 'number' || Number.isNaN(confidenceScore)) {
+    issues.push({
+      code: 'invalid_confidence_score',
+      severity: 'error',
+      detail: `Feedback entry ${entryLabel} requires a numeric confidenceScore.`,
+    })
+  } else if (confidenceScore < 0 || confidenceScore > 1) {
+    issues.push({
+      code: 'invalid_confidence_score',
+      severity: 'error',
+      detail: `Feedback entry ${entryLabel} confidenceScore must be between 0 and 1.`,
+    })
+  }
+
+  return issues
+}
+
+function collectRemediationNotes(
+  entries: readonly FeedbackChannelPayload[],
+  policy: Required<
+    Omit<FeedbackWeightPolicy, 'channelWeights'> & { channelWeights: Record<FeedbackChannelType, number> }
+  >,
+  customWeightPolicy?: FeedbackWeightPolicy
+): FeedbackRemediationNote[] {
+  const notes: FeedbackRemediationNote[] = []
+
+  for (const entry of entries) {
+    const confidenceScore = entry.confidenceScore
+    const feedbackId = normalizeToken(entry.feedbackId)
+
+    if (
+      typeof confidenceScore === 'number' &&
+      !Number.isNaN(confidenceScore) &&
+      confidenceScore >= policy.minimumConfidence &&
+      confidenceScore < policy.borderlineConfidence
+    ) {
+      notes.push({
+        code: 'confidence_borderline',
+        note: `Feedback entry "${feedbackId}" confidence ${confidenceScore} is borderline; gather reproduction evidence before roadmap prioritization.`,
+      })
+    }
+  }
+
+  if (customWeightPolicy?.channelWeights) {
+    const providedChannels = Object.keys(customWeightPolicy.channelWeights).filter(
+      (key) => customWeightPolicy.channelWeights![key as keyof FeedbackChannelWeights] !== undefined
+    )
+    if (providedChannels.length > 0 && providedChannels.length < FEEDBACK_CHANNEL_TYPES.length) {
+      notes.push({
+        code: 'channel_weight_partial',
+        note: 'Channel weight policy specifies only a subset of channel types; unspecified channels use default weights.',
+      })
+    }
+  }
+
+  return sortRemediationNotes(notes)
+}
+
+function buildRankingEntries(
+  entries: readonly FeedbackChannelPayload[],
+  policy: Required<
+    Omit<FeedbackWeightPolicy, 'channelWeights'> & { channelWeights: Record<FeedbackChannelType, number> }
+  >
+): FeedbackRankingEntry[] {
+  const rankingEntries: FeedbackRankingEntry[] = []
+
+  for (const entry of entries) {
+    const feedbackId = normalizeToken(entry.feedbackId)
+    const channelType = normalizeToken(entry.channelType) as FeedbackChannelType
+    const summary = normalizeToken(entry.summary)
+    const reporterRef = normalizeToken(entry.reporterRef)
+    const relatedSubsystemRef = normalizeToken(entry.relatedSubsystemRef)
+    const confidenceScore = roundWeight(entry.confidenceScore!)
+    const channelWeight = roundWeight(policy.channelWeights[channelType])
+    const weightedScore = computeWeightedScore(channelWeight, confidenceScore)
+
+    rankingEntries.push(
+      Object.freeze({
+        feedbackId,
+        channelType,
+        channelWeight,
+        confidenceScore,
+        weightedScore,
+        groupKey: resolveGroupKey(channelType, policy.groupingPolicy),
+        rank: 0,
+        summary,
+        reporterRef,
+        relatedSubsystemRef,
+      })
+    )
+  }
+
+  const sorted = sortRankedEntries(rankingEntries)
+
+  return sorted.map((entry, index) =>
+    Object.freeze({
+      ...entry,
+      rank: index + 1,
+    })
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateFeedbackChannelBatch(
+  batch?: FeedbackChannelBatch,
+  policy?: FeedbackWeightPolicy
+): { readonly valid: boolean; readonly issues: readonly FeedbackValidationIssue[] } {
+  const resolvedPolicy = resolvePolicy(policy)
+
+  if (!batch || typeof batch !== 'object') {
+    return freezeValidationResult([
+      {
+        code: 'invalid_payload',
+        severity: 'error',
+        detail: 'Feedback channel batch must be an object.',
+      },
+    ])
+  }
+
+  const weightIssues = validateChannelWeights(resolvedPolicy)
+  if (weightIssues.length > 0) {
+    return freezeValidationResult(weightIssues)
+  }
+
+  const entries = batch.entries
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return freezeValidationResult([
+      {
+        code: 'missing_entries',
+        severity: 'error',
+        detail: 'Feedback channel batch must include at least one entry.',
+      },
+    ])
+  }
+
+  const issues: FeedbackValidationIssue[] = []
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index]
+    if (!entry || typeof entry !== 'object') {
+      issues.push({
+        code: 'invalid_payload',
+        severity: 'error',
+        detail: `Feedback entry entries[${index}] must be an object.`,
+      })
+      continue
+    }
+
+    issues.push(...collectEntryValidationIssues(entry, index, resolvedPolicy))
+  }
+
+  return freezeValidationResult(issues)
+}
+
+/**
+ * SPE-75 follow-up baseline: deterministic segmented feedback scoring and ranking
+ * with channel weights and grouping policy — no persistence or publish side effects.
+ */
+export function evaluateSegmentedFeedbackWorkflow(
+  batch?: FeedbackChannelBatch,
+  policy?: FeedbackWeightPolicy
+): FeedbackRankingDecision {
+  const resolvedPolicy = resolvePolicy(policy)
+  const validation = validateFeedbackChannelBatch(batch, policy)
+
+  if (!validation.valid) {
+    const reasonCodes = [...new Set(validation.issues.map((issue) => issue.code))].sort((left, right) =>
+      left.localeCompare(right)
+    )
+
+    return freezeDecision({
+      status: 'rejected',
+      groupingPolicy: resolvedPolicy.groupingPolicy,
+      rankedEntries: Object.freeze([]),
+      validationIssues: validation.issues,
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const entries = batch!.entries!
+  const remediationNotes = sortRemediationNotes(
+    collectRemediationNotes(entries, resolvedPolicy, policy)
+  )
+
+  if (remediationNotes.length > 0) {
+    const reasonCodes = remediationNotes
+      .map((note) => note.code)
+      .sort((left, right) => left.localeCompare(right))
+
+    return freezeDecision({
+      status: 'needs_revision',
+      groupingPolicy: resolvedPolicy.groupingPolicy,
+      rankedEntries: Object.freeze(buildRankingEntries(entries, resolvedPolicy)),
+      validationIssues: Object.freeze([]),
+      reasonCodes,
+      remediationNotes: Object.freeze(remediationNotes.map((note) => Object.freeze({ ...note }))),
+    })
+  }
+
+  return freezeDecision({
+    status: 'ranked',
+    groupingPolicy: resolvedPolicy.groupingPolicy,
+    rankedEntries: Object.freeze(buildRankingEntries(entries, resolvedPolicy)),
+    validationIssues: Object.freeze([]),
+    reasonCodes: Object.freeze([]),
+    remediationNotes: Object.freeze([]),
+  })
+}

--- a/src/test/segmentedFeedbackWorkflow.test.ts
+++ b/src/test/segmentedFeedbackWorkflow.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BORDERLINE_FEEDBACK_CHANNEL_BATCH_FIXTURE,
+  CANONICAL_FEEDBACK_CHANNEL_BATCH_FIXTURE,
+  evaluateSegmentedFeedbackWorkflow,
+  INVALID_FEEDBACK_CHANNEL_BATCH_FIXTURE,
+  INVALID_FEEDBACK_WEIGHT_POLICY_FIXTURE,
+  validateFeedbackChannelBatch,
+} from '../domain/segmentedFeedbackWorkflow'
+
+describe('segmentedFeedbackWorkflow (SPE-2476 slice 1)', () => {
+  it('ranks the canonical feedback batch fixture with stable channel weights and ordering', () => {
+    const decision = evaluateSegmentedFeedbackWorkflow(CANONICAL_FEEDBACK_CHANNEL_BATCH_FIXTURE)
+
+    expect(decision.status).toBe('ranked')
+    expect(decision.groupingPolicy).toBe('by_channel')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual([])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.rankedEntries).toHaveLength(3)
+    expect(decision.rankedEntries[0]).toEqual({
+      feedbackId: 'feedback:security-disclosure-canonical',
+      channelType: 'security',
+      channelWeight: 1,
+      confidenceScore: 0.92,
+      weightedScore: 0.92,
+      groupKey: 'channel:security',
+      rank: 1,
+      summary:
+        'Deterministic privilege-escalation path in intake validation when malformed payloads bypass channel checks.',
+      reporterRef: 'tester:security-auditor',
+      relatedSubsystemRef: 'subsystem:contribution-intake',
+    })
+    expect(decision.rankedEntries[1]?.feedbackId).toBe('feedback:bug-repro-canonical')
+    expect(decision.rankedEntries[1]?.weightedScore).toBe(0.624)
+    expect(decision.rankedEntries[2]?.feedbackId).toBe('feedback:rfc-design-canonical')
+    expect(decision.rankedEntries[2]?.weightedScore).toBe(0.26)
+  })
+
+  it('rejects invalid channel types and channel weights with deterministic reason codes', () => {
+    const invalidChannelDecision = evaluateSegmentedFeedbackWorkflow(
+      INVALID_FEEDBACK_CHANNEL_BATCH_FIXTURE
+    )
+
+    expect(invalidChannelDecision.status).toBe('rejected')
+    expect(invalidChannelDecision.rankedEntries).toEqual([])
+    expect(invalidChannelDecision.reasonCodes).toEqual([
+      'invalid_channel_type',
+      'invalid_confidence_score',
+      'missing_channel_type',
+      'missing_feedback_id',
+      'summary_too_short',
+    ])
+    expect(invalidChannelDecision.validationIssues.map((issue) => issue.code)).toEqual(
+      invalidChannelDecision.reasonCodes
+    )
+
+    const invalidWeightDecision = evaluateSegmentedFeedbackWorkflow(
+      CANONICAL_FEEDBACK_CHANNEL_BATCH_FIXTURE,
+      INVALID_FEEDBACK_WEIGHT_POLICY_FIXTURE
+    )
+
+    expect(invalidWeightDecision.status).toBe('rejected')
+    expect(invalidWeightDecision.reasonCodes).toEqual(['invalid_channel_weight'])
+    expect(invalidWeightDecision.validationIssues).toHaveLength(2)
+  })
+
+  it('returns needs_revision for the borderline confidence fixture with bounded remediation notes', () => {
+    const decision = evaluateSegmentedFeedbackWorkflow(BORDERLINE_FEEDBACK_CHANNEL_BATCH_FIXTURE)
+
+    expect(decision.status).toBe('needs_revision')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual(['confidence_borderline'])
+    expect(decision.remediationNotes).toHaveLength(1)
+    expect(decision.remediationNotes[0]?.code).toBe('confidence_borderline')
+    expect(decision.rankedEntries).toHaveLength(1)
+    expect(decision.rankedEntries[0]?.feedbackId).toBe('feedback:borderline-confidence')
+    expect(decision.rankedEntries[0]?.weightedScore).toBe(0.24)
+  })
+
+  it('safe-fails malformed payloads without throw', () => {
+    const validation = validateFeedbackChannelBatch(null as unknown as never)
+    const decision = evaluateSegmentedFeedbackWorkflow(undefined as unknown as never)
+
+    expect(validation.valid).toBe(false)
+    expect(validation.issues[0]?.code).toBe('invalid_payload')
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['invalid_payload'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const batches = [
+      CANONICAL_FEEDBACK_CHANNEL_BATCH_FIXTURE,
+      INVALID_FEEDBACK_CHANNEL_BATCH_FIXTURE,
+      BORDERLINE_FEEDBACK_CHANNEL_BATCH_FIXTURE,
+    ] as const
+
+    for (const batch of batches) {
+      const first = evaluateSegmentedFeedbackWorkflow(batch)
+      const second = evaluateSegmentedFeedbackWorkflow(batch)
+
+      expect(first).toEqual(second)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/domain/segmentedFeedbackWorkflow.ts` — pure deterministic feedback channel scoring/ranking with bug/balance/security/RFC discrimination, channel weights, and grouping policy.
- Targeted tests cover canonical ranked output, invalid channel/weight rejection, borderline confidence needs_revision, safe-fail, and byte-stable repeat evaluation.
- Slice doc, backlog handoff, and ops doc cross-ref for the feedback contract.

## Linear

- **Slice:** [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — Segmented/weighted feedback workflow (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — remains open for deferred follow-ups (playbook variants, rights governance, publish hooks)

## Validation

- `npm run test:run -- src/test/segmentedFeedbackWorkflow.test.ts` — 5 passed
- `npm run lint` — green

## Docs updated

- `planning/segmented-feedback-workflow-slice-1.md` (new)
- `planning/backlog.md` (handoff + mirror index)
- `docs/contribution-and-release-operations.md` (feedback contract cross-ref)

## Parent status

Parent SPE-75 stays open — playbook wrong-document failure, rights governance, and publish/crediting hooks remain deferred.

Made with [Cursor](https://cursor.com)