### PR TITLE
feat(SPE-2488): publish-queue GitHub API wiring for pr-merge channel (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -65,6 +65,8 @@ Publish-queue persistence (SPE-2483) stores bounded publish-intent snapshots on 
 
 Domain publish executor baseline: `src/domain/publishQueueExecutor.ts` (SPE-2484) consumes persisted queue records and SPE-2480 hook descriptors through bounded dry-run channel stubs with deterministic `ready_to_publish` → `published` transitions — no CI/GitHub API calls or real publish side effects.
 
+Publish-queue GitHub API wiring (SPE-2488) adds an injectable `publishQueueGitHubClient` and `executePublishQueueRecordLive` path for the canonical `pr-merge` channel. Live mode is opt-in via `PUBLISH_QUEUE_EXECUTOR_MODE=live` plus `GITHUB_REPOSITORY` / `GITHUB_TOKEN` (or an injected client in tests). Failed API calls reject without mutating queue records; `advanceWeek` weekly tick remains dry-run by default.
+
 Publish-queue surfacing (SPE-2485) wires the weekly dry-run tick in `advanceWeek`, emits `contribution_release.publish_queue_execution` weekly report notes for reportable receipts, and exposes a read-only planning mirror at `/publish-queue` over hydrated `publishQueueRecords` — still no real publish side effects.
 
 ## Notation and docs standards

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,9 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**In progress:** _(none — owner reprioritizes from §14-pass alternates)_
+**In progress:** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) publish-queue GitHub API wiring (slice 1) — `pr-merge` live client + dry-run default; branch `spe-75-publish-queue-github-api-slice-1`.
+
+**Recently shipped:** [SPE-2487](https://linear.app/spectranoir/issue/SPE-2487) branch continuity stability-audit category (slice 1); branch `spe-75-branch-continuity-stability-audit-category-slice-1` (PR #2894 @ `f66edf73`).
 
 **Recently shipped:** [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) modifiable data-pack runtime import (slice 1) — `modifiableDataPackRecords` sanitize/hydrate on GameState; branch `spe-75-modifiable-data-pack-runtime-import-slice-1`.
 
@@ -52,17 +54,17 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Owner reprioritizes from §14-pass alternates below. Mission triage full refresh remains **blocked**.
+**Next step:** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) publish-queue GitHub API wiring (slice 1) in progress on `spe-75-publish-queue-github-api-slice-1`.
 
