### PR TITLE
feat(SPE-2496): publish-queue execution-receipt mirror surfacing (slice 1)

### DIFF
--- a/docs/contribution-and-release-operations.md
+++ b/docs/contribution-and-release-operations.md
@@ -79,6 +79,8 @@ Publish-queue surfacing (SPE-2485) wires the weekly execution tick in `advanceWe
 
 Publish-queue execution-receipt persistence (SPE-2495) stores bounded executor receipts on `GameState.publishQueueExecutionReceipts` keyed by `${recordId}@${executionWeek}` with sanitize/hydration on save import. `advanceWeek` merges reportable tick receipts after queue record updates; malformed, duplicate, and orphaned entries drop without corrupting queue state.
 
+Publish-queue execution-receipt mirror surfacing (SPE-2496) extends the `/publish-queue` planning mirror with a read-only execution-receipt ledger over hydrated `publishQueueExecutionReceipts`, joined to queue record labels where available. Live vs dry-run discrimination uses `publishChannelRef` presence; the mirror does not re-validate hidden truth.
+
 ## Notation and docs standards
 
 - Prefer **issue IDs** (SPE-\*) in commit and PR titles when mandated by team workflow.

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -20,7 +20,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2494](https://linear.app/spectranoir/issue/SPE-2494) modifiable data-pack publish automation integration (slice 3) — pack import → publish-intent chain; PR #2908 @ `a0532b78`.
 
-**Active:** [SPE-2495](https://linear.app/spectranoir/issue/SPE-2495) publish-queue execution-receipt persistence (slice 1) — `publishQueueExecutionReceipts` sanitize/hydrate on GameState; branch `spe-75-publish-queue-execution-receipt-persistence-slice-1` @ `b3a02c3a`.
+**Recently shipped:** [SPE-2495](https://linear.app/spectranoir/issue/SPE-2495) publish-queue execution-receipt persistence (slice 1) — `publishQueueExecutionReceipts` sanitize/hydrate on GameState; PR #2910 @ `c3521010`.
+
+**Active:** [SPE-2496](https://linear.app/spectranoir/issue/SPE-2496) publish-queue execution-receipt mirror surfacing (slice 1) — read-only receipt ledger on `/publish-queue`; branch `spe-75-publish-queue-execution-receipt-surfacing-slice-1` @ `c3521010`.
 
 **Recently shipped:** [SPE-2492](https://linear.app/spectranoir/issue/SPE-2492) modifiable data-pack planning mirror and surfacing (slice 1) — read-only `/modifiable-data-packs` mirror + Front Desk link; branch `spe-75-modifiable-data-pack-surfacing-slice-1` (PR #2904 @ `30b0099e`).
 
@@ -249,7 +251,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `publish-queue-executor-slice-1.md`                       | **Shipped**    | [SPE-2484](https://linear.app/spectranoir/issue/SPE-2484) — dry-run publish executor under SPE-75; PR #2888 @ `6399251c`. |
 | `publish-queue-surfacing-slice-1.md`                      | **Shipped**    | [SPE-2485](https://linear.app/spectranoir/issue/SPE-2485) — publish-queue mirror + weekly orchestration surfacing under SPE-75; PR #2890 @ `1a801ec0`. |
 | `publish-queue-live-orchestration-slice-1.md`             | **Shipped**    | [SPE-2491](https://linear.app/spectranoir/issue/SPE-2491) — live vs dry-run weekly orchestration under SPE-75; PR #2902 @ `67f65fd6`. |
-| `publish-queue-execution-receipt-persistence-slice-1.md` | **In Progress** | [SPE-2495](https://linear.app/spectranoir/issue/SPE-2495) — `publishQueueExecutionReceipts` GameState persistence under SPE-75; branch `spe-75-publish-queue-execution-receipt-persistence-slice-1` @ `b3a02c3a`. |
+| `publish-queue-execution-receipt-persistence-slice-1.md` | **Shipped**    | [SPE-2495](https://linear.app/spectranoir/issue/SPE-2495) — `publishQueueExecutionReceipts` GameState persistence under SPE-75; PR #2910 @ `c3521010`. |
+| `publish-queue-execution-receipt-surfacing-slice-1.md` | **In Progress** | [SPE-2496](https://linear.app/spectranoir/issue/SPE-2496) — execution-receipt ledger on `/publish-queue` mirror under SPE-75; branch `spe-75-publish-queue-execution-receipt-surfacing-slice-1` @ `c3521010`. |
 | `modular-release-packaging-slice-1.md`                    | **Shipped**    | [SPE-2475](https://linear.app/spectranoir/issue/SPE-2475) — post-curation release envelope under SPE-75; PR #2869 @ `d43f07cb`.                      |
 | `segmented-feedback-workflow-slice-1.md`                  | **Shipped**    | [SPE-2476](https://linear.app/spectranoir/issue/SPE-2476) — deterministic feedback channel scoring/ranking under SPE-75; PR #2871 @ `b82bb426`. |
 | `self-censoring-information-registry-slice-1.md`          | **Shipped**    | SPE-2108 / PR #2429; negative facts, retention decay, rediscovery loops — cognitive hazard intake slice 1.                                           |

--- a/planning/publish-queue-execution-receipt-persistence-slice-1.md
+++ b/planning/publish-queue-execution-receipt-persistence-slice-1.md
@@ -5,7 +5,7 @@ One-page implementation plan. Linear: [SPE-2495](https://linear.app/spectranoir/
 | Field      | Value                                                                                                      |
 | ---------- | ---------------------------------------------------------------------------------------------------------- |
 | **Linear** | [SPE-2495 — GameState publish-queue execution-receipt persistence (slice 1)](https://linear.app/spectranoir/issue/SPE-2495) |
-| **Status** | **In Progress** |
+| **Status** | **Shipped** — PR #2910 @ `c3521010` |
 | **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
 | **Branch** | `spe-75-publish-queue-execution-receipt-persistence-slice-1` |
 | **Base `main` SHA** | `b3a02c3a` |
@@ -67,7 +67,7 @@ Persist bounded publish-queue execution receipts on `GameState` with compose/san
 | Item | Owner | Why |
 | --- | --- | --- |
 | Additional publish channels beyond `pr-merge` | Backlog child | Out of receipt-persistence boundary |
-| Mirror surfacing over persisted receipts | Future SPE-75 child | Persistence must land first |
+| Mirror surfacing over persisted receipts | [SPE-2496](https://linear.app/spectranoir/issue/SPE-2496) | Shipped to follow-up slice after persistence |
 | Mission triage publish-queue / modifiable-pack chips | Backlog | Mission triage full refresh blocked |
 
 ## See also

--- a/planning/publish-queue-execution-receipt-surfacing-slice-1.md
+++ b/planning/publish-queue-execution-receipt-surfacing-slice-1.md
@@ -1,0 +1,78 @@
+# SPE-75 — Publish-queue execution-receipt mirror surfacing (slice 1)
+
+One-page implementation plan. Linear: [SPE-2496](https://linear.app/spectranoir/issue/SPE-2496) (child under [SPE-75](https://linear.app/spectranoir/issue/SPE-75)). Follows shipped [SPE-2495](https://linear.app/spectranoir/issue/SPE-2495) per `planning/publish-queue-execution-receipt-persistence-slice-1.md` § Deferred.
+
+| Field      | Value                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------- |
+| **Linear** | [SPE-2496 — Publish-queue execution-receipt mirror surfacing (slice 1)](https://linear.app/spectranoir/issue/SPE-2496) |
+| **Status** | **In Progress** |
+| **Parent** | [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — parent **Done** on Linear (do not reopen) |
+| **Branch** | `spe-75-publish-queue-execution-receipt-surfacing-slice-1` |
+| **Base `main` SHA** | `c3521010` |
+
+## Goal
+
+Surface hydrated `publishQueueExecutionReceipts` on the existing `/publish-queue` planning mirror — read-only ledger with summary counts and joined record labels. No executor/GitHub changes, no persistence changes, no mission triage, no SPE-75 parent reopen.
+
+## Prerequisite (on `main` @ `c3521010`)
+
+| Shipped              | Anchor                                                                 |
+| -------------------- | ---------------------------------------------------------------------- |
+| Execution-receipt persistence | `publishQueueExecutionReceipts` on `GameState` (SPE-2495 / PR #2910) |
+| Publish-queue mirror | `publishQueueMirrorView.ts` + `/publish-queue` route (SPE-2485) |
+| Label helpers | `formatPublishQueueExecutorOutcomeLabel`, `resolvePublishQueueReceiptExecutionMode`, `formatPublishQueueSkipCodeLabel` in `publishQueueSurfacing.ts` |
+
+## Scope (this slice)
+
+| In                                                                 | Out                                           |
+| ------------------------------------------------------------------ | --------------------------------------------- |
+| `summarizePublishQueueExecutionReceipts` in `publishQueueSurfacing.ts` | Executor / GitHub client changes |
+| Receipt row projection + sort in `publishQueueMirrorView.ts` | Receipt persistence compose/sanitize/merge |
+| Receipts section on `PublishQueueMirrorPage.tsx` + copy | New routes |
+| Mirror view + page smoke tests | Mission triage chips (blocked) |
+| Slice doc (this file) + backlog handoff | SPE-75 parent reopen |
+| Docs cross-ref in `contribution-and-release-operations.md` | Additional publish channels |
+
+## Surfacing contract
+
+- **Read-only ledger** — display hydrated `publishQueueExecutionReceipts` map entries only; no re-sanitize or orphan re-validation.
+- **Record join** — `publishQueueRecords[recordId]?.label ?? recordId` for display labels.
+- **Empty map** — empty receipts section, no throw.
+- **Live vs dry-run** — `publishChannelRef` presence discriminates execution mode.
+- **Deterministic sort** — `(executionWeek desc, recordId asc)` for ledger display.
+- **Independent sections** — record `isEmpty` semantics unchanged; receipts use separate `receiptsEmpty` flag.
+
+## Acceptance
+
+- [ ] Empty receipt map renders empty receipts section without throw
+- [ ] Completed dry-run and live receipts show correct outcome/mode/channel labels
+- [ ] Rejected and reportable skipped receipts surface in ledger
+- [ ] Orphan receipt (no matching queue record) shows recordId fallback label
+- [ ] Existing queue-record mirror tests unchanged
+- [ ] `npm run lint` + targeted tests green (CI gate)
+
+## File touch list (expected)
+
+| Area   | Files                                                                 |
+| ------ | --------------------------------------------------------------------- |
+| Domain | `src/domain/publishQueueSurfacing.ts`                                 |
+| View   | `src/features/operations/publishQueueMirrorView.ts`                 |
+| UI     | `src/features/operations/PublishQueueMirrorPage.tsx`                |
+| Desk   | `src/features/operations/frontDeskView.ts` (optional description)    |
+| Copy   | `src/data/copy.ts`                                                    |
+| Tests  | `src/test/publishQueueSurfacing.test.ts`, `src/features/operations/publishQueueMirrorView.test.ts`, `src/features/operations/PublishQueueMirrorPage.test.tsx` |
+| Plan   | `planning/publish-queue-execution-receipt-surfacing-slice-1.md`, `planning/backlog.md` |
+| Docs   | `docs/contribution-and-release-operations.md`                         |
+
+## Deferred
+
+| Item | Owner | Why |
+| --- | --- | --- |
+| Additional publish channels beyond `pr-merge` | Backlog child | Out of mirror surfacing boundary |
+| Mission triage publish-queue / modifiable-pack chips | Backlog | Mission triage full refresh blocked |
+
+## See also
+
+- `planning/publish-queue-execution-receipt-persistence-slice-1.md`
+- `planning/publish-queue-surfacing-slice-1.md`
+- `planning/backlog.md`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1644,7 +1644,7 @@ export const PUBLISH_QUEUE_MIRROR_UI_TEXT: Record<string, string> = {
   pageEyebrow: 'Planning mirror',
   pageHeading: 'Publish queue',
   pageSubtitle:
-    'Read-only operations view over persisted publish-queue records and dry-run execution posture.',
+    'Read-only operations view over persisted publish-queue records and execution receipts.',
   backToDeskLabel: 'Back to Operations Desk',
   totalRecordsLabel: 'Queue records',
   readyToPublishLabel: 'Ready to publish',
@@ -1662,6 +1662,22 @@ export const PUBLISH_QUEUE_MIRROR_UI_TEXT: Record<string, string> = {
   artifactColumn: 'Release artifact',
   queuedWeekColumn: 'Queued week',
   hooksColumn: 'Hook counts',
+  receiptsHeading: 'Execution receipt ledger',
+  receiptsSubtitle:
+    'Persisted executor receipts keyed by record and week — hydrated map entries only, no re-validation.',
+  totalReceiptsLabel: 'Execution receipts',
+  completedDryRunLabel: 'Completed (dry-run)',
+  completedLiveLabel: 'Completed (live)',
+  rejectedOrSkippedLabel: 'Rejected / skipped',
+  receiptsEmptyTitle: 'No execution receipts',
+  receiptsEmptyBody:
+    'Persisted publish-queue execution receipts will appear here after weekly ticks. Invalid receipts dropped on hydrate are not shown here.',
+  receiptLabelColumn: 'Label',
+  receiptWeekColumn: 'Execution week',
+  receiptOutcomeColumn: 'Outcome',
+  receiptModeColumn: 'Mode',
+  receiptChannelColumn: 'Channel',
+  receiptHooksColumn: 'Hooks',
 }
 
 export const MODIFIABLE_DATA_PACK_MIRROR_UI_TEXT: Record<string, string> = {

--- a/src/domain/publishQueueSurfacing.ts
+++ b/src/domain/publishQueueSurfacing.ts
@@ -13,6 +13,7 @@ import type {
   PublishQueueExecutorSkipCode,
 } from './publishQueueExecutor'
 import type { PublishQueueExecutionMode } from './publishQueueGitHubClient'
+import type { PublishQueueExecutionReceiptsMap } from './publishQueueExecutionReceiptPersistence'
 
 export function formatPublishQueueStatusLabel(status: PublishAutomationStatus | string): string {
   return status
@@ -134,5 +135,56 @@ export function summarizePublishQueueRecords(
     terminalCount: values.filter(
       (record) => record.status === 'needs_revision' || record.status === 'rejected'
     ).length,
+  })
+}
+
+export function summarizePublishQueueExecutionReceipts(
+  receipts: PublishQueueExecutionReceiptsMap | null | undefined
+): {
+  readonly totalReceipts: number
+  readonly completedDryRunCount: number
+  readonly completedLiveCount: number
+  readonly rejectedCount: number
+  readonly skippedReportableCount: number
+} {
+  const safeReceipts = receipts ?? {}
+  const values = Object.values(safeReceipts)
+
+  let completedDryRunCount = 0
+  let completedLiveCount = 0
+  let rejectedCount = 0
+  let skippedReportableCount = 0
+
+  for (const receipt of values) {
+    switch (receipt.outcome) {
+      case 'completed': {
+        if (resolvePublishQueueReceiptExecutionMode(receipt) === 'live') {
+          completedLiveCount += 1
+        } else {
+          completedDryRunCount += 1
+        }
+        break
+      }
+      case 'rejected':
+        rejectedCount += 1
+        break
+      case 'skipped':
+        if (receipt.skipCode !== 'already_published') {
+          skippedReportableCount += 1
+        }
+        break
+      default: {
+        const unreachable: never = receipt.outcome
+        void unreachable
+      }
+    }
+  }
+
+  return Object.freeze({
+    totalReceipts: values.length,
+    completedDryRunCount,
+    completedLiveCount,
+    rejectedCount,
+    skippedReportableCount,
   })
 }

--- a/src/features/operations/PublishQueueMirrorPage.test.tsx
+++ b/src/features/operations/PublishQueueMirrorPage.test.tsx
@@ -54,4 +54,39 @@ describe('PublishQueueMirrorPage (SPE-2485 slice 1)', () => {
       '/'
     )
   })
+
+  it('renders empty execution receipt ledger when no receipts are persisted', () => {
+    renderMirrorPage()
+
+    expect(screen.getByRole('region', { name: /execution receipt ledger/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole('region', { name: /empty execution receipt ledger/i })
+    ).toBeInTheDocument()
+    expect(screen.getByText(/no execution receipts/i)).toBeInTheDocument()
+  })
+
+  it('renders hydrated execution receipts with outcome and mode labels', () => {
+    const game = createStartingState()
+    game.publishQueueRecords = {
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    }
+    game.publishQueueExecutionReceipts = {
+      'publish-queue:domain-release-batch-1@4': {
+        recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+        outcome: 'completed',
+        executionWeek: 4,
+        appliedHooks: [],
+        publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+      },
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const ledgerRegion = screen.getByRole('region', { name: /execution receipt ledger/i })
+
+    expect(ledgerRegion).toHaveTextContent('Completed (dry-run)')
+    expect(ledgerRegion).toHaveTextContent('Dry-run')
+    expect(ledgerRegion).toHaveTextContent(CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label)
+  })
 })

--- a/src/features/operations/PublishQueueMirrorPage.tsx
+++ b/src/features/operations/PublishQueueMirrorPage.tsx
@@ -104,6 +104,80 @@ export default function PublishQueueMirrorPage() {
           </div>
         </article>
       )}
+
+      <article
+        className="panel panel-support space-y-4"
+        role="region"
+        aria-label="Execution receipt ledger"
+      >
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptsHeading}</h3>
+          <p className="text-sm opacity-60">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptsSubtitle}</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.totalReceiptsLabel}
+            value={String(view.receiptSummary.totalReceipts)}
+          />
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.completedDryRunLabel}
+            value={String(view.receiptSummary.completedDryRunCount)}
+          />
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.completedLiveLabel}
+            value={String(view.receiptSummary.completedLiveCount)}
+          />
+          <StatCard
+            label={PUBLISH_QUEUE_MIRROR_UI_TEXT.rejectedOrSkippedLabel}
+            value={String(
+              view.receiptSummary.rejectedCount + view.receiptSummary.skippedReportableCount
+            )}
+          />
+        </div>
+
+        {view.receiptsEmpty ? (
+          <div className="space-y-2" role="region" aria-label="Empty execution receipt ledger">
+            <h4 className="font-semibold">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptsEmptyTitle}</h4>
+            <p className="text-sm opacity-70">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptsEmptyBody}</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptLabelColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptWeekColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptOutcomeColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptModeColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptChannelColumn}</th>
+                  <th className="px-2 py-2">{PUBLISH_QUEUE_MIRROR_UI_TEXT.receiptHooksColumn}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {view.receipts.map((receipt) => (
+                  <tr key={receipt.mapKey} className="border-b border-white/5 align-top">
+                    <td className="px-2 py-2">
+                      <p className="font-medium">{receipt.recordLabel}</p>
+                      <p className="text-xs opacity-55">{receipt.recordId}</p>
+                    </td>
+                    <td className="px-2 py-2">{receipt.executionWeekLabel}</td>
+                    <td className="px-2 py-2">
+                      {receipt.outcomeLabel}
+                      {receipt.skipCodeLabel ? (
+                        <span className="block text-xs opacity-55">({receipt.skipCodeLabel})</span>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2">{receipt.executionModeLabel}</td>
+                    <td className="px-2 py-2">{receipt.channelLabel}</td>
+                    <td className="px-2 py-2">{receipt.appliedHookCount}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </article>
     </section>
   )
 }

--- a/src/features/operations/frontDeskView.ts
+++ b/src/features/operations/frontDeskView.ts
@@ -883,7 +883,7 @@ function buildQuickLinks(game: GameState): FrontDeskQuickLinkView[] {
     {
       label: 'Open publish queue mirror',
       href: APP_ROUTES.publishQueue,
-      description: 'Review publish-queue records and dry-run execution posture.',
+      description: 'Review publish-queue records and persisted execution receipts.',
     },
     {
       label: 'Open modifiable data-pack mirror',

--- a/src/features/operations/publishQueueMirrorView.test.ts
+++ b/src/features/operations/publishQueueMirrorView.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../../data/startingState'
 import { CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE } from '../../domain/publishAutomationCreditingHooks'
+import { buildPublishQueueExecutionReceiptKey } from '../../domain/publishQueueExecutionReceiptPersistence'
+import type { PublishQueueExecutionReceipt } from '../../domain/publishQueueExecutor'
+import { executePublishQueueRecordDryRun } from '../../domain/publishQueueExecutor'
 import { getPublishQueueMirrorView } from './publishQueueMirrorView'
 import { formatPublishQueueStatusLabel } from '../../domain/publishQueueSurfacing'
 
@@ -63,5 +66,186 @@ describe('publishQueueMirrorView (SPE-2485 slice 1)', () => {
     const second = JSON.stringify(getPublishQueueMirrorView(game))
 
     expect(first).toBe(second)
+  })
+})
+
+describe('publishQueueMirrorView receipts (SPE-2496 slice 1)', () => {
+  const dryRunReceipt: PublishQueueExecutionReceipt = {
+    recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+    outcome: 'completed',
+    executionWeek: 4,
+    appliedHooks: [],
+    publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+  }
+  const liveReceipt: PublishQueueExecutionReceipt = {
+    recordId: 'publish-queue:published',
+    outcome: 'completed',
+    executionWeek: 5,
+    appliedHooks: [],
+    publishChannelRef: 'live:publish_channel:pr-merge:pr:2910:sha:abc123',
+  }
+  const rejectedReceipt: PublishQueueExecutionReceipt = {
+    recordId: 'publish-queue:rejected',
+    outcome: 'rejected',
+    executionWeek: 4,
+    appliedHooks: [],
+    skipCode: 'record_not_ready_to_publish',
+  }
+  const skippedReceipt: PublishQueueExecutionReceipt = {
+    recordId: 'publish-queue:skipped',
+    outcome: 'skipped',
+    executionWeek: 3,
+    appliedHooks: [],
+    skipCode: 'missing_publish_channel_hook',
+  }
+
+  it('returns empty receipts section when execution-receipt map is empty', () => {
+    const game = createStartingState()
+
+    const view = getPublishQueueMirrorView(game)
+
+    expect(view.receiptsEmpty).toBe(true)
+    expect(view.receiptSummary.totalReceipts).toBe(0)
+    expect(view.receipts).toEqual([])
+  })
+
+  it('projects completed dry-run receipt with joined record label', () => {
+    const game = createStartingState()
+    game.publishQueueRecords = {
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    }
+    const receiptKey = buildPublishQueueExecutionReceiptKey(
+      dryRunReceipt.recordId,
+      dryRunReceipt.executionWeek
+    )!
+    game.publishQueueExecutionReceipts = {
+      [receiptKey]: dryRunReceipt,
+    }
+
+    const view = getPublishQueueMirrorView(game)
+    const receipt = view.receipts[0]
+
+    expect(view.receiptsEmpty).toBe(false)
+    expect(receipt?.recordLabel).toBe(CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.label)
+    expect(receipt?.outcomeLabel).toBe('Completed (dry-run)')
+    expect(receipt?.executionModeLabel).toBe('Dry-run')
+    expect(receipt?.channelLabel).toContain('dry-run:publish_channel:pr-merge')
+  })
+
+  it('projects live receipt with channel ref and live mode labels', () => {
+    const game = createStartingState()
+    game.publishQueueRecords = {
+      'publish-queue:published': {
+        ...CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+        id: 'publish-queue:published',
+        label: 'Published batch',
+        status: 'published',
+      },
+    }
+    const receiptKey = buildPublishQueueExecutionReceiptKey(
+      liveReceipt.recordId,
+      liveReceipt.executionWeek
+    )!
+    game.publishQueueExecutionReceipts = {
+      [receiptKey]: liveReceipt,
+    }
+
+    const view = getPublishQueueMirrorView(game)
+    const receipt = view.receipts[0]
+
+    expect(receipt?.outcomeLabel).toBe('Completed (live)')
+    expect(receipt?.executionModeLabel).toBe('Live')
+    expect(receipt?.channelLabel).toContain('live:publish_channel:pr-merge')
+    expect(view.receiptSummary.completedLiveCount).toBe(1)
+  })
+
+  it('surfaces rejected and reportable skipped receipts', () => {
+    const game = createStartingState()
+    game.publishQueueExecutionReceipts = {
+      [buildPublishQueueExecutionReceiptKey(rejectedReceipt.recordId, rejectedReceipt.executionWeek)!]:
+        rejectedReceipt,
+      [buildPublishQueueExecutionReceiptKey(skippedReceipt.recordId, skippedReceipt.executionWeek)!]:
+        skippedReceipt,
+    }
+
+    const view = getPublishQueueMirrorView(game)
+
+    expect(view.receiptSummary.rejectedCount).toBe(1)
+    expect(view.receiptSummary.skippedReportableCount).toBe(1)
+    expect(view.receipts.find((entry) => entry.recordId === rejectedReceipt.recordId)?.outcomeLabel).toBe(
+      'Rejected'
+    )
+    expect(
+      view.receipts.find((entry) => entry.recordId === skippedReceipt.recordId)?.skipCodeLabel
+    ).toBe('missing publish channel hook')
+  })
+
+  it('falls back to recordId when receipt has no matching queue record', () => {
+    const game = createStartingState()
+    const orphanReceipt: PublishQueueExecutionReceipt = {
+      recordId: 'publish-queue:orphan',
+      outcome: 'completed',
+      executionWeek: 4,
+      appliedHooks: [],
+      publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+    }
+    game.publishQueueExecutionReceipts = {
+      [buildPublishQueueExecutionReceiptKey(orphanReceipt.recordId, orphanReceipt.executionWeek)!]:
+        orphanReceipt,
+    }
+
+    const view = getPublishQueueMirrorView(game)
+
+    expect(view.receipts[0]?.recordLabel).toBe('publish-queue:orphan')
+  })
+
+  it('sorts receipts by execution week descending then record id ascending', () => {
+    const game = createStartingState()
+    game.publishQueueExecutionReceipts = {
+      [buildPublishQueueExecutionReceiptKey('publish-queue:b', 4)!]: {
+        ...dryRunReceipt,
+        recordId: 'publish-queue:b',
+      },
+      [buildPublishQueueExecutionReceiptKey('publish-queue:a', 5)!]: {
+        ...dryRunReceipt,
+        recordId: 'publish-queue:a',
+        executionWeek: 5,
+      },
+      [buildPublishQueueExecutionReceiptKey('publish-queue:c', 4)!]: {
+        ...dryRunReceipt,
+        recordId: 'publish-queue:c',
+      },
+    }
+
+    const view = getPublishQueueMirrorView(game)
+
+    expect(view.receipts.map((receipt) => receipt.recordId)).toEqual([
+      'publish-queue:a',
+      'publish-queue:b',
+      'publish-queue:c',
+    ])
+  })
+
+  it('uses executor dry-run receipt fixture end-to-end', () => {
+    const game = createStartingState()
+    game.publishQueueRecords = {
+      [CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id]: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+    }
+    const executorReceipt = executePublishQueueRecordDryRun(
+      CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE,
+      { week: 4 }
+    ).receipt
+    const receiptKey = buildPublishQueueExecutionReceiptKey(
+      executorReceipt.recordId,
+      executorReceipt.executionWeek
+    )!
+    game.publishQueueExecutionReceipts = {
+      [receiptKey]: executorReceipt,
+    }
+
+    const view = getPublishQueueMirrorView(game)
+
+    expect(view.receipts).toHaveLength(1)
+    expect(view.receipts[0]?.outcomeLabel).toBe('Completed (dry-run)')
   })
 })

--- a/src/features/operations/publishQueueMirrorView.ts
+++ b/src/features/operations/publishQueueMirrorView.ts
@@ -1,7 +1,12 @@
 import type { GameState } from '../../domain/models'
-import type { PublishQueueRecord } from '../../domain/publishAutomationCreditingHooks'
+import type { PublishQueueRecord, PublishQueueRecordsMap } from '../../domain/publishAutomationCreditingHooks'
+import type { PublishQueueExecutionReceipt } from '../../domain/publishQueueExecutor'
 import {
+  formatPublishQueueExecutorOutcomeLabel,
+  formatPublishQueueSkipCodeLabel,
   formatPublishQueueStatusLabel,
+  resolvePublishQueueReceiptExecutionMode,
+  summarizePublishQueueExecutionReceipts,
   summarizePublishQueueRecords,
 } from '../../domain/publishQueueSurfacing'
 
@@ -25,15 +30,52 @@ export interface PublishQueueMirrorSummaryView {
   week: number
 }
 
+export interface PublishQueueMirrorReceiptView {
+  mapKey: string
+  recordId: string
+  recordLabel: string
+  executionWeekLabel: string
+  outcomeLabel: string
+  skipCodeLabel: string | undefined
+  executionModeLabel: string
+  channelLabel: string
+  appliedHookCount: number
+}
+
+export interface PublishQueueMirrorReceiptSummaryView {
+  totalReceipts: number
+  completedDryRunCount: number
+  completedLiveCount: number
+  rejectedCount: number
+  skippedReportableCount: number
+}
+
 export interface PublishQueueMirrorView {
   isEmpty: boolean
   summary: PublishQueueMirrorSummaryView
   records: readonly PublishQueueMirrorRecordView[]
+  receiptsEmpty: boolean
+  receiptSummary: PublishQueueMirrorReceiptSummaryView
+  receipts: readonly PublishQueueMirrorReceiptView[]
 }
 
 function listPersistedRecords(game: GameState): PublishQueueRecord[] {
   const map = game.publishQueueRecords ?? {}
   return Object.values(map).sort((left, right) => left.id.localeCompare(right.id))
+}
+
+function listPersistedReceipts(
+  game: GameState
+): readonly { mapKey: string; receipt: PublishQueueExecutionReceipt }[] {
+  const map = game.publishQueueExecutionReceipts ?? {}
+  return Object.entries(map)
+    .sort(([, leftReceipt], [, rightReceipt]) => {
+      if (rightReceipt.executionWeek !== leftReceipt.executionWeek) {
+        return rightReceipt.executionWeek - leftReceipt.executionWeek
+      }
+      return leftReceipt.recordId.localeCompare(rightReceipt.recordId)
+    })
+    .map(([mapKey, receipt]) => ({ mapKey, receipt }))
 }
 
 function toRecordView(record: PublishQueueRecord): PublishQueueMirrorRecordView {
@@ -53,10 +95,43 @@ function toRecordView(record: PublishQueueRecord): PublishQueueMirrorRecordView 
   })
 }
 
+function toReceiptView(
+  mapKey: string,
+  receipt: PublishQueueExecutionReceipt,
+  records: PublishQueueRecordsMap
+): PublishQueueMirrorReceiptView {
+  const executionMode = resolvePublishQueueReceiptExecutionMode(receipt)
+  const record = records[receipt.recordId]
+
+  return Object.freeze({
+    mapKey,
+    recordId: receipt.recordId,
+    recordLabel: record?.label ?? receipt.recordId,
+    executionWeekLabel:
+      Number.isFinite(receipt.executionWeek) && receipt.executionWeek >= 1
+        ? `W${receipt.executionWeek}`
+        : '—',
+    outcomeLabel: formatPublishQueueExecutorOutcomeLabel(receipt.outcome, executionMode),
+    skipCodeLabel:
+      receipt.skipCode !== undefined
+        ? formatPublishQueueSkipCodeLabel(receipt.skipCode)
+        : undefined,
+    executionModeLabel: executionMode === 'live' ? 'Live' : 'Dry-run',
+    channelLabel:
+      receipt.publishChannelRef?.trim() ||
+      receipt.publishChannelStub?.trim() ||
+      '—',
+    appliedHookCount: receipt.appliedHooks.length,
+  })
+}
+
 /** Read-only mirror over hydrated `publishQueueRecords`; does not re-validate hidden truth. */
 export function getPublishQueueMirrorView(game: GameState): PublishQueueMirrorView {
   const records = listPersistedRecords(game)
   const counts = summarizePublishQueueRecords(game.publishQueueRecords)
+  const receiptEntries = listPersistedReceipts(game)
+  const receiptCounts = summarizePublishQueueExecutionReceipts(game.publishQueueExecutionReceipts)
+  const recordsMap = game.publishQueueRecords ?? {}
 
   return Object.freeze({
     isEmpty: records.length === 0,
@@ -65,5 +140,10 @@ export function getPublishQueueMirrorView(game: GameState): PublishQueueMirrorVi
       week: game.week,
     }),
     records: Object.freeze(records.map((record) => toRecordView(record))),
+    receiptsEmpty: receiptEntries.length === 0,
+    receiptSummary: Object.freeze(receiptCounts),
+    receipts: Object.freeze(
+      receiptEntries.map(({ mapKey, receipt }) => toReceiptView(mapKey, receipt, recordsMap))
+    ),
   })
 }

--- a/src/test/publishQueueSurfacing.test.ts
+++ b/src/test/publishQueueSurfacing.test.ts
@@ -7,6 +7,7 @@ import {
   formatPublishQueueStatusLabel,
   isReportablePublishQueueReceipt,
   listReportablePublishQueueReceipts,
+  summarizePublishQueueExecutionReceipts,
   summarizePublishQueueRecords,
 } from '../domain/publishQueueSurfacing'
 
@@ -122,5 +123,70 @@ describe('publishQueueSurfacing (SPE-2485 slice 1)', () => {
     expect(content).toContain('Publish queue (live)')
     expect(content).toContain('Completed (live)')
     expect(content).toContain('live:publish_channel:pr-merge:pr:2890:sha:abc123')
+  })
+
+  it('returns empty receipt summary for empty or missing receipt maps without throwing', () => {
+    expect(summarizePublishQueueExecutionReceipts({})).toEqual({
+      totalReceipts: 0,
+      completedDryRunCount: 0,
+      completedLiveCount: 0,
+      rejectedCount: 0,
+      skippedReportableCount: 0,
+    })
+    expect(summarizePublishQueueExecutionReceipts(undefined)).toEqual({
+      totalReceipts: 0,
+      completedDryRunCount: 0,
+      completedLiveCount: 0,
+      rejectedCount: 0,
+      skippedReportableCount: 0,
+    })
+  })
+
+  it('discriminates completed dry-run vs live and reportable skipped receipts', () => {
+    const summary = summarizePublishQueueExecutionReceipts({
+      'publish-queue:domain-release-batch-1@4': {
+        recordId: CANONICAL_PUBLISH_QUEUE_RECORD_FIXTURE.id,
+        outcome: 'completed',
+        executionWeek: 4,
+        appliedHooks: [],
+        publishChannelStub: 'dry-run:publish_channel:pr-merge:channel:pr-merge',
+      },
+      'publish-queue:published@5': {
+        recordId: 'publish-queue:published',
+        outcome: 'completed',
+        executionWeek: 5,
+        appliedHooks: [],
+        publishChannelRef: 'live:publish_channel:pr-merge:pr:2910:sha:abc123',
+      },
+      'publish-queue:rejected@4': {
+        recordId: 'publish-queue:rejected',
+        outcome: 'rejected',
+        executionWeek: 4,
+        appliedHooks: [],
+        skipCode: 'record_not_ready_to_publish',
+      },
+      'publish-queue:skipped@4': {
+        recordId: 'publish-queue:skipped',
+        outcome: 'skipped',
+        executionWeek: 4,
+        appliedHooks: [],
+        skipCode: 'missing_publish_channel_hook',
+      },
+      'publish-queue:idempotent@4': {
+        recordId: 'publish-queue:idempotent',
+        outcome: 'skipped',
+        executionWeek: 4,
+        appliedHooks: [],
+        skipCode: 'already_published',
+      },
+    })
+
+    expect(summary).toEqual({
+      totalReceipts: 5,
+      completedDryRunCount: 1,
+      completedLiveCount: 1,
+      rejectedCount: 1,
+      skippedReportableCount: 1,
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Extend `/publish-queue` planning mirror with read-only execution-receipt ledger over hydrated `publishQueueExecutionReceipts`
- Add `summarizePublishQueueExecutionReceipts` and receipt row projection with SPE-2485 label helpers and queue-record label joins
- Receipts section: summary StatCards, empty state, ledger table sorted by `(executionWeek desc, recordId asc)`

## Linear

- **Slice:** [SPE-2496](https://linear.app/spectranoir/issue/SPE-2496) — Publish-queue execution-receipt mirror surfacing (slice 1)
- **Parent:** [SPE-75](https://linear.app/spectranoir/issue/SPE-75) — remains **Done** (child-only slice)
- **Prerequisite:** [SPE-2495](https://linear.app/spectranoir/issue/SPE-2495) — shipped PR #2910

## What shipped

- Domain: `summarizePublishQueueExecutionReceipts` in `publishQueueSurfacing.ts`
- View: extended `publishQueueMirrorView.ts` with `receiptsEmpty`, `receiptSummary`, `receipts`
- UI: receipts section on `PublishQueueMirrorPage.tsx` + copy + Front Desk description
- Docs: `docs/contribution-and-release-operations.md`, slice doc, backlog handoff

## Validation

- `npm run test:run -- src/test/publishQueueSurfacing.test.ts src/features/operations/publishQueueMirrorView.test.ts src/features/operations/PublishQueueMirrorPage.test.tsx`
- `npm run lint`

## Docs updated

- `planning/publish-queue-execution-receipt-surfacing-slice-1.md`
- `planning/backlog.md`
- `docs/contribution-and-release-operations.md`

## Parent status

SPE-75 parent remains **Done**; this slice does not reopen or close the parent.