### PR TITLE
SPE-1046 add file access work queues

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -1,4 +1,4 @@
-﻿# Near-term backlog
+# Near-term backlog
 
 This file is the **canonical ordered queue** for concrete engineering and design follow-ups that were previously split across `README.md` and high-level hints in `planning/roadmap.md`. **Edit order here when priorities change**; avoid duplicating long tactical lists elsewhere.
 
@@ -120,11 +120,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2525](https://linear.app/spectranoir/issue/SPE-2525/spe-1046-roomhousing-access-enforcement-for-operations-surfaces) SPE-1046 room/housing access enforcement for operations surfaces (slice 1) — durable person-status mirror exposes read-only room-access and housing-access outcomes from existing SPE-1046 permission decisions; PR #2978 @ `a6166182`; see `planning/spe-1046-room-housing-access-enforcement-slice-1.md`.
 
-**In progress:** [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526/spe-1046-facility-specific-file-workflows) SPE-1046 facility-specific file workflows (slice 1) — durable person-status mirror derives read-only facility-file access from existing file permission and site/facility clearance decisions; branch `spe-1046-facility-file-access-workflows-slice-1`; see `planning/spe-1046-facility-file-access-workflows-slice-1.md`.
+**Recently shipped:** [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526/spe-1046-facility-specific-file-workflows) SPE-1046 facility-specific file workflows (slice 1) — durable person-status mirror derives read-only facility-file access from existing file permission and site/facility clearance decisions; PR #2980 @ `3242f52b`; see `planning/spe-1046-facility-file-access-workflows-slice-1.md`.
 
-**Next step after SPE-2526:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**In progress:** SPE-1046 file access work queues (slice 1) — existing person-status/file/facility decisions are grouped into a read-only operations queue for blocked, restricted, missing-review, and allowed file-access situations; branch `spe-1046-file-work-queues-slice-1`; see `planning/spe-1046-file-work-queues-slice-1.md`.
 
-**Base `main` SHA:** `a6166182` — includes PR #2978 / SPE-2525 room/housing access enforcement.
+**Next step after file access work queues:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `3242f52b` — includes PR #2980 / SPE-2526 facility-specific file workflows.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -268,7 +270,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-durable-person-status-mission-routing-slice-1.md`               | **Shipped**     | [SPE-2521](https://linear.app/spectranoir/issue/SPE-2521) — exact-match durable person-status records supplement existing explicit mission-routing clearance gates; PR #2970 @ `5ed06ab8`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-file-access-enforcement-slice-1.md`                             | **Shipped**     | [SPE-2524](https://linear.app/spectranoir/issue/SPE-2524) — durable person-status mirror exposes file-access outcomes from existing SPE-1046 permission decisions; PR #2976 @ `c5869e65`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-room-housing-access-enforcement-slice-1.md`                     | **Shipped**     | [SPE-2525](https://linear.app/spectranoir/issue/SPE-2525) — durable person-status mirror exposes room-access and housing-access outcomes from existing SPE-1046 permission decisions; PR #2978 @ `a6166182`; parent SPE-1046 stays **Backlog**. |
-| `spe-1046-facility-file-access-workflows-slice-1.md`                      | **In Progress** | [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526) — durable person-status mirror derives facility-file access from existing file permission and site/facility clearance decisions; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-facility-file-access-workflows-slice-1.md`                      | **Shipped**     | [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526) — durable person-status mirror derives facility-file access from existing file permission and site/facility clearance decisions; PR #2980 @ `3242f52b`; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-file-work-queues-slice-1.md`                                     | **In Progress** | New SPE-1046 child — existing person-status/file/facility decisions feed a read-only operations work queue; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-procurement-gear-access-slice-1.md`                             | **Shipped**     | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; PR #2974 @ `9f623d9a`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                                     |

--- a/planning/spe-1046-file-work-queues-slice-1.md
+++ b/planning/spe-1046-file-work-queues-slice-1.md
@@ -1,0 +1,59 @@
+# SPE-1046 - File access work queues (slice 1)
+
+One-page implementation plan. Linear: new SPE-1046 child to be created/linked for broad file-access work queues. Follows [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526/spe-1046-facility-specific-file-workflows); [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                               |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | New SPE-1046 child - file access work queues                                                                                        |
+| **Status**          | **In Progress**                                                                                                                     |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog** |
+| **Branch**          | `spe-1046-file-work-queues-slice-1`                                                                                                 |
+| **Base `main` SHA** | `3242f52b`                                                                                                                          |
+
+## Goal
+
+Turn the existing per-person file access decisions into a read-only operations queue. In plain English: staff can now see which people need file access attention, whether access is blocked, restricted, allowed, or missing review, and why.
+
+## Scope
+
+| In                                                                                                    | Out                                   |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Derived file-access work queue in the existing affiliation person-status mirror view model            | New persistence fields                |
+| Queue buckets for `blocked`, `restricted`, `missing_review`, and `allowed`                            | Mission routing or deployment changes |
+| Stable priority ordering: blocked first, then restricted, missing review, allowed                     | Procurement changes                   |
+| Page surfacing with summary counts and reason-code labels                                             | Broad editable file workflow actions  |
+| Focused view-model and page tests covering queue counts, order, blocked, restricted, and missing refs | SPE-1046 parent closure               |
+
+## Acceptance
+
+- [x] File-access queue is derived from existing person-status snapshots only.
+- [x] Blocked, restricted, missing-review, and allowed buckets have stable labels.
+- [x] Queue priority orders blocked before restricted before missing-review before allowed.
+- [x] Missing linked welfare/file permission appears as missing review instead of fabricating access.
+- [x] Operations mirror shows queue counts and row-level reasons.
+- [x] No GameState schema or routing behavior changes.
+- [x] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npm.cmd run test:run -- src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/test/affiliationPersonStatusRecords.test.ts src/test/affiliationFacilityFileAccess.test.ts`
+- `npm.cmd run lint`
+- Direct Prettier check for touched files only.
+- Full `npm.cmd run test:run` before PR.
+
+## Deferred
+
+| Item                       | Owner                    | Why                                  |
+| -------------------------- | ------------------------ | ------------------------------------ |
+| Editable file work actions | SPE-1046 follow-up child | This slice is read-only surfacing.   |
+| Mission routing changes    | SPE-1046 follow-up child | Mission gates already shipped.       |
+| Procurement changes        | SPE-1046 follow-up child | Gear/procurement path already split. |
+| SPE-1046 parent closure    | SPE-1046                 | Parent acceptance remains broader.   |
+
+## See also
+
+- `planning/spe-1046-facility-file-access-workflows-slice-1.md`
+- `planning/spe-1046-file-access-enforcement-slice-1.md`
+- `planning/spe-1046-durable-person-status-surfacing-slice-1.md`
+- `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`
+- `planning/backlog.md`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1626,6 +1626,14 @@ export const AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT: Record<string, string> = 
   emptyTitle: 'No affiliation person-status records',
   emptyBody:
     'Persisted affiliation person-status records will appear here after hydration. This mirror does not re-validate dropped entries.',
+  fileAccessQueueHeading: 'File access work queue',
+  fileAccessQueueSubtitle:
+    'Read-only queue derived from existing file permission and site/facility clearance decisions.',
+  fileAccessQueueTotalLabel: 'Total',
+  fileAccessQueueBlockedLabel: 'Blocked',
+  fileAccessQueueRestrictedLabel: 'Restricted',
+  fileAccessQueueMissingLabel: 'Missing review',
+  fileAccessQueueStatusColumn: 'Queue status',
   recordsHeading: 'Persisted records',
   recordsSubtitle:
     'Projection labels compose existing SPE-1046 evaluators at read time; mission routing still uses explicit team and member tags.',

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -58,10 +58,20 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
 
     renderMirrorPage()
 
+    const queueRegion = screen.getByRole('region', {
+      name: /file access work queue/i,
+    })
     const recordsRegion = screen.getByRole('region', {
       name: /persisted affiliation person-status records/i,
     })
 
+    expect(queueRegion).toHaveTextContent('File access work queue')
+    expect(queueRegion).toHaveTextContent('Total 2')
+    expect(queueRegion).toHaveTextContent('Blocked 0')
+    expect(queueRegion).toHaveTextContent('Restricted 2')
+    expect(queueRegion).toHaveTextContent('Missing review 0')
+    expect(queueRegion).toHaveTextContent('Facility file access: Restricted')
+    expect(queueRegion).toHaveTextContent('Facility: Briefing Room')
     expect(recordsRegion).toHaveTextContent('Cooperative Contractor')
     expect(recordsRegion).toHaveTextContent('Rival Patron Risk')
     expect(recordsRegion).toHaveTextContent('Risk: Restricted')

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
@@ -98,122 +98,209 @@ export default function AffiliationPersonStatusMirrorPage() {
           <p className="text-sm opacity-70">{AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.emptyBody}</p>
         </article>
       ) : (
-        <article
-          className="panel panel-support space-y-3"
-          role="region"
-          aria-label="Persisted affiliation person-status records"
-        >
-          <div className="space-y-1">
-            <h3 className="text-lg font-semibold">
-              {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.recordsHeading}
-            </h3>
-            <p className="text-sm opacity-60">
-              {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.recordsSubtitle}
-            </p>
-          </div>
+        <>
+          <article
+            className="panel panel-support space-y-3"
+            role="region"
+            aria-label="File access work queue"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <h3 className="text-lg font-semibold">
+                  {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessQueueHeading}
+                </h3>
+                <p className="text-sm opacity-60">
+                  {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessQueueSubtitle}
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-right text-xs sm:grid-cols-4">
+                <p>
+                  {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessQueueTotalLabel}{' '}
+                  <span className="font-semibold">{view.summary.fileAccessWorkQueueCount}</span>
+                </p>
+                <p>
+                  {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessQueueBlockedLabel}{' '}
+                  <span className="font-semibold">{view.summary.fileAccessBlockedCount}</span>
+                </p>
+                <p>
+                  {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessQueueRestrictedLabel}{' '}
+                  <span className="font-semibold">{view.summary.fileAccessRestrictedCount}</span>
+                </p>
+                <p>
+                  {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessQueueMissingLabel}{' '}
+                  <span className="font-semibold">{view.summary.fileAccessMissingReviewCount}</span>
+                </p>
+              </div>
+            </div>
 
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm">
-              <thead>
-                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.subjectColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.linksColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.onboardingColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.permissionsColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.roomAccessColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.facilityFileAccessColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.housingAccessColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.siteClearanceColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.dualLoyaltyColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.protectedStatusColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.revocationColumn}
-                  </th>
-                  <th className="px-2 py-2">
-                    {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.reasonCodesColumn}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {view.records.map((record) => (
-                  <tr key={record.id} className="border-b border-white/5 align-top">
-                    <td className="px-2 py-2">
-                      <p className="font-medium">{record.subjectLabel}</p>
-                      <p className="text-xs opacity-55">{record.id}</p>
-                      <p className="text-xs opacity-45">{record.subjectId}</p>
-                    </td>
-                    <td className="px-2 py-2">
-                      <p className="text-xs opacity-55">
-                        {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.candidateRefPrefix}{' '}
-                        {record.candidateRefLabel}
-                      </p>
-                      <p className="text-xs opacity-55">
-                        {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.welfareRefPrefix}{' '}
-                        {record.entityWelfareReclassificationRefLabel}
-                      </p>
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.onboardingLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.permissionDecisionLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.roomAccessLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.fileAccessLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.facilityFileAccessLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.housingAccessLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.siteClearanceLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.dualLoyaltyLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.protectedStatusLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.revocationLabels} />
-                    </td>
-                    <td className="px-2 py-2">
-                      <LabelStack labels={record.reasonCodeLabels} />
-                    </td>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessQueueStatusColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.subjectColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.facilityFileAccessColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.siteClearanceColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.reasonCodesColumn}
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </article>
+                </thead>
+                <tbody>
+                  {view.fileAccessWorkQueue.map((entry) => (
+                    <tr key={entry.id} className="border-b border-white/5 align-top">
+                      <td className="px-2 py-2 font-medium">{entry.bucketLabel}</td>
+                      <td className="px-2 py-2">
+                        <p className="font-medium">{entry.subjectLabel}</p>
+                        <p className="text-xs opacity-55">{entry.id}</p>
+                        <p className="text-xs opacity-45">{entry.subjectId}</p>
+                      </td>
+                      <td className="px-2 py-2 text-xs opacity-55">{entry.fileAccessLabel}</td>
+                      <td className="px-2 py-2 text-xs opacity-55">
+                        {entry.facilityFileAccessLabel}
+                      </td>
+                      <td className="px-2 py-2">
+                        <p className="text-xs opacity-55">{entry.siteLabel}</p>
+                        <p className="text-xs opacity-55">{entry.facilityLabel}</p>
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={entry.reasonCodeLabels} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </article>
+
+          <article
+            className="panel panel-support space-y-3"
+            role="region"
+            aria-label="Persisted affiliation person-status records"
+          >
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold">
+                {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.recordsHeading}
+              </h3>
+              <p className="text-sm opacity-60">
+                {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.recordsSubtitle}
+              </p>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-white/10 text-left text-xs uppercase tracking-[0.18em] opacity-55">
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.subjectColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.linksColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.onboardingColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.permissionsColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.roomAccessColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.fileAccessColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.facilityFileAccessColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.housingAccessColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.siteClearanceColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.dualLoyaltyColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.protectedStatusColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.revocationColumn}
+                    </th>
+                    <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.reasonCodesColumn}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {view.records.map((record) => (
+                    <tr key={record.id} className="border-b border-white/5 align-top">
+                      <td className="px-2 py-2">
+                        <p className="font-medium">{record.subjectLabel}</p>
+                        <p className="text-xs opacity-55">{record.id}</p>
+                        <p className="text-xs opacity-45">{record.subjectId}</p>
+                      </td>
+                      <td className="px-2 py-2">
+                        <p className="text-xs opacity-55">
+                          {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.candidateRefPrefix}{' '}
+                          {record.candidateRefLabel}
+                        </p>
+                        <p className="text-xs opacity-55">
+                          {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.welfareRefPrefix}{' '}
+                          {record.entityWelfareReclassificationRefLabel}
+                        </p>
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.onboardingLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.permissionDecisionLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.roomAccessLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.fileAccessLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.facilityFileAccessLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.housingAccessLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.siteClearanceLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.dualLoyaltyLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.protectedStatusLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.revocationLabels} />
+                      </td>
+                      <td className="px-2 py-2">
+                        <LabelStack labels={record.reasonCodeLabels} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </>
       )}
     </section>
   )

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -87,6 +87,14 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     expect(view.summary.candidateLinkedCount).toBe(1)
     expect(view.summary.welfareLinkedCount).toBe(2)
     expect(view.summary.restrictedOrBlockedCount).toBe(2)
+    expect(view.summary.fileAccessWorkQueueCount).toBe(2)
+    expect(view.summary.fileAccessBlockedCount).toBe(0)
+    expect(view.summary.fileAccessRestrictedCount).toBe(2)
+    expect(view.summary.fileAccessMissingReviewCount).toBe(0)
+    expect(view.fileAccessWorkQueue.map((entry) => [entry.id, entry.bucketLabel])).toEqual([
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id, 'Restricted'],
+      [RESTRICTED_DUAL_LOYALTY_PERSON_STATUS_FIXTURE.id, 'Restricted'],
+    ])
     expect(view.records.map((record) => record.id)).toEqual([
       COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
       RESTRICTED_DUAL_LOYALTY_PERSON_STATUS_FIXTURE.id,
@@ -145,6 +153,21 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     expect(record?.facilityFileAccessLabels).toEqual(['Facility file access: -'])
     expect(record?.housingAccessLabels).toEqual(['Housing access: -'])
     expect(record?.onboardingLabels).toEqual(['Candidate: -', 'Access: -'])
+    expect(view.summary.fileAccessMissingReviewCount).toBe(1)
+    expect(view.fileAccessWorkQueue[0]).toMatchObject({
+      id: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      bucket: 'missing_review',
+      bucketLabel: 'Missing review',
+      fileAccessLabel: 'File access: -',
+      facilityFileAccessLabel: 'Facility file access: -',
+      siteLabel: 'Site: -',
+      facilityLabel: 'Facility: -',
+    })
+    expect(view.fileAccessWorkQueue[0]?.reasonCodeLabels).toEqual([
+      'missing_candidate_ref',
+      'missing_entity_welfare_reclassification_ref',
+      'missing_onboarding_clearance',
+    ])
   })
 
   it('surfaces blocked file access from linked SPE-1046 welfare decisions', () => {
@@ -175,6 +198,8 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     const record = view.records[0]
 
     expect(view.summary.restrictedOrBlockedCount).toBe(1)
+    expect(view.summary.fileAccessBlockedCount).toBe(1)
+    expect(view.fileAccessWorkQueue[0]?.bucketLabel).toBe('Blocked')
     expect(record?.fileAccessLabels).toEqual([
       'File access: Blocked',
       'Reasons: denied_reclassification_blocked',

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -30,12 +30,36 @@ export interface AffiliationPersonStatusMirrorSummaryView {
   welfareLinkedCount: number
   restrictedOrBlockedCount: number
   missingReferenceCount: number
+  fileAccessWorkQueueCount: number
+  fileAccessBlockedCount: number
+  fileAccessRestrictedCount: number
+  fileAccessMissingReviewCount: number
   week: number
+}
+
+export type AffiliationFileAccessWorkQueueBucket =
+  | 'blocked'
+  | 'restricted'
+  | 'missing_review'
+  | 'allowed'
+
+export interface AffiliationFileAccessWorkQueueEntryView {
+  id: string
+  subjectLabel: string
+  subjectId: string
+  bucket: AffiliationFileAccessWorkQueueBucket
+  bucketLabel: string
+  fileAccessLabel: string
+  facilityFileAccessLabel: string
+  siteLabel: string
+  facilityLabel: string
+  reasonCodeLabels: readonly string[]
 }
 
 export interface AffiliationPersonStatusMirrorView {
   isEmpty: boolean
   summary: AffiliationPersonStatusMirrorSummaryView
+  fileAccessWorkQueue: readonly AffiliationFileAccessWorkQueueEntryView[]
   records: readonly AffiliationPersonStatusMirrorRecordView[]
 }
 
@@ -191,6 +215,77 @@ function hasMissingReference(snapshot: AffiliationPersonStatusSnapshot) {
   return snapshot.reasonCodes.some((reasonCode) => reasonCode.startsWith('missing_'))
 }
 
+function formatFileAccessWorkQueueBucketLabel(bucket: AffiliationFileAccessWorkQueueBucket) {
+  switch (bucket) {
+    case 'blocked':
+      return 'Blocked'
+    case 'restricted':
+      return 'Restricted'
+    case 'missing_review':
+      return 'Missing review'
+    case 'allowed':
+      return 'Allowed'
+  }
+}
+
+function fileAccessWorkQueueBucketPriority(bucket: AffiliationFileAccessWorkQueueBucket) {
+  switch (bucket) {
+    case 'blocked':
+      return 0
+    case 'restricted':
+      return 1
+    case 'missing_review':
+      return 2
+    case 'allowed':
+      return 3
+  }
+}
+
+function fileAccessDecisionLabel(snapshot: AffiliationPersonStatusSnapshot) {
+  const decision = snapshot.permissionDecisions.find((candidate) => candidate.surface === 'file')
+  return decision ? `File access: ${decision.outcomeLabel}` : 'File access: -'
+}
+
+function toFileAccessWorkQueueEntry(
+  snapshot: AffiliationPersonStatusSnapshot
+): AffiliationFileAccessWorkQueueEntryView {
+  const decision = snapshot.facilityFileAccessDecision
+  const bucket: AffiliationFileAccessWorkQueueBucket = decision?.outcome ?? 'missing_review'
+  const reasonCodes = decision
+    ? decision.reasonCodes
+    : snapshot.reasonCodes.filter((reasonCode) => reasonCode.startsWith('missing_'))
+  const reasonCodeLabels =
+    reasonCodes.length > 0 ? reasonCodes : ['missing_facility_file_access_decision']
+
+  return Object.freeze({
+    id: snapshot.recordId,
+    subjectLabel: snapshot.subjectLabel,
+    subjectId: snapshot.subjectId,
+    bucket,
+    bucketLabel: formatFileAccessWorkQueueBucketLabel(bucket),
+    fileAccessLabel: fileAccessDecisionLabel(snapshot),
+    facilityFileAccessLabel: decision?.decisionLabel ?? 'Facility file access: -',
+    siteLabel: decision ? `Site: ${decision.siteLabel}` : 'Site: -',
+    facilityLabel: decision ? `Facility: ${decision.facilityLabel}` : 'Facility: -',
+    reasonCodeLabels: Object.freeze(reasonCodeLabels),
+  })
+}
+
+function buildFileAccessWorkQueue(
+  snapshots: readonly AffiliationPersonStatusSnapshot[]
+): readonly AffiliationFileAccessWorkQueueEntryView[] {
+  return Object.freeze(
+    snapshots
+      .map((snapshot) => toFileAccessWorkQueueEntry(snapshot))
+      .sort((left, right) => {
+        const bucketCompare =
+          fileAccessWorkQueueBucketPriority(left.bucket) -
+          fileAccessWorkQueueBucketPriority(right.bucket)
+        return bucketCompare !== 0 ? bucketCompare : left.id.localeCompare(right.id)
+      })
+  )
+}
+
 function toRecordView(
   snapshot: AffiliationPersonStatusSnapshot
 ): AffiliationPersonStatusMirrorRecordView {
@@ -237,6 +332,7 @@ export function getAffiliationPersonStatusMirrorView(
   })
   let restrictedOrBlockedCount = 0
   let missingReferenceCount = 0
+  const fileAccessWorkQueue = buildFileAccessWorkQueue(snapshots)
 
   for (const snapshot of snapshots) {
     if (hasRestrictedOrBlockedOutcome(snapshot)) {
@@ -257,8 +353,18 @@ export function getAffiliationPersonStatusMirrorView(
         .length,
       restrictedOrBlockedCount,
       missingReferenceCount,
+      fileAccessWorkQueueCount: fileAccessWorkQueue.length,
+      fileAccessBlockedCount: fileAccessWorkQueue.filter((entry) => entry.bucket === 'blocked')
+        .length,
+      fileAccessRestrictedCount: fileAccessWorkQueue.filter(
+        (entry) => entry.bucket === 'restricted'
+      ).length,
+      fileAccessMissingReviewCount: fileAccessWorkQueue.filter(
+        (entry) => entry.bucket === 'missing_review'
+      ).length,
       week: game.week,
     }),
+    fileAccessWorkQueue,
     records: Object.freeze(snapshots.map((snapshot) => toRecordView(snapshot))),
   })
 }


### PR DESCRIPTION
## Summary
- Adds a read-only file access work queue to the affiliation person-status operations mirror.
- Buckets existing file/facility access decisions as blocked, restricted, missing review, or allowed without new persistence or routing changes.
- Adds slice planning docs and refreshes backlog handoff after SPE-2526 shipped.

Linear: SPE-1046 parent https://linear.app/spectranoir/issue/SPE-1046
Slice doc: planning/spe-1046-file-work-queues-slice-1.md

Note: Linear issue creation/status tools were not exposed in this local connector session; start-of-work was commented on SPE-1046 and this PR should be attached to the new SPE-1046 child when created.

## Validation
- npm.cmd run test:run -- src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/test/affiliationPersonStatusRecords.test.ts src/test/affiliationFacilityFileAccess.test.ts
- npm.cmd run lint
- npx.cmd prettier --check src/features/operations/affiliationPersonStatusMirrorView.ts src/features/operations/AffiliationPersonStatusMirrorPage.tsx src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/data/copy.ts planning/spe-1046-file-work-queues-slice-1.md
- npm.cmd run test:run