### PR TITLE
SPE-2542: add actual-content file release delivery flow

### DIFF
--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -18,7 +18,9 @@ From `README.md` **Current design notes**:
 
 **Recently shipped:** SPE-1046 file work queue release package handoff (slice 1) - persisted safe package handoff receipts after fulfillment on `main` @ `14b3f29a`; see `planning/spe-1046-file-work-queue-release-package-handoff-slice-1.md`. Parent [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) stays **Backlog**.
 
-**In progress:** SPE-1046 file work queue file-content release delivery (slice 1) - persisted metadata-only file-release delivery receipts after safe package handoff; branch `spe-1046-file-work-queue-file-release-delivery-slice-1`; see `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`. Linear child creation/status update is blocked until Linear OAuth reauthentication.
+**Recently shipped:** SPE-1046 file work queue file-content release delivery (slice 1) - persisted metadata-only file-release delivery receipts after safe package handoff; landed on `main` @ `97da46e3`; see `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`.
+
+**Next up (planning):** Actual file-content release delivery (slice 2) requires a new active Linear successor issue because [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) now reflects **Done**.
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
@@ -70,7 +72,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Current handoff:** SPE-1046 file work queue file-content release delivery (slice 1) is in progress on branch `spe-1046-file-work-queue-file-release-delivery-slice-1` from base `14b3f29a`; see `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`. Linear child creation/status update is blocked until Linear OAuth reauthentication.
+**Current handoff:** Backlog/handoff reconciliation complete for SPE-1046 file work queue file-content release delivery (slice 1) shipped on `main` @ `97da46e3`; see `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`.
+
+**Current handoff:** Prepare and execute actual file-content release delivery (slice 2) using `planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md` once a new active Linear successor issue is created.
 
 **Recently shipped:** [SPE-2497](https://linear.app/spectranoir/issue/SPE-2497) pattern source series registry weekly transition surfacing (slice 5) — `pattern_source_series.weekly_transition` notes; PR #2914 @ `f5b91540`.
 

--- a/planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md
+++ b/planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md
@@ -1,0 +1,62 @@
+# File work queue actual file-content release delivery (slice 2)
+
+One-page implementation plan. This slice follows metadata-only delivery receipts shipped in `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`.
+
+- **Linear:** [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542/file-work-queue-actual-file-content-release-delivery-slice-2)
+- **Status:** In Progress
+- **Parent context:** [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) historical chain
+- **Branch:** `spe-file-work-queue-actual-file-content-release-delivery-slice-2`
+- **Base `main` SHA:** `b177998e`
+
+## Goal
+
+Add a deterministic, durable actual file-content release delivery workflow on top of existing release package handoff and metadata-only delivery receipts, without changing mission routing, procurement, weekly progression, or SPE-947 propagation.
+
+## Scope
+
+- **In:** New delivery kind and label for actual file-content release after eligible package handoff
+- **In:** Deterministic id/ref creation and sanitizer coverage for the new delivery record kind
+- **In:** Store no-op and guard rails for missing prerequisites, missing queue row, and already-recorded delivery
+- **In:** Operations mirror action/status surface for actual content release after metadata-only and/or package prerequisites
+- **In:** Domain/store/view/page tests for new delivery flow and regression coverage for existing metadata-only behavior
+- **Out:** Backend transport/storage service integration
+- **Out:** File byte payload persistence beyond the existing deterministic ledger model
+- **Out:** Mission routing/procurement/weekly progression changes
+- **Out:** SPE-947 propagation and parent closure work
+
+## Acceptance
+
+- [ ] A new release package or delivery mapping exists for actual file-content release and is deterministic.
+- [ ] Delivery id/ref format remains stable and sanitizer rejects malformed or mismatched records.
+- [ ] Store action only records delivery when prerequisites exist; otherwise no-op with no ledger mutation.
+- [ ] Existing metadata-only delivery behavior remains unchanged.
+- [ ] Operations mirror displays clear action availability and post-delivery status text for actual content release.
+- [ ] No mission routing/procurement/weekly progression/SPE-947 behavior changes occur.
+
+## Validation
+
+- `npm.cmd run test:run -- src/test/affiliationFileWorkQueueFileReleaseDeliveryRecords.test.ts src/app/store/gameStore.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
+- `npm.cmd run lint`
+- Touched-file Prettier check.
+- `git diff --check`
+- `npm.cmd run test:run`
+
+## Deferred
+
+- **Backend file transport/storage wiring**
+  Owner: dedicated infrastructure/application slice
+  Why: This slice only extends deterministic local release ledger behavior.
+- **Mission routing/procurement policy coupling**
+  Owner: policy/routing slices
+  Why: Keep release-delivery workflow isolated from routing policy changes.
+- **SPE-947 propagation**
+  Owner: SPE-947 successor issue
+  Why: Separate parent/thread.
+
+## See also
+
+- `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`
+- `planning/spe-1046-file-work-queue-release-package-handoff-slice-1.md`
+- `planning/spe-1046-file-work-queue-file-release-fulfillment-slice-1.md`
+- `planning/spe-1046-file-work-queue-release-outcomes-slice-1.md`
+- `planning/backlog.md`

--- a/planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md
+++ b/planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md
@@ -1,9 +1,9 @@
 # SPE-1046 - File work queue file-content release delivery (slice 1)
 
-One-page implementation plan. Linear child creation/status update is blocked in this session by Linear OAuth reauthentication; intended parent is [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046). Follows file work queue release package handoff / base `14b3f29a`; [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) parent stays **Backlog**.
+One-page implementation plan. This slice shipped on `main` in commit `97da46e3` after file work queue release package handoff / base `14b3f29a`.
 
-- **Linear:** Pending SPE-1046 child - file work queue file-content release delivery
-- **Status:** In Progress
+- **Linear:** SPE-1046 chain (historical shipped slice)
+- **Status:** Shipped
 - **Parent:** [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)
 - **Branch:** `spe-1046-file-work-queue-file-release-delivery-slice-1`
 - **Base `main` SHA:** `14b3f29a`
@@ -58,9 +58,9 @@ Persist a durable metadata-only file-release delivery receipt after safe package
 - **SPE-1046 parent closure**
   Owner: SPE-1046
   Why: Broader parent acceptance remains open.
-- **Linear issue creation/update**
+- **Successor issue creation for actual file-content delivery**
   Owner: Human / next agent
-  Why: Linear connector requires OAuth reauthentication first.
+  Why: Follow-up scope must be tracked under a new active successor issue.
 
 ## See also
 

--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -2275,7 +2275,7 @@ describe('affiliation file work queue file-release delivery store action', () =>
     expect(next.affiliationFileWorkQueueReleaseFulfillmentRecords).toBeDefined()
   })
 
-  it('no-ops when package handoff is missing, the row is absent, or a delivery is already recorded', () => {
+  it('no-ops when package handoff is missing or the row is absent, then records actual-content delivery as a second step', () => {
     const game = createStartingState()
     game.week = 17
     game.candidates = [makeCooperativeContractorCandidate()]
@@ -2313,6 +2313,11 @@ describe('affiliation file work queue file-release delivery store action', () =>
     const deliveryId = buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId({
       workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
       sourcePackageKind: 'safe_file_handoff_package',
+    })
+    const actualDeliveryId = buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      sourcePackageKind: 'safe_file_handoff_package',
+      deliveryKind: 'actual_file_content_release_delivered',
     })
 
     useGameStore.setState({
@@ -2371,7 +2376,26 @@ describe('affiliation file work queue file-release delivery store action', () =>
       .recordAffiliationFileWorkQueueFileReleaseDelivery(
         COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
       )
-    expect(useGameStore.getState().game).toBe(afterFirstDelivery)
+
+    const afterSecondDelivery = useGameStore.getState().game
+    expect(afterSecondDelivery.affiliationFileWorkQueueFileReleaseDeliveryRecords).toEqual(
+      expect.objectContaining({
+        [deliveryId]: expect.objectContaining({
+          deliveryKind: 'metadata_only_file_release_delivered',
+        }),
+        [actualDeliveryId]: expect.objectContaining({
+          deliveryKind: 'actual_file_content_release_delivered',
+          deliveryLabel: 'Actual file content release delivered',
+        }),
+      })
+    )
+
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueFileReleaseDelivery(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+    expect(useGameStore.getState().game).toBe(afterSecondDelivery)
   })
 })
 

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -2017,6 +2017,7 @@ export const useGameStore = create<GameStore>()(
             s.game.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}
           ).filter(
             (record) =>
+              record &&
               record.workQueueEntryId === entry.id &&
               record.sourcePackageKind === entry.releasePackageKind &&
               record.sourcePackageRef === entry.releasePackageRef

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -177,7 +177,7 @@ import {
 } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import {
   buildAffiliationFileWorkQueueFileReleaseDeliveryRecord,
-  getAffiliationFileWorkQueueFileReleaseDeliveryForPackage,
+  getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode,
 } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
 import { buildAffiliationFileWorkQueueEvidenceRepairWorkflow } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
@@ -2008,15 +2008,35 @@ export const useGameStore = create<GameStore>()(
             !entry ||
             !entry.releasePackageKind ||
             !entry.releasePackageRef ||
-            !entry.isReleasePackageRecorded ||
-            entry.isFileReleaseDeliveryRecorded
+            !entry.isReleasePackageRecorded
           ) {
             return { game: s.game }
           }
 
-          const fileReleaseDelivery = getAffiliationFileWorkQueueFileReleaseDeliveryForPackage(
-            entry.releasePackageKind
+          const existingDeliveries = Object.values(
+            s.game.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}
+          ).filter(
+            (record) =>
+              record.workQueueEntryId === entry.id &&
+              record.sourcePackageKind === entry.releasePackageKind &&
+              record.sourcePackageRef === entry.releasePackageRef
           )
+
+          const hasMetadataDelivery = existingDeliveries.some(
+            (record) => record.deliveryKind === 'metadata_only_file_release_delivered'
+          )
+          const hasActualContentDelivery = existingDeliveries.some(
+            (record) => record.deliveryKind === 'actual_file_content_release_delivered'
+          )
+
+          if (hasActualContentDelivery) {
+            return { game: s.game }
+          }
+
+          const fileReleaseDelivery = getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode({
+            packageKind: entry.releasePackageKind,
+            mode: hasMetadataDelivery ? 'actual_file_content' : 'metadata_only',
+          })
           const record = buildAffiliationFileWorkQueueFileReleaseDeliveryRecord({
             workQueueEntryId: entry.id,
             subjectId: entry.subjectId,

--- a/src/domain/affiliationFileWorkQueueFileReleaseDeliveryRecords.ts
+++ b/src/domain/affiliationFileWorkQueueFileReleaseDeliveryRecords.ts
@@ -117,7 +117,11 @@ export function getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode(inp
   readonly deliveryLabel: string
 } {
   if (input.packageKind !== 'safe_file_handoff_package') {
-    return getAffiliationFileWorkQueueFileReleaseDeliveryForPackage(input.packageKind)
+    const delivery = getAffiliationFileWorkQueueFileReleaseDeliveryForPackage(input.packageKind)
+    if (!delivery) {
+      throw new Error(`Unsupported package kind for file release delivery: ${input.packageKind}`)
+    }
+    return delivery
   }
 
   switch (input.mode) {

--- a/src/domain/affiliationFileWorkQueueFileReleaseDeliveryRecords.ts
+++ b/src/domain/affiliationFileWorkQueueFileReleaseDeliveryRecords.ts
@@ -2,7 +2,13 @@ import type { AffiliationFileWorkQueueReleasePackageKind } from './affiliationFi
 
 export type AffiliationFileWorkQueueFileReleaseDeliveryRecordId = string
 
-export type AffiliationFileWorkQueueFileReleaseDeliveryKind = 'metadata_only_file_release_delivered'
+export type AffiliationFileWorkQueueFileReleaseDeliveryKind =
+  | 'metadata_only_file_release_delivered'
+  | 'actual_file_content_release_delivered'
+
+export type AffiliationFileWorkQueueFileReleaseDeliveryMode =
+  | 'metadata_only'
+  | 'actual_file_content'
 
 export interface AffiliationFileWorkQueueFileReleaseDeliveryRecord {
   readonly id: AffiliationFileWorkQueueFileReleaseDeliveryRecordId
@@ -71,7 +77,10 @@ function normalizeSourcePackageKind(
 function normalizeDeliveryKind(
   value: unknown
 ): AffiliationFileWorkQueueFileReleaseDeliveryKind | undefined {
-  return value === 'metadata_only_file_release_delivered' ? value : undefined
+  return value === 'metadata_only_file_release_delivered' ||
+    value === 'actual_file_content_release_delivered'
+    ? value
+    : undefined
 }
 
 function isValidDeliveryPair(input: {
@@ -80,7 +89,8 @@ function isValidDeliveryPair(input: {
 }) {
   return (
     input.sourcePackageKind === 'safe_file_handoff_package' &&
-    input.deliveryKind === 'metadata_only_file_release_delivered'
+    (input.deliveryKind === 'metadata_only_file_release_delivered' ||
+      input.deliveryKind === 'actual_file_content_release_delivered')
   )
 }
 
@@ -99,18 +109,51 @@ export function getAffiliationFileWorkQueueFileReleaseDeliveryForPackage(
   }
 }
 
+export function getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode(input: {
+  readonly packageKind: AffiliationFileWorkQueueReleasePackageKind
+  readonly mode: AffiliationFileWorkQueueFileReleaseDeliveryMode
+}): {
+  readonly deliveryKind: AffiliationFileWorkQueueFileReleaseDeliveryKind
+  readonly deliveryLabel: string
+} {
+  if (input.packageKind !== 'safe_file_handoff_package') {
+    return getAffiliationFileWorkQueueFileReleaseDeliveryForPackage(input.packageKind)
+  }
+
+  switch (input.mode) {
+    case 'metadata_only':
+      return Object.freeze({
+        deliveryKind: 'metadata_only_file_release_delivered',
+        deliveryLabel: 'Metadata-only file release delivered',
+      })
+    case 'actual_file_content':
+      return Object.freeze({
+        deliveryKind: 'actual_file_content_release_delivered',
+        deliveryLabel: 'Actual file content release delivered',
+      })
+  }
+}
+
 export function buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId(input: {
   readonly workQueueEntryId: string
   readonly sourcePackageKind: AffiliationFileWorkQueueReleasePackageKind
+  readonly deliveryKind?: AffiliationFileWorkQueueFileReleaseDeliveryKind
 }) {
-  return `affiliation-file-release-delivery:${input.workQueueEntryId}:${input.sourcePackageKind}`
+  const base = `affiliation-file-release-delivery:${input.workQueueEntryId}:${input.sourcePackageKind}`
+  return input.deliveryKind === 'actual_file_content_release_delivered'
+    ? `${base}:${input.deliveryKind}`
+    : base
 }
 
 function buildFileReleaseDeliveryRef(input: {
   readonly workQueueEntryId: string
   readonly sourcePackageKind: AffiliationFileWorkQueueReleasePackageKind
+  readonly deliveryKind?: AffiliationFileWorkQueueFileReleaseDeliveryKind
 }) {
-  return `file-release-delivery:${input.workQueueEntryId}:${input.sourcePackageKind}`
+  const base = `file-release-delivery:${input.workQueueEntryId}:${input.sourcePackageKind}`
+  return input.deliveryKind === 'actual_file_content_release_delivered'
+    ? `${base}:${input.deliveryKind}`
+    : base
 }
 
 export function buildAffiliationFileWorkQueueFileReleaseDeliveryRecord(
@@ -120,12 +163,14 @@ export function buildAffiliationFileWorkQueueFileReleaseDeliveryRecord(
   const deliveryRef = buildFileReleaseDeliveryRef({
     workQueueEntryId: input.workQueueEntryId,
     sourcePackageKind: input.sourcePackageKind,
+    deliveryKind: input.deliveryKind,
   })
 
   return Object.freeze({
     id: buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId({
       workQueueEntryId: input.workQueueEntryId,
       sourcePackageKind: input.sourcePackageKind,
+      deliveryKind: input.deliveryKind,
     }),
     workQueueEntryId: input.workQueueEntryId,
     subjectId: input.subjectId,
@@ -184,11 +229,13 @@ function sanitizeFileReleaseDeliveryRecordEntry(
       buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId({
         workQueueEntryId,
         sourcePackageKind,
+        deliveryKind,
       }) ||
     deliveryRef !==
       buildFileReleaseDeliveryRef({
         workQueueEntryId,
         sourcePackageKind,
+        deliveryKind,
       })
   ) {
     return null

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -355,7 +355,9 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
     expect(queueRegion).toHaveTextContent(
       'Metadata-only file release delivered W14 (file-release-delivery:person-status:cooperative-contractor-cleared:safe_file_handoff_package)'
     )
-    expect(screen.queryByRole('button', { name: /record file delivery/i })).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /record actual file-content delivery/i })
+    ).toBeInTheDocument()
     expect(useGameStore.getState().game.affiliationFileWorkQueueFileReleaseDeliveryRecords).toEqual(
       expect.objectContaining({
         [deliveryId]: expect.objectContaining({
@@ -364,6 +366,33 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
             'release-package:person-status:cooperative-contractor-cleared:file_release_fulfilled',
           deliveryKind: 'metadata_only_file_release_delivered',
           deliveryLabel: 'Metadata-only file release delivered',
+          recordedWeek: 14,
+        }),
+      })
+    )
+
+    await user.click(screen.getByRole('button', { name: /record actual file-content delivery/i }))
+
+    const actualDeliveryId = buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      sourcePackageKind: 'safe_file_handoff_package',
+      deliveryKind: 'actual_file_content_release_delivered',
+    })
+
+    expect(queueRegion).toHaveTextContent(
+      'Actual file content release delivered W14 (file-release-delivery:person-status:cooperative-contractor-cleared:safe_file_handoff_package:actual_file_content_release_delivered)'
+    )
+    expect(
+      screen.queryByRole('button', { name: /record actual file-content delivery/i })
+    ).not.toBeInTheDocument()
+    expect(useGameStore.getState().game.affiliationFileWorkQueueFileReleaseDeliveryRecords).toEqual(
+      expect.objectContaining({
+        [deliveryId]: expect.objectContaining({
+          deliveryKind: 'metadata_only_file_release_delivered',
+        }),
+        [actualDeliveryId]: expect.objectContaining({
+          deliveryKind: 'actual_file_content_release_delivered',
+          deliveryLabel: 'Actual file content release delivered',
           recordedWeek: 14,
         }),
       })

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
@@ -326,11 +326,12 @@ export default function AffiliationPersonStatusMirrorPage() {
                             {entry.releasePackageButtonLabel}
                           </button>
                         ) : null}
-                        {entry.isFileReleaseDeliveryRecorded ? (
+                        {entry.fileReleaseDeliveryStatusLabel ? (
                           <p className="mt-2 text-xs font-medium">
                             {entry.fileReleaseDeliveryStatusLabel}
                           </p>
-                        ) : entry.canRecordFileReleaseDelivery ? (
+                        ) : null}
+                        {entry.canRecordFileReleaseDelivery ? (
                           <button
                             type="button"
                             className="btn btn-xs btn-primary mt-2 whitespace-nowrap"

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -504,7 +504,7 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     })
   })
 
-  it('shows file-release delivery status after a delivery receipt is recorded', () => {
+  it('shows metadata delivery status and keeps actual-content delivery action available', () => {
     const game = makeStatusGame()
     game.affiliationPersonStatusRecords = {
       [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
@@ -559,10 +559,86 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
     const view = getAffiliationPersonStatusMirrorView(game)
 
     expect(view.fileAccessWorkQueue[0]).toMatchObject({
+      canRecordFileReleaseDelivery: true,
+      isFileReleaseDeliveryRecorded: true,
+      fileReleaseDeliveryButtonLabel: 'Record actual file-content delivery',
+      fileReleaseDeliveryStatusLabel:
+        'Metadata-only file release delivered W14 (file-release-delivery:person-status:cooperative-contractor-cleared:safe_file_handoff_package)',
+    })
+  })
+
+  it('hides file delivery action after actual-content delivery is recorded', () => {
+    const game = makeStatusGame()
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        entityWelfareReclassificationRef: PENDING_TO_APPROVED_FIXTURE.id,
+        permissionSurface: 'file',
+      },
+    }
+    const fulfillment = buildAffiliationFileWorkQueueReleaseFulfillmentRecord({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+      subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+      sourceOutcomeKind: 'file_released',
+      sourceBucket: 'allowed',
+      sourceReasonCodes: ['site_clearance_allowed', 'file_permission_allowed'],
+      fulfillmentKind: 'file_release_fulfilled',
+      fulfillmentLabel: 'File release fulfilled',
+      recordedWeek: 12,
+    })
+    const releasePackage = buildAffiliationFileWorkQueueReleasePackageRecord({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+      subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+      sourceOutcomeKind: 'file_released',
+      sourceFulfillmentKind: 'file_release_fulfilled',
+      sourceReasonCodes: ['site_clearance_allowed', 'file_permission_allowed'],
+      packageKind: 'safe_file_handoff_package',
+      packageLabel: 'Safe file handoff package',
+      recordedWeek: 13,
+    })
+    const metadataDelivery = buildAffiliationFileWorkQueueFileReleaseDeliveryRecord({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+      subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+      sourcePackageKind: 'safe_file_handoff_package',
+      sourcePackageRef: releasePackage.packageRef,
+      sourceReasonCodes: releasePackage.sourceReasonCodes,
+      deliveryKind: 'metadata_only_file_release_delivered',
+      deliveryLabel: 'Metadata-only file release delivered',
+      recordedWeek: 14,
+    })
+    const actualDelivery = buildAffiliationFileWorkQueueFileReleaseDeliveryRecord({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+      subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+      sourcePackageKind: 'safe_file_handoff_package',
+      sourcePackageRef: releasePackage.packageRef,
+      sourceReasonCodes: releasePackage.sourceReasonCodes,
+      deliveryKind: 'actual_file_content_release_delivered',
+      deliveryLabel: 'Actual file content release delivered',
+      recordedWeek: 15,
+    })
+
+    game.affiliationFileWorkQueueReleaseFulfillmentRecords = {
+      [fulfillment.id]: fulfillment,
+    }
+    game.affiliationFileWorkQueueReleasePackageRecords = {
+      [releasePackage.id]: releasePackage,
+    }
+    game.affiliationFileWorkQueueFileReleaseDeliveryRecords = {
+      [metadataDelivery.id]: metadataDelivery,
+      [actualDelivery.id]: actualDelivery,
+    }
+
+    const view = getAffiliationPersonStatusMirrorView(game)
+
+    expect(view.fileAccessWorkQueue[0]).toMatchObject({
       canRecordFileReleaseDelivery: false,
       isFileReleaseDeliveryRecorded: true,
       fileReleaseDeliveryStatusLabel:
-        'Metadata-only file release delivered W14 (file-release-delivery:person-status:cooperative-contractor-cleared:safe_file_handoff_package)',
+        'Actual file content release delivered W15 (file-release-delivery:person-status:cooperative-contractor-cleared:safe_file_handoff_package:actual_file_content_release_delivered)',
     })
   })
 

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -471,6 +471,7 @@ function toFileAccessWorkQueueEntry(
     releasePackageRecord
       ? Object.values(game.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}).filter(
           (record) =>
+            record &&
             record.workQueueEntryId === snapshot.recordId &&
             record.sourcePackageKind === releasePackageRecord.packageKind &&
             record.sourcePackageRef === releasePackageRecord.packageRef

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -20,7 +20,10 @@ import {
   buildAffiliationFileWorkQueueReleasePackageRecordId,
   type AffiliationFileWorkQueueReleasePackageKind,
 } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
-import { buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import {
+  buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId,
+  type AffiliationFileWorkQueueFileReleaseDeliveryRecord,
+} from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
 import { buildAffiliationFileWorkQueueEvidenceRepairWorkflowId } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import type { AffiliationFileWorkQueueReleaseOutcomeKind } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
 import {
@@ -461,9 +464,32 @@ function toFileAccessWorkQueueEntry(
         sourcePackageKind: releasePackageRecord.packageKind,
       })
     : ''
-  const fileReleaseDeliveryRecord = releasePackageRecord
+  const metadataFileReleaseDeliveryRecord = releasePackageRecord
     ? game.affiliationFileWorkQueueFileReleaseDeliveryRecords?.[fileReleaseDeliveryRecordId]
     : undefined
+  const relatedFileReleaseDeliveries: readonly AffiliationFileWorkQueueFileReleaseDeliveryRecord[] =
+    releasePackageRecord
+      ? Object.values(game.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}).filter(
+          (record) =>
+            record.workQueueEntryId === snapshot.recordId &&
+            record.sourcePackageKind === releasePackageRecord.packageKind &&
+            record.sourcePackageRef === releasePackageRecord.packageRef
+        )
+      : []
+  const fileReleaseDeliveryRecord =
+    relatedFileReleaseDeliveries.find(
+      (record) => record.deliveryKind === 'actual_file_content_release_delivered'
+    ) ??
+    relatedFileReleaseDeliveries.find(
+      (record) => record.deliveryKind === 'metadata_only_file_release_delivered'
+    ) ??
+    metadataFileReleaseDeliveryRecord
+  const hasMetadataFileReleaseDelivery = relatedFileReleaseDeliveries.some(
+    (record) => record.deliveryKind === 'metadata_only_file_release_delivered'
+  )
+  const hasActualFileReleaseDelivery = relatedFileReleaseDeliveries.some(
+    (record) => record.deliveryKind === 'actual_file_content_release_delivered'
+  )
 
   const evidenceRepairWorkflowId = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
     workQueueEntryId: snapshot.recordId,
@@ -557,9 +583,15 @@ function toFileAccessWorkQueueEntry(
           releasePackageStatusLabel: `${releasePackageRecord.packageLabel} W${releasePackageRecord.recordedWeek} (${releasePackageRecord.packageRef})`,
         }
       : {}),
-    canRecordFileReleaseDelivery: Boolean(releasePackageRecord && !fileReleaseDeliveryRecord),
+    canRecordFileReleaseDelivery: Boolean(releasePackageRecord && !hasActualFileReleaseDelivery),
     isFileReleaseDeliveryRecorded: Boolean(fileReleaseDeliveryRecord),
-    ...(releasePackageRecord ? { fileReleaseDeliveryButtonLabel: 'Record file delivery' } : {}),
+    ...(releasePackageRecord
+      ? {
+          fileReleaseDeliveryButtonLabel: hasMetadataFileReleaseDelivery
+            ? 'Record actual file-content delivery'
+            : 'Record file delivery',
+        }
+      : {}),
     ...(fileReleaseDeliveryRecord
       ? {
           fileReleaseDeliveryStatusLabel: `${fileReleaseDeliveryRecord.deliveryLabel} W${fileReleaseDeliveryRecord.recordedWeek} (${fileReleaseDeliveryRecord.deliveryRef})`,

--- a/src/test/affiliationFileWorkQueueFileReleaseDeliveryRecords.test.ts
+++ b/src/test/affiliationFileWorkQueueFileReleaseDeliveryRecords.test.ts
@@ -19,7 +19,17 @@ describe('affiliationFileWorkQueueFileReleaseDeliveryRecords persistence', () =>
     })
   })
 
-  it('maps safe handoff packages to actual file-content release delivery receipts', () => {
+  it('maps safe handoff packages to metadata-only and actual file-content release delivery receipts', () => {
+    expect(
+      getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode({
+        packageKind: 'safe_file_handoff_package',
+        mode: 'metadata_only',
+      })
+    ).toEqual({
+      deliveryKind: 'metadata_only_file_release_delivered',
+      deliveryLabel: 'Metadata-only file release delivered',
+    })
+
     expect(
       getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode({
         packageKind: 'safe_file_handoff_package',

--- a/src/test/affiliationFileWorkQueueFileReleaseDeliveryRecords.test.ts
+++ b/src/test/affiliationFileWorkQueueFileReleaseDeliveryRecords.test.ts
@@ -5,6 +5,7 @@ import {
   buildAffiliationFileWorkQueueFileReleaseDeliveryRecord,
   buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId,
   getAffiliationFileWorkQueueFileReleaseDeliveryForPackage,
+  getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode,
   sanitizeAffiliationFileWorkQueueFileReleaseDeliveryRecords,
 } from '../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
 
@@ -15,6 +16,18 @@ describe('affiliationFileWorkQueueFileReleaseDeliveryRecords persistence', () =>
     ).toEqual({
       deliveryKind: 'metadata_only_file_release_delivered',
       deliveryLabel: 'Metadata-only file release delivered',
+    })
+  })
+
+  it('maps safe handoff packages to actual file-content release delivery receipts', () => {
+    expect(
+      getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode({
+        packageKind: 'safe_file_handoff_package',
+        mode: 'actual_file_content',
+      })
+    ).toEqual({
+      deliveryKind: 'actual_file_content_release_delivered',
+      deliveryLabel: 'Actual file content release delivered',
     })
   })
 
@@ -105,6 +118,28 @@ describe('affiliationFileWorkQueueFileReleaseDeliveryRecords persistence', () =>
       })
     ).toEqual({
       [valid.id]: valid,
+    })
+  })
+
+  it('keeps valid actual-content delivery records during hydration sanitization', () => {
+    const record = buildAffiliationFileWorkQueueFileReleaseDeliveryRecord({
+      workQueueEntryId: 'person-status:actual',
+      subjectId: 'subject:actual',
+      subjectLabel: 'Actual Subject',
+      sourcePackageKind: 'safe_file_handoff_package',
+      sourcePackageRef: 'release-package:person-status:actual:file_release_fulfilled',
+      sourceReasonCodes: ['file_permission_allowed'],
+      deliveryKind: 'actual_file_content_release_delivered',
+      deliveryLabel: 'Actual file content release delivered',
+      recordedWeek: 9,
+    })
+
+    expect(
+      sanitizeAffiliationFileWorkQueueFileReleaseDeliveryRecords({
+        [record.id]: record,
+      })
+    ).toEqual({
+      [record.id]: record,
     })
   })
 


### PR DESCRIPTION
## Linear

- **Slice issue:** [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542/file-work-queue-actual-file-content-release-delivery-slice-2)
- **Parent issue (if any):** [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046)

## Scope boundary

- No backend transport/storage services.
- No mission routing/procurement/weekly progression changes.
- No SPE-947 propagation changes.

## Summary

- Added two-step file-release delivery flow: metadata-only first, actual-content second.
- Wired store action behavior to no-op only after actual-content delivery is recorded.
- Updated operations mirror action/status flow to surface metadata status while allowing second-step actual-content recording.

## Files changed

- planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md
- planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md
- planning/backlog.md
- src/domain/affiliationFileWorkQueueFileReleaseDeliveryRecords.ts
- src/app/store/gameStore.ts
- src/app/store/gameStore.test.ts
- src/features/operations/affiliationPersonStatusMirrorView.ts
- src/features/operations/affiliationPersonStatusMirrorView.test.ts
- src/features/operations/AffiliationPersonStatusMirrorPage.tsx
- src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
- src/test/affiliationFileWorkQueueFileReleaseDeliveryRecords.test.ts

## Validation

- [x] Targeted tests: `npm.cmd run test:run -- src/test/affiliationFileWorkQueueFileReleaseDeliveryRecords.test.ts src/app/store/gameStore.test.ts src/features/operations/affiliationPersonStatusMirrorView.test.ts src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx`
- [ ] Lint / verify scripts (if touched): not run in this slice

## Screenshots (UI only)

- Not included (copy/action/status behavior update covered by tests).

## Follow-ups

- Continue SPE-2542 for any additional UX copy adjustments and broader regression run before merge.

## Linear updated

- [x] Issue moved to accurate status
- [x] Merge comment added with PR URL and validation