### PR TITLE
feat(SPE-2484): publish-queue dry-run executor (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -61,6 +61,8 @@ Domain publish baseline: `src/domain/publishAutomationCreditingHooks.ts` (SPE-24
 
 Publish-queue persistence (SPE-2483) stores bounded publish-intent snapshots on `GameState.publishQueueRecords` with sanitize/hydration on save import — still no publish execution.
 
+Domain publish executor baseline: `src/domain/publishQueueExecutor.ts` (SPE-2484) consumes persisted queue records and SPE-2480 hook descriptors through bounded dry-run channel stubs with deterministic `ready_to_publish` → `published` transitions — no CI/GitHub API calls or real publish side effects.
+
 ## Notation and docs standards
 
 - Prefer **issue IDs** (SPE-\*) in commit and PR titles when mandated by team workflow.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -24,6 +24,8 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) GameState publish-queue persistence (slice 1) — `publishQueueRecords` sanitize/hydrate on GameState; branch `spe-75-publish-queue-persistence-slice-1` (PR #2886 @ `93711130`).
 
+**In progress:** [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) Runtime publish executor / CI wiring (slice 1) — dry-run channel-stub executor over persisted queue records; branch `spe-75-publish-queue-executor-slice-1`.
+
 **Recently shipped:** [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) publish automation and crediting hooks (slice 1) — deterministic publish-intent envelope with crediting/publish hook descriptors; branch `spe-75-publish-automation-crediting-hooks-slice-1` (PR #2879 @ `99161c79`).
 
 **Recently shipped:** [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) modifiable data pack safe-fail validation (slice 1) — deterministic schema-validation envelope with section-shape checks; branch `spe-75-modifiable-data-pack-validation-slice-1` (PR #2877 @ `cb4ea3ae`).
@@ -51,10 +53,10 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 **§14-pass alternates (owner creates Linear child when starting):**
 
 1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — read-only `stabilityLayer.ts` category via `buildBranchContinuityRuntimeAuditSnapshot`; partial §14 (dev/stability tooling); see `planning/branch-continuity-runtime-hooks-slice-1.md` § Deferred.
-2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** runtime publish executor / CI wiring, modifiable data-pack runtime import ([SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) deferred), or publish-queue UI/orchestration (SPE-2483 persistence shipped).
+2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** modifiable data-pack runtime import ([SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) deferred), publish-queue UI/orchestration (SPE-2483 persistence shipped), or real CI/GitHub API wiring (SPE-2484 dry-run executor shipped).
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; no slice 5+ without fresh §14 pass — see `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md` § Deferred.
 
-**Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; runtime publish executor without owner-scoped child.
+**Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; real CI/GitHub publish API wiring without owner-scoped child.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -219,6 +221,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `modifiable-data-pack-validation-slice-1.md`              | **Shipped**    | [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) — deterministic modifiable data-pack schema validation under SPE-75; PR #2877 @ `cb4ea3ae`. |
 | `publish-automation-crediting-hooks-slice-1.md`           | **Shipped**    | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; PR #2879 @ `99161c79`. |
 | `publish-queue-persistence-slice-1.md`                    | **Shipped**    | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — `publishQueueRecords` GameState persistence under SPE-75; PR #2886 @ `93711130`. |
+| `publish-queue-executor-slice-1.md`                       | **In Progress** | [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — dry-run publish executor under SPE-75; branch `spe-75-publish-queue-executor-slice-1`. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/publish-queue-executor-slice-1.md
+++ b/planning/publish-queue-executor-slice-1.md
@@ -1,0 +1,63 @@
+# SPE-75 — Runtime publish executor / CI wiring (slice 1)
+
+One-page implementation plan. Linear: [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) per `planning/publish-queue-persistence-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2484 — Runtime publish executor / CI wiring (slice 1)](https://linear.app/spectranoir/issue/SPE-2484) |
+| **Status** | **In Progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-publish-queue-executor-slice-1` |
+| **Base `main` SHA** | `fd91fd3b` |
+
+## Goal
+
+Pure domain publish-queue dry-run executor consuming persisted `publishQueueRecords` and SPE-2480 hook descriptors with deterministic status transitions — no actual CI/GitHub API calls, UI, or SPE-75 parent reopen.
+
+## Prerequisite (on `main` @ `fd91fd3b`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Publish-intent + queue persistence | `src/domain/publishAutomationCreditingHooks.ts` (SPE-2480 / SPE-2483) |
+| Registry orchestration pattern | `src/domain/truthLayerWeeklyOrchestration.ts` (SPE-1343 slice 3) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `publishQueueExecutor.ts` dry-run / channel-stub executor | Real CI/GitHub API integration |
+| `ready_to_publish` → `published` status transition | Route/UI changes |
+| Reject non-ready queue entries; idempotent re-execution | Mission triage (blocked) |
+| Batch + weekly tick stub (`applyWeeklyPublishQueueExecutionTick`) | SPE-947 / SPE-1046 parent changes |
+| Executor unit tests + canonical fixture chain | Modifiable-pack import wiring (separate child) |
+| `withPublishQueueRecordStatus` helper + `published` status union | GameState execution-receipt persistence |
+
+## Acceptance
+
+- [x] Canonical fixture chain executes with stable hook stubs and `published` transition
+- [x] Non-ready records rejected/skipped without mutation
+- [x] Re-execution byte-identical for published records
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publishQueueExecutor.ts`, `src/domain/publishAutomationCreditingHooks.ts` |
+| Tests  | `src/test/publishQueueExecutor.test.ts` |
+| Plan   | `planning/publish-queue-executor-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Real CI/GitHub API wiring | SPE-75 follow-up child | Requires external automation beyond dry-run stubs |
+| Publish-queue UI / weekly orchestration surfacing | SPE-75 follow-up child | Executor must land before UI |
+| GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond queue status transition |
+
+## See also
+
+- `planning/publish-queue-persistence-slice-1.md`
+- `planning/publish-automation-crediting-hooks-slice-1.md`
+- `planning/backlog.md`

--- a/src/domain/publishAutomationCreditingHooks.ts
+++ b/src/domain/publishAutomationCreditingHooks.ts
@@ -17,12 +17,17 @@ import type {
 // Identifiers and unions
 // ---------------------------------------------------------------------------
 
-export type PublishAutomationStatus = 'ready_to_publish' | 'needs_revision' | 'rejected'
+export type PublishAutomationStatus =
+  | 'ready_to_publish'
+  | 'needs_revision'
+  | 'rejected'
+  | 'published'
 
 export const PUBLISH_AUTOMATION_STATUSES: readonly PublishAutomationStatus[] = [
   'ready_to_publish',
   'needs_revision',
   'rejected',
+  'published',
 ] as const
 
 export type CreditingHookKind =
@@ -1020,6 +1025,26 @@ export function composePublishQueueRecord(input: {
   })
 
   return validatePublishQueueRecord(record).valid ? record : null
+}
+
+/**
+ * Returns a validated publish-queue record with an updated status, or null when
+ * the transition would fail validation.
+ */
+export function withPublishQueueRecordStatus(
+  record: PublishQueueRecord,
+  status: PublishAutomationStatus
+): PublishQueueRecord | null {
+  if (!isPublishAutomationStatus(status)) {
+    return null
+  }
+
+  const next = definePublishQueueRecord({
+    ...record,
+    status,
+  })
+
+  return validatePublishQueueRecord(next).valid ? next : null
 }
 
 function sanitizePublishQueueRecordEntry(value: unknown): PublishQueueRecord | null {

--- a/src/domain/publishQueueExecutor.ts
+++ b/src/domain/publishQueueExecutor.ts
@@ -1,0 +1,346 @@
+/**
+ * SPE-2484 slice 1: publish-queue dry-run executor.
+ *
+ * Pure deterministic executor consuming persisted publish-queue records and
+ * SPE-2480 hook descriptors with bounded channel stubs — no CI/GitHub API
+ * calls, UI, or real publish side effects.
+ */
+
+import type {
+  CreditingHookDescriptor,
+  CreditingHookKind,
+  PublishHookDescriptor,
+  PublishHookKind,
+  PublishQueueRecord,
+  PublishQueueRecordsMap,
+} from './publishAutomationCreditingHooks'
+import {
+  validatePublishQueueRecord,
+  withPublishQueueRecordStatus,
+} from './publishAutomationCreditingHooks'
+
+// ---------------------------------------------------------------------------
+// Identifiers and unions
+// ---------------------------------------------------------------------------
+
+export type PublishQueueExecutorOutcome = 'completed' | 'skipped' | 'rejected'
+
+export const PUBLISH_QUEUE_EXECUTOR_OUTCOMES: readonly PublishQueueExecutorOutcome[] = [
+  'completed',
+  'skipped',
+  'rejected',
+] as const
+
+export type PublishQueueExecutorSkipCode =
+  | 'record_not_ready_to_publish'
+  | 'already_published'
+  | 'missing_publish_channel_hook'
+
+export const PUBLISH_QUEUE_EXECUTOR_SKIP_CODES: readonly PublishQueueExecutorSkipCode[] = [
+  'record_not_ready_to_publish',
+  'already_published',
+  'missing_publish_channel_hook',
+] as const
+
+export type PublishHookStubKind = CreditingHookKind | PublishHookKind
+
+export interface PublishHookStubApplication {
+  readonly kind: PublishHookStubKind
+  readonly target: string
+  readonly payload: string
+  readonly channelStub: string
+}
+
+export interface PublishQueueExecutionReceipt {
+  readonly recordId: string
+  readonly outcome: PublishQueueExecutorOutcome
+  readonly executionWeek: number
+  readonly appliedHooks: readonly PublishHookStubApplication[]
+  readonly publishChannelStub?: string
+  readonly skipCode?: PublishQueueExecutorSkipCode
+}
+
+export interface PublishQueueExecutorOptions {
+  readonly week?: number
+  readonly maxHookApplications?: number
+}
+
+export interface PublishQueueExecutionResult {
+  readonly record: PublishQueueRecord
+  readonly receipt: PublishQueueExecutionReceipt
+}
+
+export interface PublishQueueBatchExecutionResult {
+  readonly records: PublishQueueRecordsMap
+  readonly receipts: readonly PublishQueueExecutionReceipt[]
+}
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_HOOK_APPLICATIONS = 32
+
+const EXECUTOR_OUTCOME_SET = new Set<string>(PUBLISH_QUEUE_EXECUTOR_OUTCOMES)
+const EXECUTOR_SKIP_CODE_SET = new Set<string>(PUBLISH_QUEUE_EXECUTOR_SKIP_CODES)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function normalizeWeek(week: number | undefined): number {
+  if (week === undefined || !Number.isFinite(week)) {
+    return 1
+  }
+
+  return Math.max(1, Math.trunc(week))
+}
+
+function resolveMaxHookApplications(maxHookApplications?: number): number {
+  if (
+    maxHookApplications === undefined ||
+    !Number.isFinite(maxHookApplications) ||
+    maxHookApplications < 1
+  ) {
+    return DEFAULT_MAX_HOOK_APPLICATIONS
+  }
+
+  return Math.trunc(maxHookApplications)
+}
+
+function buildChannelStub(kind: PublishHookStubKind, target: string, payload: string): string {
+  return `dry-run:${kind}:${target}:${payload}`
+}
+
+function freezeHookApplication(application: PublishHookStubApplication): PublishHookStubApplication {
+  return Object.freeze({ ...application })
+}
+
+function freezeReceipt(receipt: PublishQueueExecutionReceipt): PublishQueueExecutionReceipt {
+  return Object.freeze({
+    ...receipt,
+    appliedHooks: Object.freeze(receipt.appliedHooks.map((hook) => freezeHookApplication(hook))),
+  })
+}
+
+function creditingHookToStub(hook: CreditingHookDescriptor): PublishHookStubApplication {
+  return freezeHookApplication({
+    kind: hook.kind,
+    target: hook.target,
+    payload: hook.payload,
+    channelStub: buildChannelStub(hook.kind, hook.target, hook.payload),
+  })
+}
+
+function publishHookToStub(hook: PublishHookDescriptor): PublishHookStubApplication {
+  return freezeHookApplication({
+    kind: hook.kind,
+    target: hook.target,
+    payload: hook.payload,
+    channelStub: buildChannelStub(hook.kind, hook.target, hook.payload),
+  })
+}
+
+function findPublishChannelHook(record: PublishQueueRecord): PublishHookDescriptor | undefined {
+  return record.publishHooks.find((hook) => hook.kind === 'publish_channel')
+}
+
+function buildAppliedHookStubs(
+  record: PublishQueueRecord,
+  maxHookApplications: number
+): readonly PublishHookStubApplication[] {
+  const applications: PublishHookStubApplication[] = []
+
+  for (const hook of record.creditingHooks) {
+    if (applications.length >= maxHookApplications) {
+      break
+    }
+
+    applications.push(creditingHookToStub(hook))
+  }
+
+  for (const hook of record.publishHooks) {
+    if (applications.length >= maxHookApplications) {
+      break
+    }
+
+    applications.push(publishHookToStub(hook))
+  }
+
+  return Object.freeze(applications)
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isPublishQueueExecutorOutcome(value: string): value is PublishQueueExecutorOutcome {
+  return EXECUTOR_OUTCOME_SET.has(value)
+}
+
+export function isPublishQueueExecutorSkipCode(value: string): value is PublishQueueExecutorSkipCode {
+  return EXECUTOR_SKIP_CODE_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes one publish-queue record through bounded dry-run channel stubs.
+ * Only `ready_to_publish` records transition to `published`; other statuses
+ * are rejected without mutation. Re-execution of `published` records is
+ * idempotent (skipped, record byte-stable).
+ */
+export function executePublishQueueRecordDryRun(
+  record: PublishQueueRecord,
+  options: PublishQueueExecutorOptions = {}
+): PublishQueueExecutionResult {
+  const executionWeek = normalizeWeek(options.week)
+  const maxHookApplications = resolveMaxHookApplications(options.maxHookApplications)
+
+  if (record.status === 'published') {
+    const receipt = freezeReceipt({
+      recordId: record.id,
+      outcome: 'skipped',
+      executionWeek,
+      appliedHooks: Object.freeze([]),
+      skipCode: 'already_published',
+    })
+
+    return {
+      record,
+      receipt,
+    }
+  }
+
+  if (record.status !== 'ready_to_publish') {
+    const receipt = freezeReceipt({
+      recordId: record.id,
+      outcome: 'rejected',
+      executionWeek,
+      appliedHooks: Object.freeze([]),
+      skipCode: 'record_not_ready_to_publish',
+    })
+
+    return {
+      record,
+      receipt,
+    }
+  }
+
+  const publishChannelHook = findPublishChannelHook(record)
+  if (!publishChannelHook) {
+    const receipt = freezeReceipt({
+      recordId: record.id,
+      outcome: 'rejected',
+      executionWeek,
+      appliedHooks: Object.freeze([]),
+      skipCode: 'missing_publish_channel_hook',
+    })
+
+    return {
+      record,
+      receipt,
+    }
+  }
+
+  const appliedHooks = buildAppliedHookStubs(record, maxHookApplications)
+  const publishChannelStub = buildChannelStub(
+    publishChannelHook.kind,
+    publishChannelHook.target,
+    publishChannelHook.payload
+  )
+  const nextRecord =
+    withPublishQueueRecordStatus(record, 'published') ??
+    record
+
+  const receipt = freezeReceipt({
+    recordId: record.id,
+    outcome: 'completed',
+    executionWeek,
+    appliedHooks,
+    publishChannelStub,
+  })
+
+  if (!validatePublishQueueRecord(nextRecord).valid) {
+    return {
+      record,
+      receipt: freezeReceipt({
+        recordId: record.id,
+        outcome: 'rejected',
+        executionWeek,
+        appliedHooks: Object.freeze([]),
+        skipCode: 'record_not_ready_to_publish',
+      }),
+    }
+  }
+
+  return {
+    record: nextRecord,
+    receipt,
+  }
+}
+
+/**
+ * Executes all publish-queue records in stable id order. Invalid map entries
+ * should already be dropped by sanitize/hydrate; this pass only mutates records
+ * that complete dry-run execution.
+ */
+export function executePublishQueueRecordsDryRun(
+  records: PublishQueueRecordsMap | null | undefined,
+  options: PublishQueueExecutorOptions = {}
+): PublishQueueBatchExecutionResult {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords).sort((left, right) => left.localeCompare(right))
+
+  if (recordIds.length === 0) {
+    return {
+      records: safeRecords,
+      receipts: Object.freeze([]),
+    }
+  }
+
+  let nextRecords: PublishQueueRecordsMap | null = null
+  const receipts: PublishQueueExecutionReceipt[] = []
+
+  for (const recordId of recordIds) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const sourceRecord = (nextRecords ?? safeRecords)[recordId] ?? record
+    const result = executePublishQueueRecordDryRun(sourceRecord, options)
+
+    receipts.push(result.receipt)
+
+    if (result.record === sourceRecord) {
+      continue
+    }
+
+    if (!nextRecords) {
+      nextRecords = { ...safeRecords }
+    }
+
+    nextRecords[recordId] = result.record
+  }
+
+  return {
+    records: nextRecords ?? safeRecords,
+    receipts: Object.freeze(receipts.map((receipt) => freezeReceipt(receipt))),
+  }
+}
+
+/**
+ * Weekly batch hook: one deterministic dry-run execution pass over the publish
+ * queue. Re-applying for the same week on already-published records is
+ * idempotent (skipped receipts, records byte-stable).
+ */
+export function applyWeeklyPublishQueueExecutionTick(
+  records: PublishQueueRecordsMap | null | undefined,
+  week: number,
+  options: Omit<PublishQueueExecutorOptions, 'week'> = {}
+): PublishQueueBatchExecutionResult {
+  return executePublishQueueRecordsDryRun(records, { ...options, week })
+}

--- a/src/test/publishQueueExecutor.test.ts
+++ b/src/test/publishQueueExecutor.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+  evaluateContributionIntakeCuration,
+} from '../domain/contributionIntakeCuration'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+} from '../domain/modularReleasePackaging'
+import {
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+  composePublishQueueRecord,
+  evaluatePublishAutomationCreditingHooks,
+} from '../domain/publishAutomationCreditingHooks'
+import {
+  applyWeeklyPublishQueueExecutionTick,
+  executePublishQueueRecordDryRun,
+  executePublishQueueRecordsDryRun,
+} from '../domain/publishQueueExecutor'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+} from '../domain/submissionGovernanceRights'
+
+describe('publishQueueExecutor (SPE-2484 slice 1)', () => {
+  const acceptedCuration = evaluateContributionIntakeCuration(
+    CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE
+  )
+  const packagedRelease = evaluateModularReleasePackaging(
+    acceptedCuration,
+    CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+  )
+  const appliedGovernance = evaluateSubmissionGovernanceRights(
+    CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE
+  )
+  const decision = evaluatePublishAutomationCreditingHooks(
+    packagedRelease,
+    appliedGovernance,
+    CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+  )
+  const composedRecord = composePublishQueueRecord({
+    id: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+    label: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label,
+    releaseArtifactRef: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef,
+    decision,
+    summary: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.summary,
+    queuedWeek: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.queuedWeek,
+  })!
+
+  it('executes the canonical fixture chain with stable hook stubs and published transition', () => {
+    const result = executePublishQueueRecordDryRun(composedRecord, { week: 4 })
+
+    expect(result.receipt).toEqual({
+      recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      outcome: 'completed',
+      executionWeek: 4,
+      publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+      appliedHooks: [
+        {
+          kind: 'attribution_target',
+          target: 'CHANGELOG.md',
+          payload: 'contributor:agent-maintainer:canonical',
+          channelStub:
+            'dry-run:attribution_target:CHANGELOG.md:contributor:agent-maintainer:canonical',
+        },
+        {
+          kind: 'attribution_target',
+          target: 'CONTRIBUTORS',
+          payload: 'contributor:agent-maintainer:canonical',
+          channelStub:
+            'dry-run:attribution_target:CONTRIBUTORS:contributor:agent-maintainer:canonical',
+        },
+        {
+          kind: 'changelog_entry',
+          target: 'CHANGELOG.md',
+          payload:
+            'Add publish automation and crediting hooks baseline for SPE-75 contribution pipeline.',
+          channelStub:
+            'dry-run:changelog_entry:CHANGELOG.md:Add publish automation and crediting hooks baseline for SPE-75 contribution pipeline.',
+        },
+        {
+          kind: 'contributor_credit',
+          target: 'contributor:agent-maintainer',
+          payload:
+            'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+          channelStub:
+            'dry-run:contributor_credit:contributor:agent-maintainer:Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+        },
+        {
+          kind: 'contributor_credit',
+          target: 'contributor:release-bot',
+          payload:
+            'Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+          channelStub:
+            'dry-run:contributor_credit:contributor:release-bot:Maintainer-authored domain module with explicit MIT license and canonical release manifest alignment.',
+        },
+        {
+          kind: 'version_bump',
+          target: 'package.json:version',
+          payload: 'bump:package.json:version',
+          channelStub: 'dry-run:version_bump:package.json:version:bump:package.json:version',
+        },
+        {
+          kind: 'announcement_segment',
+          target: 'agent-packaging-pipeline',
+          payload: 'segment:agent-packaging-pipeline',
+          channelStub:
+            'dry-run:announcement_segment:agent-packaging-pipeline:segment:agent-packaging-pipeline',
+        },
+        {
+          kind: 'announcement_segment',
+          target: 'domain-release',
+          payload: 'segment:domain-release',
+          channelStub: 'dry-run:announcement_segment:domain-release:segment:domain-release',
+        },
+        {
+          kind: 'publish_channel',
+          target: 'pr-merge',
+          payload: 'channel:pr-merge',
+          channelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+        },
+      ],
+    })
+    expect(result.record.status).toBe('published')
+    expect(result.record.creditingHooks).toEqual(composedRecord.creditingHooks)
+    expect(result.record.publishHooks).toEqual(composedRecord.publishHooks)
+  })
+
+  it('rejects non-ready_to_publish records without mutation', () => {
+    const needsRevision = {
+      ...composedRecord,
+      id: 'publish-queue:needs-revision-single',
+      status: 'needs_revision' as const,
+      reasonCodes: ['crediting_targets_borderline'] as const,
+    }
+    const rejected = {
+      ...composedRecord,
+      id: 'publish-queue:rejected-single',
+      status: 'rejected' as const,
+      reasonCodes: ['missing_publish_channel'] as const,
+    }
+
+    const needsRevisionResult = executePublishQueueRecordDryRun(needsRevision)
+    const rejectedResult = executePublishQueueRecordDryRun(rejected)
+
+    expect(needsRevisionResult.receipt.outcome).toBe('rejected')
+    expect(needsRevisionResult.receipt.skipCode).toBe('record_not_ready_to_publish')
+    expect(needsRevisionResult.record).toBe(needsRevision)
+
+    expect(rejectedResult.receipt.outcome).toBe('rejected')
+    expect(rejectedResult.receipt.skipCode).toBe('record_not_ready_to_publish')
+    expect(rejectedResult.record).toBe(rejected)
+  })
+
+  it('rejects ready_to_publish records missing publish_channel hooks', () => {
+    const missingChannel = {
+      ...composedRecord,
+      publishHooks: composedRecord.publishHooks.filter((hook) => hook.kind !== 'publish_channel'),
+    }
+
+    const result = executePublishQueueRecordDryRun(missingChannel)
+
+    expect(result.receipt.outcome).toBe('rejected')
+    expect(result.receipt.skipCode).toBe('missing_publish_channel_hook')
+    expect(result.record).toBe(missingChannel)
+  })
+
+  it('is idempotent when re-executing published records', () => {
+    const first = executePublishQueueRecordDryRun(composedRecord, { week: 4 })
+    const second = executePublishQueueRecordDryRun(first.record, { week: 4 })
+
+    expect(first.receipt.outcome).toBe('completed')
+    expect(second.receipt.outcome).toBe('skipped')
+    expect(second.receipt.skipCode).toBe('already_published')
+    expect(second.record).toBe(first.record)
+
+    const third = executePublishQueueRecordDryRun(first.record, { week: 4 })
+    expect(third).toEqual(second)
+  })
+
+  it('batch-executes records in stable id order and preserves non-ready entries', () => {
+    const needsRevision = {
+      ...composedRecord,
+      id: 'publish-queue:needs-revision',
+      status: 'needs_revision' as const,
+      reasonCodes: ['crediting_targets_borderline'] as const,
+    }
+
+    const batch = executePublishQueueRecordsDryRun(
+      {
+        [needsRevision.id]: needsRevision,
+        [composedRecord.id]: composedRecord,
+      },
+      { week: 5 }
+    )
+
+    expect(batch.receipts.map((receipt) => receipt.recordId)).toEqual([
+      composedRecord.id,
+      needsRevision.id,
+    ])
+    expect(batch.records[composedRecord.id]?.status).toBe('published')
+    expect(batch.records[needsRevision.id]).toBe(needsRevision)
+  })
+
+  it('weekly batch hook matches single-pass dry-run execution', () => {
+    const records = {
+      [composedRecord.id]: composedRecord,
+    }
+
+    const singlePass = executePublishQueueRecordsDryRun(records, { week: 6 })
+    const weeklyPass = applyWeeklyPublishQueueExecutionTick(records, 6)
+
+    expect(weeklyPass).toEqual(singlePass)
+  })
+
+  it('repeated batch execution is byte-identical after records are published', () => {
+    const records = {
+      [composedRecord.id]: composedRecord,
+    }
+
+    const first = executePublishQueueRecordsDryRun(records, { week: 7 })
+    const second = executePublishQueueRecordsDryRun(first.records, { week: 7 })
+
+    expect(second.records).toEqual(first.records)
+    expect(second.receipts).toEqual(
+      first.receipts.map((receipt) => ({
+        ...receipt,
+        outcome: 'skipped',
+        skipCode: 'already_published',
+        appliedHooks: [],
+        publishChannelStub: undefined,
+      }))
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Add `src/domain/publishQueueExecutor.ts` — bounded dry-run / channel-stub executor over persisted `publishQueueRecords` and SPE-2480 hook descriptors with deterministic `ready_to_publish` → `published` transitions.
- Extend `publishAutomationCreditingHooks.ts` with `published` status union and `withPublishQueueRecordStatus` helper.
- Add targeted executor tests with canonical upstream fixture chain; batch + weekly tick stub (`applyWeeklyPublishQueueExecutionTick`).

## Linear mapping

- **Slice:** [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — Runtime publish executor / CI wiring (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — remains **Done** (child-only slice; parent not reopened)

## What shipped

- Pure domain executor: no CI/GitHub API calls, no UI, no GameState execution-receipt persistence
- Rejects non-`ready_to_publish` entries; idempotent re-execution for `published` records
- Slice doc: `planning/publish-queue-executor-slice-1.md`
- Docs cross-ref: `docs/contribution-and-release-operations.md`

## Validation

- `npm run test:run -- src/test/publishQueueExecutor.test.ts src/test/publishQueuePersistence.test.ts src/test/publishAutomationCreditingHooks.test.ts` (17 tests)
- `npm run lint`

## Docs updated

- `planning/publish-queue-executor-slice-1.md`
- `planning/backlog.md`
- `docs/contribution-and-release-operations.md`

## Parent status

SPE-75 parent remains open only via deferred follow-ons (real CI wiring, UI, execution-receipt persistence) — not satisfied by this slice alone.