### PR TITLE
SPE-2541: Implement welfare evidence repair workflow infrastructure

### DIFF
--- a/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
+++ b/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
@@ -1,14 +1,14 @@
 # SPE-1046 - File work queue welfare evidence repair mutation (slice 1)
 
-One-page implementation plan. Linear: [SPE-2537](https://linear.app/spectranoir/issue/SPE-2537/spe-1046-file-work-queue-welfare-evidence-repair-mutation) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2536](https://linear.app/spectranoir/issue/SPE-2536/spe-1046-file-work-queue-candidate-evidence-repair-mutation) / PR #3004; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+One-page implementation plan. Linear: [SPE-2541](https://linear.app/spectranoir/issue/SPE-2541/spe-1046-file-work-queue-welfare-evidence-repair-workflows-slice-2) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2536](https://linear.app/spectranoir/issue/SPE-2536/spe-1046-file-work-queue-candidate-evidence-repair-mutation) / PR #3004; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
 
-| Field               | Value                                                                                                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Linear**          | [SPE-2537 - SPE-1046 file work queue welfare evidence repair mutation](https://linear.app/spectranoir/issue/SPE-2537/spe-1046-file-work-queue-welfare-evidence-repair-mutation) |
-| **Status**          | **In Progress**                                                                                                                                                                 |
-| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                                             |
-| **Branch**          | `spe-1046-file-work-queue-welfare-evidence-repair-slice-1`                                                                                                                      |
-| **Base `main` SHA** | `9cf49c36`                                                                                                                                                                      |
+| Field               | Value                                                                                                                                                                                               |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2541 - SPE-1046 file work queue welfare evidence repair workflows (slice 2)](https://linear.app/spectranoir/issue/SPE-2541/spe-1046-file-work-queue-welfare-evidence-repair-workflows-slice-2) |
+| **Status**          | **Backlog** (ready to start)                                                                                                                                                                        |
+| **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                                                                 |
+| **Branch**          | `spe-1046-file-work-queue-welfare-evidence-repair-slice-1`                                                                                                                                          |
+| **Base `main` SHA** | `cfb28683`                                                                                                                                                                                          |
 
 ## Goal
 

--- a/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
+++ b/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
@@ -7,7 +7,7 @@ One-page implementation plan. Linear: [SPE-2541](https://linear.app/spectranoir/
 | **Linear**          | [SPE-2541 - SPE-1046 file work queue welfare evidence repair workflows (slice 2)](https://linear.app/spectranoir/issue/SPE-2541/spe-1046-file-work-queue-welfare-evidence-repair-workflows-slice-2) |
 | **Status**          | **In Progress**                                                                                                                                                                                     |
 | **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                                                                 |
-| **Branch**          | `spe-1046-file-work-queue-welfare-evidence-repair-slice-1`                                                                                                                                          |
+| **Branch**          | `spe-1046-file-work-queue-welfare-evidence-repair-slice-1` (existing PR branch for SPE-2541 slice 2)                                                                                                |
 | **Base `main` SHA** | `cfb28683`                                                                                                                                                                                          |
 
 ## Goal

--- a/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
+++ b/planning/spe-1046-file-work-queue-welfare-evidence-repair-slice-1.md
@@ -1,11 +1,11 @@
-# SPE-1046 - File work queue welfare evidence repair mutation (slice 1)
+# SPE-1046 - File work queue welfare evidence repair mutation (slice 2)
 
 One-page implementation plan. Linear: [SPE-2541](https://linear.app/spectranoir/issue/SPE-2541/spe-1046-file-work-queue-welfare-evidence-repair-workflows-slice-2) (child under [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)). Follows [SPE-2536](https://linear.app/spectranoir/issue/SPE-2536/spe-1046-file-work-queue-candidate-evidence-repair-mutation) / PR #3004; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
 
 | Field               | Value                                                                                                                                                                                               |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Linear**          | [SPE-2541 - SPE-1046 file work queue welfare evidence repair workflows (slice 2)](https://linear.app/spectranoir/issue/SPE-2541/spe-1046-file-work-queue-welfare-evidence-repair-workflows-slice-2) |
-| **Status**          | **Backlog** (ready to start)                                                                                                                                                                        |
+| **Status**          | **In Progress**                                                                                                                                                                                     |
 | **Parent**          | [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) - affiliation, clearance, and membership status system; stays **Backlog**                                                                 |
 | **Branch**          | `spe-1046-file-work-queue-welfare-evidence-repair-slice-1`                                                                                                                                          |
 | **Base `main` SHA** | `cfb28683`                                                                                                                                                                                          |

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -69,6 +69,10 @@ import {
 } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { buildAffiliationFileWorkQueueReleasePackageRecordId } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import { buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import {
+  buildAffiliationFileWorkQueueEvidenceRepairWorkflowId,
+  buildAffiliationFileWorkQueueEvidenceRepairWorkflow,
+} from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
 
 const STORE_KEY = 'containment-protocol-game-state'
@@ -2368,6 +2372,153 @@ describe('affiliation file work queue file-release delivery store action', () =>
         COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
       )
     expect(useGameStore.getState().game).toBe(afterFirstDelivery)
+  })
+})
+
+describe('affiliation file work queue evidence repair workflow store action', () => {
+  it('records deterministic welfare evidence repair workflows for missing_review queue rows', () => {
+    const game = createStartingState()
+    game.week = 13
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        permissionSurface: 'file',
+      },
+    }
+    useGameStore.setState({ game })
+
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueEvidenceRepairWorkflow(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+
+    const workflowId = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      evidenceType: 'missing_entity_welfare_reclassification_ref',
+    })
+    const next = useGameStore.getState().game
+
+    expect(next.affiliationFileWorkQueueEvidenceRepairWorkflows).toEqual({
+      [workflowId]: expect.objectContaining({
+        id: workflowId,
+        workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+        subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+        repairLabel: 'Restore minimal welfare evidence',
+        recordedWeek: 13,
+      }),
+    })
+  })
+
+  it('no-ops when entry is missing, not in missing_review, or lacks welfare evidence gap', () => {
+    const game = createStartingState()
+    game.week = 14
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        permissionSurface: 'file',
+      },
+    }
+    useGameStore.setState({ game })
+
+    const beforeAbsent = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueEvidenceRepairWorkflow('person-status:absent')
+    expect(useGameStore.getState().game).toBe(beforeAbsent)
+
+    // Change to not missing_review state
+    useGameStore.setState({
+      game: {
+        ...useGameStore.getState().game,
+        affiliationPersonStatusRecords: {
+          [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+            ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+            permissionSurface: 'allowed', // Not missing_review
+          },
+        },
+      },
+    })
+
+    const beforeNotMissingReview = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueEvidenceRepairWorkflow(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+    expect(useGameStore.getState().game).toBe(beforeNotMissingReview)
+  })
+
+  it('no-ops when welfare evidence repair workflow is already recorded', () => {
+    const game = createStartingState()
+    game.week = 15
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        permissionSurface: 'file',
+      },
+    }
+
+    const workflowId = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      evidenceType: 'missing_entity_welfare_reclassification_ref',
+    })
+    const existingWorkflow = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      evidenceType: 'missing_entity_welfare_reclassification_ref',
+      subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+      subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+      repairLabel: 'Restore minimal welfare evidence',
+      recordedWeek: 14,
+    })
+
+    game.affiliationFileWorkQueueEvidenceRepairWorkflows = {
+      [workflowId]: existingWorkflow,
+    }
+    useGameStore.setState({ game })
+
+    const before = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueEvidenceRepairWorkflow(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+
+    expect(useGameStore.getState().game).toBe(before)
+    expect(useGameStore.getState().game.affiliationFileWorkQueueEvidenceRepairWorkflows).toEqual({
+      [workflowId]: existingWorkflow,
+    })
+  })
+
+  it('maintains isolation: welfare repair workflows do not affect other ledgers', () => {
+    const game = createStartingState()
+    game.week = 16
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        permissionSurface: 'file',
+      },
+    }
+    useGameStore.setState({ game })
+
+    const beforeReleaseDeliveries =
+      useGameStore.getState().game.affiliationFileWorkQueueFileReleaseDeliveryRecords
+    const beforeRepairActions =
+      useGameStore.getState().game.affiliationFileWorkQueueRepairActionRecords
+
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueEvidenceRepairWorkflow(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+
+    const after = useGameStore.getState().game
+    expect(after.affiliationFileWorkQueueFileReleaseDeliveryRecords).toEqual(
+      beforeReleaseDeliveries
+    )
+    expect(after.affiliationFileWorkQueueRepairActionRecords).toEqual(beforeRepairActions)
   })
 })
 

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -2439,6 +2439,9 @@ describe('affiliation file work queue evidence repair workflow store action', ()
             permissionSurface: 'allowed', // Not missing_review
           },
         },
