### PR TITLE
SPE-2529 add file work queue action ledger

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -128,9 +128,11 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528/spe-1046-post-spe-2527-status-reconciliation) SPE-1046 post-SPE-2527 status reconciliation — parent Linear status and repo handoff hygiene after PR #2982; PR #2985; see `planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md`.
 
-**Next step after SPE-2528 reconciliation:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**In progress:** [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529/spe-1046-file-work-queue-operator-action-ledger) SPE-1046 file work queue operator action ledger (slice 1) — persisted deterministic operator acknowledgements for existing file access work queue recommendations; branch `spe-1046-file-work-queue-operator-action-ledger-slice-1`; see `planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md`.
 
-**Base `main` SHA:** `67da21e2` — includes PR #2982 / SPE-2527 file work queue action recommendations.
+**Next step after SPE-2529:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `b84a1fc5` — includes PR #2985 / SPE-2528 status reconciliation.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -278,6 +280,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-file-work-queues-slice-1.md`                                     | **Shipped**     | New SPE-1046 child — existing person-status/file/facility decisions feed a read-only operations work queue; commit `af849277`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-file-work-queue-action-recommendations-slice-1.md`               | **Shipped**     | [SPE-2527](https://linear.app/spectranoir/issue/SPE-2527) — file access work queue rows gain deterministic read-only recommended action guidance; PR #2982 @ `67da21e2`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-post-spe-2527-status-reconciliation-slice-1.md`                  | **Shipped**     | [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528) — parent Linear status and repo handoff hygiene after SPE-2527; PR #2985; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-file-work-queue-operator-action-ledger-slice-1.md`                | **In Progress** | [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529) — persisted deterministic operator acknowledgements for existing file access work queue recommendations; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-procurement-gear-access-slice-1.md`                             | **Shipped**     | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; PR #2974 @ `9f623d9a`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                                     |

