### PR TITLE
SPE-2532 reconcile SPE-2531 handoff

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -132,11 +132,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2530](https://linear.app/spectranoir/issue/SPE-2530/spe-1046-post-spe-2529-handoff-reconciliation) SPE-1046 post-SPE-2529 handoff reconciliation — parent Linear status and repo handoff hygiene after PR #2987; PR #2989 @ `16fd4cb1`; see `planning/spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md`.
 
-**In progress:** [SPE-2531](https://linear.app/spectranoir/issue/SPE-2531/spe-1046-post-spe-2530-handoff-reconciliation) SPE-1046 post-SPE-2530 handoff reconciliation — parent Linear status and repo handoff hygiene after PR #2989; branch `spe-1046-post-spe-2530-handoff-reconciliation-slice-1`; see `planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md`.
+**Recently shipped:** [SPE-2531](https://linear.app/spectranoir/issue/SPE-2531/spe-1046-post-spe-2530-handoff-reconciliation) SPE-1046 post-SPE-2530 handoff reconciliation — parent Linear status and repo handoff hygiene after PR #2989; PR #2991 @ `2a7f6678`; see `planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md`.
 
-**Next step after SPE-2531:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+**In progress:** [SPE-2532](https://linear.app/spectranoir/issue/SPE-2532/spe-1046-post-spe-2531-handoff-reconciliation) SPE-1046 post-SPE-2531 handoff reconciliation — parent Linear status and repo handoff hygiene after PR #2991; branch `spe-1046-post-spe-2531-handoff-reconciliation-slice-1`; see `planning/spe-1046-post-spe-2531-handoff-reconciliation-slice-1.md`.
 
-**Base `main` SHA:** `16fd4cb1` — includes PR #2989 / SPE-2530 handoff reconciliation.
+**Next step after SPE-2532:** Owner reprioritizes remaining SPE-1046 non-mission enforcement follow-ons or SPE-947 propagation follow-ons. Mission triage full refresh remains **blocked**.
+
+**Base `main` SHA:** `2a7f6678` — includes PR #2991 / SPE-2531 handoff reconciliation.
 
 **§14-pass alternates (owner creates Linear child when starting):**
 
@@ -286,7 +288,8 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-1046-post-spe-2527-status-reconciliation-slice-1.md`                  | **Shipped**     | [SPE-2528](https://linear.app/spectranoir/issue/SPE-2528) — parent Linear status and repo handoff hygiene after SPE-2527; PR #2985; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-file-work-queue-operator-action-ledger-slice-1.md`                | **Shipped**     | [SPE-2529](https://linear.app/spectranoir/issue/SPE-2529) — persisted deterministic operator acknowledgements for existing file access work queue recommendations; PR #2987 @ `2c2c060d`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-post-spe-2529-handoff-reconciliation-slice-1.md`                  | **Shipped**     | [SPE-2530](https://linear.app/spectranoir/issue/SPE-2530) — parent Linear status and repo handoff hygiene after SPE-2529; PR #2989 @ `16fd4cb1`; parent SPE-1046 stays **Backlog**. |
-| `spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md`                  | **In Progress** | [SPE-2531](https://linear.app/spectranoir/issue/SPE-2531) — parent Linear status and repo handoff hygiene after SPE-2530; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md`                  | **Shipped**     | [SPE-2531](https://linear.app/spectranoir/issue/SPE-2531) — parent Linear status and repo handoff hygiene after SPE-2530; PR #2991 @ `2a7f6678`; parent SPE-1046 stays **Backlog**. |
+| `spe-1046-post-spe-2531-handoff-reconciliation-slice-1.md`                  | **In Progress** | [SPE-2532](https://linear.app/spectranoir/issue/SPE-2532) — parent Linear status and repo handoff hygiene after SPE-2531; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-procurement-gear-access-slice-1.md`                             | **Shipped**     | [SPE-2523](https://linear.app/spectranoir/issue/SPE-2523) — restricted/rare procurement listings compose existing gear permission checks through current access fields; PR #2974 @ `9f623d9a`; parent SPE-1046 stays **Backlog**. |
 | `spe-1046-protected-status-action-restrictions-slice-1.md`                | **Shipped**     | [SPE-2507](https://linear.app/spectranoir/issue/SPE-2507) — pure protected-status action restriction evaluator; PR #2942 @ `b1915bc7`; parent SPE-1046 stays **Backlog**.                                                     |
 | `spe-1046-revocation-downgrade-outcomes-slice-1.md`                       | **Shipped**     | [SPE-2508](https://linear.app/spectranoir/issue/SPE-2508) — pure revocation/downgrade access outcome evaluator; PR #2944 @ `afb89b48`; parent SPE-1046 stays **Backlog**.                                                     |

--- a/planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md
+++ b/planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md
@@ -5,10 +5,11 @@ One-page hygiene record. Linear: [SPE-2531](https://linear.app/spectranoir/issue
 | Field               | Value                                                                                                                                                   |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Linear**          | [SPE-2531 - SPE-1046 post-SPE-2530 handoff reconciliation](https://linear.app/spectranoir/issue/SPE-2531/spe-1046-post-spe-2530-handoff-reconciliation) |
-| **Status**          | **In Progress**                                                                                                                                         |
+| **Status**          | **Shipped**                                                                                                                                             |
 | **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                     |
 | **Branch**          | `spe-1046-post-spe-2530-handoff-reconciliation-slice-1`                                                                                                 |
 | **Base `main` SHA** | `16fd4cb1`                                                                                                                                              |
+| **PR**              | [PR #2991](https://github.com/JamesJedi420/containment-protocol/pull/2991) @ `2a7f6678`                                                                 |
 
 ## Goal
 

--- a/planning/spe-1046-post-spe-2531-handoff-reconciliation-slice-1.md
+++ b/planning/spe-1046-post-spe-2531-handoff-reconciliation-slice-1.md
@@ -1,0 +1,51 @@
+# SPE-1046 - Post-SPE-2531 handoff reconciliation (slice 1)
+
+One-page hygiene record. Linear: [SPE-2532](https://linear.app/spectranoir/issue/SPE-2532/spe-1046-post-spe-2531-handoff-reconciliation) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2531](https://linear.app/spectranoir/issue/SPE-2531/spe-1046-post-spe-2530-handoff-reconciliation); [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2532 - SPE-1046 post-SPE-2531 handoff reconciliation](https://linear.app/spectranoir/issue/SPE-2532/spe-1046-post-spe-2531-handoff-reconciliation) |
+| **Status**          | **In Progress**                                                                                                                                         |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                     |
+| **Branch**          | `spe-1046-post-spe-2531-handoff-reconciliation-slice-1`                                                                                                 |
+| **Base `main` SHA** | `2a7f6678`                                                                                                                                              |
+
+## Goal
+
+Reconcile the post-merge handoff after SPE-2531 / PR #2991 so Linear and repo planning agree that the previous hygiene slice shipped while the broader SPE-1046 parent remains open.
+
+## Scope
+
+| In                                                                          | Out                        |
+| --------------------------------------------------------------------------- | -------------------------- |
+| Backlog handoff update: SPE-2531 shipped, SPE-2532 current, base `2a7f6678` | Gameplay or app code       |
+| SPE-2531 slice doc update to shipped status and PR #2991                    | SPE-947 propagation work   |
+| Linear parent remains Backlog and hygiene child closes after merge          | New SPE-1046 feature logic |
+
+## Acceptance
+
+- [x] `planning/backlog.md` marks SPE-2531 shipped and SPE-2532 current.
+- [x] `planning/backlog.md` records base `main` SHA `2a7f6678`.
+- [x] `planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md` links PR #2991 and marks shipped status.
+- [x] No application code changes.
+- [x] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npx.cmd prettier --check planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md planning/spe-1046-post-spe-2531-handoff-reconciliation-slice-1.md`
+- `npm.cmd run lint`
+- `git diff --check`
+
+## Deferred
+
+| Item                                        | Owner          | Why                                     |
+| ------------------------------------------- | -------------- | --------------------------------------- |
+| SPE-1046 non-mission enforcement follow-ons | SPE-1046 child | This slice is status/docs hygiene only. |
+| SPE-947 propagation follow-ons              | SPE-947 child  | Separate owner reprioritization lane.   |
+| SPE-1046 parent closure                     | SPE-1046       | Broader parent acceptance remains open. |
+
+## See also
+
+- `planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md`
+- `planning/spe-947-spe-1046-parent-acceptance-review-slice-1.md`
+- `planning/backlog.md`


### PR DESCRIPTION
## Summary
- reconcile SPE-1046 planning handoff after SPE-2531 / PR #2991 merged at 2a7f6678
- mark SPE-2531 shipped and record SPE-2532 as the current hygiene slice
- add the SPE-2532 docs-only hygiene record while keeping parent SPE-1046 Backlog

Linear: SPE-2532
Parent: SPE-1046 remains Backlog

## Validation
- npx.cmd prettier --check planning/spe-1046-post-spe-2530-handoff-reconciliation-slice-1.md planning/spe-1046-post-spe-2531-handoff-reconciliation-slice-1.md
- npm.cmd run lint
- git diff --check

Docs-only; no app code touched.