### PR TITLE
SPE-2557 Guard unknown event migration types

### DIFF
--- a/src/domain/events/eventMigration.test.ts
+++ b/src/domain/events/eventMigration.test.ts
@@ -154,6 +154,18 @@ describe('hydration problems 583-590 (schema migration)', () => {
 })
 
 describe('migrateEventV1toV2', () => {
+  it('keeps valid known event types on the validation path', () => {
+    const migrated = migrateEventV1toV2({
+      id: 'evt-known-type',
+      schemaVersion: 1,
+      type: 'assignment.team_assigned',
+      payload: minimalOperationEventPayloads['assignment.team_assigned'],
+    })
+
+    expect(migrated?.type).toBe('assignment.team_assigned')
+    expect(migrated?.schemaVersion).toBe(2)
+  })
+
   it('migrates valid V1 event to V2', () => {
     const migrated = migrateEventV1toV2(validV1)
     expect(migrated?.schemaVersion).toBe(2)
@@ -173,6 +185,64 @@ describe('migrateEventV1toV2', () => {
     })
 
     expect(migrated).toBeNull()
+  })
+
+  it('drops unknown string event types before payload validation', () => {
+    expect(() =>
+      migrateEventV1toV2({
+        id: 'evt-unknown-type',
+        schemaVersion: 1,
+        type: 'system.unknown_event',
+        payload: { week: 1 },
+      })
+    ).not.toThrow()
+
+    expect(
+      migrateEventV1toV2({
+        id: 'evt-unknown-type',
+        schemaVersion: 1,
+        type: 'system.unknown_event',
+        payload: { week: 1 },
+      })
+    ).toBeNull()
+  })
+
+  it('drops events with missing types before payload validation', () => {
+    expect(
+      migrateEventV1toV2({
+        id: 'evt-missing-type',
+        schemaVersion: 1,
+        payload: { week: 1 },
+      })
+    ).toBeNull()
+  })
+
+  it('drops events with non-string types before payload validation', () => {
+    expect(
+      migrateEventV1toV2({
+        id: 'evt-non-string-type',
+        schemaVersion: 1,
+        type: 42,
+        payload: { week: 1 },
+      })
+    ).toBeNull()
+  })
+
+  it('drops legacy faction.activity at the migration boundary', () => {
+    expect(
+      migrateEventV1toV2({
+        id: 'evt-legacy-faction-activity',
+        schemaVersion: 1,
+        type: 'faction.activity',
+        payload: {
+          week: 1,
+          factionId: 'faction-1',
+          factionLabel: 'Faction',
+          delta: 1,
+          reason: 'legacy import',
+        },
+      })
+    ).toBeNull()
   })
 
   it('passes through valid V2 events unchanged after validation', () => {

--- a/src/domain/events/eventMigration.ts
+++ b/src/domain/events/eventMigration.ts
@@ -46,6 +46,13 @@ const SHOULD_LOG_EVENT_MIGRATION_DIAGNOSTICS = (() => {
 
 type EventWithSchemaVersion = { schemaVersion?: number } & Record<string, unknown>
 
+function isKnownOperationEventType(value: unknown): value is OperationEventType {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(operationEventPayloadSchemas, value)
+  )
+}
+
 export function migrateEventV1toV2<TEvent extends EventWithSchemaVersion>(
   event: TEvent
 ): OperationEvent | null {
@@ -61,10 +68,7 @@ export function migrateEventV1toV2<TEvent extends EventWithSchemaVersion>(
     )
   }
 
-  const type =
-    typeof eventRecord.type === 'string' ? (eventRecord.type as OperationEventType) : undefined
-
-  if (!type || !(type in operationEventPayloadSchemas)) {
+  if (!isKnownOperationEventType(eventRecord.type)) {
     if (SHOULD_LOG_EVENT_MIGRATION_DIAGNOSTICS) {
       console.error(
         `[event-validation] Invalid or missing event type for event ID=${eventRecord.id ?? 'unknown'}`
@@ -74,10 +78,13 @@ export function migrateEventV1toV2<TEvent extends EventWithSchemaVersion>(
     return null
   }
 
+  const type = eventRecord.type
   const validation = validateOperationEventPayload(type, eventRecord.payload)
   if (!validation.success) {
     if (SHOULD_LOG_EVENT_MIGRATION_DIAGNOSTICS) {
-      console.error(`[event-validation] Invalid payload for event type ${type}: ${validation.error}`)
+      console.error(
+        `[event-validation] Invalid payload for event type ${type}: ${validation.error}`
+      )
     }
 
     return null


### PR DESCRIPTION
## Summary
- Adds an explicit known-operation-event type guard before migrateEventV1toV2 calls payload validation.
- Keeps the unknown-type policy aligned with SPE-2556: unknown, missing, non-string, and legacy import-only event types are dropped at the migration boundary.
- Adds regression tests for unknown string types, missing types, non-string types, valid known types, and legacy action.activity.

Linear: SPE-2557

## Validation
- npm run test:run -- src/domain/events/eventMigration.test.ts
- npm run lint
- npx prettier --check src/domain/events/eventMigration.ts src/domain/events/eventMigration.test.ts