### PR TITLE
SPE-1046 add file queue action recommendations

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -122,11 +122,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526/spe-1046-facility-specific-file-workflows) SPE-1046 facility-specific file workflows (slice 1) — durable person-status mirror derives read-only facility-file access from existing file permission and site/facility clearance decisions; PR #2980 @ `3242f52b`; see `planning/spe-1046-facility-file-access-workflows-slice-1.md`.
 
-**In progress:** SPE-1046 file access work queues (slice 1) — existing person-status/file/facility decisions are grouped into a read-only operations queue for blocked, restricted, missing-review, and allowed file-access situations; branch `spe-1046-file-work-queues-slice-1`; see `planning/spe-1046-file-work-queues-slice-1.md`.
+**Recently shipped:** SPE-1046 file access work queues (slice 1) — existing person-status/file/facility decisions are grouped into a read-only operations queue for blocked, restricted, missing-review, and allowed file-access situations; commit `af849277`; see `planning/spe-1046-file-work-queues-slice-1.md`.
 
-**Next step after file access work queues:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**In progress:** SPE-1046 file work queue action recommendations (slice 1) — existing file access work queue rows gain deterministic read-only recommended action guidance; branch `spe-1046-file-work-queue-action-recommendations-slice-1`; see `planning/spe-1046-file-work-queue-action-recommendations-slice-1.md`.
 
