### PR TITLE
feat(SPE-2483): GameState publish-queue persistence (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -59,6 +59,8 @@ After packaging and governance gates pass, publish-intent evaluation composes cr
 
 Domain publish baseline: `src/domain/publishAutomationCreditingHooks.ts` (SPE-2480) consumes packaged release envelopes plus applied governance metadata and crediting manifest inputs, emitting sorted crediting and publish hook descriptors — no publish execution side effects.
 
+Publish-queue persistence (SPE-2483) stores bounded publish-intent snapshots on `GameState.publishQueueRecords` with sanitize/hydration on save import — still no publish execution.
+
 ## Notation and docs standards
 
 - Prefer **issue IDs** (SPE-\*) in commit and PR titles when mandated by team workflow.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -24,6 +24,8 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) publish automation and crediting hooks (slice 1) — deterministic publish-intent envelope with crediting/publish hook descriptors; branch `spe-75-publish-automation-crediting-hooks-slice-1` (PR #2879 @ `99161c79`).
 
+**In progress:** [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) GameState publish-queue persistence (slice 1) — `publishQueueRecords` sanitize/hydrate on GameState; branch `spe-75-publish-queue-persistence-slice-1`; see `planning/publish-queue-persistence-slice-1.md`.
+
 **Recently shipped:** [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) modifiable data pack safe-fail validation (slice 1) — deterministic schema-validation envelope with section-shape checks; branch `spe-75-modifiable-data-pack-validation-slice-1` (PR #2877 @ `cb4ea3ae`).
 
 **Recently shipped:** [SPE-2478](https://linear.app/spectranoir/issue/SPE-2478) submission governance and rights policy enforcement (slice 1) — deterministic rights tier discrimination with license/attribution policy; branch `spe-75-submission-governance-rights-slice-1` (PR #2875 @ `ad8f566e`).
@@ -49,7 +51,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 **§14-pass alternates (owner creates Linear child when starting):**
 
 1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — read-only `stabilityLayer.ts` category via `buildBranchContinuityRuntimeAuditSnapshot`; partial §14 (dev/stability tooling); see `planning/branch-continuity-runtime-hooks-slice-1.md` § Deferred.
-2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** runtime publish executor / CI wiring, GameState publish-queue persistence ([SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) deferred), or modifiable data-pack runtime import ([SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) deferred).
+2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** runtime publish executor / CI wiring, modifiable data-pack runtime import ([SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) deferred), or publish-queue UI/orchestration ([SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) persistence in flight).
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; no slice 5+ without fresh §14 pass — see `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md` § Deferred.
 
 **Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; runtime publish executor without owner-scoped child.
@@ -216,6 +218,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `minor-anomaly-item-registry-slice-3.md`                  | **Shipped**    | SPE-2316 / PR #2496 — weekly disposition/custody advance hook for SPE-2104.                                                                         |
 | `modifiable-data-pack-validation-slice-1.md`              | **Shipped**    | [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) — deterministic modifiable data-pack schema validation under SPE-75; PR #2877 @ `cb4ea3ae`. |
 | `publish-automation-crediting-hooks-slice-1.md`           | **Shipped**    | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; PR #2879 @ `99161c79`. |
+| `publish-queue-persistence-slice-1.md`                    | **In Progress** | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — `publishQueueRecords` GameState persistence under SPE-75. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/publish-automation-crediting-hooks-slice-1.md
+++ b/planning/publish-automation-crediting-hooks-slice-1.md
@@ -62,10 +62,10 @@ Implement a pure domain module that composes packaged release, applied governanc
 
 ## Deferred
 
-| Item | Owner | Why |
+| Item | Owner | Why deferred |
 | --- | --- | --- |
 | Runtime publish executor / CI wiring | SPE-75 follow-up child | Requires automation integration beyond hook envelope |
-| GameState persistence for publish queue | SPE-75 follow-up child | Out of pure domain boundary |
+| GameState persistence for publish queue | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) | Shipped in follow-up slice |
 
 ## See also
 

--- a/planning/publish-queue-persistence-slice-1.md
+++ b/planning/publish-queue-persistence-slice-1.md
@@ -1,0 +1,63 @@
+# SPE-75 — GameState publish-queue persistence (slice 1)
+
+One-page implementation plan. Linear: [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) per `planning/publish-automation-crediting-hooks-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2483 — GameState publish-queue persistence (slice 1)](https://linear.app/spectranoir/issue/SPE-2483) |
+| **Status** | **In Progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-publish-queue-persistence-slice-1` |
+| **Base `main` SHA** | `14b42088` |
+
+## Goal
+
+Persist validated publish-queue records on `GameState` with sanitize/hydration and save round-trip tests. Composes read-only with `publishAutomationCreditingHooks.ts` (SPE-2480). No runtime publish executor or UI.
+
+## Prerequisite (on `main` @ `14b42088`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Publish-intent module | `src/domain/publishAutomationCreditingHooks.ts` (SPE-2480) |
+| Registry persistence pattern | `planning/visual-trigger-hazard-registry-slice-2.md` (SPE-2336) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `publishQueueRecords` on `GameState` | Runtime publish executor / CI wiring |
+| `sanitizePublishQueueRecords` + `runTransfer` hydrate wire | Route/UI changes |
+| `composePublishQueueRecord` read-only from publish decisions | Mission triage (blocked) |
+| Default `{}` in `createStartingState` | SPE-947 / SPE-1046 parent changes |
+| Sanitize unit tests + save/import round-trip (byte-stable) | Registry slice 5+ |
+
+## Acceptance
+
+- [x] Valid fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id entries dropped safely on hydrate
+- [x] `composePublishQueueRecord` matches canonical fixture from upstream chain
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publishAutomationCreditingHooks.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/publishQueuePersistence.test.ts` |
+| Plan   | `planning/publish-queue-persistence-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Runtime publish executor / CI wiring | SPE-75 follow-up child | Requires automation integration beyond persistence |
+| Publish-queue UI / weekly orchestration | SPE-75 follow-up child | Persistence must land before surfacing |
+
+## See also
+
+- `planning/publish-automation-crediting-hooks-slice-1.md`
+- `planning/visual-trigger-hazard-registry-slice-2.md`
+- `planning/backlog.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -213,6 +213,7 @@ import {
   sanitizeCoverStoryWeeklyProjectionSnapshots,
 } from '../../domain/coverStoryLifecycleRegistry'
 import { sanitizePatternSourceSeriesRecords } from '../../domain/patternSourceSeriesRegistry'
+import { sanitizePublishQueueRecords } from '../../domain/publishAutomationCreditingHooks'
 import { sanitizeMassAnomalousPopulationEmergenceRecords } from '../../domain/massAnomalousPopulationEmergenceRegistry'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
@@ -8561,6 +8562,10 @@ export function hydrateGame(
     game.patternSourceSeriesRecords,
     fallback.patternSourceSeriesRecords ?? {}
   )
+  const publishQueueRecords = sanitizePublishQueueRecords(
+    game.publishQueueRecords,
+    fallback.publishQueueRecords ?? {}
+  )
   const massAnomalousPopulationEmergenceRecords =
     sanitizeMassAnomalousPopulationEmergenceRecords(
       game.massAnomalousPopulationEmergenceRecords,
@@ -8758,6 +8763,7 @@ export function hydrateGame(
       coverStoryRecords,
       coverStoryWeeklyProjectionSnapshots,
       patternSourceSeriesRecords,
+      publishQueueRecords,
       massAnomalousPopulationEmergenceRecords,
       visualTriggerHazardRecords,
       entityWelfareReclassificationRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -55,6 +55,7 @@ const startingStateTemplate: GameState = {
   coverStoryRecords: {},
   coverStoryWeeklyProjectionSnapshots: {},
   patternSourceSeriesRecords: {},
+  publishQueueRecords: {},
   massAnomalousPopulationEmergenceRecords: {},
   visualTriggerHazardRecords: {},
   entityWelfareReclassificationRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -267,6 +267,7 @@ import type {
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
+import type { PublishQueueRecord } from './publishAutomationCreditingHooks'
 import type { TherapeuticCareScheduleRecord } from './containedPersonTherapeuticCareRegistry'
 import type {
   CoerciveProtocolRecord,
@@ -2709,6 +2710,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   patternSourceSeriesRecords?: Record<string, PatternSourceSeriesRecord>
+
+  /**
+   * SPE-2483 slice 1: persisted publish-queue records (keyed by record id).
+   * Hydration drops invalid or duplicate-id entries without throwing.
+   */
+  publishQueueRecords?: Record<string, PublishQueueRecord>
 
   /**
    * SPE-2122 slice 2: persisted mass anomalous population emergence records (keyed by record id).

--- a/src/domain/publishAutomationCreditingHooks.ts
+++ b/src/domain/publishAutomationCreditingHooks.ts
@@ -680,3 +680,486 @@ export function evaluatePublishAutomationCreditingHooks(
     publishMetadata: buildPublishMetadata(creditingManifest!, governanceMetadata, artifactType),
   })
 }
+
+// ---------------------------------------------------------------------------
+// Publish queue persistence (SPE-2483 slice 1)
+// ---------------------------------------------------------------------------
+
+export type PublishQueueRecordId = string
+
+export interface PublishQueueRecord {
+  readonly id: PublishQueueRecordId
+  readonly label: string
+  readonly summary?: string
+  readonly queuedWeek?: number
+  readonly releaseArtifactRef: string
+  readonly status: PublishAutomationStatus
+  readonly creditingHooks: readonly CreditingHookDescriptor[]
+  readonly publishHooks: readonly PublishHookDescriptor[]
+  readonly reasonCodes: readonly PublishAutomationReasonCode[]
+  readonly publishMetadata?: PublishAutomationMetadata
+}
+
+export type PublishQueueRecordsMap = Record<PublishQueueRecordId, PublishQueueRecord>
+
+export type PublishQueueValidationCode =
+  | 'missing_id'
+  | 'missing_label'
+  | 'missing_release_artifact_ref'
+  | 'invalid_status'
+  | 'invalid_crediting_hook'
+  | 'invalid_publish_hook'
+  | 'invalid_reason_code'
+  | 'invalid_queued_week'
+  | 'invalid_publish_metadata'
+
+export interface PublishQueueValidationIssue {
+  readonly code: PublishQueueValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface PublishQueueValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly PublishQueueValidationIssue[]
+}
+
+const PUBLISH_AUTOMATION_REASON_CODE_SET = new Set<string>([
+  'invalid_upstream_envelope',
+  'release_not_packaged',
+  'governance_not_applied',
+  'missing_governance_metadata',
+  'invalid_crediting_manifest',
+  'missing_version_bump_ref',
+  'missing_changelog_entry',
+  'missing_contributor_credit_refs',
+  'missing_crediting_targets',
+  'missing_publish_channel',
+  'announcement_segments_recommended',
+  'crediting_targets_borderline',
+])
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isFiniteWeek(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function isPublishAutomationReasonCode(value: string): value is PublishAutomationReasonCode {
+  return PUBLISH_AUTOMATION_REASON_CODE_SET.has(value)
+}
+
+function parseCreditingHookList(value: unknown): readonly CreditingHookDescriptor[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const hooks: CreditingHookDescriptor[] = []
+
+  for (const entry of value) {
+    if (!isPlainRecord(entry)) {
+      continue
+    }
+
+    const kind = entry.kind
+    const target = normalizeToken(entry.target)
+    const payload = normalizeToken(entry.payload)
+
+    if (
+      typeof kind !== 'string' ||
+      !isCreditingHookKind(kind) ||
+      !target ||
+      !payload
+    ) {
+      continue
+    }
+
+    hooks.push({ kind, target, payload })
+  }
+
+  return sortCreditingHooks(hooks)
+}
+
+function parsePublishHookList(value: unknown): readonly PublishHookDescriptor[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const hooks: PublishHookDescriptor[] = []
+
+  for (const entry of value) {
+    if (!isPlainRecord(entry)) {
+      continue
+    }
+
+    const kind = entry.kind
+    const target = normalizeToken(entry.target)
+    const payload = normalizeToken(entry.payload)
+
+    if (typeof kind !== 'string' || !isPublishHookKind(kind) || !target || !payload) {
+      continue
+    }
+
+    hooks.push({ kind, target, payload })
+  }
+
+  return sortPublishHooks(hooks)
+}
+
+function parseReasonCodeList(value: unknown): readonly PublishAutomationReasonCode[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const codes = value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && isPublishAutomationReasonCode(entry))
+
+  return [...new Set(codes)].sort((left, right) => left.localeCompare(right))
+}
+
+function parsePublishMetadata(value: unknown): PublishAutomationMetadata | undefined {
+  if (!isPlainRecord(value)) {
+    return undefined
+  }
+
+  const versionBumpRef = normalizeToken(value.versionBumpRef)
+  const publishChannel = normalizeToken(value.publishChannel)
+  const contributorRef = normalizeToken(value.contributorRef)
+  const rightsTier = normalizeToken(value.rightsTier)
+  const artifactType = normalizeToken(value.artifactType)
+  const creditingTargetCount = value.creditingTargetCount
+
+  if (
+    !versionBumpRef ||
+    !publishChannel ||
+    !contributorRef ||
+    !rightsTier ||
+    !artifactType ||
+    typeof creditingTargetCount !== 'number' ||
+    !Number.isInteger(creditingTargetCount) ||
+    creditingTargetCount < 0
+  ) {
+    return undefined
+  }
+
+  return Object.freeze({
+    versionBumpRef,
+    publishChannel,
+    contributorRef,
+    rightsTier,
+    artifactType,
+    creditingTargetCount,
+  })
+}
+
+function freezePublishQueueValidationResult(
+  issues: PublishQueueValidationIssue[]
+): PublishQueueValidationResult {
+  const sortedIssues = [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+export function validatePublishQueueRecord(
+  record: PublishQueueRecord
+): PublishQueueValidationResult {
+  const issues: PublishQueueValidationIssue[] = []
+  const id = normalizeToken(record.id)
+  const label = normalizeToken(record.label)
+  const releaseArtifactRef = normalizeToken(record.releaseArtifactRef)
+
+  if (!id) {
+    issues.push({
+      code: 'missing_id',
+      severity: 'error',
+      detail: 'Publish queue record is missing id.',
+    })
+  }
+
+  if (!label) {
+    issues.push({
+      code: 'missing_label',
+      severity: 'error',
+      detail: 'Publish queue record is missing label.',
+    })
+  }
+
+  if (!releaseArtifactRef) {
+    issues.push({
+      code: 'missing_release_artifact_ref',
+      severity: 'error',
+      detail: 'Publish queue record is missing releaseArtifactRef.',
+    })
+  }
+
+  if (!isPublishAutomationStatus(record.status)) {
+    issues.push({
+      code: 'invalid_status',
+      severity: 'error',
+      detail: `Publish queue record ${id || '(unknown)'} has invalid status ${String(record.status)}.`,
+    })
+  }
+
+  if (record.queuedWeek !== undefined && !isFiniteWeek(record.queuedWeek)) {
+    issues.push({
+      code: 'invalid_queued_week',
+      severity: 'error',
+      detail: `Publish queue record ${id || '(unknown)'} has invalid queuedWeek ${String(record.queuedWeek)}.`,
+    })
+  }
+
+  for (const hook of record.creditingHooks) {
+    if (
+      !isCreditingHookKind(hook.kind) ||
+      !normalizeToken(hook.target) ||
+      !normalizeToken(hook.payload)
+    ) {
+      issues.push({
+        code: 'invalid_crediting_hook',
+        severity: 'error',
+        detail: `Publish queue record ${id || '(unknown)'} has invalid crediting hook.`,
+      })
+      break
+    }
+  }
+
+  for (const hook of record.publishHooks) {
+    if (
+      !isPublishHookKind(hook.kind) ||
+      !normalizeToken(hook.target) ||
+      !normalizeToken(hook.payload)
+    ) {
+      issues.push({
+        code: 'invalid_publish_hook',
+        severity: 'error',
+        detail: `Publish queue record ${id || '(unknown)'} has invalid publish hook.`,
+      })
+      break
+    }
+  }
+
+  for (const code of record.reasonCodes) {
+    if (!isPublishAutomationReasonCode(code)) {
+      issues.push({
+        code: 'invalid_reason_code',
+        severity: 'error',
+        detail: `Publish queue record ${id || '(unknown)'} has invalid reason code ${String(code)}.`,
+      })
+      break
+    }
+  }
+
+  if (record.publishMetadata !== undefined && parsePublishMetadata(record.publishMetadata) === undefined) {
+    issues.push({
+      code: 'invalid_publish_metadata',
+      severity: 'error',
+      detail: `Publish queue record ${id || '(unknown)'} has invalid publishMetadata.`,
+    })
+  }
+
+  return freezePublishQueueValidationResult(issues)
+}
+
+function definePublishQueueRecord(record: PublishQueueRecord): PublishQueueRecord {
+  return Object.freeze({
+    ...record,
+    creditingHooks: Object.freeze(record.creditingHooks.map((hook) => Object.freeze({ ...hook }))),
+    publishHooks: Object.freeze(record.publishHooks.map((hook) => Object.freeze({ ...hook }))),
+    reasonCodes: Object.freeze([...record.reasonCodes]),
+    ...(record.publishMetadata ? { publishMetadata: Object.freeze({ ...record.publishMetadata }) } : {}),
+  })
+}
+
+/**
+ * Read-only composition: materialize a bounded publish-queue record from a
+ * publish-automation decision without executing publish actions.
+ */
+export function composePublishQueueRecord(input: {
+  readonly id: string
+  readonly label: string
+  readonly releaseArtifactRef: string
+  readonly decision: PublishAutomationDecision
+  readonly summary?: string
+  readonly queuedWeek?: number
+}): PublishQueueRecord | null {
+  const id = normalizeToken(input.id)
+  const label = normalizeToken(input.label)
+  const releaseArtifactRef = normalizeToken(input.releaseArtifactRef)
+
+  if (!id || !label || !releaseArtifactRef) {
+    return null
+  }
+
+  const record = definePublishQueueRecord({
+    id,
+    label,
+    releaseArtifactRef,
+    status: input.decision.status,
+    creditingHooks: input.decision.creditingHooks,
+    publishHooks: input.decision.publishHooks,
+    reasonCodes: input.decision.reasonCodes,
+    ...(normalizeToken(input.summary ?? '') ? { summary: normalizeToken(input.summary) } : {}),
+    ...(input.queuedWeek !== undefined && isFiniteWeek(input.queuedWeek)
+      ? { queuedWeek: input.queuedWeek }
+      : {}),
+    ...(input.decision.publishMetadata ? { publishMetadata: input.decision.publishMetadata } : {}),
+  })
+
+  return validatePublishQueueRecord(record).valid ? record : null
+}
+
+function sanitizePublishQueueRecordEntry(value: unknown): PublishQueueRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const label = normalizeToken(value.label)
+  const releaseArtifactRef = normalizeToken(value.releaseArtifactRef)
+  const status = value.status
+
+  if (
+    !id ||
+    !label ||
+    !releaseArtifactRef ||
+    typeof status !== 'string' ||
+    !isPublishAutomationStatus(status)
+  ) {
+    return null
+  }
+
+  const creditingHooks = parseCreditingHookList(value.creditingHooks)
+  const publishHooks = parsePublishHookList(value.publishHooks)
+  const reasonCodes = parseReasonCodeList(value.reasonCodes)
+  const publishMetadata = parsePublishMetadata(value.publishMetadata)
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : undefined
+  const queuedWeek = value.queuedWeek
+
+  const record = definePublishQueueRecord({
+    id,
+    label,
+    releaseArtifactRef,
+    status,
+    creditingHooks,
+    publishHooks,
+    reasonCodes,
+    ...(summary ? { summary } : {}),
+    ...(queuedWeek !== undefined && isFiniteWeek(queuedWeek) ? { queuedWeek } : {}),
+    ...(publishMetadata ? { publishMetadata } : {}),
+  })
+
+  return validatePublishQueueRecord(record).valid ? record : null
+}
+
+/** Hydration: canonical record map keyed by record id; drops invalid and duplicate-id entries. */
+export function sanitizePublishQueueRecords(
+  value: unknown,
+  fallback: PublishQueueRecordsMap = {}
+): PublishQueueRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: PublishQueueRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizePublishQueueRecordEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
+/** Ready-to-publish queue entry composed from the canonical upstream fixture chain. */
+export const CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE: PublishQueueRecord = definePublishQueueRecord({
+  id: 'publish-queue:domain-release-batch-1',
+  label: 'Domain release batch 1',
+  summary: 'Queued publish intent for SPE-75 contribution pipeline domain release.',
+  queuedWeek: 4,
+  releaseArtifactRef: 'release:domain-code-bundle-spe-2480',
+  status: 'ready_to_publish',
+  creditingHooks: Object.freeze([
+    {
+      kind: 'attribution_target',
+      target: 'CHANGELOG.md',
+      payload: 'contributor:agent-maintainer:canonical',
+    },
+    {
+      kind: 'attribution_target',
+      target: 'CONTRIBUTORS',
+      payload: 'contributor:agent-maintainer:canonical',
+    },
+    {
+      kind: 'changelog_entry',
+      target: 'CHANGELOG.md',
+      payload:
+        'Add publish automation and crediting hooks baseline for SPE-75 contribution pipeline.',
+    },
+    {
+      kind: 'contributor_credit',
+      target: 'contributor:agent-maintainer',
+      payload:
+        'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+    },
+    {
+      kind: 'contributor_credit',
+      target: 'contributor:release-bot',
+      payload:
+        'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+    },
+    {
+      kind: 'version_bump',
+      target: 'package.json:version',
+      payload: 'bump:package.json:version',
+    },
+  ]),
+  publishHooks: Object.freeze([
+    {
+      kind: 'announcement_segment',
+      target: 'agent-packaging-pipeline',
+      payload: 'segment:agent-packaging-pipeline',
+    },
+    {
+      kind: 'announcement_segment',
+      target: 'domain-release',
+      payload: 'segment:domain-release',
+    },
+    {
+      kind: 'publish_channel',
+      target: 'pr-merge',
+      payload: 'channel:pr-merge',
+    },
+  ]),
+  reasonCodes: Object.freeze([]),
+  publishMetadata: Object.freeze({
+    versionBumpRef: 'package.json:version',
+    publishChannel: 'pr-merge',
+    contributorRef: 'contributor:agent-maintainer',
+    rightsTier: 'canonical',
+    artifactType: 'domain_code_bundle',
+    creditingTargetCount: 2,
+  }),
+})

--- a/src/test/publishQueuePersistence.test.ts
+++ b/src/test/publishQueuePersistence.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+  evaluateContributionIntakeCuration,
+} from '../domain/contributionIntakeCuration'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+} from '../domain/modularReleasePackaging'
+import {
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+  composePublishQueueRecord,
+  evaluatePublishAutomationCreditingHooks,
+  sanitizePublishQueueRecords,
+} from '../domain/publishAutomationCreditingHooks'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+} from '../domain/submissionGovernanceRights'
+
+describe('publishQueue persistence (SPE-2483 slice 1)', () => {
+  it('defaults starting state to an empty publish-queue map', () => {
+    expect(createStartingState().publishQueueRecords).toEqual({})
+  })
+
+  it('composes a valid queue record read-only from a publish-automation decision', () => {
+    const acceptedCuration = evaluateContributionIntakeCuration(
+      CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE
+    )
+    const packagedRelease = evaluateModularReleasePackaging(
+      acceptedCuration,
+      CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+    )
+    const appliedGovernance = evaluateSubmissionGovernanceRights(
+      CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE
+    )
+    const decision = evaluatePublishAutomationCreditingHooks(
+      packagedRelease,
+      appliedGovernance,
+      CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+    )
+
+    const composed = composePublishQueueRecord({
+      id: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      label: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label,
+      releaseArtifactRef: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef,
+      decision,
+      summary: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.summary,
+      queuedWeek: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.queuedWeek,
+    })
+
+    expect(composed).toEqual(CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE)
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizePublishQueueRecords(
+      {
+        valid: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+        duplicate: {
+          ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+          label: 'duplicate label should lose',
+        },
+        'wrong-key': {
+          ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+          id: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+          label: 'wrong map key should lose to canonical id',
+        },
+        missingLabel: {
+          id: 'publish-queue:missing-label',
+          releaseArtifactRef: 'release:missing-label',
+          status: 'ready_to_publish',
+          creditingHooks: [],
+          publishHooks: [],
+          reasonCodes: [],
+        },
+        invalidStatus: {
+          id: 'publish-queue:invalid-status',
+          label: 'Invalid status',
+          releaseArtifactRef: 'release:invalid-status',
+          status: 'not_a_status',
+          creditingHooks: [],
+          publishHooks: [],
+          reasonCodes: [],
+        },
+        invalidHook: {
+          id: 'publish-queue:invalid-hook',
+          label: 'Invalid hook',
+          releaseArtifactRef: '',
+          status: 'ready_to_publish',
+          creditingHooks: [{ kind: 'not_a_kind', target: 'x', payload: 'y' }],
+          publishHooks: [],
+          reasonCodes: [],
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized[CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]).toEqual(
+      CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE
+    )
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['wrong-key']).toBeUndefined()
+    expect(sanitized.missingLabel).toBeUndefined()
+    expect(sanitized.invalidStatus).toBeUndefined()
+    expect(sanitized.invalidHook).toBeUndefined()
+    expect(Object.keys(sanitized)).toEqual([CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id])
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.publishQueueRecords = {
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.publishQueueRecords).toEqual(state.publishQueueRecords)
+  })
+
+  it('hydrates persisted publish-queue records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        publishQueueRecords: {
+          [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+          invalid: {
+            id: 'publish-queue:invalid',
+            label: 'Invalid queue entry',
+            releaseArtifactRef: '',
+            status: 'ready_to_publish',
+            creditingHooks: [],
+            publishHooks: [],
+            reasonCodes: [],
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.publishQueueRecords).toEqual({
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `publishQueueRecords` on `GameState` with `sanitizePublishQueueRecords` hydrate wire in `runTransfer.ts` and default `{}` in `createStartingState`.
- Extend `publishAutomationCreditingHooks.ts` with `PublishQueueRecord` types, `composePublishQueueRecord` (read-only from publish decisions), validation, and canonical fixture.
- Add `publishQueuePersistence.test.ts` for sanitize drops, serialize/import round-trip, and hydrate import.

## Linear mapping

- **Slice:** [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — GameState publish-queue persistence (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — stays **Done** (child-only slice; parent not reopened)
- **Composes with:** [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) publish automation crediting hooks

## What shipped

Persistence-only publish-queue records keyed by id with bounded status, hook descriptors, and optional metadata — no runtime publish executor, CI wiring, or UI.

## Validation

- `npm run test:run -- src/test/publishQueuePersistence.test.ts` (5 tests green)
- `npm run lint`

## Docs updated

- `planning/publish-queue-persistence-slice-1.md` (new)
- `planning/backlog.md` (handoff)
- `planning/publish-automation-crediting-hooks-slice-1.md` (deferred pointer)
- `docs/contribution-and-release-operations.md` (optional cross-ref)

## Parent status

SPE-75 remains **Done**. Runtime publish executor and publish-queue UI/orchestration deferred to new follow-up children.