### PR TITLE
feat(SPE-2478): submission governance and rights policy enforcement (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -45,6 +45,8 @@ Domain playbook baseline: `src/domain/playbookWrongDocumentFailure.ts` (SPE-2477
 - **Branch / PR policy** — small reviewable units; no silent force-push to protected branches.
 - **Noncanonical side-content** — fan mods, unofficial tools, or narrative experiments live **outside** canonical release manifests unless explicitly promoted through intake.
 
+Domain governance baseline: `src/domain/submissionGovernanceRights.ts` (SPE-2478) accepts structured submission governance payloads and emits bounded rights/policy decisions with tier discrimination, license enforcement, and attribution assumptions — no publish side effects.
+
 ## Notation and docs standards
 
 - Prefer **issue IDs** (SPE-\*) in commit and PR titles when mandated by team workflow.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,7 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** pick next SPE-75 follow-up child (rights governance, data-pack validation) or backlog grooming when unblocked work is identified; mission triage full refresh remains **blocked**.
+**Next implementation (unblocked):** [SPE-2478](https://linear.app/spectranoir/issue/SPE-2478) submission governance and rights policy enforcement (slice 1) — in progress on branch `spe-75-submission-governance-rights-slice-1`; remaining SPE-75 follow-ups (publish hooks, data-pack validation) deferred per `planning/submission-governance-rights-slice-1.md` ## Deferred; mission triage full refresh remains **blocked**.
 
 **Recently shipped:** [SPE-2477](https://linear.app/spectranoir/issue/SPE-2477) disaster playbook wrong-document failure (slice 1) — deterministic variant discrimination with wrong-document rejection under pressure; branch `spe-75-playbook-wrong-document-failure-slice-1` (PR #2873 @ `7a4fd84c`).
 
@@ -34,9 +34,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** remaining SPE-75 follow-ups (rights governance, publish hooks, data-pack validation) deferred per `planning/playbook-wrong-document-failure-slice-1.md` ## Deferred; mission triage full refresh remains **blocked**.
+**Next step:** [SPE-2478](https://linear.app/spectranoir/issue/SPE-2478) submission governance and rights policy enforcement (slice 1) — `planning/submission-governance-rights-slice-1.md`; remaining SPE-75 follow-ups (publish hooks, data-pack validation) deferred; mission triage full refresh remains **blocked**.
 
-**Base `main` SHA:** `7a4fd84c` — post SPE-2477 disaster playbook wrong-document failure merge (PR #2873).
+**Base `main` SHA:** `8fd639e0` — post SPE-2477 backlog handoff doc merge.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 

--- a/planning/submission-governance-rights-slice-1.md
+++ b/planning/submission-governance-rights-slice-1.md
@@ -1,0 +1,74 @@
+# SPE-75 — Submission governance and rights policy enforcement (slice 1)
+
+One-page implementation plan. Linear: [SPE-2478](https://linear.app/spectranoir/issue/SPE-2478) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Natural continuation after [SPE-2477](https://linear.app/spectranoir/issue/SPE-2477) per `planning/playbook-wrong-document-failure-slice-1.md` ## Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2478 — Submission governance and rights policy enforcement (slice 1)](https://linear.app/spectranoir/issue/SPE-2478) |
+| **Status** | **In progress** (PR pending) |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent remains open for deferred follow-ups |
+| **Branch** | `spe-75-submission-governance-rights-slice-1` |
+| **Base `main` SHA** | `8fd639e0` |
+
+## Goal
+
+Implement a pure domain module that accepts structured submission governance payloads and emits deterministic rights/policy decisions (license declaration, noncanonical side-content flags, contributor attribution assumptions).
+
+## Prerequisite (on `main`)
+
+| Existing surface | Anchor |
+| ---------------- | ------ |
+| License remediation patterns | `src/domain/contributionIntakeCuration.ts` (SPE-2474) |
+| Decision envelope + safe-fail patterns | `src/domain/playbookWrongDocumentFailure.ts` (SPE-2477) |
+| Freeze/sort idioms | `src/domain/modularReleasePackaging.ts` (SPE-2475) |
+| Projection test style | `src/test/playbookWrongDocumentFailure.test.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New pure domain module for submission governance and rights policy | Publish actions or release automation |
+| Rights tier discrimination (canonical / noncanonical / fan_mod) | Curation, packaging, feedback, playbook pipelines |
+| License declaration and noncanonical side-content flag policy | Route/UI/persistence changes |
+| Borderline attribution → `needs_revision` | Mission triage (blocked) |
+| Targeted unit tests + fixtures | Modifiable data pack validation |
+
+## Governance contract
+
+- **Pure deterministic evaluation** — same payload + policy yields byte-identical application decision.
+- **Safe-fail validation** — malformed payloads return structured validation errors, never throw during normal evaluation.
+- **Bounded statuses** — only `applied`, `needs_revision`, `rejected` in this slice.
+- **Rights tier discrimination** — canonical, noncanonical, fan_mod with tier-specific policy rules.
+- **License enforcement** — missing/blank license declarations reject when `requireLicenseDeclaration` is true (default).
+- **Side-content flags** — fan_mod requires `noncanonicalSideContent: true`; canonical rejects when flag is set.
+- **No side effects** — no persistence changes, no route/UI requirements, no publish actions.
+
+## Acceptance
+
+- [x] Canonical governance fixture returns `applied` with stable policy metadata.
+- [x] Missing license returns `rejected` with deterministic reason codes.
+- [x] Borderline attribution returns `needs_revision` with bounded remediation notes.
+- [x] Repeated evaluations are byte-identical for the same input set.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/submissionGovernanceRights.ts` |
+| Tests  | `src/test/submissionGovernanceRights.test.ts` |
+| Plan   | `planning/submission-governance-rights-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Publish automation and crediting hooks | SPE-75 follow-up child | Out of slice 1 boundary — governance envelope only |
+| Modifiable data pack safe-fail validation | SPE-75 follow-up child | Separate mechanic with schema-check fixtures |
+
+## See also
+
+- `planning/playbook-wrong-document-failure-slice-1.md`
+- `docs/contribution-and-release-operations.md`
+- `planning/backlog.md`

--- a/src/domain/submissionGovernanceRights.ts
+++ b/src/domain/submissionGovernanceRights.ts
@@ -1,0 +1,461 @@
+/**
+ * SPE-75 follow-up slice 1: submission governance and rights policy enforcement.
+ *
+ * Pure deterministic governance evaluation that accepts structured submission
+ * governance payloads and emits bounded rights/policy decisions — no UI,
+ * persistence writes, or publish actions.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type SubmissionRightsTier = 'canonical' | 'noncanonical' | 'fan_mod'
+
+export const SUBMISSION_RIGHTS_TIERS: readonly SubmissionRightsTier[] = [
+  'canonical',
+  'noncanonical',
+  'fan_mod',
+] as const
+
+export type GovernanceApplicationStatus = 'applied' | 'needs_revision' | 'rejected'
+
+export const GOVERNANCE_APPLICATION_STATUSES: readonly GovernanceApplicationStatus[] = [
+  'applied',
+  'needs_revision',
+  'rejected',
+] as const
+
+export type GovernanceValidationCode =
+  | 'invalid_payload'
+  | 'missing_submission_id'
+  | 'missing_contributor_ref'
+  | 'missing_rights_tier'
+  | 'invalid_rights_tier'
+  | 'invalid_noncanonical_side_content_flag'
+
+export type GovernancePolicyCode =
+  | 'license_declaration_missing'
+  | 'fan_mod_requires_side_content_flag'
+  | 'canonical_with_side_content_flag'
+
+export type GovernanceRemediationCode =
+  | 'attribution_metadata_borderline'
+  | 'noncanonical_without_attribution'
+
+export type GovernanceReasonCode =
+  | GovernanceValidationCode
+  | GovernancePolicyCode
+  | GovernanceRemediationCode
+
+// ---------------------------------------------------------------------------
+// Payload, policy, and envelopes
+// ---------------------------------------------------------------------------
+
+export interface SubmissionGovernancePayload {
+  readonly submissionId?: string
+  readonly contributorRef?: string
+  readonly rightsTier?: string
+  readonly licenseDeclaration?: string
+  readonly attributionStatement?: string
+  readonly noncanonicalSideContent?: boolean
+  readonly issueLink?: string
+}
+
+export interface SubmissionGovernancePolicy {
+  readonly requireLicenseDeclaration?: boolean
+  readonly minimumAttributionLength?: number
+  readonly borderlineAttributionLength?: number
+}
+
+export interface GovernanceValidationIssue {
+  readonly code: GovernanceValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface GovernanceRemediationNote {
+  readonly code: GovernanceRemediationCode
+  readonly note: string
+}
+
+export interface SubmissionGovernanceMetadata {
+  readonly submissionId: string
+  readonly contributorRef: string
+  readonly rightsTier: SubmissionRightsTier
+  readonly licenseDeclaration: string
+  readonly attributionStatement: string
+  readonly noncanonicalSideContent: boolean
+  readonly issueLink: string
+}
+
+export interface GovernanceApplicationDecision {
+  readonly status: GovernanceApplicationStatus
+  readonly validationIssues: readonly GovernanceValidationIssue[]
+  readonly reasonCodes: readonly GovernanceReasonCode[]
+  readonly remediationNotes: readonly GovernanceRemediationNote[]
+  readonly governanceMetadata?: SubmissionGovernanceMetadata
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const RIGHTS_TIER_SET = new Set<string>(SUBMISSION_RIGHTS_TIERS)
+
+const DEFAULT_POLICY: Required<SubmissionGovernancePolicy> = {
+  requireLicenseDeclaration: true,
+  minimumAttributionLength: 24,
+  borderlineAttributionLength: 48,
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE: SubmissionGovernancePayload = Object.freeze({
+  submissionId: 'submission:governance-canonical',
+  contributorRef: 'contributor:agent-maintainer',
+  rightsTier: 'canonical',
+  licenseDeclaration: 'MIT',
+  attributionStatement:
+    'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+  noncanonicalSideContent: false,
+  issueLink: 'SPE-2478',
+})
+
+export const MISSING_LICENSE_GOVERNANCE_FIXTURE: SubmissionGovernancePayload = Object.freeze({
+  submissionId: 'submission:governance-missing-license',
+  contributorRef: 'contributor:external-author',
+  rightsTier: 'canonical',
+  licenseDeclaration: '',
+  attributionStatement:
+    'External author contribution awaiting license declaration before governance can apply.',
+  noncanonicalSideContent: false,
+  issueLink: 'SPE-75',
+})
+
+export const BORDERLINE_ATTRIBUTION_GOVERNANCE_FIXTURE: SubmissionGovernancePayload = Object.freeze({
+  submissionId: 'submission:governance-borderline-attribution',
+  contributorRef: 'contributor:community-contributor',
+  rightsTier: 'noncanonical',
+  licenseDeclaration: 'CC-BY-4.0',
+  attributionStatement: 'Community tool pack by Jane.',
+  noncanonicalSideContent: true,
+  issueLink: 'https://linear.app/spectranoir/issue/SPE-75/contribution-intake',
+})
+
+export const FAN_MOD_GOVERNANCE_FIXTURE: SubmissionGovernancePayload = Object.freeze({
+  submissionId: 'submission:governance-fan-mod',
+  contributorRef: 'contributor:fan-author',
+  rightsTier: 'fan_mod',
+  licenseDeclaration: 'CC-BY-NC-SA-4.0',
+  attributionStatement:
+    'Fan-authored narrative experiment distributed outside canonical release manifests with explicit noncommercial terms.',
+  noncanonicalSideContent: true,
+  issueLink: 'SPE-75',
+})
+
+export const INVALID_SUBMISSION_GOVERNANCE_FIXTURE: SubmissionGovernancePayload = Object.freeze({
+  submissionId: '',
+  contributorRef: '',
+  rightsTier: 'unofficial_tier',
+  licenseDeclaration: '   ',
+  noncanonicalSideContent: 'yes' as unknown as boolean,
+})
+
+export const FAN_MOD_WITHOUT_FLAG_GOVERNANCE_FIXTURE: SubmissionGovernancePayload = Object.freeze({
+  submissionId: 'submission:governance-fan-mod-unflagged',
+  contributorRef: 'contributor:fan-author',
+  rightsTier: 'fan_mod',
+  licenseDeclaration: 'CC-BY-NC-SA-4.0',
+  attributionStatement:
+    'Fan mod submitted without explicit noncanonical side-content flag for governance review.',
+  noncanonicalSideContent: false,
+  issueLink: 'SPE-75',
+})
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isSubmissionRightsTier(value: string): value is SubmissionRightsTier {
+  return RIGHTS_TIER_SET.has(value)
+}
+
+export function isGovernanceApplicationStatus(value: string): value is GovernanceApplicationStatus {
+  return GOVERNANCE_APPLICATION_STATUSES.includes(value as GovernanceApplicationStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function resolvePolicy(policy?: SubmissionGovernancePolicy): Required<SubmissionGovernancePolicy> {
+  return {
+    requireLicenseDeclaration:
+      policy?.requireLicenseDeclaration ?? DEFAULT_POLICY.requireLicenseDeclaration,
+    minimumAttributionLength:
+      policy?.minimumAttributionLength ?? DEFAULT_POLICY.minimumAttributionLength,
+    borderlineAttributionLength:
+      policy?.borderlineAttributionLength ?? DEFAULT_POLICY.borderlineAttributionLength,
+  }
+}
+
+function sortValidationIssues(issues: GovernanceValidationIssue[]): GovernanceValidationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortRemediationNotes(notes: GovernanceRemediationNote[]): GovernanceRemediationNote[] {
+  return [...notes].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.note.localeCompare(right.note)
+  })
+}
+
+function freezeValidationResult(
+  issues: GovernanceValidationIssue[]
+): { readonly valid: boolean; readonly issues: readonly GovernanceValidationIssue[] } {
+  const sortedIssues = sortValidationIssues(issues)
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function freezeDecision(decision: GovernanceApplicationDecision): GovernanceApplicationDecision {
+  return Object.freeze({
+    status: decision.status,
+    validationIssues: Object.freeze(decision.validationIssues),
+    reasonCodes: Object.freeze([...decision.reasonCodes]),
+    remediationNotes: Object.freeze(decision.remediationNotes),
+    governanceMetadata: decision.governanceMetadata
+      ? Object.freeze({ ...decision.governanceMetadata })
+      : undefined,
+  })
+}
+
+function buildGovernanceMetadata(
+  payload: SubmissionGovernancePayload,
+  rightsTier: SubmissionRightsTier
+): SubmissionGovernanceMetadata {
+  return Object.freeze({
+    submissionId: normalizeToken(payload.submissionId),
+    contributorRef: normalizeToken(payload.contributorRef),
+    rightsTier,
+    licenseDeclaration: normalizeToken(payload.licenseDeclaration),
+    attributionStatement: normalizeToken(payload.attributionStatement),
+    noncanonicalSideContent: payload.noncanonicalSideContent === true,
+    issueLink: normalizeToken(payload.issueLink),
+  })
+}
+
+function collectPolicyViolations(
+  payload: SubmissionGovernancePayload,
+  rightsTier: SubmissionRightsTier,
+  policy: Required<SubmissionGovernancePolicy>
+): GovernancePolicyCode[] {
+  const violations: GovernancePolicyCode[] = []
+  const licenseDeclaration = normalizeToken(payload.licenseDeclaration)
+  const sideContentFlag = payload.noncanonicalSideContent === true
+
+  if (policy.requireLicenseDeclaration && licenseDeclaration.length === 0) {
+    violations.push('license_declaration_missing')
+  }
+
+  if (rightsTier === 'fan_mod' && !sideContentFlag) {
+    violations.push('fan_mod_requires_side_content_flag')
+  }
+
+  if (rightsTier === 'canonical' && sideContentFlag) {
+    violations.push('canonical_with_side_content_flag')
+  }
+
+  return violations.sort((left, right) => left.localeCompare(right))
+}
+
+function collectRemediationNotes(
+  payload: SubmissionGovernancePayload,
+  rightsTier: SubmissionRightsTier,
+  policy: Required<SubmissionGovernancePolicy>
+): GovernanceRemediationNote[] {
+  const notes: GovernanceRemediationNote[] = []
+  const attributionStatement = normalizeToken(payload.attributionStatement)
+  const attributionLength = attributionStatement.length
+
+  if (
+    rightsTier === 'noncanonical' &&
+    attributionLength > 0 &&
+    attributionLength < policy.minimumAttributionLength
+  ) {
+    notes.push({
+      code: 'noncanonical_without_attribution',
+      note: `Noncanonical submission "${normalizeToken(payload.submissionId)}" requires attribution metadata of at least ${policy.minimumAttributionLength} characters.`,
+    })
+  }
+
+  if (
+    attributionLength >= policy.minimumAttributionLength &&
+    attributionLength < policy.borderlineAttributionLength
+  ) {
+    notes.push({
+      code: 'attribution_metadata_borderline',
+      note: 'Expand contributor attribution with provenance, credit targets, and rights assumptions before governance can fully apply.',
+    })
+  }
+
+  return sortRemediationNotes(notes)
+}
+
+function collectValidationIssues(payload: SubmissionGovernancePayload): GovernanceValidationIssue[] {
+  const issues: GovernanceValidationIssue[] = []
+  const submissionId = normalizeToken(payload.submissionId)
+  const contributorRef = normalizeToken(payload.contributorRef)
+  const rightsTierToken = normalizeToken(payload.rightsTier)
+
+  if (!submissionId) {
+    issues.push({
+      code: 'missing_submission_id',
+      severity: 'error',
+      detail: 'Submission governance payload is missing submissionId.',
+    })
+  }
+
+  if (!contributorRef) {
+    issues.push({
+      code: 'missing_contributor_ref',
+      severity: 'error',
+      detail: 'Submission governance payload is missing contributorRef.',
+    })
+  }
+
+  if (!rightsTierToken) {
+    issues.push({
+      code: 'missing_rights_tier',
+      severity: 'error',
+      detail: 'Submission governance payload is missing rightsTier.',
+    })
+  } else if (!isSubmissionRightsTier(rightsTierToken)) {
+    issues.push({
+      code: 'invalid_rights_tier',
+      severity: 'error',
+      detail: `Submission governance payload has invalid rightsTier "${rightsTierToken}".`,
+    })
+  }
+
+  if (
+    payload.noncanonicalSideContent !== undefined &&
+    typeof payload.noncanonicalSideContent !== 'boolean'
+  ) {
+    issues.push({
+      code: 'invalid_noncanonical_side_content_flag',
+      severity: 'error',
+      detail:
+        'Submission governance payload noncanonicalSideContent must be a boolean when provided.',
+    })
+  }
+
+  return issues
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateSubmissionGovernancePayload(
+  payload?: SubmissionGovernancePayload,
+  policy?: SubmissionGovernancePolicy
+): { readonly valid: boolean; readonly issues: readonly GovernanceValidationIssue[] } {
+  resolvePolicy(policy)
+
+  if (!payload || typeof payload !== 'object') {
+    return freezeValidationResult([
+      {
+        code: 'invalid_payload',
+        severity: 'error',
+        detail: 'Submission governance payload must be an object.',
+      },
+    ])
+  }
+
+  return freezeValidationResult(collectValidationIssues(payload))
+}
+
+/**
+ * SPE-75 follow-up baseline: deterministic submission governance and rights
+ * policy enforcement — no persistence or publish side effects.
+ */
+export function evaluateSubmissionGovernanceRights(
+  payload?: SubmissionGovernancePayload,
+  policy?: SubmissionGovernancePolicy
+): GovernanceApplicationDecision {
+  const resolvedPolicy = resolvePolicy(policy)
+  const validation = validateSubmissionGovernancePayload(payload, policy)
+
+  if (!validation.valid) {
+    const reasonCodes = [...new Set(validation.issues.map((issue) => issue.code))].sort(
+      (left, right) => left.localeCompare(right)
+    )
+
+    return freezeDecision({
+      status: 'rejected',
+      validationIssues: validation.issues,
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const rightsTier = normalizeToken(payload!.rightsTier) as SubmissionRightsTier
+  const policyViolations = collectPolicyViolations(payload!, rightsTier, resolvedPolicy)
+
+  if (policyViolations.length > 0) {
+    return freezeDecision({
+      status: 'rejected',
+      validationIssues: Object.freeze([]),
+      reasonCodes: Object.freeze([...policyViolations]),
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const remediationNotes = sortRemediationNotes(
+    collectRemediationNotes(payload!, rightsTier, resolvedPolicy)
+  )
+
+  if (remediationNotes.length > 0) {
+    const reasonCodes = remediationNotes
+      .map((note) => note.code)
+      .sort((left, right) => left.localeCompare(right))
+
+    return freezeDecision({
+      status: 'needs_revision',
+      validationIssues: Object.freeze([]),
+      reasonCodes,
+      remediationNotes: Object.freeze(remediationNotes.map((note) => Object.freeze({ ...note }))),
+      governanceMetadata: buildGovernanceMetadata(payload!, rightsTier),
+    })
+  }
+
+  return freezeDecision({
+    status: 'applied',
+    validationIssues: Object.freeze([]),
+    reasonCodes: Object.freeze([]),
+    remediationNotes: Object.freeze([]),
+    governanceMetadata: buildGovernanceMetadata(payload!, rightsTier),
+  })
+}

--- a/src/test/submissionGovernanceRights.test.ts
+++ b/src/test/submissionGovernanceRights.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BORDERLINE_ATTRIBUTION_GOVERNANCE_FIXTURE,
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+  FAN_MOD_GOVERNANCE_FIXTURE,
+  FAN_MOD_WITHOUT_FLAG_GOVERNANCE_FIXTURE,
+  INVALID_SUBMISSION_GOVERNANCE_FIXTURE,
+  MISSING_LICENSE_GOVERNANCE_FIXTURE,
+  validateSubmissionGovernancePayload,
+} from '../domain/submissionGovernanceRights'
+
+describe('submissionGovernanceRights (SPE-2478 slice 1)', () => {
+  it('applies the canonical governance fixture with stable policy metadata', () => {
+    const decision = evaluateSubmissionGovernanceRights(CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE)
+
+    expect(decision.status).toBe('applied')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual([])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.governanceMetadata).toEqual({
+      submissionId: 'submission:governance-canonical',
+      contributorRef: 'contributor:agent-maintainer',
+      rightsTier: 'canonical',
+      licenseDeclaration: 'MIT',
+      attributionStatement:
+        'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+      noncanonicalSideContent: false,
+      issueLink: 'SPE-2478',
+    })
+  })
+
+  it('applies fan-mod fixtures when side-content flag and license are present', () => {
+    const decision = evaluateSubmissionGovernanceRights(FAN_MOD_GOVERNANCE_FIXTURE)
+
+    expect(decision.status).toBe('applied')
+    expect(decision.governanceMetadata?.rightsTier).toBe('fan_mod')
+    expect(decision.governanceMetadata?.noncanonicalSideContent).toBe(true)
+  })
+
+  it('rejects missing license declarations with deterministic policy reason codes', () => {
+    const decision = evaluateSubmissionGovernanceRights(MISSING_LICENSE_GOVERNANCE_FIXTURE)
+
+    expect(decision.status).toBe('rejected')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual(['license_declaration_missing'])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.governanceMetadata).toBeUndefined()
+  })
+
+  it('rejects fan-mod submissions without noncanonical side-content flag', () => {
+    const decision = evaluateSubmissionGovernanceRights(FAN_MOD_WITHOUT_FLAG_GOVERNANCE_FIXTURE)
+
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['fan_mod_requires_side_content_flag'])
+    expect(decision.governanceMetadata).toBeUndefined()
+  })
+
+  it('returns needs_revision for borderline attribution metadata', () => {
+    const decision = evaluateSubmissionGovernanceRights(BORDERLINE_ATTRIBUTION_GOVERNANCE_FIXTURE)
+
+    expect(decision.status).toBe('needs_revision')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual(['attribution_metadata_borderline'])
+    expect(decision.remediationNotes).toHaveLength(1)
+    expect(decision.remediationNotes[0]?.code).toBe('attribution_metadata_borderline')
+    expect(decision.governanceMetadata?.rightsTier).toBe('noncanonical')
+  })
+
+  it('rejects invalid rights tiers and malformed payloads with deterministic reason codes', () => {
+    const invalidDecision = evaluateSubmissionGovernanceRights(INVALID_SUBMISSION_GOVERNANCE_FIXTURE)
+
+    expect(invalidDecision.status).toBe('rejected')
+    expect(invalidDecision.reasonCodes).toEqual([
+      'invalid_noncanonical_side_content_flag',
+      'invalid_rights_tier',
+      'missing_contributor_ref',
+      'missing_submission_id',
+    ])
+    expect(invalidDecision.validationIssues.map((issue) => issue.code)).toEqual(
+      invalidDecision.reasonCodes
+    )
+  })
+
+  it('safe-fails malformed payloads without throw', () => {
+    const validation = validateSubmissionGovernancePayload(null as unknown as never)
+    const decision = evaluateSubmissionGovernanceRights(undefined as unknown as never)
+
+    expect(validation.valid).toBe(false)
+    expect(validation.issues[0]?.code).toBe('invalid_payload')
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['invalid_payload'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const payloads = [
+      CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+      MISSING_LICENSE_GOVERNANCE_FIXTURE,
+      BORDERLINE_ATTRIBUTION_GOVERNANCE_FIXTURE,
+      INVALID_SUBMISSION_GOVERNANCE_FIXTURE,
+      FAN_MOD_GOVERNANCE_FIXTURE,
+      FAN_MOD_WITHOUT_FLAG_GOVERNANCE_FIXTURE,
+    ] as const
+
+    for (const payload of payloads) {
+      const first = evaluateSubmissionGovernanceRights(payload)
+      const second = evaluateSubmissionGovernanceRights(payload)
+
+      expect(first).toEqual(second)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add pure domain module `src/domain/submissionGovernanceRights.ts` for deterministic submission governance and rights policy decisions (license declaration, noncanonical side-content flags, contributor attribution assumptions).
- Rights tier discrimination: canonical, noncanonical, fan_mod with tier-specific policy rules.
- Targeted tests + fixtures; slice doc and backlog handoff.

## Linear

- **Slice:** [SPE-2478](https://linear.app/spectranoir/issue/SPE-2478) — Submission governance and rights policy enforcement (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — remains open for deferred follow-ups (publish hooks, data-pack validation)

## What shipped

- `evaluateSubmissionGovernanceRights` + `validateSubmissionGovernancePayload` with safe-fail validation, freeze/sort idioms, and bounded statuses (`applied` / `needs_revision` / `rejected`)
- Fixtures for canonical, missing license, borderline attribution, fan-mod, and invalid payloads
- `planning/submission-governance-rights-slice-1.md`, backlog handoff, docs cross-ref in `docs/contribution-and-release-operations.md`

## Validation

- `npm run test:run -- src/test/submissionGovernanceRights.test.ts` (8 tests)
- `npm run lint`

## Docs updated

- `planning/submission-governance-rights-slice-1.md` (new)
- `planning/backlog.md`
- `docs/contribution-and-release-operations.md`

## Parent status

SPE-75 parent remains open — publish automation and data-pack validation deferred per slice doc.

Made with [Cursor](https://cursor.com)