### PR TITLE
SPE-2528 reconcile SPE-1046 status handoff

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -124,11 +124,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** SPE-1046 file access work queues (slice 1) — existing person-status/file/facility decisions are grouped into a read-only operations queue for blocked, restricted, missing-review, and allowed file-access situations; commit `af849277`; see `planning/spe-1046-file-work-queues-slice-1.md`.
 
-**In progress:** SPE-1046 file work queue action recommendations (slice 1) — existing file access work queue rows gain deterministic read-only recommended action guidance; branch `spe-1046-file-work-queue-action-recommendations-slice-1`; see `planning/spe-1046-file-work-queue-action-recommendations-slice-1.md`.
+**Recently shipped:** [SPE-2527](https://linear.app/spectranoir/issue/SPE-2527/spe-1046-file-work-queue-action-recommendations) SPE-1046 file work queue action recommendations (slice 1) — existing file access work queue rows gain deterministic read-only recommended action guidance; PR #2982 @ `67da21e2`; see `planning/spe-1046-file-work-queue-action-recommendations-slice-1.md`.
 
-**Next step after file work queue action recommendations:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**Recently shipped:** [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528/spe-1046-post-spe-2527-status-reconciliation) SPE-1046 post-SPE-2527 status reconciliation — parent Linear status and repo handoff hygiene after PR #2982; PR #2985; see `planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md`.
 
-**Base `main` SHA:** `af849277` — includes SPE-1046 file access work queues.
+**Next step after SPE-2528 reconciliation:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `67da21e2` — includes PR #2982 / SPE-2527 file work queue action recommendations.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -274,7 +276,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-room-housing-access-enforcement-slice-1.md`                     | **Shipped**     | [SPE-2525](https://linear.app/spectranoir/issue/SPE-2525) — durable person-status mirror exposes room-access and housing-access outcomes from existing SPE-1046 permission decisions; PR #2978 @ `a6166182`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-facility-file-access-workflows-slice-1.md`                      | **Shipped**     | [SPE-2526](https://linear.app/spectranoir/issue/SPE-2526) — durable person-status mirror derives facility-file access from existing file permission and site/facility clearance decisions; PR #2980 @ `3242f52b`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-file-work-queues-slice-1.md`                                     | **Shipped**     | New SPE-1046 child — existing person-status/file/facility decisions feed a read-only operations work queue; commit `af849277`; parent SPE-1046 stays **Backlog**. |
-| `spe-1046-file-work-queue-action-recommendations-slice-1.md`               | **In Progress** | New SPE-1046 child — file access work queue rows gain deterministic read-only recommended action guidance; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-file-work-queue-action-recommendations-slice-1.md`               | **Shipped**     | [SPE-2527](https://linear.app/spectranoir/issue/SPE-2527) — file access work queue rows gain deterministic read-only recommended action guidance; PR #2982 @ `67da21e2`; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-post-spe-2527-status-reconciliation-slice-1.md`                  | **Shipped**     | [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528) — parent Linear status and repo handoff hygiene after SPE-2527; PR #2985; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-procurement-gear-access-slice-1.md`                             | **Shipped**     | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; PR #2974 @ `9f623d9a`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                                     |

--- a/planning/spe-1046-file-work-queue-action-recommendations-slice-1.md
+++ b/planning/spe-1046-file-work-queue-action-recommendations-slice-1.md
@@ -1,14 +1,15 @@
 # SPE-1046 - File work queue action recommendations (slice 1)
 
-One-page implementation plan. Linear: new SPE-1046 child to be created/linked for file work queue action recommendations. Follows `planning/spe-1046-file-work-queues-slice-1.md`; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+One-page implementation plan. Linear: [SPE-2527](https://linear.app/spectranoir/issue/SPE-2527/spe-1046-file-work-queue-action-recommendations) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows `planning/spe-1046-file-work-queues-slice-1.md`; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
 
-| Field               | Value                                                                                                                               |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| **Linear**          | New SPE-1046 child - file work queue action recommendations                                                                         |
-| **Status**          | **In Progress**                                                                                                                     |
-| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog** |
-| **Branch**          | `spe-1046-file-work-queue-action-recommendations-slice-1`                                                                           |
-| **Base `main` SHA** | `af849277`                                                                                                                          |
+| Field               | Value                                                                                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2527 - SPE-1046 file work queue action recommendations](https://linear.app/spectranoir/issue/SPE-2527/spe-1046-file-work-queue-action-recommendations) |
+| **Status**          | **Shipped**                                                                                                                                                 |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                         |
+| **Branch**          | `spe-1046-file-work-queue-action-recommendations-slice-1`                                                                                                   |
+| **Base `main` SHA** | `af849277`                                                                                                                                                  |
+| **PR**              | [#2982](https://github.com/JamesJedi420/containment-protocol/pull/2982)                                                                                     |
 
 ## Goal
 

--- a/planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md
+++ b/planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md
@@ -1,0 +1,52 @@
+# SPE-1046 - Post-SPE-2527 status reconciliation (slice 1)
+
+One-page hygiene record. Linear: [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528/spe-1046-post-spe-2527-status-reconciliation) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2527](https://linear.app/spectranoir/issue/SPE-2527/spe-1046-file-work-queue-action-recommendations); [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2528 - SPE-1046 post-SPE-2527 status reconciliation](https://linear.app/spectranoir/issue/SPE-2528/spe-1046-post-spe-2527-status-reconciliation) |
+| **Status**          | **Shipped**                                                                                                                                           |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                   |
+| **Branch**          | `spe-2528-post-spe-2527-status-reconciliation`                                                                                                        |
+| **Base `main` SHA** | `67da21e2`                                                                                                                                            |
+| **PR**              | [#2985](https://github.com/JamesJedi420/containment-protocol/pull/2985)                                                                               |
+
+## Goal
+
+Reconcile the post-merge handoff after SPE-2527 / PR #2982 so Linear and repo planning agree that file work queue action recommendations shipped as a child-only slice while the broader SPE-1046 parent remains open.
+
+## Scope
+
+| In                                                                              | Out                            |
+| ------------------------------------------------------------------------------- | ------------------------------ |
+| Move SPE-1046 parent status back to Backlog on Linear                           | Gameplay or app code           |
+| Parent Linear comment explaining SPE-2527 shipped child-only scope              | SPE-947 propagation work       |
+| Backlog handoff update: SPE-2527 shipped, SPE-2528 current, base SHA `67da21e2` | Editable file workflow actions |
+| SPE-2527 slice doc update to link the actual Linear child and PR #2982          | Marking SPE-1046 Done          |
+
+## Acceptance
+
+- [x] SPE-1046 parent is Backlog on Linear.
+- [x] SPE-1046 parent comment records SPE-2527 / PR #2982 as child-only scope.
+- [x] `planning/backlog.md` marks SPE-2527 shipped and SPE-2528 current.
+- [x] `planning/spe-1046-file-work-queue-action-recommendations-slice-1.md` links SPE-2527 and PR #2982.
+- [x] No application code changes.
+
+## Validation
+
+- `npx.cmd prettier --check planning/backlog.md planning/spe-1046-file-work-queue-action-recommendations-slice-1.md planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md`
+- `npm.cmd run lint`
+
+## Deferred
+
+| Item                                        | Owner          | Why                                     |
+| ------------------------------------------- | -------------- | --------------------------------------- |
+| SPE-1046 non-mission enforcement follow-ons | SPE-1046 child | This slice is status/docs hygiene only. |
+| SPE-947 propagation follow-ons              | SPE-947 child  | Separate owner reprioritization lane.   |
+| SPE-1046 parent closure                     | SPE-1046       | Broader parent acceptance remains open. |
+
+## See also
+
+- `planning/spe-1046-file-work-queue-action-recommendations-slice-1.md`
+- `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`
+- `planning/backlog.md`


### PR DESCRIPTION
## Summary
- reconcile SPE-1046 handoff after SPE-2527 / PR #2982
- mark SPE-2527 file work queue action recommendations as shipped in planning docs
- add SPE-2528 hygiene slice doc while keeping parent SPE-1046 Backlog

Linear: SPE-2528
Parent: SPE-1046 remains Backlog

## Validation
- `npx.cmd prettier --check planning/spe-1046-file-work-queue-action-recommendations-slice-1.md planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md`
- `npm.cmd run lint`
- `git diff --check`

Note: the requested Prettier check including `planning/backlog.md` still hits pre-existing formatting drift in that long backlog table, so this PR keeps the docs hygiene diff scoped instead of reformatting the whole file.