+        entityWelfareReclassificationRecords: {
+          [PENDING_TO_APPROVED_FIXTURE.id]: PENDING_TO_APPROVED_FIXTURE,
+        },
       },
     })
 

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -2051,7 +2051,7 @@ export const useGameStore = create<GameStore>()(
           }
 
           // Check if missing_entity_welfare_reclassification_ref is in the missing codes
-          const hasMissingWelfareRef = (entry.missingReasonCodes ?? []).includes(
+          const hasMissingWelfareRef = entry.reasonCodeLabels.includes(
             'missing_entity_welfare_reclassification_ref'
           )
           if (!hasMissingWelfareRef) {

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -179,6 +179,10 @@ import {
   buildAffiliationFileWorkQueueFileReleaseDeliveryRecord,
   getAffiliationFileWorkQueueFileReleaseDeliveryForPackage,
 } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import {
+  buildAffiliationFileWorkQueueEvidenceRepairWorkflow,
+  sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows,
+} from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
 import {
   clearContractNextIntent,
@@ -362,6 +366,7 @@ interface GameStore {
   recordAffiliationFileWorkQueueReleaseFulfillment: (entryId: string) => void
   recordAffiliationFileWorkQueueReleasePackage: (entryId: string) => void
   recordAffiliationFileWorkQueueFileReleaseDelivery: (entryId: string) => void
+  recordAffiliationFileWorkQueueEvidenceRepairWorkflow: (entryId: string) => void
   advanceWeek: () => void
   setSeed: (seed: number) => void
   setSquadMetadata: (metadata: SquadMetadata) => void
@@ -2032,6 +2037,59 @@ export const useGameStore = create<GameStore>()(
               ...s.game,
               affiliationFileWorkQueueFileReleaseDeliveryRecords: {
                 ...(s.game.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}),
+                [record.id]: record,
+              },
+            },
+          }
+        }),
+
+      recordAffiliationFileWorkQueueEvidenceRepairWorkflow: (entryId) =>
+        set((s) => {
+          const view = getAffiliationPersonStatusMirrorView(s.game)
+          const entry = view.fileAccessWorkQueue.find((candidate) => candidate.id === entryId)
+
+          // No-op: missing entry, not missing_review, or already recorded
+          if (!entry || entry.bucket !== 'missing_review') {
+            return { game: s.game }
+          }
+
+          // Check if missing_entity_welfare_reclassification_ref is in the missing codes
+          const hasMissingWelfareRef = (entry.missingReasonCodes ?? []).includes(
+            'missing_entity_welfare_reclassification_ref'
+          )
+          if (!hasMissingWelfareRef) {
+            return { game: s.game }
+          }
+
+          // Build the repair workflow record
+          const record = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+            workQueueEntryId: entry.id,
+            evidenceType: 'missing_entity_welfare_reclassification_ref',
+            subjectId: entry.subjectId,
+            subjectLabel: entry.subjectLabel,
+            repairLabel: 'Restore minimal welfare evidence',
+            recordedWeek: s.game.week,
+          })
+
+          // Check for duplicate (same entry + evidence type already recorded)
+          const existing = Object.values(
+            s.game.affiliationFileWorkQueueEvidenceRepairWorkflows ?? {}
+          )
+          const isDuplicate = existing.some(
+            (existing) =>
+              existing.workQueueEntryId === record.workQueueEntryId &&
+              existing.evidenceType === record.evidenceType
+          )
+
+          if (isDuplicate) {
+            return { game: s.game }
+          }
+
+          return {
+            game: {
+              ...s.game,
+              affiliationFileWorkQueueEvidenceRepairWorkflows: {
+                ...(s.game.affiliationFileWorkQueueEvidenceRepairWorkflows ?? {}),
                 [record.id]: record,
               },
             },

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -179,10 +179,7 @@ import {
   buildAffiliationFileWorkQueueFileReleaseDeliveryRecord,
   getAffiliationFileWorkQueueFileReleaseDeliveryForPackage,
 } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
-import {
-  buildAffiliationFileWorkQueueEvidenceRepairWorkflow,
-  sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows,
-} from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
+import { buildAffiliationFileWorkQueueEvidenceRepairWorkflow } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
 import {
   clearContractNextIntent,

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -59,8 +59,34 @@ import { createAgent } from '../../domain/agent/factory'
 import { buildReplacementPressureState } from '../../domain/agent/attrition'
 import { buildHavenSchedule } from '../../domain/settlements/haven'
 import { DEFAULT_RESPONSE_GRID } from '../../domain/pressure'
+import { buildAffiliationFileWorkQueueEvidenceRepairWorkflow } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 
 describe('runTransfer helpers', () => {
+  it('preserves fallback affiliation file work queue evidence repair workflows for older saves', () => {
+    const fallbackWorkflow = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+      workQueueEntryId: 'person-status:legacy',
+      evidenceType: 'missing_entity_welfare_reclassification_ref',
+      subjectId: 'subject-legacy',
+      subjectLabel: 'Legacy Subject',
+      repairLabel: 'Restore legacy welfare evidence',
+      recordedWeek: 9,
+    })
+    const fallback = {
+      ...createStartingState(),
+      affiliationFileWorkQueueEvidenceRepairWorkflows: {
+        [fallbackWorkflow.id]: fallbackWorkflow,
+      },
+    }
+    const olderSave = stripGameTemplates(fallback)
+    delete olderSave.affiliationFileWorkQueueEvidenceRepairWorkflows
+
+    const hydrated = hydrateGame(olderSave, fallback)
+
+    expect(hydrated.affiliationFileWorkQueueEvidenceRepairWorkflows).toEqual(
+      fallback.affiliationFileWorkQueueEvidenceRepairWorkflows
+    )
+  })
+
   it('hydrates emergencyGrayMarketWaiverWeek when it matches the campaign week (SPE-1524)', () => {
     const fallback = createStartingState()
     const hydrated = hydrateGame(

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -8786,6 +8786,7 @@ export function hydrateGame(
     )
   const affiliationFileWorkQueueEvidenceRepairWorkflows =
     sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
+      game.affiliationFileWorkQueueEvidenceRepairWorkflows,
       game.affiliationFileWorkQueueEvidenceRepairWorkflows
     )
   const entityWelfareReclassificationRecords = sanitizeEntityWelfareReclassificationRecords(

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -221,6 +221,7 @@ import { sanitizeAffiliationFileWorkQueueReleaseOutcomeRecords } from '../../dom
 import { sanitizeAffiliationFileWorkQueueReleaseFulfillmentRecords } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { sanitizeAffiliationFileWorkQueueReleasePackageRecords } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import { sanitizeAffiliationFileWorkQueueFileReleaseDeliveryRecords } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import { sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
 import { sanitizeCustodyStatusRecords } from '../../domain/containedPersonCustodyStatusRegistry'
@@ -8783,6 +8784,10 @@ export function hydrateGame(
       game.affiliationFileWorkQueueFileReleaseDeliveryRecords,
       fallback.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}
     )
+  const affiliationFileWorkQueueEvidenceRepairWorkflows =
+    sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
+      game.affiliationFileWorkQueueEvidenceRepairWorkflows
+    )
   const entityWelfareReclassificationRecords = sanitizeEntityWelfareReclassificationRecords(
     game.entityWelfareReclassificationRecords,
     fallback.entityWelfareReclassificationRecords ?? {}
@@ -8985,6 +8990,7 @@ export function hydrateGame(
     affiliationFileWorkQueueReleaseFulfillmentRecords,
     affiliationFileWorkQueueReleasePackageRecords,
     affiliationFileWorkQueueFileReleaseDeliveryRecords,
+    affiliationFileWorkQueueEvidenceRepairWorkflows,
     entityWelfareReclassificationRecords,
     containedPersonTherapeuticCareRecords,
     containedPersonMedicationRegimenRecords,

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -8787,7 +8787,7 @@ export function hydrateGame(
   const affiliationFileWorkQueueEvidenceRepairWorkflows =
     sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
       game.affiliationFileWorkQueueEvidenceRepairWorkflows,
-      game.affiliationFileWorkQueueEvidenceRepairWorkflows
+      fallback.affiliationFileWorkQueueEvidenceRepairWorkflows ?? {}
     )
   const entityWelfareReclassificationRecords = sanitizeEntityWelfareReclassificationRecords(
     game.entityWelfareReclassificationRecords,

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
@@ -54,7 +54,7 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
 
       const record = buildAffiliationFileWorkQueueEvidenceRepairWorkflow(input)
 
-      expect(record).toBeFrozen()
+      expect(Object.isFrozen(record)).toBe(true)
       expect(record.id).toBeDefined()
       expect(record.workQueueEntryId).toBe('entry-789')
       expect(record.evidenceType).toBe('missing_entity_welfare_reclassification_ref')
@@ -110,12 +110,34 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
   })
 
   describe('sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows', () => {
-    it('returns empty map for non-record input', () => {
-      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(null)).toEqual({})
-      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(undefined)).toEqual({})
-      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows([])).toEqual({})
-      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows('string')).toEqual({})
-      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(123)).toEqual({})
+    it('returns fallback map for non-record input', () => {
+      const fallbackWorkflow = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-valid',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-valid',
+        subjectLabel: 'Valid Subject',
+        repairLabel: 'Restore welfare evidence',
+        recordedWeek: 4,
+      })
+      const fallback = {
+        [fallbackWorkflow.id]: fallbackWorkflow,
+      }
+
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(null, fallback)).toEqual(
+        fallback
+      )
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(undefined, fallback)).toEqual(
+        fallback
+      )
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows([], fallback)).toEqual(
+        fallback
+      )
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows('string', fallback)).toEqual(
+        fallback
+      )
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(123, fallback)).toEqual(
+        fallback
+      )
     })
 
     it('keeps valid records', () => {
@@ -187,18 +209,20 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
         recordedWeek: 1,
       })
 
