### PR TITLE
feat(SPE-2487): branch continuity stability-audit category (slice 1)

### DIFF
--- a/planning/branch-continuity-stability-audit-category-slice-1.md
+++ b/planning/branch-continuity-stability-audit-category-slice-1.md
@@ -1,0 +1,69 @@
+# SPE-2487 — Branch continuity stability-audit category (slice 1)
+
+One-page implementation plan. Optional follow-on from [SPE-2362](https://linear.app/spectranoir/issue/SPE-2362) deferred table.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2487 — Branch continuity stability-audit category (slice 1)](https://linear.app/spectranoir/issue/SPE-2487) |
+| **Parent** | [SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) — substrate Done; parent stays **Done**        |
+| **Branch** | `spe-2487-branch-continuity-stability-audit-category-slice-1`                                              |
+| **Status** | **In progress** — PR pending                                                                               |
+| **Base `main` SHA** | `9358d867`                                                                                          |
+
+## Goal
+
+Project `buildBranchContinuityRuntimeAuditSnapshot` into a read-only `stabilityLayer.ts` stability-audit category for dev/stability tooling.
+
+## Seam choice
+
+**Developer overlay stability projection** — extends slice 1 seam:
+
+- Reuses `buildDeveloperOverlaySnapshot` optional `branchContinuityAuthoredNodes` build option
+- Merges `branch-continuity` category issues into overlay `stability` summary via `appendStabilityIssues`
+- Keeps explicit-supply boundary: inactive snapshot emits zero stability issues
+
+## Prerequisite (on `main`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Runtime audit hook   | `src/domain/branchContinuityRuntimeHooks.ts` (SPE-2362)                |
+| Dev overlay seam     | `src/features/developer/developerOverlayView.ts` (SPE-2362)            |
+| Stability layer      | `src/domain/stabilityLayer.ts`                                         |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `branch-continuity` `StabilityIssueCategory`                       | Core `branchContinuity.ts` changes            |
+| `buildBranchContinuityStabilityIssues` + `appendStabilityIssues`   | GameState persistence keys                    |
+| Dev overlay stability merge                                        | `advanceWeek` / encounter orchestration       |
+| `src/test/branchContinuityRuntimeHooks.test.ts` extensions         | Automatic authored-graph import               |
+| `src/test/stabilityLayer.test.ts` category unit test               | Player UI                                     |
+| Slice doc (this file)                                              | Parent SPE-1464 reopen                        |
+
+## Acceptance
+
+- [x] `buildBranchContinuityStabilityIssues` maps active runtime audit snapshot → `branch-continuity` stability issues
+- [x] Inactive snapshot emits zero stability issues (no false positives)
+- [x] Dev overlay `stability` summary includes branch-continuity category when explicit nodes supplied
+- [x] Deterministic: repeated builds byte-identical for same inputs
+- [x] Integration tests + neighbor regression green
+- [x] `npm run lint` green
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Modifiable-pack UI / weekly orchestration | [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) | Publish automation integration for pack import — out of dev/stability tooling boundary |
+| Publish automation integration for pack import | Backlog grooming | Documented in SPE-2486 slice scope |
+| Dedicated exploit-access content slice | Backlog grooming | Validator shipped; defer unless scoped slice owner exists |
+
+## Validation
+
+```bash
+npm run test:run -- src/test/branchContinuityRuntimeHooks.test.ts
+npm run test:run -- src/test/stabilityLayer.test.ts
+npm run test:run -- src/test/branchContinuity.test.ts src/test/branchContinuityAuthoring.test.ts src/test/branchContinuityAudit.test.ts src/test/branchContinuityProjection.test.ts src/test/branchContinuityHarvestReconciliation.test.ts
+npm run test:run -- src/test/developerOverlayView.test.ts
+npm run lint
+```

--- a/src/domain/branchContinuityRuntimeHooks.ts
+++ b/src/domain/branchContinuityRuntimeHooks.ts
@@ -14,6 +14,7 @@ import {
 } from './branchContinuityAuthoring'
 import type { BranchPathProjectionOptions } from './branchContinuityProjection'
 import type { GameState } from './models'
+import type { StabilityIssue, StabilityIssueSeverity } from './stabilityLayer'
 
 export interface BranchContinuityRuntimeAuditInput {
   game: GameState
@@ -48,6 +49,27 @@ const INACTIVE_REPORT_LINES = [
 ] as const
 
 const TOP_WARNING_LIMIT = 8
+
+function mapBranchContinuitySeverity(severity: string): StabilityIssueSeverity {
+  return severity === 'error' ? 'error' : 'warning'
+}
+
+export function buildBranchContinuityStabilityIssues(
+  snapshot: BranchContinuityRuntimeAuditSnapshot
+): StabilityIssue[] {
+  if (!snapshot.active) {
+    return []
+  }
+
+  return snapshot.topWarnings.map((warning) => ({
+    id: `branch-continuity.${warning.nodeId}.${warning.warningClass}`,
+    category: 'branch-continuity',
+    severity: mapBranchContinuitySeverity(warning.severity),
+    summary: warning.summary,
+    details: `node=${warning.nodeId} class=${warning.warningClass}`,
+    recoveryActions: [],
+  }))
+}
 
 export function buildBranchContinuityRuntimeAuditSnapshot(
   input: BranchContinuityRuntimeAuditInput

--- a/src/domain/stabilityLayer.ts
+++ b/src/domain/stabilityLayer.ts
@@ -44,6 +44,7 @@ export type StabilityIssueCategory =
   | 'team-composition'
   | 'mission-routing'
   | 'deployment-readiness'
+  | 'branch-continuity'
 
 export type StabilityIssueSeverity = 'warning' | 'error'
 
@@ -272,6 +273,32 @@ export function hasSafeFrontDeskFallback(state: GameState) {
     safe: reasons.length === 0,
     reasons,
     directorMessageRouteId: frontDeskView.debug.directorMessageRouteId,
+  }
+}
+
+export function appendStabilityIssues(
+  report: StabilityReport,
+  additionalIssues: StabilityIssue[]
+): StabilityReport {
+  if (additionalIssues.length === 0) {
+    return report
+  }
+
+  const issues = [...report.issues, ...additionalIssues]
+  const errorCount = issues.filter((issue) => issue.severity === 'error').length
+  const warningCount = issues.length - errorCount
+  const categories = toStableUnique(issues.map((issue) => issue.category)) as StabilityIssueCategory[]
+
+  return {
+    issues,
+    summary: {
+      issueCount: issues.length,
+      errorCount,
+      warningCount,
+      softlockRisk: errorCount > 0,
+      categories,
+    },
+    recoveryActions: report.recoveryActions,
   }
 }
 

--- a/src/features/developer/developerOverlayView.ts
+++ b/src/features/developer/developerOverlayView.ts
@@ -1,5 +1,6 @@
 import {
   buildBranchContinuityRuntimeAuditSnapshot,
+  buildBranchContinuityStabilityIssues,
   type BranchContinuityRuntimeAuditSnapshot,
 } from '../../domain/branchContinuityRuntimeHooks'
 import type { AuthoredBranchContinuityNode } from '../../domain/branchContinuityAuthoring'
@@ -23,7 +24,7 @@ import {
   rankBestAvailableTeams,
 } from '../../domain/teamComposition'
 import { normalizeMissionRoutingState } from '../../domain/missionIntakeRouting'
-import { analyzeRuntimeStability } from '../../domain/stabilityLayer'
+import { analyzeRuntimeStability, appendStabilityIssues } from '../../domain/stabilityLayer'
 import { getTeamAssignedCaseId } from '../../domain/teamSimulation'
 import {
   explainDeploymentReadiness,
@@ -350,11 +351,14 @@ export function buildDeveloperOverlaySnapshot(
   const missionEntries = missionRouting.orderedMissionIds
     .map((missionId) => missionRouting.missions[missionId])
     .filter((mission): mission is NonNullable<typeof missionRouting.missions[string]> => Boolean(mission))
-  const stability = analyzeRuntimeStability(game)
   const branchContinuityAudit = buildBranchContinuityRuntimeAuditSnapshot({
     game,
     authoredNodes: options.branchContinuityAuthoredNodes ?? [],
   })
+  const stability = appendStabilityIssues(
+    analyzeRuntimeStability(game),
+    buildBranchContinuityStabilityIssues(branchContinuityAudit)
+  )
   const pressure = explainWeeklyPressureState(game)
   const latestWeakestLinks = Object.values(game.reports.at(-1)?.caseSnapshots ?? {})
     .filter((snapshot) => snapshot.missionResult?.weakestLink)

--- a/src/test/branchContinuityRuntimeHooks.test.ts
+++ b/src/test/branchContinuityRuntimeHooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
-import { buildBranchContinuityRuntimeAuditSnapshot } from '../domain/branchContinuityRuntimeHooks'
+import { buildBranchContinuityRuntimeAuditSnapshot, buildBranchContinuityStabilityIssues } from '../domain/branchContinuityRuntimeHooks'
 import { appendDeveloperLogEvent } from '../domain/developerLog'
 import { setGlobalFlag } from '../domain/gameStateManager'
 import { buildDeveloperOverlaySnapshot } from '../features/developer/developerOverlayView'
@@ -79,10 +79,78 @@ describe('branchContinuityRuntimeHooks (SPE-2362)', () => {
     expect(first).toEqual(second)
   })
 
-  it('exports only the runtime audit snapshot builder', async () => {
+  it('exports only the runtime audit snapshot builders', async () => {
     const runtimeHooksModule = await import('../domain/branchContinuityRuntimeHooks')
 
-    expect(Object.keys(runtimeHooksModule).sort()).toEqual(['buildBranchContinuityRuntimeAuditSnapshot'])
+    expect(Object.keys(runtimeHooksModule).sort()).toEqual([
+      'buildBranchContinuityRuntimeAuditSnapshot',
+      'buildBranchContinuityStabilityIssues',
+    ])
+  })
+
+  describe('stability-audit category projection', () => {
+    it('returns no stability issues when snapshot is inactive', () => {
+      const game = createStartingState()
+      const snapshot = buildBranchContinuityRuntimeAuditSnapshot({
+        game,
+        authoredNodes: [],
+      })
+
+      expect(buildBranchContinuityStabilityIssues(snapshot)).toEqual([])
+    })
+
+    it('projects active snapshot warnings into branch-continuity stability issues', () => {
+      let game = createStartingState()
+      game = setGlobalFlag(game, 'branch.seed.precisionAlign', 3)
+
+      const snapshot = buildBranchContinuityRuntimeAuditSnapshot({
+        game,
+        authoredNodes: [
+          {
+            id: 'node:stability-category-precision-gate',
+            continuity: {
+              requires: { requiredSeedValues: { 'branch.seed.precisionAlign': 7 } },
+            },
+          },
+        ],
+      })
+
+      const issues = buildBranchContinuityStabilityIssues(snapshot)
+
+      expect(issues).toHaveLength(snapshot.topWarnings.length)
+      expect(issues).toEqual(
+        snapshot.topWarnings.map((warning) => ({
+          id: `branch-continuity.${warning.nodeId}.${warning.warningClass}`,
+          category: 'branch-continuity',
+          severity: warning.severity === 'error' ? 'error' : 'warning',
+          summary: warning.summary,
+          details: `node=${warning.nodeId} class=${warning.warningClass}`,
+          recoveryActions: [],
+        }))
+      )
+      expect(issues.some((issue) => issue.severity === 'error')).toBe(true)
+    })
+
+    it('is deterministic for identical snapshot input', () => {
+      let game = createStartingState()
+      game = setGlobalFlag(game, 'branch.seed.precisionAlign', 3)
+
+      const snapshot = buildBranchContinuityRuntimeAuditSnapshot({
+        game,
+        authoredNodes: [
+          {
+            id: 'node:stability-category-precision-gate',
+            continuity: {
+              requires: { requiredSeedValues: { 'branch.seed.precisionAlign': 7 } },
+            },
+          },
+        ],
+      })
+
+      expect(buildBranchContinuityStabilityIssues(snapshot)).toEqual(
+        buildBranchContinuityStabilityIssues(snapshot)
+      )
+    })
   })
 
   describe('developer overlay seam', () => {
@@ -97,6 +165,10 @@ describe('branchContinuityRuntimeHooks (SPE-2362)', () => {
       expect(snapshot.branchContinuityAudit.reportLines).toEqual([
         'Branch continuity audit: inactive (no explicit supplied nodes)',
       ])
+      expect(snapshot.stability.categories).not.toContain('branch-continuity')
+      expect(
+        snapshot.stability.topIssues.every((issue) => issue.category !== 'branch-continuity')
+      ).toBe(true)
     })
 
     it('surfaces active audit when explicit authored nodes are supplied via overlay options', () => {
@@ -125,6 +197,15 @@ describe('branchContinuityRuntimeHooks (SPE-2362)', () => {
             warning.warningClass === 'missing_seed_prerequisite'
         )
       ).toBe(true)
+      expect(snapshot.stability.categories).toContain('branch-continuity')
+      expect(
+        snapshot.stability.topIssues.some(
+          (issue) =>
+            issue.category === 'branch-continuity' &&
+            issue.id === 'branch-continuity.node:overlay-precision-gate.missing_seed_prerequisite'
+        )
+      ).toBe(true)
+      expect(snapshot.stability.issueCount).toBeGreaterThan(0)
     })
   })
 })

--- a/src/test/stabilityLayer.test.ts
+++ b/src/test/stabilityLayer.test.ts
@@ -14,6 +14,7 @@ import { enqueueRuntimeEvent } from '../domain/eventQueue'
 import { setUiDebugState } from '../domain/gameStateManager'
 import {
   analyzeRuntimeStability,
+  appendStabilityIssues,
   clearInvalidEncounterAftermathReferences,
   clearStaleAuthoredContext,
   hasSafeFrontDeskFallback,
@@ -584,6 +585,33 @@ describe('stabilityLayer', () => {
     expect(cleaned.state.runtimeState?.encounterState['encounter.alpha']?.followUpIds).toEqual([
       'frontdesk.notice.weekly-report-tutorial',
     ])
+  })
+
+  it('appends branch-continuity issues without mutating base recovery actions', () => {
+    const state = createStartingState()
+    const base = analyzeRuntimeStability(state)
+    const branchContinuityIssue = {
+      id: 'branch-continuity.node:test.missing_seed_prerequisite',
+      category: 'branch-continuity' as const,
+      severity: 'error' as const,
+      summary: 'Seed prerequisite not met.',
+      recoveryActions: [] as const,
+    }
+
+    const merged = appendStabilityIssues(base, [branchContinuityIssue])
+
+    expect(merged.summary.issueCount).toBe(base.summary.issueCount + 1)
+    expect(merged.summary.errorCount).toBe(base.summary.errorCount + 1)
+    expect(merged.summary.categories).toContain('branch-continuity')
+    expect(merged.recoveryActions).toEqual(base.recoveryActions)
+    expect(merged.issues.at(-1)).toEqual(branchContinuityIssue)
+  })
+
+  it('returns the same report when appending zero additional issues', () => {
+    const state = createStartingState()
+    const base = analyzeRuntimeStability(state)
+
+    expect(appendStabilityIssues(base, [])).toBe(base)
   })
 
   it('remains save/load compatible after explicit recovery helper usage', () => {


### PR DESCRIPTION
## Summary

- Add `branch-continuity` `StabilityIssueCategory` and `buildBranchContinuityStabilityIssues` projecting `buildBranchContinuityRuntimeAuditSnapshot` into stability issues
- Add `appendStabilityIssues` merge helper in `stabilityLayer.ts`
- Merge branch-continuity issues into developer overlay `stability` summary when explicit authored nodes are supplied via overlay build options

## Linear

- **Slice:** [SPE-2487](https://linear.app/spectranoir/issue/SPE-2487)
- **Parent:** [SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) (stays Done)
- **Follow-on from:** [SPE-2362](https://linear.app/spectranoir/issue/SPE-2362) deferred table

## Docs

- `planning/branch-continuity-stability-audit-category-slice-1.md`

## Validation

- `npm run test:run -- src/test/branchContinuityRuntimeHooks.test.ts src/test/stabilityLayer.test.ts src/test/developerOverlayView.test.ts`
- `npm run test:run -- src/test/branchContinuity*.test.ts`
- `npm run lint`

## Parent status

SPE-1464 remains **Done** — child-only slice.

Made with [Cursor](https://cursor.com)