### PR TITLE
SPE-2524 surface file access enforcement

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -114,11 +114,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2521](https://linear.app/spectranoir/issue/SPE-2521/durable-person-status-mission-routing-evidence) SPE-1046 durable person-status mission routing evidence (slice 1) — exact-match durable person-status records supplement existing explicit mission-routing clearance gates; PR #2970 @ `5ed06ab8`; see `planning/spe-1046-durable-person-status-mission-routing-slice-1.md`.
 
-**In progress:** [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523/spe-1046-procurement-gear-access-enforcement) SPE-1046 procurement gear access enforcement (slice 1) — restricted/rare procurement listings compose the existing gear permission surface through current access fields; branch `spe-1046-procurement-gear-access-slice-1`; see `planning/spe-1046-procurement-gear-access-slice-1.md`.
+**Recently shipped:** [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523/spe-1046-procurement-gear-access-enforcement) SPE-1046 procurement gear access enforcement (slice 1) — restricted/rare procurement listings compose the existing gear permission surface through current access fields; PR #2974 @ `9f623d9a`; see `planning/spe-1046-procurement-gear-access-slice-1.md`.
 
-**Next step after SPE-2523:** Owner reprioritizes from SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**In progress:** [SPE-2524](https://linear.app/spectranoir/issue/SPE-2524/spe-1046-file-access-enforcement-for-operations-surfaces) SPE-1046 file access enforcement for operations surfaces (slice 1) — durable person-status mirror exposes read-only file-access outcomes from existing SPE-1046 permission decisions; branch `spe-1046-file-access-enforcement-slice-1`; see `planning/spe-1046-file-access-enforcement-slice-1.md`.
 
-**Base `main` SHA:** `451eac0d` — includes PR #2970 / `5ed06ab8`.
+**Next step after SPE-2524:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons (room/housing/facility-specific file workflows) or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `9f623d9a` — includes PR #2974 / SPE-2523 procurement gear access enforcement.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -260,7 +262,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-durable-person-status-surfacing-slice-1.md`                     | **Shipped**     | [SPE-2519](https://linear.app/spectranoir/issue/SPE-2519) — read-only operations mirror for durable person-status evidence and composed projection outcomes; PR #2966 @ `543f837a`; parent SPE-1046 stays **Backlog**.        |
 | `spe-1046-durable-person-status-weekly-progression-slice-1.md`            | **Shipped**     | [SPE-2520](https://linear.app/spectranoir/issue/SPE-2520) — authored weekly progression for durable person-status evidence without changing mission routing; parent SPE-1046 stays **Backlog**.                               |
 | `spe-1046-durable-person-status-mission-routing-slice-1.md`               | **Shipped**     | [SPE-2521](https://linear.app/spectranoir/issue/SPE-2521) — exact-match durable person-status records supplement existing explicit mission-routing clearance gates; PR #2970 @ `5ed06ab8`; parent SPE-1046 stays **Backlog**. |
-| `spe-1046-procurement-gear-access-slice-1.md`                             | **In Progress** | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; parent SPE-1046 stays **Backlog**.                    |
+| `spe-1046-file-access-enforcement-slice-1.md`                             | **In Progress** | [SPE-2524](https://linear.app/spectranoir/issue/SPE-2524) — durable person-status mirror exposes file-access outcomes from existing SPE-1046 permission decisions; parent SPE-1046 stays **Backlog**.                  |
+| `spe-1046-procurement-gear-access-slice-1.md`                             | **Shipped**     | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; PR #2974 @ `9f623d9a`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-947-spe-1046-parent-acceptance-review-slice-1.md`                    | **Shipped**     | [SPE-2481](https://linear.app/spectranoir/issue/SPE-2481) + [SPE-2482](https://linear.app/spectranoir/issue/SPE-2482) — registry umbrella grooming; parents SPE-947/SPE-1046 stay **Backlog**.                                |

--- a/planning/spe-1046-file-access-enforcement-slice-1.md
+++ b/planning/spe-1046-file-access-enforcement-slice-1.md
@@ -1,0 +1,56 @@
+# SPE-1046 - File access enforcement for operations surfaces (slice 1)
+
+One-page implementation plan. Linear: [SPE-2524](https://linear.app/spectranoir/issue/SPE-2524/spe-1046-file-access-enforcement-for-operations-surfaces) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523/spe-1046-procurement-gear-access-enforcement); [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                                         |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2524 - SPE-1046 file access enforcement for operations surfaces](https://linear.app/spectranoir/issue/SPE-2524/spe-1046-file-access-enforcement-for-operations-surfaces) |
+| **Status**          | **In Progress**                                                                                                                                                               |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                                           |
+| **Branch**          | `spe-1046-file-access-enforcement-slice-1`                                                                                                                                    |
+| **Base `main` SHA** | `9f623d9a`                                                                                                                                                                    |
+
+## Goal
+
+Expose file-access outcomes from the existing SPE-1046 permission evaluator on the durable person-status operations mirror without adding persistence, name inference, routing, procurement, or full parent closure.
+
+## Scope
+
+| In                                                                                            | Out                                       |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Read-only file-access labels from `EntityWelfarePermissionDecision` surface `file`            | New persistence fields                    |
+| Operations mirror surfacing through existing durable person-status projections                | Person-name guessing or broad matching    |
+| Focused view-model and page tests for no-record, restricted, and blocked file-access outcomes | Mission routing or procurement changes    |
+| Backlog handoff update                                                                        | Room, housing, facility, or file UI flows |
+| SPE-1046 parent remains **Backlog**                                                           | SPE-1046 parent closure                   |
+
+## Acceptance
+
+- [x] File access decisions reuse existing SPE-1046 permission evaluator for the `file` surface.
+- [x] No linked welfare record preserves an explicit `File access: -` mirror label.
+- [x] Restricted file permission surfaces through the person-status mirror.
+- [x] Blocked file permission surfaces through the person-status mirror.
+- [x] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npm.cmd run test:run -- src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
+- `npm.cmd run lint`
+- Direct Prettier check for touched files only.
+- Full `npm.cmd run test:run` before PR.
+
+## Deferred
+
+| Item                             | Owner                    | Why                                |
+| -------------------------------- | ------------------------ | ---------------------------------- |
+| Room and housing access gates    | SPE-1046 follow-up child | Separate permission surfaces.      |
+| Facility-specific file workflows | SPE-1046 follow-up child | Requires explicit product surface. |
+| Mission routing changes          | SPE-1046 follow-up child | Mission gates already shipped.     |
+| SPE-1046 parent closure          | SPE-1046                 | Parent acceptance remains broader. |
+
+## See also
+
+- `planning/spe-1046-procurement-gear-access-slice-1.md`
+- `planning/spe-1046-durable-person-status-surfacing-slice-1.md`
+- `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`
+- `planning/backlog.md`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1633,6 +1633,7 @@ export const AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT: Record<string, string> = 
   linksColumn: 'Links',
   onboardingColumn: 'Onboarding',
   permissionsColumn: 'Permissions',
+  fileAccessColumn: 'File access',
   siteClearanceColumn: 'Site clearance',
   dualLoyaltyColumn: 'Dual loyalty',
   protectedStatusColumn: 'Protected status',

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -65,6 +65,7 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
     expect(recordsRegion).toHaveTextContent('Cooperative Contractor')
     expect(recordsRegion).toHaveTextContent('Rival Patron Risk')
     expect(recordsRegion).toHaveTextContent('Risk: Restricted')
+    expect(recordsRegion).toHaveTextContent('File access: Restricted')
     expect(recordsRegion).toHaveTextContent('Mission: Restricted')
     expect(recordsRegion).toHaveTextContent('person-status:cooperative-contractor-cleared')
   })

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
@@ -129,6 +129,9 @@ export default function AffiliationPersonStatusMirrorPage() {
                     {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.permissionsColumn}
                   </th>
                   <th className="px-2 py-2">
+                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessColumn}
+                  </th>
+                  <th className="px-2 py-2">
                     {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.siteClearanceColumn}
                   </th>
                   <th className="px-2 py-2">
@@ -168,6 +171,9 @@ export default function AffiliationPersonStatusMirrorPage() {
                     </td>
                     <td className="px-2 py-2">
                       <LabelStack labels={record.permissionDecisionLabels} />
+                    </td>
+                    <td className="px-2 py-2">
+                      <LabelStack labels={record.fileAccessLabels} />
                     </td>
                     <td className="px-2 py-2">
                       <LabelStack labels={record.siteClearanceLabels} />

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -97,6 +97,10 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
 
     expect(cooperative?.subjectLabel).toBe('Cooperative Contractor')
     expect(cooperative?.onboardingLabels).toContain('Stage: Cleared')
+    expect(cooperative?.fileAccessLabels).toEqual([
+      'File access: Restricted',
+      'Reasons: approved_cooperative_file_restricted',
+    ])
     expect(cooperative?.siteClearanceLabels).toContain('Mission: Allowed')
     expect(cooperative?.permissionDecisionLabels).toContain('Mission: Restricted')
     expect(restricted?.dualLoyaltyLabels).toContain('Risk: Restricted')
@@ -125,6 +129,42 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     expect(record?.reasonCodeLabels).toContain('missing_candidate_ref')
     expect(record?.reasonCodeLabels).toContain('missing_entity_welfare_reclassification_ref')
     expect(record?.permissionDecisionLabels).toEqual(['-'])
+    expect(record?.fileAccessLabels).toEqual(['File access: -'])
     expect(record?.onboardingLabels).toEqual(['Candidate: -', 'Access: -'])
+  })
+
+  it('surfaces blocked file access from linked SPE-1046 welfare decisions', () => {
+    const game = createStartingState()
+    const blockedWelfareRecord = {
+      ...HOSTILE_TO_COOPERATIVE_FIXTURE,
+      id: 'reclass:file-blocked',
+      label: 'Blocked file custody',
+      proposedDisposition: 'hostile',
+      reclassificationState: 'denied',
+    } as const
+    game.entityWelfareReclassificationRecords = {
+      [blockedWelfareRecord.id]: blockedWelfareRecord,
+    }
+    game.affiliationPersonStatusRecords = {
+      'person-status:file-blocked': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:file-blocked',
+        subjectId: 'subject:file-blocked',
+        subjectLabel: 'File Blocked Subject',
+        candidateRef: undefined,
+        entityWelfareReclassificationRef: blockedWelfareRecord.id,
+        permissionSurface: 'file',
+      },
+    }
+
+    const view = getAffiliationPersonStatusMirrorView(game)
+    const record = view.records[0]
+
+    expect(view.summary.restrictedOrBlockedCount).toBe(1)
+    expect(record?.fileAccessLabels).toEqual([
+      'File access: Blocked',
+      'Reasons: denied_reclassification_blocked',
+    ])
+    expect(record?.permissionDecisionLabels).toContain('File: Blocked')
   })
 })

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -12,6 +12,7 @@ export interface AffiliationPersonStatusMirrorRecordView {
   candidateRefLabel: string
   entityWelfareReclassificationRefLabel: string
   permissionDecisionLabels: readonly string[]
+  fileAccessLabels: readonly string[]
   onboardingLabels: readonly string[]
   siteClearanceLabels: readonly string[]
   dualLoyaltyLabels: readonly string[]
@@ -45,6 +46,24 @@ function formatPermissionDecisionLabels(
   return Object.freeze(
     emptyFallback(decisions.map((decision) => `${decision.surfaceLabel}: ${decision.outcomeLabel}`))
   )
+}
+
+function formatFileAccessLabels(
+  decisions: readonly EntityWelfarePermissionDecision[]
+): readonly string[] {
+  const decision = decisions.find((candidate) => candidate.surface === 'file')
+
+  if (!decision) {
+    return Object.freeze(['File access: -'])
+  }
+
+  const labels = [`File access: ${decision.outcomeLabel}`]
+
+  if (decision.reasonCodes.length > 0) {
+    labels.push(`Reasons: ${decision.reasonCodes.join(', ')}`)
+  }
+
+  return Object.freeze(labels)
 }
 
 function formatOnboardingLabels(snapshot: AffiliationPersonStatusSnapshot): readonly string[] {
@@ -153,6 +172,7 @@ function toRecordView(
     candidateRefLabel: snapshot.candidateRef ?? '-',
     entityWelfareReclassificationRefLabel: snapshot.entityWelfareReclassificationRef ?? '-',
     permissionDecisionLabels: formatPermissionDecisionLabels(snapshot.permissionDecisions),
+    fileAccessLabels: formatFileAccessLabels(snapshot.permissionDecisions),
     onboardingLabels: formatOnboardingLabels(snapshot),
     siteClearanceLabels: formatSiteClearanceLabels(snapshot),
     dualLoyaltyLabels: formatDualLoyaltyLabels(snapshot),


### PR DESCRIPTION
## Summary
- Link: https://linear.app/spectranoir/issue/SPE-2524/spe-1046-file-access-enforcement-for-operations-surfaces
- Adds read-only file-access labels to the durable person-status operations mirror using existing SPE-1046 `file` permission decisions.
- Keeps persistence, mission routing, procurement, room/housing/facility gates, and SPE-1046 parent closure out of scope.
- Refreshes the backlog handoff and adds the SPE-2524 slice plan.

## Validation
- `npm.cmd run test:run -- src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
- `npm.cmd run lint`
- `npm.cmd run test:run`
- `npx.cmd prettier --check planning/spe-1046-file-access-enforcement-slice-1.md src/data/copy.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/features/operations/AffiliationPersonStatusMirrorPage.tsx src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/affiliationPersonStatusMirrorView.ts`

Note: `planning/backlog.md` was not run through Prettier to avoid reflowing its large existing table; `git diff --check` passed.