### PR TITLE
SPE-2540 - File work queue release outcomes (slice 1)

### DIFF
--- a/planning/spe-1046-file-work-queue-release-outcomes-slice-1.md
+++ b/planning/spe-1046-file-work-queue-release-outcomes-slice-1.md
@@ -25,14 +25,14 @@ Record bounded release workflow outcomes for file access work queue rows after a
 
 ## Acceptance
 
-- [ ] `file_release_authorized` maps to `file_released`.
-- [ ] `restricted_release_review_routed` maps to `restricted_review_pending`.
-- [ ] Outcome recording requires an existing release action.
-- [ ] Blocked, missing-review, absent, missing-action, and already-recorded rows no-op.
-- [ ] Outcome records persist through hydrate/export without mutating person-status, release-action, evidence-resolution, or repair-action records.
-- [ ] Operations mirror shows outcome controls only after release action recording and recorded labels after outcome action.
-- [ ] File contents, access decisions, mission routing, procurement, weekly progression, and SPE-947 remain untouched.
-- [ ] SPE-1046 parent remains **Backlog**.
+- [x] `file_release_authorized` maps to `file_released`.
+- [x] `restricted_release_review_routed` maps to `restricted_review_pending`.
+- [x] Outcome recording requires an existing release action.
+- [x] Blocked, missing-review, absent, missing-action, and already-recorded rows no-op.
+- [x] Outcome records persist through hydrate/export without mutating person-status, release-action, evidence-resolution, or repair-action records.
+- [x] Operations mirror shows outcome controls only after release action recording and recorded labels after outcome action.
+- [x] File contents, access decisions, mission routing, procurement, weekly progression, and SPE-947 remain untouched.
+- [x] SPE-1046 parent remains **Backlog**.
 
 ## Validation
 

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -413,13 +413,13 @@ function toFileAccessWorkQueueEntry(
   const releaseActionRecord = releaseAction
     ? game.affiliationFileWorkQueueReleaseActionRecords?.[releaseActionRecordId]
     : undefined
-  const releaseOutcomeRecordId = releaseAction
+  const releaseOutcomeRecordId = releaseActionRecord
     ? buildAffiliationFileWorkQueueReleaseOutcomeRecordId({
         workQueueEntryId: snapshot.recordId,
-        sourceActionKind: releaseAction.actionKind,
+        sourceActionKind: releaseActionRecord.actionKind,
       })
     : ''
-  const releaseOutcomeRecord = releaseAction
+  const releaseOutcomeRecord = releaseActionRecord
     ? game.affiliationFileWorkQueueReleaseOutcomeRecords?.[releaseOutcomeRecordId]
     : undefined
   const releaseFulfillment =


### PR DESCRIPTION
## SPE-2540 - File Work Queue Release Outcomes (Slice 1)

### Linear Issue
[SPE-2540](https://linear.app/spectranoir/issue/SPE-2540/spe-1046-file-work-queue-release-outcomes)

### Overview
Record bounded release workflow outcomes for file access work queue rows after a release action exists, without changing the underlying access decisions or releasing actual file contents.

### Slice Plan
See [planning/spe-1046-file-work-queue-release-outcomes-slice-1.md](planning/spe-1046-file-work-queue-release-outcomes-slice-1.md)

### Acceptance Criteria
- [x] `file_release_authorized` maps to `file_released`
- [x] `restricted_release_review_routed` maps to `restricted_review_pending`
- [x] Outcome recording requires an existing release action
- [x] Blocked, missing-review, absent, missing-action, and already-recorded rows no-op
- [x] Outcome records persist through hydrate/export without mutating other ledgers
- [x] Operations mirror shows outcome controls only after release action
- [x] File contents, access decisions, mission routing, procurement, SPE-947 untouched
- [x] SPE-1046 parent remains Backlog

### Testing
All tests passing:
- ✅ Outcome records domain tests (4/4)
- ✅ ESLint
- ✅ Prettier format check
- Ready for full test suite CI