--- a/planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md
+++ b/planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md
@@ -1,0 +1,57 @@
+# SPE-1046 - File work queue operator action ledger (slice 1)
+
+One-page implementation plan. Linear: [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529/spe-1046-file-work-queue-operator-action-ledger) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2527](https://linear.app/spectranoir/issue/SPE-2527/spe-1046-file-work-queue-action-recommendations) and [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528/spe-1046-post-spe-2527-status-reconciliation); [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2529 - SPE-1046 file work queue operator action ledger](https://linear.app/spectranoir/issue/SPE-2529/spe-1046-file-work-queue-operator-action-ledger) |
+| **Status**          | **In Progress**                                                                                                                                             |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                         |
+| **Branch**          | `spe-1046-file-work-queue-operator-action-ledger-slice-1`                                                                                                   |
+| **Base `main` SHA** | `b84a1fc5`                                                                                                                                                  |
+
+## Goal
+
+Persist deterministic operator acknowledgements for file access work queue recommended actions without changing the underlying access decisions.
+
+## Scope
+
+| In                                                            | Out                                    |
+| ------------------------------------------------------------- | -------------------------------------- |
+| Sanitized `affiliationFileWorkQueueActionRecords` ledger      | Resolving missing evidence             |
+| Store action to record the current queue row recommendation   | Releasing files or editing workflows   |
+| File access work queue action-status column and record button | Mission routing or procurement changes |
+| Focused persistence, store, view-model, and page tests        | Weekly progression changes             |
+
+## Acceptance
+
+- [ ] Action records hydrate/export as optional GameState persistence.
+- [ ] Invalid, mismatched-key, and malformed action records are dropped on hydrate.
+- [ ] Store action upserts one deterministic record for the current queue entry and recommended action.
+- [ ] Missing-entry store calls no-op.
+- [ ] Operations mirror shows unrecorded rows with a record button and recorded rows with `Recorded W{week}`.
+- [ ] No mutation to `affiliationPersonStatusRecords`, clearance outcomes, mission routing, procurement, or weekly progression.
+- [ ] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npm.cmd run test:run -- src/test/affiliationFileWorkQueueActionRecords.test.ts src/app/store/gameStore.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
+- `npm.cmd run lint`
+- Touched-file Prettier check.
+- Full `npm.cmd run test:run` before PR.
+
+## Deferred
+
+| Item                          | Owner                    | Why                                                     |
+| ----------------------------- | ------------------------ | ------------------------------------------------------- |
+| Evidence resolution workflows | SPE-1046 follow-up child | This slice records acknowledgement only.                |
+| File release workflow actions | SPE-1046 follow-up child | Access decisions remain derived from existing evidence. |
+| SPE-947 propagation work      | SPE-947 child            | Separate parent thread.                                 |
+| SPE-1046 parent closure       | SPE-1046                 | Broader parent acceptance remains open.                 |
+
+## See also
+
+- `planning/spe-1046-file-work-queue-action-recommendations-slice-1.md`
+- `planning/spe-1046-file-work-queues-slice-1.md`
+- `planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -49,6 +49,12 @@ import { createSquadKitTemplate } from '../../domain/squadKitTemplate'
 import { assignSquadKit } from '../../domain/squadKitAssignment'
 import { buildReplacementPressureState } from '../../domain/agent/attrition'
 import { recomputeMissionRouting } from '../../domain/missionIntakeRouting'
+import { COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE } from '../../domain/affiliationPersonStatusRecords'
+import {
+  HOSTILE_TO_COOPERATIVE_FIXTURE,
+  PENDING_TO_APPROVED_FIXTURE,
+} from '../../domain/entityWelfareReclassificationRegistry'
+import { buildAffiliationFileWorkQueueActionRecordId } from '../../domain/affiliationFileWorkQueueActionRecords'
 
 const STORE_KEY = 'containment-protocol-game-state'
 
@@ -179,7 +185,9 @@ describe('gameStore', () => {
 
     expect(useGameStore.getState().game).toBe(afterFirstAsk)
 
-    useGameStore.getState().askInvestigationQuestion('missing-case', 'forensic', 'forensic.present-signature')
+    useGameStore
+      .getState()
+      .askInvestigationQuestion('missing-case', 'forensic', 'forensic.present-signature')
 
     expect(useGameStore.getState().game).toBe(afterFirstAsk)
 
@@ -218,7 +226,9 @@ describe('gameStore', () => {
       status: 'in_progress',
       hiddenState: 'hidden',
       tags: ['infiltration'],
-      infiltrationProbePlan: copyInfiltrationProbePlan(caseTemplateMap['ops-004'].infiltrationProbePlan),
+      infiltrationProbePlan: copyInfiltrationProbePlan(
+        caseTemplateMap['ops-004'].infiltrationProbePlan
+      ),
       requiredTags: [],
       preferredTags: [],
       assignedTeamIds: [],
@@ -226,16 +236,20 @@ describe('gameStore', () => {
 
     useGameStore.setState({ game })
 
-    useGameStore.getState().setInfiltrationWeeklyProbeAction('case-infiltration-store', 'probe_route')
+    useGameStore
+      .getState()
+      .setInfiltrationWeeklyProbeAction('case-infiltration-store', 'probe_route')
 
     expect(
-      useGameStore.getState().game.cases['case-infiltration-store']?.infiltrationWeeklyProbeActionOverride
+      useGameStore.getState().game.cases['case-infiltration-store']
+        ?.infiltrationWeeklyProbeActionOverride
     ).toBe('probe_route')
 
     useGameStore.getState().setInfiltrationWeeklyProbeAction('case-infiltration-store', null)
 
     expect(
-      useGameStore.getState().game.cases['case-infiltration-store']?.infiltrationWeeklyProbeActionOverride
+      useGameStore.getState().game.cases['case-infiltration-store']
+        ?.infiltrationWeeklyProbeActionOverride
     ).toBeUndefined()
 
     useGameStore.getState().setInfiltrationWeeklyProbeAction('missing-case', 'cleanup')
@@ -247,7 +261,9 @@ describe('gameStore', () => {
     useGameStore.getState().assign('case-001', 't_nightwatch')
 
     expect(useGameStore.getState().game.cases['case-001'].assignedTeamIds).toEqual(['t_nightwatch'])
-    expect(getTeamAssignedCaseId(useGameStore.getState().game.teams['t_nightwatch'])).toBe('case-001')
+    expect(getTeamAssignedCaseId(useGameStore.getState().game.teams['t_nightwatch'])).toBe(
+      'case-001'
+    )
 
     useGameStore.getState().unassign('case-001', 't_nightwatch')
 
@@ -290,8 +306,12 @@ describe('gameStore', () => {
     useGameStore.getState().advanceWeek()
 
     const next = useGameStore.getState().game
-    const baselineShortfalls = Object.values(baselineResult.cases).filter((currentCase) => currentCase.supportShortfall)
-    const nextShortfalls = Object.values(next.cases).filter((currentCase) => currentCase.supportShortfall)
+    const baselineShortfalls = Object.values(baselineResult.cases).filter(
+      (currentCase) => currentCase.supportShortfall
+    )
+    const nextShortfalls = Object.values(next.cases).filter(
+      (currentCase) => currentCase.supportShortfall
+    )
 
     expect(nextShortfalls).toHaveLength(0)
     expect(baselineShortfalls).toHaveLength(2)
@@ -354,7 +374,9 @@ describe('gameStore', () => {
       consumedOneShots: ['frontdesk.tutorial.weekly-report'],
     })
     expect(
-      useGameStore.getState().game.runtimeState?.globalFlags['frontdesk.tutorial.weekly-report.acknowledged']
+      useGameStore.getState().game.runtimeState?.globalFlags[
+        'frontdesk.tutorial.weekly-report.acknowledged'
+      ]
     ).toBe(true)
     expect(useGameStore.getState().game.runtimeState?.ui.debug.eventLog).toEqual(
       expect.arrayContaining([
@@ -367,12 +389,12 @@ describe('gameStore', () => {
   })
 
   it('logs one-shot consumption only once when repeat-trigger prevention holds', () => {
-    expect(useGameStore.getState().consumeOneShotContent('frontdesk.warning.weekly-report', 'frontdesk')).toBe(
-      true
-    )
-    expect(useGameStore.getState().consumeOneShotContent('frontdesk.warning.weekly-report', 'frontdesk')).toBe(
-      false
-    )
+    expect(
+      useGameStore.getState().consumeOneShotContent('frontdesk.warning.weekly-report', 'frontdesk')
+    ).toBe(true)
+    expect(
+      useGameStore.getState().consumeOneShotContent('frontdesk.warning.weekly-report', 'frontdesk')
+    ).toBe(false)
 
     const oneShotLogs = (useGameStore.getState().game.runtimeState?.ui.debug.eventLog ?? []).filter(
       (entry) => entry.type === 'one_shot.consumed'
@@ -401,15 +423,20 @@ describe('gameStore', () => {
     expect(firstId).toBe('qevt-0001')
     expect(secondId).toBe('qevt-0002')
     expect(useGameStore.getState().peekRuntimeEvent()).toBe('qevt-0001')
-    expect(useGameStore.getState().listRuntimeEventQueue().map((entry) => entry.targetId)).toEqual([
-      'followup.alpha',
-      'followup.beta',
-    ])
+    expect(
+      useGameStore
+        .getState()
+        .listRuntimeEventQueue()
+        .map((entry) => entry.targetId)
+    ).toEqual(['followup.alpha', 'followup.beta'])
 
     expect(useGameStore.getState().dequeueRuntimeEvent()).toBe('qevt-0001')
-    expect(useGameStore.getState().listRuntimeEventQueue().map((entry) => entry.targetId)).toEqual([
-      'followup.beta',
-    ])
+    expect(
+      useGameStore
+        .getState()
+        .listRuntimeEventQueue()
+        .map((entry) => entry.targetId)
+    ).toEqual(['followup.beta'])
 
     expect(useGameStore.getState().clearRuntimeEventQueue()).toBe(1)
     expect(useGameStore.getState().listRuntimeEventQueue()).toEqual([])
@@ -572,9 +599,12 @@ describe('gameStore', () => {
       value: 1,
       max: 3,
     })
-    expect(useGameStore.getState().listRuntimeEventQueue().map((entry) => entry.targetId)).toContain(
-      'frontdesk.encounter.alpha.after-action'
-    )
+    expect(
+      useGameStore
+        .getState()
+        .listRuntimeEventQueue()
+        .map((entry) => entry.targetId)
+    ).toContain('frontdesk.encounter.alpha.after-action')
 
     const logs = game.runtimeState?.ui.debug.eventLog ?? []
     expect(logs).toEqual(
@@ -752,7 +782,9 @@ describe('gameStore', () => {
 
     useGameStore.setState({ game: initial })
 
-    expect(useGameStore.getState().contactCandidate('cand-funnel-store', 'initial outreach')).toBe(true)
+    expect(useGameStore.getState().contactCandidate('cand-funnel-store', 'initial outreach')).toBe(
+      true
+    )
     expect(useGameStore.getState().screenCandidate('cand-funnel-store', 'screen packet')).toBe(true)
 
     expect(useGameStore.getState().game.candidates[0]).toMatchObject({
@@ -793,8 +825,12 @@ describe('gameStore', () => {
 
     useGameStore.setState({ game: equipped })
 
-    const storeApplied = useGameStore.getState().applyPreparedSupportProcedure('case-001', 'a_casey')
-    const storeRefreshed = useGameStore.getState().refreshPreparedSupportProcedure('case-001', 'a_casey')
+    const storeApplied = useGameStore
+      .getState()
+      .applyPreparedSupportProcedure('case-001', 'a_casey')
+    const storeRefreshed = useGameStore
+      .getState()
+      .refreshPreparedSupportProcedure('case-001', 'a_casey')
 
     expect(storeApplied).toMatchObject({
       applied: true,
@@ -1373,7 +1409,9 @@ describe('gameStore persistence', () => {
 
     expect(next.agents['a_kellan']!.attritionState).toBeUndefined()
     expect(next.deploymentMomentum?.stacks).toBe(0)
-    expect(next.deploymentMomentum?.lastSummary).toContain('Chapter break cleared deployment momentum')
+    expect(next.deploymentMomentum?.lastSummary).toContain(
+      'Chapter break cleared deployment momentum'
+    )
     expect(next.replacementPressureState).toEqual(buildReplacementPressureState(next))
     expect(next.missionRouting).toEqual(recomputeMissionRouting(next))
     expect(next.teams.t_nightwatch?.deploymentReadinessState).toBeDefined()
@@ -1591,6 +1629,102 @@ describe('gameStore persistence', () => {
       durationModel: 'attrition',
     })
     expect(useGameStore.getState().game.templates).toEqual(caseTemplateMap)
+  })
+})
+
+describe('affiliation file work queue action ledger store action (SPE-2529 slice 1)', () => {
+  it('records deterministic operator actions for reachable queue recommendation kinds', () => {
+    const game = createStartingState()
+    game.week = 9
+    const blockedWelfareRecord = {
+      ...HOSTILE_TO_COOPERATIVE_FIXTURE,
+      id: 'reclass:file-blocked',
+      label: 'Blocked file custody',
+      proposedDisposition: 'hostile',
+      reclassificationState: 'denied',
+    } as const
+    game.entityWelfareReclassificationRecords = {
+      [PENDING_TO_APPROVED_FIXTURE.id]: PENDING_TO_APPROVED_FIXTURE,
+      [blockedWelfareRecord.id]: blockedWelfareRecord,
+    }
+    game.affiliationPersonStatusRecords = {
+      'person-status:missing-review': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:missing-review',
+        subjectId: 'subject:missing-review',
+        subjectLabel: 'Missing Review Subject',
+        candidateRef: 'candidate:missing',
+        entityWelfareReclassificationRef: 'reclass:missing',
+      },
+      'person-status:file-blocked': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:file-blocked',
+        subjectId: 'subject:file-blocked',
+        subjectLabel: 'File Blocked Subject',
+        candidateRef: undefined,
+        entityWelfareReclassificationRef: 'reclass:file-blocked',
+        permissionSurface: 'file',
+      },
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        entityWelfareReclassificationRef: PENDING_TO_APPROVED_FIXTURE.id,
+      },
+    }
+    const originalPersonStatusRecords = game.affiliationPersonStatusRecords
+
+    useGameStore.setState({ game })
+
+    useGameStore.getState().recordAffiliationFileWorkQueueAction('person-status:missing-review')
+    useGameStore.getState().recordAffiliationFileWorkQueueAction('person-status:file-blocked')
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueAction(COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id)
+
+    const next = useGameStore.getState().game
+    const missingId = buildAffiliationFileWorkQueueActionRecordId({
+      workQueueEntryId: 'person-status:missing-review',
+      actionKind: 'resolve_missing_review',
+    })
+    const blockedId = buildAffiliationFileWorkQueueActionRecordId({
+      workQueueEntryId: 'person-status:file-blocked',
+      actionKind: 'hold_blocked_access',
+    })
+    const restrictedId = buildAffiliationFileWorkQueueActionRecordId({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      actionKind: 'route_restricted_review',
+    })
+
+    expect(next.affiliationFileWorkQueueActionRecords?.[missingId]).toMatchObject({
+      id: missingId,
+      workQueueEntryId: 'person-status:missing-review',
+      subjectId: 'subject:missing-review',
+      subjectLabel: 'Missing Review Subject',
+      actionKind: 'resolve_missing_review',
+      actionLabel: 'Resolve missing review',
+      sourceBucket: 'missing_review',
+      recordedWeek: 9,
+    })
+    expect(next.affiliationFileWorkQueueActionRecords?.[blockedId]).toMatchObject({
+      actionKind: 'hold_blocked_access',
+      actionLabel: 'Hold access',
+      sourceBucket: 'blocked',
+      recordedWeek: 9,
+    })
+    expect(next.affiliationFileWorkQueueActionRecords?.[restrictedId]).toMatchObject({
+      actionKind: 'route_restricted_review',
+      actionLabel: 'Route restricted review',
+      sourceBucket: 'restricted',
+      recordedWeek: 9,
+    })
+    expect(next.affiliationPersonStatusRecords).toBe(originalPersonStatusRecords)
+  })
+
+  it('no-ops when the requested work queue entry is absent', () => {
+    const before = useGameStore.getState().game
+
+    useGameStore.getState().recordAffiliationFileWorkQueueAction('person-status:missing')
+
+    expect(useGameStore.getState().game).toBe(before)
   })
 })
 

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -153,6 +153,8 @@ import {
 } from '../../domain/missionIntakeRouting'
 import { evaluateDeploymentEligibility } from '../../domain/deploymentReadiness'
 import { reconcileAgents } from '../../domain/sim/reconciliation'
+import { buildAffiliationFileWorkQueueActionRecord } from '../../domain/affiliationFileWorkQueueActionRecords'
+import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
 import {
   clearContractNextIntent,
   launchContract as launchContractDomain,
@@ -255,20 +257,14 @@ interface GameStore {
     questionId: string
   ) => void
   /** SPE-521 deferred UX: override or clear weekly infiltration probe action on an eligible case. */
-  setInfiltrationWeeklyProbeAction: (
-    caseId: Id,
-    action: InfiltrationProbeAction | null
-  ) => void
+  setInfiltrationWeeklyProbeAction: (caseId: Id, action: InfiltrationProbeAction | null) => void
   /** SPE-521 follow-up: set or clear infiltration encounter cover stance on an eligible case. */
   setInfiltrationEncounterCoverStance: (
     caseId: Id,
     stance: InfiltrationEncounterCoverStance | null
   ) => void
   /** SPE-861 slice 4: set disclosure posture choice on an active disclosure campaign record. */
-  setPublicDisclosurePostureChoice: (
-    recordId: Id,
-    posture: PublicDisclosurePostureChoice
-  ) => void
+  setPublicDisclosurePostureChoice: (recordId: Id, posture: PublicDisclosurePostureChoice) => void
   hireCandidate: (candidateId: Id) => void
   scoutCandidate: (candidateId: Id) => void
   transitionCandidateFunnel: (
@@ -333,6 +329,7 @@ interface GameStore {
   ) => ReturnType<typeof evaluateDeploymentEligibility> | null
   assignMissionTeam: (missionId: Id, teamId: Id) => boolean
   rallySupportStaff: (amount?: number) => ReturnType<typeof applyRallySupportStaffAction>['note']
+  recordAffiliationFileWorkQueueAction: (entryId: string) => void
   advanceWeek: () => void
   setSeed: (seed: number) => void
   setSquadMetadata: (metadata: SquadMetadata) => void
@@ -1165,8 +1162,7 @@ export const useGameStore = create<GameStore>()(
       setContractNextIntent: (intent) =>
         set((s) => ({ game: setContractNextIntent(s.game, intent) })),
 
-      clearContractNextIntent: () =>
-        set((s) => ({ game: clearContractNextIntent(s.game) })),
+      clearContractNextIntent: () => set((s) => ({ game: clearContractNextIntent(s.game) })),
 
       launchMajorIncident: (caseId, teamIds, strategy = 'balanced', provisions = []) =>
         set((s) => ({
@@ -1692,6 +1688,37 @@ export const useGameStore = create<GameStore>()(
 
       applyRotatingRosterContinuityReconciliation: () =>
         set((s) => ({ game: applyRotatingRosterContinuityReconciliation(s.game) })),
+
+      recordAffiliationFileWorkQueueAction: (entryId) =>
+        set((s) => {
+          const view = getAffiliationPersonStatusMirrorView(s.game)
+          const entry = view.fileAccessWorkQueue.find((candidate) => candidate.id === entryId)
+
+          if (!entry) {
+            return { game: s.game }
+          }
+
+          const record = buildAffiliationFileWorkQueueActionRecord({
+            workQueueEntryId: entry.id,
+            subjectId: entry.subjectId,
+            subjectLabel: entry.subjectLabel,
+            actionKind: entry.recommendedActionKind,
+            actionLabel: entry.recommendedActionLabel,
+            sourceBucket: entry.bucket,
+            sourceReasonCodes: entry.reasonCodeLabels,
+            recordedWeek: s.game.week,
+          })
+
+          return {
+            game: {
+              ...s.game,
+              affiliationFileWorkQueueActionRecords: {
+                ...(s.game.affiliationFileWorkQueueActionRecords ?? {}),
+                [record.id]: record,
+              },
+            },
+          }
+        }),
 
       reset: () => set({ game: createStartingState() }),
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -213,6 +213,7 @@ import { sanitizePublishQueueExecutionReceipts } from '../../domain/publishQueue
 import { sanitizeModifiableDataPackRecords } from '../../domain/modifiableDataPackValidation'
 import { sanitizeMassAnomalousPopulationEmergenceRecords } from '../../domain/massAnomalousPopulationEmergenceRegistry'
 import { sanitizeAffiliationPersonStatusRecords } from '../../domain/affiliationPersonStatusRecords'
+import { sanitizeAffiliationFileWorkQueueActionRecords } from '../../domain/affiliationFileWorkQueueActionRecords'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
 import { sanitizeCustodyStatusRecords } from '../../domain/containedPersonCustodyStatusRegistry'
@@ -8736,6 +8737,10 @@ export function hydrateGame(
     game.affiliationPersonStatusRecords,
     fallback.affiliationPersonStatusRecords ?? {}
   )
+  const affiliationFileWorkQueueActionRecords = sanitizeAffiliationFileWorkQueueActionRecords(
+    game.affiliationFileWorkQueueActionRecords,
+    fallback.affiliationFileWorkQueueActionRecords ?? {}
+  )
   const entityWelfareReclassificationRecords = sanitizeEntityWelfareReclassificationRecords(
     game.entityWelfareReclassificationRecords,
     fallback.entityWelfareReclassificationRecords ?? {}
@@ -8930,6 +8935,7 @@ export function hydrateGame(
     massAnomalousPopulationEmergenceRecords,
     visualTriggerHazardRecords,
     affiliationPersonStatusRecords,
+    affiliationFileWorkQueueActionRecords,
     entityWelfareReclassificationRecords,
     containedPersonTherapeuticCareRecords,
     containedPersonMedicationRegimenRecords,

--- a/src/data/copy.ts
+++ b/src/data/copy.ts
@@ -1635,6 +1635,9 @@ export const AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT: Record<string, string> = 
   fileAccessQueueMissingLabel: 'Missing review',
   fileAccessQueueStatusColumn: 'Queue status',
   recommendedActionColumn: 'Recommended action',
+  actionStatusColumn: 'Action status',
+  recordActionButtonLabel: 'Record action',
+  pendingActionStatusLabel: 'Not recorded',
   recordsHeading: 'Persisted records',
   recordsSubtitle:
     'Projection labels compose existing SPE-1046 evaluators at read time; mission routing still uses explicit team and member tags.',

--- a/src/domain/affiliationFileWorkQueueActionRecords.ts
+++ b/src/domain/affiliationFileWorkQueueActionRecords.ts
@@ -1,0 +1,192 @@
+export type AffiliationFileWorkQueueActionRecordId = string
+
+export type AffiliationFileWorkQueueSourceBucket =
+  | 'blocked'
+  | 'restricted'
+  | 'missing_review'
+  | 'allowed'
+
+export type AffiliationFileWorkQueueActionKind =
+  | 'resolve_missing_review'
+  | 'hold_blocked_access'
+  | 'route_restricted_review'
+  | 'monitor_allowed_access'
+
+export interface AffiliationFileWorkQueueActionRecord {
+  readonly id: AffiliationFileWorkQueueActionRecordId
+  readonly workQueueEntryId: string
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly actionKind: AffiliationFileWorkQueueActionKind
+  readonly actionLabel: string
+  readonly sourceBucket: AffiliationFileWorkQueueSourceBucket
+  readonly sourceReasonCodes: readonly string[]
+  readonly recordedWeek: number
+}
+
+export type AffiliationFileWorkQueueActionRecordsMap = Record<
+  AffiliationFileWorkQueueActionRecordId,
+  AffiliationFileWorkQueueActionRecord
+>
+
+export interface AffiliationFileWorkQueueActionRecordInput {
+  readonly workQueueEntryId: string
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly actionKind: AffiliationFileWorkQueueActionKind
+  readonly actionLabel: string
+  readonly sourceBucket: AffiliationFileWorkQueueSourceBucket
+  readonly sourceReasonCodes: readonly string[]
+  readonly recordedWeek: number
+}
+
+const ACTION_KINDS: readonly AffiliationFileWorkQueueActionKind[] = [
+  'resolve_missing_review',
+  'hold_blocked_access',
+  'route_restricted_review',
+  'monitor_allowed_access',
+] as const
+
+const SOURCE_BUCKETS: readonly AffiliationFileWorkQueueSourceBucket[] = [
+  'blocked',
+  'restricted',
+  'missing_review',
+  'allowed',
+] as const
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeActionKind(value: unknown): AffiliationFileWorkQueueActionKind | undefined {
+  return ACTION_KINDS.includes(value as AffiliationFileWorkQueueActionKind)
+    ? (value as AffiliationFileWorkQueueActionKind)
+    : undefined
+}
+
+function normalizeSourceBucket(value: unknown): AffiliationFileWorkQueueSourceBucket | undefined {
+  return SOURCE_BUCKETS.includes(value as AffiliationFileWorkQueueSourceBucket)
+    ? (value as AffiliationFileWorkQueueSourceBucket)
+    : undefined
+}
+
+function normalizeRecordedWeek(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value === Math.trunc(value)
+    ? value
+    : undefined
+}
+
+function normalizeReasonCodes(value: unknown) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return [
+    ...new Set(value.map((entry) => normalizeToken(entry)).filter((entry) => entry.length > 0)),
+  ].sort((left, right) => left.localeCompare(right))
+}
+
+export function buildAffiliationFileWorkQueueActionRecordId(input: {
+  readonly workQueueEntryId: string
+  readonly actionKind: AffiliationFileWorkQueueActionKind
+}) {
+  return `affiliation-file-action:${input.workQueueEntryId}:${input.actionKind}`
+}
+
+export function buildAffiliationFileWorkQueueActionRecord(
+  input: AffiliationFileWorkQueueActionRecordInput
+): AffiliationFileWorkQueueActionRecord {
+  const sourceReasonCodes = normalizeReasonCodes(input.sourceReasonCodes)
+
+  return Object.freeze({
+    id: buildAffiliationFileWorkQueueActionRecordId({
+      workQueueEntryId: input.workQueueEntryId,
+      actionKind: input.actionKind,
+    }),
+    workQueueEntryId: input.workQueueEntryId,
+    subjectId: input.subjectId,
+    subjectLabel: input.subjectLabel,
+    actionKind: input.actionKind,
+    actionLabel: input.actionLabel,
+    sourceBucket: input.sourceBucket,
+    sourceReasonCodes: Object.freeze(sourceReasonCodes),
+    recordedWeek: input.recordedWeek,
+  })
+}
+
+function sanitizeActionRecordEntry(
+  value: unknown,
+  expectedKey?: string
+): AffiliationFileWorkQueueActionRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const workQueueEntryId = normalizeToken(value.workQueueEntryId)
+  const subjectId = normalizeToken(value.subjectId)
+  const subjectLabel = normalizeToken(value.subjectLabel)
+  const actionKind = normalizeActionKind(value.actionKind)
+  const actionLabel = normalizeToken(value.actionLabel)
+  const sourceBucket = normalizeSourceBucket(value.sourceBucket)
+  const recordedWeek = normalizeRecordedWeek(value.recordedWeek)
+
+  if (
+    !id ||
+    !workQueueEntryId ||
+    !subjectId ||
+    !subjectLabel ||
+    !actionKind ||
+    !actionLabel ||
+    !sourceBucket ||
+    recordedWeek === undefined ||
+    (expectedKey !== undefined && expectedKey !== id) ||
+    id !== buildAffiliationFileWorkQueueActionRecordId({ workQueueEntryId, actionKind })
+  ) {
+    return null
+  }
+
+  return Object.freeze({
+    id,
+    workQueueEntryId,
+    subjectId,
+    subjectLabel,
+    actionKind,
+    actionLabel,
+    sourceBucket,
+    sourceReasonCodes: Object.freeze(normalizeReasonCodes(value.sourceReasonCodes)),
+    recordedWeek,
+  })
+}
+
+/** Hydration: canonical action ledger keyed by deterministic action record id. */
+export function sanitizeAffiliationFileWorkQueueActionRecords(
+  value: unknown,
+  fallback: AffiliationFileWorkQueueActionRecordsMap = {}
+): AffiliationFileWorkQueueActionRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: AffiliationFileWorkQueueActionRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const [key, entry] of Object.entries(value)) {
+    const record = sanitizeActionRecordEntry(entry, key)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -275,6 +275,7 @@ import type {
 import type { PatternSourceSeriesRecord } from './patternSourceSeriesRegistry'
 import type { PopulationEmergenceRecord } from './massAnomalousPopulationEmergenceRegistry'
 import type { AffiliationPersonStatusRecord } from './affiliationPersonStatusRecords'
+import type { AffiliationFileWorkQueueActionRecord } from './affiliationFileWorkQueueActionRecords'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 import type { PublishQueueRecord } from './publishAutomationCreditingHooks'
 import type { PublishQueueExecutionReceipt } from './publishQueueExecutor'
@@ -2764,6 +2765,12 @@ export interface GameState {
    * Hydration drops invalid, duplicate-id, and mismatched-key entries without throwing.
    */
   affiliationPersonStatusRecords?: Record<string, AffiliationPersonStatusRecord>
+
+  /**
+   * SPE-2529 slice 1: persisted file work queue operator action acknowledgements.
+   * Hydration drops invalid, duplicate-id, and mismatched-key entries without throwing.
+   */
+  affiliationFileWorkQueueActionRecords?: Record<string, AffiliationFileWorkQueueActionRecord>
 
   /**
    * SPE-2114 slice 2: persisted entity welfare reclassification records (keyed by record id).

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import '../../test/setup'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { useGameStore } from '../../app/store/gameStore'
@@ -71,7 +72,9 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
     expect(queueRegion).toHaveTextContent('Restricted 2')
     expect(queueRegion).toHaveTextContent('Missing review 0')
     expect(queueRegion).toHaveTextContent('Recommended action')
+    expect(queueRegion).toHaveTextContent('Action status')
     expect(queueRegion).toHaveTextContent('Route restricted review')
+    expect(queueRegion).toHaveTextContent('Not recorded')
     expect(queueRegion).toHaveTextContent(
       'Supervisor or review-gate handling is required before any file release.'
     )
@@ -87,5 +90,42 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
     expect(recordsRegion).toHaveTextContent('Housing access: Allowed')
     expect(recordsRegion).toHaveTextContent('Mission: Restricted')
     expect(recordsRegion).toHaveTextContent('person-status:cooperative-contractor-cleared')
+  })
+
+  it('records a file work queue operator action from the queue row', async () => {
+    const user = userEvent.setup()
+    const game = createStartingState()
+    game.week = 8
+    game.entityWelfareReclassificationRecords = {
+      [PENDING_TO_APPROVED_FIXTURE.id]: PENDING_TO_APPROVED_FIXTURE,
+    }
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        entityWelfareReclassificationRef: PENDING_TO_APPROVED_FIXTURE.id,
+      },
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const queueRegion = screen.getByRole('region', {
+      name: /file access work queue/i,
+    })
+    await user.click(screen.getByRole('button', { name: /record action/i }))
+
+    expect(queueRegion).toHaveTextContent('Recorded W8')
+    expect(queueRegion).not.toHaveTextContent('Not recorded')
+    expect(useGameStore.getState().game.affiliationFileWorkQueueActionRecords).toEqual(
+      expect.objectContaining({
+        'affiliation-file-action:person-status:cooperative-contractor-cleared:route_restricted_review':
+          expect.objectContaining({
+            actionKind: 'route_restricted_review',
+            actionLabel: 'Route restricted review',
+            sourceBucket: 'restricted',
+            recordedWeek: 8,
+          }),
+      })
+    )
   })
 })

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
@@ -27,7 +27,10 @@ function LabelStack({ labels }: { labels: readonly string[] }) {
 }
 
 export default function AffiliationPersonStatusMirrorPage() {
-  const { game } = useGameStore()
+  const game = useGameStore((state) => state.game)
+  const recordAffiliationFileWorkQueueAction = useGameStore(
+    (state) => state.recordAffiliationFileWorkQueueAction
+  )
   const view = useMemo(() => getAffiliationPersonStatusMirrorView(game), [game])
 
   return (
@@ -156,6 +159,9 @@ export default function AffiliationPersonStatusMirrorPage() {
                       {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.recommendedActionColumn}
                     </th>
                     <th className="px-2 py-2">
+                      {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.actionStatusColumn}
+                    </th>
+                    <th className="px-2 py-2">
                       {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.reasonCodesColumn}
                     </th>
                   </tr>
@@ -180,6 +186,24 @@ export default function AffiliationPersonStatusMirrorPage() {
                       <td className="px-2 py-2">
                         <p className="text-xs font-medium">{entry.recommendedActionLabel}</p>
                         <p className="text-xs opacity-55">{entry.recommendedActionDetail}</p>
+                      </td>
+                      <td className="px-2 py-2">
+                        {entry.isRecommendedActionRecorded ? (
+                          <p className="text-xs font-medium">{entry.recordedActionLabel}</p>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-xs btn-primary whitespace-nowrap"
+                            onClick={() => recordAffiliationFileWorkQueueAction(entry.id)}
+                          >
+                            {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.recordActionButtonLabel}
+                          </button>
+                        )}
+                        {!entry.isRecommendedActionRecorded ? (
+                          <p className="mt-1 text-xs opacity-55">
+                            {AFFILIATION_PERSON_STATUS_MIRROR_UI_TEXT.pendingActionStatusLabel}
+                          </p>
+                        ) : null}
                       </td>
                       <td className="px-2 py-2">
                         <LabelStack labels={entry.reasonCodeLabels} />

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -4,6 +4,7 @@ import {
   COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
   RESTRICTED_DUAL_LOYALTY_PERSON_STATUS_FIXTURE,
 } from '../../domain/affiliationPersonStatusRecords'
+import { buildAffiliationFileWorkQueueActionRecord } from '../../domain/affiliationFileWorkQueueActionRecords'
 import {
   HOSTILE_TO_COOPERATIVE_FIXTURE,
   PENDING_TO_APPROVED_FIXTURE,
@@ -290,6 +291,37 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
       recommendedActionKind: 'monitor_allowed_access',
       recommendedActionLabel: 'Monitor allowed access',
       recommendedActionDetail: 'Audit visibility only; no intervention is required.',
+    })
+  })
+
+  it('joins recorded operator actions onto queue rows without changing ordering', () => {
+    const game = makeStatusGame()
+    const recorded = buildAffiliationFileWorkQueueActionRecord({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+      subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+      actionKind: 'route_restricted_review',
+      actionLabel: 'Route restricted review',
+      sourceBucket: 'restricted',
+      sourceReasonCodes: ['site_clearance_allowed', 'file_permission_restricted'],
+      recordedWeek: 6,
+    })
+    game.affiliationFileWorkQueueActionRecords = {
+      [recorded.id]: recorded,
+    }
+
+    const view = getAffiliationPersonStatusMirrorView(game)
+
+    expect(view.fileAccessWorkQueue.map((entry) => entry.id)).toEqual([
+      COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      RESTRICTED_DUAL_LOYALTY_PERSON_STATUS_FIXTURE.id,
+    ])
+    expect(view.fileAccessWorkQueue[0]).toMatchObject({
+      isRecommendedActionRecorded: true,
+      recordedActionLabel: 'Recorded W6',
+    })
+    expect(view.fileAccessWorkQueue[1]).toMatchObject({
+      isRecommendedActionRecorded: false,
     })
   })
 })

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -1,4 +1,5 @@
 import type { GameState } from '../../domain/models'
+import { buildAffiliationFileWorkQueueActionRecordId } from '../../domain/affiliationFileWorkQueueActionRecords'
 import {
   projectAffiliationPersonStatusSnapshots,
   type AffiliationPersonStatusSnapshot,
@@ -68,6 +69,8 @@ export interface AffiliationFileAccessWorkQueueEntryView {
   recommendedActionKind: AffiliationFileAccessRecommendedActionKind
   recommendedActionLabel: string
   recommendedActionDetail: string
+  isRecommendedActionRecorded: boolean
+  recordedActionLabel?: string
   reasonCodeLabels: readonly string[]
 }
 
@@ -296,7 +299,8 @@ function fileAccessDecisionLabel(snapshot: AffiliationPersonStatusSnapshot) {
 }
 
 function toFileAccessWorkQueueEntry(
-  snapshot: AffiliationPersonStatusSnapshot
+  snapshot: AffiliationPersonStatusSnapshot,
+  game: GameState
 ): AffiliationFileAccessWorkQueueEntryView {
   const decision = snapshot.facilityFileAccessDecision
   const bucket: AffiliationFileAccessWorkQueueBucket = decision?.outcome ?? 'missing_review'
@@ -306,6 +310,11 @@ function toFileAccessWorkQueueEntry(
   const reasonCodeLabels =
     reasonCodes.length > 0 ? reasonCodes : ['missing_facility_file_access_decision']
   const recommendedAction = getFileAccessWorkQueueRecommendedAction(bucket)
+  const recordedActionId = buildAffiliationFileWorkQueueActionRecordId({
+    workQueueEntryId: snapshot.recordId,
+    actionKind: recommendedAction.recommendedActionKind,
+  })
+  const recordedAction = game.affiliationFileWorkQueueActionRecords?.[recordedActionId]
 
   return Object.freeze({
     id: snapshot.recordId,
@@ -318,16 +327,19 @@ function toFileAccessWorkQueueEntry(
     siteLabel: decision ? `Site: ${decision.siteLabel}` : 'Site: -',
     facilityLabel: decision ? `Facility: ${decision.facilityLabel}` : 'Facility: -',
     ...recommendedAction,
+    isRecommendedActionRecorded: Boolean(recordedAction),
+    ...(recordedAction ? { recordedActionLabel: `Recorded W${recordedAction.recordedWeek}` } : {}),
     reasonCodeLabels: Object.freeze(reasonCodeLabels),
   })
 }
 
 function buildFileAccessWorkQueue(
-  snapshots: readonly AffiliationPersonStatusSnapshot[]
+  snapshots: readonly AffiliationPersonStatusSnapshot[],
+  game: GameState
 ): readonly AffiliationFileAccessWorkQueueEntryView[] {
   return Object.freeze(
     snapshots
-      .map((snapshot) => toFileAccessWorkQueueEntry(snapshot))
+      .map((snapshot) => toFileAccessWorkQueueEntry(snapshot, game))
       .sort((left, right) => {
         const bucketCompare =
           fileAccessWorkQueueBucketPriority(left.bucket) -
@@ -383,7 +395,7 @@ export function getAffiliationPersonStatusMirrorView(
   })
   let restrictedOrBlockedCount = 0
   let missingReferenceCount = 0
-  const fileAccessWorkQueue = buildFileAccessWorkQueue(snapshots)
+  const fileAccessWorkQueue = buildFileAccessWorkQueue(snapshots, game)
 
   for (const snapshot of snapshots) {
     if (hasRestrictedOrBlockedOutcome(snapshot)) {

--- a/src/test/affiliationFileWorkQueueActionRecords.test.ts
+++ b/src/test/affiliationFileWorkQueueActionRecords.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { hydrateGame } from '../app/store/runTransfer'
+import { createStartingState } from '../data/startingState'
+import {
+  buildAffiliationFileWorkQueueActionRecord,
+  buildAffiliationFileWorkQueueActionRecordId,
+  sanitizeAffiliationFileWorkQueueActionRecords,
+} from '../domain/affiliationFileWorkQueueActionRecords'
+
+describe('affiliationFileWorkQueueActionRecords persistence (SPE-2529 slice 1)', () => {
+  it('builds deterministic ids and sorts source reason codes', () => {
+    const record = buildAffiliationFileWorkQueueActionRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      actionKind: 'route_restricted_review',
+      actionLabel: 'Route restricted review',
+      sourceBucket: 'restricted',
+      sourceReasonCodes: ['site_restricted', ' file_restricted ', 'site_restricted'],
+      recordedWeek: 7,
+    })
+
+    expect(record).toEqual({
+      id: 'affiliation-file-action:person-status:alpha:route_restricted_review',
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      actionKind: 'route_restricted_review',
+      actionLabel: 'Route restricted review',
+      sourceBucket: 'restricted',
+      sourceReasonCodes: ['file_restricted', 'site_restricted'],
+      recordedWeek: 7,
+    })
+    expect(
+      buildAffiliationFileWorkQueueActionRecordId({
+        workQueueEntryId: 'person-status:alpha',
+        actionKind: 'route_restricted_review',
+      })
+    ).toBe(record.id)
+  })
+
+  it('drops invalid records and mismatched keys during hydration sanitization', () => {
+    const valid = buildAffiliationFileWorkQueueActionRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      actionKind: 'hold_blocked_access',
+      actionLabel: 'Hold access',
+      sourceBucket: 'blocked',
+      sourceReasonCodes: ['blocked_site'],
+      recordedWeek: 3,
+    })
+
+    expect(
+      sanitizeAffiliationFileWorkQueueActionRecords({
+        [valid.id]: valid,
+        'wrong-key': valid,
+        'bad-kind': {
+          ...valid,
+          id: 'affiliation-file-action:person-status:beta:not_real',
+          workQueueEntryId: 'person-status:beta',
+          actionKind: 'not_real',
+        },
+        'bad-week': {
+          ...valid,
+          id: 'affiliation-file-action:person-status:gamma:hold_blocked_access',
+          workQueueEntryId: 'person-status:gamma',
+          recordedWeek: 1.5,
+        },
+      })
+    ).toEqual({
+      [valid.id]: valid,
+    })
+  })
+
+  it('hydrates and exports action records through GameState without mutating person-status records', () => {
+    const state = createStartingState()
+    const valid = buildAffiliationFileWorkQueueActionRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      actionKind: 'monitor_allowed_access',
+      actionLabel: 'Monitor allowed access',
+      sourceBucket: 'allowed',
+      sourceReasonCodes: ['allowed_file'],
+      recordedWeek: 5,
+    })
+
+    state.affiliationFileWorkQueueActionRecords = {
+      [valid.id]: valid,
+    }
+
+    const hydrated = hydrateGame(JSON.parse(JSON.stringify(state)), createStartingState())
+
+    expect(hydrated.affiliationFileWorkQueueActionRecords).toEqual({
+      [valid.id]: valid,
+    })
+    expect(hydrated.affiliationPersonStatusRecords).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- add persisted `affiliationFileWorkQueueActionRecords` for deterministic file queue operator acknowledgements
- add `recordAffiliationFileWorkQueueAction(entryId)` and surface recorded/unrecorded action status on the affiliation person-status mirror
- add SPE-2529 planning handoff while keeping SPE-1046 parent Backlog

Linear: SPE-2529
Parent: SPE-1046 remains Backlog

## Validation
- `npm.cmd run test:run -- src/test/affiliationFileWorkQueueActionRecords.test.ts src/app/store/gameStore.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
- `npm.cmd run lint`
- `npx.cmd prettier --check` on touched files
- `npm.cmd run test:run`