-      const record2 = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+      const duplicate = {
+        ...record1,
+        id: 'duplicate-workflow-id',
         workQueueEntryId: 'entry-dup',
         evidenceType: 'missing_entity_welfare_reclassification_ref',
         subjectId: 'subject-2',
         subjectLabel: 'Subject 2',
         repairLabel: 'Repair 2',
         recordedWeek: 2,
-      })
+      }
 
       const input = {
         [record1.id]: record1,
-        [record2.id]: record2,
+        [duplicate.id]: duplicate,
       }
 
       const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
@@ -217,15 +241,23 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
     })
 
     it('trims whitespace from string fields', () => {
+      const canonical = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-trim',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-trim',
+        subjectLabel: 'Trimmed Subject',
+        repairLabel: 'Trim Repair',
+        recordedWeek: 1,
+      })
       const input = {
-        'id-trimmed': {
-          id: '  id-trimmed  ',
+        [`  ${canonical.id}  `]: {
+          id: `  ${canonical.id}  `,
           workQueueEntryId: '  entry-trim  ',
           evidenceType: 'missing_entity_welfare_reclassification_ref',
           subjectId: '  subject-trim  ',
           subjectLabel: '  Trimmed Subject  ',
           repairLabel: '  Trim Repair  ',
-          repairRef: '  ref-trim  ',
+          repairRef: `  ${canonical.repairRef}  `,
           recordedWeek: 1,
         },
       }
@@ -275,7 +307,7 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
       })
 
       const sanitized = Object.values(result)[0]
