### PR TITLE
SPE-2530 reconcile SPE-2529 handoff

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -128,11 +128,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528/spe-1046-post-spe-2527-status-reconciliation) SPE-1046 post-SPE-2527 status reconciliation — parent Linear status and repo handoff hygiene after PR #2982; PR #2985; see `planning/spe-1046-post-spe-2527-status-reconciliation-slice-1.md`.
 
-**In progress:** [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529/spe-1046-file-work-queue-operator-action-ledger) SPE-1046 file work queue operator action ledger (slice 1) — persisted deterministic operator acknowledgements for existing file access work queue recommendations; branch `spe-1046-file-work-queue-operator-action-ledger-slice-1`; see `planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md`.
+**Recently shipped:** [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529/spe-1046-file-work-queue-operator-action-ledger) SPE-1046 file work queue operator action ledger (slice 1) — persisted deterministic operator acknowledgements for existing file access work queue recommendations; PR #2987 @ `2c2c060d`; see `planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md`.
 
-**Next step after SPE-2529:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**In progress:** [SPE-2530](https://linear.app/spectranoir/issue/SPE-2530/spe-1046-post-spe-2529-handoff-reconciliation) SPE-1046 post-SPE-2529 handoff reconciliation — parent Linear status and repo handoff hygiene after PR #2987; branch `spe-1046-post-spe-2529-handoff-reconciliation-slice-1`; see `planning/spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md`.
 
-**Base `main` SHA:** `b84a1fc5` — includes PR #2985 / SPE-2528 status reconciliation.
+**Next step after SPE-2530:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `2c2c060d` — includes PR #2987 / SPE-2529 file work queue operator action ledger.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -280,7 +282,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-file-work-queues-slice-1.md`                                     | **Shipped**     | New SPE-1046 child — existing person-status/file/facility decisions feed a read-only operations work queue; commit `af849277`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-file-work-queue-action-recommendations-slice-1.md`               | **Shipped**     | [SPE-2527](https://linear.app/spectranoir/issue/SPE-2527) — file access work queue rows gain deterministic read-only recommended action guidance; PR #2982 @ `67da21e2`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-post-spe-2527-status-reconciliation-slice-1.md`                  | **Shipped**     | [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528) — parent Linear status and repo handoff hygiene after SPE-2527; PR #2985; parent SPE-1046 stays **Backlog**. |
-| `spe-1046-file-work-queue-operator-action-ledger-slice-1.md`                | **In Progress** | [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529) — persisted deterministic operator acknowledgements for existing file access work queue recommendations; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-file-work-queue-operator-action-ledger-slice-1.md`                | **Shipped**     | [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529) — persisted deterministic operator acknowledgements for existing file access work queue recommendations; PR #2987 @ `2c2c060d`; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md`                  | **In Progress** | [SPE-2530](https://linear.app/spectranoir/issue/SPE-2530) — parent Linear status and repo handoff hygiene after SPE-2529; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-procurement-gear-access-slice-1.md`                             | **Shipped**     | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; PR #2974 @ `9f623d9a`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                                     |

--- a/planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md
+++ b/planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md
@@ -5,10 +5,11 @@ One-page implementation plan. Linear: [SPE-2529](https://linear.app/spectranoir/
 | Field               | Value                                                                                                                                                       |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Linear**          | [SPE-2529 - SPE-1046 file work queue operator action ledger](https://linear.app/spectranoir/issue/SPE-2529/spe-1046-file-work-queue-operator-action-ledger) |
-| **Status**          | **In Progress**                                                                                                                                             |
+| **Status**          | **Shipped**                                                                                                                                                 |
 | **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                         |
 | **Branch**          | `spe-1046-file-work-queue-operator-action-ledger-slice-1`                                                                                                   |
 | **Base `main` SHA** | `b84a1fc5`                                                                                                                                                  |
+| **PR**              | [#2987](https://github.com/JamesJedi420/containment-protocol/pull/2987)                                                                                     |
 
 ## Goal
 
@@ -25,13 +26,13 @@ Persist deterministic operator acknowledgements for file access work queue recom
 
 ## Acceptance
 
-- [ ] Action records hydrate/export as optional GameState persistence.
-- [ ] Invalid, mismatched-key, and malformed action records are dropped on hydrate.
-- [ ] Store action upserts one deterministic record for the current queue entry and recommended action.
-- [ ] Missing-entry store calls no-op.
-- [ ] Operations mirror shows unrecorded rows with a record button and recorded rows with `Recorded W{week}`.
-- [ ] No mutation to `affiliationPersonStatusRecords`, clearance outcomes, mission routing, procurement, or weekly progression.
-- [ ] SPE-1046 parent remains **Backlog**.
+- [x] Action records hydrate/export as optional GameState persistence.
+- [x] Invalid, mismatched-key, and malformed action records are dropped on hydrate.
+- [x] Store action upserts one deterministic record for the current queue entry and recommended action.
+- [x] Missing-entry store calls no-op.
+- [x] Operations mirror shows unrecorded rows with a record button and recorded rows with `Recorded W{week}`.
+- [x] No mutation to `affiliationPersonStatusRecords`, clearance outcomes, mission routing, procurement, or weekly progression.
+- [x] SPE-1046 parent remains **Backlog**.
 
 ## Validation
 

--- a/planning/spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md
+++ b/planning/spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md
@@ -1,0 +1,50 @@
+# SPE-1046 - Post-SPE-2529 handoff reconciliation (slice 1)
+
+One-page hygiene record. Linear: [SPE-2530](https://linear.app/spectranoir/issue/SPE-2530/spe-1046-post-spe-2529-handoff-reconciliation) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529/spe-1046-file-work-queue-operator-action-ledger); [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2530 - SPE-1046 post-SPE-2529 handoff reconciliation](https://linear.app/spectranoir/issue/SPE-2530/spe-1046-post-spe-2529-handoff-reconciliation) |
+| **Status**          | **In Progress**                                                                                                                                         |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                     |
+| **Branch**          | `spe-1046-post-spe-2529-handoff-reconciliation-slice-1`                                                                                                 |
+| **Base `main` SHA** | `2c2c060d`                                                                                                                                              |
+
+## Goal
+
+Reconcile the post-merge handoff after SPE-2529 / PR #2987 so Linear and repo planning agree that the file work queue operator action ledger shipped as a child-only slice while the broader SPE-1046 parent remains open.
+
+## Scope
+
+| In                                                                              | Out                        |
+| ------------------------------------------------------------------------------- | -------------------------- |
+| Backlog handoff update: SPE-2529 shipped, SPE-2530 current, base SHA `2c2c060d` | Gameplay or app code       |
+| SPE-2529 slice doc update to shipped status, PR #2987, and checked acceptance   | SPE-947 propagation work   |
+| Linear parent remains Backlog and hygiene child closes after merge              | New SPE-1046 feature logic |
+
+## Acceptance
+
+- [x] `planning/backlog.md` marks SPE-2529 shipped and SPE-2530 current.
+- [x] `planning/backlog.md` records base `main` SHA `2c2c060d`.
+- [x] `planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md` links PR #2987 and marks shipped acceptance.
+- [x] No application code changes.
+- [x] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npx.cmd prettier --check planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md planning/spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md`
+- `npm.cmd run lint`
+
+## Deferred
+
+| Item                                        | Owner          | Why                                     |
+| ------------------------------------------- | -------------- | --------------------------------------- |
+| SPE-1046 non-mission enforcement follow-ons | SPE-1046 child | This slice is status/docs hygiene only. |
+| SPE-947 propagation follow-ons              | SPE-947 child  | Separate owner reprioritization lane.   |
+| SPE-1046 parent closure                     | SPE-1046       | Broader parent acceptance remains open. |
+
+## See also
+
+- `planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md`
+- `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`
+- `planning/backlog.md`


### PR DESCRIPTION
## Summary
- reconcile SPE-1046 handoff after SPE-2529 / PR #2987
- mark SPE-2529 file work queue operator action ledger as shipped in planning docs
- add SPE-2530 hygiene slice doc while keeping parent SPE-1046 Backlog

Linear: SPE-2530
Parent: SPE-1046 remains Backlog

## Validation
- `npx.cmd prettier --check planning/spe-1046-file-work-queue-operator-action-ledger-slice-1.md planning/spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md`
- `npm.cmd run lint`
- `git diff --check`

Docs-only slice; no app code touched.