### PR TITLE
feat(SPE-2494): modifiable data-pack publish automation integration (slice 3)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -59,6 +59,8 @@ Modifiable data-pack surfacing (SPE-2492) exposes a read-only planning mirror at
 
 Modifiable data-pack weekly orchestration (SPE-2493) wires `applyWeeklyModifiableDataPackGovernanceTick` into `advanceWeek`: re-validates persisted records, drops invalid entries without re-importing rejected payloads, and emits `contribution_release.modifiable_data_pack_governance` weekly report notes for `needs_revision` governance observations. Applied records are idempotent skips with no notes.
 
+Modifiable data-pack publish automation integration (SPE-2494) composes validated pack import with the contribution intake → release packaging → governance → publish-intent chain via `src/domain/modifiableDataPackPublishIntegration.ts` — rejected payloads produce no record and no publish-intent side effects; `needs_revision` import status caps publish-intent below `ready_to_publish`.
+
 ## Publish automation and crediting hooks
 
 After packaging and governance gates pass, publish-intent evaluation composes crediting targets (CONTRIBUTORS, changelog entries, version bumps) and bounded publish channel hooks without executing publish actions.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -62,14 +62,14 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Next step:** Owner reprioritizes from §14-pass alternates below. Mission triage full refresh remains **blocked**.
