### PR TITLE
feat(SPE-2486): modifiable data-pack runtime import (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -53,6 +53,8 @@ Authoring tools and contribution pipelines may ship **modifiable data packs** (t
 
 Domain validation baseline: `src/domain/modifiableDataPackValidation.ts` (SPE-2479) accepts structured modifiable data-pack payloads and emits bounded schema-validation decisions with section-shape checks and borderline schema-version remediation — no publish side effects.
 
+Runtime import (SPE-2486) persists validated packs on `GameState.modifiableDataPackRecords` with sanitize/hydration on save import — rejected payloads drop without corrupting downstream state.
+
 ## Publish automation and crediting hooks
 
 After packaging and governance gates pass, publish-intent evaluation composes crediting targets (CONTRIBUTORS, changelog entries, version bumps) and bounded publish channel hooks without executing publish actions.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,6 +20,8 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **In progress:** _(none — owner reprioritizes from §14-pass alternates)_
 
+**Recently shipped:** [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) modifiable data-pack runtime import (slice 1) — `modifiableDataPackRecords` sanitize/hydrate on GameState; branch `spe-75-modifiable-data-pack-runtime-import-slice-1`.
+
 **Recently shipped:** [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) publish-queue UI / orchestration surfacing (slice 1) — dry-run tick + weekly notes + planning mirror; branch `spe-75-publish-queue-surfacing-slice-1` (PR #2890 @ `1a801ec0`).
 
 **Recently shipped:** [SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) registry umbrella grooming — parent AC matrices + deferred tables for [SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046); parents stay **Backlog**; `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`.
@@ -50,14 +52,14 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — publish-queue UI / orchestration surfacing (slice 1). Slice doc: `planning/publish-queue-surfacing-slice-1.md`. Branch: `spe-75-publish-queue-surfacing-slice-1`. Mission triage full refresh remains **blocked**.
+**Next step:** Owner reprioritizes from §14-pass alternates below. Mission triage full refresh remains **blocked**.
 
-**Base `main` SHA:** `dff81abe` — post SPE-2484 publish-queue executor closure.
+**Base `main` SHA:** `46d03bc1` — post SPE-2485 publish-queue surfacing closure.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
 1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — read-only `stabilityLayer.ts` category via `buildBranchContinuityRuntimeAuditSnapshot`; partial §14 (dev/stability tooling); see `planning/branch-continuity-runtime-hooks-slice-1.md` § Deferred.
-2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** modifiable data-pack runtime import ([SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) deferred) or real CI/GitHub API wiring (SPE-2484 dry-run executor shipped). Publish-queue surfacing child: [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485).
+2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** real CI/GitHub API wiring (SPE-2484 dry-run executor shipped; modifiable-pack runtime import SPE-2486 shipped).
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; no slice 5+ without fresh §14 pass — see `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md` § Deferred.
 
 **Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; real CI/GitHub publish API wiring without owner-scoped child.
@@ -223,6 +225,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `minor-anomaly-item-registry-slice-2.md`                  | **Shipped**    | SPE-2314 / PR #2492; `minorAnomalyItemRecords` GameState persistence.                                                                               |
 | `minor-anomaly-item-registry-slice-3.md`                  | **Shipped**    | SPE-2316 / PR #2496 — weekly disposition/custody advance hook for SPE-2104.                                                                         |
 | `modifiable-data-pack-validation-slice-1.md`              | **Shipped**    | [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) — deterministic modifiable data-pack schema validation under SPE-75; PR #2877 @ `cb4ea3ae`. |
+| `modifiable-data-pack-runtime-import-slice-1.md`          | **Shipped**    | [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) — GameState modifiable data-pack runtime import under SPE-75. |
 | `publish-automation-crediting-hooks-slice-1.md`           | **Shipped**    | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; PR #2879 @ `99161c79`. |
 | `publish-queue-persistence-slice-1.md`                    | **Shipped**    | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — `publishQueueRecords` GameState persistence under SPE-75; PR #2886 @ `93711130`. |
 | `publish-queue-executor-slice-1.md`                       | **Shipped**    | [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — dry-run publish executor under SPE-75; PR #2888 @ `6399251c`. |

--- a/planning/modifiable-data-pack-runtime-import-slice-1.md
+++ b/planning/modifiable-data-pack-runtime-import-slice-1.md
@@ -1,0 +1,63 @@
+# SPE-75 — Modifiable data-pack runtime import (slice 1)
+
+One-page implementation plan. Linear: [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) per `planning/modifiable-data-pack-validation-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2486 — Modifiable data-pack runtime import (slice 1)](https://linear.app/spectranoir/issue/SPE-2486) |
+| **Status** | **Shipped** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-modifiable-data-pack-runtime-import-slice-1` |
+| **Base `main` SHA** | `46d03bc1` |
+
+## Goal
+
+Wire validated modifiable data-pack import into the runtime load path with safe-fail envelope from SPE-2479 — persist on `GameState` with sanitize/hydration; no publish-queue or CI changes.
+
+## Prerequisite (on `main` @ `46d03bc1`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Validation envelope  | `src/domain/modifiableDataPackValidation.ts` (SPE-2479) |
+| Sanitize/hydrate pattern | `src/domain/publishAutomationCreditingHooks.ts` (SPE-2483) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `modifiableDataPackRecords` on `GameState` | Publish-queue or CI changes |
+| `sanitizeModifiableDataPackRecords` + `runTransfer` hydrate wire | Route/UI changes |
+| `composeModifiableDataPackRecord` read-only from validation decisions | Mission triage (blocked) |
+| Default `{}` in `createStartingState` | SPE-75 parent reopen |
+| Sanitize unit tests + save/import round-trip (byte-stable) | Weekly orchestration / surfacing |
+
+## Acceptance
+
+- [x] Valid canonical fixture round-trips through serialize/import
+- [x] Invalid/duplicate-id/rejected entries dropped safely on hydrate
+- [x] `composeModifiableDataPackRecord` matches canonical fixture from upstream chain
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/modifiableDataPackValidation.ts`, `src/domain/models.ts` |
+| Store  | `src/app/store/runTransfer.ts`                                        |
+| Data   | `src/data/startingState.ts`                                           |
+| Tests  | `src/test/modifiableDataPackRuntimeImport.test.ts` |
+| Plan   | `planning/modifiable-data-pack-runtime-import-slice-1.md`, `planning/backlog.md` |
+| Docs   | optional cross-ref in `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Modifiable-pack UI / weekly orchestration | SPE-75 follow-up child | Persistence must land before surfacing |
+| Publish automation integration for pack import | SPE-75 follow-up child | Out of runtime-import boundary |
+
+## See also
+
+- `planning/modifiable-data-pack-validation-slice-1.md`
+- `planning/publish-queue-persistence-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -214,6 +214,7 @@ import {
 } from '../../domain/coverStoryLifecycleRegistry'
 import { sanitizePatternSourceSeriesRecords } from '../../domain/patternSourceSeriesRegistry'
 import { sanitizePublishQueueRecords } from '../../domain/publishAutomationCreditingHooks'
+import { sanitizeModifiableDataPackRecords } from '../../domain/modifiableDataPackValidation'
 import { sanitizeMassAnomalousPopulationEmergenceRecords } from '../../domain/massAnomalousPopulationEmergenceRegistry'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
@@ -8566,6 +8567,10 @@ export function hydrateGame(
     game.publishQueueRecords,
     fallback.publishQueueRecords ?? {}
   )
+  const modifiableDataPackRecords = sanitizeModifiableDataPackRecords(
+    game.modifiableDataPackRecords,
+    fallback.modifiableDataPackRecords ?? {}
+  )
   const massAnomalousPopulationEmergenceRecords =
     sanitizeMassAnomalousPopulationEmergenceRecords(
       game.massAnomalousPopulationEmergenceRecords,
@@ -8764,6 +8769,7 @@ export function hydrateGame(
       coverStoryWeeklyProjectionSnapshots,
       patternSourceSeriesRecords,
       publishQueueRecords,
+      modifiableDataPackRecords,
       massAnomalousPopulationEmergenceRecords,
       visualTriggerHazardRecords,
       entityWelfareReclassificationRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -56,6 +56,7 @@ const startingStateTemplate: GameState = {
   coverStoryWeeklyProjectionSnapshots: {},
   patternSourceSeriesRecords: {},
   publishQueueRecords: {},
+  modifiableDataPackRecords: {},
   massAnomalousPopulationEmergenceRecords: {},
   visualTriggerHazardRecords: {},
   entityWelfareReclassificationRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -268,6 +268,7 @@ import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 import type { PublishQueueRecord } from './publishAutomationCreditingHooks'
+import type { ModifiableDataPackRecord } from './modifiableDataPackValidation'
 import type { TherapeuticCareScheduleRecord } from './containedPersonTherapeuticCareRegistry'
 import type {
   CoerciveProtocolRecord,
@@ -2717,6 +2718,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing.
    */
   publishQueueRecords?: Record<string, PublishQueueRecord>
+
+  /**
+   * SPE-2486 slice 1: persisted modifiable data-pack records (keyed by packId).
+   * Hydration re-validates via SPE-2479 and drops rejected or duplicate-id entries.
+   */
+  modifiableDataPackRecords?: Record<string, ModifiableDataPackRecord>
 
   /**
    * SPE-2122 slice 2: persisted mass anomalous population emergence records (keyed by record id).

--- a/src/domain/modifiableDataPackValidation.ts
+++ b/src/domain/modifiableDataPackValidation.ts
@@ -576,3 +576,406 @@ export function evaluateModifiableDataPackValidation(
     packMetadata: buildPackMetadata(payload!, packKind, sectionCount),
   })
 }
+
+// ---------------------------------------------------------------------------
+// Runtime import persistence (SPE-2486 slice 1)
+// ---------------------------------------------------------------------------
+
+export type ModifiableDataPackRecordId = string
+
+export type ModifiableDataPackImportStatus = Extract<
+  DataPackValidationStatus,
+  'applied' | 'needs_revision'
+>
+
+export interface ModifiableSectionRecord {
+  readonly sectionKey: string
+  readonly fieldType: ModifiableFieldType
+  readonly defaultValue?: unknown
+}
+
+export interface ModifiableDataPackRecord {
+  readonly packId: ModifiableDataPackRecordId
+  readonly schemaVersion: string
+  readonly packKind: ModifiableDataPackKind
+  readonly authorRef: string
+  readonly issueLink: string
+  readonly modifiableSections: readonly ModifiableSectionRecord[]
+  readonly importStatus: ModifiableDataPackImportStatus
+  readonly reasonCodes: readonly DataPackReasonCode[]
+}
+
+export type ModifiableDataPackRecordsMap = Record<
+  ModifiableDataPackRecordId,
+  ModifiableDataPackRecord
+>
+
+export type ModifiableDataPackRecordValidationCode =
+  | 'missing_pack_id'
+  | 'missing_schema_version'
+  | 'missing_pack_kind'
+  | 'invalid_pack_kind'
+  | 'missing_modifiable_sections'
+  | 'invalid_section_shape'
+  | 'invalid_import_status'
+  | 'invalid_reason_code'
+  | 'validation_rejected'
+
+export interface ModifiableDataPackRecordValidationIssue {
+  readonly code: ModifiableDataPackRecordValidationCode
+  readonly severity: 'error'
+  readonly detail: string
+}
+
+export interface ModifiableDataPackRecordValidationResult {
+  readonly valid: boolean
+  readonly issues: readonly ModifiableDataPackRecordValidationIssue[]
+}
+
+const DATA_PACK_REASON_CODE_SET = new Set<string>([
+  'invalid_payload',
+  'missing_pack_id',
+  'missing_schema_version',
+  'invalid_schema_version',
+  'missing_pack_kind',
+  'invalid_pack_kind',
+  'missing_modifiable_sections',
+  'invalid_modifiable_section_shape',
+  'missing_section_key',
+  'duplicate_section_keys',
+  'invalid_field_type',
+  'default_value_type_mismatch',
+  'schema_version_borderline',
+])
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isDataPackReasonCode(value: string): value is DataPackReasonCode {
+  return DATA_PACK_REASON_CODE_SET.has(value)
+}
+
+function isModifiableDataPackImportStatus(
+  value: string
+): value is ModifiableDataPackImportStatus {
+  return value === 'applied' || value === 'needs_revision'
+}
+
+function sortModifiableSections(
+  sections: ModifiableSectionRecord[]
+): readonly ModifiableSectionRecord[] {
+  return Object.freeze(
+    [...sections]
+      .sort((left, right) => left.sectionKey.localeCompare(right.sectionKey))
+      .map((section) =>
+        Object.freeze({
+          sectionKey: section.sectionKey,
+          fieldType: section.fieldType,
+          ...(section.defaultValue !== undefined ? { defaultValue: section.defaultValue } : {}),
+        })
+      )
+  )
+}
+
+function parseModifiableSectionRecords(value: unknown): ModifiableSectionRecord[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const sections: ModifiableSectionRecord[] = []
+
+  for (const entry of value) {
+    if (!isPlainRecord(entry)) {
+      continue
+    }
+
+    const sectionKey = normalizeToken(entry.sectionKey)
+    const fieldTypeToken = normalizeToken(entry.fieldType)
+
+    if (!sectionKey || !fieldTypeToken || !isModifiableFieldType(fieldTypeToken)) {
+      continue
+    }
+
+    const defaultValue = entry.defaultValue
+
+    sections.push({
+      sectionKey,
+      fieldType: fieldTypeToken,
+      ...(defaultValue !== undefined ? { defaultValue } : {}),
+    })
+  }
+
+  return sections
+}
+
+function modifiableDataPackRecordToPayload(
+  record: ModifiableDataPackRecord
+): ModifiableDataPackPayload {
+  return {
+    packId: record.packId,
+    schemaVersion: record.schemaVersion,
+    packKind: record.packKind,
+    authorRef: record.authorRef,
+    issueLink: record.issueLink,
+    modifiableSections: record.modifiableSections.map((section) => ({
+      sectionKey: section.sectionKey,
+      fieldType: section.fieldType,
+      ...(section.defaultValue !== undefined ? { defaultValue: section.defaultValue } : {}),
+    })),
+  }
+}
+
+function freezeModifiableDataPackRecordValidationResult(
+  issues: ModifiableDataPackRecordValidationIssue[]
+): ModifiableDataPackRecordValidationResult {
+  const sortedIssues = [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+
+  return Object.freeze({
+    valid: sortedIssues.length === 0,
+    issues: Object.freeze(sortedIssues.map((issue) => Object.freeze({ ...issue }))),
+  })
+}
+
+function defineModifiableDataPackRecord(
+  record: ModifiableDataPackRecord
+): ModifiableDataPackRecord {
+  return Object.freeze({
+    packId: normalizeToken(record.packId),
+    schemaVersion: normalizeToken(record.schemaVersion),
+    packKind: record.packKind,
+    authorRef: normalizeToken(record.authorRef),
+    issueLink: normalizeToken(record.issueLink),
+    modifiableSections: sortModifiableSections([...record.modifiableSections]),
+    importStatus: record.importStatus,
+    reasonCodes: Object.freeze([...record.reasonCodes]),
+  })
+}
+
+export function validateModifiableDataPackRecord(
+  record: ModifiableDataPackRecord,
+  policy?: DataPackValidationPolicy
+): ModifiableDataPackRecordValidationResult {
+  const issues: ModifiableDataPackRecordValidationIssue[] = []
+  const packId = normalizeToken(record.packId)
+  const schemaVersion = normalizeToken(record.schemaVersion)
+  const packKindToken = normalizeToken(record.packKind)
+  const importStatus = record.importStatus
+
+  if (!packId) {
+    issues.push({
+      code: 'missing_pack_id',
+      severity: 'error',
+      detail: 'Modifiable data-pack record is missing packId.',
+    })
+  }
+
+  if (!schemaVersion) {
+    issues.push({
+      code: 'missing_schema_version',
+      severity: 'error',
+      detail: 'Modifiable data-pack record is missing schemaVersion.',
+    })
+  }
+
+  if (!packKindToken) {
+    issues.push({
+      code: 'missing_pack_kind',
+      severity: 'error',
+      detail: 'Modifiable data-pack record is missing packKind.',
+    })
+  } else if (!isModifiableDataPackKind(packKindToken)) {
+    issues.push({
+      code: 'invalid_pack_kind',
+      severity: 'error',
+      detail: `Modifiable data-pack record has invalid packKind "${packKindToken}".`,
+    })
+  }
+
+  if (!Array.isArray(record.modifiableSections) || record.modifiableSections.length === 0) {
+    issues.push({
+      code: 'missing_modifiable_sections',
+      severity: 'error',
+      detail: 'Modifiable data-pack record must include at least one modifiable section.',
+    })
+  } else {
+    for (const section of record.modifiableSections) {
+      if (
+        !section ||
+        typeof section !== 'object' ||
+        !normalizeToken(section.sectionKey) ||
+        !isModifiableFieldType(section.fieldType)
+      ) {
+        issues.push({
+          code: 'invalid_section_shape',
+          severity: 'error',
+          detail: 'Each modifiable section record must include sectionKey and fieldType.',
+        })
+        break
+      }
+    }
+  }
+
+  if (typeof importStatus !== 'string' || !isModifiableDataPackImportStatus(importStatus)) {
+    issues.push({
+      code: 'invalid_import_status',
+      severity: 'error',
+      detail: 'Modifiable data-pack record has invalid importStatus.',
+    })
+  }
+
+  for (const reasonCode of record.reasonCodes) {
+    if (!isDataPackReasonCode(reasonCode)) {
+      issues.push({
+        code: 'invalid_reason_code',
+        severity: 'error',
+        detail: `Modifiable data-pack record has invalid reasonCode "${reasonCode}".`,
+      })
+    }
+  }
+
+  if (issues.length > 0) {
+    return freezeModifiableDataPackRecordValidationResult(issues)
+  }
+
+  const decision = evaluateModifiableDataPackValidation(
+    modifiableDataPackRecordToPayload(record),
+    policy
+  )
+
+  if (decision.status === 'rejected') {
+    issues.push({
+      code: 'validation_rejected',
+      severity: 'error',
+      detail: 'Modifiable data-pack record failed upstream schema validation.',
+    })
+  } else if (decision.status !== importStatus) {
+    issues.push({
+      code: 'invalid_import_status',
+      severity: 'error',
+      detail: `Modifiable data-pack record importStatus "${importStatus}" does not match validation decision "${decision.status}".`,
+    })
+  }
+
+  const expectedReasonCodes = [...decision.reasonCodes].sort((left, right) =>
+    left.localeCompare(right)
+  )
+  const actualReasonCodes = [...record.reasonCodes].sort((left, right) => left.localeCompare(right))
+
+  if (actualReasonCodes.join('|') !== expectedReasonCodes.join('|')) {
+    issues.push({
+      code: 'invalid_reason_code',
+      severity: 'error',
+      detail: 'Modifiable data-pack record reasonCodes do not match validation decision.',
+    })
+  }
+
+  return freezeModifiableDataPackRecordValidationResult(issues)
+}
+
+/**
+ * Imports a modifiable data-pack payload through SPE-2479 validation and returns a
+ * canonical runtime record, or null when validation rejects the payload.
+ */
+export function composeModifiableDataPackRecord(
+  payload?: ModifiableDataPackPayload,
+  policy?: DataPackValidationPolicy
+): ModifiableDataPackRecord | null {
+  const decision = evaluateModifiableDataPackValidation(payload, policy)
+
+  if (decision.status === 'rejected' || !decision.packMetadata) {
+    return null
+  }
+
+  const sections = parseModifiableSectionRecords(payload?.modifiableSections)
+
+  if (sections.length === 0) {
+    return null
+  }
+
+  const record = defineModifiableDataPackRecord({
+    packId: decision.packMetadata.packId,
+    schemaVersion: decision.packMetadata.schemaVersion,
+    packKind: decision.packMetadata.packKind,
+    authorRef: decision.packMetadata.authorRef,
+    issueLink: decision.packMetadata.issueLink,
+    modifiableSections: sections,
+    importStatus: decision.status,
+    reasonCodes: decision.reasonCodes,
+  })
+
+  return validateModifiableDataPackRecord(record, policy).valid ? record : null
+}
+
+/** Alias for compose — runtime import entry point for structured pack payloads. */
+export function importModifiableDataPackPayload(
+  payload?: ModifiableDataPackPayload,
+  policy?: DataPackValidationPolicy
+): ModifiableDataPackRecord | null {
+  return composeModifiableDataPackRecord(payload, policy)
+}
+
+function sanitizeModifiableDataPackRecordEntry(
+  value: unknown,
+  policy?: DataPackValidationPolicy
+): ModifiableDataPackRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const payload: ModifiableDataPackPayload = {
+    packId: normalizeToken(value.packId),
+    schemaVersion: normalizeToken(value.schemaVersion),
+    packKind: normalizeToken(value.packKind),
+    authorRef: normalizeToken(value.authorRef),
+    issueLink: normalizeToken(value.issueLink),
+    modifiableSections: parseModifiableSectionRecords(value.modifiableSections),
+  }
+
+  return composeModifiableDataPackRecord(payload, policy)
+}
+
+/** Hydration: canonical record map keyed by packId; drops invalid and duplicate-id entries. */
+export function sanitizeModifiableDataPackRecords(
+  value: unknown,
+  fallback: ModifiableDataPackRecordsMap = {},
+  policy?: DataPackValidationPolicy
+): ModifiableDataPackRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: ModifiableDataPackRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeModifiableDataPackRecordEntry(entry, policy)
+    if (!record || seenIds.has(record.packId)) {
+      continue
+    }
+
+    seenIds.add(record.packId)
+    next[record.packId] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
+/** Applied pack record composed from the canonical SPE-2479 fixture chain. */
+export const CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE: ModifiableDataPackRecord =
+  defineModifiableDataPackRecord(
+    composeModifiableDataPackRecord(CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE)!
+  )
+
+/** Borderline-schema pack record composed from the SPE-2479 borderline fixture. */
+export const BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE: ModifiableDataPackRecord =
+  defineModifiableDataPackRecord(
+    composeModifiableDataPackRecord(BORDERLINE_SCHEMA_DATA_PACK_FIXTURE)!
+  )

--- a/src/test/modifiableDataPackRuntimeImport.test.ts
+++ b/src/test/modifiableDataPackRuntimeImport.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import {
+  BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+  BORDERLINE_SCHEMA_DATA_PACK_FIXTURE,
+  CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE,
+  CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+  INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+  PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE,
+  composeModifiableDataPackRecord,
+  importModifiableDataPackPayload,
+  sanitizeModifiableDataPackRecords,
+} from '../domain/modifiableDataPackValidation'
+
+describe('modifiableDataPack runtime import (SPE-2486 slice 1)', () => {
+  it('defaults starting state to an empty modifiable data-pack map', () => {
+    expect(createStartingState().modifiableDataPackRecords).toEqual({})
+  })
+
+  it('composes a valid record read-only from the canonical validation fixture', () => {
+    const composed = composeModifiableDataPackRecord(CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE)
+
+    expect(composed).toEqual(CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE)
+    expect(importModifiableDataPackPayload(CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE)).toEqual(
+      composed
+    )
+  })
+
+  it('composes a needs_revision record from the borderline schema fixture', () => {
+    const composed = composeModifiableDataPackRecord(BORDERLINE_SCHEMA_DATA_PACK_FIXTURE)
+
+    expect(composed).toEqual(BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE)
+    expect(composed?.importStatus).toBe('needs_revision')
+    expect(composed?.reasonCodes).toEqual(['schema_version_borderline'])
+  })
+
+  it('returns null for rejected validation payloads without throwing', () => {
+    expect(composeModifiableDataPackRecord(INVALID_MODIFIABLE_DATA_PACK_FIXTURE)).toBeNull()
+    expect(composeModifiableDataPackRecord(PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE)).toBeNull()
+    expect(composeModifiableDataPackRecord(undefined)).toBeNull()
+  })
+
+  it('drops invalid and duplicate-id entries during sanitize without throwing', () => {
+    const fallback = {}
+    const sanitized = sanitizeModifiableDataPackRecords(
+      {
+        valid: CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+        duplicate: {
+          ...CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+          authorRef: 'contributor:duplicate-should-lose',
+        },
+        'wrong-key': {
+          ...CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+          packId: CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId,
+          authorRef: 'contributor:wrong-map-key-should-lose',
+        },
+        rejected: INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+        partial: PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE,
+        staleStatus: {
+          ...CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+          importStatus: 'rejected',
+        },
+        driftedReasonCodes: {
+          ...CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+          reasonCodes: ['invalid_payload'],
+        },
+      },
+      fallback
+    )
+
+    expect(sanitized[CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]).toEqual(
+      CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE
+    )
+    expect(sanitized.duplicate).toBeUndefined()
+    expect(sanitized['wrong-key']).toBeUndefined()
+    expect(sanitized.rejected).toBeUndefined()
+    expect(sanitized.partial).toBeUndefined()
+    expect(sanitized.staleStatus).toBeUndefined()
+    expect(sanitized.driftedReasonCodes).toBeUndefined()
+    expect(Object.keys(sanitized)).toEqual([CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId])
+  })
+
+  it('round-trips fixture records byte-stable through save/load', () => {
+    const state = createStartingState()
+    state.modifiableDataPackRecords = {
+      [CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+      [BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.modifiableDataPackRecords).toEqual(state.modifiableDataPackRecords)
+  })
+
+  it('hydrates persisted modifiable data-pack records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        modifiableDataPackRecords: {
+          [CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+            CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+          invalid: INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+          partial: PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE,
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.modifiableDataPackRecords).toEqual({
+      [CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Persist validated modifiable data packs on `GameState.modifiableDataPackRecords` with SPE-2479 safe-fail validation on import.
- Add `composeModifiableDataPackRecord` / `sanitizeModifiableDataPackRecords` and wire hydration through `runTransfer`.
- Rejected, partial, duplicate-id, and schema-drift entries drop on hydrate without corrupting downstream state.

## Linear mapping

- **Slice:** [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) — Modifiable data-pack runtime import (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — remains **Done** (do not reopen)

## What shipped

- `modifiableDataPackRecords` on GameState + default `{}` in starting state
- Runtime import persistence in `modifiableDataPackValidation.ts` (compose, sanitize, canonical fixtures)
- Save/import round-trip and hydrate tests

## Validation

- `npm run test:run -- src/test/modifiableDataPackRuntimeImport.test.ts src/test/modifiableDataPackValidation.test.ts` (13 passed)
- `npm run lint` on touched files (clean)

## Docs updated

- `docs/contribution-and-release-operations.md`
- `planning/modifiable-data-pack-runtime-import-slice-1.md`
- `planning/backlog.md`

## Parent status

SPE-75 parent remains **Done** — this is a deferred follow-on child only.

Made with [Cursor](https://cursor.com)