### PR TITLE
SPE-2558 Validate aggregate battle event payloads

### DIFF
--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -5,6 +5,9 @@ import type { OperationEventType } from './types'
 const idSchema = z.string().min(1)
 const weekSchema = z.number().int().min(1)
 const nonNegativeIntSchema = z.number().int().min(0)
+const finiteNonNegativeIntSchema = z.number().finite().int().min(0)
+const caseModeSchema = z.enum(['threshold', 'probability', 'deterministic', 'standard'])
+const caseKindSchema = z.enum(['case', 'raid', 'standard', 'anomaly'])
 const relationshipReasonSchema = z.enum([
   'mission_success',
   'mission_partial',
@@ -150,6 +153,64 @@ const caseRaidConvertedSchema = z
     maxTeams: z.number(),
   })
   .strict()
+
+const caseAggregateBattleSchema = z
+  .object({
+    week: weekSchema,
+    caseId: idSchema,
+    caseTitle: z.string(),
+    mode: caseModeSchema,
+    kind: caseKindSchema,
+    battleId: idSchema,
+    roundsResolved: finiteNonNegativeIntSchema,
+    winnerSideId: idSchema.nullable(),
+    winnerLabel: z.string().min(1).nullable(),
+    friendlyLabel: z.string().min(1),
+    hostileLabel: z.string().min(1),
+    movementDeniedCount: finiteNonNegativeIntSchema,
+    friendlyRoutedCount: finiteNonNegativeIntSchema,
+    hostileRoutedCount: finiteNonNegativeIntSchema,
+    friendlyRoutedUnits: z.array(idSchema),
+    hostileRoutedUnits: z.array(idSchema),
+    specialDamageCount: finiteNonNegativeIntSchema,
+    specialDamage: z.array(z.string().min(1)),
+    parallelObjectiveId: idSchema.optional(),
+    parallelObjectiveOutcome: z.enum(['success', 'partial', 'fail']).optional(),
+    parallelObjectiveProgress: z.string().min(1).optional(),
+    extractionRequired: z.boolean().optional(),
+    extractionOutcome: z.enum(['not_required', 'secured', 'contested', 'overrun']).optional(),
+    extractionPressure: z.enum(['low', 'medium', 'high']).optional(),
+    extractionResidualThreatUnits: finiteNonNegativeIntSchema.optional(),
+    ceasefireApplied: z.boolean().optional(),
+    ceasefireObjectiveId: idSchema.optional(),
+    ceasefireTacticalValue: z.enum(['temporary_manpower', 'specialist_knowledge']).optional(),
+  })
+  .strict()
+  .superRefine((payload, context) => {
+    if (payload.friendlyRoutedCount !== payload.friendlyRoutedUnits.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'friendlyRoutedCount must match friendlyRoutedUnits length',
+        path: ['friendlyRoutedCount'],
+      })
+    }
+
+    if (payload.hostileRoutedCount !== payload.hostileRoutedUnits.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'hostileRoutedCount must match hostileRoutedUnits length',
+        path: ['hostileRoutedCount'],
+      })
+    }
+
+    if (payload.specialDamageCount !== payload.specialDamage.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'specialDamageCount must match specialDamage length',
+        path: ['specialDamageCount'],
+      })
+    }
+  })
 
 const intelReportGeneratedSchema = z
   .object({
@@ -590,13 +651,7 @@ const infiltrationProbeEventSchema = z
     probeAction: z.enum(['probe_access', 'probe_route', 'cleanup']).optional(),
     probeActionSource: z.enum(['override', 'authored', 'heuristic']).optional(),
     coverRole: z
-      .enum([
-        'uniform_guard',
-        'civilian_staff',
-        'courier',
-        'maintenance',
-        'official_inspector',
-      ])
+      .enum(['uniform_guard', 'civilian_staff', 'courier', 'maintenance', 'official_inspector'])
       .optional(),
     leaveBehindId: z.string().optional(),
     leaveBehindLabel: z.string().optional(),
@@ -696,7 +751,7 @@ export const operationEventPayloadSchemas = {
   'concealment.activated': concealmentActivatedEventSchema,
   'system.academy_upgraded': systemAcademyUpgradedSchema,
   'system.equipment_recovered': z.object({}).passthrough(),
-  'case.aggregate_battle': z.object({}).passthrough(),
+  'case.aggregate_battle': caseAggregateBattleSchema,
   'staff.coping.applied': z.object({
     week: z.number(),
     agentId: z.string(),

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { operationEventPayloadSchemas, validateOperationEventPayload } from '../domain/events/eventValidation'
+import {
+  operationEventPayloadSchemas,
+  validateOperationEventPayload,
+} from '../domain/events/eventValidation'
 import { EVENT_TYPE_TO_SOURCE_SYSTEM } from '../domain/events/types'
+import { minimalOperationEventPayloads } from './fixtures/minimalOperationEventPayloads'
 
 describe('event payload validation coverage', () => {
   it('provides a schema for every operation event type', () => {
@@ -94,58 +98,70 @@ describe('event payload validation coverage', () => {
   })
 
   it('accepts market.emergency_gray_market_waiver_granted payloads', () => {
-    const validation = validateOperationEventPayload('market.emergency_gray_market_waiver_granted', {
-      week: 4,
-      marketWeek: 2,
-      crisisPressureScore: 130,
-      sanctionLevel: 'sanctioned',
-      packetId: 'gray_market_broker',
-      falloutRiskApplied: 'risk',
-      waiverPrecedentCount: 1,
-      institutionKey: 'containment_protocol',
-      authorityRoute: 'crisis_director_self',
-      authorityBasis: 'Director institutional self-authorization under crisis procurement rules (baseline institution).',
-      regulatoryArbitrageSignal: 'none',
-      ruleConflictSignal: 'sanctioned_procurement_vs_crisis_waiver',
-    })
+    const validation = validateOperationEventPayload(
+      'market.emergency_gray_market_waiver_granted',
+      {
+        week: 4,
+        marketWeek: 2,
+        crisisPressureScore: 130,
+        sanctionLevel: 'sanctioned',
+        packetId: 'gray_market_broker',
+        falloutRiskApplied: 'risk',
+        waiverPrecedentCount: 1,
+        institutionKey: 'containment_protocol',
+        authorityRoute: 'crisis_director_self',
+        authorityBasis:
+          'Director institutional self-authorization under crisis procurement rules (baseline institution).',
+        regulatoryArbitrageSignal: 'none',
+        ruleConflictSignal: 'sanctioned_procurement_vs_crisis_waiver',
+      }
+    )
 
     expect(validation.success).toBe(true)
   })
 
   it('accepts market.emergency_gray_market_waiver_granted with cross_institution regulatory arbitrage signal', () => {
-    const validation = validateOperationEventPayload('market.emergency_gray_market_waiver_granted', {
-      week: 4,
-      marketWeek: 2,
-      crisisPressureScore: 130,
-      sanctionLevel: 'sanctioned',
-      packetId: 'gray_market_broker',
-      falloutRiskApplied: 'risk',
-      waiverPrecedentCount: 1,
-      institutionKey: 'joint_oversight_concordat',
-      authorityRoute: 'joint_oversight_clearance_ratification',
-      authorityBasis: 'Joint Oversight Concordat emergency authorization ratified at clearanceLevel 3.',
-      regulatoryArbitrageSignal: 'cross_institution_clearance_route',
-      ruleConflictSignal: 'sanctioned_procurement_vs_crisis_waiver',
-    })
+    const validation = validateOperationEventPayload(
+      'market.emergency_gray_market_waiver_granted',
+      {
+        week: 4,
+        marketWeek: 2,
+        crisisPressureScore: 130,
+        sanctionLevel: 'sanctioned',
+        packetId: 'gray_market_broker',
+        falloutRiskApplied: 'risk',
+        waiverPrecedentCount: 1,
+        institutionKey: 'joint_oversight_concordat',
+        authorityRoute: 'joint_oversight_clearance_ratification',
+        authorityBasis:
+          'Joint Oversight Concordat emergency authorization ratified at clearanceLevel 3.',
+        regulatoryArbitrageSignal: 'cross_institution_clearance_route',
+        ruleConflictSignal: 'sanctioned_procurement_vs_crisis_waiver',
+      }
+    )
 
     expect(validation.success).toBe(true)
   })
 
   it('accepts market.emergency_gray_market_waiver_granted with ruleConflictSignal none', () => {
-    const validation = validateOperationEventPayload('market.emergency_gray_market_waiver_granted', {
-      week: 4,
-      marketWeek: 2,
-      crisisPressureScore: 130,
-      sanctionLevel: 'sanctioned',
-      packetId: 'gray_market_broker',
-      falloutRiskApplied: 'risk',
-      waiverPrecedentCount: 1,
-      institutionKey: 'containment_protocol',
-      authorityRoute: 'crisis_director_self',
-      authorityBasis: 'Director institutional self-authorization under crisis procurement rules (baseline institution).',
-      regulatoryArbitrageSignal: 'none',
-      ruleConflictSignal: 'none',
-    })
+    const validation = validateOperationEventPayload(
+      'market.emergency_gray_market_waiver_granted',
+      {
+        week: 4,
+        marketWeek: 2,
+        crisisPressureScore: 130,
+        sanctionLevel: 'sanctioned',
+        packetId: 'gray_market_broker',
+        falloutRiskApplied: 'risk',
+        waiverPrecedentCount: 1,
+        institutionKey: 'containment_protocol',
+        authorityRoute: 'crisis_director_self',
+        authorityBasis:
+          'Director institutional self-authorization under crisis procurement rules (baseline institution).',
+        regulatoryArbitrageSignal: 'none',
+        ruleConflictSignal: 'none',
+      }
+    )
 
     expect(validation.success).toBe(true)
   })
@@ -179,5 +195,90 @@ describe('event payload validation coverage', () => {
     })
 
     expect(validation.success).toBe(true)
+  })
+
+  it('rejects case.aggregate_battle payloads missing battleId', () => {
+    const payload: Record<string, unknown> = {
+      ...minimalOperationEventPayloads['case.aggregate_battle'],
+    }
+    delete payload.battleId
+
+    const validation = validateOperationEventPayload('case.aggregate_battle', payload)
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects case.aggregate_battle payloads with negative rounds', () => {
+    const validation = validateOperationEventPayload('case.aggregate_battle', {
+      ...minimalOperationEventPayloads['case.aggregate_battle'],
+      roundsResolved: -1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects case.aggregate_battle payloads with invalid extraction pressure', () => {
+    const validation = validateOperationEventPayload('case.aggregate_battle', {
+      ...minimalOperationEventPayloads['case.aggregate_battle'],
+      extractionRequired: true,
+      extractionOutcome: 'contested',
+      extractionPressure: 'severe',
+      extractionResidualThreatUnits: 2,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects case.aggregate_battle payloads with routed and special damage count mismatches', () => {
+    const routedMismatch = validateOperationEventPayload('case.aggregate_battle', {
+      ...minimalOperationEventPayloads['case.aggregate_battle'],
+      hostileRoutedCount: 1,
+      hostileRoutedUnits: [],
+    })
+
+    const damageMismatch = validateOperationEventPayload('case.aggregate_battle', {
+      ...minimalOperationEventPayloads['case.aggregate_battle'],
+      specialDamageCount: 2,
+      specialDamage: ['Reliquary Guardian 1/3'],
+    })
+
+    expect(routedMismatch.success).toBe(false)
+    expect(damageMismatch.success).toBe(false)
+  })
+
+  it('rejects case.aggregate_battle payloads with malformed unit arrays', () => {
+    const validation = validateOperationEventPayload('case.aggregate_battle', {
+      ...minimalOperationEventPayloads['case.aggregate_battle'],
+      friendlyRoutedCount: 1,
+      friendlyRoutedUnits: [''],
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('accepts detailed case.aggregate_battle payloads with optional follow-through fields', () => {
+    const validation = validateOperationEventPayload('case.aggregate_battle', {
+      ...minimalOperationEventPayloads['case.aggregate_battle'],
+      roundsResolved: 3,
+      winnerSideId: null,
+      winnerLabel: null,
+      movementDeniedCount: 2,
+      hostileRoutedCount: 2,
+      hostileRoutedUnits: ['Hostile Screen', 'Reserve Cell'],
+      specialDamageCount: 1,
+      specialDamage: ['Reliquary Guardian 2/3'],
+      parallelObjectiveId: 'seal-threshold',
+      parallelObjectiveOutcome: 'partial',
+      parallelObjectiveProgress: '2/3',
+      extractionRequired: true,
+      extractionOutcome: 'contested',
+      extractionPressure: 'medium',
+      extractionResidualThreatUnits: 1,
+      ceasefireApplied: true,
+      ceasefireObjectiveId: 'seal-threshold',
+      ceasefireTacticalValue: 'specialist_knowledge',
+    })
+
+    expect(validation.success, validation.error).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Replaces the case.aggregate_battle passthrough payload schema with a strict schema matching OperationEventPayloadMap and produced aggregate battle events.
- Validates week/case/battle identity, case mode/kind enums, winner nullability, nonnegative integer counts, routed unit arrays, special damage, parallel objective, extraction, and ceasefire fields.
- Adds regression coverage for missing attleId, negative rounds, invalid extraction pressure, routed/special damage count mismatches, malformed unit arrays, and a detailed valid payload.

Linear: SPE-2558

## Validation
- npm run test:run -- src/test/events.validation.test.ts src/test/events.producerValidation.test.ts src/test/minimalOperationEventPayloads.test.ts
- npm run lint
- npx prettier --check src/domain/events/eventValidation.ts src/test/events.validation.test.ts