-      expect(sanitized).toBeFrozen()
+      expect(Object.isFrozen(sanitized)).toBe(true)
     })
 
     it('requires week to be non-negative integer', () => {

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
@@ -142,7 +142,7 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
       const input = {
         'id-1': {
           id: 'id-1',
-          workQueueEntryId: '',  // Empty
+          workQueueEntryId: '', // Empty
           evidenceType: 'missing_entity_welfare_reclassification_ref',
           subjectId: 'subject',
           subjectLabel: 'Label',
@@ -153,7 +153,7 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
         'id-2': {
           id: 'id-2',
           workQueueEntryId: 'entry',
-          evidenceType: 'invalid_type',  // Invalid
+          evidenceType: 'invalid_type', // Invalid
           subjectId: 'subject',
           subjectLabel: 'Label',
           repairLabel: 'Repair',
@@ -168,7 +168,7 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
           subjectLabel: 'Label',
           repairLabel: 'Repair',
           repairRef: 'ref',
-          recordedWeek: -1,  // Invalid week
+          recordedWeek: -1, // Invalid week
         },
       }
 
@@ -289,7 +289,7 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
           subjectLabel: 'Label',
           repairLabel: 'Repair',
           repairRef: 'ref',
-          recordedWeek: 1.5,  // Float, not integer
+          recordedWeek: 1.5, // Float, not integer
         },
         'negative-week': {
           id: 'negative-week',

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
@@ -3,6 +3,7 @@ import {
   buildAffiliationFileWorkQueueEvidenceRepairWorkflow,
   buildAffiliationFileWorkQueueEvidenceRepairWorkflowId,
   sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows,
+  type AffiliationFileWorkQueueEvidenceRepairWorkflow,
 } from './affiliationFileWorkQueueEvidenceRepairWorkflows'
 
 describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
@@ -200,36 +201,45 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
     })
 
     it('deduplicates by (workQueueEntryId, evidenceType), keeping first occurrence', () => {
-      const record1 = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+      const expectedId = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+        workQueueEntryId: 'entry-dup',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+      })
+
+      // First occurrence with correct ID
+      const record1: AffiliationFileWorkQueueEvidenceRepairWorkflow = Object.freeze({
+        id: expectedId,
         workQueueEntryId: 'entry-dup',
         evidenceType: 'missing_entity_welfare_reclassification_ref',
         subjectId: 'subject-1',
         subjectLabel: 'Subject 1',
         repairLabel: 'Repair 1',
+        repairRef: 'evidence-repair:entry-dup:missing_entity_welfare_reclassification_ref',
         recordedWeek: 1,
       })
 
-      const duplicate = {
-        ...record1,
-        id: 'duplicate-workflow-id',
+      // Duplicate with same (workQueueEntryId, evidenceType) but stale/old ID
+      const duplicate: AffiliationFileWorkQueueEvidenceRepairWorkflow = Object.freeze({
+        id: 'stale-evidence-repair-id-old-format',
         workQueueEntryId: 'entry-dup',
         evidenceType: 'missing_entity_welfare_reclassification_ref',
         subjectId: 'subject-2',
         subjectLabel: 'Subject 2',
         repairLabel: 'Repair 2',
+        repairRef: 'evidence-repair:entry-dup:missing_entity_welfare_reclassification_ref',
         recordedWeek: 2,
-      }
+      })
 
       const input = {
-        [record1.id]: record1,
-        [duplicate.id]: duplicate,
+        [expectedId]: record1,
+        'stale-evidence-repair-id-old-format': duplicate,
       }
 
       const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
 
-      // Should keep first occurrence (record1)
+      // Should keep first occurrence (record1) and skip duplicate due to (workQueueEntryId, evidenceType) pair
       expect(Object.keys(result)).toHaveLength(1)
-      expect(result[record1.id]).toEqual(record1)
+      expect(result[expectedId]).toEqual(record1)
     })
 
     it('handles array input gracefully', () => {

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
@@ -305,5 +305,20 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
       const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
       expect(Object.keys(result)).toHaveLength(0)
     })
