### PR TITLE
SPE-1046 add file release fulfillment receipts

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -66,7 +66,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Current handoff:** [SPE-2540](https://linear.app/spectranoir/issue/SPE-2540/spe-1046-file-work-queue-release-outcomes) SPE-1046 file work queue release outcomes (slice 1) is **in progress** on branch `spe-1046-file-work-queue-release-outcomes-slice-1` from base `f1d96633`; see `planning/spe-1046-file-work-queue-release-outcomes-slice-1.md`. [SPE-2539](https://linear.app/spectranoir/issue/SPE-2539/spe-1046-file-work-queue-release-actions) shipped in PR #3011 @ `f1d96633`.
+**Current handoff:** SPE-1046 file work queue file-release fulfillment (slice 1) is implemented locally on branch `spe-1046-file-work-queue-file-release-fulfillment-slice-1` from base `320e356e`; see `planning/spe-1046-file-work-queue-file-release-fulfillment-slice-1.md`. Linear child creation/status update is blocked until Linear OAuth reauthentication. [SPE-2540](https://linear.app/spectranoir/issue/SPE-2540/spe-1046-file-work-queue-release-outcomes) is already on `main` @ `320e356e`.
 
 **Recently shipped:** [SPE-2497](https://linear.app/spectranoir/issue/SPE-2497) pattern source series registry weekly transition surfacing (slice 5) — `pattern_source_series.weekly_transition` notes; PR #2914 @ `f5b91540`.
 

--- a/planning/spe-1046-file-work-queue-file-release-fulfillment-slice-1.md
+++ b/planning/spe-1046-file-work-queue-file-release-fulfillment-slice-1.md
@@ -1,0 +1,59 @@
+# SPE-1046 - File work queue file-release fulfillment (slice 1)
+
+One-page implementation plan. Linear child creation/status update is blocked in this session by Linear OAuth reauthentication; intended parent is [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046). Follows [SPE-2540](https://linear.app/spectranoir/issue/SPE-2540/spe-1046-file-work-queue-release-outcomes) / commit `320e356e`; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+
+| Field               | Value                                                        |
+| ------------------- | ------------------------------------------------------------ |
+| **Linear**          | Pending SPE-1046 child - file work queue release fulfillment |
+| **Status**          | Local implementation                                         |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)    |
+| **Branch**          | `spe-1046-file-work-queue-file-release-fulfillment-slice-1`  |
+| **Base `main` SHA** | `320e356e`                                                   |
+
+## Goal
+
+Persist bounded file-release fulfillment receipts after a release outcome exists, without storing file contents or changing SPE-1046 access decisions.
+
+## Scope
+
+| In                                                                                 | Out                                                 |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Persisted release-fulfillment ledger for eligible `file_released` outcome rows     | Actual file payload storage or delivery             |
+| Store action over existing derived queue rows and release outcome records          | Mission routing, procurement, or weekly progression |
+| Operations mirror surfacing for fulfillment controls and recorded week labels      | SPE-947 propagation work                            |
+| Hydration and page/view/store/domain tests for fulfillment records and no-op paths | SPE-1046 parent closure                             |
+
+## Acceptance
+
+- [x] `file_released` maps to `file_release_fulfilled`.
+- [x] `restricted_review_pending` has no fulfillment action.
+- [x] Fulfillment recording requires an existing release action and release outcome on an allowed row.
+- [x] Missing-outcome, restricted-review, absent, and ineligible rows no-op.
+- [x] Fulfillment records persist through hydrate/export without mutating person-status, release-action, or release-outcome records.
+- [x] Operations mirror exposes fulfillment controls only for eligible allowed release outcomes and recorded labels after fulfillment.
+- [x] File contents, access decisions, mission routing, procurement, weekly progression, and SPE-947 remain untouched.
+- [x] SPE-1046 parent remains **Backlog**.
+
+## Validation
+
+- `npm.cmd run test:run -- src/app/store/gameStore.test.ts src/app/store/runTransfer.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/test/affiliationFileWorkQueueReleaseFulfillmentRecords.test.ts`
+- `npm.cmd run lint`
+- Touched-file Prettier check.
+- `git diff --check`
+- `npm.cmd run test:run`
+
+## Deferred
+
+| Item                          | Owner                    | Why                                                     |
+| ----------------------------- | ------------------------ | ------------------------------------------------------- |
+| Actual file content release   | SPE-1046 follow-up child | This slice records fulfillment receipts only.           |
+| Mission routing / procurement | SPE-1046 follow-up child | Existing gates remain separate from file workflow UI.   |
+| SPE-947 propagation work      | SPE-947 child            | Separate parent thread.                                 |
+| SPE-1046 parent closure       | SPE-1046                 | Broader parent acceptance remains open.                 |
+| Linear issue creation/update  | Human / next agent       | Linear connector requires OAuth reauthentication first. |
+
+## See also
+
+- `planning/spe-1046-file-work-queue-release-outcomes-slice-1.md`
+- `planning/spe-1046-file-work-queue-release-actions-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -63,6 +63,7 @@ import {
 import { buildAffiliationFileWorkQueueRepairActionRecordId } from '../../domain/affiliationFileWorkQueueRepairActionRecords'
 import { buildAffiliationFileWorkQueueReleaseActionRecordId } from '../../domain/affiliationFileWorkQueueReleaseActionRecords'
 import { buildAffiliationFileWorkQueueReleaseOutcomeRecordId } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
+import { buildAffiliationFileWorkQueueReleaseFulfillmentRecordId } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
 
 const STORE_KEY = 'containment-protocol-game-state'
@@ -1993,6 +1994,61 @@ describe('affiliation file work queue release outcome store action', () => {
       .getState()
       .recordAffiliationFileWorkQueueReleaseOutcome(COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id)
     expect(useGameStore.getState().game).toBe(afterFirstOutcome)
+  })
+})
+
+describe('affiliation file work queue release fulfillment store action', () => {
+  it('no-ops for missing outcome, restricted review outcomes, absent rows, and already ineligible rows', () => {
+    const game = createStartingState()
+    game.week = 15
+    game.entityWelfareReclassificationRecords = {
+      [PENDING_TO_APPROVED_FIXTURE.id]: PENDING_TO_APPROVED_FIXTURE,
+    }
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        entityWelfareReclassificationRef: PENDING_TO_APPROVED_FIXTURE.id,
+      },
+    }
+    useGameStore.setState({ game })
+
+    const beforeMissingOutcome = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueReleaseFulfillment(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+    expect(useGameStore.getState().game).toBe(beforeMissingOutcome)
+
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueReleaseAction(COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id)
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueReleaseOutcome(COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id)
+
+    const beforeRestrictedReview = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueReleaseFulfillment(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+    expect(useGameStore.getState().game).toBe(beforeRestrictedReview)
+
+    const beforeAbsent = useGameStore.getState().game
+    useGameStore.getState().recordAffiliationFileWorkQueueReleaseFulfillment('person-status:absent')
+    expect(useGameStore.getState().game).toBe(beforeAbsent)
+    expect(useGameStore.getState().game.affiliationFileWorkQueueReleaseFulfillmentRecords).toBe(
+      undefined
+    )
+    expect(
+      buildAffiliationFileWorkQueueReleaseFulfillmentRecordId({
+        workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+        sourceOutcomeKind: 'file_released',
+      })
+    ).toBe(
+      `affiliation-file-release-fulfillment:${COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id}:file_released`
+    )
   })
 })
 

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -167,6 +167,10 @@ import {
   buildAffiliationFileWorkQueueReleaseOutcomeRecord,
   getAffiliationFileWorkQueueReleaseOutcomeForAction,
 } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
+import {
+  buildAffiliationFileWorkQueueReleaseFulfillmentRecord,
+  getAffiliationFileWorkQueueReleaseFulfillmentForOutcome,
+} from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
 import {
   clearContractNextIntent,
@@ -347,6 +351,7 @@ interface GameStore {
   recordAffiliationFileWorkQueueRepairAction: (entryId: string, reasonCode: string) => void
   recordAffiliationFileWorkQueueReleaseAction: (entryId: string) => void
   recordAffiliationFileWorkQueueReleaseOutcome: (entryId: string) => void
+  recordAffiliationFileWorkQueueReleaseFulfillment: (entryId: string) => void
   advanceWeek: () => void
   setSeed: (seed: number) => void
   setSquadMetadata: (metadata: SquadMetadata) => void
@@ -1888,6 +1893,53 @@ export const useGameStore = create<GameStore>()(
               ...s.game,
               affiliationFileWorkQueueReleaseOutcomeRecords: {
                 ...(s.game.affiliationFileWorkQueueReleaseOutcomeRecords ?? {}),
+                [record.id]: record,
+              },
+            },
+          }
+        }),
+
+      recordAffiliationFileWorkQueueReleaseFulfillment: (entryId) =>
+        set((s) => {
+          const view = getAffiliationPersonStatusMirrorView(s.game)
+          const entry = view.fileAccessWorkQueue.find((candidate) => candidate.id === entryId)
+
+          if (
+            !entry ||
+            entry.bucket !== 'allowed' ||
+            !entry.releaseOutcomeKind ||
+            !entry.isReleaseActionRecorded ||
+            !entry.isReleaseOutcomeRecorded ||
+            entry.isReleaseFulfillmentRecorded
+          ) {
+            return { game: s.game }
+          }
+
+          const fulfillment = getAffiliationFileWorkQueueReleaseFulfillmentForOutcome(
+            entry.releaseOutcomeKind
+          )
+
+          if (!fulfillment) {
+            return { game: s.game }
+          }
+
+          const record = buildAffiliationFileWorkQueueReleaseFulfillmentRecord({
+            workQueueEntryId: entry.id,
+            subjectId: entry.subjectId,
+            subjectLabel: entry.subjectLabel,
+            sourceOutcomeKind: entry.releaseOutcomeKind,
+            sourceBucket: 'allowed',
+            sourceReasonCodes: entry.reasonCodeLabels,
+            fulfillmentKind: fulfillment.fulfillmentKind,
+            fulfillmentLabel: fulfillment.fulfillmentLabel,
+            recordedWeek: s.game.week,
+          })
+
+          return {
+            game: {
+              ...s.game,
+              affiliationFileWorkQueueReleaseFulfillmentRecords: {
+                ...(s.game.affiliationFileWorkQueueReleaseFulfillmentRecords ?? {}),
                 [record.id]: record,
               },
             },

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -218,6 +218,7 @@ import { sanitizeAffiliationFileWorkQueueEvidenceResolutionRecords } from '../..
 import { sanitizeAffiliationFileWorkQueueRepairActionRecords } from '../../domain/affiliationFileWorkQueueRepairActionRecords'
 import { sanitizeAffiliationFileWorkQueueReleaseActionRecords } from '../../domain/affiliationFileWorkQueueReleaseActionRecords'
 import { sanitizeAffiliationFileWorkQueueReleaseOutcomeRecords } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
+import { sanitizeAffiliationFileWorkQueueReleaseFulfillmentRecords } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
 import { sanitizeCustodyStatusRecords } from '../../domain/containedPersonCustodyStatusRegistry'
@@ -8765,6 +8766,11 @@ export function hydrateGame(
       game.affiliationFileWorkQueueReleaseOutcomeRecords,
       fallback.affiliationFileWorkQueueReleaseOutcomeRecords ?? {}
     )
+  const affiliationFileWorkQueueReleaseFulfillmentRecords =
+    sanitizeAffiliationFileWorkQueueReleaseFulfillmentRecords(
+      game.affiliationFileWorkQueueReleaseFulfillmentRecords,
+      fallback.affiliationFileWorkQueueReleaseFulfillmentRecords ?? {}
+    )
   const entityWelfareReclassificationRecords = sanitizeEntityWelfareReclassificationRecords(
     game.entityWelfareReclassificationRecords,
     fallback.entityWelfareReclassificationRecords ?? {}
@@ -8964,6 +8970,7 @@ export function hydrateGame(
     affiliationFileWorkQueueRepairActionRecords,
     affiliationFileWorkQueueReleaseActionRecords,
     affiliationFileWorkQueueReleaseOutcomeRecords,
+    affiliationFileWorkQueueReleaseFulfillmentRecords,
     entityWelfareReclassificationRecords,
     containedPersonTherapeuticCareRecords,
     containedPersonMedicationRegimenRecords,

--- a/src/domain/affiliationFileWorkQueueReleaseFulfillmentRecords.ts
+++ b/src/domain/affiliationFileWorkQueueReleaseFulfillmentRecords.ts
@@ -1,0 +1,217 @@
+import type { AffiliationFileWorkQueueReleaseSourceBucket } from './affiliationFileWorkQueueReleaseActionRecords'
+import type { AffiliationFileWorkQueueReleaseOutcomeKind } from './affiliationFileWorkQueueReleaseOutcomeRecords'
+
+export type AffiliationFileWorkQueueReleaseFulfillmentRecordId = string
+
+export type AffiliationFileWorkQueueReleaseFulfillmentKind = 'file_release_fulfilled'
+
+export interface AffiliationFileWorkQueueReleaseFulfillmentRecord {
+  readonly id: AffiliationFileWorkQueueReleaseFulfillmentRecordId
+  readonly workQueueEntryId: string
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly sourceOutcomeKind: AffiliationFileWorkQueueReleaseOutcomeKind
+  readonly sourceBucket: AffiliationFileWorkQueueReleaseSourceBucket
+  readonly sourceReasonCodes: readonly string[]
+  readonly fulfillmentKind: AffiliationFileWorkQueueReleaseFulfillmentKind
+  readonly fulfillmentLabel: string
+  readonly recordedWeek: number
+}
+
+export type AffiliationFileWorkQueueReleaseFulfillmentRecordsMap = Record<
+  AffiliationFileWorkQueueReleaseFulfillmentRecordId,
+  AffiliationFileWorkQueueReleaseFulfillmentRecord
+>
+
+export interface AffiliationFileWorkQueueReleaseFulfillmentRecordInput {
+  readonly workQueueEntryId: string
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly sourceOutcomeKind: AffiliationFileWorkQueueReleaseOutcomeKind
+  readonly sourceBucket: AffiliationFileWorkQueueReleaseSourceBucket
+  readonly sourceReasonCodes: readonly string[]
+  readonly fulfillmentKind: AffiliationFileWorkQueueReleaseFulfillmentKind
+  readonly fulfillmentLabel: string
+  readonly recordedWeek: number
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeRecordedWeek(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value === Math.trunc(value)
+    ? value
+    : undefined
+}
+
+function normalizeReasonCodes(value: unknown) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return [
+    ...new Set(value.map((entry) => normalizeToken(entry)).filter((entry) => entry.length > 0)),
+  ].sort((left, right) => left.localeCompare(right))
+}
+
+function normalizeSourceOutcomeKind(
+  value: unknown
+): AffiliationFileWorkQueueReleaseOutcomeKind | undefined {
+  return value === 'file_released' || value === 'restricted_review_pending' ? value : undefined
+}
+
+function normalizeSourceBucket(
+  value: unknown
+): AffiliationFileWorkQueueReleaseSourceBucket | undefined {
+  return value === 'allowed' || value === 'restricted' ? value : undefined
+}
+
+function normalizeFulfillmentKind(
+  value: unknown
+): AffiliationFileWorkQueueReleaseFulfillmentKind | undefined {
+  return value === 'file_release_fulfilled' ? value : undefined
+}
+
+export function getAffiliationFileWorkQueueReleaseFulfillmentForOutcome(
+  outcomeKind: AffiliationFileWorkQueueReleaseOutcomeKind
+): {
+  readonly fulfillmentKind: AffiliationFileWorkQueueReleaseFulfillmentKind
+  readonly fulfillmentLabel: string
+} | null {
+  switch (outcomeKind) {
+    case 'file_released':
+      return Object.freeze({
+        fulfillmentKind: 'file_release_fulfilled',
+        fulfillmentLabel: 'File release fulfilled',
+      })
+    case 'restricted_review_pending':
+      return null
+  }
+}
+
+function isValidFulfillmentPair(input: {
+  readonly sourceOutcomeKind: AffiliationFileWorkQueueReleaseOutcomeKind
+  readonly sourceBucket: AffiliationFileWorkQueueReleaseSourceBucket
+  readonly fulfillmentKind: AffiliationFileWorkQueueReleaseFulfillmentKind
+}) {
+  return (
+    input.sourceOutcomeKind === 'file_released' &&
+    input.sourceBucket === 'allowed' &&
+    input.fulfillmentKind === 'file_release_fulfilled'
+  )
+}
+
+export function buildAffiliationFileWorkQueueReleaseFulfillmentRecordId(input: {
+  readonly workQueueEntryId: string
+  readonly sourceOutcomeKind: AffiliationFileWorkQueueReleaseOutcomeKind
+}) {
+  return `affiliation-file-release-fulfillment:${input.workQueueEntryId}:${input.sourceOutcomeKind}`
+}
+
+export function buildAffiliationFileWorkQueueReleaseFulfillmentRecord(
+  input: AffiliationFileWorkQueueReleaseFulfillmentRecordInput
+): AffiliationFileWorkQueueReleaseFulfillmentRecord {
+  const sourceReasonCodes = normalizeReasonCodes(input.sourceReasonCodes)
+
+  return Object.freeze({
+    id: buildAffiliationFileWorkQueueReleaseFulfillmentRecordId({
+      workQueueEntryId: input.workQueueEntryId,
+      sourceOutcomeKind: input.sourceOutcomeKind,
+    }),
+    workQueueEntryId: input.workQueueEntryId,
+    subjectId: input.subjectId,
+    subjectLabel: input.subjectLabel,
+    sourceOutcomeKind: input.sourceOutcomeKind,
+    sourceBucket: input.sourceBucket,
+    sourceReasonCodes: Object.freeze(sourceReasonCodes),
+    fulfillmentKind: input.fulfillmentKind,
+    fulfillmentLabel: input.fulfillmentLabel,
+    recordedWeek: input.recordedWeek,
+  })
+}
+
+function sanitizeReleaseFulfillmentRecordEntry(
+  value: unknown,
+  expectedKey?: string
+): AffiliationFileWorkQueueReleaseFulfillmentRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const workQueueEntryId = normalizeToken(value.workQueueEntryId)
+  const subjectId = normalizeToken(value.subjectId)
+  const subjectLabel = normalizeToken(value.subjectLabel)
+  const sourceOutcomeKind = normalizeSourceOutcomeKind(value.sourceOutcomeKind)
+  const sourceBucket = normalizeSourceBucket(value.sourceBucket)
+  const fulfillmentKind = normalizeFulfillmentKind(value.fulfillmentKind)
+  const fulfillmentLabel = normalizeToken(value.fulfillmentLabel)
+  const recordedWeek = normalizeRecordedWeek(value.recordedWeek)
+
+  if (
+    !id ||
+    !workQueueEntryId ||
+    !subjectId ||
+    !subjectLabel ||
+    !sourceOutcomeKind ||
+    !sourceBucket ||
+    !fulfillmentKind ||
+    !fulfillmentLabel ||
+    recordedWeek === undefined ||
+    !isValidFulfillmentPair({ sourceOutcomeKind, sourceBucket, fulfillmentKind }) ||
+    (expectedKey !== undefined && expectedKey !== id) ||
+    id !==
+      buildAffiliationFileWorkQueueReleaseFulfillmentRecordId({
+        workQueueEntryId,
+        sourceOutcomeKind,
+      })
+  ) {
+    return null
+  }
+
+  return Object.freeze({
+    id,
+    workQueueEntryId,
+    subjectId,
+    subjectLabel,
+    sourceOutcomeKind,
+    sourceBucket,
+    sourceReasonCodes: Object.freeze(normalizeReasonCodes(value.sourceReasonCodes)),
+    fulfillmentKind,
+    fulfillmentLabel,
+    recordedWeek,
+  })
+}
+
+/** Hydration: canonical release-fulfillment ledger keyed by deterministic fulfillment record id. */
+export function sanitizeAffiliationFileWorkQueueReleaseFulfillmentRecords(
+  value: unknown,
+  fallback: AffiliationFileWorkQueueReleaseFulfillmentRecordsMap = {}
+): AffiliationFileWorkQueueReleaseFulfillmentRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: AffiliationFileWorkQueueReleaseFulfillmentRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const [key, entry] of Object.entries(value)) {
+    const record = sanitizeReleaseFulfillmentRecordEntry(entry, key)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -280,6 +280,7 @@ import type { AffiliationFileWorkQueueEvidenceResolutionRecord } from './affilia
 import type { AffiliationFileWorkQueueRepairActionRecord } from './affiliationFileWorkQueueRepairActionRecords'
 import type { AffiliationFileWorkQueueReleaseActionRecord } from './affiliationFileWorkQueueReleaseActionRecords'
 import type { AffiliationFileWorkQueueReleaseOutcomeRecord } from './affiliationFileWorkQueueReleaseOutcomeRecords'
+import type { AffiliationFileWorkQueueReleaseFulfillmentRecord } from './affiliationFileWorkQueueReleaseFulfillmentRecords'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 import type { PublishQueueRecord } from './publishAutomationCreditingHooks'
 import type { PublishQueueExecutionReceipt } from './publishQueueExecutor'
@@ -2810,6 +2811,15 @@ export interface GameState {
   affiliationFileWorkQueueReleaseOutcomeRecords?: Record<
     string,
     AffiliationFileWorkQueueReleaseOutcomeRecord
+  >
+
+  /**
+   * SPE-1046 file work queue release fulfillment: persisted file-release fulfillment receipts.
+   * Hydration drops invalid, duplicate-id, and mismatched-key entries without throwing.
+   */
+  affiliationFileWorkQueueReleaseFulfillmentRecords?: Record<
+    string,
+    AffiliationFileWorkQueueReleaseFulfillmentRecord
   >
 
   /**

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -209,6 +209,7 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
 
     expect(queueRegion).toHaveTextContent('Restricted review pending W10')
     expect(screen.queryByRole('button', { name: /record review hold/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /record fulfillment/i })).not.toBeInTheDocument()
     expect(useGameStore.getState().game.affiliationFileWorkQueueReleaseOutcomeRecords).toEqual(
       expect.objectContaining({
         [outcomeId]: expect.objectContaining({

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
@@ -43,6 +43,9 @@ export default function AffiliationPersonStatusMirrorPage() {
   const recordAffiliationFileWorkQueueReleaseOutcome = useGameStore(
     (state) => state.recordAffiliationFileWorkQueueReleaseOutcome
   )
+  const recordAffiliationFileWorkQueueReleaseFulfillment = useGameStore(
+    (state) => state.recordAffiliationFileWorkQueueReleaseFulfillment
+  )
   const view = useMemo(() => getAffiliationPersonStatusMirrorView(game), [game])
 
   return (
@@ -287,6 +290,21 @@ export default function AffiliationPersonStatusMirrorPage() {
                             onClick={() => recordAffiliationFileWorkQueueReleaseOutcome(entry.id)}
                           >
                             {entry.releaseOutcomeButtonLabel}
+                          </button>
+                        ) : null}
+                        {entry.isReleaseFulfillmentRecorded ? (
+                          <p className="mt-2 text-xs font-medium">
+                            {entry.releaseFulfillmentStatusLabel}
+                          </p>
+                        ) : entry.canRecordReleaseFulfillment ? (
+                          <button
+                            type="button"
+                            className="btn btn-xs btn-primary mt-2 whitespace-nowrap"
+                            onClick={() =>
+                              recordAffiliationFileWorkQueueReleaseFulfillment(entry.id)
+                            }
+                          >
+                            {entry.releaseFulfillmentButtonLabel}
                           </button>
                         ) : null}
                       </td>

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -407,6 +407,8 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
       isReleaseOutcomeRecorded: true,
       releaseOutcomeStatusLabel: 'Restricted review pending W11',
       releaseOutcomeButtonLabel: 'Record review hold',
+      canRecordReleaseFulfillment: false,
+      isReleaseFulfillmentRecorded: false,
     })
     expect(view.fileAccessWorkQueue[1]).toMatchObject({
       canRecordReleaseOutcome: false,

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -12,6 +12,11 @@ import {
 } from '../../domain/affiliationFileWorkQueueReleaseActionRecords'
 import { buildAffiliationFileWorkQueueReleaseOutcomeRecordId } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
 import {
+  buildAffiliationFileWorkQueueReleaseFulfillmentRecordId,
+  getAffiliationFileWorkQueueReleaseFulfillmentForOutcome,
+} from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
+import type { AffiliationFileWorkQueueReleaseOutcomeKind } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
+import {
   projectAffiliationPersonStatusSnapshots,
   type AffiliationPersonStatusSnapshot,
 } from '../../domain/affiliationPersonStatusRecords'
@@ -101,8 +106,13 @@ export interface AffiliationFileAccessWorkQueueEntryView {
   releaseActionButtonLabel?: string
   canRecordReleaseOutcome: boolean
   isReleaseOutcomeRecorded: boolean
+  releaseOutcomeKind?: AffiliationFileWorkQueueReleaseOutcomeKind
   releaseOutcomeStatusLabel?: string
   releaseOutcomeButtonLabel?: string
+  canRecordReleaseFulfillment: boolean
+  isReleaseFulfillmentRecorded: boolean
+  releaseFulfillmentStatusLabel?: string
+  releaseFulfillmentButtonLabel?: string
   reasonCodeLabels: readonly string[]
 }
 
@@ -393,6 +403,21 @@ function toFileAccessWorkQueueEntry(
   const releaseOutcomeRecord = releaseAction
     ? game.affiliationFileWorkQueueReleaseOutcomeRecords?.[releaseOutcomeRecordId]
     : undefined
+  const releaseFulfillment =
+    bucket === 'allowed' && releaseOutcomeRecord?.sourceBucket === 'allowed'
+      ? getAffiliationFileWorkQueueReleaseFulfillmentForOutcome(releaseOutcomeRecord.outcomeKind)
+      : null
+  const releaseFulfillmentRecordId =
+    releaseOutcomeRecord && releaseFulfillment
+      ? buildAffiliationFileWorkQueueReleaseFulfillmentRecordId({
+          workQueueEntryId: snapshot.recordId,
+          sourceOutcomeKind: releaseOutcomeRecord.outcomeKind,
+        })
+      : ''
+  const releaseFulfillmentRecord =
+    releaseOutcomeRecord && releaseFulfillment
+      ? game.affiliationFileWorkQueueReleaseFulfillmentRecords?.[releaseFulfillmentRecordId]
+      : undefined
 
   return Object.freeze({
     id: snapshot.recordId,
@@ -435,6 +460,7 @@ function toFileAccessWorkQueueEntry(
       : {}),
     canRecordReleaseOutcome: Boolean(releaseActionRecord && !releaseOutcomeRecord),
     isReleaseOutcomeRecorded: Boolean(releaseOutcomeRecord),
+    ...(releaseOutcomeRecord ? { releaseOutcomeKind: releaseOutcomeRecord.outcomeKind } : {}),
     ...(releaseAction
       ? {
           releaseOutcomeButtonLabel:
@@ -446,6 +472,14 @@ function toFileAccessWorkQueueEntry(
     ...(releaseOutcomeRecord
       ? {
           releaseOutcomeStatusLabel: `${releaseOutcomeRecord.outcomeLabel} W${releaseOutcomeRecord.recordedWeek}`,
+        }
+      : {}),
+    canRecordReleaseFulfillment: Boolean(releaseFulfillment && !releaseFulfillmentRecord),
+    isReleaseFulfillmentRecorded: Boolean(releaseFulfillmentRecord),
+    ...(releaseFulfillment ? { releaseFulfillmentButtonLabel: 'Record fulfillment' } : {}),
+    ...(releaseFulfillmentRecord
+      ? {
+          releaseFulfillmentStatusLabel: `${releaseFulfillmentRecord.fulfillmentLabel} W${releaseFulfillmentRecord.recordedWeek}`,
         }
       : {}),
     reasonCodeLabels: Object.freeze(reasonCodeLabels),

--- a/src/test/affiliationFileWorkQueueReleaseFulfillmentRecords.test.ts
+++ b/src/test/affiliationFileWorkQueueReleaseFulfillmentRecords.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { hydrateGame } from '../app/store/runTransfer'
+import { createStartingState } from '../data/startingState'
+import {
+  buildAffiliationFileWorkQueueReleaseFulfillmentRecord,
+  buildAffiliationFileWorkQueueReleaseFulfillmentRecordId,
+  getAffiliationFileWorkQueueReleaseFulfillmentForOutcome,
+  sanitizeAffiliationFileWorkQueueReleaseFulfillmentRecords,
+} from '../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
+
+describe('affiliationFileWorkQueueReleaseFulfillmentRecords persistence', () => {
+  it('maps only file-released outcomes to fulfillment receipts', () => {
+    expect(getAffiliationFileWorkQueueReleaseFulfillmentForOutcome('file_released')).toEqual({
+      fulfillmentKind: 'file_release_fulfilled',
+      fulfillmentLabel: 'File release fulfilled',
+    })
+    expect(
+      getAffiliationFileWorkQueueReleaseFulfillmentForOutcome('restricted_review_pending')
+    ).toBeNull()
+  })
+
+  it('builds deterministic ids from work queue entry and source outcome kind', () => {
+    const record = buildAffiliationFileWorkQueueReleaseFulfillmentRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceOutcomeKind: 'file_released',
+      sourceBucket: 'allowed',
+      sourceReasonCodes: ['site_clearance_allowed', 'file_permission_allowed'],
+      fulfillmentKind: 'file_release_fulfilled',
+      fulfillmentLabel: 'File release fulfilled',
+      recordedWeek: 9,
+    })
+
+    expect(record).toEqual({
+      id: 'affiliation-file-release-fulfillment:person-status:alpha:file_released',
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceOutcomeKind: 'file_released',
+      sourceBucket: 'allowed',
+      sourceReasonCodes: ['file_permission_allowed', 'site_clearance_allowed'],
+      fulfillmentKind: 'file_release_fulfilled',
+      fulfillmentLabel: 'File release fulfilled',
+      recordedWeek: 9,
+    })
+    expect(
+      buildAffiliationFileWorkQueueReleaseFulfillmentRecordId({
+        workQueueEntryId: 'person-status:alpha',
+        sourceOutcomeKind: 'file_released',
+      })
+    ).toBe(record.id)
+  })
+
+  it('drops invalid records and mismatched keys during hydration sanitization', () => {
+    const valid = buildAffiliationFileWorkQueueReleaseFulfillmentRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceOutcomeKind: 'file_released',
+      sourceBucket: 'allowed',
+      sourceReasonCodes: ['file_permission_allowed'],
+      fulfillmentKind: 'file_release_fulfilled',
+      fulfillmentLabel: 'File release fulfilled',
+      recordedWeek: 6,
+    })
+
+    expect(
+      sanitizeAffiliationFileWorkQueueReleaseFulfillmentRecords({
+        [valid.id]: valid,
+        'wrong-key': valid,
+        'bad-pair': {
+          ...valid,
+          id: 'affiliation-file-release-fulfillment:person-status:beta:restricted_review_pending',
+          workQueueEntryId: 'person-status:beta',
+          sourceOutcomeKind: 'restricted_review_pending',
+        },
+        'bad-bucket': {
+          ...valid,
+          id: 'affiliation-file-release-fulfillment:person-status:gamma:file_released',
+          workQueueEntryId: 'person-status:gamma',
+          sourceBucket: 'restricted',
+        },
+        'bad-week': {
+          ...valid,
+          id: 'affiliation-file-release-fulfillment:person-status:delta:file_released',
+          workQueueEntryId: 'person-status:delta',
+          recordedWeek: 1.5,
+        },
+      })
+    ).toEqual({
+      [valid.id]: valid,
+    })
+  })
+
+  it('hydrates and exports fulfillment records without mutating source ledgers', () => {
+    const state = createStartingState()
+    const valid = buildAffiliationFileWorkQueueReleaseFulfillmentRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceOutcomeKind: 'file_released',
+      sourceBucket: 'allowed',
+      sourceReasonCodes: ['file_permission_allowed'],
+      fulfillmentKind: 'file_release_fulfilled',
+      fulfillmentLabel: 'File release fulfilled',
+      recordedWeek: 5,
+    })
+
+    state.affiliationFileWorkQueueReleaseFulfillmentRecords = {
+      [valid.id]: valid,
+    }
+
+    const hydrated = hydrateGame(JSON.parse(JSON.stringify(state)), createStartingState())
+
+    expect(hydrated.affiliationFileWorkQueueReleaseFulfillmentRecords).toEqual({
+      [valid.id]: valid,
+    })
+    expect(hydrated.affiliationPersonStatusRecords).toEqual({})
+    expect(hydrated.affiliationFileWorkQueueReleaseActionRecords).toEqual({})
+    expect(hydrated.affiliationFileWorkQueueReleaseOutcomeRecords).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a persisted SPE-1046 file work queue release-fulfillment receipt ledger for eligible `file_released` outcomes.
- Wires sanitize/hydrate/export through GameState and exposes Operations mirror fulfillment controls/status labels.
- Keeps fulfillment receipt-only: no file payload storage, access-decision mutation, mission routing, procurement, weekly progression, or SPE-947 propagation changes.

## Linear
- Parent: https://linear.app/spectranoir/issue/SPE-1046 (stays Backlog)
- Required child issue pending Linear OAuth reauthentication: `SPE-1046 file work queue file-release fulfillment`
- Intended child metadata: branch `spe-1046-file-work-queue-file-release-fulfillment-slice-1`, base `320e356e`, commit `0c8ed979`, planning doc `planning/spe-1046-file-work-queue-file-release-fulfillment-slice-1.md`.

## Validation
- `npm.cmd run test:run -- src/app/store/gameStore.test.ts src/app/store/runTransfer.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx src/test/affiliationFileWorkQueueReleaseFulfillmentRecords.test.ts`
- `npm.cmd run lint`
- `npx.cmd prettier --check planning/spe-1046-file-work-queue-file-release-fulfillment-slice-1.md src/domain/affiliationFileWorkQueueReleaseFulfillmentRecords.ts src/domain/models.ts src/app/store/runTransfer.ts src/app/store/gameStore.ts src/features/operations/affiliationPersonStatusMirrorView.ts src/features/operations/AffiliationPersonStatusMirrorPage.tsx src/test/affiliationFileWorkQueueReleaseFulfillmentRecords.test.ts src/app/store/gameStore.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
- `git diff --check`
- `npm.cmd run test:run`