### PR TITLE
feat(SPE-2492): modifiable data-pack planning mirror and surfacing (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -55,6 +55,8 @@ Domain validation baseline: `src/domain/modifiableDataPackValidation.ts` (SPE-24
 
 Runtime import (SPE-2486) persists validated packs on `GameState.modifiableDataPackRecords` with sanitize/hydration on save import — rejected payloads drop without corrupting downstream state.
 
+Modifiable data-pack surfacing (SPE-2492) exposes a read-only planning mirror at `/modifiable-data-packs` over hydrated `modifiableDataPackRecords` with CP-neutral import-status and section-summary labels.
+
 ## Publish automation and crediting hooks
 
 After packaging and governance gates pass, publish-intent evaluation composes crediting targets (CONTRIBUTORS, changelog entries, version bumps) and bounded publish channel hooks without executing publish actions.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,9 @@ From `README.md` **Current design notes**:
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
-**In progress:** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) publish-queue live `advanceWeek` orchestration (slice 1) — branch `spe-75-publish-queue-live-orchestration-slice-1`; see `planning/publish-queue-live-orchestration-slice-1.md`.
+**In progress:** [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) modifiable data-pack planning mirror and surfacing (slice 1) — branch `spe-75-modifiable-data-pack-surfacing-slice-1`; see `planning/modifiable-data-pack-surfacing-slice-1.md`.
+
+**Pending merge:** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) publish-queue live `advanceWeek` orchestration (slice 1) — PR #2902 open (CI green); branch `spe-75-publish-queue-live-orchestration-slice-1`; see `planning/publish-queue-live-orchestration-slice-1.md`.
 
 **Recently shipped:** [SPE-2490](https://linear.app/spectranoir/issue/SPE-2490) entity-welfare reclassification registry weekly transition surfacing (slice 5) — `entity_welfare_reclassification.weekly_transition` notes; branch `spe-2114-entity-welfare-reclassification-weekly-surfacing-slice-5` (PR #2900 @ `d5b795ae`). Parents [SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) stay **Backlog**.
 
@@ -58,14 +60,14 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Owner reprioritizes from §14-pass alternates below. Mission triage full refresh remains **blocked**.
+**Next step:** [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) modifiable data-pack surfacing (slice 1) — in progress. Merge [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) PR #2902 when `gh`/UI available. Mission triage full refresh remains **blocked**.
 
-**Base `main` SHA:** `96452e9e` — post SPE-2489 visual-trigger hazard weekly surfacing closure.
+**Base `main` SHA:** `2e655e18` — pre SPE-2491 merge; active branch includes SPE-2491 until main sync.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
 1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — **shipped** [SPE-2487](https://linear.app/spectranoir/issue/SPE-2487); see `planning/branch-continuity-stability-audit-category-slice-1.md`.
-2. **Contribution/release ops follow-on** — **shipped** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) (`pr-merge` GitHub API wiring slice 1); **in progress** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) live `advanceWeek` orchestration; additional channels deferred.
+2. **Contribution/release ops follow-on** — **shipped** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) (`pr-merge` GitHub API wiring slice 1); **pending merge** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) live `advanceWeek` orchestration (PR #2902); **in progress** [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) modifiable data-pack surfacing; additional channels deferred.
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; [SPE-2489](https://linear.app/spectranoir/issue/SPE-2489) SPE-947 slice 5 **shipped**; [SPE-2490](https://linear.app/spectranoir/issue/SPE-2490) SPE-1046 entity-welfare slice 5 **shipped** — see `planning/entity-welfare-reclassification-registry-slice-5.md`.
 
 **Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; additional publish channels beyond `pr-merge`.
@@ -232,12 +234,13 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `minor-anomaly-item-registry-slice-3.md`                  | **Shipped**    | SPE-2316 / PR #2496 — weekly disposition/custody advance hook for SPE-2104.                                                                         |
 | `modifiable-data-pack-validation-slice-1.md`              | **Shipped**    | [SPE-2479](https://linear.app/spectranoir/issue/SPE-2479) — deterministic modifiable data-pack schema validation under SPE-75; PR #2877 @ `cb4ea3ae`. |
 | `modifiable-data-pack-runtime-import-slice-1.md`          | **Shipped**    | [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) — GameState modifiable data-pack runtime import under SPE-75. |
+| `modifiable-data-pack-surfacing-slice-1.md`               | **In progress** | [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) — planning mirror and surfacing under SPE-75. |
 | `publish-automation-crediting-hooks-slice-1.md`           | **Shipped**    | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; PR #2879 @ `99161c79`. |
 | `publish-queue-persistence-slice-1.md`                    | **Shipped**    | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — `publishQueueRecords` GameState persistence under SPE-75; PR #2886 @ `93711130`. |
 | `publish-queue-github-api-slice-1.md`                   | **Shipped**    | [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) — `pr-merge` GitHub API wiring under SPE-75; PR #2896 @ `4acb1b9e`. |
 | `publish-queue-executor-slice-1.md`                       | **Shipped**    | [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — dry-run publish executor under SPE-75; PR #2888 @ `6399251c`. |
 | `publish-queue-surfacing-slice-1.md`                      | **Shipped**    | [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — publish-queue mirror + weekly orchestration surfacing under SPE-75; PR #2890 @ `1a801ec0`. |
-| `publish-queue-live-orchestration-slice-1.md`             | **In progress** | [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) — live vs dry-run weekly orchestration under SPE-75. |
+| `publish-queue-live-orchestration-slice-1.md`             | **Pending merge** | [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) — live vs dry-run weekly orchestration under SPE-75; PR #2902. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/modifiable-data-pack-surfacing-slice-1.md
+++ b/planning/modifiable-data-pack-surfacing-slice-1.md
@@ -1,0 +1,78 @@
+# SPE-75 — Modifiable data-pack planning mirror and surfacing (slice 1)
+
+One-page implementation plan. Linear: [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) per `planning/modifiable-data-pack-runtime-import-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2492 — Modifiable data-pack planning mirror and surfacing (slice 1)](https://linear.app/spectranoir/issue/SPE-2492) |
+| **Status** | In progress |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-modifiable-data-pack-surfacing-slice-1` |
+| **Base `main` SHA** | `2e655e18` (pre SPE-2491 merge; branch includes SPE-2491 publish-queue live orchestration until main sync) |
+
+## Goal
+
+Surface persisted `modifiableDataPackRecords` via read-only planning mirror and CP-neutral projection helpers — no publish-queue changes, weekly orchestration, mission triage, or SPE-75 parent reopen.
+
+## Prerequisite (on branch)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Validation envelope  | `src/domain/modifiableDataPackValidation.ts` (SPE-2479) |
+| Runtime persistence | `modifiableDataPackRecords` on `GameState` (SPE-2486) |
+| Planning mirror template | `publishQueueMirrorView.ts` + `PublishQueueMirrorPage.tsx` (SPE-2485) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `modifiableDataPackSurfacing.ts` projection helpers (CP-neutral labels) | Publish-queue or GitHub API changes |
+| Planning mirror page + route `/modifiable-data-packs` + Front Desk link | SPE-75 parent reopen |
+| Mirror + projection tests | Weekly `advanceWeek` orchestration (slice 2) |
+| Slice doc (this file) + backlog handoff | Publish automation integration |
+| Docs cross-ref in `docs/contribution-and-release-operations.md` | Mission triage chips (blocked) |
+
+## Surfacing contract
+
+- **Read-only mirror** — display hydrated `modifiableDataPackRecords`; no mutations from mirror surface.
+- **Safe labels** — pack id, schema version, pack kind, import status, section summary, author ref, issue link.
+- **Empty map** — mirror `isEmpty: true`; no throw.
+- **Status discrimination** — `applied` vs `needs_revision` visible in mirror summary and per-record rows.
+- **Rejected on hydrate** — invalid/rejected payloads never appear in mirror (sanitize drops them).
+
+## Acceptance
+
+- [x] Empty `modifiableDataPackRecords` renders mirror empty state without throw
+- [x] Valid canonical fixture records display safe labels (id, schema version, pack kind, import status)
+- [x] Rejected / invalid hydrated entries do not corrupt mirror output
+- [x] Front Desk quick link routes to mirror page
+- [x] `npm run lint` + targeted tests green (unverified locally — Node.js not on agent PATH; IDE lints clean)
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/modifiableDataPackSurfacing.ts` |
+| View   | `src/features/operations/modifiableDataPackMirrorView.ts` |
+| UI     | `src/features/operations/ModifiableDataPackMirrorPage.tsx` |
+| Route  | `src/app/routes.ts`, `src/app/App.tsx`, `src/app/appShellRoutePaths.ts` |
+| Desk   | `src/features/operations/frontDeskView.ts` |
+| Copy   | `src/data/copy.ts` |
+| Tests  | `src/test/modifiableDataPackSurfacing.test.ts`, `src/features/operations/modifiableDataPackMirrorView.test.ts`, `src/features/operations/ModifiableDataPackMirrorPage.test.tsx` |
+| Plan   | `planning/modifiable-data-pack-surfacing-slice-1.md`, `planning/backlog.md` |
+| Docs   | `docs/contribution-and-release-operations.md` |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Weekly orchestration / report notes | SPE-75 follow-up child (slice 2) | Mirror must land before weekly tick |
+| Publish automation integration for pack import | SPE-75 follow-up child | Out of surfacing boundary |
+| Mission triage modifiable-pack chips | Backlog | Mission triage full refresh blocked |
+
+## See also
+
+- `planning/modifiable-data-pack-runtime-import-slice-1.md`
+- `planning/modifiable-data-pack-validation-slice-1.md`
+- `planning/publish-queue-surfacing-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -84,6 +84,9 @@ const PatternSourceSeriesMirrorRoute = createRouteComponent(
 const PublishQueueMirrorRoute = createRouteComponent(
   () => import('../features/operations/PublishQueueMirrorPage')
 )
+const ModifiableDataPackMirrorRoute = createRouteComponent(
+  () => import('../features/operations/ModifiableDataPackMirrorPage')
+)
 const SelfCensoringInformationMirrorRoute = createRouteComponent(
   () => import('../features/operations/SelfCensoringInformationMirrorPage')
 )
@@ -199,6 +202,10 @@ export default function App() {
           element={renderLazyRoute(PatternSourceSeriesMirrorRoute)}
         />
         <Route path="publish-queue" element={renderLazyRoute(PublishQueueMirrorRoute)} />
+        <Route
+          path="modifiable-data-packs"
+          element={renderLazyRoute(ModifiableDataPackMirrorRoute)}
+        />
         <Route
           path="self-censoring-information"
           element={renderLazyRoute(SelfCensoringInformationMirrorRoute)}

--- a/src/app/appShellRoutePaths.ts
+++ b/src/app/appShellRoutePaths.ts
@@ -30,6 +30,7 @@ export const APP_SHELL_STATIC_ROUTE_PATHS = [
   'truth-layer-records',
   'cover-story-records',
   'mass-anomalous-population-emergence',
+  'modifiable-data-packs',
   'visual-trigger-hazard',
   'entity-welfare-reclassification',
   'contained-person-therapeutic-care',

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -27,6 +27,7 @@ export const APP_ROUTES = {
   intelDetail: (templateId: string) => `/intel/${encodeURIComponent(templateId)}`,
   patternSourceSeries: '/pattern-source-series',
   publishQueue: '/publish-queue',
+  modifiableDataPacks: '/modifiable-data-packs',
   selfCensoringInformation: '/self-censoring-information',
   publicDisclosureState: '/public-disclosure-state',
   publicDisclosureCampaign: '/campaign/public-disclosure',

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1664,6 +1664,31 @@ export const PUBLISH_QUEUE_MIRROR_UI_TEXT: Record<string, string> = {
   hooksColumn: 'Hook counts',
 }
 
+export const MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT: Record<string, string> = {
+  pageEyebrow: 'Planning mirror',
+  pageHeading: 'Modifiable data packs',
+  pageSubtitle:
+    'Read-only operations view over persisted modifiable data-pack records and safe-fail import posture.',
+  backToDeskLabel: 'Back to Operations Desk',
+  totalRecordsLabel: 'Pack records',
+  appliedLabel: 'Applied',
+  needsRevisionLabel: 'Needs revision',
+  weekLabel: 'Campaign week',
+  readOnlyNote:
+    'Records reflect hydrated GameState only. Rejected or invalid payloads dropped on hydrate are not shown here.',
+  emptyTitle: 'No modifiable data-pack records',
+  emptyBody:
+    'Persisted modifiable data-pack records will appear here after hydration. Invalid records dropped on hydrate are not shown here.',
+  recordsHeading: 'Persisted pack records',
+  recordsSubtitle:
+    'Applied vs needs-revision discrimination uses import status only — no hidden validation truth.',
+  packIdColumn: 'Pack id',
+  statusColumn: 'Import status',
+  kindColumn: 'Pack kind',
+  schemaColumn: 'Schema version',
+  sectionsColumn: 'Sections',
+}
+
 export const PATTERN_SOURCE_SERIES_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Pattern source series intake',

--- a/src/domain/modifiableDataPackSurfacing.ts
+++ b/src/domain/modifiableDataPackSurfacing.ts
@@ -1,0 +1,63 @@
+/**
+ * SPE-2492 slice 1: read-only surfacing for modifiable data-pack records.
+ *
+ * CP-neutral labels only; no validation or import side effects from surfacing helpers.
+ */
+
+import type {
+  ModifiableDataPackImportStatus,
+  ModifiableDataPackKind,
+  ModifiableDataPackRecord,
+  ModifiableDataPackRecordsMap,
+} from './modifiableDataPackValidation'
+
+export function formatModifiableDataPackKindLabel(kind: ModifiableDataPackKind | string): string {
+  return kind
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+export function formatModifiableDataPackImportStatusLabel(
+  status: ModifiableDataPackImportStatus | string
+): string {
+  return status
+    .split('_')
+    .map((part) => (part.length > 0 ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+    .join(' ')
+}
+
+export function summarizeModifiableDataPackRecords(
+  records: ModifiableDataPackRecordsMap | null | undefined
+): {
+  readonly totalRecords: number
+  readonly appliedCount: number
+  readonly needsRevisionCount: number
+  readonly totalSectionCount: number
+} {
+  const safeRecords = records ?? {}
+  const values = Object.values(safeRecords)
+
+  return Object.freeze({
+    totalRecords: values.length,
+    appliedCount: values.filter((record) => record.importStatus === 'applied').length,
+    needsRevisionCount: values.filter((record) => record.importStatus === 'needs_revision').length,
+    totalSectionCount: values.reduce(
+      (sum, record) => sum + record.modifiableSections.length,
+      0
+    ),
+  })
+}
+
+export function formatModifiableDataPackSectionSummary(record: ModifiableDataPackRecord): string {
+  const count = record.modifiableSections.length
+  if (count === 0) {
+    return 'No sections'
+  }
+
+  if (count === 1) {
+    return `1 section (${record.modifiableSections[0]?.sectionKey ?? '—'})`
+  }
+
+  return `${count} sections`
+}

--- a/src/features/operations/ModifiableDataPackMirrorPage.test.tsx
+++ b/src/features/operations/ModifiableDataPackMirrorPage.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import '../../test/setup'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import { CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE } from '../../domain/modifiableDataPackValidation'
+import { useGameStore } from '../../app/store/gameStore'
+import ModifiableDataPackMirrorPage from './ModifiableDataPackMirrorPage'
+
+function renderMirrorPage() {
+  return render(
+    <MemoryRouter initialEntries={['/modifiable-data-packs']}>
+      <Routes>
+        <Route path="/modifiable-data-packs" element={<ModifiableDataPackMirrorPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  useGameStore.persist.clearStorage()
+  useGameStore.setState({ game: createStartingState() })
+})
+
+describe('ModifiableDataPackMirrorPage (SPE-2492 slice 1)', () => {
+  it('renders empty state when no persisted modifiable data-pack records exist', () => {
+    renderMirrorPage()
+
+    expect(screen.getByRole('region', { name: /modifiable data-pack mirror/i })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /empty data-pack state/i })).toBeInTheDocument()
+    expect(screen.getByText(/no modifiable data-pack records/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid records dropped on hydrate are not shown here/i)
+    ).toBeInTheDocument()
+  })
+
+  it('renders persisted pack records when fixtures are hydrated', () => {
+    const game = createStartingState()
+    game.modifiableDataPackRecords = {
+      [CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const recordsRegion = screen.getByRole('region', {
+      name: /persisted modifiable data-pack records/i,
+    })
+
+    expect(recordsRegion).toBeInTheDocument()
+    expect(recordsRegion).toHaveTextContent(CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId)
+    expect(recordsRegion).toHaveTextContent('Applied')
+    expect(recordsRegion).toHaveTextContent('Tuning Table')
+  })
+})

--- a/src/features/operations/ModifiableDataPackMirrorPage.tsx
+++ b/src/features/operations/ModifiableDataPackMirrorPage.tsx
@@ -1,0 +1,124 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router'
+import { APP_ROUTES } from '../../app/routes'
+import { useGameStore } from '../../app/store/gameStore'
+import { MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT } from '../../data/copy'
+import { getModifiableDataPackMirrorView } from './modifiableDataPackMirrorView'
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-white/10 bg-white/5 px-3 py-2">
+      <p className="text-xs uppercase tracking-[0.24em] opacity-50">{label}</p>
+      <p className="mt-1 text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+export default function ModifiableDataPackMirrorPage() {
+  const { game } = useGameStore()
+  const view = useMemo(() => getModifiableDataPackMirrorView(game), [game])
+
+  return (
+    <section className="space-y-4" aria-label="Modifiable data-pack mirror">
+      <article
+        className="panel panel-primary space-y-4"
+        role="region"
+        aria-label="Modifiable data-pack summary"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-[0.24em] opacity-50">
+              {MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.pageEyebrow}
+            </p>
+            <h2 className="text-xl font-semibold">
+              {MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.pageHeading}
+            </h2>
+            <p className="text-sm opacity-60">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.pageSubtitle}</p>
+          </div>
+          <Link to={APP_ROUTES.operationsDesk} className="btn btn-sm btn-ghost">
+            {MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.backToDeskLabel}
+          </Link>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.totalRecordsLabel}
+            value={String(view.summary.totalRecords)}
+          />
+          <StatCard
+            label={MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.appliedLabel}
+            value={String(view.summary.appliedCount)}
+          />
+          <StatCard
+            label={MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.needsRevisionLabel}
+            value={String(view.summary.needsRevisionCount)}
+          />
+          <StatCard
+            label={MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.weekLabel}
+            value={`W${view.summary.week}`}
+          />
+        </div>
+
+        <p className="text-xs opacity-55">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.readOnlyNote}</p>
+      </article>
+
+      {view.isEmpty ? (
+        <article
+          className="panel panel-support space-y-2"
+          role="region"
+          aria-label="Empty data-pack state"
+        >
+          <h3 className="text-lg font-semibold">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.emptyTitle}</h3>
+          <p className="text-sm opacity-70">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.emptyBody}</p>
+        </article>
+      ) : (
+        <article
+          className="panel panel-support space-y-3"
+          role="region"
+          aria-label="Persisted modifiable data-pack records"
+        >
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">
+              {MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.recordsHeading}
+            </h3>
+            <p className="text-sm opacity-60">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.recordsSubtitle}</p>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.packIdColumn}</th>
+                  <th className="px-2 py-2">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.statusColumn}</th>
+                  <th className="px-2 py-2">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.kindColumn}</th>
+                  <th className="px-2 py-2">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.schemaColumn}</th>
+                  <th className="px-2 py-2">{MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT.sectionsColumn}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.records.map((record) => (
+                  <tr key={record.packId} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{record.packId}</p>
+                      <p className="text-xs opacity-55">{record.authorRef}</p>
+                      <p className="text-xs opacity-45">{record.issueLinkLabel}</p>
+                    </td>
+                    <td className="px-2 py-2">{record.importStatusLabel}</td>
+                    <td className="px-2 py-2">{record.packKindLabel}</td>
+                    <td className="px-2 py-2">{record.schemaVersion}</td>
+                    <td className="px-2 py-2">
+                      {record.sectionSummaryLabel}
+                      {record.reasonCodeCount > 0
+                        ? ` · ${record.reasonCodeCount} reason code(s)`
+                        : ''}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      )}
+    </section>
+  )
+}

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -886,6 +886,11 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
       description: 'Review publish-queue records and dry-run execution posture.',
     },
     {
+      label: 'Open modifiable data-pack mirror',
+      href: APP_ROUTES.modifiableDataPacks,
+      description: 'Review persisted modifiable data-pack records and import validation posture.',
+    },
+    {
       label: 'Open self-censoring information mirror',
       href: APP_ROUTES.selfCensoringInformation,
       description: 'Review retention timers, rediscovery loops, and negative-fact posture.',

--- a/src/features/operations/modifiableDataPackMirrorView.test.ts
+++ b/src/features/operations/modifiableDataPackMirrorView.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../../data/startingState'
+import {
+  BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+  CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+} from '../../domain/modifiableDataPackValidation'
+import {
+  formatModifiableDataPackImportStatusLabel,
+  formatModifiableDataPackKindLabel,
+} from '../../domain/modifiableDataPackSurfacing'
+import { getModifiableDataPackMirrorView } from './modifiableDataPackMirrorView'
+
+describe('modifiableDataPackMirrorView (SPE-2492 slice 1)', () => {
+  it('returns empty mirror when modifiableDataPackRecords map is empty', () => {
+    const game = createStartingState()
+
+    expect(game.modifiableDataPackRecords).toEqual({})
+
+    const view = getModifiableDataPackMirrorView(game)
+
+    expect(view.isEmpty).toBe(true)
+    expect(view.summary.totalRecords).toBe(0)
+    expect(view.summary.appliedCount).toBe(0)
+    expect(view.summary.needsRevisionCount).toBe(0)
+    expect(view.records).toEqual([])
+  })
+
+  it('discriminates applied vs needs_revision import status labels', () => {
+    const game = createStartingState()
+    game.modifiableDataPackRecords = {
+      [CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+      [BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+    }
+
+    const view = getModifiableDataPackMirrorView(game)
+
+    expect(view.isEmpty).toBe(false)
+    expect(view.summary.appliedCount).toBe(1)
+    expect(view.summary.needsRevisionCount).toBe(1)
+
+    const appliedRecord = view.records.find(
+      (record) => record.packId === CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId
+    )
+    const borderlineRecord = view.records.find(
+      (record) => record.packId === BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId
+    )
+
+    expect(appliedRecord?.importStatusLabel).toBe('Applied')
+    expect(borderlineRecord?.importStatusLabel).toBe('Needs Revision')
+    expect(appliedRecord?.packKindLabel).toBe('Tuning Table')
+    expect(appliedRecord?.schemaVersion).toBe(
+      CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.schemaVersion
+    )
+  })
+
+  it('formats enum labels for CP-neutral UI copy', () => {
+    expect(formatModifiableDataPackKindLabel('doctrine_note')).toBe('Doctrine Note')
+    expect(formatModifiableDataPackImportStatusLabel('needs_revision')).toBe('Needs Revision')
+  })
+
+  it('is byte-stable for repeated mirror builds', () => {
+    const game = createStartingState()
+    game.modifiableDataPackRecords = {
+      [CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+    }
+
+    const first = JSON.stringify(getModifiableDataPackMirrorView(game))
+    const second = JSON.stringify(getModifiableDataPackMirrorView(game))
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/features/operations/modifiableDataPackMirrorView.ts
+++ b/src/features/operations/modifiableDataPackMirrorView.ts
@@ -1,0 +1,66 @@
+import type { GameState } from '../../domain/models'
+import type { ModifiableDataPackRecord } from '../../domain/modifiableDataPackValidation'
+import {
+  formatModifiableDataPackImportStatusLabel,
+  formatModifiableDataPackKindLabel,
+  formatModifiableDataPackSectionSummary,
+  summarizeModifiableDataPackRecords,
+} from '../../domain/modifiableDataPackSurfacing'
+
+export interface ModifiableDataPackMirrorRecordView {
+  packId: string
+  schemaVersion: string
+  packKindLabel: string
+  authorRef: string
+  issueLinkLabel: string
+  importStatusLabel: string
+  sectionSummaryLabel: string
+  reasonCodeCount: number
+}
+
+export interface ModifiableDataPackMirrorSummaryView {
+  totalRecords: number
+  appliedCount: number
+  needsRevisionCount: number
+  totalSectionCount: number
+  week: number
+}
+
+export interface ModifiableDataPackMirrorView {
+  isEmpty: boolean
+  summary: ModifiableDataPackMirrorSummaryView
+  records: readonly ModifiableDataPackMirrorRecordView[]
+}
+
+function listPersistedRecords(game: GameState): ModifiableDataPackRecord[] {
+  const map = game.modifiableDataPackRecords ?? {}
+  return Object.values(map).sort((left, right) => left.packId.localeCompare(right.packId))
+}
+
+function toRecordView(record: ModifiableDataPackRecord): ModifiableDataPackMirrorRecordView {
+  return Object.freeze({
+    packId: record.packId,
+    schemaVersion: record.schemaVersion,
+    packKindLabel: formatModifiableDataPackKindLabel(record.packKind),
+    authorRef: record.authorRef,
+    issueLinkLabel: record.issueLink.trim() ? record.issueLink : '—',
+    importStatusLabel: formatModifiableDataPackImportStatusLabel(record.importStatus),
+    sectionSummaryLabel: formatModifiableDataPackSectionSummary(record),
+    reasonCodeCount: record.reasonCodes.length,
+  })
+}
+
+/** Read-only mirror over hydrated `modifiableDataPackRecords`; does not re-validate hidden truth. */
+export function getModifiableDataPackMirrorView(game: GameState): ModifiableDataPackMirrorView {
+  const records = listPersistedRecords(game)
+  const counts = summarizeModifiableDataPackRecords(game.modifiableDataPackRecords)
+
+  return Object.freeze({
+    isEmpty: records.length === 0,
+    summary: Object.freeze({
+      ...counts,
+      week: game.week,
+    }),
+    records: Object.freeze(records.map((record) => toRecordView(record))),
+  })
+}

--- a/src/test/modifiableDataPackSurfacing.test.ts
+++ b/src/test/modifiableDataPackSurfacing.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+  CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+} from '../domain/modifiableDataPackValidation'
+import {
+  formatModifiableDataPackSectionSummary,
+  summarizeModifiableDataPackRecords,
+} from '../domain/modifiableDataPackSurfacing'
+
+describe('modifiableDataPackSurfacing (SPE-2492 slice 1)', () => {
+  it('summarizes applied and needs_revision counts from hydrated records', () => {
+    const summary = summarizeModifiableDataPackRecords({
+      [CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+      [BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.packId]:
+        BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+    })
+
+    expect(summary.totalRecords).toBe(2)
+    expect(summary.appliedCount).toBe(1)
+    expect(summary.needsRevisionCount).toBe(1)
+    expect(summary.totalSectionCount).toBe(
+      CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.modifiableSections.length +
+        BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE.modifiableSections.length
+    )
+  })
+
+  it('treats nullish maps as empty without throwing', () => {
+    expect(summarizeModifiableDataPackRecords(undefined)).toEqual({
+      totalRecords: 0,
+      appliedCount: 0,
+      needsRevisionCount: 0,
+      totalSectionCount: 0,
+    })
+  })
+
+  it('formats section summary labels deterministically', () => {
+    expect(
+      formatModifiableDataPackSectionSummary(CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE)
+    ).toContain('section')
+  })
+})


### PR DESCRIPTION
## Linear

- **Slice:** [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) — Modifiable data-pack planning mirror and surfacing (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) (parent remains **Done** on Linear; do not reopen)

## Summary

- Add read-only modifiable data-pack planning mirror at `/modifiable-data-packs` with Front Desk link
- Add `modifiableDataPackSurfacing.ts` CP-neutral projection helpers over persisted `modifiableDataPackRecords`
- Mirror + projection + page tests; slice doc `planning/modifiable-data-pack-surfacing-slice-1.md` and backlog handoff

## What shipped

Surfacing slice 1 only: planning mirror UI, routing, domain projection, tests, docs cross-ref in `docs/contribution-and-release-operations.md`. No publish-queue, weekly orchestration, or mission triage changes.

## Validation

- `npm run lint`
- Targeted tests: `modifiableDataPackSurfacing`, `modifiableDataPackMirrorView`, `ModifiableDataPackMirrorPage`

## Docs updated

- `planning/modifiable-data-pack-surfacing-slice-1.md`
- `planning/backlog.md`
- `docs/contribution-and-release-operations.md`

## Parent status

SPE-75 stays **Done**; deferred weekly orchestration (slice 2) tracked in slice doc `## Deferred`.