### PR TITLE
SPE-2556 Enforce operation event migration validation

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -8,11 +8,12 @@ Documents versioning strategy for OperationEvent types to ensure backward compat
 
 - **Version**: 2
 - **Target**: 1 | 2 union type
-- **Compatibility**: V1 events auto-convert to V2
+- **Compatibility**: Valid V1 events auto-convert to V2; invalid payloads are rejected at migration
 
 ## Migration Path
 
-- V1 → V2: No breaking changes; all V1 events remain valid
+- V1 → V2: No breaking shape changes; valid V1 events remain valid
+- Invalid or missing payloads are dropped during migration so canonical runtime history contains only schema-valid OperationEvents
 - All new events created with V2 schema
 - Legacy V1 events automatically migrated on load
 

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -1173,6 +1173,10 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
     payload: entry.payload,
   })
 
+  if (!migrated) {
+    return null
+  }
+
   return {
     ...migrated,
     id: entry.id,

--- a/src/domain/events/eventMigration.test.ts
+++ b/src/domain/events/eventMigration.test.ts
@@ -73,8 +73,8 @@ describe('hydration problems 519-526 (schema migration)', () => {
         payload: minimalOperationEventPayloads[type],
       })
 
-      expect(migrated.schemaVersion).toBe(2)
-      expect(migrated.type).toBe(type)
+      expect(migrated?.schemaVersion).toBe(2)
+      expect(migrated?.type).toBe(type)
     }
   })
 })
@@ -99,8 +99,8 @@ describe('hydration problems 527-534 (schema migration)', () => {
         payload: minimalOperationEventPayloads[type],
       })
 
-      expect(migrated.schemaVersion).toBe(2)
-      expect(migrated.type).toBe(type)
+      expect(migrated?.schemaVersion).toBe(2)
+      expect(migrated?.type).toBe(type)
     }
   })
 })
@@ -112,15 +112,15 @@ describe('hydration problems 535-542 (schema migration)', () => {
       schemaVersion: 2,
     })
 
-    expect(v2.schemaVersion).toBe(2)
-    expect(v2.id).toBe(validV1.id)
-    expect(v2.type).toBe(validV1.type)
+    expect(v2?.schemaVersion).toBe(2)
+    expect(v2?.id).toBe(validV1.id)
+    expect(v2?.type).toBe(validV1.type)
   })
 
   it('542 getEventMigrator exposes v1→v2 step targeting schema 2', () => {
     const migrator = getEventMigrator()
     expect(migrator['1']?.target).toBe(2)
-    expect(migrator['1']?.migrate(validV1).schemaVersion).toBe(2)
+    expect(migrator['1']?.migrate(validV1)?.schemaVersion).toBe(2)
   })
 })
 
@@ -147,8 +147,8 @@ describe('hydration problems 583-590 (schema migration)', () => {
         payload: minimalOperationEventPayloads[type],
       })
 
-      expect(migrated.schemaVersion).toBe(2)
-      expect(migrated.type).toBe(type)
+      expect(migrated?.schemaVersion).toBe(2)
+      expect(migrated?.type).toBe(type)
     }
   })
 })