-**Base `main` SHA:** `3242f52b` — includes PR #2980 / SPE-2526 facility-specific file workflows.
+**Next step after file work queue action recommendations:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `af849277` — includes SPE-1046 file access work queues.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -271,7 +273,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-file-access-enforcement-slice-1.md`                             | **Shipped**     | [SPE-2524](https://linear.app/spectranoir/issue/SPE-2524) — durable person-status mirror exposes file-access outcomes from existing SPE-1046 permission decisions; PR #2976 @ `c5869e65`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-room-housing-access-enforcement-slice-1.md`                     | **Shipped**     | [SPE-2525](https://linear.app/spectranoir/issue/SPE-2525) — durable person-status mirror exposes room-access and housing-access outcomes from existing SPE-1046 permission decisions; PR #2978 @ `a6166182`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-facility-file-access-workflows-slice-1.md`                      | **Shipped**     | [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526) — durable person-status mirror derives facility-file access from existing file permission and site/facility clearance decisions; PR #2980 @ `3242f52b`; parent SPE-1046 stays **Backlog**. |
-| `spe-1046-file-work-queues-slice-1.md`                                     | **In Progress** | New SPE-1046 child — existing person-status/file/facility decisions feed a read-only operations work queue; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-file-work-queues-slice-1.md`                                     | **Shipped**     | New SPE-1046 child — existing person-status/file/facility decisions feed a read-only operations work queue; commit `af849277`; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-file-work-queue-action-recommendations-slice-1.md`               | **In Progress** | New SPE-1046 child — file access work queue rows gain deterministic read-only recommended action guidance; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-procurement-gear-access-slice-1.md`                             | **Shipped**     | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; PR #2974 @ `9f623d9a`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                                     |

--- a/planning/spe-1046-file-work-queue-action-recommendations-slice-1.md
+++ b/planning/spe-1046-file-work-queue-action-recommendations-slice-1.md
@@ -1,0 +1,61 @@
+# SPE-1046 - File work queue action recommendations (slice 1)
+
+One-page implementation plan. Linear: new SPE-1046 child to be created/linked for file work queue action recommendations. Follows `planning/spe-1046-file-work-queues-slice-1.md`; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                               |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | New SPE-1046 child - file work queue action recommendations                                                                         |
+| **Status**          | **In Progress**                                                                                                                     |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog** |
+| **Branch**          | `spe-1046-file-work-queue-action-recommendations-slice-1`                                                                           |
+| **Base `main` SHA** | `af849277`                                                                                                                          |
+
+## Goal
+
+Add deterministic read-only action guidance to the existing file access work queue. In plain English: staff can see what kind of follow-up each queue row needs without introducing editable file workflow actions or mutating state.
+
+## Scope
+
+| In                                                                                                 | Out                                   |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| Read-only recommended action kind, label, and detail on file access work queue rows                | New persistence fields                |
+| Stable mappings for missing-review, blocked, restricted, and allowed queue buckets                 | Editable file workflow actions        |
+| Operations mirror table column for recommended action guidance                                     | Mission routing or deployment changes |
+| Focused view-model and page tests covering mapping, rendered guidance, and existing queue ordering | Procurement changes                   |
+| Backlog handoff refresh showing file work queues shipped and this slice current                    | SPE-1046 parent closure               |
+
+## Acceptance
+
+- [x] File-access queue entries include deterministic recommended action kind, label, and detail.
+- [x] Missing-review rows recommend resolving missing candidate/welfare/onboarding/file/site evidence.
+- [x] Blocked rows recommend holding access until blocked file/site/facility reasons are resolved.
+- [x] Restricted rows recommend supervisor or review-gate handling before release.
+- [x] Allowed bucket mapping recommends monitoring only.
+- [x] Operations mirror shows recommended action guidance in the file access work queue.
+- [x] No GameState schema, routing, procurement, or editable workflow changes.
+- [x] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npm.cmd run test:run -- src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
+- `npm.cmd run lint`
+- Direct Prettier check for touched files only.
+- Full `npm.cmd run test:run` before PR.
+
+## Deferred
+
+| Item                       | Owner                    | Why                                  |
+| -------------------------- | ------------------------ | ------------------------------------ |
+| Editable file work actions | SPE-1046 follow-up child | This slice is read-only surfacing.   |
+| Mission routing changes    | SPE-1046 follow-up child | Mission gates already shipped.       |
+| Procurement changes        | SPE-1046 follow-up child | Gear/procurement path already split. |
+| SPE-1046 parent closure    | SPE-1046                 | Parent acceptance remains broader.   |
+
+## See also
+
+- `planning/spe-1046-file-work-queues-slice-1.md`
+- `planning/spe-1046-facility-file-access-workflows-slice-1.md`
+- `planning/spe-1046-file-access-enforcement-slice-1.md`
+- `planning/spe-1046-durable-person-status-surfacing-slice-1.md`
+- `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`
+- `planning/backlog.md`

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1634,6 +1634,7 @@ export const AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT: Record<string, string> = 
   fileAccessQueueRestrictedLabel: 'Restricted',
   fileAccessQueueMissingLabel: 'Missing review',
   fileAccessQueueStatusColumn: 'Queue status',
+  recommendedActionColumn: 'Recommended action',
   recordsHeading: 'Persisted records',
   recordsSubtitle:
     'Projection labels compose existing SPE-1046 evaluators at read time; mission routing still uses explicit team and member tags.',

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -70,6 +70,11 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
     expect(queueRegion).toHaveTextContent('Blocked 0')
     expect(queueRegion).toHaveTextContent('Restricted 2')
     expect(queueRegion).toHaveTextContent('Missing review 0')
+    expect(queueRegion).toHaveTextContent('Recommended action')
+    expect(queueRegion).toHaveTextContent('Route restricted review')
+    expect(queueRegion).toHaveTextContent(
+      'Supervisor or review-gate handling is required before any file release.'
+    )
     expect(queueRegion).toHaveTextContent('Facility file access: Restricted')
     expect(queueRegion).toHaveTextContent('Facility: Briefing Room')
     expect(recordsRegion).toHaveTextContent('Cooperative Contractor')

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
@@ -153,6 +153,9 @@ export default function AffiliationPersonStatusMirrorPage() {
                       {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.siteClearanceColumn}
                     </th>
                     <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.recommendedActionColumn}
+                    </th>
+                    <th className="px-2 py-2">
                       {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.reasonCodesColumn}
                     </th>
                   </tr>
@@ -173,6 +176,10 @@ export default function AffiliationPersonStatusMirrorPage() {
                       <td className="px-2 py-2">
                         <p className="text-xs opacity-55">{entry.siteLabel}</p>
                         <p className="text-xs opacity-55">{entry.facilityLabel}</p>
+                      </td>
+                      <td className="px-2 py-2">
+                        <p className="text-xs font-medium">{entry.recommendedActionLabel}</p>
+                        <p className="text-xs opacity-55">{entry.recommendedActionDetail}</p>
                       </td>
                       <td className="px-2 py-2">
                         <LabelStack labels={entry.reasonCodeLabels} />

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -9,7 +9,10 @@ import {
   PENDING_TO_APPROVED_FIXTURE,
 } from '../../domain/entityWelfareReclassificationRegistry'
 import type { Candidate } from '../../domain/recruitment'
-import { getAffiliationPersonStatusMirrorView } from './affiliationPersonStatusMirrorView'
+import {
+  getAffiliationPersonStatusMirrorView,
+  getFileAccessWorkQueueRecommendedAction,
+} from './affiliationPersonStatusMirrorView'
 
 function makeCandidate(overrides: Partial<Candidate> = {}): Candidate {
   return {
@@ -95,6 +98,12 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
       [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id, 'Restricted'],
       [RESTRICTED_DUAL_LOYALTY_PERSON_STATUS_FIXTURE.id, 'Restricted'],
     ])
+    expect(view.fileAccessWorkQueue[0]).toMatchObject({
+      recommendedActionKind: 'route_restricted_review',
+      recommendedActionLabel: 'Route restricted review',
+      recommendedActionDetail:
+        'Supervisor or review-gate handling is required before any file release.',
+    })
     expect(view.records.map((record) => record.id)).toEqual([
       COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
       RESTRICTED_DUAL_LOYALTY_PERSON_STATUS_FIXTURE.id,
@@ -162,6 +171,10 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
       facilityFileAccessLabel: 'Facility file access: -',
       siteLabel: 'Site: -',
       facilityLabel: 'Facility: -',
+      recommendedActionKind: 'resolve_missing_review',
+      recommendedActionLabel: 'Resolve missing review',
+      recommendedActionDetail:
+        'Attach missing candidate, welfare, onboarding, file, or site evidence before evaluating access.',
     })
     expect(view.fileAccessWorkQueue[0]?.reasonCodeLabels).toEqual([
       'missing_candidate_ref',
@@ -200,6 +213,12 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     expect(view.summary.restrictedOrBlockedCount).toBe(1)
     expect(view.summary.fileAccessBlockedCount).toBe(1)
     expect(view.fileAccessWorkQueue[0]?.bucketLabel).toBe('Blocked')
+    expect(view.fileAccessWorkQueue[0]).toMatchObject({
+      recommendedActionKind: 'hold_blocked_access',
+      recommendedActionLabel: 'Hold access',
+      recommendedActionDetail:
+        'Resolve blocked file, site, or facility reason before moving this file workflow forward.',
+    })
     expect(record?.fileAccessLabels).toEqual([
       'File access: Blocked',
       'Reasons: denied_reclassification_blocked',
@@ -246,5 +265,31 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     ])
     expect(record?.permissionDecisionLabels).toContain('Room: Restricted')
     expect(record?.permissionDecisionLabels).toContain('Housing: Restricted')
+  })
+
+  it('maps every file-access queue bucket to stable recommended action guidance', () => {
+    expect(getFileAccessWorkQueueRecommendedAction('missing_review')).toEqual({
+      recommendedActionKind: 'resolve_missing_review',
+      recommendedActionLabel: 'Resolve missing review',
+      recommendedActionDetail:
+        'Attach missing candidate, welfare, onboarding, file, or site evidence before evaluating access.',
+    })
+    expect(getFileAccessWorkQueueRecommendedAction('blocked')).toEqual({
+      recommendedActionKind: 'hold_blocked_access',
+      recommendedActionLabel: 'Hold access',
+      recommendedActionDetail:
+        'Resolve blocked file, site, or facility reason before moving this file workflow forward.',
+    })
+    expect(getFileAccessWorkQueueRecommendedAction('restricted')).toEqual({
+      recommendedActionKind: 'route_restricted_review',
+      recommendedActionLabel: 'Route restricted review',
+      recommendedActionDetail:
+        'Supervisor or review-gate handling is required before any file release.',
+    })
+    expect(getFileAccessWorkQueueRecommendedAction('allowed')).toEqual({
+      recommendedActionKind: 'monitor_allowed_access',
+      recommendedActionLabel: 'Monitor allowed access',
+      recommendedActionDetail: 'Audit visibility only; no intervention is required.',
+    })
   })
 })

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -43,6 +43,18 @@ export type AffiliationFileAccessWorkQueueBucket =
   | 'missing_review'
   | 'allowed'
 
+export type AffiliationFileAccessRecommendedActionKind =
+  | 'resolve_missing_review'
+  | 'hold_blocked_access'
+  | 'route_restricted_review'
+  | 'monitor_allowed_access'
+
+export interface AffiliationFileAccessRecommendedActionView {
+  recommendedActionKind: AffiliationFileAccessRecommendedActionKind
+  recommendedActionLabel: string
+  recommendedActionDetail: string
+}
+
 export interface AffiliationFileAccessWorkQueueEntryView {
   id: string
   subjectLabel: string
@@ -53,6 +65,9 @@ export interface AffiliationFileAccessWorkQueueEntryView {
   facilityFileAccessLabel: string
   siteLabel: string
   facilityLabel: string
+  recommendedActionKind: AffiliationFileAccessRecommendedActionKind
+  recommendedActionLabel: string
+  recommendedActionDetail: string
   reasonCodeLabels: readonly string[]
 }
 
@@ -241,6 +256,40 @@ function fileAccessWorkQueueBucketPriority(bucket: AffiliationFileAccessWorkQueu
   }
 }
 
+export function getFileAccessWorkQueueRecommendedAction(
+  bucket: AffiliationFileAccessWorkQueueBucket
+): AffiliationFileAccessRecommendedActionView {
+  switch (bucket) {
+    case 'missing_review':
+      return Object.freeze({
+        recommendedActionKind: 'resolve_missing_review',
+        recommendedActionLabel: 'Resolve missing review',
+        recommendedActionDetail:
+          'Attach missing candidate, welfare, onboarding, file, or site evidence before evaluating access.',
+      })
+    case 'blocked':
+      return Object.freeze({
+        recommendedActionKind: 'hold_blocked_access',
+        recommendedActionLabel: 'Hold access',
+        recommendedActionDetail:
+          'Resolve blocked file, site, or facility reason before moving this file workflow forward.',
+      })
+    case 'restricted':
+      return Object.freeze({
+        recommendedActionKind: 'route_restricted_review',
+        recommendedActionLabel: 'Route restricted review',
+        recommendedActionDetail:
+          'Supervisor or review-gate handling is required before any file release.',
+      })
+    case 'allowed':
+      return Object.freeze({
+        recommendedActionKind: 'monitor_allowed_access',
+        recommendedActionLabel: 'Monitor allowed access',
+        recommendedActionDetail: 'Audit visibility only; no intervention is required.',
+      })
+  }
+}
+
 function fileAccessDecisionLabel(snapshot: AffiliationPersonStatusSnapshot) {
   const decision = snapshot.permissionDecisions.find((candidate) => candidate.surface === 'file')
   return decision ? `File access: ${decision.outcomeLabel}` : 'File access: -'
@@ -256,6 +305,7 @@ function toFileAccessWorkQueueEntry(
     : snapshot.reasonCodes.filter((reasonCode) => reasonCode.startsWith('missing_'))
   const reasonCodeLabels =
     reasonCodes.length > 0 ? reasonCodes : ['missing_facility_file_access_decision']
+  const recommendedAction = getFileAccessWorkQueueRecommendedAction(bucket)
 
   return Object.freeze({
     id: snapshot.recordId,
@@ -267,6 +317,7 @@ function toFileAccessWorkQueueEntry(
     facilityFileAccessLabel: decision?.decisionLabel ?? 'Facility file access: -',
     siteLabel: decision ? `Site: ${decision.siteLabel}` : 'Site: -',
     facilityLabel: decision ? `Facility: ${decision.facilityLabel}` : 'Facility: -',
+    ...recommendedAction,
     reasonCodeLabels: Object.freeze(reasonCodeLabels),
   })
 }


### PR DESCRIPTION
## Linear

- Parent: SPE-1046 — Affiliation, clearance, and membership status system (stays Backlog)
- Slice child: Linear write tools were unavailable in this session; create/link child issue titled `SPE-1046 file work queue action recommendations` and keep it In Progress until merge.

## What shipped

- Added deterministic read-only recommended action guidance to file access work queue entries.
- Rendered a Recommended action column on the affiliation person-status operations mirror.
- Added slice planning doc and refreshed backlog handoff from file work queues to this slice.

## Validation

- `npm.cmd run test:run -- src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
- `npm.cmd run lint`
- `npx.cmd prettier --check src/features/operations/affiliationPersonStatusMirrorView.ts src/features/operations/AffiliationPersonStatusMirrorPage.tsx src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/data/copy.ts planning/spe-1046-file-work-queue-action-recommendations-slice-1.md`
- `npm.cmd run test:run`

## Docs updated

- `planning/spe-1046-file-work-queue-action-recommendations-slice-1.md`
- `planning/backlog.md`

## Parent status

- SPE-1046 remains Backlog; this is a child-only read-only surfacing slice.