-**Base `main` SHA:** `46d03bc1` — post SPE-2485 publish-queue surfacing closure.
+**Base `main` SHA:** `f66edf73` — post SPE-2487 branch-continuity stability-audit category closure.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
-1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — read-only `stabilityLayer.ts` category via `buildBranchContinuityRuntimeAuditSnapshot`; partial §14 (dev/stability tooling); see `planning/branch-continuity-runtime-hooks-slice-1.md` § Deferred.
-2. **Contribution/release ops follow-on (new Linear child — do not reopen [SPE-75](https://linear.app/spectranoir/issue/SPE-75) Done parent):** real CI/GitHub API wiring (SPE-2484 dry-run executor shipped; modifiable-pack runtime import SPE-2486 shipped).
+1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — **shipped** [SPE-2487](https://linear.app/spectranoir/issue/SPE-2487); see `planning/branch-continuity-stability-audit-category-slice-1.md`.
+2. **Contribution/release ops follow-on ([SPE-2488](https://linear.app/spectranoir/issue/SPE-2488))** — real CI/GitHub API wiring for `pr-merge` channel (in progress).
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; no slice 5+ without fresh §14 pass — see `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md` § Deferred.
 
-**Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; real CI/GitHub publish API wiring without owner-scoped child.
+**Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; additional publish channels beyond `pr-merge`; `advanceWeek` live orchestration.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -228,6 +230,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `modifiable-data-pack-runtime-import-slice-1.md`          | **Shipped**    | [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) — GameState modifiable data-pack runtime import under SPE-75. |
 | `publish-automation-crediting-hooks-slice-1.md`           | **Shipped**    | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; PR #2879 @ `99161c79`. |
 | `publish-queue-persistence-slice-1.md`                    | **Shipped**    | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — `publishQueueRecords` GameState persistence under SPE-75; PR #2886 @ `93711130`. |
+| `publish-queue-github-api-slice-1.md`                   | **In progress** | [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) — `pr-merge` GitHub API wiring under SPE-75; branch `spe-75-publish-queue-github-api-slice-1`. |
 | `publish-queue-executor-slice-1.md`                       | **Shipped**    | [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — dry-run publish executor under SPE-75; PR #2888 @ `6399251c`. |
 | `publish-queue-surfacing-slice-1.md`                      | **Shipped**    | [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — publish-queue mirror + weekly orchestration surfacing under SPE-75; PR #2890 @ `1a801ec0`. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |

--- a/planning/publish-queue-executor-slice-1.md
+++ b/planning/publish-queue-executor-slice-1.md
@@ -52,7 +52,7 @@ Pure domain publish-queue dry-run executor consuming persisted `publishQueueReco
 
 | Item | Owner | Why |
 | --- | --- | --- |
-| Real CI/GitHub API wiring | SPE-75 follow-up child | Requires external automation beyond dry-run stubs |
+| Real CI/GitHub API wiring | [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) | Shipped in follow-up slice 1 (`pr-merge` channel) |
 | Publish-queue UI / weekly orchestration surfacing | SPE-75 follow-up child | Executor must land before UI |
 | GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond queue status transition |
 

--- a/planning/publish-queue-github-api-slice-1.md
+++ b/planning/publish-queue-github-api-slice-1.md
@@ -1,0 +1,78 @@
+# SPE-75 — Publish-queue GitHub API wiring (slice 1)
+
+One-page implementation plan. Linear: [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) per `planning/publish-queue-executor-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2488 — Publish-queue GitHub API wiring (slice 1)](https://linear.app/spectranoir/issue/SPE-2488) |
+| **Status** | **In progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-publish-queue-github-api-slice-1` |
+| **Base `main` SHA** | `f66edf73` |
+
+## Goal
+
+Smallest wiring slice for one publish channel stub (`pr-merge`) → real GitHub API call path with documented dry-run → live toggle — no SPE-75 parent reopen, no modifiable-pack UI.
+
+## Prerequisite (on `main` @ `f66edf73`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Dry-run executor | `src/domain/publishQueueExecutor.ts` (SPE-2484 / PR #2888) |
+| Publish-queue persistence | `publishQueueRecords` on `GameState` (SPE-2483 / PR #2886) |
+| Weekly surfacing | `applyWeeklyPublishQueueExecutionTick` in `advanceWeek` (SPE-2485 / PR #2890) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `publishQueueGitHubClient.ts` injectable fetch client for `pr-merge` | Additional publish channels |
+| `executePublishQueueRecordLive` + batch helper | `advanceWeek` live mode (stays dry-run) |
+| `PUBLISH_QUEUE_EXECUTOR_MODE` / env reader (`dry-run` default) | Mission triage (blocked) |
+| API failure → reject without record mutation | SPE-75 parent status change |
+| Idempotent already-merged handling | GameState execution-receipt persistence map |
+| Mocked executor + client unit tests | Modifiable-pack UI |
+
+## Live toggle contract
+
+| Input | Behavior |
+| --- | --- |
+| Default / browser | `dry-run` — existing SPE-2484 stubs |
+| `PUBLISH_QUEUE_EXECUTOR_MODE=live` + `GITHUB_REPOSITORY` + `GITHUB_TOKEN` | CI/automation may construct live client |
+| `executePublishQueueRecordLive(..., { githubClient })` | Explicit live path for tests/ops scripts |
+
+Pull request resolution for `pr-merge`:
+
+- `publishHooks[].payload` suffix `channel:pr-merge:{n}`, or
+- `releaseArtifactRef` pattern `release:pr:{n}`
+
+## Acceptance
+
+- [x] Live `pr-merge` success transitions `ready_to_publish` → `published` with `publishChannelRef`
+- [x] API failure / unresolved PR rejects without mutation
+- [x] Dry-run executor + weekly tick regression unchanged
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publishQueueGitHubClient.ts`, `src/domain/publishQueueExecutor.ts` |
+| Tests  | `src/test/publishQueueGitHubClient.test.ts`, `src/test/publishQueueExecutor.test.ts` |
+| Plan   | `planning/publish-queue-github-api-slice-1.md`, `planning/backlog.md` |
+| Docs   | `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Additional publish channels | SPE-75 follow-up child | Slice 1 wires `pr-merge` only |
+| `advanceWeek` live orchestration | SPE-75 follow-up child | Browser default must stay dry-run |
+| GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond queue status transition |
+| Surfacing labels for live receipts | SPE-75 follow-up child | Mirror copy still dry-run scoped |
+
+## See also
+
+- `planning/publish-queue-executor-slice-1.md`
+- `planning/publish-queue-surfacing-slice-1.md`
+- `planning/backlog.md`

--- a/planning/publish-queue-surfacing-slice-1.md
+++ b/planning/publish-queue-surfacing-slice-1.md
@@ -70,7 +70,7 @@ Surface persisted `publishQueueRecords` and dry-run execution receipts via read-
 
 | Item | Owner | Why |
 | --- | --- | --- |
-| Real CI/GitHub API wiring | SPE-75 follow-up child | External automation beyond dry-run stubs |
+| Real CI/GitHub API wiring | [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) | Shipped in follow-up slice 1 (`pr-merge` channel) |
 | GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond queue status transition |
 | Modifiable data-pack runtime import | SPE-2479 follow-up child | Separate boundary from surfacing |
 | Mission triage publish-queue chips | Backlog | Mission triage full refresh blocked |

--- a/src/domain/publishQueueExecutor.ts
+++ b/src/domain/publishQueueExecutor.ts
@@ -1,9 +1,10 @@
 /**
  * SPE-2484 slice 1: publish-queue dry-run executor.
+ * SPE-2488 slice 1: optional live `pr-merge` GitHub API path with dry-run default.
  *
  * Pure deterministic executor consuming persisted publish-queue records and
- * SPE-2480 hook descriptors with bounded channel stubs — no CI/GitHub API
- * calls, UI, or real publish side effects.
+ * SPE-2480 hook descriptors. Dry-run uses bounded channel stubs; live mode
+ * calls an injectable GitHub client and only mutates records on API success.
  */
 
 import type {
@@ -18,6 +19,14 @@ import {
   validatePublishQueueRecord,
   withPublishQueueRecordStatus,
 } from './publishAutomationCreditingHooks'
+import type {
+  PublishQueueGitHubClient,
+  PublishQueueGitHubConfig,
+} from './publishQueueGitHubClient'
+import {
+  buildPrMergeGitHubRequest,
+  formatPublishQueueGitHubMergeSuccessRef,
+} from './publishQueueGitHubClient'
 
 // ---------------------------------------------------------------------------
 // Identifiers and unions
@@ -35,11 +44,17 @@ export type PublishQueueExecutorSkipCode =
   | 'record_not_ready_to_publish'
   | 'already_published'
   | 'missing_publish_channel_hook'
+  | 'unsupported_publish_channel_target'
+  | 'publish_channel_pull_request_unresolved'
+  | 'publish_channel_api_failed'
 
 export const PUBLISH_QUEUE_EXECUTOR_SKIP_CODES: readonly PublishQueueExecutorSkipCode[] = [
   'record_not_ready_to_publish',
   'already_published',
   'missing_publish_channel_hook',
+  'unsupported_publish_channel_target',
+  'publish_channel_pull_request_unresolved',
+  'publish_channel_api_failed',
 ] as const
 
 export type PublishHookStubKind = CreditingHookKind | PublishHookKind
@@ -57,12 +72,18 @@ export interface PublishQueueExecutionReceipt {
   readonly executionWeek: number
   readonly appliedHooks: readonly PublishHookStubApplication[]
   readonly publishChannelStub?: string
+  readonly publishChannelRef?: string
   readonly skipCode?: PublishQueueExecutorSkipCode
 }
 
 export interface PublishQueueExecutorOptions {
   readonly week?: number
   readonly maxHookApplications?: number
+}
+
+export interface PublishQueueLiveExecutorOptions extends PublishQueueExecutorOptions {
+  readonly githubClient: PublishQueueGitHubClient
+  readonly githubConfig: Pick<PublishQueueGitHubConfig, 'owner' | 'repo'>
 }
 
 export interface PublishQueueExecutionResult {
@@ -192,75 +213,78 @@ export function isPublishQueueExecutorSkipCode(value: string): value is PublishQ
  * are rejected without mutation. Re-execution of `published` records is
  * idempotent (skipped, record byte-stable).
  */
-export function executePublishQueueRecordDryRun(
+function buildPreExecutionReceipt(
   record: PublishQueueRecord,
-  options: PublishQueueExecutorOptions = {}
-): PublishQueueExecutionResult {
-  const executionWeek = normalizeWeek(options.week)
-  const maxHookApplications = resolveMaxHookApplications(options.maxHookApplications)
-
+  executionWeek: number
+):
+  | { readonly kind: 'continue' }
+  | { readonly kind: 'result'; readonly result: PublishQueueExecutionResult } {
   if (record.status === 'published') {
-    const receipt = freezeReceipt({
-      recordId: record.id,
-      outcome: 'skipped',
-      executionWeek,
-      appliedHooks: Object.freeze([]),
-      skipCode: 'already_published',
-    })
-
     return {
-      record,
-      receipt,
+      kind: 'result',
+      result: {
+        record,
+        receipt: freezeReceipt({
+          recordId: record.id,
+          outcome: 'skipped',
+          executionWeek,
+          appliedHooks: Object.freeze([]),
+          skipCode: 'already_published',
+        }),
+      },
     }
   }
 
   if (record.status !== 'ready_to_publish') {
-    const receipt = freezeReceipt({
-      recordId: record.id,
-      outcome: 'rejected',
-      executionWeek,
-      appliedHooks: Object.freeze([]),
-      skipCode: 'record_not_ready_to_publish',
-    })
-
     return {
-      record,
-      receipt,
+      kind: 'result',
+      result: {
+        record,
+        receipt: freezeReceipt({
+          recordId: record.id,
+          outcome: 'rejected',
+          executionWeek,
+          appliedHooks: Object.freeze([]),
+          skipCode: 'record_not_ready_to_publish',
+        }),
+      },
     }
   }
 
   const publishChannelHook = findPublishChannelHook(record)
   if (!publishChannelHook) {
-    const receipt = freezeReceipt({
-      recordId: record.id,
-      outcome: 'rejected',
-      executionWeek,
-      appliedHooks: Object.freeze([]),
-      skipCode: 'missing_publish_channel_hook',
-    })
-
     return {
-      record,
-      receipt,
+      kind: 'result',
+      result: {
+        record,
+        receipt: freezeReceipt({
+          recordId: record.id,
+          outcome: 'rejected',
+          executionWeek,
+          appliedHooks: Object.freeze([]),
+          skipCode: 'missing_publish_channel_hook',
+        }),
+      },
     }
   }
 
-  const appliedHooks = buildAppliedHookStubs(record, maxHookApplications)
-  const publishChannelStub = buildChannelStub(
-    publishChannelHook.kind,
-    publishChannelHook.target,
-    publishChannelHook.payload
-  )
-  const nextRecord =
-    withPublishQueueRecordStatus(record, 'published') ??
-    record
+  return { kind: 'continue' }
+}
+
+function finalizePublishedExecution(
+  record: PublishQueueRecord,
+  executionWeek: number,
+  appliedHooks: readonly PublishHookStubApplication[],
+  channelReceipt: Pick<PublishQueueExecutionReceipt, 'publishChannelStub' | 'publishChannelRef'>
+): PublishQueueExecutionResult {
+  const nextRecord = withPublishQueueRecordStatus(record, 'published') ?? record
 
   const receipt = freezeReceipt({
     recordId: record.id,
     outcome: 'completed',
     executionWeek,
     appliedHooks,
-    publishChannelStub,
+    ...channelReceipt,
   })
 
   if (!validatePublishQueueRecord(nextRecord).valid) {
@@ -280,6 +304,102 @@ export function executePublishQueueRecordDryRun(
     record: nextRecord,
     receipt,
   }
+}
+
+export function executePublishQueueRecordDryRun(
+  record: PublishQueueRecord,
+  options: PublishQueueExecutorOptions = {}
+): PublishQueueExecutionResult {
+  const executionWeek = normalizeWeek(options.week)
+  const maxHookApplications = resolveMaxHookApplications(options.maxHookApplications)
+  const preExecution = buildPreExecutionReceipt(record, executionWeek)
+
+  if (preExecution.kind === 'result') {
+    return preExecution.result
+  }
+
+  const publishChannelHook = findPublishChannelHook(record)!
+  const appliedHooks = buildAppliedHookStubs(record, maxHookApplications)
+  const publishChannelStub = buildChannelStub(
+    publishChannelHook.kind,
+    publishChannelHook.target,
+    publishChannelHook.payload
+  )
+
+  return finalizePublishedExecution(record, executionWeek, appliedHooks, {
+    publishChannelStub,
+  })
+}
+
+/**
+ * Executes one publish-queue record through the live `pr-merge` GitHub API path.
+ * Failed API calls reject without mutating the record. Re-execution of
+ * `published` records remains idempotent (skipped, record byte-stable).
+ */
+export async function executePublishQueueRecordLive(
+  record: PublishQueueRecord,
+  options: PublishQueueLiveExecutorOptions
+): Promise<PublishQueueExecutionResult> {
+  const executionWeek = normalizeWeek(options.week)
+  const maxHookApplications = resolveMaxHookApplications(options.maxHookApplications)
+  const preExecution = buildPreExecutionReceipt(record, executionWeek)
+
+  if (preExecution.kind === 'result') {
+    return preExecution.result
+  }
+
+  const publishChannelHook = findPublishChannelHook(record)!
+  const appliedHooks = buildAppliedHookStubs(record, maxHookApplications)
+
+  if (publishChannelHook.target !== 'pr-merge') {
+    return {
+      record,
+      receipt: freezeReceipt({
+        recordId: record.id,
+        outcome: 'rejected',
+        executionWeek,
+        appliedHooks: Object.freeze([]),
+        skipCode: 'unsupported_publish_channel_target',
+      }),
+    }
+  }
+
+  const mergeRequest = buildPrMergeGitHubRequest(
+    publishChannelHook,
+    record,
+    options.githubConfig
+  )
+
+  if (!mergeRequest) {
+    return {
+      record,
+      receipt: freezeReceipt({
+        recordId: record.id,
+        outcome: 'rejected',
+        executionWeek,
+        appliedHooks: Object.freeze([]),
+        skipCode: 'publish_channel_pull_request_unresolved',
+      }),
+    }
+  }
+
+  const mergeResult = await options.githubClient.mergePullRequest(mergeRequest)
+  if (!mergeResult.ok) {
+    return {
+      record,
+      receipt: freezeReceipt({
+        recordId: record.id,
+        outcome: 'rejected',
+        executionWeek,
+        appliedHooks: Object.freeze([]),
+        skipCode: 'publish_channel_api_failed',
+      }),
+    }
+  }
+
+  return finalizePublishedExecution(record, executionWeek, appliedHooks, {
+    publishChannelRef: formatPublishQueueGitHubMergeSuccessRef(mergeRequest, mergeResult),
+  })
 }
 
 /**
@@ -343,4 +463,53 @@ export function applyWeeklyPublishQueueExecutionTick(
   options: Omit<PublishQueueExecutorOptions, 'week'> = {}
 ): PublishQueueBatchExecutionResult {
   return executePublishQueueRecordsDryRun(records, { ...options, week })
+}
+
+/**
+ * Batch live execution in stable id order. Only records that complete a
+ * successful GitHub merge transition mutate the returned map.
+ */
+export async function executePublishQueueRecordsLive(
+  records: PublishQueueRecordsMap | null | undefined,
+  options: PublishQueueLiveExecutorOptions
+): Promise<PublishQueueBatchExecutionResult> {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords).sort((left, right) => left.localeCompare(right))
+
+  if (recordIds.length === 0) {
+    return {
+      records: safeRecords,
+      receipts: Object.freeze([]),
+    }
+  }
+
+  let nextRecords: PublishQueueRecordsMap | null = null
+  const receipts: PublishQueueExecutionReceipt[] = []
+
+  for (const recordId of recordIds) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const sourceRecord = (nextRecords ?? safeRecords)[recordId] ?? record
+    const result = await executePublishQueueRecordLive(sourceRecord, options)
+
+    receipts.push(result.receipt)
+
+    if (result.record === sourceRecord) {
+      continue
+    }
+
+    if (!nextRecords) {
+      nextRecords = { ...safeRecords }
+    }
+
+    nextRecords[recordId] = result.record
+  }
+
+  return {
+    records: nextRecords ?? safeRecords,
+    receipts: Object.freeze(receipts.map((receipt) => freezeReceipt(receipt))),
+  }
 }

--- a/src/domain/publishQueueGitHubClient.ts
+++ b/src/domain/publishQueueGitHubClient.ts
@@ -1,0 +1,321 @@
+/**
+ * SPE-2488 slice 1: injectable GitHub client for publish-queue `pr-merge` channel.
+ *
+ * Pure domain HTTP adapter — no GameState mutation. Live mode requires explicit
+ * credentials; browser runtime defaults to dry-run via executor options.
+ */
+
+import type { PublishHookDescriptor } from './publishAutomationCreditingHooks'
+import type { PublishQueueRecord } from './publishAutomationCreditingHooks'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PublishQueueExecutionMode = 'dry-run' | 'live'
+
+export const PUBLISH_QUEUE_EXECUTION_MODES: readonly PublishQueueExecutionMode[] = [
+  'dry-run',
+  'live',
+] as const
+
+export interface PublishQueueGitHubMergeRequest {
+  readonly owner: string
+  readonly repo: string
+  readonly pullNumber: number
+  readonly recordId: string
+  readonly releaseArtifactRef: string
+  readonly channelTarget: string
+  readonly channelPayload: string
+}
+
+export interface PublishQueueGitHubMergeSuccess {
+  readonly ok: true
+  readonly sha: string
+  readonly merged: boolean
+  readonly alreadyMerged: boolean
+}
+
+export interface PublishQueueGitHubMergeFailure {
+  readonly ok: false
+  readonly statusCode: number
+  readonly message: string
+}
+
+export type PublishQueueGitHubMergeResult =
+  | PublishQueueGitHubMergeSuccess
+  | PublishQueueGitHubMergeFailure
+
+export interface PublishQueueGitHubClient {
+  mergePullRequest(
+    request: PublishQueueGitHubMergeRequest
+  ): Promise<PublishQueueGitHubMergeResult>
+}
+
+export interface PublishQueueGitHubConfig {
+  readonly owner: string
+  readonly repo: string
+  readonly token: string
+}
+
+export interface PublishQueueExecutorEnvironment {
+  readonly mode: PublishQueueExecutionMode
+  readonly githubOwner?: string
+  readonly githubRepo?: string
+  readonly githubToken?: string
+}
+
+export type PublishQueueGitHubEnvSource = Record<string, string | undefined>
+
+// ---------------------------------------------------------------------------
+// Calibration
+// ---------------------------------------------------------------------------
+
+const EXECUTION_MODE_SET = new Set<string>(PUBLISH_QUEUE_EXECUTION_MODES)
+
+const DEFAULT_EXECUTOR_ENVIRONMENT: PublishQueueExecutorEnvironment = Object.freeze({
+  mode: 'dry-run',
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return undefined
+  }
+
+  return Math.trunc(parsed)
+}
+
+function parseRepositorySlug(slug: string | undefined): { owner: string; repo: string } | undefined {
+  if (!slug) {
+    return undefined
+  }
+
+  const [owner, repo] = slug.split('/')
+  if (!owner || !repo) {
+    return undefined
+  }
+
+  return { owner, repo }
+}
+
+function parsePullNumberFromChannelPayload(payload: string): number | undefined {
+  const parts = payload.split(':')
+  if (parts.length < 3 || parts[0] !== 'channel' || parts[1] !== 'pr-merge') {
+    return undefined
+  }
+
+  return parsePositiveInt(parts[2])
+}
+
+function parsePullNumberFromReleaseArtifactRef(releaseArtifactRef: string): number | undefined {
+  const parts = releaseArtifactRef.split(':')
+  if (parts.length < 3 || parts[0] !== 'release' || parts[1] !== 'pr') {
+    return undefined
+  }
+
+  return parsePositiveInt(parts[2])
+}
+
+function buildLiveChannelRef(request: PublishQueueGitHubMergeRequest, sha: string): string {
+  return `live:publish_channel:${request.channelTarget}:pr:${request.pullNumber}:sha:${sha}`
+}
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+export function isPublishQueueExecutionMode(value: string): value is PublishQueueExecutionMode {
+  return EXECUTION_MODE_SET.has(value)
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves pull request number for the canonical `pr-merge` channel from hook
+ * payload (`channel:pr-merge:{n}`) or `releaseArtifactRef` (`release:pr:{n}`).
+ */
+export function resolvePrMergePullNumber(
+  hook: PublishHookDescriptor,
+  record: PublishQueueRecord
+): number | undefined {
+  if (hook.kind !== 'publish_channel' || hook.target !== 'pr-merge') {
+    return undefined
+  }
+
+  return (
+    parsePullNumberFromChannelPayload(hook.payload) ??
+    parsePullNumberFromReleaseArtifactRef(record.releaseArtifactRef)
+  )
+}
+
+export function buildPrMergeGitHubRequest(
+  hook: PublishHookDescriptor,
+  record: PublishQueueRecord,
+  config: Pick<PublishQueueGitHubConfig, 'owner' | 'repo'>
+): PublishQueueGitHubMergeRequest | undefined {
+  const pullNumber = resolvePrMergePullNumber(hook, record)
+  if (!pullNumber) {
+    return undefined
+  }
+
+  return Object.freeze({
+    owner: config.owner,
+    repo: config.repo,
+    pullNumber,
+    recordId: record.id,
+    releaseArtifactRef: record.releaseArtifactRef,
+    channelTarget: hook.target,
+    channelPayload: hook.payload,
+  })
+}
+
+export function readPublishQueueExecutorEnvironment(
+  env: PublishQueueGitHubEnvSource = readProcessEnv()
+): PublishQueueExecutorEnvironment {
+  const modeValue = env.PUBLISH_QUEUE_EXECUTOR_MODE
+  const mode =
+    modeValue !== undefined && isPublishQueueExecutionMode(modeValue) ? modeValue : 'dry-run'
+
+  const repository = parseRepositorySlug(env.GITHUB_REPOSITORY)
+  const token = env.GITHUB_TOKEN ?? env.GH_TOKEN
+
+  return Object.freeze({
+    mode,
+    ...(repository ? { githubOwner: repository.owner, githubRepo: repository.repo } : {}),
+    ...(token ? { githubToken: token } : {}),
+  })
+}
+
+export function buildPublishQueueGitHubConfig(
+  environment: PublishQueueExecutorEnvironment
+): PublishQueueGitHubConfig | undefined {
+  if (!environment.githubOwner || !environment.githubRepo || !environment.githubToken) {
+    return undefined
+  }
+
+  return Object.freeze({
+    owner: environment.githubOwner,
+    repo: environment.githubRepo,
+    token: environment.githubToken,
+  })
+}
+
+export function formatPublishQueueGitHubMergeSuccessRef(
+  request: PublishQueueGitHubMergeRequest,
+  result: PublishQueueGitHubMergeSuccess
+): string {
+  return buildLiveChannelRef(request, result.sha)
+}
+
+// ---------------------------------------------------------------------------
+// Default client
+// ---------------------------------------------------------------------------
+
+function readProcessEnv(): PublishQueueGitHubEnvSource {
+  if (typeof process === 'undefined' || !process.env) {
+    return {}
+  }
+
+  return process.env
+}
+
+function parseGitHubMergeResponseBody(body: string): { sha?: string; message?: string } {
+  if (!body) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(body) as { sha?: unknown; message?: unknown }
+    return {
+      ...(typeof parsed.sha === 'string' ? { sha: parsed.sha } : {}),
+      ...(typeof parsed.message === 'string' ? { message: parsed.message } : {}),
+    }
+  } catch {
+    return { message: body }
+  }
+}
+
+function isAlreadyMergedMessage(message: string | undefined): boolean {
+  if (!message) {
+    return false
+  }
+
+  const normalized = message.toLowerCase()
+  return normalized.includes('already been merged') || normalized.includes('pull request successfully merged')
+}
+
+/**
+ * Creates a fetch-backed GitHub client for `pr-merge` channel merge calls.
+ * Intended for CI/automation with injected credentials — not browser defaults.
+ */
+export function createPublishQueueGitHubClient(
+  config: PublishQueueGitHubConfig,
+  fetchImpl: typeof fetch = fetch
+): PublishQueueGitHubClient {
+  return {
+    async mergePullRequest(request) {
+      const url = `https://api.github.com/repos/${request.owner}/${request.repo}/pulls/${request.pullNumber}/merge`
+
+      try {
+        const response = await fetchImpl(url, {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${config.token}`,
+            Accept: 'application/vnd.github+json',
+            'Content-Type': 'application/json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          body: JSON.stringify({
+            merge_method: 'squash',
+          }),
+        })
+
+        const bodyText = await response.text()
+        const body = parseGitHubMergeResponseBody(bodyText)
+
+        if (response.ok) {
+          return {
+            ok: true,
+            sha: body.sha ?? 'unknown',
+            merged: true,
+            alreadyMerged: false,
+          }
+        }
+
+        if (response.status === 405 && isAlreadyMergedMessage(body.message)) {
+          return {
+            ok: true,
+            sha: body.sha ?? 'already-merged',
+            merged: false,
+            alreadyMerged: true,
+          }
+        }
+
+        return {
+          ok: false,
+          statusCode: response.status,
+          message: body.message ?? `GitHub merge failed with status ${response.status}`,
+        }
+      } catch (error) {
+        return {
+          ok: false,
+          statusCode: 0,
+          message: error instanceof Error ? error.message : 'GitHub merge request failed',
+        }
+      }
+    },
+  }
+}
+
+export const DEFAULT_PUBLISH_QUEUE_EXECUTOR_ENVIRONMENT = DEFAULT_EXECUTOR_ENVIRONMENT

--- a/src/test/publishQueueGitHubClient.test.ts
+++ b/src/test/publishQueueGitHubClient.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+  evaluateContributionIntakeCuration,
+} from '../domain/contributionIntakeCuration'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+} from '../domain/modularReleasePackaging'
+import {
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+  composePublishQueueRecord,
+  evaluatePublishAutomationCreditingHooks,
+} from '../domain/publishAutomationCreditingHooks'
+import {
+  applyWeeklyPublishQueueExecutionTick,
+  executePublishQueueRecordDryRun,
+  executePublishQueueRecordLive,
+  executePublishQueueRecordsDryRun,
+  executePublishQueueRecordsLive,
+} from '../domain/publishQueueExecutor'
+import {
+  buildPublishQueueGitHubConfig,
+  createPublishQueueGitHubClient,
+  readPublishQueueExecutorEnvironment,
+  resolvePrMergePullNumber,
+} from '../domain/publishQueueGitHubClient'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+} from '../domain/submissionGovernanceRights'
+
+describe('publishQueueGitHubClient (SPE-2488 slice 1)', () => {
+  it('defaults executor environment to dry-run without credentials', () => {
+    expect(readPublishQueueExecutorEnvironment({})).toEqual({
+      mode: 'dry-run',
+    })
+  })
+
+  it('reads live mode and repository credentials from CI-style env', () => {
+    const environment = readPublishQueueExecutorEnvironment({
+      PUBLISH_QUEUE_EXECUTOR_MODE: 'live',
+      GITHUB_REPOSITORY: 'JamesJedi420/containment-protocol',
+      GITHUB_TOKEN: 'ghp_test_token',
+    })
+
+    expect(environment).toEqual({
+      mode: 'live',
+      githubOwner: 'JamesJedi420',
+      githubRepo: 'containment-protocol',
+      githubToken: 'ghp_test_token',
+    })
+    expect(buildPublishQueueGitHubConfig(environment)).toEqual({
+      owner: 'JamesJedi420',
+      repo: 'containment-protocol',
+      token: 'ghp_test_token',
+    })
+  })
+
+  it('resolves pull number from channel payload suffix', () => {
+    const hook = {
+      kind: 'publish_channel' as const,
+      target: 'pr-merge',
+      payload: 'channel:pr-merge:2890',
+    }
+
+    expect(
+      resolvePrMergePullNumber(hook, {
+        ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+        releaseArtifactRef: 'release:domain-code-bundle-spe-2480',
+      })
+    ).toBe(2890)
+  })
+
+  it('merges pull requests through fetch and treats already-merged as idempotent success', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ sha: 'abc123def456' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Pull Request successfully merged' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+    const client = createPublishQueueGitHubClient(
+      {
+        owner: 'JamesJedi420',
+        repo: 'containment-protocol',
+        token: 'ghp_test_token',
+      },
+      fetchImpl
+    )
+
+    const request = {
+      owner: 'JamesJedi420',
+      repo: 'containment-protocol',
+      pullNumber: 2890,
+      recordId: 'publish-queue:test',
+      releaseArtifactRef: 'release:pr:2890',
+      channelTarget: 'pr-merge',
+      channelPayload: 'channel:pr-merge:2890',
+    }
+
+    await expect(client.mergePullRequest(request)).resolves.toEqual({
+      ok: true,
+      sha: 'abc123def456',
+      merged: true,
+      alreadyMerged: false,
+    })
+
+    await expect(client.mergePullRequest(request)).resolves.toEqual({
+      ok: true,
+      sha: 'already-merged',
+      merged: false,
+      alreadyMerged: true,
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe(
+      'https://api.github.com/repos/JamesJedi420/containment-protocol/pulls/2890/merge'
+    )
+  })
+
+  it('returns structured failure without throwing on network errors', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'))
+    const client = createPublishQueueGitHubClient(
+      {
+        owner: 'JamesJedi420',
+        repo: 'containment-protocol',
+        token: 'ghp_test_token',
+      },
+      fetchImpl
+    )
+
+    await expect(
+      client.mergePullRequest({
+        owner: 'JamesJedi420',
+        repo: 'containment-protocol',
+        pullNumber: 1,
+        recordId: 'publish-queue:test',
+        releaseArtifactRef: 'release:pr:1',
+        channelTarget: 'pr-merge',
+        channelPayload: 'channel:pr-merge:1',
+      })
+    ).resolves.toEqual({
+      ok: false,
+      statusCode: 0,
+      message: 'network down',
+    })
+  })
+})
+
+describe('publishQueueExecutor live path (SPE-2488 slice 1)', () => {
+  const acceptedCuration = evaluateContributionIntakeCuration(
+    CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE
+  )
+  const packagedRelease = evaluateModularReleasePackaging(
+    acceptedCuration,
+    CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+  )
+  const appliedGovernance = evaluateSubmissionGovernanceRights(
+    CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE
+  )
+  const decision = evaluatePublishAutomationCreditingHooks(
+    packagedRelease,
+    appliedGovernance,
+    CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+  )
+  const composedRecord = composePublishQueueRecord({
+    id: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+    label: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label,
+    releaseArtifactRef: 'release:pr:2890',
+    decision,
+    summary: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.summary,
+    queuedWeek: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.queuedWeek,
+  })!
+
+  const liveGithubClient = {
+    mergePullRequest: vi.fn(),
+  }
+
+  const liveOptions = {
+    week: 8,
+    githubConfig: {
+      owner: 'JamesJedi420',
+      repo: 'containment-protocol',
+    },
+    githubClient: liveGithubClient,
+  }
+
+  it('publishes on successful GitHub merge without mutating hooks', async () => {
+    liveGithubClient.mergePullRequest.mockResolvedValueOnce({
+      ok: true,
+      sha: 'abc123def456',
+      merged: true,
+      alreadyMerged: false,
+    })
+
+    const result = await executePublishQueueRecordLive(composedRecord, liveOptions)
+
+    expect(result.record.status).toBe('published')
+    expect(result.receipt.outcome).toBe('completed')
+    expect(result.receipt.publishChannelRef).toBe(
+      'live:publish_channel:pr-merge:pr:2890:sha:abc123def456'
+    )
+    expect(result.receipt.publishChannelStub).toBeUndefined()
+    expect(result.record.creditingHooks).toEqual(composedRecord.creditingHooks)
+    expect(liveGithubClient.mergePullRequest).toHaveBeenCalledOnce()
+  })
+
+  it('rejects without mutation when GitHub merge fails', async () => {
+    liveGithubClient.mergePullRequest.mockResolvedValueOnce({
+      ok: false,
+      statusCode: 403,
+      message: 'Resource not accessible by integration',
+    })
+
+    const failingClient = liveGithubClient
+
+    const result = await executePublishQueueRecordLive(composedRecord, {
+      ...liveOptions,
+      githubClient: failingClient,
+    })
+
+    expect(result.record).toBe(composedRecord)
+    expect(result.receipt.outcome).toBe('rejected')
+    expect(result.receipt.skipCode).toBe('publish_channel_api_failed')
+  })
+
+  it('rejects without mutation when pull request number cannot be resolved', async () => {
+    const unresolvedClient = {
+      mergePullRequest: vi.fn(),
+    }
+    const unresolvedRecord = composePublishQueueRecord({
+      id: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      label: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label,
+      releaseArtifactRef: 'release:domain-code-bundle-spe-2480',
+      decision,
+      summary: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.summary,
+      queuedWeek: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.queuedWeek,
+    })!
+
+    const result = await executePublishQueueRecordLive(unresolvedRecord, {
+      ...liveOptions,
+      githubClient: unresolvedClient,
+    })
+
+    expect(result.record).toBe(unresolvedRecord)
+    expect(result.receipt.outcome).toBe('rejected')
+    expect(result.receipt.skipCode).toBe('publish_channel_pull_request_unresolved')
+    expect(unresolvedClient.mergePullRequest).not.toHaveBeenCalled()
+  })
+
+  it('batch live execution preserves non-ready records and stable ordering', async () => {
+    liveGithubClient.mergePullRequest.mockResolvedValueOnce({
+      ok: true,
+      sha: 'abc123def456',
+      merged: true,
+      alreadyMerged: false,
+    })
+    const needsRevision = {
+      ...composedRecord,
+      id: 'publish-queue:needs-revision-live',
+      status: 'needs_revision' as const,
+      reasonCodes: ['crediting_targets_borderline'] as const,
+    }
+
+    const batch = await executePublishQueueRecordsLive(
+      {
+        [needsRevision.id]: needsRevision,
+        [composedRecord.id]: composedRecord,
+      },
+      liveOptions
+    )
+
+    expect(batch.receipts.map((receipt) => receipt.recordId)).toEqual([
+      composedRecord.id,
+      needsRevision.id,
+    ])
+    expect(batch.records[composedRecord.id]?.status).toBe('published')
+    expect(batch.records[needsRevision.id]).toBe(needsRevision)
+  })
+
+  it('keeps dry-run executor behavior unchanged for weekly tick regression', () => {
+    const dryRun = executePublishQueueRecordDryRun(
+      {
+        ...composedRecord,
+        releaseArtifactRef: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef,
+      },
+      { week: 4 }
+    )
+    const weeklyPass = applyWeeklyPublishQueueExecutionTick(
+      {
+        [composedRecord.id]: {
+          ...composedRecord,
+          releaseArtifactRef: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef,
+        },
+      },
+      4
+    )
+    const batchPass = executePublishQueueRecordsDryRun(
+      {
+        [composedRecord.id]: {
+          ...composedRecord,
+          releaseArtifactRef: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef,
+        },
+      },
+      { week: 4 }
+    )
+
+    expect(dryRun.receipt.publishChannelStub).toBe(
+      'dry-run:publish_channel:pr-merge:channel:pr-merge'
+    )
+    expect(weeklyPass).toEqual(batchPass)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `publishQueueGitHubClient` with injectable fetch-backed `pr-merge` merge calls and CI env reader (`PUBLISH_QUEUE_EXECUTOR_MODE`, `GITHUB_REPOSITORY`, `GITHUB_TOKEN`).
- Adds `executePublishQueueRecordLive` / `executePublishQueueRecordsLive` on the SPE-2484 executor seam: API success transitions `ready_to_publish` → `published` with `publishChannelRef`; failures reject without record mutation.
- `advanceWeek` weekly tick remains dry-run by default; dry-run executor regression preserved.

## Linear

- **Slice:** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) — Publish-queue GitHub API wiring (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — stays **Done** (not reopened)

## What shipped

- `src/domain/publishQueueGitHubClient.ts` — client, env toggle, PR resolution
- `src/domain/publishQueueExecutor.ts` — live execution path + new skip codes
- `src/test/publishQueueGitHubClient.test.ts` — mocked client + live executor tests

## Validation

- `npm run lint`
- `npx vitest run src/test/publishQueueGitHubClient.test.ts src/test/publishQueueExecutor.test.ts src/test/publishQueuePersistence.test.ts src/test/publishQueueSurfacing.test.ts`

## Docs updated

- `planning/publish-queue-github-api-slice-1.md`
- `planning/backlog.md` (§14 alternates grooming)
- `docs/contribution-and-release-operations.md`

## Parent status

SPE-75 parent remains **Done** — slice-only follow-on; additional channels / live `advanceWeek` orchestration deferred.