### PR TITLE
SPE-2537 repair welfare evidence from file queue

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -66,6 +66,8 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
+**Current handoff:** [SPE-2537](https://linear.app/spectranoir/issue/SPE-2537/spe-1046-file-work-queue-welfare-evidence-repair-mutation) SPE-1046 file work queue welfare evidence repair mutation (slice 1) is **in progress** on branch `spe-1046-file-work-queue-welfare-evidence-repair-slice-1` from base `9cf49c36`; see `planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md`. [SPE-2536](https://linear.app/spectranoir/issue/SPE-2536/spe-1046-file-work-queue-candidate-evidence-repair-mutation) shipped in PR #3004 @ `7ab3739f`.
+
 **Recently shipped:** [SPE-2497](https://linear.app/spectranoir/issue/SPE-2497) pattern source series registry weekly transition surfacing (slice 5) — `pattern_source_series.weekly_transition` notes; PR #2914 @ `f5b91540`.
 
 **Recently shipped:** [SPE-2500](https://linear.app/spectranoir/issue/SPE-2500) modifiable data-pack publish queue enqueue weekly orchestration (slice 4) — governance → enqueue → execution in `advanceWeek`; PR #2922 @ `b734f03b`.

--- a/planning/spe-1046-file-work-queue-candidate-evidence-repair-slice-1.md
+++ b/planning/spe-1046-file-work-queue-candidate-evidence-repair-slice-1.md
@@ -5,7 +5,7 @@ One-page implementation plan. Linear: [SPE-2536](https://linear.app/spectranoir/
 | Field               | Value                                                                                                                                                                               |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Linear**          | [SPE-2536 - SPE-1046 file work queue candidate evidence repair mutation](https://linear.app/spectranoir/issue/SPE-2536/spe-1046-file-work-queue-candidate-evidence-repair-mutation) |
-| **Status**          | **In Progress**                                                                                                                                                                     |
+| **Status**          | **Shipped** - PR #3004 @ `7ab3739f`                                                                                                                                                 |
 | **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                                                 |
 | **Branch**          | `spe-1046-file-work-queue-candidate-evidence-repair-slice-1`                                                                                                                        |
 | **Base `main` SHA** | `5c165a7c`                                                                                                                                                                          |
@@ -45,7 +45,7 @@ Turn the recorded file work queue repair-action step into a bounded evidence rep
 
 | Item                          | Owner                    | Why                                                     |
 | ----------------------------- | ------------------------ | ------------------------------------------------------- |
-| Welfare evidence repair       | SPE-1046 follow-up child | This slice only repairs `missing_candidate_ref`.        |
+| Welfare evidence repair       | SPE-1046 follow-up child | Followed by SPE-2537.                                   |
 | Onboarding/site repair lanes  | SPE-1046 follow-up child | Requires separate lane policy and tests.                |
 | File release workflow actions | SPE-1046 follow-up child | Access decisions remain derived from existing evidence. |
 | SPE-947 propagation work      | SPE-947 child            | Separate parent thread.                                 |

--- a/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
+++ b/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
@@ -1,0 +1,58 @@
+# SPE-1046 - File work queue welfare evidence repair mutation (slice 1)
+
+One-page implementation plan. Linear: [SPE-2537](https://linear.app/spectranoir/issue/SPE-2537/spe-1046-file-work-queue-welfare-evidence-repair-mutation) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2536](https://linear.app/spectranoir/issue/SPE-2536/spe-1046-file-work-queue-candidate-evidence-repair-mutation) / PR #3004; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2537 - SPE-1046 file work queue welfare evidence repair mutation](https://linear.app/spectranoir/issue/SPE-2537/spe-1046-file-work-queue-welfare-evidence-repair-mutation) |
+| **Status**          | **In Progress**                                                                                                                                                                 |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                                             |
+| **Branch**          | `spe-1046-file-work-queue-welfare-evidence-repair-slice-1`                                                                                                                      |
+| **Base `main` SHA** | `9cf49c36`                                                                                                                                                                      |
+
+## Goal
+
+Turn the recorded file work queue repair-action step into a bounded evidence repair workflow for the second narrow lane: `missing_entity_welfare_reclassification_ref`.
+
+## Scope
+
+| In                                                                                                       | Out                                                 |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Deterministic welfare reclassification evidence repair for resolved `missing_review` rows                | File release workflow actions                       |
+| Existing repair-action ledger remains the UI/store entry point                                           | Candidate, onboarding, site, or broad repair lanes  |
+| Minimal repaired `entityWelfareReclassificationRecords` evidence for existing person-status welfare refs | Mission routing, procurement, or weekly progression |
+| Mirror/page tests proving rows move only through existing derived access decisions                       | SPE-947 propagation work                            |
+
+## Acceptance
+
+- [x] `missing_entity_welfare_reclassification_ref` repair records the existing deterministic repair-action ledger entry.
+- [x] The same repair restores minimal valid welfare evidence for the existing person-status `entityWelfareReclassificationRef`.
+- [x] Restored evidence is written only to `entityWelfareReclassificationRecords` without duplicating existing welfare records.
+- [x] Rows leave only the welfare missing reason through existing SPE-1046 derivations; remaining missing evidence keeps rows in `missing_review`.
+- [x] Unsupported or unresolved repair lanes remain no-op for evidence mutation.
+- [x] File release, mission routing, procurement, weekly progression, and SPE-947 remain untouched.
+- [x] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npm.cmd run test:run -- src/app/store/gameStore.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/test/affiliationFileWorkQueueRepairActionRecords.test.ts`
+- `npm.cmd run lint`
+- Touched-file Prettier check.
+- `git diff --check`
+- Full `npm.cmd run test:run` before PR.
+
+## Deferred
+
+| Item                          | Owner                    | Why                                                     |
+| ----------------------------- | ------------------------ | ------------------------------------------------------- |
+| Onboarding/site repair lanes  | SPE-1046 follow-up child | Requires separate lane policy and tests.                |
+| File release workflow actions | SPE-1046 follow-up child | Access decisions remain derived from existing evidence. |
+| SPE-947 propagation work      | SPE-947 child            | Separate parent thread.                                 |
+| SPE-1046 parent closure       | SPE-1046                 | Broader parent acceptance remains open.                 |
+
+## See also
+
+- `planning/spe-1046-file-work-queue-candidate-evidence-repair-slice-1.md`
+- `planning/spe-1046-file-work-queue-repair-action-ledger-slice-1.md`
+- `planning/spe-1046-file-work-queue-evidence-repair-candidates-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -53,6 +53,7 @@ import { COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE } from '../../domain/affil
 import {
   HOSTILE_TO_COOPERATIVE_FIXTURE,
   PENDING_TO_APPROVED_FIXTURE,
+  validateEntityWelfareReclassificationRecord,
 } from '../../domain/entityWelfareReclassificationRegistry'
 import { buildAffiliationFileWorkQueueActionRecordId } from '../../domain/affiliationFileWorkQueueActionRecords'
 import {
@@ -1950,6 +1951,90 @@ describe('affiliation file work queue repair action store action', () => {
     )
   })
 
+  it('records repair actions and restores welfare evidence for resolved welfare-link rows', () => {
+    const game = createStartingState()
+    game.week = 12
+    game.candidates = [
+      {
+        id: 'candidate:present',
+        name: 'Welfare Repair Subject',
+        age: 30,
+        category: 'agent',
+        hireStatus: 'available',
+        weeklyCost: 0,
+        weeklyWage: 0,
+        revealLevel: 2,
+      },
+    ]
+    game.recruitmentPool = [...game.candidates]
+    game.affiliationPersonStatusRecords = {
+      'person-status:welfare-missing': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:welfare-missing',
+        subjectId: 'subject:welfare-missing',
+        subjectLabel: 'Welfare Repair Subject',
+        candidateRef: 'candidate:present',
+        entityWelfareReclassificationRef: 'reclass:welfare-missing',
+      },
+    }
+    const resolutionRecord = buildAffiliationFileWorkQueueEvidenceResolutionRecord({
+      workQueueEntryId: 'person-status:welfare-missing',
+      subjectId: 'subject:welfare-missing',
+      subjectLabel: 'Welfare Repair Subject',
+      sourceBucket: 'missing_review',
+      missingReasonCodes: ['missing_entity_welfare_reclassification_ref'],
+      recordedWeek: 11,
+    })
+    game.affiliationFileWorkQueueEvidenceResolutionRecords = {
+      [resolutionRecord.id]: resolutionRecord,
+    }
+    const originalPersonStatusRecords = game.affiliationPersonStatusRecords
+    const originalCandidates = game.candidates
+    const originalRecruitmentPool = game.recruitmentPool
+    useGameStore.setState({ game })
+
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueRepairAction(
+        'person-status:welfare-missing',
+        'missing_entity_welfare_reclassification_ref'
+      )
+
+    const next = useGameStore.getState().game
+    const repairActionId = buildAffiliationFileWorkQueueRepairActionRecordId({
+      workQueueEntryId: 'person-status:welfare-missing',
+      reasonCode: 'missing_entity_welfare_reclassification_ref',
+    })
+    const restored = next.entityWelfareReclassificationRecords?.['reclass:welfare-missing']
+    const view = getAffiliationPersonStatusMirrorView(next)
+
+    expect(next.affiliationFileWorkQueueRepairActionRecords?.[repairActionId]).toEqual({
+      id: repairActionId,
+      workQueueEntryId: 'person-status:welfare-missing',
+      subjectId: 'subject:welfare-missing',
+      subjectLabel: 'Welfare Repair Subject',
+      reasonCode: 'missing_entity_welfare_reclassification_ref',
+      repairLabel:
+        'Welfare link repair: attach or restore entity welfare reclassification evidence.',
+      recordedWeek: 12,
+    })
+    expect(restored).toMatchObject({
+      id: 'reclass:welfare-missing',
+      label: 'Welfare Repair Subject welfare link repair',
+      proposedDisposition: 'unknown',
+      reclassificationState: 'pending',
+    })
+    expect(restored ? validateEntityWelfareReclassificationRecord(restored).valid : false).toBe(
+      true
+    )
+    expect(next.affiliationPersonStatusRecords).toBe(originalPersonStatusRecords)
+    expect(next.candidates).toBe(originalCandidates)
+    expect(next.recruitmentPool).toBe(originalRecruitmentPool)
+    expect(view.records[0]?.reasonCodeLabels).not.toContain(
+      'missing_entity_welfare_reclassification_ref'
+    )
+  })
+
   it('no-ops for absent, unresolved, non-matching, and already-recorded rows', () => {
     const game = createStartingState()
     game.week = 12
@@ -2032,11 +2117,51 @@ describe('affiliation file work queue repair action store action', () => {
     const beforeUnsupported = useGameStore.getState().game
     useGameStore
       .getState()
+      .recordAffiliationFileWorkQueueRepairAction('person-status:missing-review', 'missing_unknown')
+    expect(useGameStore.getState().game.candidates).toBe(beforeUnsupported.candidates)
+
+    const beforeWelfareUnresolved = useGameStore.getState().game
+    useGameStore
+      .getState()
       .recordAffiliationFileWorkQueueRepairAction(
         'person-status:missing-review',
         'missing_entity_welfare_reclassification_ref'
       )
-    expect(useGameStore.getState().game.candidates).toBe(beforeUnsupported.candidates)
+    expect(useGameStore.getState().game).toBe(beforeWelfareUnresolved)
+
+    const welfareResolutionRecord = buildAffiliationFileWorkQueueEvidenceResolutionRecord({
+      workQueueEntryId: 'person-status:missing-review',
+      subjectId: 'subject:missing-review',
+      subjectLabel: 'Missing Review Subject',
+      sourceBucket: 'missing_review',
+      missingReasonCodes: ['missing_entity_welfare_reclassification_ref'],
+      recordedWeek: 14,
+    })
+    useGameStore.setState({
+      game: {
+        ...useGameStore.getState().game,
+        affiliationFileWorkQueueEvidenceResolutionRecords: {
+          [welfareResolutionRecord.id]: welfareResolutionRecord,
+        },
+        entityWelfareReclassificationRecords: {
+          'reclass:missing': PENDING_TO_APPROVED_FIXTURE,
+        },
+      },
+    })
+
+    const beforeWelfarePresent = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueRepairAction(
+        'person-status:missing-review',
+        'missing_entity_welfare_reclassification_ref'
+      )
+    expect(useGameStore.getState().game.affiliationFileWorkQueueRepairActionRecords).toBe(
+      beforeWelfarePresent.affiliationFileWorkQueueRepairActionRecords
+    )
+    expect(useGameStore.getState().game.entityWelfareReclassificationRecords).toBe(
+      beforeWelfarePresent.entityWelfareReclassificationRecords
+    )
   })
 })
 

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -156,7 +156,7 @@ import { reconcileAgents } from '../../domain/sim/reconciliation'
 import { buildAffiliationFileWorkQueueActionRecord } from '../../domain/affiliationFileWorkQueueActionRecords'
 import { buildAffiliationFileWorkQueueEvidenceResolutionRecord } from '../../domain/affiliationFileWorkQueueEvidenceResolutionRecords'
 import {
-  applyAffiliationFileWorkQueueCandidateEvidenceRepair,
+  applyAffiliationFileWorkQueueEvidenceRepair,
   buildAffiliationFileWorkQueueRepairActionRecord,
 } from '../../domain/affiliationFileWorkQueueRepairActionRecords'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
@@ -1790,7 +1790,7 @@ export const useGameStore = create<GameStore>()(
             recordedWeek: s.game.week,
           })
 
-          const repaired = applyAffiliationFileWorkQueueCandidateEvidenceRepair({
+          const repaired = applyAffiliationFileWorkQueueEvidenceRepair({
             state: s.game,
             workQueueEntryId: entry.id,
             reasonCode: repairCandidate.reasonCode,

--- a/src/domain/affiliationFileWorkQueueRepairActionRecords.ts
+++ b/src/domain/affiliationFileWorkQueueRepairActionRecords.ts
@@ -1,5 +1,6 @@
 import type { GameState } from './models'
 import type { Candidate } from './recruitment'
+import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 
 export type AffiliationFileWorkQueueRepairActionRecordId = string
 
@@ -27,18 +28,20 @@ export interface AffiliationFileWorkQueueRepairActionRecordInput {
   readonly recordedWeek: number
 }
 
-export type AffiliationFileWorkQueueCandidateEvidenceRepairReason =
+export type AffiliationFileWorkQueueEvidenceRepairReason =
   | 'applied'
   | 'unsupported-reason-code'
   | 'missing-person-status-record'
   | 'missing-candidate-ref'
+  | 'missing-welfare-ref'
   | 'candidate-already-present'
+  | 'welfare-record-already-present'
   | 'missing-evidence-resolution'
 
-export interface AffiliationFileWorkQueueCandidateEvidenceRepairResult {
+export interface AffiliationFileWorkQueueEvidenceRepairResult {
   readonly state: GameState
   readonly applied: boolean
-  readonly reason: AffiliationFileWorkQueueCandidateEvidenceRepairReason
+  readonly reason: AffiliationFileWorkQueueEvidenceRepairReason
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -72,6 +75,14 @@ function hasRecordedCandidateEvidenceResolution(state: GameState, entryId: strin
     (record) =>
       record.workQueueEntryId === entryId &&
       record.missingReasonCodes.includes('missing_candidate_ref')
+  )
+}
+
+function hasRecordedWelfareEvidenceResolution(state: GameState, entryId: string) {
+  return Object.values(state.affiliationFileWorkQueueEvidenceResolutionRecords ?? {}).some(
+    (record) =>
+      record.workQueueEntryId === entryId &&
+      record.missingReasonCodes.includes('missing_entity_welfare_reclassification_ref')
   )
 }
 
@@ -119,6 +130,23 @@ function buildRepairedCandidateEvidence(input: {
   })
 }
 
+function buildRepairedWelfareEvidence(input: {
+  readonly recordId: string
+  readonly subjectLabel: string
+  readonly week: number
+}): EntityWelfareReclassificationRecord {
+  return Object.freeze({
+    id: input.recordId,
+    label: `${input.subjectLabel} welfare link repair`,
+    summary: 'Minimal restored welfare reclassification evidence from file work queue repair.',
+    priorThreatLabel: 'unreviewed affiliation custody',
+    proposedDisposition: 'unknown',
+    reclassificationState: 'pending',
+    evidenceBundleRefs: [`affiliation-file-work-queue-repair:${input.recordId}:week-${input.week}`],
+    confidence: 0.5,
+  })
+}
+
 function appendCandidateIfMissing(
   candidates: readonly Candidate[] | undefined,
   candidate: Candidate
@@ -128,15 +156,18 @@ function appendCandidateIfMissing(
     : [...(candidates ?? []), candidate]
 }
 
-export function applyAffiliationFileWorkQueueCandidateEvidenceRepair(input: {
+export function applyAffiliationFileWorkQueueEvidenceRepair(input: {
   readonly state: GameState
   readonly workQueueEntryId: string
   readonly reasonCode: string
   readonly recordedWeek: number
-}): AffiliationFileWorkQueueCandidateEvidenceRepairResult {
+}): AffiliationFileWorkQueueEvidenceRepairResult {
   const reasonCode = normalizeReasonCode(input.reasonCode)
 
-  if (reasonCode !== 'missing_candidate_ref') {
+  if (
+    reasonCode !== 'missing_candidate_ref' &&
+    reasonCode !== 'missing_entity_welfare_reclassification_ref'
+  ) {
     return Object.freeze({
       state: input.state,
       applied: false,
@@ -150,6 +181,51 @@ export function applyAffiliationFileWorkQueueCandidateEvidenceRepair(input: {
       state: input.state,
       applied: false,
       reason: 'missing-person-status-record',
+    })
+  }
+
+  if (reasonCode === 'missing_entity_welfare_reclassification_ref') {
+    const welfareRef = normalizeToken(record.entityWelfareReclassificationRef)
+    if (!welfareRef) {
+      return Object.freeze({
+        state: input.state,
+        applied: false,
+        reason: 'missing-welfare-ref',
+      })
+    }
+
+    if (!hasRecordedWelfareEvidenceResolution(input.state, input.workQueueEntryId)) {
+      return Object.freeze({
+        state: input.state,
+        applied: false,
+        reason: 'missing-evidence-resolution',
+      })
+    }
+
+    if (input.state.entityWelfareReclassificationRecords?.[welfareRef]) {
+      return Object.freeze({
+        state: input.state,
+        applied: false,
+        reason: 'welfare-record-already-present',
+      })
+    }
+
+    const welfareRecord = buildRepairedWelfareEvidence({
+      recordId: welfareRef,
+      subjectLabel: record.subjectLabel,
+      week: input.recordedWeek,
+    })
+
+    return Object.freeze({
+      state: {
+        ...input.state,
+        entityWelfareReclassificationRecords: {
+          ...(input.state.entityWelfareReclassificationRecords ?? {}),
+          [welfareRecord.id]: welfareRecord,
+        },
+      },
+      applied: true,
+      reason: 'applied',
     })
   }
 
@@ -197,6 +273,9 @@ export function applyAffiliationFileWorkQueueCandidateEvidenceRepair(input: {
     reason: 'applied',
   })
 }
+
+export const applyAffiliationFileWorkQueueCandidateEvidenceRepair =
+  applyAffiliationFileWorkQueueEvidenceRepair
 
 export function buildAffiliationFileWorkQueueRepairActionRecordId(input: {
   readonly workQueueEntryId: string

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -184,7 +184,9 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
       reasonCode: 'missing_entity_welfare_reclassification_ref',
     })
 
-    expect(queueRegion).toHaveTextContent('Repair recorded W10')
+    expect(queueRegion).toHaveTextContent('Missing review 0')
+    expect(queueRegion).toHaveTextContent('Restricted 1')
+    expect(queueRegion).not.toHaveTextContent('missing_entity_welfare_reclassification_ref')
     expect(useGameStore.getState().game.affiliationFileWorkQueueRepairActionRecords).toEqual(
       expect.objectContaining({
         [repairActionId]: expect.objectContaining({
@@ -250,5 +252,60 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
         name: 'Missing Review Subject',
       }),
     ])
+  })
+
+  it('repairs welfare evidence from a resolved missing-review queue row', async () => {
+    const user = userEvent.setup()
+    const game = createStartingState()
+    game.week = 10
+    game.candidates = [
+      {
+        id: 'candidate:present',
+        name: 'Welfare Repair Subject',
+        age: 30,
+        category: 'agent',
+        hireStatus: 'available',
+        weeklyCost: 0,
+        weeklyWage: 0,
+        revealLevel: 2,
+      },
+    ]
+    game.recruitmentPool = [...game.candidates]
+    game.affiliationPersonStatusRecords = {
+      'person-status:welfare-missing': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:welfare-missing',
+        subjectId: 'subject:welfare-missing',
+        subjectLabel: 'Welfare Repair Subject',
+        candidateRef: 'candidate:present',
+        entityWelfareReclassificationRef: 'reclass:welfare-missing',
+      },
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const queueRegion = screen.getByRole('region', {
+      name: /file access work queue/i,
+    })
+
+    expect(queueRegion).toHaveTextContent('Missing review 1')
+    expect(queueRegion).toHaveTextContent('missing_entity_welfare_reclassification_ref')
+
+    await user.click(screen.getByRole('button', { name: /record evidence resolution/i }))
+    await user.click(screen.getAllByRole('button', { name: /record repair action/i })[0])
+
+    expect(queueRegion).toHaveTextContent('Missing review 0')
+    expect(queueRegion).not.toHaveTextContent('missing_entity_welfare_reclassification_ref')
+    expect(
+      useGameStore.getState().game.entityWelfareReclassificationRecords?.['reclass:welfare-missing']
+    ).toEqual(
+      expect.objectContaining({
+        id: 'reclass:welfare-missing',
+        label: 'Welfare Repair Subject welfare link repair',
+        proposedDisposition: 'unknown',
+        reclassificationState: 'pending',
+      })
+    )
   })
 })

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -431,4 +431,44 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     })
     expect(view.records[0]?.reasonCodeLabels).not.toContain('missing_candidate_ref')
   })
+
+  it('moves repaired welfare evidence out of missing-review through existing derivations', () => {
+    const game = createStartingState()
+    game.recruitmentPool = [makeCandidate({ id: 'candidate:present', name: 'Welfare Subject' })]
+    game.candidates = [makeCandidate({ id: 'candidate:present', name: 'Welfare Subject' })]
+    game.entityWelfareReclassificationRecords = {
+      'reclass:welfare-repaired': {
+        id: 'reclass:welfare-repaired',
+        label: 'Welfare Subject welfare link repair',
+        summary: 'Minimal restored welfare reclassification evidence from file work queue repair.',
+        priorThreatLabel: 'unreviewed affiliation custody',
+        proposedDisposition: 'unknown',
+        reclassificationState: 'pending',
+        evidenceBundleRefs: ['affiliation-file-work-queue-repair:reclass:welfare-repaired:week-12'],
+        confidence: 0.5,
+      },
+    }
+    game.affiliationPersonStatusRecords = {
+      'person-status:repaired-welfare': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:repaired-welfare',
+        subjectId: 'subject:repaired-welfare',
+        subjectLabel: 'Welfare Subject',
+        candidateRef: 'candidate:present',
+        entityWelfareReclassificationRef: 'reclass:welfare-repaired',
+      },
+    }
+
+    const view = getAffiliationPersonStatusMirrorView(game)
+
+    expect(view.records[0]?.reasonCodeLabels).not.toContain(
+      'missing_entity_welfare_reclassification_ref'
+    )
+    expect(view.fileAccessWorkQueue[0]).toMatchObject({
+      id: 'person-status:repaired-welfare',
+      bucket: 'restricted',
+      fileAccessLabel: 'File access: Restricted',
+      facilityFileAccessLabel: 'Facility file access: Restricted',
+    })
+  })
 })

--- a/src/test/affiliationFileWorkQueueRepairActionRecords.test.ts
+++ b/src/test/affiliationFileWorkQueueRepairActionRecords.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import { hydrateGame } from '../app/store/runTransfer'
 import { createStartingState } from '../data/startingState'
+import { COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE } from '../domain/affiliationPersonStatusRecords'
+import { buildAffiliationFileWorkQueueEvidenceResolutionRecord } from '../domain/affiliationFileWorkQueueEvidenceResolutionRecords'
 import {
+  applyAffiliationFileWorkQueueEvidenceRepair,
   buildAffiliationFileWorkQueueRepairActionRecord,
   buildAffiliationFileWorkQueueRepairActionRecordId,
   sanitizeAffiliationFileWorkQueueRepairActionRecords,
 } from '../domain/affiliationFileWorkQueueRepairActionRecords'
+import { validateEntityWelfareReclassificationRecord } from '../domain/entityWelfareReclassificationRegistry'
 
 describe('affiliationFileWorkQueueRepairActionRecords persistence', () => {
   it('builds deterministic ids from work queue entry and missing reason code', () => {
@@ -88,5 +92,55 @@ describe('affiliationFileWorkQueueRepairActionRecords persistence', () => {
       [valid.id]: valid,
     })
     expect(hydrated.affiliationPersonStatusRecords).toEqual({})
+  })
+
+  it('restores minimal valid welfare evidence for resolved welfare-link repairs', () => {
+    const state = createStartingState()
+    state.week = 13
+    state.affiliationPersonStatusRecords = {
+      'person-status:welfare-missing': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:welfare-missing',
+        subjectId: 'subject:welfare-missing',
+        subjectLabel: 'Welfare Missing Subject',
+        entityWelfareReclassificationRef: 'reclass:welfare-missing',
+      },
+    }
+    const resolution = buildAffiliationFileWorkQueueEvidenceResolutionRecord({
+      workQueueEntryId: 'person-status:welfare-missing',
+      subjectId: 'subject:welfare-missing',
+      subjectLabel: 'Welfare Missing Subject',
+      sourceBucket: 'missing_review',
+      missingReasonCodes: ['missing_entity_welfare_reclassification_ref'],
+      recordedWeek: 12,
+    })
+    state.affiliationFileWorkQueueEvidenceResolutionRecords = {
+      [resolution.id]: resolution,
+    }
+
+    const result = applyAffiliationFileWorkQueueEvidenceRepair({
+      state,
+      workQueueEntryId: 'person-status:welfare-missing',
+      reasonCode: 'missing_entity_welfare_reclassification_ref',
+      recordedWeek: 13,
+    })
+    const restored = result.state.entityWelfareReclassificationRecords?.['reclass:welfare-missing']
+
+    expect(result).toMatchObject({ applied: true, reason: 'applied' })
+    expect(restored).toMatchObject({
+      id: 'reclass:welfare-missing',
+      label: 'Welfare Missing Subject welfare link repair',
+      priorThreatLabel: 'unreviewed affiliation custody',
+      proposedDisposition: 'unknown',
+      reclassificationState: 'pending',
+      confidence: 0.5,
+    })
+    expect(restored?.evidenceBundleRefs).toEqual([
+      'affiliation-file-work-queue-repair:reclass:welfare-missing:week-13',
+    ])
+    expect(restored ? validateEntityWelfareReclassificationRecord(restored).valid : false).toBe(
+      true
+    )
+    expect(result.state.affiliationPersonStatusRecords).toBe(state.affiliationPersonStatusRecords)
   })
 })


### PR DESCRIPTION
## Summary
- Links SPE-2537
- Extends the file work queue repair mutation path to support `missing_entity_welfare_reclassification_ref` alongside the existing candidate repair lane.
- Restores minimal valid `entityWelfareReclassificationRecords` evidence only after evidence resolution plus repair-action recording.
- Adds store, view, page, and domain tests for welfare repair success and no-op guards.

## Validation
- `npm.cmd run test:run -- src/app/store/gameStore.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/test/affiliationFileWorkQueueRepairActionRecords.test.ts`
- `npm.cmd run lint`
- `npx.cmd prettier --check planning/spe-1046-file-work-queue-candidate-evidence-repair-slice-1.md planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md src/app/store/gameStore.ts src/app/store/gameStore.test.ts src/domain/affiliationFileWorkQueueRepairActionRecords.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/features/operations/affiliationPersonStatusMirrorView.test.ts src/test/affiliationFileWorkQueueRepairActionRecords.test.ts`
- `git diff --check`
- `npm.cmd run test:run`

## Notes
- SPE-1046 parent remains Backlog.
- `planning/backlog.md` was updated with a minimal current-handoff line only; broad markdown table reflow was intentionally avoided.