### PR TITLE
SPE-1046: add non-mission file-access enforcement ledger

### DIFF
--- a/src/app/store/gameStore.test.ts
+++ b/src/app/store/gameStore.test.ts
@@ -69,6 +69,7 @@ import {
 } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { buildAffiliationFileWorkQueueReleasePackageRecordId } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import { buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import { buildAffiliationFileWorkQueueNonMissionEnforcementRecordId } from '../../domain/affiliationFileWorkQueueNonMissionEnforcementRecords'
 import {
   buildAffiliationFileWorkQueueEvidenceRepairWorkflowId,
   buildAffiliationFileWorkQueueEvidenceRepairWorkflow,
@@ -2396,6 +2397,133 @@ describe('affiliation file work queue file-release delivery store action', () =>
         COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
       )
     expect(useGameStore.getState().game).toBe(afterSecondDelivery)
+  })
+})
+
+describe('affiliation file work queue non-mission enforcement store action', () => {
+  it('records deterministic non-mission enforcement receipts for blocked and restricted queue rows', () => {
+    const game = createStartingState()
+    game.week = 18
+    const blockedWelfareRecord = {
+      ...HOSTILE_TO_COOPERATIVE_FIXTURE,
+      id: 'reclass:file-blocked',
+      label: 'Blocked file custody',
+      proposedDisposition: 'hostile',
+      reclassificationState: 'denied',
+    } as const
+    game.entityWelfareReclassificationRecords = {
+      [PENDING_TO_APPROVED_FIXTURE.id]: PENDING_TO_APPROVED_FIXTURE,
+      [blockedWelfareRecord.id]: blockedWelfareRecord,
+    }
+    game.affiliationPersonStatusRecords = {
+      'person-status:file-blocked': {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        id: 'person-status:file-blocked',
+        subjectId: 'subject:file-blocked',
+        subjectLabel: 'File Blocked Subject',
+        candidateRef: undefined,
+        entityWelfareReclassificationRef: 'reclass:file-blocked',
+        permissionSurface: 'file',
+      },
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        entityWelfareReclassificationRef: PENDING_TO_APPROVED_FIXTURE.id,
+      },
+    }
+    useGameStore.setState({ game })
+
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueNonMissionEnforcement('person-status:file-blocked')
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueNonMissionEnforcement(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+
+    const next = useGameStore.getState().game
+    const blockedId = buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+      workQueueEntryId: 'person-status:file-blocked',
+      sourceBucket: 'blocked',
+    })
+    const restrictedId = buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      sourceBucket: 'restricted',
+    })
+
+    expect(next.affiliationFileWorkQueueNonMissionEnforcementRecords).toEqual({
+      [blockedId]: expect.objectContaining({
+        id: blockedId,
+        workQueueEntryId: 'person-status:file-blocked',
+        sourceBucket: 'blocked',
+        enforcementKind: 'blocked_non_mission_access_enforced',
+        enforcementLabel: 'Blocked non-mission access enforced',
+        recordedWeek: 18,
+      }),
+      [restrictedId]: expect.objectContaining({
+        id: restrictedId,
+        workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+        sourceBucket: 'restricted',
+        enforcementKind: 'restricted_non_mission_access_enforced',
+        enforcementLabel: 'Restricted non-mission access enforced',
+        recordedWeek: 18,
+      }),
+    })
+  })
+
+  it('no-ops for missing-review, absent, and duplicate requests', () => {
+    const game = createStartingState()
+    game.week = 19
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        candidateRef: 'candidate:missing-review',
+        entityWelfareReclassificationRef: undefined,
+      },
+    }
+    useGameStore.setState({ game })
+
+    const beforeMissingReview = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueNonMissionEnforcement(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+    expect(useGameStore.getState().game).toBe(beforeMissingReview)
+
+    const beforeAbsent = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueNonMissionEnforcement('person-status:absent')
+    expect(useGameStore.getState().game).toBe(beforeAbsent)
+
+    useGameStore.setState({
+      game: {
+        ...useGameStore.getState().game,
+        entityWelfareReclassificationRecords: {
+          [PENDING_TO_APPROVED_FIXTURE.id]: PENDING_TO_APPROVED_FIXTURE,
+        },
+        affiliationPersonStatusRecords: {
+          [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+            ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+            entityWelfareReclassificationRef: PENDING_TO_APPROVED_FIXTURE.id,
+          },
+        },
+      },
+    })
+
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueNonMissionEnforcement(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+    const afterFirstRecord = useGameStore.getState().game
+    useGameStore
+      .getState()
+      .recordAffiliationFileWorkQueueNonMissionEnforcement(
+        COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id
+      )
+    expect(useGameStore.getState().game).toBe(afterFirstRecord)
   })
 })
 

