### PR TITLE
SPE-2521 durable person-status mission routing evidence

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -110,11 +110,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2519](https://linear.app/spectranoir/issue/SPE-2519/durable-person-status-surfacing-for-operations-mirror) SPE-1046 durable person-status surfacing for operations mirror (slice 1) — read-only route/page over persisted person-status evidence and composed projection outcomes; PR #2966 @ `543f837a`; see `planning/spe-1046-durable-person-status-surfacing-slice-1.md`.
 
-**In progress:** [SPE-2520](https://linear.app/spectranoir/issue/SPE-2520/durable-person-status-weekly-progression) SPE-1046 durable person-status weekly progression (slice 1) — authored weekly onboarding/access/review evidence advances persisted person-status records without changing mission routing; branch `spe-1046-durable-person-status-weekly-progression-slice-1`; see `planning/spe-1046-durable-person-status-weekly-progression-slice-1.md`.
+**Recently shipped:** [SPE-2520](https://linear.app/spectranoir/issue/SPE-2520/durable-person-status-weekly-progression) SPE-1046 durable person-status weekly progression (slice 1) — authored weekly onboarding/access/review evidence advances persisted person-status records without changing mission routing; PR #2968 @ `a0196aa7`; see `planning/spe-1046-durable-person-status-weekly-progression-slice-1.md`.
 
-**Next step after SPE-2520:** Owner reprioritizes from SPE-1046 durable enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**In progress:** [SPE-2521](https://linear.app/spectranoir/issue/SPE-2521/durable-person-status-mission-routing-evidence) SPE-1046 durable person-status mission routing evidence (slice 1) — exact-match durable person-status records supplement existing explicit mission-routing clearance gates; branch `spe-1046-durable-person-status-mission-routing-slice-1`; see `planning/spe-1046-durable-person-status-mission-routing-slice-1.md`.
 
-**Base `main` SHA:** `543f837a` — post SPE-2519 durable person-status surfacing for operations mirror.
+**Next step after SPE-2521:** Owner reprioritizes from SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `a0196aa7` — post SPE-2520 durable person-status weekly progression.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -254,7 +256,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-revocation-enforcement-slice-1.md`                              | **Shipped**     | [SPE-2517](https://linear.app/spectranoir/issue/SPE-2517) / PR #2962 — explicit revocation/downgrade mission-routing gate @ `03fd0867`; parent SPE-1046 stays **Backlog**.                                             |
 | `spe-1046-durable-person-status-records-slice-1.md`                       | **Shipped**     | [SPE-2518](https://linear.app/spectranoir/issue/SPE-2518) — persisted affiliation/person-status evidence records and pure projection helper; parent SPE-1046 stays **Backlog**.                                        |
 | `spe-1046-durable-person-status-surfacing-slice-1.md`                     | **Shipped**     | [SPE-2519](https://linear.app/spectranoir/issue/SPE-2519) — read-only operations mirror for durable person-status evidence and composed projection outcomes; PR #2966 @ `543f837a`; parent SPE-1046 stays **Backlog**. |
-| `spe-1046-durable-person-status-weekly-progression-slice-1.md`            | **In Progress** | [SPE-2520](https://linear.app/spectranoir/issue/SPE-2520) — authored weekly progression for durable person-status evidence without changing mission routing; parent SPE-1046 stays **Backlog**.                        |
+| `spe-1046-durable-person-status-weekly-progression-slice-1.md`            | **Shipped**     | [SPE-2520](https://linear.app/spectranoir/issue/SPE-2520) — authored weekly progression for durable person-status evidence without changing mission routing; parent SPE-1046 stays **Backlog**.                        |
+| `spe-1046-durable-person-status-mission-routing-slice-1.md`               | **In Progress** | [SPE-2521](https://linear.app/spectranoir/issue/SPE-2521) — exact-match durable person-status records supplement existing explicit mission-routing clearance gates; parent SPE-1046 stays **Backlog**.                 |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                              |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                              |
 | `spe-947-spe-1046-parent-acceptance-review-slice-1.md`                    | **Shipped**     | [SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) + [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) — registry umbrella grooming; parents SPE-947/SPE-1046 stay **Backlog**.                         |

--- a/planning/spe-1046-durable-person-status-mission-routing-slice-1.md
+++ b/planning/spe-1046-durable-person-status-mission-routing-slice-1.md
@@ -1,0 +1,57 @@
+# SPE-1046 - Durable person-status mission routing evidence (slice 1)
+
+One-page implementation plan. Linear: [SPE-2521](https://linear.app/spectranoir/issue/SPE-2521/durable-person-status-mission-routing-evidence) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2520](https://linear.app/spectranoir/issue/SPE-2520/durable-person-status-weekly-progression); [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2521 - Durable person-status mission routing evidence](https://linear.app/spectranoir/issue/SPE-2521/durable-person-status-mission-routing-evidence) |
+| **Status**          | **In Progress**                                                                                                                                           |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                       |
+| **Branch**          | `spe-1046-durable-person-status-mission-routing-slice-1`                                                                                                  |
+| **Base `main` SHA** | `a0196aa7`                                                                                                                                                |
+
+## Goal
+
+Let persisted `affiliationPersonStatusRecords` participate in existing explicit mission-routing clearance gates without adding new blocker codes, persistence fields, UI, or non-mission enforcement.
+
+## Scope
+
+| In                                                                                                 | Out                                                 |
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Exact `subjectId` match to routed team id or member agent ids                                      | Name/label/candidate inference                      |
+| Durable evidence for existing site, facility, dual-loyalty, protected-status, and revocation gates | New mission requirement tags or blocker codes       |
+| Reuse existing SPE-1046 evaluators/projections                                                     | New persistence, schema, UI, or weekly mutation     |
+| Focused mission-routing and weekly-progression integration tests                                   | Procurement, facility, or broader non-mission gates |
+| Backlog handoff update                                                                             | SPE-1046 parent closure                             |
+
+## Acceptance
+
+- [x] Missions without explicit SPE-1046 clearance requirements route unchanged.
+- [x] Durable site/facility grants can satisfy explicit mission clearance requirements for exact matched team/member subjects.
+- [x] Non-matching durable records do not affect routing.
+- [x] Durable dual-loyalty, protected-status, and revocation evidence can surface existing hard blocker codes.
+- [x] Weekly progression can advance durable evidence and change later mission-routing eligibility.
+- [x] No new persistence fields, UI surfaces, weekly mutation policy, non-mission gates, or blocker codes.
+
+## Validation
+
+- `npm.cmd run test:run -- src/test/mission.intake.triage.routing.test.ts src/test/missionRevocationEnforcement.test.ts src/test/missionProtectedStatusEnforcement.test.ts src/test/missionDualLoyaltyEnforcement.test.ts src/test/advanceWeek.affiliationPersonStatus.integration.test.ts src/test/affiliationPersonStatusRecords.test.ts`
+- `npm.cmd run lint`
+- Direct Prettier check for touched files only.
+- Full `npm.cmd run test:run` before PR.
+
+## Deferred
+
+| Item                                   | Owner                    | Why                                      |
+| -------------------------------------- | ------------------------ | ---------------------------------------- |
+| Procurement/facility/non-mission gates | SPE-1046 follow-up child | Separate gate surfaces and policy.       |
+| SPE-947 propagation follow-ons         | SPE-947 follow-up child  | Separate registry parent thread.         |
+| SPE-1046 parent closure                | SPE-1046                 | Parent acceptance remains broader scope. |
+
+## See also
+
+- `planning/spe-1046-durable-person-status-records-slice-1.md`
+- `planning/spe-1046-durable-person-status-weekly-progression-slice-1.md`
+- `planning/spe-1046-site-clearance-enforcement-slice-1.md`
+- `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`
+- `planning/backlog.md`

--- a/src/domain/affiliationPersonStatusMissionRoutingEvidence.ts
+++ b/src/domain/affiliationPersonStatusMissionRoutingEvidence.ts
@@ -1,0 +1,42 @@
+import {
+  projectAffiliationPersonStatusSnapshot,
+  type AffiliationPersonStatusRecord,
+  type AffiliationPersonStatusRecordsMap,
+  type AffiliationPersonStatusSnapshot,
+} from './affiliationPersonStatusRecords'
+import type { EntityWelfareReclassificationRecordsMap } from './entityWelfareReclassificationRegistry'
+import type { Agent, Team } from './models'
+import type { Candidate } from './recruitment'
+
+export interface AffiliationPersonStatusMissionRoutingEvidenceEntry {
+  readonly record: AffiliationPersonStatusRecord
+  readonly snapshot: AffiliationPersonStatusSnapshot
+}
+
+export function selectAffiliationPersonStatusMissionRoutingEvidence(input: {
+  readonly records: AffiliationPersonStatusRecordsMap | null | undefined
+  readonly team: Pick<Team, 'id'>
+  readonly members: readonly Pick<Agent, 'id'>[]
+  readonly candidates?: readonly Candidate[] | Record<string, Candidate> | null
+  readonly entityWelfareReclassificationRecords?: EntityWelfareReclassificationRecordsMap | null
+}): readonly AffiliationPersonStatusMissionRoutingEvidenceEntry[] {
+  const records = input.records ?? {}
+  const subjectIds = new Set([input.team.id, ...input.members.map((member) => member.id)])
+
+  return Object.freeze(
+    Object.keys(records)
+      .sort((left, right) => left.localeCompare(right))
+      .filter((recordId) => subjectIds.has(records[recordId]?.subjectId ?? ''))
+      .map((recordId) => {
+        const record = records[recordId]!
+        return Object.freeze({
+          record,
+          snapshot: projectAffiliationPersonStatusSnapshot({
+            record,
+            candidates: input.candidates,
+            entityWelfareReclassificationRecords: input.entityWelfareReclassificationRecords,
+          }),
+        })
+      })
+  )
+}

--- a/src/domain/deploymentReadiness.ts
+++ b/src/domain/deploymentReadiness.ts
@@ -29,6 +29,7 @@ import {
   evaluateMissionRevocationEnforcement,
   isMissionRevocationClearanceTag,
 } from './missionRevocationEnforcement'
+import { selectAffiliationPersonStatusMissionRoutingEvidence } from './affiliationPersonStatusMissionRoutingEvidence'
 import type {
   Agent,
   AgentAvailabilityState,
@@ -329,25 +330,39 @@ export function evaluateDeploymentEligibility(
   const tagCoverage = new Set(
     members.flatMap((member) => member.tags.map((tag) => tag.trim()).filter(Boolean))
   )
+  const durablePersonStatusEvidence = selectAffiliationPersonStatusMissionRoutingEvidence({
+    records: state.affiliationPersonStatusRecords,
+    team,
+    members,
+    candidates:
+      state.recruitmentPool && state.recruitmentPool.length > 0
+        ? state.recruitmentPool
+        : state.candidates,
+    entityWelfareReclassificationRecords: state.entityWelfareReclassificationRecords,
+  })
   const siteClearance = evaluateMissionSiteClearanceEnforcement({
     mission,
     team,
     members,
+    durableEvidence: durablePersonStatusEvidence,
   })
   const dualLoyalty = evaluateMissionDualLoyaltyEnforcement({
     mission,
     team,
     members,
+    durableEvidence: durablePersonStatusEvidence,
   })
   const protectedStatus = evaluateMissionProtectedStatusEnforcement({
     mission,
     team,
     members,
+    durableEvidence: durablePersonStatusEvidence,
   })
   const revocation = evaluateMissionRevocationEnforcement({
     mission,
     team,
     members,
+    durableEvidence: durablePersonStatusEvidence,
   })
 
   const missingRequiredTags = mission.requiredTags.filter(

--- a/src/domain/missionDualLoyaltyEnforcement.ts
+++ b/src/domain/missionDualLoyaltyEnforcement.ts
@@ -4,6 +4,7 @@ import {
   type AffiliationDualLoyaltyDecision,
   type AffiliationLoyaltyAnchor,
 } from './affiliationDualLoyaltyRisk'
+import type { AffiliationPersonStatusMissionRoutingEvidenceEntry } from './affiliationPersonStatusMissionRoutingEvidence'
 import type { Agent, CaseInstance, Team } from './models'
 
 const DUAL_LOYALTY_REQUIREMENT_TAG = 'dual-loyalty-clearance'
@@ -93,6 +94,7 @@ export function evaluateMissionDualLoyaltyEnforcement(input: {
   readonly mission: Pick<CaseInstance, 'requiredTags'>
   readonly team: Pick<Team, 'id' | 'name' | 'tags'>
   readonly members: readonly Pick<Agent, 'tags'>[]
+  readonly durableEvidence?: readonly AffiliationPersonStatusMissionRoutingEvidenceEntry[]
 }): MissionDualLoyaltyEnforcementResult {
   if (!missionRequiresDualLoyaltyClearance(input.mission)) {
     return Object.freeze({
@@ -104,7 +106,7 @@ export function evaluateMissionDualLoyaltyEnforcement(input: {
   }
 
   const tags = [...input.team.tags, ...input.members.flatMap((member) => member.tags)]
-  const decision = evaluateAffiliationDualLoyaltyRisk({
+  const tagDecision = evaluateAffiliationDualLoyaltyRisk({
     subjectId: input.team.id,
     subjectLabel: input.team.name,
     primaryAnchor: collectPrimaryAnchor(tags),
@@ -112,15 +114,21 @@ export function evaluateMissionDualLoyaltyEnforcement(input: {
     evidenceTags: collectEvidenceTags(tags),
     onboardingDecision: buildClearedTeamOnboarding(input.team),
   })
-  const allowed =
-    decision.riskLevel === 'none' ||
-    decision.riskLevel === 'watch' ||
-    !decision.restrictedSurfaces.includes('mission')
+  const decisions = [
+    tagDecision,
+    ...(input.durableEvidence ?? []).map((entry) => entry.snapshot.dualLoyaltyDecision),
+  ]
+  const allowed = decisions.every(
+    (decision) =>
+      decision.riskLevel === 'none' ||
+      decision.riskLevel === 'watch' ||
+      !decision.restrictedSurfaces.includes('mission')
+  )
 
   return Object.freeze({
     required: true,
     allowed,
-    decisions: Object.freeze([decision]),
-    reasonCodes: Object.freeze(uniqueSorted(decision.reasonCodes)),
+    decisions: Object.freeze(decisions),
+    reasonCodes: Object.freeze(uniqueSorted(decisions.flatMap((decision) => decision.reasonCodes))),
   })
 }

--- a/src/domain/missionProtectedStatusEnforcement.ts
+++ b/src/domain/missionProtectedStatusEnforcement.ts
@@ -4,6 +4,7 @@ import {
   type AffiliationProtectedActionDecision,
   type AffiliationProtectedStatus,
 } from './affiliationProtectedStatusActions'
+import type { AffiliationPersonStatusMissionRoutingEvidenceEntry } from './affiliationPersonStatusMissionRoutingEvidence'
 import type { Agent, CaseInstance, Team } from './models'
 
 const PROTECTED_STATUS_REQUIREMENT_TAG = 'protected-status-clearance'
@@ -68,10 +69,25 @@ function collectReviewEvidenceRefs(tags: readonly string[]) {
   )
 }
 
+function hasProtectedStatusEvidence(tags: readonly string[]) {
+  return tags.some((tag) => {
+    const normalized = normalizeToken(tag)
+    return (
+      normalized.startsWith(PROTECTED_STATUS_PREFIX) ||
+      normalized.startsWith(PROTECTED_REVIEW_PREFIX) ||
+      normalized === 'protected-minor' ||
+      normalized === 'protected-medical-hold' ||
+      normalized === 'protected-care-duty-active' ||
+      normalized === 'protected-due-process-required'
+    )
+  })
+}
+
 export function evaluateMissionProtectedStatusEnforcement(input: {
   readonly mission: Pick<CaseInstance, 'requiredTags'>
   readonly team: Pick<Team, 'id' | 'name' | 'tags'>
   readonly members: readonly Pick<Agent, 'tags'>[]
+  readonly durableEvidence?: readonly AffiliationPersonStatusMissionRoutingEvidenceEntry[]
 }): MissionProtectedStatusEnforcementResult {
   if (!missionRequiresProtectedStatusClearance(input.mission)) {
     return Object.freeze({
@@ -86,20 +102,26 @@ export function evaluateMissionProtectedStatusEnforcement(input: {
   const statuses = collectProtectedStatuses(tags)
   const reviewEvidenceRefs = collectReviewEvidenceRefs(tags)
   const hasFlag = (flag: string) => tags.some((tag) => normalizeToken(tag) === flag)
-  const candidateStatuses = statuses.length > 0 ? statuses : (['unknown'] as const)
-  const decisions = candidateStatuses.map((protectedStatus) =>
-    evaluateAffiliationProtectedStatusAction({
-      subjectId: input.team.id,
-      subjectLabel: input.team.name,
-      protectedStatus,
-      action: 'assign_mission',
-      minor: hasFlag('protected-minor'),
-      medicalHold: hasFlag('protected-medical-hold'),
-      careDutyActive: hasFlag('protected-care-duty-active'),
-      dueProcessRequired: hasFlag('protected-due-process-required'),
-      reviewEvidenceRefs,
-    })
+  const durableDecisions = (input.durableEvidence ?? []).map(
+    (entry) => entry.snapshot.protectedActionDecision
   )
+  const shouldUseTagEvidence = hasProtectedStatusEvidence(tags) || durableDecisions.length === 0
+  const tagDecisions = shouldUseTagEvidence
+    ? (statuses.length > 0 ? statuses : (['unknown'] as const)).map((protectedStatus) =>
+        evaluateAffiliationProtectedStatusAction({
+          subjectId: input.team.id,
+          subjectLabel: input.team.name,
+          protectedStatus,
+          action: 'assign_mission',
+          minor: hasFlag('protected-minor'),
+          medicalHold: hasFlag('protected-medical-hold'),
+          careDutyActive: hasFlag('protected-care-duty-active'),
+          dueProcessRequired: hasFlag('protected-due-process-required'),
+          reviewEvidenceRefs,
+        })
+      )
+    : []
+  const decisions = [...tagDecisions, ...durableDecisions]
 
   return Object.freeze({
     required: true,

--- a/src/domain/missionRevocationEnforcement.ts
+++ b/src/domain/missionRevocationEnforcement.ts
@@ -10,6 +10,7 @@ import {
 } from './affiliationRevocationOutcomes'
 import { ENTITY_WELFARE_PERMISSION_SURFACES } from './entityWelfareStatusPermissions'
 import type { EntityWelfarePermissionSurface } from './entityWelfareStatusPermissions'
+import type { AffiliationPersonStatusMissionRoutingEvidenceEntry } from './affiliationPersonStatusMissionRoutingEvidence'
 import type { Agent, CaseInstance, Team } from './models'
 
 const REVOCATION_REQUIREMENT_TAG = 'revocation-clearance'
@@ -138,6 +139,7 @@ export function evaluateMissionRevocationEnforcement(input: {
   readonly mission: Pick<CaseInstance, 'requiredTags'>
   readonly team: Pick<Team, 'id' | 'name' | 'tags'>
   readonly members: readonly Pick<Agent, 'tags'>[]
+  readonly durableEvidence?: readonly AffiliationPersonStatusMissionRoutingEvidenceEntry[]
 }): MissionRevocationEnforcementResult {
   if (!missionRequiresRevocationClearance(input.mission)) {
     return Object.freeze({
@@ -150,8 +152,16 @@ export function evaluateMissionRevocationEnforcement(input: {
 
   const tags = [...input.team.tags, ...input.members.flatMap((member) => member.tags)]
   const revocationKinds = collectRevocationKinds(tags)
+  const durableDecisions = (input.durableEvidence ?? [])
+    .map((entry) => entry.snapshot.revocationDecision)
+    .filter(
+      (decision) =>
+        decision.kind !== 'unknown' ||
+        decision.outcome !== 'unchanged' ||
+        decision.reviewEvidenceRefs.length > 0
+    )
 
-  if (revocationKinds.length === 0) {
+  if (revocationKinds.length === 0 && durableDecisions.length === 0) {
     return Object.freeze({
       required: true,
       allowed: true,
@@ -164,7 +174,7 @@ export function evaluateMissionRevocationEnforcement(input: {
   const affectedSurfaces = collectAffectedSurfaces(tags)
   const priorTrustBand = collectPriorTrust(tags)
   const reviewEvidenceRefs = collectReviewEvidenceRefs(tags)
-  const decisions = revocationKinds.map((kind) =>
+  const tagDecisions = revocationKinds.map((kind) =>
     evaluateAffiliationRevocationOutcome({
       subjectId: input.team.id,
       subjectLabel: input.team.name,
@@ -175,6 +185,7 @@ export function evaluateMissionRevocationEnforcement(input: {
       reviewEvidenceRefs,
     } satisfies AffiliationRevocationOutcomeInput)
   )
+  const decisions = [...tagDecisions, ...durableDecisions]
 
   return Object.freeze({
     required: true,

--- a/src/domain/missionSiteClearanceEnforcement.ts
+++ b/src/domain/missionSiteClearanceEnforcement.ts
@@ -2,6 +2,8 @@ import {
   evaluateAffiliationSiteClearance,
   type AffiliationSiteClearanceDecision,
 } from './affiliationSiteClearance'
+import type { AffiliationPersonStatusMissionRoutingEvidenceEntry } from './affiliationPersonStatusMissionRoutingEvidence'
+import type { EntityWelfarePermissionSurface } from './entityWelfareStatusPermissions'
 import type { Agent, CaseInstance, Team } from './models'
 
 const SITE_CLEARANCE_PREFIX = 'site-clearance:'
@@ -75,10 +77,73 @@ function collectGrantTags(team: Pick<Team, 'tags'>, members: readonly Pick<Agent
   }
 }
 
+function missionPermissionDecision(
+  entry: AffiliationPersonStatusMissionRoutingEvidenceEntry,
+  surface: EntityWelfarePermissionSurface
+) {
+  return entry.snapshot.permissionDecisions.find((decision) => decision.surface === surface)
+}
+
+function buildDurableSiteClearanceDecisions(input: {
+  readonly mission: Pick<CaseInstance, 'id' | 'title' | 'requiredTags' | 'siteLayer'>
+  readonly requirement: MissionSiteClearanceRequirement
+  readonly durableEvidence: readonly AffiliationPersonStatusMissionRoutingEvidenceEntry[]
+}) {
+  return input.durableEvidence.flatMap((entry) => [
+    ...input.requirement.siteIds.map((siteId) =>
+      evaluateAffiliationSiteClearance({
+        subjectId: entry.record.subjectId,
+        subjectLabel: entry.record.subjectLabel,
+        surface: 'mission',
+        onboardingDecision: entry.snapshot.onboardingDecision,
+        basePermissionDecision: missionPermissionDecision(entry, 'mission'),
+        context: {
+          boundary: 'site',
+          siteId,
+          siteLabel: siteId,
+          siteLayer: input.mission.siteLayer ?? entry.record.siteLayer ?? 'transition',
+          grantedSiteIds: entry.record.grantedSiteIds,
+          restrictedSiteIds: entry.record.restrictedSiteIds,
+          blockedSiteIds: entry.record.blockedSiteIds,
+          minimumOnboardingStage: entry.record.minimumOnboardingStage,
+        },
+      })
+    ),
+    ...input.requirement.facilityIds.map((facilityId) =>
+      evaluateAffiliationSiteClearance({
+        subjectId: entry.record.subjectId,
+        subjectLabel: entry.record.subjectLabel,
+        surface: 'mission',
+        onboardingDecision: entry.snapshot.onboardingDecision,
+        basePermissionDecision: missionPermissionDecision(entry, 'mission'),
+        context: {
+          boundary: 'facility',
+          facilityId,
+          facilityLabel: facilityId,
+          siteLayer: input.mission.siteLayer ?? entry.record.siteLayer ?? 'transition',
+          grantedFacilityIds: entry.record.grantedFacilityIds,
+          restrictedFacilityIds: entry.record.restrictedFacilityIds,
+          blockedFacilityIds: entry.record.blockedFacilityIds,
+          minimumOnboardingStage: entry.record.minimumOnboardingStage,
+        },
+      })
+    ),
+  ])
+}
+
+function requirementAllowed(
+  decisions: readonly AffiliationSiteClearanceDecision[],
+  field: 'siteId' | 'facilityId',
+  value: string
+) {
+  return decisions.some((decision) => decision[field] === value && decision.outcome === 'allowed')
+}
+
 export function evaluateMissionSiteClearanceEnforcement(input: {
   readonly mission: Pick<CaseInstance, 'id' | 'title' | 'requiredTags' | 'siteLayer'>
   readonly team: Pick<Team, 'id' | 'name' | 'tags'>
   readonly members: readonly Pick<Agent, 'tags'>[]
+  readonly durableEvidence?: readonly AffiliationPersonStatusMissionRoutingEvidenceEntry[]
 }): MissionSiteClearanceEnforcementResult {
   const requirement = parseMissionSiteClearanceRequirement(input.mission)
   const required = requirement.siteIds.length > 0 || requirement.facilityIds.length > 0
@@ -94,7 +159,7 @@ export function evaluateMissionSiteClearanceEnforcement(input: {
 
   const grants = collectGrantTags(input.team, input.members)
   const onboardingDecision = buildClearedTeamOnboarding(input.team)
-  const decisions = [
+  const tagDecisions = [
     ...requirement.siteIds.map((siteId) =>
       evaluateAffiliationSiteClearance({
         subjectId: input.team.id,
@@ -126,11 +191,24 @@ export function evaluateMissionSiteClearanceEnforcement(input: {
       })
     ),
   ]
+  const decisions = [
+    ...tagDecisions,
+    ...buildDurableSiteClearanceDecisions({
+      mission: input.mission,
+      requirement,
+      durableEvidence: input.durableEvidence ?? [],
+    }),
+  ]
   const reasonCodes = uniqueSorted(decisions.flatMap((decision) => decision.reasonCodes))
+  const allowed =
+    requirement.siteIds.every((siteId) => requirementAllowed(decisions, 'siteId', siteId)) &&
+    requirement.facilityIds.every((facilityId) =>
+      requirementAllowed(decisions, 'facilityId', facilityId)
+    )
 
   return Object.freeze({
     required: true,
-    allowed: decisions.every((decision) => decision.outcome === 'allowed'),
+    allowed,
     decisions: Object.freeze(decisions),
     reasonCodes: Object.freeze(reasonCodes),
   })

--- a/src/test/advanceWeek.affiliationPersonStatus.integration.test.ts
+++ b/src/test/advanceWeek.affiliationPersonStatus.integration.test.ts
@@ -4,6 +4,7 @@ import { createStartingState } from '../data/startingState'
 import type { AffiliationPersonStatusRecord } from '../domain/affiliationPersonStatusRecords'
 import { evaluateDeploymentEligibility } from '../domain/deploymentReadiness'
 import { advanceWeek } from '../domain/sim/advanceWeek'
+import type { Candidate } from '../domain/recruitment'
 
 function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
   for (const currentCase of Object.values(state.cases)) {
@@ -15,12 +16,54 @@ function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) 
   }
 }
 
-function weeklyRecord(): AffiliationPersonStatusRecord {
+function makeClearedCandidate(id: string, name: string): Candidate {
+  return {
+    id,
+    name,
+    age: 31,
+    category: 'agent',
+    hireStatus: 'available',
+    weeklyCost: 20,
+    weeklyWage: 20,
+    funnelStage: 'hired',
+    revealLevel: 2,
+    expiryWeek: 52,
+    origin: 'open-call',
+    roleInclination: 'field',
+    skills: ['recon-sweep'],
+    liabilities: [],
+    createdWeek: 1,
+    lastUpdatedWeek: 1,
+    evaluation: {
+      overallVisible: true,
+      overall: 65,
+      overallValue: 65,
+      potentialVisible: true,
+      potentialTier: 'mid',
+      rumorTags: [],
+    },
+    agentData: {
+      role: 'field',
+      specialization: 'recon',
+      stats: {
+        combat: 45,
+        investigation: 55,
+        utility: 50,
+        social: 40,
+      },
+      traits: [],
+    },
+  } as Candidate
+}
+
+function weeklyRecord(
+  overrides: Partial<AffiliationPersonStatusRecord> = {}
+): AffiliationPersonStatusRecord {
   return {
     id: 'person-status:advance-week-weekly',
-    subjectId: 'subject:advance-week-weekly',
-    subjectLabel: 'Advance Week Contractor',
-    candidateRef: 'candidate:advance-week-weekly',
+    subjectId: overrides.subjectId ?? 'subject:advance-week-weekly',
+    subjectLabel: overrides.subjectLabel ?? 'Advance Week Contractor',
+    candidateRef: overrides.candidateRef ?? 'candidate:advance-week-weekly',
     backgroundCleared: false,
     trainingCompleted: false,
     oathContractSigned: false,
@@ -30,11 +73,13 @@ function weeklyRecord(): AffiliationPersonStatusRecord {
         week: 6,
         backgroundCleared: true,
         trainingCompleted: true,
-        grantedSiteIds: ['site:annex-7'],
+        oathContractSigned: true,
+        grantedSiteIds: ['annex-7'],
         grantedFacilityIds: ['facility:archive'],
         protectedReviewEvidenceRefs: ['review:protected-week-6'],
       },
     ],
+    ...overrides,
   }
 }
 
@@ -59,7 +104,8 @@ describe('advanceWeek affiliation person-status weekly progression integration (
     expect(nextState.week).toBe(6)
     expect(nextRecord?.backgroundCleared).toBe(true)
     expect(nextRecord?.trainingCompleted).toBe(true)
-    expect(nextRecord?.grantedSiteIds).toEqual(['site:annex-7'])
+    expect(nextRecord?.oathContractSigned).toBe(true)
+    expect(nextRecord?.grantedSiteIds).toEqual(['annex-7'])
     expect(nextRecord?.grantedFacilityIds).toEqual(['facility:archive'])
     expect(nextRecord?.protectedReviewEvidenceRefs).toEqual(['review:protected-week-6'])
     expect(nextRecord?.weeklyProgression).toEqual(record.weeklyProgression)
@@ -68,7 +114,7 @@ describe('advanceWeek affiliation person-status weekly progression integration (
     expect(progressionNotes[0]?.metadata?.recordId).toBe(record.id)
   })
 
-  it('leaves mission routing behavior unchanged by durable person-status records', () => {
+  it('lets weekly durable person-status progression satisfy explicit mission clearance after advanceWeek', () => {
     const state = createStartingState()
     freezeCasesForQuietWeek(state)
     state.week = 5
@@ -81,8 +127,18 @@ describe('advanceWeek affiliation person-status weekly progression integration (
     state.cases[missionId] = {
       ...state.cases[missionId],
       requiredTags: ['site-clearance:annex-7'],
+      requiredRoles: [],
     }
-    const record = weeklyRecord()
+    const memberId = state.teams[teamId]!.memberIds?.[0] ?? state.teams[teamId]!.agentIds[0]!
+    const candidateId = `candidate:${memberId}`
+    state.candidates = [makeClearedCandidate(candidateId, state.agents[memberId]!.name)]
+    state.recruitmentPool = state.candidates
+    const record = weeklyRecord({
+      id: `person-status:${memberId}`,
+      subjectId: memberId,
+      subjectLabel: state.agents[memberId]!.name,
+      candidateRef: candidateId,
+    })
     state.affiliationPersonStatusRecords = {
       [record.id]: record,
     }
@@ -92,6 +148,6 @@ describe('advanceWeek affiliation person-status weekly progression integration (
     const afterEligibility = evaluateDeploymentEligibility(nextState, missionId, teamId)
 
     expect(beforeEligibility.hardBlockers).toContain('site-clearance-required')
-    expect(afterEligibility.hardBlockers).toContain('site-clearance-required')
+    expect(afterEligibility.hardBlockers).not.toContain('site-clearance-required')
   })
 })

--- a/src/test/mission.intake.triage.routing.test.ts
+++ b/src/test/mission.intake.triage.routing.test.ts
@@ -19,6 +19,50 @@ import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
 import { evaluateDeploymentEligibility } from '../domain/deploymentReadiness'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { assignTeam } from '../domain/sim/assign'
+import type { AffiliationPersonStatusRecord } from '../domain/affiliationPersonStatusRecords'
+import type { Candidate } from '../domain/recruitment'
+
+function makeClearedCandidate(id: string, name: string): Candidate {
+  return {
+    id,
+    name,
+    hireStatus: 'available',
+    funnelStage: 'hired',
+    revealLevel: 2,
+    roleInclination: 'field',
+    agentData: {
+      role: 'field',
+      specialization: 'recon',
+      stats: {
+        combat: 45,
+        investigation: 55,
+        utility: 50,
+        social: 40,
+      },
+      traits: [],
+    },
+  } as Candidate
+}
+
+function clearedPersonStatusRecord(
+  overrides: Partial<AffiliationPersonStatusRecord>
+): AffiliationPersonStatusRecord {
+  const subjectId = overrides.subjectId ?? 'subject:mission-routing'
+  const candidateRef = overrides.candidateRef ?? `candidate:${subjectId}`
+
+  return {
+    id: overrides.id ?? `person-status:${subjectId}`,
+    subjectId,
+    subjectLabel: overrides.subjectLabel ?? subjectId,
+    candidateRef,
+    backgroundCleared: true,
+    trainingCompleted: true,
+    oathContractSigned: true,
+    protectedStatus: 'full_staff',
+    protectedAction: 'assign_mission',
+    ...overrides,
+  }
+}
 
 describe('mission intake, triage, and routing', () => {
   it('generates deterministic weekly intake batches with stable mission ordering', () => {
@@ -263,6 +307,67 @@ describe('mission intake, triage, and routing', () => {
     expect(routed.candidateTeamIds).not.toContain(missingTeamId)
   })
 
+  it('allows explicit site clearance through exact-match durable person-status evidence', () => {
+    const state = createStartingState()
+    const missionId = state.cases['case-001'].id
+    const teamId = Object.keys(state.teams)[0]!
+    const memberId = state.teams[teamId]!.memberIds?.[0] ?? state.teams[teamId]!.agentIds[0]!
+    const candidateId = `candidate:${memberId}`
+    state.cases[missionId] = {
+      ...state.cases[missionId],
+      requiredTags: ['site-clearance:annex-7'],
+      requiredRoles: [],
+    }
+    state.candidates = [makeClearedCandidate(candidateId, state.agents[memberId]!.name)]
+    state.recruitmentPool = state.candidates
+    state.affiliationPersonStatusRecords = {
+      [`person-status:${memberId}`]: clearedPersonStatusRecord({
+        id: `person-status:${memberId}`,
+        subjectId: memberId,
+        subjectLabel: state.agents[memberId]!.name,
+        candidateRef: candidateId,
+        grantedSiteIds: ['annex-7'],
+      }),
+    }
+
+    const eligibility = evaluateDeploymentEligibility(state, missionId, teamId)
+    const routed = routeMission(state, missionId)
+
+    expect(eligibility.hardBlockers).not.toContain('site-clearance-required')
+    expect(eligibility.hardBlockers).not.toContain('invalid-loadout-gate')
+    expect(routed.candidateTeamIds).toContain(teamId)
+    expect(routed.routingBlockers).not.toContain('site-clearance-required')
+  })
+
+  it('ignores durable person-status evidence that does not exactly match team or member ids', () => {
+    const state = createStartingState()
+    const missionId = state.cases['case-001'].id
+    const teamId = Object.keys(state.teams)[0]!
+    const candidateId = 'candidate:nonmatching'
+    state.cases[missionId] = {
+      ...state.cases[missionId],
+      requiredTags: ['site-clearance:annex-7'],
+      requiredRoles: [],
+    }
+    state.candidates = [makeClearedCandidate(candidateId, 'Nonmatching Record')]
+    state.recruitmentPool = state.candidates
+    state.affiliationPersonStatusRecords = {
+      'person-status:nonmatching': clearedPersonStatusRecord({
+        id: 'person-status:nonmatching',
+        subjectId: 'agent:not-on-team',
+        subjectLabel: 'Nonmatching Record',
+        candidateRef: candidateId,
+        grantedSiteIds: ['annex-7'],
+      }),
+    }
+
+    const eligibility = evaluateDeploymentEligibility(state, missionId, teamId)
+    const routed = routeMission(state, missionId)
+
+    expect(eligibility.hardBlockers).toContain('site-clearance-required')
+    expect(routed.routingBlockers).toContain('site-clearance-required')
+  })
+
   it('leaves existing missions without explicit dual-loyalty requirements unchanged', () => {
     const state = createStartingState()
     const missionId = state.cases['case-001'].id
@@ -349,6 +454,40 @@ describe('mission intake, triage, and routing', () => {
     expect(routed.routingBlockers).not.toContain('invalid-loadout-gate')
   })
 
+  it('blocks explicit dual-loyalty review from durable person-status evidence', () => {
+    const state = createStartingState()
+    const missionId = state.cases['case-001'].id
+    const teamId = Object.keys(state.teams)[0]!
+    state.cases[missionId] = {
+      ...state.cases[missionId],
+      requiredTags: ['dual-loyalty-clearance'],
+      requiredRoles: [],
+    }
+    state.affiliationPersonStatusRecords = Object.fromEntries(
+      Object.values(state.teams).map((team) => {
+        const memberId = team.memberIds?.[0] ?? team.agentIds[0]!
+        return [
+          `person-status:${memberId}`,
+          clearedPersonStatusRecord({
+            id: `person-status:${memberId}`,
+            subjectId: memberId,
+            subjectLabel: state.agents[memberId]!.name,
+            primaryLoyaltyAnchor: 'agency',
+            secondaryLoyaltyAnchors: ['patron'],
+            dualLoyaltyEvidenceTags: ['dual_loyalty:restricted'],
+          }),
+        ]
+      })
+    )
+
+    const eligibility = evaluateDeploymentEligibility(state, missionId, teamId)
+    const routed = routeMission(state, missionId)
+
+    expect(eligibility.hardBlockers).toContain('dual-loyalty-restricted')
+    expect(routed.routingBlockers).toContain('dual-loyalty-restricted')
+    expect(routed.routingBlockers).not.toContain('invalid-loadout-gate')
+  })
+
   it('leaves existing missions without explicit protected-status requirements unchanged', () => {
     const state = createStartingState()
     const missionId = state.cases['case-001'].id
@@ -415,6 +554,34 @@ describe('mission intake, triage, and routing', () => {
     expect(routed.routingBlockers).not.toContain('invalid-loadout-gate')
   })
 
+  it('blocks explicit protected-status review from durable person-status evidence', () => {
+    const state = createStartingState()
+    const missionId = state.cases['case-001'].id
+    const teamId = Object.keys(state.teams)[0]!
+    const memberId = state.teams[teamId]!.memberIds?.[0] ?? state.teams[teamId]!.agentIds[0]!
+    state.cases[missionId] = {
+      ...state.cases[missionId],
+      requiredTags: ['protected-status-clearance'],
+      requiredRoles: [],
+    }
+    state.affiliationPersonStatusRecords = {
+      [`person-status:${memberId}`]: clearedPersonStatusRecord({
+        id: `person-status:${memberId}`,
+        subjectId: memberId,
+        subjectLabel: state.agents[memberId]!.name,
+        protectedStatus: 'minor',
+        protectedAction: 'assign_mission',
+      }),
+    }
+
+    const eligibility = evaluateDeploymentEligibility(state, missionId, teamId)
+    const routed = routeMission(state, missionId)
+
+    expect(eligibility.hardBlockers).toContain('protected-status-restricted')
+    expect(routed.routingBlockers).toContain('protected-status-restricted')
+    expect(routed.routingBlockers).not.toContain('invalid-loadout-gate')
+  })
+
   it('allows explicit revocation clearance when no active revocation evidence exists', () => {
     const state = createStartingState()
     const missionId = state.cases['case-001'].id
@@ -459,6 +626,40 @@ describe('mission intake, triage, and routing', () => {
     expect(eligibility.hardBlockers).toContain('revocation-restricted')
     expect(eligibility.hardBlockers).not.toContain('invalid-loadout-gate')
     expect(routed.routingState).toBe('blocked')
+    expect(routed.routingBlockers).toContain('revocation-restricted')
+    expect(routed.routingBlockers).not.toContain('invalid-loadout-gate')
+  })
+
+  it('blocks explicit revocation review from durable person-status evidence', () => {
+    const state = createStartingState()
+    const missionId = state.cases['case-001'].id
+    const teamId = Object.keys(state.teams)[0]!
+    state.cases[missionId] = {
+      ...state.cases[missionId],
+      requiredTags: ['revocation-clearance'],
+      requiredRoles: [],
+    }
+    state.affiliationPersonStatusRecords = Object.fromEntries(
+      Object.values(state.teams).map((team) => {
+        const memberId = team.memberIds?.[0] ?? team.agentIds[0]!
+        return [
+          `person-status:${memberId}`,
+          clearedPersonStatusRecord({
+            id: `person-status:${memberId}`,
+            subjectId: memberId,
+            subjectLabel: state.agents[memberId]!.name,
+            revocationKind: 'revocation',
+            revocationCause: 'site_breach',
+            revocationAffectedSurfaces: ['mission'],
+          }),
+        ]
+      })
+    )
+
+    const eligibility = evaluateDeploymentEligibility(state, missionId, teamId)
+    const routed = routeMission(state, missionId)
+
+    expect(eligibility.hardBlockers).toContain('revocation-restricted')
     expect(routed.routingBlockers).toContain('revocation-restricted')
     expect(routed.routingBlockers).not.toContain('invalid-loadout-gate')
   })


### PR DESCRIPTION
## Summary
- Links SPE-2521.
- Adds exact-match durable person-status evidence selection for mission routing.
- Threads matched durable evidence through existing SPE-1046 site/facility, dual-loyalty, protected-status, and revocation mission gates without new blocker codes or persistence.
- Adds routing and advanceWeek regression coverage for durable grants/restrictions.

## Validation
- npm.cmd run test:run -- src/test/mission.intake.triage.routing.test.ts src/test/missionRevocationEnforcement.test.ts src/test/missionProtectedStatusEnforcement.test.ts src/test/missionDualLoyaltyEnforcement.test.ts src/test/advanceWeek.affiliationPersonStatus.integration.test.ts src/test/affiliationPersonStatusRecords.test.ts
- npm.cmd run lint
- npm.cmd exec prettier -- --check src/domain/affiliationPersonStatusMissionRoutingEvidence.ts src/domain/missionSiteClearanceEnforcement.ts src/domain/missionDualLoyaltyEnforcement.ts src/domain/missionProtectedStatusEnforcement.ts src/domain/missionRevocationEnforcement.ts src/domain/deploymentReadiness.ts src/test/mission.intake.triage.routing.test.ts src/test/advanceWeek.affiliationPersonStatus.integration.test.ts planning/spe-1046-durable-person-status-mission-routing-slice-1.md planning/backlog.md
- npm.cmd run test:run