### PR TITLE
feat(SPE-2477): disaster playbook wrong-document failure (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -33,6 +33,12 @@ Separate **bug reports**, **balance discussion**, **security disclosures**, and 
 
 Domain feedback baseline: `src/domain/segmentedFeedbackWorkflow.ts` (SPE-2476) accepts structured channel payloads and emits weighted ranking decisions with channel-type discrimination and grouping policy — no publish side effects.
 
+## Disaster playbook variants
+
+Disaster-type playbooks carry distinct procedural assumptions and resource risks. Teams under pressure must apply the variant that matches the active disaster — wrong-document application fails deterministically rather than silently.
+
+Domain playbook baseline: `src/domain/playbookWrongDocumentFailure.ts` (SPE-2477) accepts structured playbook variant payloads and emits bounded application decisions with variant-type discrimination and wrong-document failure — no publish side effects.
+
 ## Submission governance
 
 - **Required metadata** — issue link, scope statement, test evidence for code.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,7 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** mission triage full refresh remains **blocked**; pick next SPE-75 follow-up child (playbook variants, rights governance) or backlog grooming when unblocked work is identified.
+**Next implementation (unblocked):** [SPE-2477](https://linear.app/spectranoir/issue/SPE-2477) disaster playbook wrong-document failure (slice 1) — in progress on branch `spe-75-playbook-wrong-document-failure-slice-1` @ `251c639d`; mission triage full refresh remains **blocked**.
 
 **Recently shipped:** [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) segmented/weighted feedback workflow (slice 1) — deterministic channel scoring/ranking with weights + grouping policy; branch `spe-75-segmented-feedback-workflow-slice-1` (PR #2871 @ `b82bb426`).
 
@@ -32,9 +32,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** mission triage full refresh remains **blocked**; remaining SPE-75 follow-ups (playbook variants, rights governance, publish hooks) deferred per `planning/segmented-feedback-workflow-slice-1.md` ## Deferred.
+**Next step:** SPE-2477 disaster playbook wrong-document failure (slice 1) in progress; remaining SPE-75 follow-ups (rights governance, publish hooks, data-pack validation) deferred per `planning/playbook-wrong-document-failure-slice-1.md` ## Deferred.
 
-**Base `main` SHA:** `b82bb426` — post SPE-2476 segmented feedback workflow merge (PR #2871).
+**Base `main` SHA:** `251c639d` — post SPE-2476 backlog handoff finalize.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 

--- a/planning/playbook-wrong-document-failure-slice-1.md
+++ b/planning/playbook-wrong-document-failure-slice-1.md
@@ -1,0 +1,75 @@
+# SPE-75 — Disaster playbook wrong-document failure (slice 1)
+
+One-page implementation plan. Linear: [SPE-2477](https://linear.app/spectranoir/issue/SPE-2477) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Natural continuation after [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) per `planning/segmented-feedback-workflow-slice-1.md` ## Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2477 — Disaster playbook wrong-document failure (slice 1)](https://linear.app/spectranoir/issue/SPE-2477) |
+| **Status** | **Shipped** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent remains open for deferred follow-ups |
+| **Branch** | `spe-75-playbook-wrong-document-failure-slice-1` |
+| **Base `main` SHA** | `251c639d` |
+
+## Goal
+
+Implement a pure domain module that accepts structured playbook variant payloads and emits deterministic failure when the wrong disaster document is applied under pressure.
+
+## Prerequisite (on `main`)
+
+| Existing surface | Anchor |
+| ---------------- | ------ |
+| Decision envelope patterns | `src/domain/contributionIntakeCuration.ts` (SPE-2474) |
+| Freeze/sort idioms | `src/domain/modularReleasePackaging.ts` (SPE-2475) |
+| Segmented feedback baseline | `src/domain/segmentedFeedbackWorkflow.ts` (SPE-2476) |
+| Projection test style | `src/test/segmentedFeedbackWorkflow.test.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New pure domain module for disaster playbook variant discrimination | Publish actions or release automation |
+| Wrong-document failure under pressure | Feedback workflow, curation, packaging pipelines |
+| Variant-type discrimination (fire/flood/containment breach/etc.) | Route/UI/persistence changes |
+| Borderline partial-match → `needs_revision` | Rights governance automation |
+| Targeted unit tests + fixtures | Mission triage (blocked) |
+
+## Playbook contract
+
+- **Pure deterministic evaluation** — same payload + policy yields byte-identical application decision.
+- **Safe-fail validation** — malformed payloads return structured validation errors, never throw during normal evaluation.
+- **Bounded statuses** — only `applied`, `needs_revision`, `rejected` in this slice.
+- **Variant discrimination** — fire, flood, containment_breach, earthquake, chemical_spill.
+- **Wrong-document failure** — mismatched variant types (no partial overlap) return `rejected` with `wrong_document_variant`.
+- **Partial overlap** — related variant pairs (e.g. fire/chemical_spill) return `needs_revision` with bounded remediation notes.
+- **No side effects** — no persistence changes, no route/UI requirements, no publish actions.
+
+## Acceptance
+
+- [x] Canonical playbook fixture returns `applied` with stable match metadata.
+- [x] Wrong-document match returns `rejected` with deterministic reason codes.
+- [x] Borderline partial match returns `needs_revision` with bounded remediation notes.
+- [x] Repeated evaluations are byte-identical for the same input set.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/playbookWrongDocumentFailure.ts` |
+| Tests  | `src/test/playbookWrongDocumentFailure.test.ts` |
+| Plan   | `planning/playbook-wrong-document-failure-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Submission governance and rights policy enforcement | SPE-75 follow-up child | Requires policy artifact model beyond playbook baseline |
+| Publish automation and crediting hooks | SPE-75 follow-up child | Out of slice 1 boundary — application envelope only |
+| Modifiable data pack safe-fail validation | SPE-75 follow-up child | Separate mechanic with schema-check fixtures |
+
+## See also
+
+- `planning/segmented-feedback-workflow-slice-1.md`
+- `docs/contribution-and-release-operations.md`
+- `planning/backlog.md`

--- a/src/domain/playbookWrongDocumentFailure.ts
+++ b/src/domain/playbookWrongDocumentFailure.ts
@@ -1,0 +1,510 @@
+/**
+ * SPE-75 follow-up slice 1: disaster playbook wrong-document failure.
+ *
+ * Pure deterministic playbook variant discrimination that accepts structured
+ * disaster playbook payloads and emits bounded application decisions when teams
+ * apply the wrong document under pressure — no UI, persistence writes, or
+ * publish actions.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type DisasterVariantType =
+  | 'fire'
+  | 'flood'
+  | 'containment_breach'
+  | 'earthquake'
+  | 'chemical_spill'
+
+export const DISASTER_VARIANT_TYPES: readonly DisasterVariantType[] = [
+  'fire',
+  'flood',
+  'containment_breach',
+  'earthquake',
+  'chemical_spill',
+] as const
+
+export type PlaybookApplicationStatus = 'applied' | 'needs_revision' | 'rejected'
+
+export const PLAYBOOK_APPLICATION_STATUSES: readonly PlaybookApplicationStatus[] = [
+  'applied',
+  'needs_revision',
+  'rejected',
+] as const
+
+export type PlaybookValidationCode =
+  | 'invalid_payload'
+  | 'missing_playbook_document_id'
+  | 'missing_playbook_variant_type'
+  | 'invalid_playbook_variant_type'
+  | 'missing_active_disaster_type'
+  | 'invalid_active_disaster_type'
+  | 'missing_procedural_assumptions'
+  | 'procedural_assumption_too_short'
+  | 'invalid_under_pressure_flag'
+
+export type PlaybookFailureCode = 'wrong_document_variant'
+
+export type PlaybookRemediationCode =
+  | 'variant_partial_overlap'
+  | 'procedural_assumption_borderline'
+
+export type PlaybookReasonCode =
+  | PlaybookValidationCode
+  | PlaybookFailureCode
+  | PlaybookRemediationCode
+
+// ---------------------------------------------------------------------------
+// Payload, policy, and envelopes
+// ---------------------------------------------------------------------------
+
+export interface PlaybookVariantPayload {
+  readonly playbookDocumentId?: string
+  readonly playbookVariantType?: string
+  readonly activeDisasterType?: string
+  readonly proceduralAssumptions?: readonly string[]
+  readonly operatorRef?: string
+  readonly underPressure?: boolean
+}
+
+export interface DisasterPressurePolicy {
+  readonly minimumProceduralAssumptions?: number
+  readonly minimumAssumptionLength?: number
+}
+
+export interface PlaybookValidationIssue {
+  readonly code: PlaybookValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface PlaybookRemediationNote {
+  readonly code: PlaybookRemediationCode
+  readonly note: string
+}
+
+export interface PlaybookMatchMetadata {
+  readonly playbookDocumentId: string
+  readonly playbookVariantType: DisasterVariantType
+  readonly activeDisasterType: DisasterVariantType
+  readonly proceduralAssumptionCount: number
+  readonly underPressure: boolean
+  readonly operatorRef: string
+}
+
+export interface PlaybookApplicationDecision {
+  readonly status: PlaybookApplicationStatus
+  readonly validationIssues: readonly PlaybookValidationIssue[]
+  readonly reasonCodes: readonly PlaybookReasonCode[]
+  readonly remediationNotes: readonly PlaybookRemediationNote[]
+  readonly matchMetadata?: PlaybookMatchMetadata
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const DISASTER_VARIANT_TYPE_SET = new Set<string>(DISASTER_VARIANT_TYPES)
+
+const DEFAULT_POLICY: Required<DisasterPressurePolicy> = {
+  minimumProceduralAssumptions: 2,
+  minimumAssumptionLength: 16,
+}
+
+const PARTIAL_OVERLAP_PAIRS: ReadonlyArray<readonly [DisasterVariantType, DisasterVariantType]> =
+  Object.freeze([
+    Object.freeze(['fire', 'chemical_spill'] as const),
+    Object.freeze(['flood', 'containment_breach'] as const),
+    Object.freeze(['earthquake', 'containment_breach'] as const),
+  ])
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_PLAYBOOK_VARIANT_FIXTURE: PlaybookVariantPayload = Object.freeze({
+  playbookDocumentId: 'playbook:fire-suppression-canonical',
+  playbookVariantType: 'fire',
+  activeDisasterType: 'fire',
+  operatorRef: 'operator:facility-response-lead',
+  underPressure: true,
+  proceduralAssumptions: Object.freeze([
+    'Isolate affected zone ventilation before suppression to prevent smoke spread.',
+    'Confirm personnel accountability at muster points before re-entry assessment.',
+    'Deploy rated suppression agents matched to fuel class before structural cooling.',
+  ]),
+})
+
+export const WRONG_DOCUMENT_PLAYBOOK_VARIANT_FIXTURE: PlaybookVariantPayload = Object.freeze({
+  playbookDocumentId: 'playbook:fire-suppression-misapplied',
+  playbookVariantType: 'fire',
+  activeDisasterType: 'flood',
+  operatorRef: 'operator:facility-response-lead',
+  underPressure: true,
+  proceduralAssumptions: Object.freeze([
+    'Isolate affected zone ventilation before suppression to prevent smoke spread.',
+    'Confirm personnel accountability at muster points before re-entry assessment.',
+  ]),
+})
+
+export const BORDERLINE_PLAYBOOK_VARIANT_FIXTURE: PlaybookVariantPayload = Object.freeze({
+  playbookDocumentId: 'playbook:fire-suppression-borderline',
+  playbookVariantType: 'fire',
+  activeDisasterType: 'chemical_spill',
+  operatorRef: 'operator:hazmat-liaison',
+  underPressure: true,
+  proceduralAssumptions: Object.freeze([
+    'Establish hot-warm-cold zones before any suppression attempt near reactants.',
+    'Confirm compatible PPE and agent selection against material safety sheets.',
+  ]),
+})
+
+export const INVALID_PLAYBOOK_VARIANT_FIXTURE: PlaybookVariantPayload = Object.freeze({
+  playbookDocumentId: '',
+  playbookVariantType: 'volcanic_eruption',
+  activeDisasterType: '',
+  underPressure: 'yes' as unknown as boolean,
+  proceduralAssumptions: Object.freeze(['too short', '']),
+})
+
+export const BORDERLINE_PROCEDURAL_PLAYBOOK_VARIANT_FIXTURE: PlaybookVariantPayload = Object.freeze({
+  playbookDocumentId: 'playbook:fire-suppression-thin-assumptions',
+  playbookVariantType: 'fire',
+  activeDisasterType: 'fire',
+  operatorRef: 'operator:junior-responder',
+  underPressure: true,
+  proceduralAssumptions: Object.freeze([
+    'Isolate affected zone ventilation before suppression to prevent smoke spread.',
+  ]),
+})
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isDisasterVariantType(value: string): value is DisasterVariantType {
+  return DISASTER_VARIANT_TYPE_SET.has(value)
+}
+
+export function isPlaybookApplicationStatus(value: string): value is PlaybookApplicationStatus {
+  return PLAYBOOK_APPLICATION_STATUSES.includes(value as PlaybookApplicationStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function resolvePolicy(policy?: DisasterPressurePolicy): Required<DisasterPressurePolicy> {
+  return {
+    minimumProceduralAssumptions:
+      policy?.minimumProceduralAssumptions ?? DEFAULT_POLICY.minimumProceduralAssumptions,
+    minimumAssumptionLength:
+      policy?.minimumAssumptionLength ?? DEFAULT_POLICY.minimumAssumptionLength,
+  }
+}
+
+function sortValidationIssues(issues: PlaybookValidationIssue[]): PlaybookValidationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortRemediationNotes(notes: PlaybookRemediationNote[]): PlaybookRemediationNote[] {
+  return [...notes].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.note.localeCompare(right.note)
+  })
+}
+
+function freezeValidationResult(
+  issues: PlaybookValidationIssue[]
+): { readonly valid: boolean; readonly issues: readonly PlaybookValidationIssue[] } {
+  const sortedIssues = sortValidationIssues(issues)
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function freezeDecision(decision: PlaybookApplicationDecision): PlaybookApplicationDecision {
+  return Object.freeze({
+    status: decision.status,
+    validationIssues: Object.freeze(decision.validationIssues),
+    reasonCodes: Object.freeze([...decision.reasonCodes]),
+    remediationNotes: Object.freeze(decision.remediationNotes),
+    matchMetadata: decision.matchMetadata
+      ? Object.freeze({ ...decision.matchMetadata })
+      : undefined,
+  })
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => entry.length > 0)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function hasPartialOverlap(
+  playbookVariant: DisasterVariantType,
+  activeDisaster: DisasterVariantType
+): boolean {
+  if (playbookVariant === activeDisaster) {
+    return false
+  }
+
+  return PARTIAL_OVERLAP_PAIRS.some(
+    ([left, right]) =>
+      (left === playbookVariant && right === activeDisaster) ||
+      (right === playbookVariant && left === activeDisaster)
+  )
+}
+
+function buildMatchMetadata(
+  payload: PlaybookVariantPayload,
+  playbookVariant: DisasterVariantType,
+  activeDisaster: DisasterVariantType,
+  proceduralAssumptions: readonly string[]
+): PlaybookMatchMetadata {
+  return Object.freeze({
+    playbookDocumentId: normalizeToken(payload.playbookDocumentId),
+    playbookVariantType: playbookVariant,
+    activeDisasterType: activeDisaster,
+    proceduralAssumptionCount: proceduralAssumptions.length,
+    underPressure: payload.underPressure === true,
+    operatorRef: normalizeToken(payload.operatorRef),
+  })
+}
+
+function collectRemediationNotes(
+  payload: PlaybookVariantPayload,
+  playbookVariant: DisasterVariantType,
+  activeDisaster: DisasterVariantType,
+  proceduralAssumptions: readonly string[],
+  policy: Required<DisasterPressurePolicy>
+): PlaybookRemediationNote[] {
+  const notes: PlaybookRemediationNote[] = []
+
+  if (hasPartialOverlap(playbookVariant, activeDisaster)) {
+    notes.push({
+      code: 'variant_partial_overlap',
+      note: `Playbook variant "${playbookVariant}" partially overlaps active disaster "${activeDisaster}"; confirm correct document before applying procedures under pressure.`,
+    })
+  }
+
+  if (
+    payload.underPressure === true &&
+    playbookVariant === activeDisaster &&
+    proceduralAssumptions.length > 0 &&
+    proceduralAssumptions.length < policy.minimumProceduralAssumptions
+  ) {
+    notes.push({
+      code: 'procedural_assumption_borderline',
+      note: `Under pressure, playbook "${normalizeToken(payload.playbookDocumentId)}" has ${proceduralAssumptions.length} procedural assumption(s); at least ${policy.minimumProceduralAssumptions} are required before application.`,
+    })
+  }
+
+  return sortRemediationNotes(notes)
+}
+
+function collectValidationIssues(
+  payload: PlaybookVariantPayload,
+  policy: Required<DisasterPressurePolicy>
+): PlaybookValidationIssue[] {
+  const issues: PlaybookValidationIssue[] = []
+  const playbookDocumentId = normalizeToken(payload.playbookDocumentId)
+  const playbookVariantToken = normalizeToken(payload.playbookVariantType)
+  const activeDisasterToken = normalizeToken(payload.activeDisasterType)
+  const proceduralAssumptions = asStringArray(payload.proceduralAssumptions)
+
+  if (!playbookDocumentId) {
+    issues.push({
+      code: 'missing_playbook_document_id',
+      severity: 'error',
+      detail: 'Playbook variant payload is missing playbookDocumentId.',
+    })
+  }
+
+  if (!playbookVariantToken) {
+    issues.push({
+      code: 'missing_playbook_variant_type',
+      severity: 'error',
+      detail: 'Playbook variant payload is missing playbookVariantType.',
+    })
+  } else if (!isDisasterVariantType(playbookVariantToken)) {
+    issues.push({
+      code: 'invalid_playbook_variant_type',
+      severity: 'error',
+      detail: `Playbook variant payload has invalid playbookVariantType "${playbookVariantToken}".`,
+    })
+  }
+
+  if (!activeDisasterToken) {
+    issues.push({
+      code: 'missing_active_disaster_type',
+      severity: 'error',
+      detail: 'Playbook variant payload is missing activeDisasterType.',
+    })
+  } else if (!isDisasterVariantType(activeDisasterToken)) {
+    issues.push({
+      code: 'invalid_active_disaster_type',
+      severity: 'error',
+      detail: `Playbook variant payload has invalid activeDisasterType "${activeDisasterToken}".`,
+    })
+  }
+
+  if (!Array.isArray(payload.proceduralAssumptions) || proceduralAssumptions.length === 0) {
+    issues.push({
+      code: 'missing_procedural_assumptions',
+      severity: 'error',
+      detail: 'Playbook variant payload must include at least one procedural assumption.',
+    })
+  } else {
+    for (const assumption of proceduralAssumptions) {
+      if (assumption.length < policy.minimumAssumptionLength) {
+        issues.push({
+          code: 'procedural_assumption_too_short',
+          severity: 'error',
+          detail: `Procedural assumption must be at least ${policy.minimumAssumptionLength} characters.`,
+        })
+        break
+      }
+    }
+  }
+
+  if (
+    payload.underPressure !== undefined &&
+    typeof payload.underPressure !== 'boolean'
+  ) {
+    issues.push({
+      code: 'invalid_under_pressure_flag',
+      severity: 'error',
+      detail: 'Playbook variant payload underPressure must be a boolean when provided.',
+    })
+  }
+
+  return issues
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validatePlaybookVariantPayload(
+  payload?: PlaybookVariantPayload,
+  policy?: DisasterPressurePolicy
+): { readonly valid: boolean; readonly issues: readonly PlaybookValidationIssue[] } {
+  const resolvedPolicy = resolvePolicy(policy)
+
+  if (!payload || typeof payload !== 'object') {
+    return freezeValidationResult([
+      {
+        code: 'invalid_payload',
+        severity: 'error',
+        detail: 'Playbook variant payload must be an object.',
+      },
+    ])
+  }
+
+  return freezeValidationResult(collectValidationIssues(payload, resolvedPolicy))
+}
+
+/**
+ * SPE-75 follow-up baseline: deterministic disaster playbook application with
+ * wrong-document failure under pressure — no persistence or publish side effects.
+ */
+export function evaluatePlaybookWrongDocumentFailure(
+  payload?: PlaybookVariantPayload,
+  policy?: DisasterPressurePolicy
+): PlaybookApplicationDecision {
+  const resolvedPolicy = resolvePolicy(policy)
+  const validation = validatePlaybookVariantPayload(payload, policy)
+
+  if (!validation.valid) {
+    const reasonCodes = [...new Set(validation.issues.map((issue) => issue.code))].sort(
+      (left, right) => left.localeCompare(right)
+    )
+
+    return freezeDecision({
+      status: 'rejected',
+      validationIssues: validation.issues,
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const playbookVariant = normalizeToken(payload!.playbookVariantType) as DisasterVariantType
+  const activeDisaster = normalizeToken(payload!.activeDisasterType) as DisasterVariantType
+  const proceduralAssumptions = asStringArray(payload!.proceduralAssumptions)
+
+  if (playbookVariant !== activeDisaster && !hasPartialOverlap(playbookVariant, activeDisaster)) {
+    return freezeDecision({
+      status: 'rejected',
+      validationIssues: Object.freeze([]),
+      reasonCodes: Object.freeze(['wrong_document_variant']),
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const remediationNotes = sortRemediationNotes(
+    collectRemediationNotes(
+      payload!,
+      playbookVariant,
+      activeDisaster,
+      proceduralAssumptions,
+      resolvedPolicy
+    )
+  )
+
+  if (remediationNotes.length > 0) {
+    const reasonCodes = remediationNotes
+      .map((note) => note.code)
+      .sort((left, right) => left.localeCompare(right))
+
+    return freezeDecision({
+      status: 'needs_revision',
+      validationIssues: Object.freeze([]),
+      reasonCodes,
+      remediationNotes: Object.freeze(remediationNotes.map((note) => Object.freeze({ ...note }))),
+      matchMetadata: buildMatchMetadata(
+        payload!,
+        playbookVariant,
+        activeDisaster,
+        proceduralAssumptions
+      ),
+    })
+  }
+
+  return freezeDecision({
+    status: 'applied',
+    validationIssues: Object.freeze([]),
+    reasonCodes: Object.freeze([]),
+    remediationNotes: Object.freeze([]),
+    matchMetadata: buildMatchMetadata(
+      payload!,
+      playbookVariant,
+      activeDisaster,
+      proceduralAssumptions
+    ),
+  })
+}

--- a/src/test/playbookWrongDocumentFailure.test.ts
+++ b/src/test/playbookWrongDocumentFailure.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BORDERLINE_PLAYBOOK_VARIANT_FIXTURE,
+  BORDERLINE_PROCEDURAL_PLAYBOOK_VARIANT_FIXTURE,
+  CANONICAL_PLAYBOOK_VARIANT_FIXTURE,
+  evaluatePlaybookWrongDocumentFailure,
+  INVALID_PLAYBOOK_VARIANT_FIXTURE,
+  validatePlaybookVariantPayload,
+  WRONG_DOCUMENT_PLAYBOOK_VARIANT_FIXTURE,
+} from '../domain/playbookWrongDocumentFailure'
+
+describe('playbookWrongDocumentFailure (SPE-2477 slice 1)', () => {
+  it('applies the canonical playbook fixture with stable match metadata', () => {
+    const decision = evaluatePlaybookWrongDocumentFailure(CANONICAL_PLAYBOOK_VARIANT_FIXTURE)
+
+    expect(decision.status).toBe('applied')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual([])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.matchMetadata).toEqual({
+      playbookDocumentId: 'playbook:fire-suppression-canonical',
+      playbookVariantType: 'fire',
+      activeDisasterType: 'fire',
+      proceduralAssumptionCount: 3,
+      underPressure: true,
+      operatorRef: 'operator:facility-response-lead',
+    })
+  })
+
+  it('rejects wrong-document matches with deterministic failure reason codes', () => {
+    const decision = evaluatePlaybookWrongDocumentFailure(WRONG_DOCUMENT_PLAYBOOK_VARIANT_FIXTURE)
+
+    expect(decision.status).toBe('rejected')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual(['wrong_document_variant'])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.matchMetadata).toBeUndefined()
+  })
+
+  it('returns needs_revision for borderline partial variant overlap', () => {
+    const decision = evaluatePlaybookWrongDocumentFailure(BORDERLINE_PLAYBOOK_VARIANT_FIXTURE)
+
+    expect(decision.status).toBe('needs_revision')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual(['variant_partial_overlap'])
+    expect(decision.remediationNotes).toHaveLength(1)
+    expect(decision.remediationNotes[0]?.code).toBe('variant_partial_overlap')
+    expect(decision.matchMetadata?.playbookVariantType).toBe('fire')
+    expect(decision.matchMetadata?.activeDisasterType).toBe('chemical_spill')
+  })
+
+  it('returns needs_revision when procedural assumptions are borderline under pressure', () => {
+    const decision = evaluatePlaybookWrongDocumentFailure(
+      BORDERLINE_PROCEDURAL_PLAYBOOK_VARIANT_FIXTURE
+    )
+
+    expect(decision.status).toBe('needs_revision')
+    expect(decision.reasonCodes).toEqual(['procedural_assumption_borderline'])
+    expect(decision.remediationNotes).toHaveLength(1)
+    expect(decision.remediationNotes[0]?.code).toBe('procedural_assumption_borderline')
+    expect(decision.matchMetadata?.proceduralAssumptionCount).toBe(1)
+  })
+
+  it('rejects invalid variant types and malformed payloads with deterministic reason codes', () => {
+    const invalidDecision = evaluatePlaybookWrongDocumentFailure(INVALID_PLAYBOOK_VARIANT_FIXTURE)
+
+    expect(invalidDecision.status).toBe('rejected')
+    expect(invalidDecision.reasonCodes).toEqual([
+      'invalid_playbook_variant_type',
+      'invalid_under_pressure_flag',
+      'missing_active_disaster_type',
+      'missing_playbook_document_id',
+      'procedural_assumption_too_short',
+    ])
+    expect(invalidDecision.validationIssues.map((issue) => issue.code)).toEqual(
+      invalidDecision.reasonCodes
+    )
+  })
+
+  it('safe-fails malformed payloads without throw', () => {
+    const validation = validatePlaybookVariantPayload(null as unknown as never)
+    const decision = evaluatePlaybookWrongDocumentFailure(undefined as unknown as never)
+
+    expect(validation.valid).toBe(false)
+    expect(validation.issues[0]?.code).toBe('invalid_payload')
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['invalid_payload'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const payloads = [
+      CANONICAL_PLAYBOOK_VARIANT_FIXTURE,
+      WRONG_DOCUMENT_PLAYBOOK_VARIANT_FIXTURE,
+      BORDERLINE_PLAYBOOK_VARIANT_FIXTURE,
+      INVALID_PLAYBOOK_VARIANT_FIXTURE,
+      BORDERLINE_PROCEDURAL_PLAYBOOK_VARIANT_FIXTURE,
+    ] as const
+
+    for (const payload of payloads) {
+      const first = evaluatePlaybookWrongDocumentFailure(payload)
+      const second = evaluatePlaybookWrongDocumentFailure(payload)
+
+      expect(first).toEqual(second)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add \src/domain/playbookWrongDocumentFailure.ts\ — pure deterministic disaster playbook variant discrimination with wrong-document rejection under pressure, borderline partial-overlap remediation, and safe-fail validation.
- Add targeted tests and fixtures in \src/test/playbookWrongDocumentFailure.test.ts\.
- Add slice doc \planning/playbook-wrong-document-failure-slice-1.md\; update \planning/backlog.md\ handoff and cross-ref in \docs/contribution-and-release-operations.md\.

## Linear mapping

- **Slice issue:** [SPE-2477](https://linear.app/spectranoir/issue/SPE-2477) — Disaster playbook wrong-document failure (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — Contribution intake and modular release operations (remains open)

## What shipped

Deterministic playbook application envelope with variant types (fire/flood/containment_breach/earthquake/chemical_spill), statuses (\pplied\ / \
eeds_revision\ / \ejected\), wrong-document failure code, partial-overlap remediation, and byte-stable repeat evaluation. No UI, persistence, or publish side effects.

## Validation

- \
pm run test:run -- src/test/playbookWrongDocumentFailure.test.ts\ (7 tests, pass)
- \
pm run lint\ (pass)

## Docs updated

- \planning/playbook-wrong-document-failure-slice-1.md\ (new)
- \planning/backlog.md\
- \docs/contribution-and-release-operations.md\

## Parent status

SPE-75 remains **open** — rights governance, publish hooks, and data-pack validation deferred per slice doc ## Deferred.

Made with [Cursor](https://cursor.com)