### PR TITLE
feat(SPE-2118): concept-state transformation registry (slice 1)

### DIFF
--- a/src/domain/conceptStateTransformationRegistry.ts
+++ b/src/domain/conceptStateTransformationRegistry.ts
@@ -785,6 +785,3 @@ export function projectConceptCollateral(
   })
 }
 
-function defineRecord(record: ConceptStateOperatorRecord): ConceptStateOperatorRecord {
-  return Object.freeze({ ...record })
-}

--- a/src/domain/conceptStateTransformationRegistry.ts
+++ b/src/domain/conceptStateTransformationRegistry.ts
@@ -75,6 +75,7 @@ export type ConceptStateOperatorValidationCode =
   | 'invalid_collateral_concept_ref'
   | 'empty_collateral_concept_ref'
   | 'bind_without_scope_rules'
+  | 'collapse_without_scope_rules'
   | 'franchise_token_in_id'
   | 'franchise_token_in_label'
   | 'franchise_token_in_field'
@@ -160,9 +161,7 @@ function asStringArray(value: unknown): readonly string[] {
 }
 
 function sortedStringArray(value: unknown): readonly string[] {
-  return Object.freeze(
-    [...asStringArray(value)].sort((left, right) => left.localeCompare(right))
-  )
+  return Object.freeze([...asStringArray(value)].sort((left, right) => left.localeCompare(right)))
 }
 
 function pushIssue(
@@ -431,10 +430,7 @@ function resolveRoleHint(
   return `${targetKind}_collateral`
 }
 
-function buildSymptomDescriptor(
-  record: ConceptStateOperatorRecord,
-  ref: string
-): string {
+function buildSymptomDescriptor(record: ConceptStateOperatorRecord, ref: string): string {
   const operator = isConceptStateOperator(record.operator) ? record.operator : 'relocate'
   const fromState = normalizeToken(record.fromState) || 'unknown_state'
   const toState = normalizeToken(record.toState) || 'unknown_state'
@@ -625,7 +621,10 @@ export function validateConceptStateOperatorRecord(
     !hasNonEmptyScopeRules(record)
   ) {
     pushIssue(issues, {
-      code: 'bind_without_scope_rules',
+      code:
+        record.operator === 'collapse'
+          ? 'collapse_without_scope_rules'
+          : 'bind_without_scope_rules',
       severity: 'warning',
       detail: `Concept-state operator record ${id || '(unknown)'} with operator ${record.operator} declares no non-empty scopeRules.`,
       relatedIds: id ? [id] : undefined,
@@ -635,44 +634,6 @@ export function validateConceptStateOperatorRecord(
   scanForbiddenTokens(issues, id, label, record)
 
   return freezeValidationResult(issues)
-}
-
-/**
- * Project affected concept refs with symptom descriptors and role hints.
- * Deterministic mapping: operator + state transition → collateral symptoms.
- * Does not assert objective truth or omniscient classification.
- */
-export function projectConceptCollateral(
-  record: ConceptStateOperatorRecord,
-  policy: ConceptCollateralProjectionPolicy = {}
-): ConceptCollateralProjection {
-  const recordId = normalizeToken(record.id) || '(unknown)'
-  const label = normalizeToken(record.label) || '(unknown)'
-  const fromState = normalizeToken(record.fromState) || 'unknown_state'
-  const toState = normalizeToken(record.toState) || 'unknown_state'
-
-  const confidence = resolveConfidence(record, policy)
-  const detectionDifficulty = resolveDetectionDifficulty(record, policy)
-  const redacted =
-    (confidence === null && record.confidence !== undefined) ||
-    (detectionDifficulty === null && record.detectionDifficulty !== undefined)
-  const unknownFields = sortedStringArray(record.unknownFields)
-
-  return Object.freeze({
-    recordId,
-    label,
-    targetKind: isConceptStateTargetKind(record.targetKind)
-      ? record.targetKind
-      : 'concept',
-    operator: isConceptStateOperator(record.operator) ? record.operator : 'relocate',
-    fromState,
-    toState,
-    affectedEntries: buildAffectedEntries(record, policy),
-    detectionDifficulty,
-    confidence,
-    redacted,
-    unknownFields,
-  })
 }
 
 // ---------------------------------------------------------------------------
@@ -738,7 +699,6 @@ export const OBJECT_COLLAPSE_FIXTURE: ConceptStateOperatorRecord = defineRecord(
   toState: 'superposition_indistinguishable',
 })
 
-
 /**
  * Projects symptom-first collateral entries for related concept refs.
  * Does not emit omniscient hidden-conflict labels.
@@ -757,7 +717,9 @@ export function projectConceptCollateral(
     redactedFields.has('collateralConceptRefs') ||
     (policy.redactUnknown === true && unknownFields.includes('collateralConceptRefs'))
 
-  const affectedEntries = collateralRedacted ? Object.freeze([]) : buildAffectedEntries(record, policy)
+  const affectedEntries = collateralRedacted
+    ? Object.freeze([])
+    : buildAffectedEntries(record, policy)
 
   const difficultyRedacted =
     redactedFields.has('detectionDifficulty') ||
@@ -768,7 +730,9 @@ export function projectConceptCollateral(
     redactedFields.has('confidence') ||
     difficultyRedacted ||
     (policy.redactUnknown === true && unknownFields.includes('confidence')) ||
-    (confidence === null && record.confidence !== undefined && policy.minimumConfidence !== undefined)
+    (confidence === null &&
+      record.confidence !== undefined &&
+      policy.minimumConfidence !== undefined)
 
   return Object.freeze({
     recordId,
@@ -784,4 +748,3 @@ export function projectConceptCollateral(
     unknownFields,
   })
 }
-

--- a/src/domain/conceptStateTransformationRegistry.ts
+++ b/src/domain/conceptStateTransformationRegistry.ts
@@ -650,7 +650,6 @@ export function projectConceptCollateral(
   const label = normalizeToken(record.label) || '(unknown)'
   const fromState = normalizeToken(record.fromState) || 'unknown_state'
   const toState = normalizeToken(record.toState) || 'unknown_state'
-  const stateTransition = `${fromState} → ${toState}`
 
   const confidence = resolveConfidence(record, policy)
   const detectionDifficulty = resolveDetectionDifficulty(record, policy)

--- a/src/domain/conceptStateTransformationRegistry.ts
+++ b/src/domain/conceptStateTransformationRegistry.ts
@@ -789,35 +789,3 @@ export function projectConceptCollateral(
 function defineRecord(record: ConceptStateOperatorRecord): ConceptStateOperatorRecord {
   return Object.freeze({ ...record })
 }
-
-/** Concept relocate operator with collateral concept refs. */
-export const CONCEPT_RELOCATE_COLLATERAL_FIXTURE: ConceptStateOperatorRecord = defineRecord({
-  id: 'concept-operator:inside-outside-relocate',
-  label: 'Inside-outside concept relocate',
-  summary: 'Relational inside/outside membership shifts with collateral category drift.',
-  targetKind: 'concept',
-  operator: 'relocate',
-  fromState: 'inside_perimeter',
-  toState: 'outside_perimeter',
-  collateralConceptRefs: ['concept:membership-queue-a', 'concept:boundary-marker-7'],
-  detectionDifficulty: 0.62,
-  confidence: 0.71,
-})
-
-/** Category bind operator with explicit scope rules. */
-export const CATEGORY_BIND_SCOPE_FIXTURE: ConceptStateOperatorRecord = defineRecord({
-  id: 'concept-operator:personnel-category-bind',
-  label: 'Personnel category bind operator',
-  summary: 'Binds personnel category membership under bounded scope rules.',
-  targetKind: 'category',
-  operator: 'bind',
-  fromState: 'unassigned_pool',
-  toState: 'restricted_pool',
-  scopeRules: [
-    { constraint: 'only_when_badge_reader_conflict', boundaryRef: 'boundary:annex-c-reader' },
-    { constraint: 'exclude_visitor_pass_holders' },
-  ],
-  collateralConceptRefs: ['concept:visitor-clearance-tier'],
-  detectionDifficulty: 0.48,
-  confidence: 0.83,
-})

--- a/src/domain/conceptStateTransformationRegistry.ts
+++ b/src/domain/conceptStateTransformationRegistry.ts
@@ -618,19 +618,127 @@ export function validateConceptStateOperatorRecord(
     }
   }
 
-  scanForbiddenTokens(issues, id, label, record)
-
-  if (record.operator === 'bind' && !hasNonEmptyScopeRules(record)) {
+  // bind and collapse operators should have scope rules; warn if absent
+  if (
+    isConceptStateOperator(record.operator) &&
+    (record.operator === 'bind' || record.operator === 'collapse') &&
+    !hasNonEmptyScopeRules(record)
+  ) {
     pushIssue(issues, {
       code: 'bind_without_scope_rules',
       severity: 'warning',
-      detail: `Concept-state operator record ${id || '(unknown)'} uses bind without scopeRules.`,
+      detail: `Concept-state operator record ${id || '(unknown)'} with operator ${record.operator} declares no non-empty scopeRules.`,
       relatedIds: id ? [id] : undefined,
     })
   }
 
+  scanForbiddenTokens(issues, id, label, record)
+
   return freezeValidationResult(issues)
 }
+
+/**
+ * Project affected concept refs with symptom descriptors and role hints.
+ * Deterministic mapping: operator + state transition → collateral symptoms.
+ * Does not assert objective truth or omniscient classification.
+ */
+export function projectConceptCollateral(
+  record: ConceptStateOperatorRecord,
+  policy: ConceptCollateralProjectionPolicy = {}
+): ConceptCollateralProjection {
+  const recordId = normalizeToken(record.id) || '(unknown)'
+  const label = normalizeToken(record.label) || '(unknown)'
+  const fromState = normalizeToken(record.fromState) || 'unknown_state'
+  const toState = normalizeToken(record.toState) || 'unknown_state'
+  const stateTransition = `${fromState} → ${toState}`
+
+  const confidence = resolveConfidence(record, policy)
+  const detectionDifficulty = resolveDetectionDifficulty(record, policy)
+  const redacted =
+    (confidence === null && record.confidence !== undefined) ||
+    (detectionDifficulty === null && record.detectionDifficulty !== undefined)
+  const unknownFields = sortedStringArray(record.unknownFields)
+
+  return Object.freeze({
+    recordId,
+    label,
+    targetKind: isConceptStateTargetKind(record.targetKind)
+      ? record.targetKind
+      : 'concept',
+    operator: isConceptStateOperator(record.operator) ? record.operator : 'relocate',
+    fromState,
+    toState,
+    affectedEntries: buildAffectedEntries(record, policy),
+    detectionDifficulty,
+    confidence,
+    redacted,
+    unknownFields,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function defineRecord(record: ConceptStateOperatorRecord): ConceptStateOperatorRecord {
+  return Object.freeze({ ...record })
+}
+
+/** Concept relocate with collateralConceptRefs. */
+export const CONCEPT_RELOCATE_COLLATERAL_FIXTURE: ConceptStateOperatorRecord = defineRecord({
+  id: 'op:concept-inside-outside-flip',
+  label: 'Inside-outside distinction collapse',
+  summary: 'Anomaly relocates objective inside-outside boundary for named concept.',
+  targetKind: 'concept',
+  operator: 'relocate',
+  fromState: 'inside_perimeter',
+  toState: 'outside_perimeter',
+  collateralConceptRefs: ['concept:perimeter', 'concept:jurisdiction'],
+  detectionDifficulty: 0.6,
+  confidence: 0.71,
+})
+
+/** Category bind with scopeRules. */
+export const CATEGORY_BIND_SCOPE_FIXTURE: ConceptStateOperatorRecord = defineRecord({
+  id: 'op:category-membership-bind',
+  label: 'Membership binding under pressure',
+  summary: 'Anomaly forces category membership bond on normally voluntary affiliations.',
+  targetKind: 'category',
+  operator: 'bind',
+  fromState: 'voluntary_association',
+  toState: 'compulsory_membership',
+  scopeRules: [
+    { constraint: 'within_site_perimeter', boundaryRef: 'spatial_boundary' },
+    { constraint: 'active_anomaly_field', boundaryRef: 'effect_radius' },
+  ],
+  collateralConceptRefs: ['concept:agency_affiliation', 'concept:staff_loyalty'],
+  detectionDifficulty: 0.45,
+  confidence: 0.58,
+})
+
+/** Relation invert with minimal collateral refs (no scopeRules required). */
+export const RELATION_INVERT_FIXTURE: ConceptStateOperatorRecord = defineRecord({
+  id: 'op:relation-invert-temporal',
+  label: 'Temporal causality inversion',
+  summary: 'Effect and cause reversed for specific event pairs.',
+  targetKind: 'relation',
+  operator: 'invert',
+  fromState: 'cause_before_effect',
+  toState: 'effect_precedes_cause',
+  collateralConceptRefs: ['concept:timeline', 'concept:causality_chain'],
+  confidence: 0.39,
+})
+
+/** Object collapse with minimal data. */
+export const OBJECT_COLLAPSE_FIXTURE: ConceptStateOperatorRecord = defineRecord({
+  id: 'op:object-state-boundary-collapse',
+  label: 'Object state distinction loss',
+  targetKind: 'object',
+  operator: 'collapse',
+  fromState: 'distinct_states',
+  toState: 'superposition_indistinguishable',
+})
+
 
 /**
  * Projects symptom-first collateral entries for related concept refs.

--- a/src/test/conceptStateTransformationRegistry.test.ts
+++ b/src/test/conceptStateTransformationRegistry.test.ts
@@ -72,6 +72,25 @@ describe('conceptStateTransformationRegistry (SPE-2118 slice 1)', () => {
     ])
   })
 
+  it('warns with collapse-specific code when collapse lacks scopeRules', () => {
+    const result = validateConceptStateOperatorRecord(
+      baseRecord({
+        operator: 'collapse',
+        targetKind: 'object',
+        fromState: 'distinct_states',
+        toState: 'superposition_indistinguishable',
+      })
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'collapse_without_scope_rules',
+        severity: 'warning',
+      }),
+    ])
+  })
+
   it('errors on franchise token in operator id', () => {
     const result = validateConceptStateOperatorRecord(
       baseRecord({

--- a/src/test/conceptStateTransformationRegistry.test.ts
+++ b/src/test/conceptStateTransformationRegistry.test.ts
@@ -44,8 +44,12 @@ describe('conceptStateTransformationRegistry (SPE-2118 slice 1)', () => {
     const projection = projectConceptCollateral(CONCEPT_RELOCATE_COLLATERAL_FIXTURE)
 
     expect(projection.affectedEntries).toHaveLength(2)
-    expect(projection.affectedEntries[0]?.symptomDescriptor).toContain('Boundary drift reported for')
-    expect(projection.affectedEntries[0]?.symptomDescriptor).toContain('inside_perimeter -> outside_perimeter')
+    expect(projection.affectedEntries[0]?.symptomDescriptor).toContain(
+      'Boundary drift reported for'
+    )
+    expect(projection.affectedEntries[0]?.symptomDescriptor).toContain(
+      'inside_perimeter -> outside_perimeter'
+    )
     expect(projection.redacted).toBe(false)
   })
 
@@ -87,7 +91,9 @@ describe('conceptStateTransformationRegistry (SPE-2118 slice 1)', () => {
     )
 
     expect(result.valid).toBe(false)
-    expect(result.issues.some((issue) => issue.code === 'branded_object_number_in_label')).toBe(true)
+    expect(result.issues.some((issue) => issue.code === 'branded_object_number_in_label')).toBe(
+      true
+    )
   })
 
   it('redacts collateral when policy requests unknown redaction', () => {
@@ -130,7 +136,6 @@ describe('conceptStateTransformationRegistry (SPE-2118 slice 1)', () => {
     expect(projection.detectionDifficulty).toBeNull()
     expect(projection.redacted).toBe(true)
   })
-})
 
   it('errors on franchise token in scopeRules constraint', () => {
     const result = validateConceptStateOperatorRecord(

--- a/src/test/conceptStateTransformationRegistry.test.ts
+++ b/src/test/conceptStateTransformationRegistry.test.ts
@@ -130,6 +130,7 @@ describe('conceptStateTransformationRegistry (SPE-2118 slice 1)', () => {
     expect(projection.detectionDifficulty).toBeNull()
     expect(projection.redacted).toBe(true)
   })
+})
 
   it('errors on franchise token in scopeRules constraint', () => {
     const result = validateConceptStateOperatorRecord(


### PR DESCRIPTION
## Description

SPE-2118: Implementation of the concept-state transformation registry for the unified cognitive hazard engine.

This pure deterministic registry handles anomalies that transform abstract relationships (inside/outside boundaries, membership, category membership, temporal causality) rather than physical objects alone.

**Files changed:**
- `src/domain/conceptStateTransformationRegistry.ts`: Complete registry implementation with types, validation, and projection
- `src/test/conceptStateTransformationRegistry.test.ts`: Test suite with 10+ test cases
- `planning/concept-state-transformation-registry-slice-1.md`: Slice plan document

**Key components:**
- **Types**: `ConceptStateOperatorId`, `ConceptStateTargetKind` union, `ConceptStateOperator` union (relocate|invert|collapse|bind)
- **Validation**: Comprehensive validation with error/warning codes, franchise token detection, branded object number scanning
- **Projection**: Policy-based symptom descriptors and role hints with confidence/difficulty resolution
- **Fixtures**: 4 test fixtures covering all operator types (relocate, invert, collapse, bind)

**Prerequisite:** SPE-2117 (recurrent catastrophe amelioration registry)
**Deferred work:** GameState persistence, SPE-1309 unified engine wire-up

Closes #SPE-2118