+
+    it('returns fallback map when input is not a valid record', () => {
+      const fallback = {
+        'wf-1': buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+          workQueueEntryId: 'entry-1',
+          evidenceType: 'missing_entity_welfare_reclassification_ref',
+          subjectId: 'subj-1',
+          subjectLabel: 'Subject 1',
+          repairLabel: 'Repair 1',
+          recordedWeek: 5,
+        }).record,
+      }
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(null, fallback)
+      expect(result).toEqual(fallback)
+    })
   })
 })

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildAffiliationFileWorkQueueEvidenceRepairWorkflow,
+  buildAffiliationFileWorkQueueEvidenceRepairWorkflowId,
+  sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows,
+} from './affiliationFileWorkQueueEvidenceRepairWorkflows'
+
+describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
+  describe('buildAffiliationFileWorkQueueEvidenceRepairWorkflowId', () => {
+    it('generates deterministic ID from entryId and evidenceType', () => {
+      const id1 = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+        workQueueEntryId: 'entry-123',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+      })
+      const id2 = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+        workQueueEntryId: 'entry-123',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+      })
+      expect(id1).toBe(id2)
+    })
+
+    it('includes both entry ID and evidence type in ID', () => {
+      const id = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+        workQueueEntryId: 'entry-456',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+      })
+      expect(id).toContain('entry-456')
+      expect(id).toContain('missing_entity_welfare_reclassification_ref')
+    })
+
+    it('produces different IDs for different entry IDs', () => {
+      const id1 = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+        workQueueEntryId: 'entry-1',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+      })
+      const id2 = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+        workQueueEntryId: 'entry-2',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+      })
+      expect(id1).not.toBe(id2)
+    })
+  })
+
+  describe('buildAffiliationFileWorkQueueEvidenceRepairWorkflow', () => {
+    it('creates frozen repair workflow record with all required fields', () => {
+      const input = {
+        workQueueEntryId: 'entry-789',
+        evidenceType: 'missing_entity_welfare_reclassification_ref' as const,
+        subjectId: 'subject-001',
+        subjectLabel: 'Test Subject',
+        repairLabel: 'Restore minimal welfare evidence',
+        recordedWeek: 5,
+      }
+
+      const record = buildAffiliationFileWorkQueueEvidenceRepairWorkflow(input)
+
+      expect(record).toBeFrozen()
+      expect(record.id).toBeDefined()
+      expect(record.workQueueEntryId).toBe('entry-789')
+      expect(record.evidenceType).toBe('missing_entity_welfare_reclassification_ref')
+      expect(record.subjectId).toBe('subject-001')
+      expect(record.subjectLabel).toBe('Test Subject')
+      expect(record.repairLabel).toBe('Restore minimal welfare evidence')
+      expect(record.recordedWeek).toBe(5)
+    })
+
+    it('generates deterministic ID for record', () => {
+      const input = {
+        workQueueEntryId: 'entry-test',
+        evidenceType: 'missing_entity_welfare_reclassification_ref' as const,
+        subjectId: 'subject-123',
+        subjectLabel: 'Test',
+        repairLabel: 'Restore welfare',
+        recordedWeek: 3,
+      }
+
+      const record1 = buildAffiliationFileWorkQueueEvidenceRepairWorkflow(input)
+      const record2 = buildAffiliationFileWorkQueueEvidenceRepairWorkflow(input)
+
+      expect(record1.id).toBe(record2.id)
+    })
+
+    it('creates repair reference from entry ID and evidence type', () => {
+      const record = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-ref-test',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-abc',
+        subjectLabel: 'Test Subject',
+        repairLabel: 'Restore welfare evidence',
+        recordedWeek: 2,
+      })
+
+      expect(record.repairRef).toContain('entry-ref-test')
+      expect(record.repairRef).toContain('missing_entity_welfare_reclassification_ref')
+    })
+
+    it('handles special characters in labels', () => {
+      const record = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-special',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-special-123!@#',
+        subjectLabel: 'Subject: "Test" & More',
+        repairLabel: 'Restore/Repair Welfare Evidence (Rev 2)',
+        recordedWeek: 1,
+      })
+
+      expect(record.subjectLabel).toBe('Subject: "Test" & More')
+      expect(record.repairLabel).toBe('Restore/Repair Welfare Evidence (Rev 2)')
+    })
+  })
+
+  describe('sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows', () => {
+    it('returns empty map for non-record input', () => {
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(null)).toEqual({})
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(undefined)).toEqual({})
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows([])).toEqual({})
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows('string')).toEqual({})
+      expect(sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(123)).toEqual({})
+    })
+
+    it('keeps valid records', () => {
+      const record = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-valid',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-valid',
+        subjectLabel: 'Valid Subject',
+        repairLabel: 'Restore welfare evidence',
+        recordedWeek: 4,
+      })
+
+      const input = {
+        [record.id]: record,
+      }
+
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
+
+      expect(result[record.id]).toBeDefined()
+      expect(result[record.id]).toEqual(record)
+    })
+
+    it('drops records with missing required fields', () => {
+      const input = {
+        'id-1': {
+          id: 'id-1',
+          workQueueEntryId: '',  // Empty
+          evidenceType: 'missing_entity_welfare_reclassification_ref',
+          subjectId: 'subject',
+          subjectLabel: 'Label',
+          repairLabel: 'Repair',
+          repairRef: 'ref',
+          recordedWeek: 1,
+        },
+        'id-2': {
+          id: 'id-2',
+          workQueueEntryId: 'entry',
+          evidenceType: 'invalid_type',  // Invalid
+          subjectId: 'subject',
+          subjectLabel: 'Label',
+          repairLabel: 'Repair',
+          repairRef: 'ref',
+          recordedWeek: 1,
+        },
+        'id-3': {
+          id: 'id-3',
+          workQueueEntryId: 'entry',
+          evidenceType: 'missing_entity_welfare_reclassification_ref',
+          subjectId: 'subject',
+          subjectLabel: 'Label',
+          repairLabel: 'Repair',
+          repairRef: 'ref',
+          recordedWeek: -1,  // Invalid week
+        },
+      }
+
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
+
+      expect(Object.keys(result)).toHaveLength(0)
+    })
+
+    it('deduplicates by (workQueueEntryId, evidenceType), keeping first occurrence', () => {
+      const record1 = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-dup',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-1',
+        subjectLabel: 'Subject 1',
+        repairLabel: 'Repair 1',
+        recordedWeek: 1,
+      })
+
+      const record2 = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-dup',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-2',
+        subjectLabel: 'Subject 2',
+        repairLabel: 'Repair 2',
+        recordedWeek: 2,
+      })
+
+      const input = {
+        [record1.id]: record1,
+        [record2.id]: record2,
+      }
+
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
+
+      // Should keep first occurrence (record1)
+      expect(Object.keys(result)).toHaveLength(1)
+      expect(result[record1.id]).toEqual(record1)
+    })
+
+    it('handles array input gracefully', () => {
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows([
+        { id: 'some-id' },
+      ] as unknown)
+
+      expect(result).toEqual({})
+    })
+
+    it('trims whitespace from string fields', () => {
+      const input = {
+        'id-trimmed': {
+          id: '  id-trimmed  ',
+          workQueueEntryId: '  entry-trim  ',
+          evidenceType: 'missing_entity_welfare_reclassification_ref',
+          subjectId: '  subject-trim  ',
+          subjectLabel: '  Trimmed Subject  ',
+          repairLabel: '  Trim Repair  ',
+          repairRef: '  ref-trim  ',
+          recordedWeek: 1,
+        },
+      }
+
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
+
+      const entry = Object.values(result)[0]
+      expect(entry.workQueueEntryId).toBe('entry-trim')
+      expect(entry.subjectLabel).toBe('Trimmed Subject')
+      expect(entry.repairLabel).toBe('Trim Repair')
+    })
+
+    it('validates evidence type strictly', () => {
+      const validTypes = ['missing_entity_welfare_reclassification_ref']
+      const invalidTypes = ['missing_welfare', 'welfare_ref', 'missing_entity_welfare']
+
+      for (const invalidType of invalidTypes) {
+        const input = {
+          [invalidType]: {
+            id: invalidType,
+            workQueueEntryId: 'entry',
+            evidenceType: invalidType,
+            subjectId: 'subject',
+            subjectLabel: 'Label',
+            repairLabel: 'Repair',
+            repairRef: 'ref',
+            recordedWeek: 1,
+          },
+        }
+
+        const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
+        expect(Object.keys(result)).toHaveLength(0)
+      }
+    })
+
+    it('preserves frozen state on sanitized records', () => {
+      const record = buildAffiliationFileWorkQueueEvidenceRepairWorkflow({
+        workQueueEntryId: 'entry-frozen',
+        evidenceType: 'missing_entity_welfare_reclassification_ref',
+        subjectId: 'subject-frozen',
+        subjectLabel: 'Frozen Subject',
+        repairLabel: 'Freeze Repair',
+        recordedWeek: 1,
+      })
+
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows({
+        [record.id]: record,
+      })
+
+      const sanitized = Object.values(result)[0]
+      expect(sanitized).toBeFrozen()
+    })
+
+    it('requires week to be non-negative integer', () => {
+      const input = {
+        'float-week': {
+          id: 'float-week',
+          workQueueEntryId: 'entry',
+          evidenceType: 'missing_entity_welfare_reclassification_ref',
+          subjectId: 'subject',
+          subjectLabel: 'Label',
+          repairLabel: 'Repair',
+          repairRef: 'ref',
+          recordedWeek: 1.5,  // Float, not integer
+        },
+        'negative-week': {
+          id: 'negative-week',
+          workQueueEntryId: 'entry',
+          evidenceType: 'missing_entity_welfare_reclassification_ref',
+          subjectId: 'subject',
+          subjectLabel: 'Label',
+          repairLabel: 'Repair',
+          repairRef: 'ref',
+          recordedWeek: -5,
+        },
+      }
+
+      const result = sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(input)
+      expect(Object.keys(result)).toHaveLength(0)
+    })
+  })
+})

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts
@@ -239,7 +239,6 @@ describe('affiliationFileWorkQueueEvidenceRepairWorkflows', () => {
     })
 
     it('validates evidence type strictly', () => {
-      const validTypes = ['missing_entity_welfare_reclassification_ref']
       const invalidTypes = ['missing_welfare', 'welfare_ref', 'missing_entity_welfare']
 
       for (const invalidType of invalidTypes) {

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
@@ -130,7 +130,6 @@ function sanitizeEvidenceRepairWorkflowEntry(
 }
 
 export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
-export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
   records: unknown,
   fallback: AffiliationFileWorkQueueEvidenceRepairWorkflowsMap = {}
 ): AffiliationFileWorkQueueEvidenceRepairWorkflowsMap {
@@ -155,7 +154,11 @@ export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
     const expectedRepairRef = `evidence-repair:${entry.workQueueEntryId}:${entry.evidenceType}`
     const normalizedKey = normalizeToken(rawKey)
 
-    if (normalizedKey !== expectedId || entry.id !== expectedId || entry.repairRef !== expectedRepairRef) {
+    if (
+      normalizedKey !== expectedId ||
+      entry.id !== expectedId ||
+      entry.repairRef !== expectedRepairRef
+    ) {
       continue
     }
 

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
@@ -1,6 +1,7 @@
 export type AffiliationFileWorkQueueEvidenceRepairWorkflowId = string
 
-export type AffiliationFileWorkQueueEvidenceRepairEvidenceType = 'missing_entity_welfare_reclassification_ref'
+export type AffiliationFileWorkQueueEvidenceRepairEvidenceType =
+  'missing_entity_welfare_reclassification_ref'
 
 export interface AffiliationFileWorkQueueEvidenceRepairWorkflow {
   readonly id: AffiliationFileWorkQueueEvidenceRepairWorkflowId

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
@@ -130,6 +130,7 @@ function sanitizeEvidenceRepairWorkflowEntry(
 }
 
 export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
+export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
   records: unknown,
   fallback: AffiliationFileWorkQueueEvidenceRepairWorkflowsMap = {}
 ): AffiliationFileWorkQueueEvidenceRepairWorkflowsMap {

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
@@ -138,20 +138,35 @@ export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
     return { ...fallback }
   }
 
-  const seen = new Set<string>()
+  const seenPairs = new Set<string>()
+  const seenIds = new Set<string>()
   const result: AffiliationFileWorkQueueEvidenceRepairWorkflowsMap = {}
 
-  const entries = Object.entries(records)
-    .map(([, entry]) => sanitizeEvidenceRepairWorkflowEntry(entry))
-    .filter((entry): entry is AffiliationFileWorkQueueEvidenceRepairWorkflow => entry !== undefined)
-
-  // Dedup by (workQueueEntryId, evidenceType), keep first occurrence
-  for (const entry of entries) {
-    const key = `${entry.workQueueEntryId}:${entry.evidenceType}`
-    if (!seen.has(key)) {
-      seen.add(key)
-      result[entry.id] = entry
+  for (const [rawKey, value] of Object.entries(records)) {
+    const entry = sanitizeEvidenceRepairWorkflowEntry(value)
+    if (!entry) {
+      continue
     }
+
+    const expectedId = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+      workQueueEntryId: entry.workQueueEntryId,
+      evidenceType: entry.evidenceType,
+    })
+    const expectedRepairRef = `evidence-repair:${entry.workQueueEntryId}:${entry.evidenceType}`
+    const normalizedKey = normalizeToken(rawKey)
+
+    if (normalizedKey !== expectedId || entry.id !== expectedId || entry.repairRef !== expectedRepairRef) {
+      continue
+    }
+
+    const pairKey = `${entry.workQueueEntryId}:${entry.evidenceType}`
+    if (seenPairs.has(pairKey) || seenIds.has(expectedId)) {
+      continue
+    }
+
+    seenPairs.add(pairKey)
+    seenIds.add(expectedId)
+    result[expectedId] = entry
   }
 
   return result

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
@@ -1,0 +1,155 @@
+export type AffiliationFileWorkQueueEvidenceRepairWorkflowId = string
+
+export type AffiliationFileWorkQueueEvidenceRepairEvidenceType = 'missing_entity_welfare_reclassification_ref'
+
+export interface AffiliationFileWorkQueueEvidenceRepairWorkflow {
+  readonly id: AffiliationFileWorkQueueEvidenceRepairWorkflowId
+  readonly workQueueEntryId: string
+  readonly evidenceType: AffiliationFileWorkQueueEvidenceRepairEvidenceType
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly repairLabel: string
+  readonly repairRef: string
+  readonly recordedWeek: number
+}
+
+export type AffiliationFileWorkQueueEvidenceRepairWorkflowsMap = Record<
+  AffiliationFileWorkQueueEvidenceRepairWorkflowId,
+  AffiliationFileWorkQueueEvidenceRepairWorkflow
+>
+
+export interface AffiliationFileWorkQueueEvidenceRepairWorkflowInput {
+  readonly workQueueEntryId: string
+  readonly evidenceType: AffiliationFileWorkQueueEvidenceRepairEvidenceType
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly repairLabel: string
+  readonly recordedWeek: number
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeRecordedWeek(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value === Math.trunc(value)
+    ? value
+    : undefined
+}
+
+function normalizeEvidenceType(
+  value: unknown
+): AffiliationFileWorkQueueEvidenceRepairEvidenceType | undefined {
+  return value === 'missing_entity_welfare_reclassification_ref' ? value : undefined
+}
+
+export function buildAffiliationFileWorkQueueEvidenceRepairWorkflowId(input: {
+  readonly workQueueEntryId: string
+  readonly evidenceType: AffiliationFileWorkQueueEvidenceRepairEvidenceType
+}) {
+  return `affiliation-file-work-queue-evidence-repair:${input.workQueueEntryId}:${input.evidenceType}`
+}
+
+function buildEvidenceRepairRef(input: {
+  readonly workQueueEntryId: string
+  readonly evidenceType: AffiliationFileWorkQueueEvidenceRepairEvidenceType
+}) {
+  return `evidence-repair:${input.workQueueEntryId}:${input.evidenceType}`
+}
+
+export function buildAffiliationFileWorkQueueEvidenceRepairWorkflow(
+  input: AffiliationFileWorkQueueEvidenceRepairWorkflowInput
+): AffiliationFileWorkQueueEvidenceRepairWorkflow {
+  const repairRef = buildEvidenceRepairRef({
+    workQueueEntryId: input.workQueueEntryId,
+    evidenceType: input.evidenceType,
+  })
+
+  return Object.freeze({
+    id: buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+      workQueueEntryId: input.workQueueEntryId,
+      evidenceType: input.evidenceType,
+    }),
+    workQueueEntryId: input.workQueueEntryId,
+    evidenceType: input.evidenceType,
+    subjectId: input.subjectId,
+    subjectLabel: input.subjectLabel,
+    repairLabel: input.repairLabel,
+    repairRef,
+    recordedWeek: input.recordedWeek,
+  })
+}
+
+function sanitizeEvidenceRepairWorkflowEntry(
+  value: unknown
+): AffiliationFileWorkQueueEvidenceRepairWorkflow | undefined {
+  if (!isPlainRecord(value)) {
+    return undefined
+  }
+
+  const id = normalizeToken(value.id)
+  const workQueueEntryId = normalizeToken(value.workQueueEntryId)
+  const subjectId = normalizeToken(value.subjectId)
+  const subjectLabel = normalizeToken(value.subjectLabel)
+  const repairLabel = normalizeToken(value.repairLabel)
+  const repairRef = normalizeToken(value.repairRef)
+  const evidenceType = normalizeEvidenceType(value.evidenceType)
+  const recordedWeek = normalizeRecordedWeek(value.recordedWeek)
+
+  if (
+    !id ||
+    !workQueueEntryId ||
+    !subjectId ||
+    !subjectLabel ||
+    !repairLabel ||
+    !repairRef ||
+    !evidenceType ||
+    recordedWeek === undefined
+  ) {
+    return undefined
+  }
+
+  return Object.freeze({
+    id,
+    workQueueEntryId,
+    evidenceType,
+    subjectId,
+    subjectLabel,
+    repairLabel,
+    repairRef,
+    recordedWeek,
+  })
+}
+
+export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
+  records: unknown
+): AffiliationFileWorkQueueEvidenceRepairWorkflowsMap {
+  if (!isPlainRecord(records)) {
+    return {}
+  }
+
+  const seen = new Set<string>()
+  const result: AffiliationFileWorkQueueEvidenceRepairWorkflowsMap = {}
+
+  const entries = Object.entries(records)
+    .map(([, entry]) => sanitizeEvidenceRepairWorkflowEntry(entry))
+    .filter((entry): entry is AffiliationFileWorkQueueEvidenceRepairWorkflow => entry !== undefined)
+
+  // Dedup by (workQueueEntryId, evidenceType), keep first occurrence
+  for (const entry of entries) {
+    const key = `${entry.workQueueEntryId}:${entry.evidenceType}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      result[entry.id] = entry
+    }
+  }
+
+  return result
+}

--- a/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
+++ b/src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts
@@ -130,10 +130,11 @@ function sanitizeEvidenceRepairWorkflowEntry(
 }
 
 export function sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
-  records: unknown
+  records: unknown,
+  fallback: AffiliationFileWorkQueueEvidenceRepairWorkflowsMap = {}
 ): AffiliationFileWorkQueueEvidenceRepairWorkflowsMap {
   if (!isPlainRecord(records)) {
-    return {}
+    return { ...fallback }
   }
 
   const seen = new Set<string>()

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -283,6 +283,7 @@ import type { AffiliationFileWorkQueueReleaseOutcomeRecord } from './affiliation
 import type { AffiliationFileWorkQueueReleaseFulfillmentRecord } from './affiliationFileWorkQueueReleaseFulfillmentRecords'
 import type { AffiliationFileWorkQueueReleasePackageRecord } from './affiliationFileWorkQueueReleasePackageRecords'
 import type { AffiliationFileWorkQueueFileReleaseDeliveryRecord } from './affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import type { AffiliationFileWorkQueueEvidenceRepairWorkflow } from './affiliationFileWorkQueueEvidenceRepairWorkflows'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 import type { PublishQueueRecord } from './publishAutomationCreditingHooks'
 import type { PublishQueueExecutionReceipt } from './publishQueueExecutor'
@@ -2840,6 +2841,15 @@ export interface GameState {
   affiliationFileWorkQueueFileReleaseDeliveryRecords?: Record<
     string,
     AffiliationFileWorkQueueFileReleaseDeliveryRecord
+  >
+
+  /**
+   * SPE-2541 file work queue welfare evidence repair: persisted repair workflow candidates (read-only guidance).
+   * Keyed by workflow id; hydration drops invalid, duplicate-key, or mismatched (entryId, evidenceType) entries without throwing.
+   */
+  affiliationFileWorkQueueEvidenceRepairWorkflows?: Record<
+    string,
+    AffiliationFileWorkQueueEvidenceRepairWorkflow
   >
 
   /**

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -21,6 +21,7 @@ import {
   type AffiliationFileWorkQueueReleasePackageKind,
 } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import { buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import { buildAffiliationFileWorkQueueEvidenceRepairWorkflowId } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import type { AffiliationFileWorkQueueReleaseOutcomeKind } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
 import {
   projectAffiliationPersonStatusSnapshots,
@@ -132,6 +133,9 @@ export interface AffiliationFileAccessWorkQueueEntryView {
   isFileReleaseDeliveryRecorded: boolean
   fileReleaseDeliveryStatusLabel?: string
   fileReleaseDeliveryButtonLabel?: string
+  canRecordEvidenceRepairWorkflow: boolean
+  isEvidenceRepairWorkflowRecorded: boolean
+  evidenceRepairWorkflowStatusLabel?: string
   reasonCodeLabels: readonly string[]
 }
 
@@ -461,6 +465,13 @@ function toFileAccessWorkQueueEntry(
     ? game.affiliationFileWorkQueueFileReleaseDeliveryRecords?.[fileReleaseDeliveryRecordId]
     : undefined
 
+  const evidenceRepairWorkflowId = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
+    workQueueEntryId: snapshot.recordId,
+    evidenceType: 'missing_entity_welfare_reclassification_ref',
+  })
+  const evidenceRepairWorkflow =
+    game.affiliationFileWorkQueueEvidenceRepairWorkflows?.[evidenceRepairWorkflowId]
+
   return Object.freeze({
     id: snapshot.recordId,
     subjectLabel: snapshot.subjectLabel,
@@ -552,6 +563,16 @@ function toFileAccessWorkQueueEntry(
     ...(fileReleaseDeliveryRecord
       ? {
           fileReleaseDeliveryStatusLabel: `${fileReleaseDeliveryRecord.deliveryLabel} W${fileReleaseDeliveryRecord.recordedWeek} (${fileReleaseDeliveryRecord.deliveryRef})`,
+        }
+      : {}),
+    canRecordEvidenceRepairWorkflow:
+      bucket === 'missing_review' &&
+      (missingReasonCodes ?? []).includes('missing_entity_welfare_reclassification_ref') &&
+      !evidenceRepairWorkflow,
+    isEvidenceRepairWorkflowRecorded: Boolean(evidenceRepairWorkflow),
+    ...(evidenceRepairWorkflow
+      ? {
+          evidenceRepairWorkflowStatusLabel: `Repair candidate: welfare evidence (${evidenceRepairWorkflow.repairRef})`,
         }
       : {}),
     reasonCodeLabels: Object.freeze(reasonCodeLabels),


### PR DESCRIPTION
## SPE-2541: Welfare Evidence Repair Workflow Infrastructure

Implements deterministic repair workflow records for missing-review file-access queue entries with evidence gaps.

### Scope
This is child slice 1 of SPE-1046 parent (file-work-queue-file-release-delivery).

### Changes
- **Domain Layer**: New evaluator with deterministic ID/ref, pure builder, sanitizer with dedup logic
- **Store Integration**: Action \ecordAffiliationFileWorkQueueEvidenceRepairWorkflow()\ with no-op on invalid/duplicate
- **Hydration/Export**: Sanitization applied via \unTransfer.ts\
- **Mirror Surfacing**: UI fields \canRecordEvidenceRepairWorkflow\, \isEvidenceRepairWorkflowRecorded\, status label
- **Tests**: ~50 assertions covering domain, store, and edge cases

### Acceptance Criteria (All Met ✅)
1. ✅ Deterministic ID format: \ffiliation-file-work-queue-evidence-repair:\:\\
2. ✅ Sanitizer complete (dedup by entryId+evidenceType, drops invalid entries)
3. ✅ Persistence via hydrate/export with sanitization
4. ✅ Store action no-ops on missing entry, wrong state, or duplicate
5. ✅ Mirror surfacing with read-only guidance labels
6. ✅ Out-of-scope validation (SPE-947, file-release, routing untouched)
7. ✅ Lint + TypeScript strict mode compliant
8. ✅ SPE-1046 parent remains Backlog (child slice only)

### Files Modified
- \src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.ts\ (new)
- \src/domain/affiliationFileWorkQueueEvidenceRepairWorkflows.test.ts\ (new)
- \src/domain/models.ts\ (GameState field added)
- \src/app/store/gameStore.ts\ (action + tests)
- \src/app/store/gameStore.test.ts\ (store action tests)
- \src/app/store/runTransfer.ts\ (hydration/export)
- \src/features/operations/affiliationPersonStatusMirrorView.ts\ (UI integration)

### Commit
2b43706b - SPE-2541: Implement welfare evidence repair workflow infrastructure

Closes SPE-2541