### PR TITLE
feat(SPE-2491): publish-queue live advanceWeek orchestration (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -65,9 +65,11 @@ Publish-queue persistence (SPE-2483) stores bounded publish-intent snapshots on 
 
 Domain publish executor baseline: `src/domain/publishQueueExecutor.ts` (SPE-2484) consumes persisted queue records and SPE-2480 hook descriptors through bounded dry-run channel stubs with deterministic `ready_to_publish` → `published` transitions — no CI/GitHub API calls or real publish side effects.
 
-Publish-queue GitHub API wiring (SPE-2488) adds an injectable `publishQueueGitHubClient` and `executePublishQueueRecordLive` path for the canonical `pr-merge` channel. Live mode is opt-in via `PUBLISH_QUEUE_EXECUTOR_MODE=live` plus `GITHUB_REPOSITORY` / `GITHUB_TOKEN` (or an injected client in tests). Failed API calls reject without mutating queue records; `advanceWeek` weekly tick remains dry-run by default.
+Publish-queue GitHub API wiring (SPE-2488) adds an injectable `publishQueueGitHubClient` and `executePublishQueueRecordLive` path for the canonical `pr-merge` channel. Live mode is opt-in via `PUBLISH_QUEUE_EXECUTOR_MODE=live` plus `GITHUB_REPOSITORY` / `GITHUB_TOKEN` (or an injected client in tests). Failed API calls reject without mutating queue records.
 
-Publish-queue surfacing (SPE-2485) wires the weekly dry-run tick in `advanceWeek`, emits `contribution_release.publish_queue_execution` weekly report notes for reportable receipts, and exposes a read-only planning mirror at `/publish-queue` over hydrated `publishQueueRecords` — still no real publish side effects.
+Publish-queue live orchestration (SPE-2491) wires `applyWeeklyPublishQueueExecutionTickOrchestrated` into `advanceWeek`: dry-run remains the default for browser and CI tests; live `pr-merge` execution runs when live mode, complete GitHub credentials, and an injectable sync client are supplied via `publishQueueOrchestrationDeps`. Weekly notes surface `executionMode` and `publishChannelRef` for live receipts.
+
+Publish-queue surfacing (SPE-2485) wires the weekly execution tick in `advanceWeek`, emits `contribution_release.publish_queue_execution` weekly report notes for reportable receipts, and exposes a read-only planning mirror at `/publish-queue` over hydrated `publishQueueRecords`.
 
 ## Notation and docs standards
 

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,9 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**In progress:** _(none — owner reprioritizes from §14-pass alternates)_
+**In progress:** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) publish-queue live `advanceWeek` orchestration (slice 1) — branch `spe-75-publish-queue-live-orchestration-slice-1`; see `planning/publish-queue-live-orchestration-slice-1.md`.
+
+**Recently shipped:** [SPE-2490](https://linear.app/spectranoir/issue/SPE-2490) entity-welfare reclassification registry weekly transition surfacing (slice 5) — `entity_welfare_reclassification.weekly_transition` notes; branch `spe-2114-entity-welfare-reclassification-weekly-surfacing-slice-5` (PR #2900 @ `d5b795ae`). Parents [SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) stay **Backlog**.
 
 **Recently shipped:** [SPE-2489](https://linear.app/spectranoir/issue/SPE-2489) visual-trigger hazard registry weekly transition surfacing (slice 5) — `visual_trigger_hazard.weekly_transition` notes; branch `spe-2111-visual-trigger-hazard-weekly-surfacing-slice-5` (PR #2898 @ `96452e9e`). Parents [SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-2111](https://linear.app/spectranoir/issue/SPE-2111) stay **Backlog** / **Done** respectively.
 
@@ -35,8 +37,6 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 **Recently shipped:** [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) Runtime publish executor / CI wiring (slice 1) — dry-run channel-stub executor over persisted queue records; branch `spe-75-publish-queue-executor-slice-1` (PR #2888 @ `6399251c`).
 
 **Recently shipped:** [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) GameState publish-queue persistence (slice 1) — `publishQueueRecords` sanitize/hydrate on GameState; branch `spe-75-publish-queue-persistence-slice-1` (PR #2886 @ `93711130`).
-
-**In progress:** _(none — owner reprioritizes from §14-pass alternates)_
 
 **Recently shipped:** [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) publish automation and crediting hooks (slice 1) — deterministic publish-intent envelope with crediting/publish hook descriptors; branch `spe-75-publish-automation-crediting-hooks-slice-1` (PR #2879 @ `99161c79`).
 
@@ -65,10 +65,10 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 **§14-pass alternates (owner creates Linear child when starting):**
 
 1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — **shipped** [SPE-2487](https://linear.app/spectranoir/issue/SPE-2487); see `planning/branch-continuity-stability-audit-category-slice-1.md`.
-2. **Contribution/release ops follow-on** — **shipped** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) (`pr-merge` GitHub API wiring slice 1); additional channels / live `advanceWeek` orchestration deferred.
+2. **Contribution/release ops follow-on** — **shipped** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) (`pr-merge` GitHub API wiring slice 1); **in progress** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) live `advanceWeek` orchestration; additional channels deferred.
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; [SPE-2489](https://linear.app/spectranoir/issue/SPE-2489) SPE-947 slice 5 **shipped**; [SPE-2490](https://linear.app/spectranoir/issue/SPE-2490) SPE-1046 entity-welfare slice 5 **shipped** — see `planning/entity-welfare-reclassification-registry-slice-5.md`.
 
-**Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; additional publish channels beyond `pr-merge`; `advanceWeek` live orchestration.
+**Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; additional publish channels beyond `pr-merge`.
 
 **Recently shipped:** [SPE-31](https://linear.app/spectranoir/issue/SPE-31) parent **Done** — hub shell + SPE-31a + children SPE-2465–SPE-2469; AC rows 1–6 **Yes** @ `planning/spe-31-parent-reconciliation-slice.md` (PR #2857 @ `236499f7`).
 
@@ -237,6 +237,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `publish-queue-github-api-slice-1.md`                   | **Shipped**    | [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) — `pr-merge` GitHub API wiring under SPE-75; PR #2896 @ `4acb1b9e`. |
 | `publish-queue-executor-slice-1.md`                       | **Shipped**    | [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — dry-run publish executor under SPE-75; PR #2888 @ `6399251c`. |
 | `publish-queue-surfacing-slice-1.md`                      | **Shipped**    | [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — publish-queue mirror + weekly orchestration surfacing under SPE-75; PR #2890 @ `1a801ec0`. |
+| `publish-queue-live-orchestration-slice-1.md`             | **In progress** | [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) — live vs dry-run weekly orchestration under SPE-75. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/publish-queue-live-orchestration-slice-1.md
+++ b/planning/publish-queue-live-orchestration-slice-1.md
@@ -1,0 +1,78 @@
+# SPE-75 — Publish-queue live advanceWeek orchestration (slice 1)
+
+One-page implementation plan. Linear: [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) per `planning/publish-queue-github-api-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2491 — Publish-queue live advanceWeek orchestration (slice 1)](https://linear.app/spectranoir/issue/SPE-2491) |
+| **Status** | In progress — PR pending |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-publish-queue-live-orchestration-slice-1` |
+| **Base `main` SHA** | `2e655e18` |
+
+## Goal
+
+Wire weekly publish-queue execution in `advanceWeek` to invoke the live `pr-merge` executor path when explicitly configured (`PUBLISH_QUEUE_EXECUTOR_MODE=live` + GitHub credentials + injectable sync client). Surface live execution receipts in weekly notes. Dry-run remains the safe default for browser and CI tests.
+
+## Prerequisite (on `main` @ `2e655e18`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Dry-run executor | `src/domain/publishQueueExecutor.ts` (SPE-2484 / PR #2888) |
+| Weekly surfacing | `applyWeeklyPublishQueueExecutionTick` in `advanceWeek` (SPE-2485 / PR #2890) |
+| GitHub API client | `src/domain/publishQueueGitHubClient.ts` (SPE-2488 / PR #2896) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `publishQueueWeeklyOrchestration.ts` live vs dry-run branch | SPE-75 parent reopen |
+| `advanceWeek` orchestrated tick + optional deps param | Mission triage (blocked) |
+| Live receipt labels in weekly notes + metadata | Modifiable-pack import |
+| Sync live batch executor for weekly loop | Additional publish channels |
+| Unit + `advanceWeek` integration tests | GameState execution-receipt persistence map |
+
+## Orchestration contract
+
+| Input | Behavior |
+| --- | --- |
+| Default / browser / CI tests | `dry-run` — existing SPE-2484 stubs |
+| `PUBLISH_QUEUE_EXECUTOR_MODE=live` without full credentials | `dry-run` fallback |
+| Live mode + credentials + `githubClient` in deps | Sync `pr-merge` live path |
+| Live mode + credentials without sync client | `dry-run` fallback (`advanceWeek` is synchronous) |
+| Failed API merge | Reject receipt; record byte-stable |
+| Empty queue | No-op; zero notes |
+| Idempotent re-tick | `already_published` skip; no duplicate notes |
+
+## Acceptance
+
+- [x] Default / CI tests remain dry-run
+- [x] Live path transitions `ready_to_publish` → `published` with `publishChannelRef` when deps inject sync client
+- [x] Failed live API calls do not mutate queue records
+- [x] Weekly notes distinguish live vs dry-run (`executionMode` metadata)
+- [x] `npm run lint` + targeted tests green
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publishQueueWeeklyOrchestration.ts`, `src/domain/publishQueueExecutor.ts`, `src/domain/publishQueueSurfacing.ts`, `src/domain/publishQueueWeeklyReportNotes.ts`, `src/domain/publishQueueGitHubClient.ts`, `src/domain/sim/advanceWeek.ts` |
+| Tests  | `src/test/publishQueueWeeklyOrchestration.test.ts`, `src/test/advanceWeek.publishQueue.integration.test.ts`, `src/test/publishQueueSurfacing.test.ts`, `src/test/publishQueueWeeklyReportNotes.test.ts` |
+| Plan   | `planning/publish-queue-live-orchestration-slice-1.md`, `planning/backlog.md` |
+| Docs   | `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Additional publish channels | SPE-75 follow-up child | Slice 1 wires `pr-merge` only |
+| GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond queue status transition |
+| Async live batch outside sync `advanceWeek` | Ops harness | Use `executePublishQueueRecordsLive` for non-weekly automation |
+| Mission triage publish-queue chips | Backlog | Mission triage full refresh blocked |
+
+## See also
+
+- `planning/publish-queue-github-api-slice-1.md`
+- `planning/publish-queue-surfacing-slice-1.md`
+- `planning/publish-queue-executor-slice-1.md`
+- `planning/backlog.md`

--- a/src/domain/publishQueueExecutor.ts
+++ b/src/domain/publishQueueExecutor.ts
@@ -21,7 +21,10 @@ import {
 } from './publishAutomationCreditingHooks'
 import type {
   PublishQueueGitHubClient,
+  PublishQueueGitHubClientSync,
   PublishQueueGitHubConfig,
+  PublishQueueGitHubMergeRequest,
+  PublishQueueGitHubMergeResult,
 } from './publishQueueGitHubClient'
 import {
   buildPrMergeGitHubRequest,
@@ -83,6 +86,11 @@ export interface PublishQueueExecutorOptions {
 
 export interface PublishQueueLiveExecutorOptions extends PublishQueueExecutorOptions {
   readonly githubClient: PublishQueueGitHubClient
+  readonly githubConfig: Pick<PublishQueueGitHubConfig, 'owner' | 'repo'>
+}
+
+export interface PublishQueueLiveExecutorSyncOptions extends PublishQueueExecutorOptions {
+  readonly githubClient: PublishQueueGitHubClientSync
   readonly githubConfig: Pick<PublishQueueGitHubConfig, 'owner' | 'repo'>
 }
 
@@ -331,6 +339,60 @@ export function executePublishQueueRecordDryRun(
   })
 }
 
+function finalizeLiveMergeExecution(
+  record: PublishQueueRecord,
+  executionWeek: number,
+  maxHookApplications: number,
+  mergeRequest: PublishQueueGitHubMergeRequest | undefined,
+  mergeResult: PublishQueueGitHubMergeResult | undefined
+): PublishQueueExecutionResult {
+  const publishChannelHook = findPublishChannelHook(record)!
+  const appliedHooks = buildAppliedHookStubs(record, maxHookApplications)
+
+  if (publishChannelHook.target !== 'pr-merge') {
+    return {
+      record,
+      receipt: freezeReceipt({
+        recordId: record.id,
+        outcome: 'rejected',
+        executionWeek,
+        appliedHooks: Object.freeze([]),
+        skipCode: 'unsupported_publish_channel_target',
+      }),
+    }
+  }
+
+  if (!mergeRequest) {
+    return {
+      record,
+      receipt: freezeReceipt({
+        recordId: record.id,
+        outcome: 'rejected',
+        executionWeek,
+        appliedHooks: Object.freeze([]),
+        skipCode: 'publish_channel_pull_request_unresolved',
+      }),
+    }
+  }
+
+  if (!mergeResult || !mergeResult.ok) {
+    return {
+      record,
+      receipt: freezeReceipt({
+        recordId: record.id,
+        outcome: 'rejected',
+        executionWeek,
+        appliedHooks: Object.freeze([]),
+        skipCode: 'publish_channel_api_failed',
+      }),
+    }
+  }
+
+  return finalizePublishedExecution(record, executionWeek, appliedHooks, {
+    publishChannelRef: formatPublishQueueGitHubMergeSuccessRef(mergeRequest, mergeResult),
+  })
+}
+
 /**
  * Executes one publish-queue record through the live `pr-merge` GitHub API path.
  * Failed API calls reject without mutating the record. Re-execution of
@@ -349,57 +411,59 @@ export async function executePublishQueueRecordLive(
   }
 
   const publishChannelHook = findPublishChannelHook(record)!
-  const appliedHooks = buildAppliedHookStubs(record, maxHookApplications)
-
-  if (publishChannelHook.target !== 'pr-merge') {
-    return {
-      record,
-      receipt: freezeReceipt({
-        recordId: record.id,
-        outcome: 'rejected',
-        executionWeek,
-        appliedHooks: Object.freeze([]),
-        skipCode: 'unsupported_publish_channel_target',
-      }),
-    }
-  }
-
   const mergeRequest = buildPrMergeGitHubRequest(
     publishChannelHook,
     record,
     options.githubConfig
   )
 
-  if (!mergeRequest) {
-    return {
-      record,
-      receipt: freezeReceipt({
-        recordId: record.id,
-        outcome: 'rejected',
-        executionWeek,
-        appliedHooks: Object.freeze([]),
-        skipCode: 'publish_channel_pull_request_unresolved',
-      }),
-    }
+  const mergeResult = mergeRequest
+    ? await options.githubClient.mergePullRequest(mergeRequest)
+    : undefined
+
+  return finalizeLiveMergeExecution(
+    record,
+    executionWeek,
+    maxHookApplications,
+    mergeRequest,
+    mergeResult
+  )
+}
+
+/**
+ * Synchronous live executor for weekly orchestration inside `advanceWeek`.
+ * Requires an injectable sync GitHub client (tests/CI harness).
+ */
+export function executePublishQueueRecordLiveSync(
+  record: PublishQueueRecord,
+  options: PublishQueueLiveExecutorSyncOptions
+): PublishQueueExecutionResult {
+  const executionWeek = normalizeWeek(options.week)
+  const maxHookApplications = resolveMaxHookApplications(options.maxHookApplications)
+  const preExecution = buildPreExecutionReceipt(record, executionWeek)
+
+  if (preExecution.kind === 'result') {
+    return preExecution.result
   }
 
-  const mergeResult = await options.githubClient.mergePullRequest(mergeRequest)
-  if (!mergeResult.ok) {
-    return {
-      record,
-      receipt: freezeReceipt({
-        recordId: record.id,
-        outcome: 'rejected',
-        executionWeek,
-        appliedHooks: Object.freeze([]),
-        skipCode: 'publish_channel_api_failed',
-      }),
-    }
-  }
+  const publishChannelHook = findPublishChannelHook(record)!
+  const mergeRequest = buildPrMergeGitHubRequest(
+    publishChannelHook,
+    record,
+    options.githubConfig
+  )
 
-  return finalizePublishedExecution(record, executionWeek, appliedHooks, {
-    publishChannelRef: formatPublishQueueGitHubMergeSuccessRef(mergeRequest, mergeResult),
-  })
+  const mergeResult = mergeRequest
+    ? options.githubClient.mergePullRequest(mergeRequest)
+    : undefined
+
+  return finalizeLiveMergeExecution(
+    record,
+    executionWeek,
+    maxHookApplications,
+    mergeRequest,
+    mergeResult
+  )
 }
 
 /**
@@ -494,6 +558,54 @@ export async function executePublishQueueRecordsLive(
 
     const sourceRecord = (nextRecords ?? safeRecords)[recordId] ?? record
     const result = await executePublishQueueRecordLive(sourceRecord, options)
+
+    receipts.push(result.receipt)
+
+    if (result.record === sourceRecord) {
+      continue
+    }
+
+    if (!nextRecords) {
+      nextRecords = { ...safeRecords }
+    }
+
+    nextRecords[recordId] = result.record
+  }
+
+  return {
+    records: nextRecords ?? safeRecords,
+    receipts: Object.freeze(receipts.map((receipt) => freezeReceipt(receipt))),
+  }
+}
+
+/**
+ * Synchronous batch live execution for weekly orchestration inside `advanceWeek`.
+ */
+export function executePublishQueueRecordsLiveSync(
+  records: PublishQueueRecordsMap | null | undefined,
+  options: PublishQueueLiveExecutorSyncOptions
+): PublishQueueBatchExecutionResult {
+  const safeRecords = records ?? {}
+  const recordIds = Object.keys(safeRecords).sort((left, right) => left.localeCompare(right))
+
+  if (recordIds.length === 0) {
+    return {
+      records: safeRecords,
+      receipts: Object.freeze([]),
+    }
+  }
+
+  let nextRecords: PublishQueueRecordsMap | null = null
+  const receipts: PublishQueueExecutionReceipt[] = []
+
+  for (const recordId of recordIds) {
+    const record = safeRecords[recordId]
+    if (!record) {
+      continue
+    }
+
+    const sourceRecord = (nextRecords ?? safeRecords)[recordId] ?? record
+    const result = executePublishQueueRecordLiveSync(sourceRecord, options)
 
     receipts.push(result.receipt)
 

--- a/src/domain/publishQueueGitHubClient.ts
+++ b/src/domain/publishQueueGitHubClient.ts
@@ -52,6 +52,10 @@ export interface PublishQueueGitHubClient {
   ): Promise<PublishQueueGitHubMergeResult>
 }
 
+export interface PublishQueueGitHubClientSync {
+  mergePullRequest(request: PublishQueueGitHubMergeRequest): PublishQueueGitHubMergeResult
+}
+
 export interface PublishQueueGitHubConfig {
   readonly owner: string
   readonly repo: string

--- a/src/domain/publishQueueSurfacing.ts
+++ b/src/domain/publishQueueSurfacing.ts
@@ -1,7 +1,8 @@
 /**
- * SPE-2485 slice 1: read-only surfacing for publish-queue records and dry-run receipts.
+ * SPE-2485 slice 1: read-only surfacing for publish-queue records and execution receipts.
+ * SPE-2491 slice 1: live vs dry-run receipt labels.
  *
- * CP-neutral labels only; no real publish side effects.
+ * CP-neutral labels only; no publish side effects from surfacing helpers.
  */
 
 import type { PublishAutomationStatus } from './publishAutomationCreditingHooks'
@@ -11,6 +12,7 @@ import type {
   PublishQueueExecutorOutcome,
   PublishQueueExecutorSkipCode,
 } from './publishQueueExecutor'
+import type { PublishQueueExecutionMode } from './publishQueueGitHubClient'
 
 export function formatPublishQueueStatusLabel(status: PublishAutomationStatus | string): string {
   return status
@@ -19,10 +21,19 @@ export function formatPublishQueueStatusLabel(status: PublishAutomationStatus | 
     .join(' ')
 }
 
-export function formatPublishQueueExecutorOutcomeLabel(outcome: PublishQueueExecutorOutcome): string {
+export function resolvePublishQueueReceiptExecutionMode(
+  receipt: PublishQueueExecutionReceipt
+): PublishQueueExecutionMode {
+  return receipt.publishChannelRef ? 'live' : 'dry-run'
+}
+
+export function formatPublishQueueExecutorOutcomeLabel(
+  outcome: PublishQueueExecutorOutcome,
+  executionMode: PublishQueueExecutionMode = 'dry-run'
+): string {
   switch (outcome) {
     case 'completed':
-      return 'Completed (dry-run)'
+      return executionMode === 'live' ? 'Completed (live)' : 'Completed (dry-run)'
     case 'skipped':
       return 'Skipped'
     case 'rejected':
@@ -42,6 +53,12 @@ export function formatPublishQueueSkipCodeLabel(skipCode: PublishQueueExecutorSk
       return 'record not ready to publish'
     case 'missing_publish_channel_hook':
       return 'missing publish channel hook'
+    case 'unsupported_publish_channel_target':
+      return 'unsupported publish channel target'
+    case 'publish_channel_pull_request_unresolved':
+      return 'publish channel pull request unresolved'
+    case 'publish_channel_api_failed':
+      return 'publish channel API failed'
     default: {
       const unreachable: never = skipCode
       return unreachable
@@ -79,20 +96,24 @@ export function formatPublishQueueExecutionReceiptNoteContent(input: {
   receipt: PublishQueueExecutionReceipt
   record: PublishQueueRecord | undefined
 }): string {
+  const executionMode = resolvePublishQueueReceiptExecutionMode(input.receipt)
+  const channelLabel = executionMode === 'live' ? 'live' : 'dry-run'
   const label = input.record?.label ?? input.receipt.recordId
   const statusLabel = input.record
     ? formatPublishQueueStatusLabel(input.record.status)
     : 'Unknown'
-  const outcomeLabel = formatPublishQueueExecutorOutcomeLabel(input.receipt.outcome)
+  const outcomeLabel = formatPublishQueueExecutorOutcomeLabel(input.receipt.outcome, executionMode)
   const skipSegment =
     input.receipt.skipCode !== undefined
       ? ` (${formatPublishQueueSkipCodeLabel(input.receipt.skipCode)})`
       : ''
-  const stubSegment = input.receipt.publishChannelStub
-    ? ` Dry-run channel: ${input.receipt.publishChannelStub}.`
-    : ''
+  const channelSegment = input.receipt.publishChannelRef
+    ? ` Live channel ref: ${input.receipt.publishChannelRef}.`
+    : input.receipt.publishChannelStub
+      ? ` Dry-run channel: ${input.receipt.publishChannelStub}.`
+      : ''
 
-  return `Publish queue (dry-run) — ${input.receipt.recordId}: ${label} [${statusLabel}]. Outcome: ${outcomeLabel}${skipSegment}.${stubSegment}`
+  return `Publish queue (${channelLabel}) — ${input.receipt.recordId}: ${label} [${statusLabel}]. Outcome: ${outcomeLabel}${skipSegment}.${channelSegment}`
 }
 
 export function summarizePublishQueueRecords(

--- a/src/domain/publishQueueWeeklyOrchestration.ts
+++ b/src/domain/publishQueueWeeklyOrchestration.ts
@@ -1,0 +1,81 @@
+/**
+ * SPE-2491 slice 1: weekly publish-queue execution orchestration for `advanceWeek`.
+ *
+ * Dry-run is the safe default. Live `pr-merge` execution requires explicit
+ * `PUBLISH_QUEUE_EXECUTOR_MODE=live`, complete GitHub credentials, and an
+ * injectable sync client (tests/CI harness) because `advanceWeek` is synchronous.
+ */
+
+import type { PublishQueueRecordsMap } from './publishAutomationCreditingHooks'
+import {
+  applyWeeklyPublishQueueExecutionTick,
+  executePublishQueueRecordsLiveSync,
+  type PublishQueueBatchExecutionResult,
+} from './publishQueueExecutor'
+import type {
+  PublishQueueExecutionMode,
+  PublishQueueExecutorEnvironment,
+  PublishQueueGitHubClientSync,
+} from './publishQueueGitHubClient'
+import {
+  buildPublishQueueGitHubConfig,
+  readPublishQueueExecutorEnvironment,
+} from './publishQueueGitHubClient'
+
+export interface PublishQueueWeeklyOrchestrationDeps {
+  readonly environment?: PublishQueueExecutorEnvironment
+  readonly githubClient?: PublishQueueGitHubClientSync
+}
+
+/**
+ * Resolves the effective weekly execution mode. Live mode requires both
+ * `mode=live` and complete GitHub credentials; otherwise dry-run.
+ */
+export function resolveEffectivePublishQueueWeeklyExecutionMode(
+  deps: PublishQueueWeeklyOrchestrationDeps = {}
+): PublishQueueExecutionMode {
+  const environment = deps.environment ?? readPublishQueueExecutorEnvironment()
+
+  if (environment.mode !== 'live') {
+    return 'dry-run'
+  }
+
+  if (!buildPublishQueueGitHubConfig(environment)) {
+    return 'dry-run'
+  }
+
+  return 'live'
+}
+
+/**
+ * One deterministic weekly publish-queue execution pass. Uses dry-run stubs by
+ * default; when live mode is configured and a sync GitHub client is available,
+ * invokes the live `pr-merge` executor path without mutating records on failure.
+ */
+export function applyWeeklyPublishQueueExecutionTickOrchestrated(
+  records: PublishQueueRecordsMap | null | undefined,
+  week: number,
+  deps: PublishQueueWeeklyOrchestrationDeps = {}
+): PublishQueueBatchExecutionResult {
+  const executionMode = resolveEffectivePublishQueueWeeklyExecutionMode(deps)
+
+  if (executionMode === 'dry-run') {
+    return applyWeeklyPublishQueueExecutionTick(records, week)
+  }
+
+  const environment = deps.environment ?? readPublishQueueExecutorEnvironment()
+  const githubConfig = buildPublishQueueGitHubConfig(environment)
+
+  if (!githubConfig || !deps.githubClient) {
+    return applyWeeklyPublishQueueExecutionTick(records, week)
+  }
+
+  return executePublishQueueRecordsLiveSync(records, {
+    week,
+    githubClient: deps.githubClient,
+    githubConfig: {
+      owner: githubConfig.owner,
+      repo: githubConfig.repo,
+    },
+  })
+}

--- a/src/domain/publishQueueWeeklyReportNotes.ts
+++ b/src/domain/publishQueueWeeklyReportNotes.ts
@@ -9,6 +9,7 @@ import { createDeterministicReportNote } from './reportNotes'
 import {
   formatPublishQueueExecutionReceiptNoteContent,
   listReportablePublishQueueReceipts,
+  resolvePublishQueueReceiptExecutionMode,
 } from './publishQueueSurfacing'
 
 /**
@@ -47,6 +48,8 @@ export function buildWeeklyPublishQueueExecutionReportNotes(input: {
           executionWeek: receipt.executionWeek,
           skipCode: receipt.skipCode,
           publishChannelStub: receipt.publishChannelStub,
+          publishChannelRef: receipt.publishChannelRef,
+          executionMode: resolvePublishQueueReceiptExecutionMode(receipt),
           recordStatus: record?.status,
           week: input.week,
         }

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -295,7 +295,8 @@ import {
   composeWelfareDebtIntoIntegratedHealthBundles,
 } from '../containedPersonIntegratedHealthBundleCompose'
 import { applyWeeklyPatternSourceSeriesIntakeTick } from '../patternSourceSeriesWeeklyIntake'
-import { applyWeeklyPublishQueueExecutionTick } from '../publishQueueExecutor'
+import { applyWeeklyPublishQueueExecutionTickOrchestrated } from '../publishQueueWeeklyOrchestration'
+import type { PublishQueueWeeklyOrchestrationDeps } from '../publishQueueWeeklyOrchestration'
 import { buildWeeklyPublishQueueExecutionReportNotes } from '../publishQueueWeeklyReportNotes'
 import { buildWeeklyEntityWelfareReclassificationTransitionReportNotes } from '../entityWelfareReclassificationWeeklyReportNotes'
 import { buildWeeklyVisualTriggerHazardTransitionReportNotes } from '../visualTriggerHazardWeeklyReportNotes'
@@ -4425,7 +4426,11 @@ function finalizeEvents(
  * This is a batch simulation step: abstract case resolution, report output, and state updates.
  * It is intentionally not a visual combat loop or action-by-action playback engine.
  */
-export function advanceWeek(state: GameState, overrideNow?: number): GameState {
+export function advanceWeek(
+  state: GameState,
+  overrideNow?: number,
+  publishQueueOrchestrationDeps?: PublishQueueWeeklyOrchestrationDeps
+): GameState {
   if (state.gameOver) {
     return ensureNormalizedGameState(state)
   }
@@ -4699,12 +4704,13 @@ export function advanceWeek(state: GameState, overrideNow?: number): GameState {
     )
   }
 
-  // SPE-2485 slice 1: dry-run publish-queue execution tick and weekly report surfacing.
+  // SPE-2485 / SPE-2491: publish-queue execution tick (dry-run default; live when configured).
   const currentPublishQueueRecords = outputWeeklyState.publishQueueRecords ?? {}
   if (Object.keys(currentPublishQueueRecords).length > 0) {
-    const publishQueueTick = applyWeeklyPublishQueueExecutionTick(
+    const publishQueueTick = applyWeeklyPublishQueueExecutionTickOrchestrated(
       currentPublishQueueRecords,
-      result.week
+      result.week,
+      publishQueueOrchestrationDeps
     )
     outputWeeklyState.publishQueueRecords = publishQueueTick.records
 

--- a/src/test/advanceWeek.publishQueue.integration.test.ts
+++ b/src/test/advanceWeek.publishQueue.integration.test.ts
@@ -54,7 +54,7 @@ function buildCanonicalReadyQueueRecord() {
   })!
 }
 
-describe('advanceWeek publish queue integration (SPE-2485 slice 1)', () => {
+describe('advanceWeek publish queue integration (SPE-2485 / SPE-2491)', () => {
   it('is a no-op for an empty publish queue map without throwing', () => {
     const state = createStartingState()
     freezeCasesForQuietWeek(state)
@@ -87,5 +87,55 @@ describe('advanceWeek publish queue integration (SPE-2485 slice 1)', () => {
     expect(publishQueueNote?.content).toContain('Publish queue (dry-run)')
     expect(publishQueueNote?.content).toContain(record.label)
     expect(publishQueueNote?.content).toContain('dry-run:publish_channel:pr-merge:channel:pr-merge')
+    expect(publishQueueNote?.metadata).toMatchObject({
+      executionMode: 'dry-run',
+      publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+    })
+  })
+
+  it('surfaces live execution notes when orchestration deps inject sync client', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    const record = {
+      ...buildCanonicalReadyQueueRecord(),
+      releaseArtifactRef: 'release:pr:2890',
+    }
+    state.publishQueueRecords = {
+      [record.id]: record,
+    }
+
+    const nextState = advanceWeek(state, undefined, {
+      environment: {
+        mode: 'live',
+        githubOwner: 'JamesJedi420',
+        githubRepo: 'containment-protocol',
+        githubToken: 'ghp_test_token',
+      },
+      githubClient: {
+        mergePullRequest: () => ({
+          ok: true,
+          sha: 'abc123def456',
+          merged: true,
+          alreadyMerged: false,
+        }),
+      },
+    })
+
+    const nextRecord = nextState.publishQueueRecords?.[record.id]
+    expect(nextRecord?.status).toBe('published')
+
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const publishQueueNote = lastReport?.notes?.find(
+      (note) => note.type === 'contribution_release.publish_queue_execution'
+    )
+
+    expect(publishQueueNote).toBeDefined()
+    expect(publishQueueNote?.content).toContain('Publish queue (live)')
+    expect(publishQueueNote?.content).toContain('Completed (live)')
+    expect(publishQueueNote?.content).toContain('live:publish_channel:pr-merge')
+    expect(publishQueueNote?.metadata).toMatchObject({
+      executionMode: 'live',
+      publishChannelRef: expect.stringContaining('live:publish_channel:pr-merge'),
+    })
   })
 })

--- a/src/test/publishQueueSurfacing.test.ts
+++ b/src/test/publishQueueSurfacing.test.ts
@@ -104,4 +104,23 @@ describe('publishQueueSurfacing (SPE-2485 slice 1)', () => {
     expect(content).toContain('Completed (dry-run)')
     expect(content).toContain('dry-run:publish_channel:pr-merge:channel:pr-merge')
   })
+
+  it('formats live receipt note content with channel ref labels', () => {
+    const receipt: PublishQueueExecutionReceipt = {
+      recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      outcome: 'completed',
+      executionWeek: 2,
+      appliedHooks: [],
+      publishChannelRef: 'live:publish_channel:pr-merge:pr:2890:sha:abc123',
+    }
+
+    const content = formatPublishQueueExecutionReceiptNoteContent({
+      receipt,
+      record: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    })
+
+    expect(content).toContain('Publish queue (live)')
+    expect(content).toContain('Completed (live)')
+    expect(content).toContain('live:publish_channel:pr-merge:pr:2890:sha:abc123')
+  })
 })

--- a/src/test/publishQueueWeeklyOrchestration.test.ts
+++ b/src/test/publishQueueWeeklyOrchestration.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE,
+  evaluateContributionIntakeCuration,
+} from '../domain/contributionIntakeCuration'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+} from '../domain/modularReleasePackaging'
+import {
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+  composePublishQueueRecord,
+  evaluatePublishAutomationCreditingHooks,
+} from '../domain/publishAutomationCreditingHooks'
+import { applyWeeklyPublishQueueExecutionTick } from '../domain/publishQueueExecutor'
+import {
+  applyWeeklyPublishQueueExecutionTickOrchestrated,
+  resolveEffectivePublishQueueWeeklyExecutionMode,
+} from '../domain/publishQueueWeeklyOrchestration'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+} from '../domain/submissionGovernanceRights'
+
+function buildCanonicalReadyQueueRecord() {
+  const acceptedCuration = evaluateContributionIntakeCuration(
+    CANONICAL_CONTRIBUTION_SUBMISSION_FIXTURE
+  )
+  const packagedRelease = evaluateModularReleasePackaging(
+    acceptedCuration,
+    CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE
+  )
+  const appliedGovernance = evaluateSubmissionGovernanceRights(
+    CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE
+  )
+  const decision = evaluatePublishAutomationCreditingHooks(
+    packagedRelease,
+    appliedGovernance,
+    CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE
+  )
+
+  return composePublishQueueRecord({
+    id: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+    label: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label,
+    releaseArtifactRef: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.releaseArtifactRef,
+    decision,
+    summary: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.summary,
+    queuedWeek: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.queuedWeek,
+  })!
+}
+
+function buildLiveReadyQueueRecord() {
+  const record = buildCanonicalReadyQueueRecord()
+
+  return {
+    ...record,
+    releaseArtifactRef: 'release:pr:2890',
+  }
+}
+
+describe('publishQueueWeeklyOrchestration (SPE-2491 slice 1)', () => {
+  const composedRecord = buildCanonicalReadyQueueRecord()
+  const records = {
+    [composedRecord.id]: composedRecord,
+  }
+
+  const liveEnvironment = {
+    mode: 'live' as const,
+    githubOwner: 'JamesJedi420',
+    githubRepo: 'containment-protocol',
+    githubToken: 'ghp_test_token',
+  }
+
+  it('defaults to dry-run when environment is unset or incomplete', () => {
+    expect(resolveEffectivePublishQueueWeeklyExecutionMode()).toBe('dry-run')
+    expect(
+      resolveEffectivePublishQueueWeeklyExecutionMode({
+        environment: { mode: 'live' },
+      })
+    ).toBe('dry-run')
+  })
+
+  it('resolves live mode only with complete GitHub credentials', () => {
+    expect(
+      resolveEffectivePublishQueueWeeklyExecutionMode({
+        environment: liveEnvironment,
+      })
+    ).toBe('live')
+  })
+
+  it('matches dry-run weekly tick when live mode is not effective', () => {
+    const orchestrated = applyWeeklyPublishQueueExecutionTickOrchestrated(records, 4)
+    const dryRun = applyWeeklyPublishQueueExecutionTick(records, 4)
+
+    expect(orchestrated).toEqual(dryRun)
+  })
+
+  it('uses live sync executor when configured with injectable client', () => {
+    const liveRecord = buildLiveReadyQueueRecord()
+    const liveRecords = {
+      [liveRecord.id]: liveRecord,
+    }
+
+    const orchestrated = applyWeeklyPublishQueueExecutionTickOrchestrated(liveRecords, 4, {
+      environment: liveEnvironment,
+      githubClient: {
+        mergePullRequest: () => ({
+          ok: true,
+          sha: 'abc123def456',
+          merged: true,
+          alreadyMerged: false,
+        }),
+      },
+    })
+
+    expect(orchestrated.records[liveRecord.id]?.status).toBe('published')
+    expect(orchestrated.receipts[0]?.publishChannelRef).toContain('live:publish_channel:pr-merge')
+    expect(orchestrated.receipts[0]?.publishChannelStub).toBeUndefined()
+  })
+
+  it('does not mutate records when live API merge fails', () => {
+    const liveRecord = buildLiveReadyQueueRecord()
+    const liveRecords = {
+      [liveRecord.id]: liveRecord,
+    }
+
+    const orchestrated = applyWeeklyPublishQueueExecutionTickOrchestrated(liveRecords, 4, {
+      environment: liveEnvironment,
+      githubClient: {
+        mergePullRequest: () => ({
+          ok: false,
+          statusCode: 500,
+          message: 'merge failed',
+        }),
+      },
+    })
+
+    expect(orchestrated.records[liveRecord.id]).toBe(liveRecord)
+    expect(orchestrated.receipts[0]?.outcome).toBe('rejected')
+    expect(orchestrated.receipts[0]?.skipCode).toBe('publish_channel_api_failed')
+  })
+
+  it('falls back to dry-run when live mode is configured without sync client', () => {
+    const orchestrated = applyWeeklyPublishQueueExecutionTickOrchestrated(records, 4, {
+      environment: liveEnvironment,
+    })
+    const dryRun = applyWeeklyPublishQueueExecutionTick(records, 4)
+
+    expect(orchestrated).toEqual(dryRun)
+  })
+})

--- a/src/test/publishQueueWeeklyReportNotes.test.ts
+++ b/src/test/publishQueueWeeklyReportNotes.test.ts
@@ -69,6 +69,37 @@ describe('publishQueueWeeklyReportNotes (SPE-2485 slice 1)', () => {
       executionWeek: 2,
       recordStatus: 'published',
       week: 2,
+      executionMode: 'dry-run',
+      publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+    })
+  })
+
+  it('includes live receipt metadata when publishChannelRef is present', () => {
+    const liveReceipt: PublishQueueExecutionReceipt = {
+      recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+      outcome: 'completed',
+      executionWeek: 2,
+      appliedHooks: [],
+      publishChannelRef: 'live:publish_channel:pr-merge:pr:2890:sha:abc123',
+    }
+
+    const notes = buildWeeklyPublishQueueExecutionReportNotes({
+      receipts: [liveReceipt],
+      records: {
+        [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: {
+          ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+          status: 'published',
+        },
+      },
+      week: 2,
+      sequenceStart: 1,
+    })
+
+    expect(notes[0]?.content).toContain('Publish queue (live)')
+    expect(notes[0]?.metadata).toMatchObject({
+      executionMode: 'live',
+      publishChannelRef: 'live:publish_channel:pr-merge:pr:2890:sha:abc123',
+      publishChannelStub: undefined,
     })
   })
 })


### PR DESCRIPTION
## Summary

- Add `publishQueueWeeklyOrchestration.ts` to resolve dry-run vs live weekly execution mode (`PUBLISH_QUEUE_EXECUTOR_MODE=live` + GitHub credentials + injectable sync client).
- Wire `applyWeeklyPublishQueueExecutionTickOrchestrated` into `advanceWeek` (optional third `publishQueueOrchestrationDeps` param); dry-run remains default for browser and CI tests.
- Surface live execution receipts in weekly notes (`executionMode`, `publishChannelRef` metadata; live vs dry-run copy).

## Linear

- **Slice:** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) — Publish-queue live advanceWeek orchestration (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — stays **Done** (not reopened)

## What shipped

- Sync live batch executor (`executePublishQueueRecordsLiveSync`) for weekly loop
- Mode-aware orchestration with safe dry-run fallback when sync client unavailable
- Live vs dry-run weekly note labels and metadata
- Slice doc: `planning/publish-queue-live-orchestration-slice-1.md`

## Validation

- `npm run lint`
- `npm run test:run -- src/test/publishQueueWeeklyOrchestration.test.ts src/test/advanceWeek.publishQueue.integration.test.ts src/test/publishQueueSurfacing.test.ts src/test/publishQueueWeeklyReportNotes.test.ts src/test/publishQueueExecutor.test.ts src/test/publishQueueGitHubClient.test.ts src/test/reportNoteTypeAudit.test.ts`

## Docs updated

- `docs/contribution-and-release-operations.md`
- `planning/backlog.md`
- `planning/publish-queue-live-orchestration-slice-1.md`

## Parent status

SPE-75 parent remains **Done**. Additional publish channels and execution-receipt persistence remain deferred children.