### PR TITLE
feat(SPE-2479): modifiable data pack safe-fail validation (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -47,6 +47,12 @@ Domain playbook baseline: `src/domain/playbookWrongDocumentFailure.ts` (SPE-2477
 
 Domain governance baseline: `src/domain/submissionGovernanceRights.ts` (SPE-2478) accepts structured submission governance payloads and emits bounded rights/policy decisions with tier discrimination, license enforcement, and attribution assumptions — no publish side effects.
 
+## Modifiable data packs
+
+Authoring tools and contribution pipelines may ship **modifiable data packs** (tuning tables, reference sheets, doctrine notes) with typed section definitions. Packs must pass schema validation before import — corrupt structure fails safely rather than silently corrupting downstream state.
+
+Domain validation baseline: `src/domain/modifiableDataPackValidation.ts` (SPE-2479) accepts structured modifiable data-pack payloads and emits bounded schema-validation decisions with section-shape checks and borderline schema-version remediation — no publish side effects.
+
 ## Notation and docs standards
 
 - Prefer **issue IDs** (SPE-\*) in commit and PR titles when mandated by team workflow.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,9 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** pick next SPE-75 follow-up child (publish hooks, data-pack validation) or backlog grooming when unblocked work is identified; mission triage full refresh remains **blocked**.
+**Next implementation (unblocked):** SPE-75 publish-hooks follow-up child or backlog grooming when unblocked work is identified; mission triage full refresh remains **blocked**.
+
+**In progress:** [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) modifiable data pack safe-fail validation (slice 1) — deterministic schema-validation envelope under SPE-75; branch `spe-75-modifiable-data-pack-validation-slice-1` @ `940b27b2`.
 
 **Recently shipped:** [SPE-2478](https://linear.app/spectranoir/issue/SPE-2478) submission governance and rights policy enforcement (slice 1) — deterministic rights tier discrimination with license/attribution policy; branch `spe-75-submission-governance-rights-slice-1` (PR #2875 @ `ad8f566e`).
 
@@ -36,9 +38,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** remaining SPE-75 follow-ups (publish hooks, data-pack validation) deferred per `planning/submission-governance-rights-slice-1.md` ## Deferred; mission triage full refresh remains **blocked**.
+**Next step:** remaining SPE-75 follow-up (publish hooks) deferred per `planning/modifiable-data-pack-validation-slice-1.md` ## Deferred; mission triage full refresh remains **blocked**.
 
-**Base `main` SHA:** `ad8f566e` — post SPE-2478 submission governance and rights policy enforcement merge (PR #2875).
+**Base `main` SHA:** `940b27b2` — pre SPE-2479 modifiable data pack safe-fail validation slice.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -199,6 +201,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `minor-anomaly-item-registry-slice-1.md`                  | **Shipped**    | SPE-2104 / PR #2428; low-priority item intake schema.                                                                                               |
 | `minor-anomaly-item-registry-slice-2.md`                  | **Shipped**    | SPE-2314 / PR #2492; `minorAnomalyItemRecords` GameState persistence.                                                                               |
 | `minor-anomaly-item-registry-slice-3.md`                  | **Shipped**    | SPE-2316 / PR #2496 — weekly disposition/custody advance hook for SPE-2104.                                                                         |
+| `modifiable-data-pack-validation-slice-1.md`              | **In Progress** | [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) — deterministic modifiable data-pack schema validation under SPE-75; branch `spe-75-modifiable-data-pack-validation-slice-1` @ `940b27b2`. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/modifiable-data-pack-validation-slice-1.md
+++ b/planning/modifiable-data-pack-validation-slice-1.md
@@ -1,0 +1,72 @@
+# SPE-75 — Modifiable data pack safe-fail validation (slice 1)
+
+One-page implementation plan. Linear: [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Natural continuation after [SPE-2478](https://linear.app/spectranoir/issue/SPE-2478) per `planning/submission-governance-rights-slice-1.md` ## Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2479 — Modifiable data pack safe-fail validation (slice 1)](https://linear.app/spectranoir/issue/SPE-2479) |
+| **Status** | **In Progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent remains open for deferred follow-ups |
+| **Branch** | `spe-75-modifiable-data-pack-validation-slice-1` |
+| **Base `main` SHA** | `940b27b2` |
+
+## Goal
+
+Implement a pure domain module that accepts structured modifiable data-pack payloads and emits deterministic schema-validation decisions with safe-fail on corrupt/malformed structure.
+
+## Prerequisite (on `main`)
+
+| Existing surface | Anchor |
+| ---------------- | ------ |
+| Decision envelope + safe-fail patterns | `src/domain/submissionGovernanceRights.ts` (SPE-2478) |
+| Validation/freeze/sort idioms | `src/domain/playbookWrongDocumentFailure.ts` (SPE-2477) |
+| Projection test style | `src/test/submissionGovernanceRights.test.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New pure domain module for modifiable data-pack schema validation | Publish actions or release automation |
+| Safe-fail validation for malformed/corrupt payloads | Curation, packaging, feedback, playbook pipelines |
+| Borderline schema version → `needs_revision` | Route/UI/persistence changes |
+| Targeted unit tests + fixtures | Mission triage (blocked) |
+| | Submission governance module changes |
+
+## Validation contract
+
+- **Pure deterministic evaluation** — same payload + policy yields byte-identical validation decision.
+- **Safe-fail validation** — malformed payloads return structured validation errors, never throw during normal evaluation.
+- **Bounded statuses** — only `applied`, `needs_revision`, `rejected` in this slice.
+- **Schema version discrimination** — supported versions list with borderline below recommended threshold.
+- **Section shape checks** — required keys, duplicate detection, field-type/default-value alignment.
+- **No side effects** — no persistence changes, no route/UI requirements, no publish actions.
+
+## Acceptance
+
+- [x] Canonical pack fixture returns `applied` with stable pack metadata.
+- [x] Corrupt structure returns `rejected` with deterministic reason codes.
+- [x] Borderline schema version returns `needs_revision` with bounded remediation notes.
+- [x] Repeated evaluations are byte-identical for the same input set.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/modifiableDataPackValidation.ts` |
+| Tests  | `src/test/modifiableDataPackValidation.test.ts` |
+| Plan   | `planning/modifiable-data-pack-validation-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Publish automation and crediting hooks | SPE-75 follow-up child | Out of slice 1 boundary — validation envelope only |
+| Runtime import/persistence wiring for modifiable packs | SPE-75 follow-up child | Requires GameState integration beyond pure validation |
+
+## See also
+
+- `planning/submission-governance-rights-slice-1.md`
+- `docs/contribution-and-release-operations.md`
+- `planning/backlog.md`

--- a/src/domain/modifiableDataPackValidation.ts
+++ b/src/domain/modifiableDataPackValidation.ts
@@ -1,0 +1,578 @@
+/**
+ * SPE-75 follow-up slice 1: modifiable data pack safe-fail validation.
+ *
+ * Pure deterministic schema validation that accepts structured modifiable
+ * data-pack payloads and emits bounded validation decisions — no UI,
+ * persistence writes, or publish actions.
+ */
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type ModifiableDataPackKind =
+  | 'tuning_table'
+  | 'content_accessory'
+  | 'reference_sheet'
+  | 'doctrine_note'
+
+export const MODIFIABLE_DATA_PACK_KINDS: readonly ModifiableDataPackKind[] = [
+  'tuning_table',
+  'content_accessory',
+  'reference_sheet',
+  'doctrine_note',
+] as const
+
+export type ModifiableFieldType = 'string' | 'number' | 'boolean' | 'string_array'
+
+export const MODIFIABLE_FIELD_TYPES: readonly ModifiableFieldType[] = [
+  'string',
+  'number',
+  'boolean',
+  'string_array',
+] as const
+
+export type DataPackValidationStatus = 'applied' | 'needs_revision' | 'rejected'
+
+export const DATA_PACK_VALIDATION_STATUSES: readonly DataPackValidationStatus[] = [
+  'applied',
+  'needs_revision',
+  'rejected',
+] as const
+
+export type DataPackValidationCode =
+  | 'invalid_payload'
+  | 'missing_pack_id'
+  | 'missing_schema_version'
+  | 'invalid_schema_version'
+  | 'missing_pack_kind'
+  | 'invalid_pack_kind'
+  | 'missing_modifiable_sections'
+  | 'invalid_modifiable_section_shape'
+  | 'missing_section_key'
+  | 'duplicate_section_keys'
+  | 'invalid_field_type'
+  | 'default_value_type_mismatch'
+
+export type DataPackRemediationCode = 'schema_version_borderline'
+
+export type DataPackReasonCode = DataPackValidationCode | DataPackRemediationCode
+
+// ---------------------------------------------------------------------------
+// Payload, policy, and envelopes
+// ---------------------------------------------------------------------------
+
+export interface ModifiableSectionDefinition {
+  readonly sectionKey?: string
+  readonly fieldType?: string
+  readonly defaultValue?: unknown
+}
+
+export interface ModifiableDataPackPayload {
+  readonly packId?: string
+  readonly schemaVersion?: string
+  readonly packKind?: string
+  readonly authorRef?: string
+  readonly modifiableSections?: readonly ModifiableSectionDefinition[]
+  readonly issueLink?: string
+}
+
+export interface DataPackValidationPolicy {
+  readonly minimumSchemaVersion?: string
+  readonly recommendedSchemaVersion?: string
+  readonly supportedSchemaVersions?: readonly string[]
+}
+
+export interface DataPackValidationIssue {
+  readonly code: DataPackValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface DataPackRemediationNote {
+  readonly code: DataPackRemediationCode
+  readonly note: string
+}
+
+export interface DataPackValidationMetadata {
+  readonly packId: string
+  readonly schemaVersion: string
+  readonly packKind: ModifiableDataPackKind
+  readonly authorRef: string
+  readonly sectionCount: number
+  readonly issueLink: string
+}
+
+export interface DataPackValidationDecision {
+  readonly status: DataPackValidationStatus
+  readonly validationIssues: readonly DataPackValidationIssue[]
+  readonly reasonCodes: readonly DataPackReasonCode[]
+  readonly remediationNotes: readonly DataPackRemediationNote[]
+  readonly packMetadata?: DataPackValidationMetadata
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const PACK_KIND_SET = new Set<string>(MODIFIABLE_DATA_PACK_KINDS)
+const FIELD_TYPE_SET = new Set<string>(MODIFIABLE_FIELD_TYPES)
+
+const DEFAULT_SUPPORTED_SCHEMA_VERSIONS: readonly string[] = Object.freeze([
+  '1.0.0',
+  '1.1.0',
+  '2.0.0',
+])
+
+const DEFAULT_POLICY: Required<
+  Pick<DataPackValidationPolicy, 'minimumSchemaVersion' | 'recommendedSchemaVersion'>
+> &
+  Pick<DataPackValidationPolicy, 'supportedSchemaVersions'> = {
+  minimumSchemaVersion: '1.0.0',
+  recommendedSchemaVersion: '1.1.0',
+  supportedSchemaVersions: DEFAULT_SUPPORTED_SCHEMA_VERSIONS,
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE: ModifiableDataPackPayload = Object.freeze({
+  packId: 'datapack:tuning-containment-thresholds',
+  schemaVersion: '1.1.0',
+  packKind: 'tuning_table',
+  authorRef: 'contributor:agent-maintainer',
+  issueLink: 'SPE-2479',
+  modifiableSections: Object.freeze([
+    Object.freeze({
+      sectionKey: 'containment.alertThreshold',
+      fieldType: 'number',
+      defaultValue: 0.75,
+    }),
+    Object.freeze({
+      sectionKey: 'containment.escalationLabels',
+      fieldType: 'string_array',
+      defaultValue: Object.freeze(['watch', 'elevated', 'critical']),
+    }),
+    Object.freeze({
+      sectionKey: 'containment.autoNotify',
+      fieldType: 'boolean',
+      defaultValue: true,
+    }),
+  ]),
+})
+
+export const BORDERLINE_SCHEMA_DATA_PACK_FIXTURE: ModifiableDataPackPayload = Object.freeze({
+  packId: 'datapack:reference-sheet-borderline',
+  schemaVersion: '1.0.0',
+  packKind: 'reference_sheet',
+  authorRef: 'contributor:community-author',
+  issueLink: 'SPE-75',
+  modifiableSections: Object.freeze([
+    Object.freeze({
+      sectionKey: 'reference.title',
+      fieldType: 'string',
+      defaultValue: 'Containment reference sheet',
+    }),
+    Object.freeze({
+      sectionKey: 'reference.revision',
+      fieldType: 'number',
+      defaultValue: 1,
+    }),
+  ]),
+})
+
+export const INVALID_MODIFIABLE_DATA_PACK_FIXTURE: ModifiableDataPackPayload = Object.freeze({
+  packId: '',
+  schemaVersion: '0.9.0',
+  packKind: 'unsupported_kind',
+  authorRef: '',
+  modifiableSections: Object.freeze([
+    Object.freeze({
+      sectionKey: 'duplicate.key',
+      fieldType: 'text',
+      defaultValue: 42,
+    }),
+    Object.freeze({
+      sectionKey: 'duplicate.key',
+      fieldType: 'boolean',
+      defaultValue: 'not-a-boolean',
+    }),
+    'not-an-object' as unknown as ModifiableSectionDefinition,
+  ]),
+})
+
+export const PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE: ModifiableDataPackPayload = Object.freeze({
+  packId: 'datapack:partial-sections',
+  schemaVersion: '1.1.0',
+  packKind: 'doctrine_note',
+  modifiableSections: Object.freeze([
+    Object.freeze({
+      fieldType: 'string',
+      defaultValue: 'Missing section key',
+    }),
+  ]),
+})
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isModifiableDataPackKind(value: string): value is ModifiableDataPackKind {
+  return PACK_KIND_SET.has(value)
+}
+
+export function isModifiableFieldType(value: string): value is ModifiableFieldType {
+  return FIELD_TYPE_SET.has(value)
+}
+
+export function isDataPackValidationStatus(value: string): value is DataPackValidationStatus {
+  return DATA_PACK_VALIDATION_STATUSES.includes(value as DataPackValidationStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function resolvePolicy(policy?: DataPackValidationPolicy): {
+  readonly minimumSchemaVersion: string
+  readonly recommendedSchemaVersion: string
+  readonly supportedSchemaVersions: readonly string[]
+} {
+  const supportedSchemaVersions =
+    policy?.supportedSchemaVersions && policy.supportedSchemaVersions.length > 0
+      ? [...policy.supportedSchemaVersions].sort((left, right) => left.localeCompare(right))
+      : DEFAULT_POLICY.supportedSchemaVersions!
+
+  return {
+    minimumSchemaVersion:
+      policy?.minimumSchemaVersion ?? DEFAULT_POLICY.minimumSchemaVersion,
+    recommendedSchemaVersion:
+      policy?.recommendedSchemaVersion ?? DEFAULT_POLICY.recommendedSchemaVersion,
+    supportedSchemaVersions: Object.freeze(supportedSchemaVersions),
+  }
+}
+
+function schemaVersionRank(version: string, supportedVersions: readonly string[]): number {
+  return supportedVersions.indexOf(version)
+}
+
+function isSupportedSchemaVersion(version: string, supportedVersions: readonly string[]): boolean {
+  return schemaVersionRank(version, supportedVersions) >= 0
+}
+
+function isBorderlineSchemaVersion(
+  version: string,
+  policy: ReturnType<typeof resolvePolicy>
+): boolean {
+  const versionRank = schemaVersionRank(version, policy.supportedSchemaVersions)
+  const recommendedRank = schemaVersionRank(
+    policy.recommendedSchemaVersion,
+    policy.supportedSchemaVersions
+  )
+  const minimumRank = schemaVersionRank(
+    policy.minimumSchemaVersion,
+    policy.supportedSchemaVersions
+  )
+
+  return versionRank >= minimumRank && versionRank < recommendedRank
+}
+
+function defaultValueMatchesFieldType(
+  fieldType: ModifiableFieldType,
+  defaultValue: unknown
+): boolean {
+  switch (fieldType) {
+    case 'string':
+      return typeof defaultValue === 'string'
+    case 'number':
+      return typeof defaultValue === 'number' && Number.isFinite(defaultValue)
+    case 'boolean':
+      return typeof defaultValue === 'boolean'
+    case 'string_array':
+      return (
+        Array.isArray(defaultValue) &&
+        defaultValue.every((entry) => typeof entry === 'string')
+      )
+    default: {
+      const exhaustive: never = fieldType
+      return exhaustive
+    }
+  }
+}
+
+function sortValidationIssues(issues: DataPackValidationIssue[]): DataPackValidationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortRemediationNotes(notes: DataPackRemediationNote[]): DataPackRemediationNote[] {
+  return [...notes].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.note.localeCompare(right.note)
+  })
+}
+
+function freezeValidationResult(
+  issues: DataPackValidationIssue[]
+): { readonly valid: boolean; readonly issues: readonly DataPackValidationIssue[] } {
+  const sortedIssues = sortValidationIssues(issues)
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function freezeDecision(decision: DataPackValidationDecision): DataPackValidationDecision {
+  return Object.freeze({
+    status: decision.status,
+    validationIssues: Object.freeze(decision.validationIssues),
+    reasonCodes: Object.freeze([...decision.reasonCodes]),
+    remediationNotes: Object.freeze(decision.remediationNotes),
+    packMetadata: decision.packMetadata ? Object.freeze({ ...decision.packMetadata }) : undefined,
+  })
+}
+
+function buildPackMetadata(
+  payload: ModifiableDataPackPayload,
+  packKind: ModifiableDataPackKind,
+  sectionCount: number
+): DataPackValidationMetadata {
+  return Object.freeze({
+    packId: normalizeToken(payload.packId),
+    schemaVersion: normalizeToken(payload.schemaVersion),
+    packKind,
+    authorRef: normalizeToken(payload.authorRef),
+    sectionCount,
+    issueLink: normalizeToken(payload.issueLink),
+  })
+}
+
+function collectValidationIssues(
+  payload: ModifiableDataPackPayload,
+  policy: ReturnType<typeof resolvePolicy>
+): DataPackValidationIssue[] {
+  const issues: DataPackValidationIssue[] = []
+  const packId = normalizeToken(payload.packId)
+  const schemaVersion = normalizeToken(payload.schemaVersion)
+  const packKindToken = normalizeToken(payload.packKind)
+  const sections = payload.modifiableSections
+
+  if (!packId) {
+    issues.push({
+      code: 'missing_pack_id',
+      severity: 'error',
+      detail: 'Modifiable data-pack payload is missing packId.',
+    })
+  }
+
+  if (!schemaVersion) {
+    issues.push({
+      code: 'missing_schema_version',
+      severity: 'error',
+      detail: 'Modifiable data-pack payload is missing schemaVersion.',
+    })
+  } else if (!isSupportedSchemaVersion(schemaVersion, policy.supportedSchemaVersions)) {
+    issues.push({
+      code: 'invalid_schema_version',
+      severity: 'error',
+      detail: `Modifiable data-pack payload has unsupported schemaVersion "${schemaVersion}".`,
+    })
+  }
+
+  if (!packKindToken) {
+    issues.push({
+      code: 'missing_pack_kind',
+      severity: 'error',
+      detail: 'Modifiable data-pack payload is missing packKind.',
+    })
+  } else if (!isModifiableDataPackKind(packKindToken)) {
+    issues.push({
+      code: 'invalid_pack_kind',
+      severity: 'error',
+      detail: `Modifiable data-pack payload has invalid packKind "${packKindToken}".`,
+    })
+  }
+
+  if (!Array.isArray(sections) || sections.length === 0) {
+    issues.push({
+      code: 'missing_modifiable_sections',
+      severity: 'error',
+      detail: 'Modifiable data-pack payload must include at least one modifiable section.',
+    })
+    return issues
+  }
+
+  const sectionKeys: string[] = []
+
+  for (const section of sections) {
+    if (!section || typeof section !== 'object' || Array.isArray(section)) {
+      issues.push({
+        code: 'invalid_modifiable_section_shape',
+        severity: 'error',
+        detail: 'Each modifiable section must be a plain object.',
+      })
+      continue
+    }
+
+    const sectionKey = normalizeToken(section.sectionKey)
+    const fieldTypeToken = normalizeToken(section.fieldType)
+
+    if (!sectionKey) {
+      issues.push({
+        code: 'missing_section_key',
+        severity: 'error',
+        detail: 'Each modifiable section must include a non-empty sectionKey.',
+      })
+    } else {
+      sectionKeys.push(sectionKey)
+    }
+
+    if (!fieldTypeToken) {
+      issues.push({
+        code: 'invalid_field_type',
+        severity: 'error',
+        detail: 'Each modifiable section must include a fieldType.',
+      })
+    } else if (!isModifiableFieldType(fieldTypeToken)) {
+      issues.push({
+        code: 'invalid_field_type',
+        severity: 'error',
+        detail: `Modifiable section has invalid fieldType "${fieldTypeToken}".`,
+      })
+    } else if (
+      section.defaultValue !== undefined &&
+      !defaultValueMatchesFieldType(fieldTypeToken, section.defaultValue)
+    ) {
+      issues.push({
+        code: 'default_value_type_mismatch',
+        severity: 'error',
+        detail: `Modifiable section "${sectionKey || '<unknown>'}" defaultValue does not match fieldType "${fieldTypeToken}".`,
+      })
+    }
+  }
+
+  const duplicateKeys = sectionKeys.filter(
+    (key, index) => sectionKeys.indexOf(key) !== index
+  )
+  const uniqueDuplicateKeys = [...new Set(duplicateKeys)].sort((left, right) =>
+    left.localeCompare(right)
+  )
+
+  for (const duplicateKey of uniqueDuplicateKeys) {
+    issues.push({
+      code: 'duplicate_section_keys',
+      severity: 'error',
+      detail: `Modifiable data-pack payload has duplicate sectionKey "${duplicateKey}".`,
+    })
+  }
+
+  return issues
+}
+
+function collectRemediationNotes(
+  payload: ModifiableDataPackPayload,
+  policy: ReturnType<typeof resolvePolicy>
+): DataPackRemediationNote[] {
+  const schemaVersion = normalizeToken(payload.schemaVersion)
+
+  if (!schemaVersion || !isBorderlineSchemaVersion(schemaVersion, policy)) {
+    return []
+  }
+
+  return sortRemediationNotes([
+    {
+      code: 'schema_version_borderline',
+      note: `Schema version "${schemaVersion}" is below recommended "${policy.recommendedSchemaVersion}"; upgrade pack schema before applying modifiable sections.`,
+    },
+  ])
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validateModifiableDataPackPayload(
+  payload?: ModifiableDataPackPayload,
+  policy?: DataPackValidationPolicy
+): { readonly valid: boolean; readonly issues: readonly DataPackValidationIssue[] } {
+  const resolvedPolicy = resolvePolicy(policy)
+
+  if (!payload || typeof payload !== 'object') {
+    return freezeValidationResult([
+      {
+        code: 'invalid_payload',
+        severity: 'error',
+        detail: 'Modifiable data-pack payload must be an object.',
+      },
+    ])
+  }
+
+  return freezeValidationResult(collectValidationIssues(payload, resolvedPolicy))
+}
+
+/**
+ * SPE-75 follow-up baseline: deterministic modifiable data-pack schema validation
+ * with safe-fail on corrupt structure — no persistence or publish side effects.
+ */
+export function evaluateModifiableDataPackValidation(
+  payload?: ModifiableDataPackPayload,
+  policy?: DataPackValidationPolicy
+): DataPackValidationDecision {
+  const resolvedPolicy = resolvePolicy(policy)
+  const validation = validateModifiableDataPackPayload(payload, policy)
+
+  if (!validation.valid) {
+    const reasonCodes = [...new Set(validation.issues.map((issue) => issue.code))].sort(
+      (left, right) => left.localeCompare(right)
+    )
+
+    return freezeDecision({
+      status: 'rejected',
+      validationIssues: validation.issues,
+      reasonCodes,
+      remediationNotes: Object.freeze([]),
+    })
+  }
+
+  const packKind = normalizeToken(payload!.packKind) as ModifiableDataPackKind
+  const sectionCount = payload!.modifiableSections!.length
+  const remediationNotes = collectRemediationNotes(payload!, resolvedPolicy)
+
+  if (remediationNotes.length > 0) {
+    const reasonCodes = remediationNotes
+      .map((note) => note.code)
+      .sort((left, right) => left.localeCompare(right))
+
+    return freezeDecision({
+      status: 'needs_revision',
+      validationIssues: Object.freeze([]),
+      reasonCodes,
+      remediationNotes: Object.freeze(remediationNotes.map((note) => Object.freeze({ ...note }))),
+      packMetadata: buildPackMetadata(payload!, packKind, sectionCount),
+    })
+  }
+
+  return freezeDecision({
+    status: 'applied',
+    validationIssues: Object.freeze([]),
+    reasonCodes: Object.freeze([]),
+    remediationNotes: Object.freeze([]),
+    packMetadata: buildPackMetadata(payload!, packKind, sectionCount),
+  })
+}

--- a/src/test/modifiableDataPackValidation.test.ts
+++ b/src/test/modifiableDataPackValidation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BORDERLINE_SCHEMA_DATA_PACK_FIXTURE,
+  CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE,
+  evaluateModifiableDataPackValidation,
+  INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+  PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE,
+  validateModifiableDataPackPayload,
+} from '../domain/modifiableDataPackValidation'
+
+describe('modifiableDataPackValidation (SPE-2479 slice 1)', () => {
+  it('applies the canonical data-pack fixture with stable pack metadata', () => {
+    const decision = evaluateModifiableDataPackValidation(CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE)
+
+    expect(decision.status).toBe('applied')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual([])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.packMetadata).toEqual({
+      packId: 'datapack:tuning-containment-thresholds',
+      schemaVersion: '1.1.0',
+      packKind: 'tuning_table',
+      authorRef: 'contributor:agent-maintainer',
+      sectionCount: 3,
+      issueLink: 'SPE-2479',
+    })
+  })
+
+  it('rejects corrupt structure with deterministic reason codes', () => {
+    const decision = evaluateModifiableDataPackValidation(INVALID_MODIFIABLE_DATA_PACK_FIXTURE)
+
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual([
+      'default_value_type_mismatch',
+      'duplicate_section_keys',
+      'invalid_field_type',
+      'invalid_modifiable_section_shape',
+      'invalid_pack_kind',
+      'invalid_schema_version',
+      'missing_pack_id',
+    ])
+    expect(decision.validationIssues.map((issue) => issue.code)).toEqual(decision.reasonCodes)
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.packMetadata).toBeUndefined()
+  })
+
+  it('rejects partial schema payloads with missing required section keys', () => {
+    const decision = evaluateModifiableDataPackValidation(PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE)
+
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['missing_section_key'])
+    expect(decision.packMetadata).toBeUndefined()
+  })
+
+  it('returns needs_revision for borderline schema versions', () => {
+    const decision = evaluateModifiableDataPackValidation(BORDERLINE_SCHEMA_DATA_PACK_FIXTURE)
+
+    expect(decision.status).toBe('needs_revision')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual(['schema_version_borderline'])
+    expect(decision.remediationNotes).toHaveLength(1)
+    expect(decision.remediationNotes[0]?.code).toBe('schema_version_borderline')
+    expect(decision.packMetadata).toEqual({
+      packId: 'datapack:reference-sheet-borderline',
+      schemaVersion: '1.0.0',
+      packKind: 'reference_sheet',
+      authorRef: 'contributor:community-author',
+      sectionCount: 2,
+      issueLink: 'SPE-75',
+    })
+  })
+
+  it('safe-fails malformed payloads without throw', () => {
+    const validation = validateModifiableDataPackPayload(null as unknown as never)
+    const decision = evaluateModifiableDataPackValidation(undefined as unknown as never)
+
+    expect(validation.valid).toBe(false)
+    expect(validation.issues[0]?.code).toBe('invalid_payload')
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['invalid_payload'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const payloads = [
+      CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE,
+      BORDERLINE_SCHEMA_DATA_PACK_FIXTURE,
+      INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+      PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE,
+    ] as const
+
+    for (const payload of payloads) {
+      const first = evaluateModifiableDataPackValidation(payload)
+      const second = evaluateModifiableDataPackValidation(payload)
+
+      expect(first).toEqual(second)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/domain/modifiableDataPackValidation.ts` — pure deterministic schema-validation envelope for modifiable data packs (safe-fail on corrupt structure, borderline schema version → `needs_revision`).
- Add targeted tests + fixtures in `src/test/modifiableDataPackValidation.test.ts`.
- Add slice plan `planning/modifiable-data-pack-validation-slice-1.md` and backlog handoff; cross-ref in `docs/contribution-and-release-operations.md`.

## Linear mapping

- **Slice:** [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) — Modifiable data pack safe-fail validation (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — Contribution intake and modular release operations (remains open)
- **Child covered:** SPE-2479 only

## What shipped

Deterministic modifiable data-pack validation with section-shape checks, duplicate-key detection, field-type/default-value alignment, and borderline schema-version remediation — no UI, persistence, or publish side effects.

## Validation

- `npm run test:run -- src/test/modifiableDataPackValidation.test.ts`
- `npm run lint`

## Docs updated

- `planning/modifiable-data-pack-validation-slice-1.md` (new)
- `planning/backlog.md`
- `docs/contribution-and-release-operations.md`

## Parent status

SPE-75 remains **open** — publish-hooks follow-up still deferred.