+**Next step:** [SPE-2494](https://linear.app/spectranoir/issue/SPE-2494) modifiable data-pack publish automation integration (slice 3) — `planning/modifiable-data-pack-publish-automation-integration-slice-3.md`; branch `spe-75-modifiable-data-pack-publish-automation-integration-slice-3` from `main` @ `ab890d33`. Mission triage full refresh remains **blocked**.
 
-**Base `main` SHA:** `30b0099e` — post SPE-2492 modifiable data-pack surfacing closure (includes SPE-2491 via #2902).
+**Base `main` SHA:** `ab890d33` — post SPE-2493 modifiable data-pack weekly orchestration closure (PR #2906 @ `0ccfd463`).
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
 1. **Branch continuity stability-audit category ([SPE-1464](https://linear.app/spectranoir/issue/SPE-1464) optional follow-on)** — **shipped** [SPE-2487](https://linear.app/spectranoir/issue/SPE-2487); see `planning/branch-continuity-stability-audit-category-slice-1.md`.
-2. **Contribution/release ops follow-on** — **shipped** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) (`pr-merge` GitHub API wiring slice 1); **shipped** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) live `advanceWeek` orchestration (PR #2902); **shipped** [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) modifiable data-pack surfacing (PR #2904); **shipped** [SPE-2493](https://linear.app/spectranoir/issue/SPE-2493) modifiable-pack weekly orchestration (PR #2906); deferred: additional publish channels, execution-receipt persistence, publish automation integration for pack import.
+2. **Contribution/release ops follow-on** — **shipped** [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) (`pr-merge` GitHub API wiring slice 1); **shipped** [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) live `advanceWeek` orchestration (PR #2902); **shipped** [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) modifiable data-pack surfacing (PR #2904); **shipped** [SPE-2493](https://linear.app/spectranoir/issue/SPE-2493) modifiable-pack weekly orchestration (PR #2906); **next:** [SPE-2494](https://linear.app/spectranoir/issue/SPE-2494) publish automation integration for pack import; deferred: additional publish channels, execution-receipt persistence.
 3. **Registry umbrella follow-ons ([SPE-947](https://linear.app/spectranoir/issue/SPE-947) / [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046))** — grooming closed ([SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) / [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) **Done**); parents stay **Backlog**; [SPE-2489](https://linear.app/spectranoir/issue/SPE-2489) SPE-947 slice 5 **shipped**; [SPE-2490](https://linear.app/spectranoir/issue/SPE-2490) SPE-1046 entity-welfare slice 5 **shipped** — see `planning/entity-welfare-reclassification-registry-slice-5.md`.
 
 **Explicitly deferred:** mission triage full refresh; SPE-2250 batch-4+; dedicated exploit-access content; registry slice 5+ without §14 pass; additional publish channels beyond `pr-merge`.
@@ -238,6 +238,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `modifiable-data-pack-runtime-import-slice-1.md`          | **Shipped**    | [SPE-2486](https://linear.app/spectranoir/issue/SPE-2486) — GameState modifiable data-pack runtime import under SPE-75. |
 | `modifiable-data-pack-surfacing-slice-1.md`               | **Shipped**    | [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) — planning mirror and surfacing under SPE-75; PR #2904 @ `30b0099e`. |
 | `modifiable-data-pack-weekly-orchestration-slice-2.md`    | **Shipped**    | [SPE-2493](https://linear.app/spectranoir/issue/SPE-2493) — weekly governance tick + report notes under SPE-75; PR #2906 @ `0ccfd463`. |
+| `modifiable-data-pack-publish-automation-integration-slice-3.md` | **Planned** | [SPE-2494](https://linear.app/spectranoir/issue/SPE-2494) — pack import → publish-intent integration under SPE-75; base `main` @ `ab890d33`. |
 | `publish-automation-crediting-hooks-slice-1.md`           | **Shipped**    | [SPE-2480](https://linear.app/spectranoir/issue/SPE-2480) — deterministic publish-intent + crediting hooks under SPE-75; PR #2879 @ `99161c79`. |
 | `publish-queue-persistence-slice-1.md`                    | **Shipped**    | [SPE-2483](https://linear.app/spectranoir/issue/SPE-2483) — `publishQueueRecords` GameState persistence under SPE-75; PR #2886 @ `93711130`. |
 | `publish-queue-github-api-slice-1.md`                   | **Shipped**    | [SPE-2488](https://linear.app/spectranoir/issue/SPE-2488) — `pr-merge` GitHub API wiring under SPE-75; PR #2896 @ `4acb1b9e`. |

--- a/planning/modifiable-data-pack-publish-automation-integration-slice-3.md
+++ b/planning/modifiable-data-pack-publish-automation-integration-slice-3.md
@@ -1,0 +1,120 @@
+# SPE-75 — Modifiable data-pack publish automation integration (slice 3)
+
+One-page implementation plan. Linear: [SPE-2494](https://linear.app/spectranoir/issue/SPE-2494) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Natural next deferred item from [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) / [SPE-2493](https://linear.app/spectranoir/issue/SPE-2493) slice docs § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2494 — Modifiable data-pack publish automation integration (slice 3)](https://linear.app/spectranoir/issue/SPE-2494) |
+| **Status** | **In progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-modifiable-data-pack-publish-automation-integration-slice-3` |
+| **Base `main` SHA** | `ab890d33` |
+
+## Goal
+
+Wire validated modifiable data-pack import into the publish automation / contribution pipeline — connect `composeModifiableDataPackRecord` and the SPE-2479 validation envelope to the SPE-2480 publish-intent flow. No mirror UI changes, weekly tick changes, or SPE-75 parent reopen.
+
+## Prerequisite (on `main` @ `ab890d33`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Validation envelope  | `src/domain/modifiableDataPackValidation.ts` (SPE-2479) |
+| Runtime persistence | `modifiableDataPackRecords` on `GameState` (SPE-2486) |
+| Publish-intent evaluation | `src/domain/publishAutomationCreditingHooks.ts` (SPE-2480) |
+| Upstream contribution chain | `contributionIntakeCuration.ts`, `modularReleasePackaging.ts`, `submissionGovernanceRights.ts` (SPE-2474–2478) |
+| Weekly governance tick | `modifiableDataPackWeeklyOrchestration.ts` (SPE-2493, read-only downstream) |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| Domain integration module bridging pack import → publish-intent | Mirror UI changes |
+| `composeModifiableDataPackRecord` as single import path into integration | Weekly `advanceWeek` orchestration changes |
+| Publish-intent envelope aligned with validation `importStatus` | Publish-queue executor / GitHub client |
+| Targeted domain unit tests + fixtures | Mission triage chips (blocked) |
+| Slice doc (this file) + backlog handoff | SPE-75 parent reopen |
+| Docs cross-ref in `docs/contribution-and-release-operations.md` | GameState execution-receipt persistence (alternate tail) |
+
+## Integration contract
+
+| Input | Behavior |
+| --- | --- |
+| Rejected / invalid pack payload | Return integration envelope with `record: null`; no publish-intent side effects; no throw |
+| `needs_revision` pack record | Compose record; publish-intent returns `needs_revision` or rejects per upstream gates — import status stays aligned with validation decision |
+| `applied` pack + canonical upstream chain | Compose record; publish-intent returns `ready_to_publish` with stable hook descriptors |
+| Empty / undefined payload | No-op; `record: null`; publish-intent absent or rejected without throw |
+| Duplicate compose paths | Single entry point delegates to `composeModifiableDataPackRecord` — no parallel import logic |
+| Determinism | Same inputs yield byte-identical integration envelope; sorted reason codes and hook descriptors |
+
+## Proposed domain surface
+
+New module `src/domain/modifiableDataPackPublishIntegration.ts` (name may adjust to match repo conventions):
+
+| Function | Role |
+| --- | --- |
+| `evaluateModifiableDataPackPublishIntegration(input)` | Orchestrates pack compose → contribution curation → release packaging → governance → publish-intent |
+| `ModifiableDataPackPublishIntegrationEnvelope` | Bounded result: optional `record`, optional `publishDecision`, validation issues, reason codes |
+
+Integration input bundles:
+
+- `packPayload` — `ModifiableDataPackPayload` (required for compose)
+- `contributionPayload` — `ContributionSubmissionPayload` (or derived from pack `authorRef` / `issueLink` when omitted)
+- `releaseManifest` — `ReleaseArtifactManifest`
+- `governancePayload` — submission governance fixture shape
+- `creditingManifest` — `PublishCreditingManifest`
+- Optional policy objects per upstream module
+
+**Do not** add a second compose path in `runTransfer` or weekly orchestration — integration is pure domain composition for callers that need import + publish-intent in one deterministic step.
+
+## Acceptance
+
+- [x] Canonical fixture chain: `applied` pack record + `ready_to_publish` publish-intent with stable hooks
+- [x] Invalid / rejected pack payloads return `record: null` without corrupting publish-intent envelope
+- [x] Borderline `needs_revision` pack preserves aligned `importStatus` and bounded publish-intent status
+- [x] Empty payload / empty map inputs no-op without throw
+- [x] Repeated evaluations byte-identical for same input set
+- [x] `npm run lint` + targeted tests green (6 tests via vitest; npm not on agent PATH)
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/modifiableDataPackPublishIntegration.ts` (new), possible thin re-exports in `modifiableDataPackValidation.ts` or `publishAutomationCreditingHooks.ts` only if needed for fixture sharing |
+| Tests  | `src/test/modifiableDataPackPublishIntegration.test.ts` |
+| Plan   | `planning/modifiable-data-pack-publish-automation-integration-slice-3.md`, `planning/backlog.md` |
+| Docs   | `docs/contribution-and-release-operations.md` |
+
+## Risks and edge cases
+
+| Risk | Mitigation |
+| --- | --- |
+| Rejected payloads persist | Integration returns `record: null`; callers must not write to `modifiableDataPackRecords` |
+| `importStatus` drift | Reuse `validateModifiableDataPackRecord` alignment checks; integration must not override validation decision |
+| Duplicate import paths | All compose flows delegate to existing `composeModifiableDataPackRecord` |
+| Non-deterministic ordering | Freeze envelopes; sort reason codes and hooks via existing upstream helpers |
+| Upstream gate mismatch | Pack `applied` does not bypass contribution/packaging/governance gates — document gate order in tests |
+
+## Implementation sequence
+
+1. Branch from `main` @ `ab890d33`: `spe-75-modifiable-data-pack-publish-automation-integration-slice-3`
+2. Move SPE-2494 to **In Progress** on Linear
+3. Define integration envelope types + `evaluateModifiableDataPackPublishIntegration`
+4. Wire upstream chain read-only (mirror `publishAutomationCreditingHooks.test.ts` fixture chain)
+5. Add targeted tests: canonical, rejected, borderline, empty, determinism
+6. Update `docs/contribution-and-release-operations.md` § Modifiable data packs
+7. Pre-ship audit → commit → push → PR → babysit → merge → Linear Done
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond integration envelope |
+| Mission triage modifiable-pack chips | Backlog | Mission triage full refresh blocked |
+| Runtime wire integration into `runTransfer` | Out of slice unless required for acceptance | Pure domain boundary first |
+
+## See also
+
+- `planning/modifiable-data-pack-weekly-orchestration-slice-2.md`
+- `planning/modifiable-data-pack-runtime-import-slice-1.md`
+- `planning/publish-automation-crediting-hooks-slice-1.md`
+- `planning/backlog.md`

--- a/planning/modifiable-data-pack-weekly-orchestration-slice-2.md
+++ b/planning/modifiable-data-pack-weekly-orchestration-slice-2.md
@@ -64,7 +64,7 @@ Wire weekly governance tick + operations-report notes for `modifiableDataPackRec
 
 | Item | Owner | Why |
 | --- | --- | --- |
-| Publish automation integration for pack import | SPE-75 follow-up child | Out of weekly orchestration boundary |
+| Publish automation integration for pack import | [SPE-2494](https://linear.app/spectranoir/issue/SPE-2494) | Out of weekly orchestration boundary |
 | GameState execution-receipt persistence | SPE-75 follow-up child | Optional ledger beyond governance receipts |
 | Mission triage modifiable-pack chips | Backlog | Mission triage full refresh blocked |
 

--- a/src/domain/modifiableDataPackPublishIntegration.ts
+++ b/src/domain/modifiableDataPackPublishIntegration.ts
@@ -1,0 +1,257 @@
+/**
+ * SPE-2494 slice 3: modifiable data-pack import → publish-intent integration.
+ *
+ * Pure deterministic composition that connects SPE-2479 pack validation/import
+ * with the SPE-2480 publish-automation upstream chain — no persistence, UI, or
+ * publish execution side effects.
+ */
+
+import type {
+  ContributionCurationPolicy,
+  ContributionSubmissionPayload,
+} from './contributionIntakeCuration'
+import { evaluateContributionIntakeCuration } from './contributionIntakeCuration'
+import type { ReleaseArtifactManifest } from './modularReleasePackaging'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+  evaluateModularReleasePackaging,
+} from './modularReleasePackaging'
+import type {
+  DataPackValidationPolicy,
+  ModifiableDataPackKind,
+  ModifiableDataPackPayload,
+  ModifiableDataPackRecord,
+} from './modifiableDataPackValidation'
+import {
+  CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE,
+  composeModifiableDataPackRecord,
+} from './modifiableDataPackValidation'
+import type {
+  PublishAutomationDecision,
+  PublishAutomationPolicy,
+  PublishCreditingManifest,
+} from './publishAutomationCreditingHooks'
+import {
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  evaluatePublishAutomationCreditingHooks,
+} from './publishAutomationCreditingHooks'
+import type { SubmissionGovernancePayload } from './submissionGovernanceRights'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+  evaluateSubmissionGovernanceRights,
+} from './submissionGovernanceRights'
+
+// ---------------------------------------------------------------------------
+// Identifiers and envelopes
+// ---------------------------------------------------------------------------
+
+export type ModifiableDataPackPublishIntegrationCode =
+  | 'pack_import_rejected'
+  | 'pack_import_needs_revision'
+
+export interface ModifiableDataPackPublishIntegrationIssue {
+  readonly code: ModifiableDataPackPublishIntegrationCode
+  readonly severity: 'error' | 'info'
+  readonly detail: string
+}
+
+export interface ModifiableDataPackPublishIntegrationInput {
+  readonly packPayload?: ModifiableDataPackPayload
+  readonly contributionPayload?: ContributionSubmissionPayload
+  readonly releaseManifest?: ReleaseArtifactManifest
+  readonly governancePayload?: SubmissionGovernancePayload
+  readonly creditingManifest?: PublishCreditingManifest
+  readonly dataPackPolicy?: DataPackValidationPolicy
+  readonly contributionPolicy?: ContributionCurationPolicy
+  readonly publishPolicy?: PublishAutomationPolicy
+}
+
+export interface ModifiableDataPackPublishIntegrationEnvelope {
+  readonly record: ModifiableDataPackRecord | null
+  readonly publishDecision: PublishAutomationDecision | null
+  readonly validationIssues: readonly ModifiableDataPackPublishIntegrationIssue[]
+  readonly reasonCodes: readonly string[]
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const CANONICAL_MODIFIABLE_DATA_PACK_PUBLISH_INTEGRATION_INPUT: ModifiableDataPackPublishIntegrationInput =
+  Object.freeze({
+    packPayload: CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE,
+    releaseManifest: CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+    governancePayload: CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+    creditingManifest: CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+  })
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sortIntegrationIssues(
+  issues: ModifiableDataPackPublishIntegrationIssue[]
+): ModifiableDataPackPublishIntegrationIssue[] {
+  return [...issues].sort((left, right) => {
+    const codeOrder = left.code.localeCompare(right.code)
+    if (codeOrder !== 0) {
+      return codeOrder
+    }
+
+    return left.detail.localeCompare(right.detail)
+  })
+}
+
+function sortReasonCodes(reasonCodes: readonly string[]): readonly string[] {
+  return Object.freeze([...new Set(reasonCodes)].sort((left, right) => left.localeCompare(right)))
+}
+
+function freezeIntegrationEnvelope(
+  envelope: ModifiableDataPackPublishIntegrationEnvelope
+): ModifiableDataPackPublishIntegrationEnvelope {
+  return Object.freeze({
+    record: envelope.record,
+    publishDecision: envelope.publishDecision,
+    validationIssues: Object.freeze(
+      envelope.validationIssues.map((issue) => Object.freeze({ ...issue }))
+    ),
+    reasonCodes: sortReasonCodes(envelope.reasonCodes),
+  })
+}
+
+function rejectEnvelope(
+  detail: string,
+  code: ModifiableDataPackPublishIntegrationCode = 'pack_import_rejected'
+): ModifiableDataPackPublishIntegrationEnvelope {
+  return freezeIntegrationEnvelope({
+    record: null,
+    publishDecision: null,
+    validationIssues: Object.freeze([
+      Object.freeze({
+        code,
+        severity: 'error',
+        detail,
+      }),
+    ]),
+    reasonCodes: Object.freeze([code]),
+  })
+}
+
+function mapPackKindToArtifactKind(
+  packKind: ModifiableDataPackKind
+): ContributionSubmissionPayload['artifactKind'] {
+  switch (packKind) {
+    case 'tuning_table':
+    case 'content_accessory':
+      return 'content'
+    case 'reference_sheet':
+    case 'doctrine_note':
+      return 'docs'
+    default: {
+      const _exhaustive: never = packKind
+      return _exhaustive
+    }
+  }
+}
+
+function deriveContributionSubmissionFromPack(
+  record: ModifiableDataPackRecord
+): ContributionSubmissionPayload {
+  const sectionCount = record.modifiableSections.length
+
+  return Object.freeze({
+    submissionId: `submission:${record.packId}`,
+    contributorRef: record.authorRef,
+    issueLink: record.issueLink,
+    title: `Modifiable data pack ${record.packId}`,
+    scopeStatement: `Import modifiable data pack ${record.packId} with ${sectionCount} typed sections through the SPE-75 publish-automation integration pipeline.`,
+    artifactKind: mapPackKindToArtifactKind(record.packKind),
+    summary:
+      `Deterministic modifiable data pack (${record.packKind}) import and publish-intent integration ` +
+      `for ${record.packId} with schema version ${record.schemaVersion}.`,
+    testEvidenceRefs: Object.freeze(['src/test/modifiableDataPackPublishIntegration.test.ts']),
+    licenseDeclaration: 'MIT',
+  })
+}
+
+function applyPackImportStatusGate(
+  record: ModifiableDataPackRecord,
+  publishDecision: PublishAutomationDecision
+): {
+  readonly publishDecision: PublishAutomationDecision
+  readonly validationIssues: readonly ModifiableDataPackPublishIntegrationIssue[]
+  readonly reasonCodes: readonly string[]
+} {
+  if (record.importStatus !== 'needs_revision' || publishDecision.status !== 'ready_to_publish') {
+    return {
+      publishDecision,
+      validationIssues: Object.freeze([]),
+      reasonCodes: publishDecision.reasonCodes,
+    }
+  }
+
+  const packIssue: ModifiableDataPackPublishIntegrationIssue = Object.freeze({
+    code: 'pack_import_needs_revision',
+    severity: 'info',
+    detail: `Modifiable data-pack record "${record.packId}" has importStatus needs_revision — publish-intent capped from ready_to_publish.`,
+  })
+
+  const reasonCodes = sortReasonCodes([
+    ...publishDecision.reasonCodes,
+    'pack_import_needs_revision',
+    ...record.reasonCodes,
+  ])
+
+  return {
+    publishDecision: Object.freeze({
+      ...publishDecision,
+      status: 'needs_revision',
+      reasonCodes,
+    }),
+    validationIssues: Object.freeze([packIssue]),
+    reasonCodes,
+  }
+}
+
+/**
+ * SPE-2494 baseline: deterministic modifiable data-pack import composed with
+ * contribution intake → release packaging → governance → publish-intent evaluation.
+ */
+export function evaluateModifiableDataPackPublishIntegration(
+  input: ModifiableDataPackPublishIntegrationInput = {}
+): ModifiableDataPackPublishIntegrationEnvelope {
+  const record = composeModifiableDataPackRecord(input.packPayload, input.dataPackPolicy)
+
+  if (!record) {
+    return rejectEnvelope(
+      'Modifiable data-pack payload failed validation — no record composed and no publish-intent evaluation performed.'
+    )
+  }
+
+  const contributionPayload =
+    input.contributionPayload ?? deriveContributionSubmissionFromPack(record)
+  const curationDecision = evaluateContributionIntakeCuration(
+    contributionPayload,
+    input.contributionPolicy
+  )
+  const releasePackage = evaluateModularReleasePackaging(
+    curationDecision,
+    input.releaseManifest
+  )
+  const governanceDecision = evaluateSubmissionGovernanceRights(input.governancePayload)
+  const publishDecision = evaluatePublishAutomationCreditingHooks(
+    releasePackage,
+    governanceDecision,
+    input.creditingManifest,
+    input.publishPolicy
+  )
+
+  const gated = applyPackImportStatusGate(record, publishDecision)
+
+  return freezeIntegrationEnvelope({
+    record,
+    publishDecision: gated.publishDecision,
+    validationIssues: Object.freeze(sortIntegrationIssues([...gated.validationIssues])),
+    reasonCodes: gated.reasonCodes,
+  })
+}

--- a/src/test/modifiableDataPackPublishIntegration.test.ts
+++ b/src/test/modifiableDataPackPublishIntegration.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE,
+  CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+  BORDERLINE_SCHEMA_DATA_PACK_FIXTURE,
+  BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE,
+  INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+  PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE,
+} from '../domain/modifiableDataPackValidation'
+import {
+  CANONICAL_MODIFIABLE_DATA_PACK_PUBLISH_INTEGRATION_INPUT,
+  evaluateModifiableDataPackPublishIntegration,
+} from '../domain/modifiableDataPackPublishIntegration'
+import {
+  CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+} from '../domain/publishAutomationCreditingHooks'
+import {
+  CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+} from '../domain/modularReleasePackaging'
+import {
+  CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+} from '../domain/submissionGovernanceRights'
+
+describe('modifiableDataPackPublishIntegration (SPE-2494 slice 3)', () => {
+  it('returns applied record and ready_to_publish publish-intent for the canonical integration chain', () => {
+    const envelope = evaluateModifiableDataPackPublishIntegration(
+      CANONICAL_MODIFIABLE_DATA_PACK_PUBLISH_INTEGRATION_INPUT
+    )
+
+    expect(envelope.record).toEqual(CANONICAL_MODIFIABLE_DATA_PACK_RECORD_FIXTURE)
+    expect(envelope.record?.importStatus).toBe('applied')
+    expect(envelope.validationIssues).toEqual([])
+    expect(envelope.publishDecision?.status).toBe('ready_to_publish')
+    expect(envelope.publishDecision?.publishMetadata).toEqual({
+      versionBumpRef: 'package.json:version',
+      publishChannel: 'pr-merge',
+      contributorRef: 'contributor:agent-maintainer',
+      rightsTier: 'canonical',
+      artifactType: 'content_accessory',
+      creditingTargetCount: 2,
+    })
+    expect(envelope.publishDecision?.creditingHooks.length).toBeGreaterThan(0)
+    expect(envelope.publishDecision?.publishHooks).toEqual([
+      {
+        kind: 'announcement_segment',
+        target: 'agent-packaging-pipeline',
+        payload: 'segment:agent-packaging-pipeline',
+      },
+      {
+        kind: 'announcement_segment',
+        target: 'domain-release',
+        payload: 'segment:domain-release',
+      },
+      {
+        kind: 'publish_channel',
+        target: 'pr-merge',
+        payload: 'channel:pr-merge',
+      },
+    ])
+  })
+
+  it('returns null record and no publish-intent for rejected validation payloads', () => {
+    for (const packPayload of [
+      INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+      PARTIAL_MODIFIABLE_DATA_PACK_FIXTURE,
+      undefined,
+    ]) {
+      const envelope = evaluateModifiableDataPackPublishIntegration({
+        packPayload,
+        releaseManifest: CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+        governancePayload: CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+        creditingManifest: CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+      })
+
+      expect(envelope.record).toBeNull()
+      expect(envelope.publishDecision).toBeNull()
+      expect(envelope.reasonCodes).toEqual(['pack_import_rejected'])
+      expect(envelope.validationIssues[0]?.code).toBe('pack_import_rejected')
+    }
+  })
+
+  it('caps publish-intent when borderline pack importStatus is needs_revision', () => {
+    const envelope = evaluateModifiableDataPackPublishIntegration({
+      packPayload: BORDERLINE_SCHEMA_DATA_PACK_FIXTURE,
+      releaseManifest: CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+      governancePayload: CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+      creditingManifest: CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+    })
+
+    expect(envelope.record).toEqual(BORDERLINE_MODIFIABLE_DATA_PACK_RECORD_FIXTURE)
+    expect(envelope.record?.importStatus).toBe('needs_revision')
+    expect(envelope.publishDecision?.status).toBe('needs_revision')
+    expect(envelope.reasonCodes).toContain('pack_import_needs_revision')
+    expect(envelope.reasonCodes).toContain('schema_version_borderline')
+    expect(envelope.validationIssues[0]?.code).toBe('pack_import_needs_revision')
+  })
+
+  it('safe-fails empty integration input without throw', () => {
+    expect(() => evaluateModifiableDataPackPublishIntegration({})).not.toThrow()
+
+    const envelope = evaluateModifiableDataPackPublishIntegration({})
+
+    expect(envelope.record).toBeNull()
+    expect(envelope.publishDecision).toBeNull()
+    expect(envelope.reasonCodes).toEqual(['pack_import_rejected'])
+  })
+
+  it('returns byte-stable output on repeated evaluation calls', () => {
+    const inputs = [
+      CANONICAL_MODIFIABLE_DATA_PACK_PUBLISH_INTEGRATION_INPUT,
+      {
+        packPayload: BORDERLINE_SCHEMA_DATA_PACK_FIXTURE,
+        releaseManifest: CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+        governancePayload: CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+        creditingManifest: CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+      },
+      {
+        packPayload: INVALID_MODIFIABLE_DATA_PACK_FIXTURE,
+      },
+    ] as const
+
+    for (const input of inputs) {
+      const first = evaluateModifiableDataPackPublishIntegration(input)
+      const second = evaluateModifiableDataPackPublishIntegration(input)
+
+      expect(first).toEqual(second)
+    }
+  })
+
+  it('derives contribution metadata from pack authorRef and issueLink when omitted', () => {
+    const envelope = evaluateModifiableDataPackPublishIntegration({
+      packPayload: CANONICAL_MODIFIABLE_DATA_PACK_FIXTURE,
+      releaseManifest: CANONICAL_RELEASE_ARTIFACT_MANIFEST_FIXTURE,
+      governancePayload: CANONICAL_SUBMISSION_GOVERNANCE_FIXTURE,
+      creditingManifest: CANONICAL_PUBLISH_CREDITING_MANIFEST_FIXTURE,
+    })
+
+    expect(envelope.record?.authorRef).toBe('contributor:agent-maintainer')
+    expect(envelope.record?.issueLink).toBe('SPE-2479')
+    expect(envelope.publishDecision?.publishMetadata?.contributorRef).toBe(
+      'contributor:agent-maintainer'
+    )
+  })
+})


### PR DESCRIPTION
## Linear
- **Slice:** SPE-2494
- **Parent:** SPE-75 (remains **Done**)

## What shipped
- Pure domain module `modifiableDataPackPublishIntegration.ts` wiring `composeModifiableDataPackRecord` into the contribution intake → publish-intent chain.
- Vitest coverage for publish automation integration (slice 3).
- Slice doc, backlog, and weekly orchestration slice-2 planning updates.
- `docs/contribution-and-release-operations.md` updated for publish automation integration.

## Validation
- Vitest: 6 tests (`modifiableDataPackPublishIntegration.test.ts`)
- ESLint on changed files

## Docs updated
- `docs/contribution-and-release-operations.md`
- `planning/modifiable-data-pack-publish-automation-integration-slice-3.md`
- `planning/backlog.md`
- `planning/modifiable-data-pack-weekly-orchestration-slice-2.md`

## Parent status
SPE-75 remains **Done** (this PR completes slice 3 only).