### PR TITLE
feat(SPE-2480): publish automation and crediting hooks (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -53,6 +53,12 @@ Authoring tools and contribution pipelines may ship **modifiable data packs** (t
 
 Domain validation baseline: `src/domain/modifiableDataPackValidation.ts` (SPE-2479) accepts structured modifiable data-pack payloads and emits bounded schema-validation decisions with section-shape checks and borderline schema-version remediation — no publish side effects.
 
+## Publish automation and crediting hooks
+
+After packaging and governance gates pass, publish-intent evaluation composes crediting targets (CONTRIBUTORS, changelog entries, version bumps) and bounded publish channel hooks without executing publish actions.
+
+Domain publish baseline: `src/domain/publishAutomationCreditingHooks.ts` (SPE-2480) consumes packaged release envelopes plus applied governance metadata and crediting manifest inputs, emitting sorted crediting and publish hook descriptors — no publish execution side effects.
+
 ## Notation and docs standards
 
 - Prefer **issue IDs** (SPE-\*) in commit and PR titles when mandated by team workflow.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,9 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** SPE-75 publish-hooks follow-up child or backlog grooming when unblocked work is identified; mission triage full refresh remains **blocked**.
+**Next implementation (unblocked):** [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) publish automation and crediting hooks (slice 1) — in flight; mission triage full refresh remains **blocked**.
+
+**In progress:** [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) publish automation and crediting hooks (slice 1) — deterministic publish-intent envelope under SPE-75; branch `spe-75-publish-automation-crediting-hooks-slice-1` @ `2a56d78c`.
 
 **Recently shipped:** [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) modifiable data pack safe-fail validation (slice 1) — deterministic schema-validation envelope with section-shape checks; branch `spe-75-modifiable-data-pack-validation-slice-1` (PR #2877 @ `cb4ea3ae`).
 
@@ -38,9 +40,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** remaining SPE-75 follow-up (publish hooks) deferred per `planning/modifiable-data-pack-validation-slice-1.md` ## Deferred; mission triage full refresh remains **blocked**.
+**Next step:** SPE-2480 publish-hooks slice in flight (`planning/publish-automation-crediting-hooks-slice-1.md`); mission triage full refresh remains **blocked**.
 
-**Base `main` SHA:** `cb4ea3ae` — post SPE-2479 modifiable data pack safe-fail validation merge (PR #2877).
+**Base `main` SHA:** `2a56d78c` — pre SPE-2480 publish automation and crediting hooks slice.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -202,6 +204,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `minor-anomaly-item-registry-slice-2.md`                  | **Shipped**    | SPE-2314 / PR #2492; `minorAnomalyItemRecords` GameState persistence.                                                                               |
 | `minor-anomaly-item-registry-slice-3.md`                  | **Shipped**    | SPE-2316 / PR #2496 — weekly disposition/custody advance hook for SPE-2104.                                                                         |
 | `modifiable-data-pack-validation-slice-1.md`              | **Shipped**    | [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) — deterministic modifiable data-pack schema validation under SPE-75; PR #2877 @ `cb4ea3ae`. |
+| `publish-automation-crediting-hooks-slice-1.md`           | **In Progress** | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; branch `spe-75-publish-automation-crediting-hooks-slice-1` @ `2a56d78c`. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/publish-automation-crediting-hooks-slice-1.md
+++ b/planning/publish-automation-crediting-hooks-slice-1.md
@@ -1,0 +1,74 @@
+# SPE-75 — Publish automation and crediting hooks (slice 1)
+
+One-page implementation plan. Linear: [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Natural continuation after [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) per `planning/modifiable-data-pack-validation-slice-1.md` ## Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2480 — Publish automation and crediting hooks (slice 1)](https://linear.app/spectranoir/issue/SPE-2480) |
+| **Status** | **In Progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent remains open until publish-hooks slice ships |
+| **Branch** | `spe-75-publish-automation-crediting-hooks-slice-1` |
+| **Base `main` SHA** | `2a56d78c` |
+
+## Goal
+
+Implement a pure domain module that composes packaged release, applied governance, and crediting manifest inputs into a bounded publish-intent decision (crediting metadata, changelog targets, release manifest hooks) without actual publish execution, UI, or GameState persistence writes.
+
+## Prerequisite (on `main`)
+
+| Existing surface | Anchor |
+| ---------------- | ------ |
+| Packaged release envelope | `src/domain/modularReleasePackaging.ts` (SPE-2475) |
+| Applied governance metadata | `src/domain/submissionGovernanceRights.ts` (SPE-2478) |
+| Accepted curation chain | `src/domain/contributionIntakeCuration.ts` (SPE-2474) |
+| Projection test style | `src/test/modularReleasePackaging.test.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| New pure domain module for publish-intent + crediting hook envelopes | Actual publish execution or CI automation |
+| Packaged-only + applied-governance upstream gates | Route/UI/persistence changes |
+| Deterministic crediting and publish hook descriptors | Modifiable data-pack runtime import wiring |
+| Targeted unit tests + fixtures | Mission triage (blocked) |
+| | Changes to upstream curation/packaging/governance modules beyond read-only composition |
+
+## Publish contract
+
+- **Packaged-only gate** — non-packaged release envelopes reject before crediting evaluation.
+- **Applied-governance gate** — non-applied governance decisions reject before crediting evaluation.
+- **Pure deterministic evaluation** — same upstream envelopes + manifest yields byte-identical decision.
+- **Safe-fail validation** — malformed upstream or manifest payloads return structured errors, never throw during normal evaluation.
+- **Bounded statuses** — only `ready_to_publish`, `needs_revision`, `rejected` in this slice.
+- **Sorted hook descriptors** — hook kind then target then payload, localeCompare.
+- **No side effects** — no persistence changes, no route/UI requirements, no publish execution.
+
+## Acceptance
+
+- [x] Canonical upstream fixture chain returns `ready_to_publish` with stable crediting and publish hooks.
+- [x] Non-packaged release or non-applied governance returns `rejected` with deterministic reason codes.
+- [x] Borderline crediting manifest returns `needs_revision` with bounded remediation notes.
+- [x] Repeated evaluations are byte-identical for the same input set.
+- [x] Targeted tests + lint green.
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publishAutomationCreditingHooks.ts` |
+| Tests  | `src/test/publishAutomationCreditingHooks.test.ts` |
+| Plan   | `planning/publish-automation-crediting-hooks-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Runtime publish executor / CI wiring | SPE-75 follow-up child | Requires automation integration beyond hook envelope |
+| GameState persistence for publish queue | SPE-75 follow-up child | Out of pure domain boundary |
+
+## See also
+
+- `planning/modifiable-data-pack-validation-slice-1.md`
+- `docs/contribution-and-release-operations.md`
+- `planning/backlog.md`

--- a/src/domain/publishAutomationCreditingHooks.ts
+++ b/src/domain/publishAutomationCreditingHooks.ts
@@ -1,0 +1,682 @@
+/**
+ * SPE-2480 slice 1: publish automation and crediting hooks.
+ *
+ * Pure deterministic post-packaging publish-intent evaluation that composes
+ * packaged release envelopes, applied governance metadata, and crediting
+ * manifest inputs into bounded hook descriptors — no publish execution,
+ * UI, or persistence writes.
+ */
+
+import type { ReleasePackageEnvelope } from './modularReleasePackaging'
+import type {
+  GovernanceApplicationDecision,
+  SubmissionGovernanceMetadata,
+} from './submissionGovernanceRights'
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type PublishAutomationStatus = 'ready_to_publish' | 'needs_revision' | 'rejected'
+
+export const PUBLISH_AUTOMATION_STATUSES: readonly PublishAutomationStatus[] = [
+  'ready_to_publish',
+  'needs_revision',
+  'rejected',
+] as const
+
+export type CreditingHookKind =
+  | 'contributor_credit'
+  | 'changelog_entry'
+  | 'attribution_target'
+  | 'version_bump'
+
+export const CREDITING_HOOK_KINDS: readonly CreditingHookKind[] = [
+  'contributor_credit',
+  'changelog_entry',
+  'attribution_target',
+  'version_bump',
+] as const
+
+export type PublishHookKind = 'publish_channel' | 'announcement_segment'
+
+export const PUBLISH_HOOK_KINDS: readonly PublishHookKind[] = [
+  'publish_channel',
+  'announcement_segment',
+] as const
+
+export type PublishAutomationValidationCode =
+  | 'invalid_upstream_envelope'
+  | 'release_not_packaged'
+  | 'governance_not_applied'
+  | 'missing_governance_metadata'
+  | 'invalid_crediting_manifest'
+  | 'missing_version_bump_ref'
+  | 'missing_changelog_entry'
+  | 'missing_contributor_credit_refs'
+  | 'missing_crediting_targets'
+  | 'missing_publish_channel'
+
+export type PublishAutomationRemediationCode =
+  | 'announcement_segments_recommended'
+  | 'crediting_targets_borderline'
+
+export type PublishAutomationReasonCode =
+  | PublishAutomationValidationCode
+  | PublishAutomationRemediationCode
+
+// ---------------------------------------------------------------------------
+// Payload, policy, and envelopes
+// ---------------------------------------------------------------------------
+
+export interface PublishCreditingManifest {
+  readonly versionBumpRef?: string
+  readonly changelogEntry?: string
+  readonly contributorCreditRefs?: readonly string[]
+  readonly creditingTargets?: readonly string[]
+  readonly publishChannel?: string
+  readonly announcementSegments?: readonly string[]
+}
+
+export interface PublishAutomationPolicy {
+  readonly minimumCreditingTargetCount?: number
+  readonly recommendedCreditingTargetCount?: number
+}
+
+export interface PublishAutomationValidationIssue {
+  readonly code: PublishAutomationValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface PublishAutomationRemediationNote {
+  readonly code: PublishAutomationRemediationCode
+  readonly note: string
+}
+
+export interface CreditingHookDescriptor {
+  readonly kind: CreditingHookKind
+  readonly target: string
+  readonly payload: string
+}
+
+export interface PublishHookDescriptor {
+  readonly kind: PublishHookKind
+  readonly target: string
+  readonly payload: string
+}
+
+export interface PublishAutomationMetadata {
+  readonly versionBumpRef: string
+  readonly publishChannel: string
+  readonly contributorRef: string
+  readonly rightsTier: string
+  readonly artifactType: string
+  readonly creditingTargetCount: number
+}
+
+export interface PublishAutomationDecision {
+  readonly status: PublishAutomationStatus
+  readonly creditingHooks: readonly CreditingHookDescriptor[]
+  readonly publishHooks: readonly PublishHookDescriptor[]
+  readonly validationIssues: readonly PublishAutomationValidationIssue[]
+  readonly reasonCodes: readonly PublishAutomationReasonCode[]
+  readonly remediationNotes: readonly PublishAutomationRemediationNote[]
+  readonly publishMetadata?: PublishAutomationMetadata
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const CREDITING_HOOK_KIND_SET = new Set<string>(CREDITING_HOOK_KINDS)
+const PUBLISH_HOOK_KIND_SET = new Set<string>(PUBLISH_HOOK_KINDS)
+
+const DEFAULT_POLICY: Required<PublishAutomationPolicy> = {
+  minimumCreditingTargetCount: 1,
+  recommendedCreditingTargetCount: 2,
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE: PublishCreditingManifest = Object.freeze({
+  versionBumpRef: 'package.json:version',
+  changelogEntry:
+    'Add publish automation and crediting hooks baseline for SPE-75 contribution pipeline.',
+  contributorCreditRefs: Object.freeze([
+    'contributor:agent-maintainer',
+    'contributor:release-bot',
+  ]),
+  creditingTargets: Object.freeze(['CONTRIBUTORS', 'CHANGELOG.md']),
+  publishChannel: 'pr-merge',
+  announcementSegments: Object.freeze([
+    'domain-release',
+    'agent-packaging-pipeline',
+  ]),
+})
+
+export const BORDERLINE_PUBLISH_CREDITING_MANIFEST_FIXTURE: PublishCreditingManifest = Object.freeze({
+  versionBumpRef: 'package.json:version',
+  changelogEntry: 'Borderline crediting manifest awaiting expanded attribution targets.',
+  contributorCreditRefs: Object.freeze(['contributor:community-contributor']),
+  creditingTargets: Object.freeze(['CHANGELOG.md']),
+  publishChannel: 'pr-merge',
+})
+
+export const INVALID_PUBLISH_CREDITING_MANIFEST_FIXTURE: PublishCreditingManifest = Object.freeze({
+  versionBumpRef: '',
+  changelogEntry: '',
+  contributorCreditRefs: Object.freeze([]),
+  creditingTargets: Object.freeze([]),
+  publishChannel: '',
+})
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isPublishAutomationStatus(value: string): value is PublishAutomationStatus {
+  return PUBLISH_AUTOMATION_STATUSES.includes(value as PublishAutomationStatus)
+}
+
+export function isCreditingHookKind(value: string): value is CreditingHookKind {
+  return CREDITING_HOOK_KIND_SET.has(value)
+}
+
+export function isPublishHookKind(value: string): value is PublishHookKind {
+  return PUBLISH_HOOK_KIND_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function asStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((entry) => normalizeToken(entry))
+    .filter((entry) => entry.length > 0)
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function resolvePolicy(policy?: PublishAutomationPolicy): Required<PublishAutomationPolicy> {
+  return {
+    minimumCreditingTargetCount:
+      policy?.minimumCreditingTargetCount ?? DEFAULT_POLICY.minimumCreditingTargetCount,
+    recommendedCreditingTargetCount:
+      policy?.recommendedCreditingTargetCount ?? DEFAULT_POLICY.recommendedCreditingTargetCount,
+  }
+}
+
+function sortValidationIssues(
+  issues: PublishAutomationValidationIssue[]
+): PublishAutomationValidationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortRemediationNotes(
+  notes: PublishAutomationRemediationNote[]
+): PublishAutomationRemediationNote[] {
+  return [...notes].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.note.localeCompare(right.note)
+  })
+}
+
+function sortCreditingHooks(hooks: CreditingHookDescriptor[]): CreditingHookDescriptor[] {
+  return [...hooks].sort((left, right) => {
+    const kindOrder = left.kind.localeCompare(right.kind)
+    if (kindOrder !== 0) {
+      return kindOrder
+    }
+
+    const targetOrder = left.target.localeCompare(right.target)
+    if (targetOrder !== 0) {
+      return targetOrder
+    }
+
+    return left.payload.localeCompare(right.payload)
+  })
+}
+
+function sortPublishHooks(hooks: PublishHookDescriptor[]): PublishHookDescriptor[] {
+  return [...hooks].sort((left, right) => {
+    const kindOrder = left.kind.localeCompare(right.kind)
+    if (kindOrder !== 0) {
+      return kindOrder
+    }
+
+    const targetOrder = left.target.localeCompare(right.target)
+    if (targetOrder !== 0) {
+      return targetOrder
+    }
+
+    return left.payload.localeCompare(right.payload)
+  })
+}
+
+function freezeValidationResult(
+  issues: PublishAutomationValidationIssue[]
+): { readonly valid: boolean; readonly issues: readonly PublishAutomationValidationIssue[] } {
+  const sortedIssues = sortValidationIssues(issues)
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function freezeDecision(decision: PublishAutomationDecision): PublishAutomationDecision {
+  return Object.freeze({
+    status: decision.status,
+    creditingHooks: Object.freeze(
+      decision.creditingHooks.map((hook) => Object.freeze({ ...hook }))
+    ),
+    publishHooks: Object.freeze(decision.publishHooks.map((hook) => Object.freeze({ ...hook }))),
+    validationIssues: Object.freeze(decision.validationIssues),
+    reasonCodes: Object.freeze([...decision.reasonCodes]),
+    remediationNotes: Object.freeze(decision.remediationNotes),
+    publishMetadata: decision.publishMetadata
+      ? Object.freeze({ ...decision.publishMetadata })
+      : undefined,
+  })
+}
+
+function validateReleaseGate(
+  releasePackage: ReleasePackageEnvelope | undefined
+): PublishAutomationValidationIssue[] {
+  if (!releasePackage || typeof releasePackage !== 'object') {
+    return [
+      {
+        code: 'invalid_upstream_envelope',
+        severity: 'error',
+        detail: 'Publish automation requires a release package envelope object.',
+      },
+    ]
+  }
+
+  if (releasePackage.status !== 'packaged') {
+    return [
+      {
+        code: 'release_not_packaged',
+        severity: 'error',
+        detail: `Publish automation requires packaged release status; received "${releasePackage.status}".`,
+      },
+    ]
+  }
+
+  if (!releasePackage.artifactType) {
+    return [
+      {
+        code: 'invalid_upstream_envelope',
+        severity: 'error',
+        detail: 'Packaged release envelopes must include artifactType for publish hook composition.',
+      },
+    ]
+  }
+
+  return []
+}
+
+function validateGovernanceGate(
+  governanceDecision: GovernanceApplicationDecision | undefined
+): PublishAutomationValidationIssue[] {
+  if (!governanceDecision || typeof governanceDecision !== 'object') {
+    return [
+      {
+        code: 'invalid_upstream_envelope',
+        severity: 'error',
+        detail: 'Publish automation requires a governance application decision object.',
+      },
+    ]
+  }
+
+  if (governanceDecision.status !== 'applied') {
+    return [
+      {
+        code: 'governance_not_applied',
+        severity: 'error',
+        detail: `Publish automation requires applied governance status; received "${governanceDecision.status}".`,
+      },
+    ]
+  }
+
+  if (!governanceDecision.governanceMetadata) {
+    return [
+      {
+        code: 'missing_governance_metadata',
+        severity: 'error',
+        detail: 'Applied governance decisions must include governanceMetadata for crediting hooks.',
+      },
+    ]
+  }
+
+  return []
+}
+
+function validateCreditingManifestShape(
+  manifest: unknown
+): PublishAutomationValidationIssue[] {
+  if (!manifest || typeof manifest !== 'object') {
+    return [
+      {
+        code: 'invalid_crediting_manifest',
+        severity: 'error',
+        detail: 'Publish crediting manifest must be an object.',
+      },
+    ]
+  }
+
+  return []
+}
+
+function collectManifestIssues(
+  manifest: PublishCreditingManifest
+): PublishAutomationValidationIssue[] {
+  const issues: PublishAutomationValidationIssue[] = []
+  const versionBumpRef = normalizeToken(manifest.versionBumpRef)
+  const changelogEntry = normalizeToken(manifest.changelogEntry)
+  const contributorCreditRefs = asStringArray(manifest.contributorCreditRefs)
+  const creditingTargets = asStringArray(manifest.creditingTargets)
+  const publishChannel = normalizeToken(manifest.publishChannel)
+
+  if (!versionBumpRef) {
+    issues.push({
+      code: 'missing_version_bump_ref',
+      severity: 'error',
+      detail: 'Publish crediting manifest must declare versionBumpRef.',
+    })
+  }
+
+  if (!changelogEntry) {
+    issues.push({
+      code: 'missing_changelog_entry',
+      severity: 'error',
+      detail: 'Publish crediting manifest must declare changelogEntry.',
+    })
+  }
+
+  if (contributorCreditRefs.length === 0) {
+    issues.push({
+      code: 'missing_contributor_credit_refs',
+      severity: 'error',
+      detail: 'Publish crediting manifest must declare at least one contributorCreditRef.',
+    })
+  }
+
+  if (creditingTargets.length === 0) {
+    issues.push({
+      code: 'missing_crediting_targets',
+      severity: 'error',
+      detail: 'Publish crediting manifest must declare at least one creditingTarget.',
+    })
+  }
+
+  if (!publishChannel) {
+    issues.push({
+      code: 'missing_publish_channel',
+      severity: 'error',
+      detail: 'Publish crediting manifest must declare publishChannel.',
+    })
+  }
+
+  return issues
+}
+
+function collectRemediationNotes(
+  manifest: PublishCreditingManifest,
+  policy: Required<PublishAutomationPolicy>
+): PublishAutomationRemediationNote[] {
+  const notes: PublishAutomationRemediationNote[] = []
+  const creditingTargets = asStringArray(manifest.creditingTargets)
+  const announcementSegments = asStringArray(manifest.announcementSegments)
+
+  if (
+    creditingTargets.length >= policy.minimumCreditingTargetCount &&
+    creditingTargets.length < policy.recommendedCreditingTargetCount
+  ) {
+    notes.push({
+      code: 'crediting_targets_borderline',
+      note: `Declare at least ${policy.recommendedCreditingTargetCount} crediting targets (for example CONTRIBUTORS and CHANGELOG.md) before publish automation can fully apply.`,
+    })
+  }
+
+  if (announcementSegments.length === 0) {
+    notes.push({
+      code: 'announcement_segments_recommended',
+      note: 'Add announcementSegments so segmented publish channels receive bounded release copy.',
+    })
+  }
+
+  return sortRemediationNotes(notes)
+}
+
+function buildCreditingHooks(
+  manifest: PublishCreditingManifest,
+  governanceMetadata: SubmissionGovernanceMetadata
+): CreditingHookDescriptor[] {
+  const hooks: CreditingHookDescriptor[] = []
+  const versionBumpRef = normalizeToken(manifest.versionBumpRef)
+  const changelogEntry = normalizeToken(manifest.changelogEntry)
+  const contributorCreditRefs = asStringArray(manifest.contributorCreditRefs)
+  const creditingTargets = asStringArray(manifest.creditingTargets)
+
+  if (versionBumpRef) {
+    hooks.push({
+      kind: 'version_bump',
+      target: versionBumpRef,
+      payload: `bump:${versionBumpRef}`,
+    })
+  }
+
+  if (changelogEntry) {
+    hooks.push({
+      kind: 'changelog_entry',
+      target: 'CHANGELOG.md',
+      payload: changelogEntry,
+    })
+  }
+
+  for (const creditRef of contributorCreditRefs) {
+    hooks.push({
+      kind: 'contributor_credit',
+      target: creditRef,
+      payload: governanceMetadata.attributionStatement,
+    })
+  }
+
+  for (const target of creditingTargets) {
+    hooks.push({
+      kind: 'attribution_target',
+      target,
+      payload: `${governanceMetadata.contributorRef}:${governanceMetadata.rightsTier}`,
+    })
+  }
+
+  return sortCreditingHooks(hooks)
+}
+
+function buildPublishHooks(manifest: PublishCreditingManifest): PublishHookDescriptor[] {
+  const hooks: PublishHookDescriptor[] = []
+  const publishChannel = normalizeToken(manifest.publishChannel)
+  const announcementSegments = asStringArray(manifest.announcementSegments)
+
+  if (publishChannel) {
+    hooks.push({
+      kind: 'publish_channel',
+      target: publishChannel,
+      payload: `channel:${publishChannel}`,
+    })
+  }
+
+  for (const segment of announcementSegments) {
+    hooks.push({
+      kind: 'announcement_segment',
+      target: segment,
+      payload: `segment:${segment}`,
+    })
+  }
+
+  return sortPublishHooks(hooks)
+}
+
+function buildPublishMetadata(
+  manifest: PublishCreditingManifest,
+  governanceMetadata: SubmissionGovernanceMetadata,
+  artifactType: string
+): PublishAutomationMetadata {
+  return Object.freeze({
+    versionBumpRef: normalizeToken(manifest.versionBumpRef),
+    publishChannel: normalizeToken(manifest.publishChannel),
+    contributorRef: governanceMetadata.contributorRef,
+    rightsTier: governanceMetadata.rightsTier,
+    artifactType,
+    creditingTargetCount: asStringArray(manifest.creditingTargets).length,
+  })
+}
+
+function rejectDecision(
+  issues: PublishAutomationValidationIssue[]
+): PublishAutomationDecision {
+  const sortedIssues = sortValidationIssues(issues)
+  const reasonCodes = [...new Set(sortedIssues.map((issue) => issue.code))].sort((left, right) =>
+    left.localeCompare(right)
+  )
+
+  return freezeDecision({
+    status: 'rejected',
+    creditingHooks: Object.freeze([]),
+    publishHooks: Object.freeze([]),
+    validationIssues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+    reasonCodes,
+    remediationNotes: Object.freeze([]),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function validatePublishAutomationInputs(
+  releasePackage?: ReleasePackageEnvelope,
+  governanceDecision?: GovernanceApplicationDecision,
+  creditingManifest?: PublishCreditingManifest
+): { readonly valid: boolean; readonly issues: readonly PublishAutomationValidationIssue[] } {
+  const releaseIssues = validateReleaseGate(releasePackage)
+  if (releaseIssues.length > 0) {
+    return freezeValidationResult(releaseIssues)
+  }
+
+  const governanceIssues = validateGovernanceGate(governanceDecision)
+  if (governanceIssues.length > 0) {
+    return freezeValidationResult(governanceIssues)
+  }
+
+  const shapeIssues = validateCreditingManifestShape(creditingManifest)
+  if (shapeIssues.length > 0) {
+    return freezeValidationResult(shapeIssues)
+  }
+
+  return freezeValidationResult(collectManifestIssues(creditingManifest!))
+}
+
+/**
+ * SPE-75 follow-up baseline: deterministic publish-intent evaluation with
+ * bounded crediting and publish hook descriptors — no publish execution.
+ */
+export function evaluatePublishAutomationCreditingHooks(
+  releasePackage?: ReleasePackageEnvelope,
+  governanceDecision?: GovernanceApplicationDecision,
+  creditingManifest?: PublishCreditingManifest,
+  policy?: PublishAutomationPolicy
+): PublishAutomationDecision {
+  const resolvedPolicy = resolvePolicy(policy)
+
+  const releaseIssues = validateReleaseGate(releasePackage)
+  if (releaseIssues.length > 0) {
+    return rejectDecision(releaseIssues)
+  }
+
+  const governanceIssues = validateGovernanceGate(governanceDecision)
+  if (governanceIssues.length > 0) {
+    return rejectDecision(governanceIssues)
+  }
+
+  const shapeIssues = validateCreditingManifestShape(creditingManifest)
+  if (shapeIssues.length > 0) {
+    return rejectDecision(shapeIssues)
+  }
+
+  const manifestIssues = collectManifestIssues(creditingManifest!)
+  if (manifestIssues.length > 0) {
+    return rejectDecision(manifestIssues)
+  }
+
+  const governanceMetadata = governanceDecision!.governanceMetadata!
+  const artifactType = releasePackage!.artifactType!
+  const remediationNotes = sortRemediationNotes(
+    collectRemediationNotes(creditingManifest!, resolvedPolicy)
+  )
+
+  if (remediationNotes.length > 0) {
+    const reasonCodes = remediationNotes
+      .map((note) => note.code)
+      .sort((left, right) => left.localeCompare(right))
+
+    return freezeDecision({
+      status: 'needs_revision',
+      creditingHooks: Object.freeze(
+        buildCreditingHooks(creditingManifest!, governanceMetadata).map((hook) =>
+          Object.freeze({ ...hook })
+        )
+      ),
+      publishHooks: Object.freeze(
+        buildPublishHooks(creditingManifest!).map((hook) => Object.freeze({ ...hook }))
+      ),
+      validationIssues: Object.freeze([]),
+      reasonCodes,
+      remediationNotes: Object.freeze(remediationNotes.map((note) => Object.freeze({ ...note }))),
+      publishMetadata: buildPublishMetadata(
+        creditingManifest!,
+        governanceMetadata,
+        artifactType
+      ),
+    })
+  }
+
+  return freezeDecision({
+    status: 'ready_to_publish',
+    creditingHooks: Object.freeze(
+      buildCreditingHooks(creditingManifest!, governanceMetadata).map((hook) =>
+        Object.freeze({ ...hook })
+      )
+    ),
+    publishHooks: Object.freeze(
+      buildPublishHooks(creditingManifest!).map((hook) => Object.freeze({ ...hook }))
+    ),
+    validationIssues: Object.freeze([]),
+    reasonCodes: Object.freeze([]),
+    remediationNotes: Object.freeze([]),
+    publishMetadata: buildPublishMetadata(creditingManifest!, governanceMetadata, artifactType),
+  })
+}

--- a/src/test/publishAutomationCreditingHooks.test.ts
+++ b/src/test/publishAutomationCreditingHooks.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+  evaluateContributionIntakeCuration,
+  INVALID_CONTRIBUTION_SUBMISSION_FIXTURE,
+} from '../domain/contributionIntakeCuration'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+  INVALID_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+} from '../domain/modularReleasePackaging'
+import {
+  BORDERLINE_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  evaluatePublishAutomationCreditingHooks,
+  INVALID_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  validatePublishAutomationInputs,
+} from '../domain/publishAutomationCreditingHooks'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+  MISSING_LICENSE_GOVERNANCE_FIXTURE,
+} from '../domain/submissionGovernanceRights'
+
+describe('publishAutomationCreditingHooks (SPE-2480 slice 1)', () => {
+  const acceptedCuration = evaluateContributionIntakeCuration(
+    CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE
+  )
+  const packagedRelease = evaluateModularReleasePackaging(
+    acceptedCuration,
+    CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+  )
+  const appliedGovernance = evaluateSubmissionGovernanceRights(
+    CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE
+  )
+
+  it('returns ready_to_publish for the canonical upstream fixture chain with stable hooks', () => {
+    const decision = evaluatePublishAutomationCreditingHooks(
+      packagedRelease,
+      appliedGovernance,
+      CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+    )
+
+    expect(decision.status).toBe('ready_to_publish')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual([])
+    expect(decision.remediationNotes).toEqual([])
+    expect(decision.publishMetadata).toEqual({
+      versionBumpRef: 'package.json:version',
+      publishChannel: 'pr-merge',
+      contributorRef: 'contributor:agent-maintainer',
+      rightsTier: 'canonical',
+      artifactType: 'domain_code_bundle',
+      creditingTargetCount: 2,
+    })
+    expect(decision.creditingHooks).toEqual([
+      {
+        kind: 'attribution_target',
+        target: 'CHANGELOG.md',
+        payload: 'contributor:agent-maintainer:canonical',
+      },
+      {
+        kind: 'attribution_target',
+        target: 'CONTRIBUTORS',
+        payload: 'contributor:agent-maintainer:canonical',
+      },
+      {
+        kind: 'changelog_entry',
+        target: 'CHANGELOG.md',
+        payload:
+          'Add publish automation and crediting hooks baseline for SPE-75 contribution pipeline.',
+      },
+      {
+        kind: 'contributor_credit',
+        target: 'contributor:agent-maintainer',
+        payload:
+          'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+      },
+      {
+        kind: 'contributor_credit',
+        target: 'contributor:release-bot',
+        payload:
+          'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+      },
+      {
+        kind: 'version_bump',
+        target: 'package.json:version',
+        payload: 'bump:package.json:version',
+      },
+    ])
+    expect(decision.publishHooks).toEqual([
+      {
+        kind: 'announcement_segment',
+        target: 'agent-packaging-pipeline',
+        payload: 'segment:agent-packaging-pipeline',
+      },
+      {
+        kind: 'announcement_segment',
+        target: 'domain-release',
+        payload: 'segment:domain-release',
+      },
+      {
+        kind: 'publish_channel',
+        target: 'pr-merge',
+        payload: 'channel:pr-merge',
+      },
+    ])
+  })
+
+  it('rejects non-packaged release and non-applied governance with deterministic reason codes', () => {
+    const rejectedCuration = evaluateContributionIntakeCuration(
+      INVALID_CONTRIBUTION_SUBMISSION_FIXTURE
+    )
+    const rejectedRelease = evaluateModularReleasePackaging(
+      rejectedCuration,
+      CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+
+    const rejectedReleaseDecision = evaluatePublishAutomationCreditingHooks(
+      rejectedRelease,
+      appliedGovernance,
+      CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+    )
+
+    expect(rejectedReleaseDecision.status).toBe('rejected')
+    expect(rejectedReleaseDecision.reasonCodes).toEqual(['release_not_packaged'])
+    expect(rejectedReleaseDecision.validationIssues[0]?.code).toBe('release_not_packaged')
+
+    const rejectedGovernance = evaluateSubmissionGovernanceRights(
+      MISSING_LICENSE_GOVERNANCE_FIXTURE
+    )
+    const rejectedGovernanceDecision = evaluatePublishAutomationCreditingHooks(
+      packagedRelease,
+      rejectedGovernance,
+      CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+    )
+
+    expect(rejectedGovernanceDecision.status).toBe('rejected')
+    expect(rejectedGovernanceDecision.reasonCodes).toEqual(['governance_not_applied'])
+    expect(rejectedGovernanceDecision.validationIssues[0]?.code).toBe('governance_not_applied')
+
+    const invalidManifestDecision = evaluatePublishAutomationCreditingHooks(
+      packagedRelease,
+      appliedGovernance,
+      INVALID_PUBLISH_CREDITING_MANIFEST_FIXTURE
+    )
+
+    expect(invalidManifestDecision.status).toBe('rejected')
+    expect(invalidManifestDecision.reasonCodes).toEqual([
+      'missing_changelog_entry',
+      'missing_contributor_credit_refs',
+      'missing_crediting_targets',
+      'missing_publish_channel',
+      'missing_version_bump_ref',
+    ])
+    expect(invalidManifestDecision.validationIssues.map((issue) => issue.code)).toEqual(
+      invalidManifestDecision.reasonCodes
+    )
+  })
+
+  it('returns needs_revision for the borderline crediting manifest with bounded remediation notes', () => {
+    const decision = evaluatePublishAutomationCreditingHooks(
+      packagedRelease,
+      appliedGovernance,
+      BORDERLINE_PUBLISH_CREDITING_MANIFEST_FIXTURE
+    )
+
+    expect(decision.status).toBe('needs_revision')
+    expect(decision.validationIssues).toEqual([])
+    expect(decision.reasonCodes).toEqual([
+      'announcement_segments_recommended',
+      'crediting_targets_borderline',
+    ])
+    expect(decision.remediationNotes).toHaveLength(2)
+    expect(decision.remediationNotes[0]?.code).toBe('announcement_segments_recommended')
+    expect(decision.remediationNotes[1]?.code).toBe('crediting_targets_borderline')
+    expect(decision.publishMetadata?.creditingTargetCount).toBe(1)
+    expect(decision.creditingHooks.length).toBeGreaterThan(0)
+    expect(decision.publishHooks).toEqual([
+      {
+        kind: 'publish_channel',
+        target: 'pr-merge',
+        payload: 'channel:pr-merge',
+      },
+    ])
+  })
+
+  it('safe-fails malformed upstream payloads without throw', () => {
+    const validation = validatePublishAutomationInputs(undefined, undefined, undefined)
+    const decision = evaluatePublishAutomationCreditingHooks(undefined, undefined, undefined)
+
+    expect(validation.valid).toBe(false)
+    expect(validation.issues[0]?.code).toBe('invalid_upstream_envelope')
+    expect(decision.status).toBe('rejected')
+    expect(decision.reasonCodes).toEqual(['invalid_upstream_envelope'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const notPackagedRelease = evaluateModularReleasePackaging(
+      acceptedCuration,
+      INVALID_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+    const rejectedGovernance = evaluateSubmissionGovernanceRights(
+      MISSING_LICENSE_GOVERNANCE_FIXTURE
+    )
+
+    const releasePackages = [packagedRelease, notPackagedRelease, packagedRelease] as const
+    const governanceDecisions = [appliedGovernance, appliedGovernance, rejectedGovernance] as const
+    const manifests = [
+      CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+      INVALID_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+      BORDERLINE_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+    ] as const
+
+    for (let index = 0; index < releasePackages.length; index += 1) {
+      const releasePackage = releasePackages[index]!
+      const governanceDecision = governanceDecisions[index]!
+      const manifest = manifests[index]!
+      const first = evaluatePublishAutomationCreditingHooks(
+        releasePackage,
+        governanceDecision,
+        manifest
+      )
+      const second = evaluatePublishAutomationCreditingHooks(
+        releasePackage,
+        governanceDecision,
+        manifest
+      )
+
+      expect(first).toEqual(second)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add src/domain/publishAutomationCreditingHooks.ts — pure deterministic publish-intent evaluation composing packaged release envelopes, applied governance metadata, and crediting manifest inputs into sorted crediting/publish hook descriptors (eady_to_publish | 
eeds_revision | ejected).
- Add targeted tests and fixtures in src/test/publishAutomationCreditingHooks.test.ts.
- Add slice plan planning/publish-automation-crediting-hooks-slice-1.md; update planning/backlog.md and cross-ref in docs/contribution-and-release-operations.md.

## Linear mapping

- **Slice:** [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — Publish automation and crediting hooks (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — Contribution intake and modular release operations (remains open until parent reconciliation after this slice)

## Validation

- 
pm run test:run -- src/test/publishAutomationCreditingHooks.test.ts — 5 tests pass
- 
pm run lint -- --max-warnings=0 src/domain/publishAutomationCreditingHooks.ts src/test/publishAutomationCreditingHooks.test.ts — green

## Docs updated

- planning/publish-automation-crediting-hooks-slice-1.md
- planning/backlog.md
- docs/contribution-and-release-operations.md

## Parent status

SPE-75 parent remains **In Progress** — publish-hooks was the remaining deferred follow-up from SPE-2474–2479; runtime publish executor and GameState wiring deferred per slice doc.

Made with [Cursor](https://cursor.com)