--- a/src/app/store/gameStore.ts
+++ b/src/app/store/gameStore.ts
@@ -179,6 +179,11 @@ import {
   buildAffiliationFileWorkQueueFileReleaseDeliveryRecord,
   getAffiliationFileWorkQueueFileReleaseDeliveryForPackageMode,
 } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import {
+  buildAffiliationFileWorkQueueNonMissionEnforcementRecord,
+  buildAffiliationFileWorkQueueNonMissionEnforcementRecordId,
+  getAffiliationFileWorkQueueNonMissionEnforcementForBucket,
+} from '../../domain/affiliationFileWorkQueueNonMissionEnforcementRecords'
 import { buildAffiliationFileWorkQueueEvidenceRepairWorkflow } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import { getAffiliationPersonStatusMirrorView } from '../../features/operations/affiliationPersonStatusMirrorView'
 import {
@@ -363,6 +368,7 @@ interface GameStore {
   recordAffiliationFileWorkQueueReleaseFulfillment: (entryId: string) => void
   recordAffiliationFileWorkQueueReleasePackage: (entryId: string) => void
   recordAffiliationFileWorkQueueFileReleaseDelivery: (entryId: string) => void
+  recordAffiliationFileWorkQueueNonMissionEnforcement: (entryId: string) => void
   recordAffiliationFileWorkQueueEvidenceRepairWorkflow: (entryId: string) => void
   advanceWeek: () => void
   setSeed: (seed: number) => void
@@ -2055,6 +2061,54 @@ export const useGameStore = create<GameStore>()(
               ...s.game,
               affiliationFileWorkQueueFileReleaseDeliveryRecords: {
                 ...(s.game.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}),
+                [record.id]: record,
+              },
+            },
+          }
+        }),
+
+      recordAffiliationFileWorkQueueNonMissionEnforcement: (entryId) =>
+        set((s) => {
+          const view = getAffiliationPersonStatusMirrorView(s.game)
+          const entry = view.fileAccessWorkQueue.find((candidate) => candidate.id === entryId)
+
+          if (!entry) {
+            return { game: s.game }
+          }
+
+          const enforcement = getAffiliationFileWorkQueueNonMissionEnforcementForBucket(
+            entry.bucket
+          )
+
+          if (!enforcement) {
+            return { game: s.game }
+          }
+
+          const recordId = buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+            workQueueEntryId: entry.id,
+            sourceBucket: entry.bucket,
+          })
+
+          if (s.game.affiliationFileWorkQueueNonMissionEnforcementRecords?.[recordId]) {
+            return { game: s.game }
+          }
+
+          const record = buildAffiliationFileWorkQueueNonMissionEnforcementRecord({
+            workQueueEntryId: entry.id,
+            subjectId: entry.subjectId,
+            subjectLabel: entry.subjectLabel,
+            sourceBucket: entry.bucket,
+            sourceReasonCodes: entry.reasonCodeLabels,
+            enforcementKind: enforcement.enforcementKind,
+            enforcementLabel: enforcement.enforcementLabel,
+            recordedWeek: s.game.week,
+          })
+
+          return {
+            game: {
+              ...s.game,
+              affiliationFileWorkQueueNonMissionEnforcementRecords: {
+                ...(s.game.affiliationFileWorkQueueNonMissionEnforcementRecords ?? {}),
                 [record.id]: record,
               },
             },

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -221,6 +221,7 @@ import { sanitizeAffiliationFileWorkQueueReleaseOutcomeRecords } from '../../dom
 import { sanitizeAffiliationFileWorkQueueReleaseFulfillmentRecords } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { sanitizeAffiliationFileWorkQueueReleasePackageRecords } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import { sanitizeAffiliationFileWorkQueueFileReleaseDeliveryRecords } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import { sanitizeAffiliationFileWorkQueueNonMissionEnforcementRecords } from '../../domain/affiliationFileWorkQueueNonMissionEnforcementRecords'
 import { sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import { sanitizeEntityWelfareReclassificationRecords } from '../../domain/entityWelfareReclassificationRegistry'
 import { sanitizeTherapeuticCareScheduleRecords } from '../../domain/containedPersonTherapeuticCareRegistry'
@@ -8784,6 +8785,11 @@ export function hydrateGame(
       game.affiliationFileWorkQueueFileReleaseDeliveryRecords,
       fallback.affiliationFileWorkQueueFileReleaseDeliveryRecords ?? {}
     )
+  const affiliationFileWorkQueueNonMissionEnforcementRecords =
+    sanitizeAffiliationFileWorkQueueNonMissionEnforcementRecords(
+      game.affiliationFileWorkQueueNonMissionEnforcementRecords,
+      fallback.affiliationFileWorkQueueNonMissionEnforcementRecords ?? {}
+    )
   const affiliationFileWorkQueueEvidenceRepairWorkflows =
     sanitizeAffiliationFileWorkQueueEvidenceRepairWorkflows(
       game.affiliationFileWorkQueueEvidenceRepairWorkflows,
@@ -8991,6 +8997,7 @@ export function hydrateGame(
     affiliationFileWorkQueueReleaseFulfillmentRecords,
     affiliationFileWorkQueueReleasePackageRecords,
     affiliationFileWorkQueueFileReleaseDeliveryRecords,
+    affiliationFileWorkQueueNonMissionEnforcementRecords,
     affiliationFileWorkQueueEvidenceRepairWorkflows,
     entityWelfareReclassificationRecords,
     containedPersonTherapeuticCareRecords,

--- a/src/domain/affiliationFileWorkQueueNonMissionEnforcementRecords.ts
+++ b/src/domain/affiliationFileWorkQueueNonMissionEnforcementRecords.ts
@@ -1,0 +1,234 @@
+import type { AffiliationFileWorkQueueSourceBucket } from './affiliationFileWorkQueueActionRecords'
+
+export type AffiliationFileWorkQueueNonMissionEnforcementRecordId = string
+
+export type AffiliationFileWorkQueueNonMissionEnforcementKind =
+  | 'blocked_non_mission_access_enforced'
+  | 'restricted_non_mission_access_enforced'
+  | 'allowed_non_mission_access_verified'
+
+export interface AffiliationFileWorkQueueNonMissionEnforcementRecord {
+  readonly id: AffiliationFileWorkQueueNonMissionEnforcementRecordId
+  readonly workQueueEntryId: string
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly sourceBucket: AffiliationFileWorkQueueSourceBucket
+  readonly sourceReasonCodes: readonly string[]
+  readonly enforcementKind: AffiliationFileWorkQueueNonMissionEnforcementKind
+  readonly enforcementLabel: string
+  readonly recordedWeek: number
+}
+
+export type AffiliationFileWorkQueueNonMissionEnforcementRecordsMap = Record<
+  AffiliationFileWorkQueueNonMissionEnforcementRecordId,
+  AffiliationFileWorkQueueNonMissionEnforcementRecord
+>
+
+export interface AffiliationFileWorkQueueNonMissionEnforcementRecordInput {
+  readonly workQueueEntryId: string
+  readonly subjectId: string
+  readonly subjectLabel: string
+  readonly sourceBucket: AffiliationFileWorkQueueSourceBucket
+  readonly sourceReasonCodes: readonly string[]
+  readonly enforcementKind: AffiliationFileWorkQueueNonMissionEnforcementKind
+  readonly enforcementLabel: string
+  readonly recordedWeek: number
+}
+
+const ENFORCEMENT_KINDS: readonly AffiliationFileWorkQueueNonMissionEnforcementKind[] = [
+  'blocked_non_mission_access_enforced',
+  'restricted_non_mission_access_enforced',
+  'allowed_non_mission_access_verified',
+] as const
+
+const SOURCE_BUCKETS: readonly AffiliationFileWorkQueueSourceBucket[] = [
+  'blocked',
+  'restricted',
+  'missing_review',
+  'allowed',
+] as const
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeToken(value: unknown) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeRecordedWeek(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 0 &&
+    value === Math.trunc(value)
+    ? value
+    : undefined
+}
+
+function normalizeReasonCodes(value: unknown) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return [
+    ...new Set(value.map((entry) => normalizeToken(entry)).filter((entry) => entry.length > 0)),
+  ].sort((left, right) => left.localeCompare(right))
+}
+
+function normalizeSourceBucket(value: unknown): AffiliationFileWorkQueueSourceBucket | undefined {
+  return SOURCE_BUCKETS.includes(value as AffiliationFileWorkQueueSourceBucket)
+    ? (value as AffiliationFileWorkQueueSourceBucket)
+    : undefined
+}
+
+function normalizeEnforcementKind(
+  value: unknown
+): AffiliationFileWorkQueueNonMissionEnforcementKind | undefined {
+  return ENFORCEMENT_KINDS.includes(value as AffiliationFileWorkQueueNonMissionEnforcementKind)
+    ? (value as AffiliationFileWorkQueueNonMissionEnforcementKind)
+    : undefined
+}
+
+export function getAffiliationFileWorkQueueNonMissionEnforcementForBucket(
+  bucket: AffiliationFileWorkQueueSourceBucket
+): {
+  readonly enforcementKind: AffiliationFileWorkQueueNonMissionEnforcementKind
+  readonly enforcementLabel: string
+} | null {
+  switch (bucket) {
+    case 'blocked':
+      return Object.freeze({
+        enforcementKind: 'blocked_non_mission_access_enforced',
+        enforcementLabel: 'Blocked non-mission access enforced',
+      })
+    case 'restricted':
+      return Object.freeze({
+        enforcementKind: 'restricted_non_mission_access_enforced',
+        enforcementLabel: 'Restricted non-mission access enforced',
+      })
+    case 'allowed':
+      return Object.freeze({
+        enforcementKind: 'allowed_non_mission_access_verified',
+        enforcementLabel: 'Allowed non-mission access verified',
+      })
+    case 'missing_review':
+      return null
+  }
+}
+
+function isValidEnforcementPair(input: {
+  readonly sourceBucket: AffiliationFileWorkQueueSourceBucket
+  readonly enforcementKind: AffiliationFileWorkQueueNonMissionEnforcementKind
+}) {
+  return (
+    (input.sourceBucket === 'blocked' &&
+      input.enforcementKind === 'blocked_non_mission_access_enforced') ||
+    (input.sourceBucket === 'restricted' &&
+      input.enforcementKind === 'restricted_non_mission_access_enforced') ||
+    (input.sourceBucket === 'allowed' &&
+      input.enforcementKind === 'allowed_non_mission_access_verified')
+  )
+}
+
+export function buildAffiliationFileWorkQueueNonMissionEnforcementRecordId(input: {
+  readonly workQueueEntryId: string
+  readonly sourceBucket: AffiliationFileWorkQueueSourceBucket
+}) {
+  return `affiliation-file-non-mission-enforcement:${input.workQueueEntryId}:${input.sourceBucket}`
+}
+
+export function buildAffiliationFileWorkQueueNonMissionEnforcementRecord(
+  input: AffiliationFileWorkQueueNonMissionEnforcementRecordInput
+): AffiliationFileWorkQueueNonMissionEnforcementRecord {
+  const sourceReasonCodes = normalizeReasonCodes(input.sourceReasonCodes)
+
+  return Object.freeze({
+    id: buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+      workQueueEntryId: input.workQueueEntryId,
+      sourceBucket: input.sourceBucket,
+    }),
+    workQueueEntryId: input.workQueueEntryId,
+    subjectId: input.subjectId,
+    subjectLabel: input.subjectLabel,
+    sourceBucket: input.sourceBucket,
+    sourceReasonCodes: Object.freeze(sourceReasonCodes),
+    enforcementKind: input.enforcementKind,
+    enforcementLabel: input.enforcementLabel,
+    recordedWeek: input.recordedWeek,
+  })
+}
+
+function sanitizeNonMissionEnforcementRecordEntry(
+  value: unknown,
+  expectedKey?: string
+): AffiliationFileWorkQueueNonMissionEnforcementRecord | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeToken(value.id)
+  const workQueueEntryId = normalizeToken(value.workQueueEntryId)
+  const subjectId = normalizeToken(value.subjectId)
+  const subjectLabel = normalizeToken(value.subjectLabel)
+  const sourceBucket = normalizeSourceBucket(value.sourceBucket)
+  const enforcementKind = normalizeEnforcementKind(value.enforcementKind)
+  const enforcementLabel = normalizeToken(value.enforcementLabel)
+  const recordedWeek = normalizeRecordedWeek(value.recordedWeek)
+
+  if (
+    !id ||
+    !workQueueEntryId ||
+    !subjectId ||
+    !subjectLabel ||
+    !sourceBucket ||
+    !enforcementKind ||
+    !enforcementLabel ||
+    recordedWeek === undefined ||
+    !isValidEnforcementPair({ sourceBucket, enforcementKind }) ||
+    (expectedKey !== undefined && expectedKey !== id) ||
+    id !==
+      buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+        workQueueEntryId,
+        sourceBucket,
+      })
+  ) {
+    return null
+  }
+
+  return Object.freeze({
+    id,
+    workQueueEntryId,
+    subjectId,
+    subjectLabel,
+    sourceBucket,
+    sourceReasonCodes: Object.freeze(normalizeReasonCodes(value.sourceReasonCodes)),
+    enforcementKind,
+    enforcementLabel,
+    recordedWeek,
+  })
+}
+
+/** Hydration: canonical non-mission enforcement ledger keyed by deterministic record id. */
+export function sanitizeAffiliationFileWorkQueueNonMissionEnforcementRecords(
+  value: unknown,
+  fallback: AffiliationFileWorkQueueNonMissionEnforcementRecordsMap = {}
+): AffiliationFileWorkQueueNonMissionEnforcementRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: AffiliationFileWorkQueueNonMissionEnforcementRecordsMap = {}
+  const seenIds = new Set<string>()
+
+  for (const [key, entry] of Object.entries(value)) {
+    const record = sanitizeNonMissionEnforcementRecordEntry(entry, key)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -283,6 +283,7 @@ import type { AffiliationFileWorkQueueReleaseOutcomeRecord } from './affiliation
 import type { AffiliationFileWorkQueueReleaseFulfillmentRecord } from './affiliationFileWorkQueueReleaseFulfillmentRecords'
 import type { AffiliationFileWorkQueueReleasePackageRecord } from './affiliationFileWorkQueueReleasePackageRecords'
 import type { AffiliationFileWorkQueueFileReleaseDeliveryRecord } from './affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import type { AffiliationFileWorkQueueNonMissionEnforcementRecord } from './affiliationFileWorkQueueNonMissionEnforcementRecords'
 import type { AffiliationFileWorkQueueEvidenceRepairWorkflow } from './affiliationFileWorkQueueEvidenceRepairWorkflows'
 import type { EntityWelfareReclassificationRecord } from './entityWelfareReclassificationRegistry'
 import type { PublishQueueRecord } from './publishAutomationCreditingHooks'
@@ -2841,6 +2842,15 @@ export interface GameState {
   affiliationFileWorkQueueFileReleaseDeliveryRecords?: Record<
     string,
     AffiliationFileWorkQueueFileReleaseDeliveryRecord
+  >
+
+  /**
+   * SPE-1046 non-mission file-access enforcement follow-on: persisted non-mission enforcement receipts.
+   * Hydration drops invalid, duplicate-id, and mismatched-key entries without throwing.
+   */
+  affiliationFileWorkQueueNonMissionEnforcementRecords?: Record<
+    string,
+    AffiliationFileWorkQueueNonMissionEnforcementRecord
   >
 
   /**

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.test.tsx
@@ -21,6 +21,7 @@ import { buildAffiliationFileWorkQueueReleaseOutcomeRecordId } from '../../domai
 import { buildAffiliationFileWorkQueueReleaseFulfillmentRecord } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { buildAffiliationFileWorkQueueReleasePackageRecordId } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import { buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import { buildAffiliationFileWorkQueueNonMissionEnforcementRecordId } from '../../domain/affiliationFileWorkQueueNonMissionEnforcementRecords'
 import AffiliationPersonStatusMirrorPage from './AffiliationPersonStatusMirrorPage'
 
 function renderMirrorPage() {
@@ -132,6 +133,53 @@ describe('AffiliationPersonStatusMirrorPage (SPE-2519 slice 1)', () => {
             sourceBucket: 'restricted',
             recordedWeek: 8,
           }),
+      })
+    )
+  })
+
+  it('records a non-mission enforcement entry from the queue row', async () => {
+    const user = userEvent.setup()
+    const game = createStartingState()
+    game.week = 8
+    game.entityWelfareReclassificationRecords = {
+      [PENDING_TO_APPROVED_FIXTURE.id]: PENDING_TO_APPROVED_FIXTURE,
+    }
+    game.affiliationPersonStatusRecords = {
+      [COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id]: {
+        ...COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE,
+        entityWelfareReclassificationRef: PENDING_TO_APPROVED_FIXTURE.id,
+      },
+    }
+    useGameStore.setState({ game })
+
+    renderMirrorPage()
+
+    const queueRegion = screen.getByRole('region', {
+      name: /file access work queue/i,
+    })
+
+    await user.click(
+      screen.getByRole('button', { name: /record restricted non-mission enforcement/i })
+    )
+
+    const enforcementId = buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      sourceBucket: 'restricted',
+    })
+
+    expect(queueRegion).toHaveTextContent('Restricted non-mission access enforced W8')
+    expect(
+      screen.queryByRole('button', { name: /record restricted non-mission enforcement/i })
+    ).not.toBeInTheDocument()
+    expect(
+      useGameStore.getState().game.affiliationFileWorkQueueNonMissionEnforcementRecords
+    ).toEqual(
+      expect.objectContaining({
+        [enforcementId]: expect.objectContaining({
+          enforcementKind: 'restricted_non_mission_access_enforced',
+          enforcementLabel: 'Restricted non-mission access enforced',
+          recordedWeek: 8,
+        }),
       })
     )
   })

--- a/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
+++ b/src/features/operations/AffiliationPersonStatusMirrorPage.tsx
@@ -52,6 +52,9 @@ export default function AffiliationPersonStatusMirrorPage() {
   const recordAffiliationFileWorkQueueFileReleaseDelivery = useGameStore(
     (state) => state.recordAffiliationFileWorkQueueFileReleaseDelivery
   )
+  const recordAffiliationFileWorkQueueNonMissionEnforcement = useGameStore(
+    (state) => state.recordAffiliationFileWorkQueueNonMissionEnforcement
+  )
   const view = useMemo(() => getAffiliationPersonStatusMirrorView(game), [game])
 
   return (
@@ -340,6 +343,21 @@ export default function AffiliationPersonStatusMirrorPage() {
                             }
                           >
                             {entry.fileReleaseDeliveryButtonLabel}
+                          </button>
+                        ) : null}
+                        {entry.isNonMissionEnforcementRecorded ? (
+                          <p className="mt-2 text-xs font-medium">
+                            {entry.nonMissionEnforcementStatusLabel}
+                          </p>
+                        ) : entry.canRecordNonMissionEnforcement ? (
+                          <button
+                            type="button"
+                            className="btn btn-xs btn-ghost mt-2 whitespace-nowrap"
+                            onClick={() =>
+                              recordAffiliationFileWorkQueueNonMissionEnforcement(entry.id)
+                            }
+                          >
+                            {entry.nonMissionEnforcementButtonLabel}
                           </button>
                         ) : null}
                       </td>

--- a/src/features/operations/affiliationPersonStatusMirrorView.test.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.test.ts
@@ -12,6 +12,7 @@ import { buildAffiliationFileWorkQueueReleaseOutcomeRecord } from '../../domain/
 import { buildAffiliationFileWorkQueueReleaseFulfillmentRecord } from '../../domain/affiliationFileWorkQueueReleaseFulfillmentRecords'
 import { buildAffiliationFileWorkQueueReleasePackageRecord } from '../../domain/affiliationFileWorkQueueReleasePackageRecords'
 import { buildAffiliationFileWorkQueueFileReleaseDeliveryRecord } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import { buildAffiliationFileWorkQueueNonMissionEnforcementRecord } from '../../domain/affiliationFileWorkQueueNonMissionEnforcementRecords'
 import {
   HOSTILE_TO_COOPERATIVE_FIXTURE,
   PENDING_TO_APPROVED_FIXTURE,
@@ -564,6 +565,40 @@ describe('affiliationPersonStatusMirrorView (SPE-2519 slice 1)', () => {
       fileReleaseDeliveryButtonLabel: 'Record actual file-content delivery',
       fileReleaseDeliveryStatusLabel:
         'Metadata-only file release delivered W14 (file-release-delivery:person-status:cooperative-contractor-cleared:safe_file_handoff_package)',
+    })
+  })
+
+  it('shows non-mission enforcement controls and recorded status for restricted rows', () => {
+    const game = makeStatusGame()
+    const view = getAffiliationPersonStatusMirrorView(game)
+
+    expect(view.fileAccessWorkQueue[0]).toMatchObject({
+      canRecordNonMissionEnforcement: true,
+      isNonMissionEnforcementRecorded: false,
+      nonMissionEnforcementButtonLabel: 'Record restricted non-mission enforcement',
+    })
+
+    const recorded = buildAffiliationFileWorkQueueNonMissionEnforcementRecord({
+      workQueueEntryId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.id,
+      subjectId: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectId,
+      subjectLabel: COOPERATIVE_CONTRACTOR_PERSON_STATUS_FIXTURE.subjectLabel,
+      sourceBucket: 'restricted',
+      sourceReasonCodes: ['approved_cooperative_file_restricted'],
+      enforcementKind: 'restricted_non_mission_access_enforced',
+      enforcementLabel: 'Restricted non-mission access enforced',
+      recordedWeek: 11,
+    })
+    game.affiliationFileWorkQueueNonMissionEnforcementRecords = {
+      [recorded.id]: recorded,
+    }
+
+    const recordedView = getAffiliationPersonStatusMirrorView(game)
+
+    expect(recordedView.fileAccessWorkQueue[0]).toMatchObject({
+      canRecordNonMissionEnforcement: false,
+      isNonMissionEnforcementRecorded: true,
+      nonMissionEnforcementStatusLabel:
+        'Restricted non-mission access enforced W11 (affiliation-file-non-mission-enforcement:person-status:cooperative-contractor-cleared:restricted)',
     })
   })
 

--- a/src/features/operations/affiliationPersonStatusMirrorView.ts
+++ b/src/features/operations/affiliationPersonStatusMirrorView.ts
@@ -24,6 +24,10 @@ import {
   buildAffiliationFileWorkQueueFileReleaseDeliveryRecordId,
   type AffiliationFileWorkQueueFileReleaseDeliveryRecord,
 } from '../../domain/affiliationFileWorkQueueFileReleaseDeliveryRecords'
+import {
+  buildAffiliationFileWorkQueueNonMissionEnforcementRecordId,
+  getAffiliationFileWorkQueueNonMissionEnforcementForBucket,
+} from '../../domain/affiliationFileWorkQueueNonMissionEnforcementRecords'
 import { buildAffiliationFileWorkQueueEvidenceRepairWorkflowId } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
 import type { AffiliationFileWorkQueueReleaseOutcomeKind } from '../../domain/affiliationFileWorkQueueReleaseOutcomeRecords'
 import {
@@ -136,6 +140,10 @@ export interface AffiliationFileAccessWorkQueueEntryView {
   isFileReleaseDeliveryRecorded: boolean
   fileReleaseDeliveryStatusLabel?: string
   fileReleaseDeliveryButtonLabel?: string
+  canRecordNonMissionEnforcement: boolean
+  isNonMissionEnforcementRecorded: boolean
+  nonMissionEnforcementStatusLabel?: string
+  nonMissionEnforcementButtonLabel?: string
   canRecordEvidenceRepairWorkflow: boolean
   isEvidenceRepairWorkflowRecorded: boolean
   evidenceRepairWorkflowStatusLabel?: string
@@ -491,6 +499,16 @@ function toFileAccessWorkQueueEntry(
   const hasActualFileReleaseDelivery = relatedFileReleaseDeliveries.some(
     (record) => record.deliveryKind === 'actual_file_content_release_delivered'
   )
+  const nonMissionEnforcement = getAffiliationFileWorkQueueNonMissionEnforcementForBucket(bucket)
+  const nonMissionEnforcementRecordId = nonMissionEnforcement
+    ? buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+        workQueueEntryId: snapshot.recordId,
+        sourceBucket: bucket,
+      })
+    : ''
+  const nonMissionEnforcementRecord = nonMissionEnforcement
+    ? game.affiliationFileWorkQueueNonMissionEnforcementRecords?.[nonMissionEnforcementRecordId]
+    : undefined
 
   const evidenceRepairWorkflowId = buildAffiliationFileWorkQueueEvidenceRepairWorkflowId({
     workQueueEntryId: snapshot.recordId,
@@ -596,6 +614,18 @@ function toFileAccessWorkQueueEntry(
     ...(fileReleaseDeliveryRecord
       ? {
           fileReleaseDeliveryStatusLabel: `${fileReleaseDeliveryRecord.deliveryLabel} W${fileReleaseDeliveryRecord.recordedWeek} (${fileReleaseDeliveryRecord.deliveryRef})`,
+        }
+      : {}),
+    canRecordNonMissionEnforcement: Boolean(nonMissionEnforcement && !nonMissionEnforcementRecord),
+    isNonMissionEnforcementRecorded: Boolean(nonMissionEnforcementRecord),
+    ...(nonMissionEnforcement
+      ? {
+          nonMissionEnforcementButtonLabel: `Record ${bucket} non-mission enforcement`,
+        }
+      : {}),
+    ...(nonMissionEnforcementRecord
+      ? {
+          nonMissionEnforcementStatusLabel: `${nonMissionEnforcementRecord.enforcementLabel} W${nonMissionEnforcementRecord.recordedWeek} (${nonMissionEnforcementRecord.id})`,
         }
       : {}),
     canRecordEvidenceRepairWorkflow:

--- a/src/test/affiliationFileWorkQueueNonMissionEnforcementRecords.test.ts
+++ b/src/test/affiliationFileWorkQueueNonMissionEnforcementRecords.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { hydrateGame } from '../app/store/runTransfer'
+import { createStartingState } from '../data/startingState'
+import {
+  buildAffiliationFileWorkQueueNonMissionEnforcementRecord,
+  buildAffiliationFileWorkQueueNonMissionEnforcementRecordId,
+  getAffiliationFileWorkQueueNonMissionEnforcementForBucket,
+  sanitizeAffiliationFileWorkQueueNonMissionEnforcementRecords,
+} from '../domain/affiliationFileWorkQueueNonMissionEnforcementRecords'
+
+describe('affiliationFileWorkQueueNonMissionEnforcementRecords persistence', () => {
+  it('maps eligible buckets to deterministic non-mission enforcement outcomes', () => {
+    expect(getAffiliationFileWorkQueueNonMissionEnforcementForBucket('blocked')).toEqual({
+      enforcementKind: 'blocked_non_mission_access_enforced',
+      enforcementLabel: 'Blocked non-mission access enforced',
+    })
+    expect(getAffiliationFileWorkQueueNonMissionEnforcementForBucket('restricted')).toEqual({
+      enforcementKind: 'restricted_non_mission_access_enforced',
+      enforcementLabel: 'Restricted non-mission access enforced',
+    })
+    expect(getAffiliationFileWorkQueueNonMissionEnforcementForBucket('allowed')).toEqual({
+      enforcementKind: 'allowed_non_mission_access_verified',
+      enforcementLabel: 'Allowed non-mission access verified',
+    })
+    expect(getAffiliationFileWorkQueueNonMissionEnforcementForBucket('missing_review')).toBeNull()
+  })
+
+  it('builds deterministic ids and sorts source reason codes', () => {
+    const record = buildAffiliationFileWorkQueueNonMissionEnforcementRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceBucket: 'blocked',
+      sourceReasonCodes: [' blocked_site ', 'file_blocked', 'blocked_site'],
+      enforcementKind: 'blocked_non_mission_access_enforced',
+      enforcementLabel: 'Blocked non-mission access enforced',
+      recordedWeek: 11,
+    })
+
+    expect(record).toEqual({
+      id: 'affiliation-file-non-mission-enforcement:person-status:alpha:blocked',
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceBucket: 'blocked',
+      sourceReasonCodes: ['blocked_site', 'file_blocked'],
+      enforcementKind: 'blocked_non_mission_access_enforced',
+      enforcementLabel: 'Blocked non-mission access enforced',
+      recordedWeek: 11,
+    })
+    expect(
+      buildAffiliationFileWorkQueueNonMissionEnforcementRecordId({
+        workQueueEntryId: 'person-status:alpha',
+        sourceBucket: 'blocked',
+      })
+    ).toBe(record.id)
+  })
+
+  it('drops invalid records and mismatched keys during hydration sanitization', () => {
+    const valid = buildAffiliationFileWorkQueueNonMissionEnforcementRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceBucket: 'restricted',
+      sourceReasonCodes: ['file_restricted'],
+      enforcementKind: 'restricted_non_mission_access_enforced',
+      enforcementLabel: 'Restricted non-mission access enforced',
+      recordedWeek: 9,
+    })
+
+    expect(
+      sanitizeAffiliationFileWorkQueueNonMissionEnforcementRecords({
+        [valid.id]: valid,
+        'wrong-key': valid,
+        'bad-pair': {
+          ...valid,
+          id: 'affiliation-file-non-mission-enforcement:person-status:beta:restricted',
+          workQueueEntryId: 'person-status:beta',
+          sourceBucket: 'restricted',
+          enforcementKind: 'blocked_non_mission_access_enforced',
+        },
+        'bad-week': {
+          ...valid,
+          id: 'affiliation-file-non-mission-enforcement:person-status:gamma:restricted',
+          workQueueEntryId: 'person-status:gamma',
+          recordedWeek: 7.25,
+        },
+      })
+    ).toEqual({
+      [valid.id]: valid,
+    })
+  })
+
+  it('hydrates and exports non-mission enforcement records through GameState', () => {
+    const state = createStartingState()
+    const valid = buildAffiliationFileWorkQueueNonMissionEnforcementRecord({
+      workQueueEntryId: 'person-status:alpha',
+      subjectId: 'subject:alpha',
+      subjectLabel: 'Alpha Subject',
+      sourceBucket: 'allowed',
+      sourceReasonCodes: ['file_permission_allowed'],
+      enforcementKind: 'allowed_non_mission_access_verified',
+      enforcementLabel: 'Allowed non-mission access verified',
+      recordedWeek: 10,
+    })
+
+    state.affiliationFileWorkQueueNonMissionEnforcementRecords = {
+      [valid.id]: valid,
+    }
+
+    const hydrated = hydrateGame(JSON.parse(JSON.stringify(state)), createStartingState())
+
+    expect(hydrated.affiliationFileWorkQueueNonMissionEnforcementRecords).toEqual({
+      [valid.id]: valid,
+    })
+    expect(hydrated.affiliationPersonStatusRecords).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary\n- add a new non-mission file-access enforcement ledger domain module with deterministic ids and hydration sanitizer\n- wire the new ledger through GameState models, store hydration, and store action handling\n- add domain persistence tests and store action coverage for blocked/restricted/no-op paths\n\n## Validation\n- npm run lint\n- targeted tests passed (81):\n  - src/test/affiliationFileWorkQueueNonMissionEnforcementRecords.test.ts\n  - src/app/store/gameStore.test.ts\n