### PR TITLE
feat(SPE-2485): publish-queue surfacing mirror and weekly orchestration (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -63,6 +63,8 @@ Publish-queue persistence (SPE-2483) stores bounded publish-intent snapshots on 
 
 Domain publish executor baseline: `src/domain/publishQueueExecutor.ts` (SPE-2484) consumes persisted queue records and SPE-2480 hook descriptors through bounded dry-run channel stubs with deterministic `ready_to_publish` → `published` transitions — no CI/GitHub API calls or real publish side effects.
 
+Publish-queue surfacing (SPE-2485) wires the weekly dry-run tick in `advanceWeek`, emits `contribution_release.publish_queue_execution` weekly report notes for reportable receipts, and exposes a read-only planning mirror at `/publish-queue` over hydrated `publishQueueRecords` — still no real publish side effects.
+
 ## Notation and docs standards
 
 - Prefer **issue IDs** (SPE-\*) in commit and PR titles when mandated by team workflow.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,7 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**Next implementation (unblocked):** Owner reprioritizes from §14-pass alternates below; mission triage full refresh remains **blocked**.
+**In progress:** [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) publish-queue UI / orchestration surfacing — branch `spe-75-publish-queue-surfacing-slice-1`.
 
 **Recently shipped:** [SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) registry umbrella grooming — parent AC matrices + deferred tables for [SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046); parents stay **Backlog**; `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`.
 
@@ -48,14 +48,14 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** owner reprioritizes from §14-pass alternates below; mission triage full refresh remains **blocked**.
+**Next step:** [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — publish-queue UI / orchestration surfacing (slice 1). Slice doc: `planning/publish-queue-surfacing-slice-1.md`. Branch: `spe-75-publish-queue-surfacing-slice-1`. Mission triage full refresh remains **blocked**.
 
-**Base `main` SHA:** `e0f7c38f` — post SPE-2481/SPE-2482 registry umbrella grooming closure.
+**Base `main` SHA:** `dff81abe` — post SPE-2484 publish-queue executor closure.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
 1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — read-only `stabilityLayer.ts` category via `buildBranchContinuityRuntimeAuditSnapshot`; partial §14 (dev/stability tooling); see `planning/branch-continuity-runtime-hooks-slice-1.md` § Deferred.
-2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** modifiable data-pack runtime import ([SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) deferred), publish-queue UI/orchestration (SPE-2483 persistence shipped), or real CI/GitHub API wiring (SPE-2484 dry-run executor shipped).
+2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** modifiable data-pack runtime import ([SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) deferred) or real CI/GitHub API wiring (SPE-2484 dry-run executor shipped). Publish-queue surfacing child: [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485).
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; no slice 5+ without fresh §14 pass — see `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md` § Deferred.
 
 **Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; real CI/GitHub publish API wiring without owner-scoped child.
@@ -224,6 +224,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `publish-automation-crediting-hooks-slice-1.md`           | **Shipped**    | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; PR #2879 @ `99161c79`. |
 | `publish-queue-persistence-slice-1.md`                    | **Shipped**    | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — `publishQueueRecords` GameState persistence under SPE-75; PR #2886 @ `93711130`. |
 | `publish-queue-executor-slice-1.md`                       | **Shipped**    | [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — dry-run publish executor under SPE-75; PR #2888 @ `6399251c`. |
+| `publish-queue-surfacing-slice-1.md`                      | **In progress** | [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — publish-queue mirror + weekly orchestration surfacing under SPE-75; branch `spe-75-publish-queue-surfacing-slice-1`. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/publish-queue-surfacing-slice-1.md
+++ b/planning/publish-queue-surfacing-slice-1.md
@@ -1,0 +1,84 @@
+# SPE-75 — Publish-queue UI / orchestration surfacing (slice 1)
+
+One-page implementation plan. Linear: [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) per `planning/publish-queue-executor-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2485 — Publish-queue UI / orchestration surfacing (slice 1)](https://linear.app/spectranoir/issue/SPE-2485) |
+| **Status** | **In progress** — branch `spe-75-publish-queue-surfacing-slice-1` |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-publish-queue-surfacing-slice-1` |
+| **Base `main` SHA** | `dff81abe` |
+
+## Goal
+
+Surface persisted `publishQueueRecords` and dry-run execution receipts via read-only planning mirror and weekly report notes; wire `applyWeeklyPublishQueueExecutionTick` into `advanceWeek` — no real CI/GitHub API calls, mission triage, or SPE-75 parent reopen.
+
+## Prerequisite (on `main` @ `dff81abe`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Publish-queue persistence | `publishQueueRecords` on `GameState` (SPE-2483 / PR #2886) |
+| Dry-run executor | `src/domain/publishQueueExecutor.ts` (SPE-2484 / PR #2888) |
+| Planning mirror template | `patternSourceSeriesMirrorView.ts` + `PatternSourceSeriesMirrorPage.tsx` (SPE-2110 slice 4) |
+| Weekly note template | `informationIntakeExtranormalCrossLinkWeeklyReportNotes.ts` (SPE-2470) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `publishQueueSurfacing.ts` projection helpers (CP-neutral labels) | Real CI/GitHub API integration |
+| `applyWeeklyPublishQueueExecutionTick` in `advanceWeek` | Mission triage chips (blocked) |
+| `publishQueueWeeklyReportNotes.ts` + `ReportNoteType` registration | GameState execution-receipt persistence map |
+| Planning mirror page + route `/publish-queue` + Front Desk link | SPE-75 parent status change |
+| Mirror + projection + `advanceWeek` integration tests | Modifiable-pack runtime import (SPE-2479 deferred) |
+| Slice doc (this file) + backlog handoff | Re-validation on mirror (hydrated truth only) |
+
+## Surfacing contract
+
+- **Read-only mirror** — display hydrated `publishQueueRecords`; no mutations from mirror surface.
+- **Weekly orchestration** — one deterministic dry-run tick per week when queue non-empty; mutates only queue record status via existing executor.
+- **Safe labels** — record id, label, `releaseArtifactRef`, formatted status, dry-run stub prefixes; copy states simulation / dry-run channel.
+- **Empty queue** — mirror `isEmpty: true`; tick no-op; zero weekly notes; no throw.
+- **Status discrimination** — `ready_to_publish` vs `published` vs terminal (`needs_revision`, `rejected`) visible in mirror and notes.
+- **Weekly notes** — emit when tick produces reportable receipts (completed or non-idempotent skip/reject); omit idempotent `already_published` skips.
+
+## Acceptance
+
+- [x] Empty `publishQueueRecords` renders mirror empty state without throw
+- [x] `ready_to_publish` records transition to `published` on weekly tick (canonical fixture chain)
+- [x] Weekly report note uses safe labels and new `contribution_release.publish_queue_execution` type
+- [x] Mirror summary counts and per-record status labels discriminate published vs ready
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publishQueueSurfacing.ts`, `src/domain/publishQueueWeeklyReportNotes.ts`, `src/domain/sim/advanceWeek.ts`, `src/domain/models.ts` |
+| View   | `src/features/operations/publishQueueMirrorView.ts`                 |
+| UI     | `src/features/operations/PublishQueueMirrorPage.tsx`                |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`, `src/app/appShellRoutePaths.ts` |
+| Desk   | `src/features/operations/frontDeskView.ts`                            |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/publishQueueSurfacing.test.ts`, `src/test/publishQueueWeeklyReportNotes.test.ts`, `src/test/advanceWeek.publishQueue.integration.test.ts`, `src/features/operations/publishQueueMirrorView.test.ts`, `src/features/operations/PublishQueueMirrorPage.test.tsx`, `src/test/reportNoteTypeAudit.test.ts` |
+| Plan   | `planning/publish-queue-surfacing-slice-1.md`, `planning/backlog.md` |
+| Docs   | `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Real CI/GitHub API wiring | SPE-75 follow-up child | External automation beyond dry-run stubs |
+| GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond queue status transition |
+| Modifiable data-pack runtime import | SPE-2479 follow-up child | Separate boundary from surfacing |
+| Mission triage publish-queue chips | Backlog | Mission triage full refresh blocked |
+
+## See also
+
+- `planning/publish-queue-executor-slice-1.md`
+- `planning/publish-queue-persistence-slice-1.md`
+- `planning/pattern-source-series-registry-slice-4.md`
+- `planning/information-intake-extranormal-cross-link-surfacing-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -81,6 +81,9 @@ const HelpRoute = createRouteComponent(() => import('../features/divisions/HelpP
 const PatternSourceSeriesMirrorRoute = createRouteComponent(
   () => import('../features/operations/PatternSourceSeriesMirrorPage')
 )
+const PublishQueueMirrorRoute = createRouteComponent(
+  () => import('../features/operations/PublishQueueMirrorPage')
+)
 const SelfCensoringInformationMirrorRoute = createRouteComponent(
   () => import('../features/operations/SelfCensoringInformationMirrorPage')
 )
@@ -195,6 +198,7 @@ export default function App() {
           path="pattern-source-series"
           element={renderLazyRoute(PatternSourceSeriesMirrorRoute)}
         />
+        <Route path="publish-queue" element={renderLazyRoute(PublishQueueMirrorRoute)} />
         <Route
           path="self-censoring-information"
           element={renderLazyRoute(SelfCensoringInformationMirrorRoute)}

--- a/src/app/appShellRoutePaths.ts
+++ b/src/app/appShellRoutePaths.ts
@@ -23,6 +23,7 @@ export const APP_SHELL_STATIC_ROUTE_PATHS = [
   'report',
   'intel',
   'pattern-source-series',
+  'publish-queue',
   'self-censoring-information',
   'public-disclosure-state',
   'campaign/public-disclosure',

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -26,6 +26,7 @@ export const APP_ROUTES = {
   intel: '/intel',
   intelDetail: (templateId: string) => `/intel/${encodeURIComponent(templateId)}`,
   patternSourceSeries: '/pattern-source-series',
+  publishQueue: '/publish-queue',
   selfCensoringInformation: '/self-censoring-information',
   publicDisclosureState: '/public-disclosure-state',
   publicDisclosureCampaign: '/campaign/public-disclosure',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1640,6 +1640,30 @@ export const VISUAL_TRIGGER_HAZARD_MIRROR_UI_TEXT: Record<string, string> = {
   validationWarningPrefix: 'Validation warnings:',
 }
 
+export const PUBLISH_QUEUE_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Publish queue',
+  pageSubtitle:
+    'Read-only operations view over persisted publish-queue records and dry-run execution posture.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Queue records',
+  readyToPublishLabel: 'Ready to publish',
+  publishedLabel: 'Published (dry-run)',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Statuses reflect hydrated GameState only. Weekly dry-run execution transitions ready records without real CI or GitHub publish side effects.',
+  emptyTitle: 'No publish queue records',
+  emptyBody:
+    'Persisted publish-queue records will appear here after hydration. Invalid records dropped on hydrate are not shown here.',
+  recordsHeading: 'Persisted queue records',
+  recordsSubtitle: 'Ready vs published discrimination uses queue status only — no hidden channel truth.',
+  labelColumn: 'Label',
+  statusColumn: 'Status',
+  artifactColumn: 'Release artifact',
+  queuedWeekColumn: 'Queued week',
+  hooksColumn: 'Hook counts',
+}
+
 export const PATTERN_SOURCE_SERIES_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Pattern source series intake',

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -1554,6 +1554,7 @@ export type ReportNoteType =
   | 'public_disclosure.trust_outcome'
   | 'public_disclosure.segment_trust_divergence'
   | 'cognitive_hazard.simulation_trigger'
+  | 'contribution_release.publish_queue_execution'
 
 export type ReportNoteMetadataValue =
   | string

--- a/src/domain/publishQueueSurfacing.ts
+++ b/src/domain/publishQueueSurfacing.ts
@@ -1,0 +1,117 @@
+/**
+ * SPE-2485 slice 1: read-only surfacing for publish-queue records and dry-run receipts.
+ *
+ * CP-neutral labels only; no real publish side effects.
+ */
+
+import type { PublishAutomationStatus } from './publishAutomationCreditingHooks'
+import type { PublishQueueRecord, PublishQueueRecordsMap } from './publishAutomationCreditingHooks'
+import type {
+  PublishQueueExecutionReceipt,
+  PublishQueueExecutorOutcome,
+  PublishQueueExecutorSkipCode,
+} from './publishQueueExecutor'
+
+export function formatPublishQueueStatusLabel(status: PublishAutomationStatus | string): string {
+  return status
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+export function formatPublishQueueExecutorOutcomeLabel(outcome: PublishQueueExecutorOutcome): string {
+  switch (outcome) {
+    case 'completed':
+      return 'Completed (dry-run)'
+    case 'skipped':
+      return 'Skipped'
+    case 'rejected':
+      return 'Rejected'
+    default: {
+      const unreachable: never = outcome
+      return unreachable
+    }
+  }
+}
+
+export function formatPublishQueueSkipCodeLabel(skipCode: PublishQueueExecutorSkipCode): string {
+  switch (skipCode) {
+    case 'already_published':
+      return 'already published'
+    case 'record_not_ready_to_publish':
+      return 'record not ready to publish'
+    case 'missing_publish_channel_hook':
+      return 'missing publish channel hook'
+    default: {
+      const unreachable: never = skipCode
+      return unreachable
+    }
+  }
+}
+
+export function isReportablePublishQueueReceipt(receipt: PublishQueueExecutionReceipt): boolean {
+  if (receipt.outcome === 'completed' || receipt.outcome === 'rejected') {
+    return true
+  }
+
+  if (receipt.outcome === 'skipped' && receipt.skipCode !== 'already_published') {
+    return true
+  }
+
+  return false
+}
+
+export function listReportablePublishQueueReceipts(
+  receipts: readonly PublishQueueExecutionReceipt[] | null | undefined
+): readonly PublishQueueExecutionReceipt[] {
+  if (!receipts || receipts.length === 0) {
+    return Object.freeze([])
+  }
+
+  return Object.freeze(
+    [...receipts]
+      .filter((receipt) => isReportablePublishQueueReceipt(receipt))
+      .sort((left, right) => left.recordId.localeCompare(right.recordId))
+  )
+}
+
+export function formatPublishQueueExecutionReceiptNoteContent(input: {
+  receipt: PublishQueueExecutionReceipt
+  record: PublishQueueRecord | undefined
+}): string {
+  const label = input.record?.label ?? input.receipt.recordId
+  const statusLabel = input.record
+    ? formatPublishQueueStatusLabel(input.record.status)
+    : 'Unknown'
+  const outcomeLabel = formatPublishQueueExecutorOutcomeLabel(input.receipt.outcome)
+  const skipSegment =
+    input.receipt.skipCode !== undefined
+      ? ` (${formatPublishQueueSkipCodeLabel(input.receipt.skipCode)})`
+      : ''
+  const stubSegment = input.receipt.publishChannelStub
+    ? ` Dry-run channel: ${input.receipt.publishChannelStub}.`
+    : ''
+
+  return `Publish queue (dry-run) — ${input.receipt.recordId}: ${label} [${statusLabel}]. Outcome: ${outcomeLabel}${skipSegment}.${stubSegment}`
+}
+
+export function summarizePublishQueueRecords(
+  records: PublishQueueRecordsMap | null | undefined
+): {
+  readonly totalRecords: number
+  readonly readyToPublishCount: number
+  readonly publishedCount: number
+  readonly terminalCount: number
+} {
+  const safeRecords = records ?? {}
+  const values = Object.values(safeRecords)
+
+  return Object.freeze({
+    totalRecords: values.length,
+    readyToPublishCount: values.filter((record) => record.status === 'ready_to_publish').length,
+    publishedCount: values.filter((record) => record.status === 'published').length,
+    terminalCount: values.filter(
+      (record) => record.status === 'needs_revision' || record.status === 'rejected'
+    ).length,
+  })
+}

--- a/src/domain/publishQueueWeeklyReportNotes.ts
+++ b/src/domain/publishQueueWeeklyReportNotes.ts
@@ -1,0 +1,59 @@
+/**
+ * SPE-2485 slice 1: weekly report notes for publish-queue dry-run execution receipts.
+ */
+
+import type { PublishQueueRecordsMap } from './publishAutomationCreditingHooks'
+import type { PublishQueueExecutionReceipt } from './publishQueueExecutor'
+import type { ReportNote } from './models'
+import { createDeterministicReportNote } from './reportNotes'
+import {
+  formatPublishQueueExecutionReceiptNoteContent,
+  listReportablePublishQueueReceipts,
+} from './publishQueueSurfacing'
+
+/**
+ * Builds weekly report notes for reportable publish-queue dry-run execution receipts.
+ */
+export function buildWeeklyPublishQueueExecutionReportNotes(input: {
+  receipts: readonly PublishQueueExecutionReceipt[] | null | undefined
+  records: PublishQueueRecordsMap | null | undefined
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const reportableReceipts = listReportablePublishQueueReceipts(input.receipts)
+
+  if (reportableReceipts.length === 0) {
+    return []
+  }
+
+  const safeRecords = input.records ?? {}
+  const notes: ReportNote[] = []
+  let sequence = input.sequenceStart
+
+  for (const receipt of reportableReceipts) {
+    const record = safeRecords[receipt.recordId]
+
+    notes.push(
+      createDeterministicReportNote(
+        formatPublishQueueExecutionReceiptNoteContent({ receipt, record }),
+        input.week,
+        sequence,
+        input.baseTimestamp,
+        'contribution_release.publish_queue_execution',
+        {
+          recordId: receipt.recordId,
+          outcome: receipt.outcome,
+          executionWeek: receipt.executionWeek,
+          skipCode: receipt.skipCode,
+          publishChannelStub: receipt.publishChannelStub,
+          recordStatus: record?.status,
+          week: input.week,
+        }
+      )
+    )
+    sequence += 1
+  }
+
+  return notes
+}

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -295,6 +295,8 @@ import {
   composeWelfareDebtIntoIntegratedHealthBundles,
 } from '../containedPersonIntegratedHealthBundleCompose'
 import { applyWeeklyPatternSourceSeriesIntakeTick } from '../patternSourceSeriesWeeklyIntake'
+import { applyWeeklyPublishQueueExecutionTick } from '../publishQueueExecutor'
+import { buildWeeklyPublishQueueExecutionReportNotes } from '../publishQueueWeeklyReportNotes'
 import { composePopulationEmergenceNormalizationIntoDisclosureRecords } from '../publicDisclosureNormalizationCompose'
 import { applyWeeklyPublicDisclosureProgressionTick } from '../publicDisclosureWeeklyProgression'
 import { buildWeeklyPublicDisclosureTrustOutcomeReportNotes } from '../publicDisclosureTrustOutcomeWeeklyReportNotes'
@@ -4693,6 +4695,38 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
       currentPatternSourceSeriesRecords,
       result.week
     )
+  }
+
+  // SPE-2485 slice 1: dry-run publish-queue execution tick and weekly report surfacing.
+  const currentPublishQueueRecords = outputWeeklyState.publishQueueRecords ?? {}
+  if (Object.keys(currentPublishQueueRecords).length > 0) {
+    const publishQueueTick = applyWeeklyPublishQueueExecutionTick(
+      currentPublishQueueRecords,
+      result.week
+    )
+    outputWeeklyState.publishQueueRecords = publishQueueTick.records
+
+    if (publishQueueTick.receipts.length > 0 && result.reports.length > 0) {
+      const lastWeeklyReport = result.reports[result.reports.length - 1]
+      const publishQueueNotes = buildWeeklyPublishQueueExecutionReportNotes({
+        receipts: publishQueueTick.receipts,
+        records: publishQueueTick.records,
+        week: result.week,
+        sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
+        baseTimestamp: noteBaseTimestamp,
+      })
+
+      if (publishQueueNotes.length > 0) {
+        const reports = [...result.reports]
+        const lastReportIndex = reports.length - 1
+        const lastReport = reports[lastReportIndex]
+        reports[lastReportIndex] = {
+          ...lastReport,
+          notes: [...(lastReport.notes ?? []), ...publishQueueNotes],
+        }
+        result.reports = reports
+      }
+    }
   }
 
   // SPE-2122 slice 3: decay registration backlog on persisted population emergence records.

--- a/src/features/operations/PublishQueueMirrorPage.test.tsx
+++ b/src/features/operations/PublishQueueMirrorPage.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import { CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE } from '../../domain/publishAutomationCreditingHooks'
+import { useGameStore } from '../../app/store/gameStore'
+import PublishQueueMirrorPage from './PublishQueueMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/publish-queue']}>
+      <Routes>
+        <Route path="/publish-queue" element={<PublishQueueMirrorPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('PublishQueueMirrorPage (SPE-2485 slice 1)', () => {
+  it('renders empty state when no persisted publish queue records exist', () => {
+    renderMirrorPage()
+
+    expect(screen.getByRole('region', { name: /publish queue mirror/i })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty queue state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no publish queue records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted queue records when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.publishQueueRecords = {
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', { name: /persisted publish queue records/i })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label)
+    expect(recordsRegion).toHaveTextContent('Ready To Publish')
+    expect(screen.getByRole('link', { name: /back to operations desk/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/features/operations/PublishQueueMirrorPage.tsx
+++ b/src/features/operations/PublishQueueMirrorPage.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { PUBLISH_QUEUE_MIRROR_UI_TEXT } from '../../data/copy'
+import { getPublishQueueMirrorView } from './publishQueueMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function PublishQueueMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getPublishQueueMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Publish queue mirror">
+      <article className="panel panel-primary space-y-4" role="region" aria-label="Publish queue summary">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {PUBLISH_QUEUE_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">{PUBLISH_QUEUE_MIRROR_UI_TEXT.pageHeading}</h2>
+            <p className="text-sm opacity-60">{PUBLISH_QUEUE_MIRROR_UI_TEXT.pageSubtitle}</p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {PUBLISH_QUEUE_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.readyToPublishLabel}
+            value={String(view.summary.readyToPublishCount)}
+          />
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.publishedLabel}
+            value={String(view.summary.publishedCount)}
+          />
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">{PUBLISH_QUEUE_MIRROR_UI_TEXT.readOnlyNote}</p>
+      </article>
+
+      {view.isEmpty ? (
+        <article className="panel panel-support space-y-2" role="region" aria-label="Empty queue state">
+          <h3 className="text-lg font-semibold">{PUBLISH_QUEUE_MIRROR_UI_TEXT.emptyTitle}</h3>
+          <p className="text-sm opacity-70">{PUBLISH_QUEUE_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted publish queue records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">{PUBLISH_QUEUE_MIRROR_UI_TEXT.recordsHeading}</h3>
+            <p className="text-sm opacity-60">{PUBLISH_QUEUE_MIRROR_UI_TEXT.recordsSubtitle}</p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.labelColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.statusColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.artifactColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.queuedWeekColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.hooksColumn}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.id} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.label}</p>
+                      <p className="text-xs opacity-55">{record.id}</p>
+                      <p className="text-xs opacity-45">{record.summaryLabel}</p>
+                    </td>
+                    <td className="px-2 py-2">{record.statusLabel}</td>
+                    <td className="px-2 py-2">{record.releaseArtifactRef}</td>
+                    <td className="px-2 py-2">{record.queuedWeekLabel}</td>
+                    <td className="px-2 py-2">
+                      {record.creditingHookCount} crediting / {record.publishHookCount} publish
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -881,6 +881,11 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
       description: 'Review pattern source series queue rank and processing posture.',
     },
     {
+      label: 'Open publish queue mirror',
+      href: APP_ROUTES.publishQueue,
+      description: 'Review publish-queue records and dry-run execution posture.',
+    },
+    {
       label: 'Open self-censoring information mirror',
       href: APP_ROUTES.selfCensoringInformation,
       description: 'Review retention timers, rediscovery loops, and negative-fact posture.',

--- a/src/features/operations/publishQueueMirrorView.test.ts
+++ b/src/features/operations/publishQueueMirrorView.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import { CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE } from '../../domain/publishAutomationCreditingHooks'
+import { getPublishQueueMirrorView } from './publishQueueMirrorView'
+import { formatPublishQueueStatusLabel } from '../../domain/publishQueueSurfacing'
+
+describe('publishQueueMirrorView (SPE-2485 slice 1)', () => {
+  it('returns empty mirror when publishQueueRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.publishQueueRecords).toEqual({})
+
+    const view = getPublishQueueMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.summary.readyToPublishCount).toBe(0)
+    expect(view.summary.publishedCount).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('discriminates ready_to_publish vs published status labels', () => {
+    const game = createStartingState()
+    game.publishQueueRecords = {
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+      'publish-queue:published': {
+        ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+        id: 'publish-queue:published',
+        label: 'Published batch',
+        status: 'published',
+      },
+    }
+
+    const view = getPublishQueueMirrorView(game)
+
+    expect(view.isEmpty).toBe(false)
+    expect(view.summary.readyToPublishCount).toBe(1)
+    expect(view.summary.publishedCount).toBe(1)
+
+    const readyRecord = view.records.find(
+      (record) => record.id === CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id
+    )
+    const publishedRecord = view.records.find((record) => record.id === 'publish-queue:published')
+
+    expect(readyRecord?.statusLabel).toBe('Ready To Publish')
+    expect(publishedRecord?.statusLabel).toBe('Published')
+    expect(readyRecord?.releaseArtifactRef).toBe(
+      CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef
+    )
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatPublishQueueStatusLabel('needs_revision')).toBe('Needs Revision')
+  })
+
+  it('is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.publishQueueRecords = {
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    }
+
+    const first = JSON.stringify(getPublishQueueMirrorView(game))
+    const second = JSON.stringify(getPublishQueueMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/features/operations/publishQueueMirrorView.ts
+++ b/src/features/operations/publishQueueMirrorView.ts
@@ -1,0 +1,69 @@
+import type { GameState } from '../../domain/models'
+import type { PublishQueueRecord } from '../../domain/publishAutomationCreditingHooks'
+import {
+  formatPublishQueueStatusLabel,
+  summarizePublishQueueRecords,
+} from '../../domain/publishQueueSurfacing'
+
+export interface PublishQueueMirrorRecordView {
+  id: string
+  label: string
+  summaryLabel: string
+  releaseArtifactRef: string
+  statusLabel: string
+  queuedWeekLabel: string
+  creditingHookCount: number
+  publishHookCount: number
+  reasonCodeCount: number
+}
+
+export interface PublishQueueMirrorSummaryView {
+  totalRecords: number
+  readyToPublishCount: number
+  publishedCount: number
+  terminalCount: number
+  week: number
+}
+
+export interface PublishQueueMirrorView {
+  isEmpty: boolean
+  summary: PublishQueueMirrorSummaryView
+  records: readonly PublishQueueMirrorRecordView[]
+}
+
+function listPersistedRecords(game: GameState): PublishQueueRecord[] {
+  const map = game.publishQueueRecords ?? {}
+  return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function toRecordView(record: PublishQueueRecord): PublishQueueMirrorRecordView {
+  return Object.freeze({
+    id: record.id,
+    label: record.label,
+    summaryLabel: record.summary?.trim() ? record.summary : '—',
+    releaseArtifactRef: record.releaseArtifactRef,
+    statusLabel: formatPublishQueueStatusLabel(record.status),
+    queuedWeekLabel:
+      record.queuedWeek !== undefined && Number.isFinite(record.queuedWeek)
+        ? `W${record.queuedWeek}`
+        : '—',
+    creditingHookCount: record.creditingHooks.length,
+    publishHookCount: record.publishHooks.length,
+    reasonCodeCount: record.reasonCodes.length,
+  })
+}
+
+/** Read-only mirror over hydrated `publishQueueRecords`; does not re-validate hidden truth. */
+export function getPublishQueueMirrorView(game: GameState): PublishQueueMirrorView {
+  const records = listPersistedRecords(game)
+  const counts = summarizePublishQueueRecords(game.publishQueueRecords)
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      ...counts,
+      week: game.week,
+    }),
+    records: Object.freeze(records.map((record) => toRecordView(record))),
+  })
+}

--- a/src/features/report/reportNoteView.ts
+++ b/src/features/report/reportNoteView.ts
@@ -79,6 +79,7 @@ const SYSTEM_NOTE_TYPES: ReportNoteType[] = [
   'concealment.activated',
   'hub.opportunity',
   'hub.rumor',
+  'contribution_release.publish_queue_execution',
 ]
 
 export function getReportNoteCategory(note: ReportNote): ReportNoteCategory {

--- a/src/test/advanceWeek.publishQueue.integration.test.ts
+++ b/src/test/advanceWeek.publishQueue.integration.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import {
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+  composePublishQueueRecord,
+  evaluatePublishAutomationCreditingHooks,
+} from '../domain/publishAutomationCreditingHooks'
+import { evaluateContributionIntakeCuration, CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE } from '../domain/contributionIntakeCuration'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+} from '../domain/modularReleasePackaging'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+} from '../domain/submissionGovernanceRights'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+function buildCanonicalReadyQueueRecord() {
+  const acceptedCuration = evaluateContributionIntakeCuration(
+    CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE
+  )
+  const packagedRelease = evaluateModularReleasePackaging(
+    acceptedCuration,
+    CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+  )
+  const appliedGovernance = evaluateSubmissionGovernanceRights(
+    CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE
+  )
+  const decision = evaluatePublishAutomationCreditingHooks(
+    packagedRelease,
+    appliedGovernance,
+    CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+  )
+
+  return composePublishQueueRecord({
+    id: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+    label: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label,
+    releaseArtifactRef: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef,
+    decision,
+    summary: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.summary,
+    queuedWeek: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.queuedWeek,
+  })!
+}
+
+describe('advanceWeek publish queue integration (SPE-2485 slice 1)', () => {
+  it('is a no-op for an empty publish queue map without throwing', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.publishQueueRecords = {}
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.publishQueueRecords).toEqual({})
+  })
+
+  it('transitions ready_to_publish records and surfaces dry-run execution notes', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    const record = buildCanonicalReadyQueueRecord()
+    state.publishQueueRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state)
+    const nextRecord = nextState.publishQueueRecords?.[record.id]
+
+    expect(nextRecord?.status).toBe('published')
+
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const publishQueueNote = lastReport?.notes?.find(
+      (note) => note.type === 'contribution_release.publish_queue_execution'
+    )
+
+    expect(publishQueueNote).toBeDefined()
+    expect(publishQueueNote?.content).toContain('Publish queue (dry-run)')
+    expect(publishQueueNote?.content).toContain(record.label)
+    expect(publishQueueNote?.content).toContain('dry-run:publish_channel:pr-merge:channel:pr-merge')
+  })
+})

--- a/src/test/publishQueueSurfacing.test.ts
+++ b/src/test/publishQueueSurfacing.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE } from '../domain/publishAutomationCreditingHooks'
+import type { PublishQueueExecutionReceipt } from '../domain/publishQueueExecutor'
+import {
+  formatPublishQueueExecutionReceiptNoteContent,
+  formatPublishQueueStatusLabel,
+  isReportablePublishQueueReceipt,
+  listReportablePublishQueueReceipts,
+  summarizePublishQueueRecords,
+} from '../domain/publishQueueSurfacing'
+
+describe('publishQueueSurfacing (SPE-2485 slice 1)', () => {
+  it('returns empty summary for empty queue map without throwing', () => {
+    expect(summarizePublishQueueRecords({})).toEqual({
+      totalRecords: 0,
+      readyToPublishCount: 0,
+      publishedCount: 0,
+      terminalCount: 0,
+    })
+    expect(summarizePublishQueueRecords(undefined)).toEqual({
+      totalRecords: 0,
+      readyToPublishCount: 0,
+      publishedCount: 0,
+      terminalCount: 0,
+    })
+  })
+
+  it('discriminates ready_to_publish vs published vs terminal statuses', () => {
+    const summary = summarizePublishQueueRecords({
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+      'publish-queue:published': {
+        ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+        id: 'publish-queue:published',
+        status: 'published',
+      },
+      'publish-queue:needs-revision': {
+        ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+        id: 'publish-queue:needs-revision',
+        status: 'needs_revision',
+      },
+    })
+
+    expect(summary).toEqual({
+      totalRecords: 3,
+      readyToPublishCount: 1,
+      publishedCount: 1,
+      terminalCount: 1,
+    })
+    expect(formatPublishQueueStatusLabel('ready_to_publish')).toBe('Ready To Publish')
+    expect(formatPublishQueueStatusLabel('published')).toBe('Published')
+  })
+
+  it('filters reportable receipts and omits idempotent already_published skips', () => {
+    const completedReceipt: PublishQueueExecutionReceipt = {
+      recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      outcome: 'completed',
+      executionWeek: 2,
+      appliedHooks: [],
+      publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+    }
+    const skippedReceipt: PublishQueueExecutionReceipt = {
+      recordId: 'publish-queue:published',
+      outcome: 'skipped',
+      executionWeek: 2,
+      appliedHooks: [],
+      skipCode: 'already_published',
+    }
+    const rejectedReceipt: PublishQueueExecutionReceipt = {
+      recordId: 'publish-queue:rejected',
+      outcome: 'rejected',
+      executionWeek: 2,
+      appliedHooks: [],
+      skipCode: 'record_not_ready_to_publish',
+    }
+
+    expect(isReportablePublishQueueReceipt(completedReceipt)).toBe(true)
+    expect(isReportablePublishQueueReceipt(skippedReceipt)).toBe(false)
+    expect(isReportablePublishQueueReceipt(rejectedReceipt)).toBe(true)
+
+    expect(listReportablePublishQueueReceipts([skippedReceipt, rejectedReceipt, completedReceipt])).toEqual([
+      completedReceipt,
+      rejectedReceipt,
+    ])
+  })
+
+  it('formats dry-run receipt note content with safe labels only', () => {
+    const receipt: PublishQueueExecutionReceipt = {
+      recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      outcome: 'completed',
+      executionWeek: 2,
+      appliedHooks: [],
+      publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+    }
+
+    const content = formatPublishQueueExecutionReceiptNoteContent({
+      receipt,
+      record: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    })
+
+    expect(content).toContain('Publish queue (dry-run)')
+    expect(content).toContain(CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label)
+    expect(content).toContain('[Ready To Publish]')
+    expect(content).toContain('Completed (dry-run)')
+    expect(content).toContain('dry-run:publish_channel:pr-merge:channel:pr-merge')
+  })
+})

--- a/src/test/publishQueueWeeklyReportNotes.test.ts
+++ b/src/test/publishQueueWeeklyReportNotes.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE } from '../domain/publishAutomationCreditingHooks'
+import type { PublishQueueExecutionReceipt } from '../domain/publishQueueExecutor'
+import { buildWeeklyPublishQueueExecutionReportNotes } from '../domain/publishQueueWeeklyReportNotes'
+
+describe('publishQueueWeeklyReportNotes (SPE-2485 slice 1)', () => {
+  const completedReceipt: PublishQueueExecutionReceipt = {
+    recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+    outcome: 'completed',
+    executionWeek: 2,
+    appliedHooks: [],
+    publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+  }
+
+  it('returns no notes when receipts are empty or only idempotent skips', () => {
+    expect(
+      buildWeeklyPublishQueueExecutionReportNotes({
+        receipts: [],
+        records: {},
+        week: 2,
+        sequenceStart: 1,
+      })
+    ).toEqual([])
+
+    expect(
+      buildWeeklyPublishQueueExecutionReportNotes({
+        receipts: [
+          {
+            recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+            outcome: 'skipped',
+            executionWeek: 2,
+            appliedHooks: [],
+            skipCode: 'already_published',
+          },
+        ],
+        records: {
+          [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: {
+            ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+            status: 'published',
+          },
+        },
+        week: 2,
+        sequenceStart: 1,
+      })
+    ).toEqual([])
+  })
+
+  it('emits deterministic contribution_release notes for reportable receipts', () => {
+    const notes = buildWeeklyPublishQueueExecutionReportNotes({
+      receipts: [completedReceipt],
+      records: {
+        [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: {
+          ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+          status: 'published',
+        },
+      },
+      week: 2,
+      sequenceStart: 3,
+      baseTimestamp: 1_700_000_000_000,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.type).toBe('contribution_release.publish_queue_execution')
+    expect(notes[0]?.content).toContain('Publish queue (dry-run)')
+    expect(notes[0]?.metadata).toMatchObject({
+      recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      outcome: 'completed',
+      executionWeek: 2,
+      recordStatus: 'published',
+      week: 2,
+    })
+  })
+})

--- a/src/test/reportNoteTypeAudit.test.ts
+++ b/src/test/reportNoteTypeAudit.test.ts
@@ -108,6 +108,11 @@ export const REPORT_NOTE_TYPE_AUDIT = {
     producer: 'cognitiveHazardSimulationTriggerWeeklyReportNotes',
     category: 'system',
   },
+  'contribution_release.publish_queue_execution': {
+    status: 'active',
+    producer: 'publishQueueWeeklyReportNotes',
+    category: 'system',
+  },
 } as const satisfies Record<
   ReportNoteType,
   { status: 'active' | 'future-reserved' | 'stale'; producer: string; category: string }
@@ -119,7 +124,7 @@ describe('ReportNoteType audit (SPE-216)', () => {
       [ReportNoteType, (typeof REPORT_NOTE_TYPE_AUDIT)[ReportNoteType]]
     >
 
-    expect(entries).toHaveLength(50)
+    expect(entries).toHaveLength(51)
     expect(entries.every(([, audit]) => audit.status === 'active')).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- Wire `applyWeeklyPublishQueueExecutionTick` into `advanceWeek` for non-empty `publishQueueRecords`
- Add `contribution_release.publish_queue_execution` weekly report notes for reportable dry-run receipts
- Add read-only planning mirror at `/publish-queue` with Front Desk quick link

## Linear

- **Slice:** [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — Publish-queue UI / orchestration surfacing (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — stays **Done** (do not reopen)

## What shipped

- `publishQueueSurfacing.ts` + `publishQueueWeeklyReportNotes.ts`
- `publishQueueMirrorView.ts` + `PublishQueueMirrorPage.tsx` + route/desk wiring
- `advanceWeek` weekly tick + report note surfacing

## Validation

- `npm run test:run -- src/test/publishQueueSurfacing.test.ts src/test/publishQueueWeeklyReportNotes.test.ts src/test/advanceWeek.publishQueue.integration.test.ts src/features/operations/publishQueueMirrorView.test.ts src/features/operations/PublishQueueMirrorPage.test.tsx src/test/reportNoteTypeAudit.test.ts`
- `npm run lint`

## Docs updated

- `planning/publish-queue-surfacing-slice-1.md`
- `planning/backlog.md`
- `docs/contribution-and-release-operations.md`

## Parent status

SPE-75 parent remains **Done** — child-only surfacing slice; no parent reopen.