@@ -156,14 +156,33 @@ describe('hydration problems 583-590 (schema migration)', () => {
 describe('migrateEventV1toV2', () => {
   it('migrates valid V1 event to V2', () => {
     const migrated = migrateEventV1toV2(validV1)
-    expect(migrated.schemaVersion).toBe(2)
-    expect(migrated.id).toBe(validV1.id)
+    expect(migrated?.schemaVersion).toBe(2)
+    expect(migrated?.id).toBe(validV1.id)
   })
 
-  it('logs error for invalid payload', () => {
-    // Should log error, but still migrate
+  it('drops invalid known-type payloads instead of carrying them into canonical history', () => {
     const migrated = migrateEventV1toV2(invalidV1)
-    expect(migrated.schemaVersion).toBe(2)
-    expect(migrated.id).toBe(invalidV1.id)
+    expect(migrated).toBeNull()
+  })
+
+  it('drops known-type events with missing payloads', () => {
+    const migrated = migrateEventV1toV2({
+      id: 'evt-missing-payload',
+      schemaVersion: 1,
+      type: 'assignment.team_assigned',
+    })
+
+    expect(migrated).toBeNull()
+  })
+
+  it('passes through valid V2 events unchanged after validation', () => {
+    const validV2 = {
+      ...validV1,
+      schemaVersion: 2,
+    }
+
+    const migrated = migrateEventV1toV2(validV2)
+
+    expect(migrated).toBe(validV2)
   })
 })

--- a/src/domain/events/eventMigration.ts
+++ b/src/domain/events/eventMigration.ts
@@ -1,12 +1,12 @@
 import type { OperationEvent, OperationEventType } from './types'
-import { validateOperationEventPayload } from './eventValidation'
+import { operationEventPayloadSchemas, validateOperationEventPayload } from './eventValidation'
 
 /**
  * Operation event schema versions (hydration 542).
  *
- * - **v1 → v2:** structural-compatible bump — payloads are not reshaped; hydration assigns
+ * - **v1 → v2:** structural-compatible bump — payloads are not reshaped; migration assigns
  *   `schemaVersion: 2` and validates against `operationEventPayloadSchemas`. Invalid payloads are
- *   logged in non-test environments but still carried forward so saves remain loadable.
+ *   logged in non-test environments and dropped so canonical runtime history remains valid.
  * - **v2:** current canonical version used by `sanitizeOperationEvents` / `migrateOperationEventToCurrentSchema`.
  *
  * Per-type payload migrations belong in `eventValidation` or `sanitizeOperationEvents` when a
@@ -48,7 +48,7 @@ type EventWithSchemaVersion = { schemaVersion?: number } & Record<string, unknow
 
 export function migrateEventV1toV2<TEvent extends EventWithSchemaVersion>(
   event: TEvent
-): OperationEvent {
+): OperationEvent | null {
   const eventRecord = event as EventWithSchemaVersion & {
     type?: unknown
     payload?: unknown
@@ -64,17 +64,29 @@ export function migrateEventV1toV2<TEvent extends EventWithSchemaVersion>(
   const type =
     typeof eventRecord.type === 'string' ? (eventRecord.type as OperationEventType) : undefined
 
-  if (type) {
-    const validation = validateOperationEventPayload(type, eventRecord.payload)
-    if (SHOULD_LOG_EVENT_MIGRATION_DIAGNOSTICS && !validation.success) {
+  if (!type || !(type in operationEventPayloadSchemas)) {
+    if (SHOULD_LOG_EVENT_MIGRATION_DIAGNOSTICS) {
       console.error(
-        `[event-validation] Invalid payload for event type ${type}: ${validation.error}`
+        `[event-validation] Invalid or missing event type for event ID=${eventRecord.id ?? 'unknown'}`
       )
     }
+
+    return null
   }
+
+  const validation = validateOperationEventPayload(type, eventRecord.payload)
+  if (!validation.success) {
+    if (SHOULD_LOG_EVENT_MIGRATION_DIAGNOSTICS) {
+      console.error(`[event-validation] Invalid payload for event type ${type}: ${validation.error}`)
+    }
+
+    return null
+  }
+
   if (event.schemaVersion === 2) {
     return event as unknown as OperationEvent
   }
+
   // V1 events are compatible with V2 schema
   return {
     ...event,
@@ -85,10 +97,7 @@ export function migrateEventV1toV2<TEvent extends EventWithSchemaVersion>(
 export function getEventMigrator() {
   return {
     '1': {
-      migrate: (event: EventWithSchemaVersion) => ({
-        ...event,
-        schemaVersion: 2,
-      }),
+      migrate: (event: EventWithSchemaVersion) => migrateEventV1toV2(event),
       target: 2,
     },
   }


### PR DESCRIPTION
## Summary
- Enforces operation-event migration validation by dropping invalid or missing payloads instead of carrying them forward as canonical OperationEvents.
- Keeps valid v1/v2 events intact and updates agent history normalization for the nullable migration result.
- Documents the policy in the schema registry and adds migration tests for invalid known-type payloads, missing payloads, valid v1 payloads, and valid v2 payloads.

Linear: SPE-2556

## Validation
- npm run test:run -- src/domain/events/eventMigration.test.ts
- npm run lint

Note: npm run format:check still reports baseline formatter drift across the repository; touched files were kept minimal to avoid broad unrelated formatting churn.