### PR TITLE
Harden hydration import sanitizers

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -792,7 +792,7 @@ describe('game app routes', () => {
     expect(useGameStore.getState().game.config.durationModel).toBe('attrition')
   })
 
-  it('updates dashboard config controls and rounds persisted numeric values', async () => {
+  it('updates dashboard config controls and preserves persisted simulation precision', async () => {
     const user = userEvent.setup()
     renderApp()
 
@@ -829,13 +829,13 @@ describe('game app routes', () => {
 
     expect(screen.getByText(/week 1 \/ active cap 11/i)).toBeInTheDocument()
     expect(useGameStore.getState().game.config).toMatchObject({
-      stageScalar: 1.23,
+      stageScalar: 1.234,
       partialMargin: 19,
       maxActiveCases: 11,
       challengeModeEnabled: true,
       attritionPerWeek: 6,
       probabilityK: 2.66,
-      raidCoordinationPenaltyPerExtraTeam: 0.57,
+      raidCoordinationPenaltyPerExtraTeam: 0.575,
       durationModel: 'attrition',
     })
   })

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -26,10 +26,7 @@ import { resolveMapMetadata } from '../../domain/siteGeneration/mapMetadata'
 import type { SiteGenerationStageSnapshot } from '../../domain/siteGeneration/packets'
 import type { DistortionState } from '../../domain/shared/distortion'
 import { queueTraining } from '../../domain/sim/training'
-import {
-  LEGACY_THREAT_FAMILY_ALIASES,
-  MAX_CASE_STAGE,
-} from '../../domain/case/normalizeCase'
+import { LEGACY_THREAT_FAMILY_ALIASES, MAX_CASE_STAGE } from '../../domain/case/normalizeCase'
 import {
   GAME_STORE_VERSION,
   RUN_EXPORT_KIND,
@@ -60,6 +57,7 @@ import { buildReplacementPressureState } from '../../domain/agent/attrition'
 import { buildHavenSchedule } from '../../domain/settlements/haven'
 import { DEFAULT_RESPONSE_GRID } from '../../domain/pressure'
 import { buildAffiliationFileWorkQueueEvidenceRepairWorkflow } from '../../domain/affiliationFileWorkQueueEvidenceRepairWorkflows'
+import { generateHubState } from '../../domain/hub/hubState'
 
 describe('runTransfer helpers', () => {
   it('preserves fallback affiliation file work queue evidence repair workflows for older saves', () => {
@@ -749,8 +747,7 @@ describe('runTransfer helpers', () => {
     const xpAmount = 12
     const totalXp = 44
     const expectedLevel = getLevelForXp(totalXp)
-    const expectedLevelsGained =
-      expectedLevel - getLevelForXp(totalXp - xpAmount)
+    const expectedLevelsGained = expectedLevel - getLevelForXp(totalXp - xpAmount)
 
     expect(roundTripped.events).toEqual(
       expect.arrayContaining([
@@ -1533,9 +1530,72 @@ describe('runTransfer helpers', () => {
         week: 3,
         agentId: 'agent-1',
         agentName: 'Agent 1',
-        trainingId: 'training-1',
-        trainingName: 'Training 1',
+        trainingId: 'combat-drills',
+        trainingName: 'Close-Quarters Drills',
         refund: 0,
+      },
+    })
+  })
+
+  it('sanitizes legacy unknown training event payloads to catalog-backed IDs/names and bounded refund', () => {
+    const fallback = createStartingState()
+    const imported = parseRunExport(
+      JSON.stringify({
+        kind: RUN_EXPORT_KIND,
+        version: GAME_STORE_VERSION,
+        exportedAt: new Date().toISOString(),
+        game: {
+          ...fallback,
+          week: 3,
+          allowLegacySyntheticRepair: true,
+          events: [
+            {
+              id: 'evt-legacy-training-started',
+              type: 'agent.training_started',
+              payload: {
+                week: 3,
+                queueId: 'queue-legacy',
+                agentId: 'a_mina',
+                agentName: 'Mina',
+                trainingId: 'legacy-unknown-program',
+                trainingName: 'Legacy Course Name',
+                etaWeeks: 2,
+                fundingCost: 10,
+              },
+            },
+            {
+              id: 'evt-legacy-training-cancelled',
+              type: 'agent.training_cancelled',
+              payload: {
+                week: 3,
+                agentId: 'a_mina',
+                agentName: 'Mina',
+                trainingId: 'legacy-unknown-program',
+                trainingName: 'Legacy Course Name',
+                refund: 999,
+              },
+            },
+          ],
+        },
+      })
+    )
+
+    expect(imported.events).toHaveLength(2)
+    expect(imported.events[0]).toMatchObject({
+      type: 'agent.training_started',
+      payload: {
+        trainingId: 'combat-drills',
+        trainingName: 'Close-Quarters Drills',
+        etaWeeks: 2,
+        fundingCost: 10,
+      },
+    })
+    expect(imported.events[1]).toMatchObject({
+      type: 'agent.training_cancelled',
+      payload: {
+        trainingId: 'combat-drills',
+        trainingName: 'Close-Quarters Drills',
+        refund: 10,
       },
     })
   })
@@ -1584,6 +1644,53 @@ describe('runTransfer helpers', () => {
     ],
   ])('rejects invalid import payloads', (raw, expectedMessage) => {
     expect(() => parseRunExport(raw)).toThrow(expectedMessage)
+  })
+
+  it('rejects run exports with missing, invalid, or future exportedAt metadata', () => {
+    const fallback = createStartingState()
+    const basePayload = {
+      kind: RUN_EXPORT_KIND,
+      version: GAME_STORE_VERSION,
+      game: stripGameTemplates(fallback),
+    }
+
+    expect(() => parseRunExport(JSON.stringify(basePayload))).toThrow(
+      'Run payload exportedAt timestamp is missing or invalid.'
+    )
+    expect(() =>
+      parseRunExport(
+        JSON.stringify({
+          ...basePayload,
+          exportedAt: 'not-a-date',
+        })
+      )
+    ).toThrow('Run payload exportedAt timestamp is missing or invalid.')
+    expect(() =>
+      parseRunExport(
+        JSON.stringify({
+          ...basePayload,
+          exportedAt: '2999-01-01T00:00:00.000Z',
+        })
+      )
+    ).toThrow('Run payload exportedAt timestamp is from the future.')
+  })
+
+  it('accepts run exports with valid exportedAt metadata', () => {
+    const fallback = createStartingState()
+
+    const imported = parseRunExport(
+      JSON.stringify({
+        kind: RUN_EXPORT_KIND,
+        version: GAME_STORE_VERSION,
+        exportedAt: '2026-01-01T00:00:00.000Z',
+        game: {
+          ...stripGameTemplates(fallback),
+          week: 3,
+        },
+      })
+    )
+
+    expect(imported.week).toBe(3)
   })
 
   it('keeps canonical candidates when recruitmentPool mirror diverges on hydrate (312)', () => {
@@ -1898,6 +2005,73 @@ describe('runTransfer import sanitization (326-332)', () => {
     })
   })
 
+  it('326 trims padded IDs and rejects whitespace-only required IDs during import sanitization', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-case-padded',
+            type: 'case.resolved',
+            payload: {
+              week: 2,
+              caseId: '  case-001  ',
+              caseTitle: 'Padded case',
+              mode: 'threshold',
+              kind: 'case',
+              stage: 1,
+              teamIds: ['team-1'],
+            },
+          },
+          {
+            id: 'evt-relationship-whitespace-agent',
+            type: 'agent.relationship_changed',
+            payload: {
+              week: 2,
+              agentId: '   ',
+              agentName: 'Mina',
+              counterpartId: 'a_sato',
+              counterpartName: 'Dr. Sato',
+              previousValue: 0,
+              nextValue: 1,
+              delta: 1,
+              reason: 'passive_drift',
+            },
+          },
+          {
+            id: 'evt-relationship-padded-counterpart',
+            type: 'agent.relationship_changed',
+            payload: {
+              week: 2,
+              agentId: 'a_mina',
+              agentName: 'Mina',
+              counterpartId: '  a_sato  ',
+              counterpartName: 'Dr. Sato',
+              previousValue: 0,
+              nextValue: 1,
+              delta: 1,
+              reason: 'passive_drift',
+            },
+          },
+        ],
+      },
+      fallback
+    )
+
+    expect(hydrated.events).toHaveLength(2)
+    expect(hydrated.events[0]).toMatchObject({
+      id: 'evt-case-padded',
+      type: 'case.resolved',
+      payload: expect.objectContaining({ caseId: 'case-001' }),
+    })
+    expect(hydrated.events[1]).toMatchObject({
+      id: 'evt-relationship-padded-counterpart',
+      type: 'agent.relationship_changed',
+      payload: expect.objectContaining({ counterpartId: 'a_sato' }),
+    })
+  })
+
   it('normalizes malformed relationship and betrayal numbers to finite values (327)', () => {
     const fallback = createStartingState()
     const imported = hydrateGame(
@@ -2182,7 +2356,13 @@ describe('runTransfer import sanitization (326-332)', () => {
               maxStage: 0,
               avgFatigue: 0,
               teamStatus: [],
-              notes: [{ id: 'note-week-4-a', content: 'first', timestamp: buildReportNoteTimestamp(4, 0) }],
+              notes: [
+                {
+                  id: 'note-week-4-a',
+                  content: 'first',
+                  timestamp: buildReportNoteTimestamp(4, 0),
+                },
+              ],
             },
             {
               week: 2,
@@ -2214,7 +2394,13 @@ describe('runTransfer import sanitization (326-332)', () => {
               maxStage: 0,
               avgFatigue: 0,
               teamStatus: [],
-              notes: [{ id: 'note-week-4-b', content: 'second', timestamp: buildReportNoteTimestamp(4, 1) }],
+              notes: [
+                {
+                  id: 'note-week-4-b',
+                  content: 'second',
+                  timestamp: buildReportNoteTimestamp(4, 1),
+                },
+              ],
             },
           ],
         },
@@ -3573,13 +3759,7 @@ describe('runTransfer import sanitization (326-332)', () => {
               ...baseAgent,
               history: {
                 ...baseAgent.history!,
-                alliesWorkedWith: [
-                  agentId,
-                  counterpartId,
-                  'a_missing',
-                  '',
-                  counterpartId,
-                ],
+                alliesWorkedWith: [agentId, counterpartId, 'a_missing', '', counterpartId],
               },
             },
           },
@@ -3665,10 +3845,7 @@ describe('runTransfer import sanitization (326-332)', () => {
   })
 
   describe('hydration problems 374-381', () => {
-    function makeHydrationCase(
-      id: string,
-      overrides: Partial<CaseInstance> = {}
-    ): CaseInstance {
+    function makeHydrationCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
       const fallback = createStartingState()
       const seed = fallback.cases['case-001']!
 
@@ -4020,10 +4197,7 @@ describe('runTransfer import sanitization (326-332)', () => {
   })
 
   describe('hydration problems 382-388', () => {
-    function makeHydrationCase(
-      id: string,
-      overrides: Partial<CaseInstance> = {}
-    ): CaseInstance {
+    function makeHydrationCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
       const fallback = createStartingState()
       const seed = fallback.cases['case-001']!
 
@@ -4383,10 +4557,7 @@ describe('runTransfer import sanitization (326-332)', () => {
   })
 
   describe('hydration problems 389-395', () => {
-    function makeHydrationCase(
-      id: string,
-      overrides: Partial<CaseInstance> = {}
-    ): CaseInstance {
+    function makeHydrationCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
       const fallback = createStartingState()
       const seed = fallback.cases['case-001']!
 
@@ -4660,10 +4831,7 @@ describe('runTransfer import sanitization (326-332)', () => {
   })
 
   describe('hydration problems 396-402', () => {
-    function makeHydrationCase(
-      id: string,
-      overrides: Partial<CaseInstance> = {}
-    ): CaseInstance {
+    function makeHydrationCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
       const fallback = createStartingState()
       const seed = fallback.cases['case-001']!
 
@@ -4940,10 +5108,7 @@ describe('runTransfer import sanitization (326-332)', () => {
   })
 
   describe('hydration problems 403-409', () => {
-    function makeHydrationCase(
-      id: string,
-      overrides: Partial<CaseInstance> = {}
-    ): CaseInstance {
+    function makeHydrationCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
       const fallback = createStartingState()
       const seed = fallback.cases['case-001']!
 
@@ -5811,7 +5976,10 @@ describe('runTransfer import sanitization (326-332)', () => {
               },
             ],
             lore: {
-              discovered: [{ label: 'Ledger', summary: 'Recovered index' }, { label: '', summary: '' }],
+              discovered: [
+                { label: 'Ledger', summary: 'Recovered index' },
+                { label: '', summary: '' },
+              ],
               remainingCount: -2,
             },
           },
@@ -5898,7 +6066,7 @@ describe('runTransfer import sanitization (326-332)', () => {
         week: 10,
         facilityState: {
           facilities: {
-            'research_lab': {
+            research_lab: {
               facilityId: 'research_lab',
               category: 'research_lab',
               level: 99,
@@ -5929,6 +6097,110 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(lab?.status).toBe('inactive')
       expect(lab?.effects).toEqual({ researchSpeedMultiplier: 1.5 })
       expect(lab?.upgradeInProgress).toBeUndefined()
+    })
+
+    it('425b repairs facility upgrade chronology and status contradictions', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 10,
+        facilityState: {
+          facilities: {
+            'complete-before-start': {
+              facilityId: 'complete-before-start',
+              category: 'research_lab',
+              level: 1,
+              maxLevel: 3,
+              status: 'upgrading',
+              effects: {},
+              upgradeInProgress: true,
+              upgradeStartedWeek: 8,
+              upgradeCompleteWeek: 4,
+              pendingEffectDeltas: { researchSpeedMultiplier: 0.25 },
+            },
+            'future-complete-without-upgrade': {
+              facilityId: 'future-complete-without-upgrade',
+              category: 'research_lab',
+              level: 1,
+              maxLevel: 3,
+              status: 'active',
+              effects: {},
+              upgradeInProgress: false,
+              upgradeStartedWeek: 3,
+              upgradeCompleteWeek: 20,
+              pendingEffectDeltas: { researchSpeedMultiplier: 0.5 },
+            },
+            'pending-without-upgrade': {
+              facilityId: 'pending-without-upgrade',
+              category: 'training_annex',
+              level: 1,
+              maxLevel: 3,
+              status: 'available',
+              effects: {},
+              pendingEffectDeltas: { trainingSlots: 2 },
+            },
+            'inactive-but-upgrading': {
+              facilityId: 'inactive-but-upgrading',
+              category: 'containment_ward',
+              level: 1,
+              maxLevel: 3,
+              status: 'inactive',
+              effects: {},
+              upgradeInProgress: true,
+              upgradeStartedWeek: 9,
+              upgradeCompleteWeek: 12,
+              pendingEffectDeltas: { recoveryThroughput: 1 },
+            },
+            'valid-upgrade': {
+              facilityId: 'valid-upgrade',
+              category: 'research_lab',
+              level: 1,
+              maxLevel: 3,
+              status: 'upgrading',
+              effects: { researchSlots: 1 },
+              upgradeInProgress: true,
+              upgradeStartedWeek: 7,
+              upgradeCompleteWeek: 10,
+              pendingEffectDeltas: { researchSpeedMultiplier: 0.5 },
+            },
+          },
+        },
+      })
+
+      const facilities = hydrated.facilityState?.facilities ?? {}
+      expect(facilities['complete-before-start']).toMatchObject({
+        status: 'inactive',
+      })
+      expect(facilities['complete-before-start']?.upgradeInProgress).toBeUndefined()
+      expect(facilities['complete-before-start']?.pendingEffectDeltas).toBeUndefined()
+
+      expect(facilities['future-complete-without-upgrade']).toMatchObject({
+        status: 'active',
+      })
+      expect(facilities['future-complete-without-upgrade']?.upgradeCompleteWeek).toBeUndefined()
+      expect(facilities['future-complete-without-upgrade']?.pendingEffectDeltas).toBeUndefined()
+
+      expect(facilities['pending-without-upgrade']).toMatchObject({
+        status: 'available',
+      })
+      expect(facilities['pending-without-upgrade']?.pendingEffectDeltas).toBeUndefined()
+
+      expect(facilities['inactive-but-upgrading']).toMatchObject({
+        status: 'upgrading',
+        upgradeInProgress: true,
+        upgradeStartedWeek: 9,
+        upgradeCompleteWeek: 12,
+        pendingEffectDeltas: { recoveryThroughput: 1 },
+      })
+
+      expect(facilities['valid-upgrade']).toMatchObject({
+        status: 'upgrading',
+        upgradeInProgress: true,
+        upgradeStartedWeek: 7,
+        upgradeCompleteWeek: 10,
+        pendingEffectDeltas: { researchSpeedMultiplier: 0.5 },
+      })
     })
 
     it('426 drops invalid relationship snapshots and clamps valid ones', () => {
@@ -6039,6 +6311,247 @@ describe('runTransfer import sanitization (326-332)', () => {
         factionPresence: { institutions: 40 },
       })
       expect(retained.hubState?.opportunities[0]?.confidence).toBe(1)
+    })
+
+    it('428b drops malformed hub opportunities and stale faction references', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        hubState: {
+          districtKey: 'nonexistent_district',
+          factionPresence: {
+            institutions: 25,
+            stale_faction: 80,
+          },
+          opportunities: [
+            {
+              id: 'valid-opp',
+              label: 'Valid lead',
+              detail: 'Valid detail',
+              factionId: 'institutions',
+              confidence: 0.75,
+              accessState: 'risky',
+              requiredSanctionLevel: 'covert',
+            },
+            {
+              id: 'stale-opp',
+              label: 'Stale lead',
+              detail: 'Stale detail',
+              factionId: 'stale_faction',
+              confidence: 0.9,
+            },
+            {
+              id: 'missing-detail',
+              label: 'Malformed lead',
+              factionId: 'institutions',
+              confidence: 0.9,
+            },
+          ],
+          rumors: [],
+        },
+      })
+
+      expect(hydrated.hubState).toMatchObject({
+        districtKey: 'central_hub',
+        factionPresence: { institutions: 25 },
+      })
+      expect(hydrated.hubState?.factionPresence).not.toHaveProperty('stale_faction')
+      expect(hydrated.hubState?.opportunities).toHaveLength(1)
+      expect(hydrated.hubState?.opportunities[0]).toMatchObject({
+        id: 'valid-opp',
+        factionId: 'institutions',
+        confidence: 0.75,
+        accessState: 'risky',
+        requiredSanctionLevel: 'covert',
+      })
+    })
+
+    it('428c clamps invalid hub confidence and strips invalid access enums', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        hubState: {
+          districtKey: 'industrial_zone',
+          factionPresence: { institutions: Number.POSITIVE_INFINITY },
+          opportunities: [
+            {
+              id: 'opp-invalid-confidence',
+              label: 'Invalid confidence',
+              detail: 'Invalid confidence detail',
+              factionId: 'institutions',
+              confidence: Number.NaN,
+              accessState: 'forbidden',
+              requiredSanctionLevel: 'public',
+              accessExplanation: '  Needs review.  ',
+            },
+          ],
+          rumors: [
+            {
+              id: 'rumor-invalid-confidence',
+              label: 'Rumor',
+              detail: 'Rumor detail',
+              confidence: 9,
+              misleading: true,
+              filtered: true,
+            },
+          ],
+        },
+      })
+
+      expect(hydrated.hubState?.districtKey).toBe('industrial_zone')
+      expect(hydrated.hubState?.factionPresence.institutions).toBe(0)
+      expect(hydrated.hubState?.opportunities[0]).toMatchObject({
+        confidence: 0.5,
+        accessExplanation: 'Needs review.',
+      })
+      expect(hydrated.hubState?.opportunities[0]).not.toHaveProperty('accessState')
+      expect(hydrated.hubState?.opportunities[0]).not.toHaveProperty('requiredSanctionLevel')
+      expect(hydrated.hubState?.rumors[0]).toMatchObject({
+        confidence: 1,
+        misleading: true,
+        filtered: true,
+      })
+    })
+
+    it('428d hydrates valid generated hub state without dropping bounded fields', () => {
+      const fallback = createStartingState()
+      const generatedHub = generateHubState(fallback)
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        hubState: generatedHub,
+        prevHubState: generatedHub,
+      })
+
+      expect(hydrated.hubState).toEqual(generatedHub)
+      expect(hydrated.prevHubState).toEqual(generatedHub)
+    })
+
+    it('428e sanitizes malformed prevHubState with the same hub-state bounds', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        prevHubState: {
+          districtKey: 'stale_district',
+          factionPresence: {
+            oversight: 15,
+            retired_faction: 70,
+          },
+          opportunities: [
+            {
+              id: '',
+              label: 'Invalid id',
+              detail: 'Should be dropped',
+              factionId: 'oversight',
+              confidence: 0.7,
+            },
+            {
+              id: 'prev-valid-opp',
+              label: 'Previous lead',
+              detail: 'Previous lead detail',
+              factionId: 'oversight',
+              confidence: -4,
+              accessState: 'blocked',
+              requiredSanctionLevel: 'sanctioned',
+            },
+            {
+              id: 'prev-stale-faction',
+              label: 'Stale faction lead',
+              detail: 'Should be dropped',
+              factionId: 'retired_faction',
+              confidence: 0.9,
+            },
+          ],
+          rumors: [
+            {
+              id: '',
+              label: 'Invalid rumor',
+              detail: 'Should be dropped',
+              confidence: 0.8,
+            },
+          ],
+        },
+      })
+
+      expect(hydrated.prevHubState).toMatchObject({
+        districtKey: 'central_hub',
+        factionPresence: { oversight: 15 },
+        rumors: [],
+      })
+      expect(hydrated.prevHubState?.factionPresence).not.toHaveProperty('retired_faction')
+      expect(hydrated.prevHubState?.opportunities).toHaveLength(1)
+      expect(hydrated.prevHubState?.opportunities[0]).toMatchObject({
+        id: 'prev-valid-opp',
+        factionId: 'oversight',
+        confidence: 0,
+        accessState: 'blocked',
+        requiredSanctionLevel: 'sanctioned',
+      })
+    })
+
+    it('428f leaves missing prevHubState absent on hydration', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+      })
+
+      expect(hydrated.prevHubState).toBeUndefined()
+    })
+
+    it('428g sanitizes damaged equipment recovery queue against inventory and catalog state', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        inventory: {
+          ...fallback.inventory,
+          medkits: 2,
+          ward_seals: 1,
+          silver_rounds: 0,
+        },
+        damagedEquipmentQueue: [
+          ' medkits ',
+          'medkits',
+          '',
+          'unknown_equipment',
+          42,
+          'ward_seals',
+          'silver_rounds',
+        ],
+      })
+
+      expect(hydrated.damagedEquipmentQueue).toEqual(['medkits', 'ward_seals'])
+    })
+
+    it('428h preserves an empty damaged equipment recovery queue', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        damagedEquipmentQueue: [],
+      })
+
+      expect(hydrated.damagedEquipmentQueue).toEqual([])
+    })
+
+    it('428i keeps a valid damaged equipment recovery queue in order', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        inventory: {
+          ...fallback.inventory,
+          silver_rounds: 1,
+          signal_jammers: 1,
+        },
+        damagedEquipmentQueue: ['silver_rounds', 'signal_jammers'],
+      })
+
+      expect(hydrated.damagedEquipmentQueue).toEqual(['silver_rounds', 'signal_jammers'])
     })
 
     it('429 validates squad metadata, kit templates, and assignments against live teams', () => {
@@ -6219,7 +6732,9 @@ describe('runTransfer import sanitization (326-332)', () => {
 
       expect(hydrated.runtimeState?.encounterState['enc-locked']?.status).toBe('locked')
       expect(hydrated.runtimeState?.encounterState['enc-failed']?.latestOutcome).toBe('failed')
-      expect(hydrated.runtimeState?.encounterState['enc-dismissed']?.latestOutcome).toBe('dismissed')
+      expect(hydrated.runtimeState?.encounterState['enc-dismissed']?.latestOutcome).toBe(
+        'dismissed'
+      )
     })
 
     it('432 repairs encounter temporal metadata on active and resolved records', () => {
@@ -6388,7 +6903,10 @@ describe('runTransfer import sanitization (326-332)', () => {
       const entries = hydrated.runtimeState?.eventQueue.entries ?? []
 
       expect(entries.map((entry) => entry.id)).toEqual(['qevt-0001', 'qevt-0002'])
-      expect(entries.map((entry) => entry.type)).toEqual(['authored.follow_up', 'encounter.follow_up'])
+      expect(entries.map((entry) => entry.type)).toEqual([
+        'authored.follow_up',
+        'encounter.follow_up',
+      ])
     })
 
     it('435 recomputes nextSequence from retained queue entry ids', () => {
@@ -6613,6 +7131,136 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(Number.isFinite(hydrated.agency?.fundingState?.budgetPressure ?? NaN)).toBe(true)
     })
 
+    it('441b hydrates fundingState-only legacy saves into all funding mirrors', () => {
+      const fallback = createStartingState()
+      const legacy = {
+        ...stripGameTemplates(fallback),
+        week: 4,
+        agency: {
+          ...fallback.agency!,
+          funding: Number.NaN,
+          fundingState: {
+            ...fallback.agency!.fundingState,
+            funding: 77,
+            budgetPressure: 99,
+          },
+        },
+      } as Record<string, unknown>
+      delete legacy.funding
+
+      const hydrated = hydrateGame(legacy)
+
+      expect(hydrated.funding).toBe(77)
+      expect(hydrated.agency?.funding).toBe(77)
+      expect(hydrated.agency?.fundingState?.funding).toBe(77)
+      expect(hydrated.agency?.fundingState?.budgetPressure).toBeLessThanOrEqual(4)
+    })
+
+    it('441c hydrates agency-only funding into all funding mirrors', () => {
+      const fallback = createStartingState()
+      const legacy = {
+        ...stripGameTemplates(fallback),
+        week: 4,
+        agency: {
+          ...fallback.agency!,
+          funding: 88,
+          fundingState: {
+            ...fallback.agency!.fundingState,
+            funding: Number.NaN,
+          },
+        },
+      } as Record<string, unknown>
+      delete legacy.funding
+
+      const hydrated = hydrateGame(legacy)
+
+      expect(hydrated.funding).toBe(88)
+      expect(hydrated.agency?.funding).toBe(88)
+      expect(hydrated.agency?.fundingState?.funding).toBe(88)
+    })
+
+    it('441d hydrates top-level-only legacy funding into agency mirrors', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 4,
+        funding: 66,
+        agency: {
+          containmentRating: fallback.containmentRating,
+          clearanceLevel: fallback.clearanceLevel,
+        },
+      })
+
+      expect(hydrated.funding).toBe(66)
+      expect(hydrated.agency?.funding).toBe(66)
+      expect(hydrated.agency?.fundingState?.funding).toBe(66)
+    })
+
+    it('441e lets sanitized top-level funding win conflicting agency funding values', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 4,
+        funding: 55,
+        agency: {
+          ...fallback.agency!,
+          funding: 88,
+          fundingState: {
+            ...fallback.agency!.fundingState,
+            funding: 99,
+          },
+        },
+      })
+
+      expect(hydrated.funding).toBe(55)
+      expect(hydrated.agency?.funding).toBe(55)
+      expect(hydrated.agency?.fundingState?.funding).toBe(55)
+    })
+
+    it('441f repairs malformed fundingState while preserving the canonical funding mirror', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 4,
+        funding: 33,
+        agency: {
+          ...fallback.agency!,
+          fundingState: {
+            funding: Number.POSITIVE_INFINITY,
+            fundingBasePerWeek: Number.NaN,
+            fundingPerResolution: Number.NaN,
+            fundingPenaltyPerFail: Number.NaN,
+            fundingPenaltyPerUnresolved: Number.NaN,
+            budgetPressure: Number.POSITIVE_INFINITY,
+            courierShellBudgetPressureDebt: Number.POSITIVE_INFINITY,
+            fundingHistory: [{ week: 99, delta: Number.NaN, reason: '' }],
+            procurementBacklog: [
+              {
+                requestId: '',
+                itemId: 'phantom-widget',
+                quantity: -1,
+                status: 'pending',
+                requestedWeek: Number.NaN,
+                cost: Number.NaN,
+              },
+            ],
+          },
+        },
+      })
+
+      const fundingState = hydrated.agency?.fundingState
+      expect(hydrated.funding).toBe(33)
+      expect(hydrated.agency?.funding).toBe(33)
+      expect(fundingState?.funding).toBe(33)
+      expect(Number.isFinite(fundingState?.budgetPressure ?? NaN)).toBe(true)
+      expect(fundingState?.courierShellBudgetPressureDebt).toBeUndefined()
+      expect(fundingState?.fundingHistory).toEqual([])
+      expect(fundingState?.procurementBacklog).toEqual([])
+    })
+
     it('442-445 sanitize funding history, procurement backlog, and shell debt', () => {
       const fallback = createStartingState()
       const knownItemId = Object.keys(fallback.inventory)[0]
@@ -6679,18 +7327,24 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(fs?.courierShellBudgetPressureDebt).toBeUndefined()
       expect(Number.isFinite(fs?.budgetPressure ?? NaN)).toBe(true)
       expect(fs?.fundingHistory).toHaveLength(2)
-      expect(fs?.fundingHistory.find((entry) => entry.reason === 'market_transaction')).toMatchObject({
+      expect(
+        fs?.fundingHistory.find((entry) => entry.reason === 'market_transaction')
+      ).toMatchObject({
         week: 5,
         reason: 'market_transaction',
         sourceId: 'req-known',
       })
-      expect(fs?.fundingHistory.find((entry) => entry.reason === 'not_a_real_reason')).toMatchObject({
+      expect(
+        fs?.fundingHistory.find((entry) => entry.reason === 'not_a_real_reason')
+      ).toMatchObject({
         week: 5,
         reason: 'not_a_real_reason',
         delta: 1,
       })
       expect(fs?.procurementBacklog.find((e) => e.requestId === 'req-zero')).toBeUndefined()
-      expect(fs?.procurementBacklog.find((e) => e.requestId === 'req-known')?.status).toBe('pending')
+      expect(fs?.procurementBacklog.find((e) => e.requestId === 'req-known')?.status).toBe(
+        'pending'
+      )
       const unknown = fs?.procurementBacklog.find((e) => e.requestId === 'req-unknown')
       expect(unknown?.status).toBe('cancelled')
       expect(unknown?.blockedReason).toBe('unknown_item')
@@ -6698,6 +7352,51 @@ describe('runTransfer import sanitization (326-332)', () => {
       const fulfilled = fs?.procurementBacklog.find((e) => e.requestId === 'req-fulfilled')
       expect(fulfilled?.status).toBe('fulfilled')
       expect(fulfilled?.fulfilledWeek).toBeGreaterThanOrEqual(4)
+    })
+
+    it('445b bounds and dedupes hydrated funding history audit rows', () => {
+      const fallback = createStartingState()
+      const longReason = `custom-${'x'.repeat(120)}`
+      const longSourceId = `source-${'y'.repeat(160)}`
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 5,
+        funding: 200,
+        agency: {
+          ...fallback.agency!,
+          funding: 200,
+          fundingState: {
+            funding: 200,
+            fundingBasePerWeek: 8,
+            fundingPerResolution: 8,
+            fundingPenaltyPerFail: 7,
+            fundingPenaltyPerUnresolved: 12,
+            budgetPressure: 0,
+            fundingHistory: [
+              { week: 99, delta: 12.345, reason: ' weekly_income ', sourceId: ' source-a ' },
+              { week: 2, delta: Number.NaN, reason: 'resolution_reward' },
+              { week: 3, delta: 9, reason: '   ' },
+              { week: 4, delta: 10, reason: longReason, sourceId: longSourceId },
+              { week: 4, delta: 11, reason: longReason, sourceId: longSourceId },
+              { week: 5, delta: -9_999_999, reason: 'failure_penalty' },
+              { week: 5, delta: 4, reason: 'market_transaction', sourceId: 'missing-request' },
+            ],
+            procurementBacklog: [],
+          },
+        },
+      })
+
+      expect(hydrated.agency?.fundingState?.fundingHistory).toEqual([
+        {
+          week: 4,
+          delta: 10,
+          reason: longReason.slice(0, 80),
+          sourceId: longSourceId.slice(0, 120),
+        },
+        { week: 5, delta: -1_000_000, reason: 'failure_penalty' },
+        { week: 5, delta: 12.35, reason: 'weekly_income', sourceId: 'source-a' },
+      ])
     })
   })
 
@@ -6801,6 +7500,73 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(hydrated.agency?.activeProtocolIds).toEqual(['field-clearance-protocol'])
     })
 
+    it('451b clamps negative protocolSelectionLimit and dedupes activeProtocolIds', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 2,
+        clearanceLevel: 3,
+        agency: {
+          ...fallback.agency!,
+          protocolSelectionLimit: -4,
+          activeProtocolIds: [
+            ' field-clearance-protocol ',
+            'field-clearance-protocol',
+            'containment-doctrine-alpha',
+          ],
+        },
+      })
+
+      expect(hydrated.agency?.protocolSelectionLimit).toBe(1)
+      expect(hydrated.agency?.activeProtocolIds).toEqual(['field-clearance-protocol'])
+    })
+
+    it('451c drops non-finite protocolSelectionLimit while still sanitizing activeProtocolIds', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 2,
+        clearanceLevel: 2,
+        agency: {
+          ...fallback.agency!,
+          protocolSelectionLimit: Number.NaN,
+          activeProtocolIds: [
+            'field-clearance-protocol',
+            'containment-doctrine-alpha',
+            'unknown-renamed-protocol',
+          ],
+        },
+      })
+
+      expect(hydrated.agency?.protocolSelectionLimit).toBeUndefined()
+      expect(hydrated.agency?.activeProtocolIds).toEqual([
+        'field-clearance-protocol',
+        'containment-doctrine-alpha',
+      ])
+    })
+
+    it('451d preserves valid agency protocol state', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 2,
+        agency: {
+          ...fallback.agency!,
+          protocolSelectionLimit: 2,
+          activeProtocolIds: ['field-clearance-protocol', 'containment-doctrine-alpha'],
+        },
+      })
+
+      expect(hydrated.agency?.protocolSelectionLimit).toBe(2)
+      expect(hydrated.agency?.activeProtocolIds).toEqual([
+        'field-clearance-protocol',
+        'containment-doctrine-alpha',
+      ])
+    })
+
     it('452 clamps maintenanceSpecialistsAvailable to bounded non-negative capacity', () => {
       const fallback = createStartingState()
 
@@ -6893,13 +7659,7 @@ describe('runTransfer import sanitization (326-332)', () => {
           },
         },
         caseQueue: {
-          queuedCaseIds: [
-            missingCaseId,
-            openCaseId,
-            resolvedCaseId,
-            openCaseId,
-            '  ',
-          ],
+          queuedCaseIds: [missingCaseId, openCaseId, resolvedCaseId, openCaseId, '  '],
           priorities: {
             [openCaseId]: 'critical',
             [resolvedCaseId]: 'high',
@@ -6979,6 +7739,153 @@ describe('runTransfer import sanitization (326-332)', () => {
         cost: 0,
         quantity: 1,
       })
+    })
+
+    it('458b repairs procurement backlog chronology and stale delayed supplier references', () => {
+      const fallback = createStartingState()
+      const longRequestId = `req-${'x'.repeat(160)}`
+      const longBlockedReason = `blocked-${'y'.repeat(160)}`
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 5,
+        agency: {
+          ...fallback.agency!,
+          fundingState: {
+            funding: 500,
+            fundingBasePerWeek: 8,
+            fundingPerResolution: 8,
+            fundingPenaltyPerFail: 7,
+            fundingPenaltyPerUnresolved: 12,
+            budgetPressure: 0,
+            fundingHistory: [],
+            procurementBacklog: [
+              {
+                requestId: ' req-fulfilled-before ',
+                itemId: ' medkits ',
+                quantity: 2.9,
+                status: 'fulfilled',
+                requestedWeek: 4,
+                fulfilledWeek: 2,
+                cost: 12.345,
+                blockedReason: longBlockedReason,
+              },
+              {
+                requestId: 'req-future',
+                itemId: 'medkits',
+                quantity: 1,
+                status: 'pending',
+                requestedWeek: 99,
+                cost: 4,
+              },
+              {
+                requestId: 'req-invalid-status',
+                itemId: 'medkits',
+                quantity: 1,
+                status: 'lost' as 'pending',
+                requestedWeek: 3,
+                cost: 4,
+              },
+              {
+                requestId: 'req-unknown-item',
+                itemId: 'unknown_widget',
+                quantity: 1,
+                status: 'pending',
+                requestedWeek: 3,
+                cost: 7,
+              },
+              {
+                requestId: 'req-negative-cost',
+                itemId: 'medkits',
+                quantity: 1,
+                status: 'pending',
+                requestedWeek: 3,
+                cost: -9,
+              },
+              {
+                requestId: longRequestId,
+                itemId: 'medkits',
+                quantity: 1,
+                status: 'pending',
+                requestedWeek: 3,
+                cost: 8,
+                listingId: 'gear:field_plate',
+                delayWeeks: 2.8,
+              },
+              {
+                requestId: 'req-valid-delay',
+                itemId: 'medkits',
+                quantity: 1,
+                status: 'pending',
+                requestedWeek: 3,
+                cost: 8,
+                listingId: 'med-kits',
+                delayWeeks: 2,
+              },
+            ],
+          },
+        },
+      })
+
+      expect(hydrated.agency?.fundingState?.procurementBacklog).toEqual([
+        {
+          requestId: 'req-negative-cost',
+          itemId: 'medkits',
+          quantity: 1,
+          requestedWeek: 3,
+          cost: 0,
+          status: 'pending',
+        },
+        {
+          requestId: 'req-unknown-item',
+          itemId: 'unknown_widget',
+          quantity: 1,
+          requestedWeek: 3,
+          cost: 7,
+          status: 'cancelled',
+          fulfilledWeek: 3,
+          blockedReason: 'unknown_item',
+        },
+        {
+          requestId: 'req-valid-delay',
+          itemId: 'medkits',
+          quantity: 1,
+          requestedWeek: 3,
+          cost: 8,
+          status: 'pending',
+          listingId: 'med-kits',
+          delayWeeks: 2,
+        },
+        {
+          requestId: longRequestId.slice(0, 120),
+          itemId: 'medkits',
+          quantity: 1,
+          requestedWeek: 3,
+          cost: 8,
+          status: 'cancelled',
+          fulfilledWeek: 3,
+          blockedReason: 'stale_listing',
+          delayWeeks: 2,
+        },
+        {
+          requestId: 'req-fulfilled-before',
+          itemId: 'medkits',
+          quantity: 2,
+          requestedWeek: 4,
+          cost: 12.35,
+          status: 'fulfilled',
+          fulfilledWeek: 4,
+          blockedReason: longBlockedReason.slice(0, 120),
+        },
+        {
+          requestId: 'req-future',
+          itemId: 'medkits',
+          quantity: 1,
+          requestedWeek: 5,
+          cost: 4,
+          status: 'pending',
+        },
+      ])
     })
 
     it('459 canonicalizes caseSnapshots record keys to embedded caseId', () => {
@@ -7203,9 +8110,7 @@ describe('runTransfer import sanitization (326-332)', () => {
       const materials = hydrated.contracts?.offers[0]?.rewards.materials ?? []
       expect(materials.some((drop) => drop.itemId === 'phantom-widget')).toBe(false)
       expect(materials.length).toBeGreaterThan(0)
-      expect(materials.every((drop) => drop.itemId.length > 0 && drop.label.length > 0)).toBe(
-        true
-      )
+      expect(materials.every((drop) => drop.itemId.length > 0 && drop.label.length > 0)).toBe(true)
     })
   })
 
@@ -7273,9 +8178,9 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(mission?.routingBlockers).not.toContain('not-a-blocker')
       expect(hydrated.missionRouting?.orderedMissionIds).not.toContain('case-missing')
       expect(hydrated.missionRouting?.missions['case-missing']).toBeUndefined()
-      expect(
-        hydrated.missionRouting?.nextGeneratedSequence
-      ).toBeGreaterThanOrEqual((hydrated.missionRouting?.orderedMissionIds.length ?? 0) + 1)
+      expect(hydrated.missionRouting?.nextGeneratedSequence).toBeGreaterThanOrEqual(
+        (hydrated.missionRouting?.orderedMissionIds.length ?? 0) + 1
+      )
     })
 
     it('464 strips corrupt replacement pressure scalars and unknown backlog arrays', () => {
@@ -8984,6 +9889,84 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(sanitized.containmentDeltaPerFail).toBe(-1000)
     })
 
+    it('507b preserves precision for bounded simulation scalars during hydration', () => {
+      const fallback = createStartingState()
+      const [agentAId, agentBId] = Object.keys(fallback.agents)
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 6,
+        config: {
+          ...fallback.config,
+          stageScalar: 0.123456,
+          probabilityK: 0.987654,
+          raidCoordinationPenaltyPerExtraTeam: 0.333333,
+        },
+        facilityState: {
+          facilities: {
+            precision_lab: {
+              facilityId: 'precision_lab',
+              category: 'research_lab',
+              level: 1,
+              maxLevel: 3,
+              status: 'active',
+              effects: {
+                researchSpeedMultiplier: 1.234567,
+                dataPoolPerWeek: 2.345678,
+              },
+            },
+          },
+        },
+        relationshipHistory: [
+          {
+            week: 6,
+            agentAId,
+            agentBId,
+            value: 0.123456,
+            trustDamage: 0.234567,
+            modifiers: ['precision'],
+            reason: 'passive_drift',
+          },
+        ],
+        hubState: {
+          districtKey: 'central_hub',
+          factionPresence: { institutions: 12.345678 },
+          opportunities: [
+            {
+              id: 'opp-precision',
+              label: 'Precision lead',
+              detail: 'Precision detail',
+              factionId: 'institutions',
+              confidence: 0.345678,
+            },
+          ],
+          rumors: [
+            {
+              id: 'rumor-precision',
+              label: 'Precision rumor',
+              detail: 'Precision rumor detail',
+              confidence: 0.456789,
+            },
+          ],
+        },
+      })
+
+      expect(hydrated.config.stageScalar).toBe(0.123456)
+      expect(hydrated.config.probabilityK).toBe(0.987654)
+      expect(hydrated.config.raidCoordinationPenaltyPerExtraTeam).toBe(0.333333)
+      expect(hydrated.facilityState?.facilities.precision_lab?.effects).toMatchObject({
+        researchSpeedMultiplier: 1.234567,
+        dataPoolPerWeek: 2.345678,
+      })
+      expect(hydrated.relationshipHistory?.[0]).toMatchObject({
+        value: 0.123456,
+        trustDamage: 0.234567,
+      })
+      expect(hydrated.hubState?.factionPresence.institutions).toBe(12.345678)
+      expect(hydrated.hubState?.opportunities[0]?.confidence).toBe(0.345678)
+      expect(hydrated.hubState?.rumors[0]?.confidence).toBe(0.456789)
+    })
+
     it('508 normalizes relationship_changed and agent.betrayed numeric fields without NaN', () => {
       const fallback = createStartingState()
 
@@ -9027,13 +10010,45 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(hydrated.events[0]?.payload).toMatchObject({
         previousValue: 0.5,
         nextValue: 0,
-        delta: 0,
+        delta: -0.5,
       })
       expect(hydrated.events[1]?.payload).toMatchObject({
         trustDamageDelta: 0,
         trustDamageTotal: 0,
       })
       expect(hydrated.events.every((event) => !JSON.stringify(event).includes('NaN'))).toBe(true)
+    })
+
+    it('508b clamps legacy relationship_changed values to -2..2 and recomputes delta', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-relationship-legacy-wide-scale',
+            type: 'agent.relationship_changed',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              agentId: Object.keys(fallback.agents)[0]!,
+              agentName: 'Agent',
+              counterpartId: 'a_stale_counterpart',
+              counterpartName: 'Retired',
+              previousValue: 5,
+              nextValue: -3,
+              delta: 999,
+              reason: 'passive_drift',
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        previousValue: 2,
+        nextValue: -2,
+        delta: -4,
+      })
     })
 
     it('509 enforces non-decreasing case stage transitions and raid conversion consistency', () => {
@@ -9157,6 +10172,50 @@ describe('runTransfer import sanitization (326-332)', () => {
         )
       ).toBe(false)
     })
+
+    it('510b keeps only catalog-backed nonnegative integer material rows for legacy unknown-recipe production events', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-production-legacy-materials',
+            type: 'production.queue_started',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              queueId: 'q-legacy',
+              queueName: 'Legacy Queue',
+              recipeId: 'legacy-recipe',
+              outputId: 'ward_seals',
+              outputName: 'Output',
+              outputQuantity: 1,
+              etaWeeks: 1,
+              fundingCost: 0,
+              inputMaterials: [
+                { materialId: ' electronic_parts ', materialName: '   ', quantity: 0 },
+                { materialId: 'medical_supplies', materialName: 'Medical Supplies', quantity: 1.5 },
+                { materialId: 'occult_reagents', materialName: 'Occult Reagents', quantity: -1 },
+                { materialId: 'mystery_powder', materialName: 'Mystery Powder', quantity: 1 },
+                { materialId: '   ', materialName: 'Blank Id', quantity: 1 },
+              ],
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        recipeId: 'legacy-recipe',
+        inputMaterials: [
+          {
+            materialId: 'electronic_parts',
+            materialName: 'Electronic Parts',
+            quantity: 0,
+          },
+        ],
+      })
+    })
   })
 
   describe('hydration problems 511-518', () => {
@@ -9242,6 +10301,192 @@ describe('runTransfer import sanitization (326-332)', () => {
         allocations: [
           expect.objectContaining({
             allocationId: 'alloc-511-b',
+            substitutionStatus: 'degraded_substitute',
+          }),
+        ],
+      })
+    })
+
+    it('511b bounds market transaction listing resource status capacities', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-market-txn-511b',
+            type: 'market.transaction_recorded',
+            timestamp: buildOperationEventTimestamp(3, 0),
+            payload: {
+              week: 3,
+              marketWeek: 3,
+              transactionId: 'market-3-2',
+              action: 'buy',
+              listingId: 'gear:combat_stims',
+              itemId: 'combat_stims',
+              itemName: 'Combat Stims',
+              category: 'equipment',
+              quantity: 1,
+              bundleCount: 1,
+              unitPrice: 12,
+              totalPrice: 12,
+              remainingAvailability: 4,
+              listingResourceStatuses: [
+                {
+                  resourceClass: 'licensed_handling_capacity',
+                  sourceId: ' licensed_handling_desk ',
+                  label: ' Licensed handling desk ',
+                  capacity: -2,
+                  available: -5,
+                  allocations: [' alloc-a ', 'alloc-a', '', 42],
+                },
+                {
+                  resourceClass: 'reagent_stock',
+                  capacity: 2,
+                  available: 9,
+                  allocations: ['reagent-2', ' reagent-1 ', 'reagent-2'],
+                },
+                {
+                  resourceClass: 'supplier_attention_slot',
+                  capacity: 3.9,
+                  available: 2.8,
+                },
+              ],
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        listingResourceStatuses: [
+          {
+            resourceClass: 'licensed_handling_capacity',
+            sourceId: 'licensed_handling_desk',
+            label: 'Licensed handling desk',
+            capacity: 0,
+            available: 0,
+            allocations: ['alloc-a'],
+          },
+          {
+            resourceClass: 'reagent_stock',
+            capacity: 2,
+            available: 2,
+            allocations: ['reagent-1', 'reagent-2'],
+          },
+          {
+            resourceClass: 'supplier_attention_slot',
+            capacity: 3,
+            available: 2,
+          },
+        ],
+      })
+    })
+
+    it('511c bounds market transaction procurement allocation priority and delay', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-market-txn-511c',
+            type: 'market.transaction_recorded',
+            timestamp: buildOperationEventTimestamp(3, 0),
+            payload: {
+              week: 3,
+              marketWeek: 3,
+              transactionId: 'market-3-3',
+              action: 'buy',
+              listingId: 'gear:combat_stims',
+              itemId: 'combat_stims',
+              itemName: 'Combat Stims',
+              category: 'equipment',
+              quantity: 1,
+              bundleCount: 1,
+              unitPrice: 12,
+              totalPrice: 12,
+              remainingAvailability: 4,
+              allocation: {
+                allocationId: 'alloc-huge',
+                resourceClass: 'reagent_stock',
+                source: 'broker_a',
+                sourceLabel: 'Broker A',
+                destinationUse: 'field_kit',
+                destinationLabel: 'Field kit',
+                urgency: 'contingency',
+                expectedBenefit: 'stabilize supply',
+                priority: 9999,
+                delayWeeks: 9999,
+                substitutionStatus: 'none',
+              },
+              allocations: [
+                {
+                  allocationId: 'alloc-negative',
+                  resourceClass: 'supplier_attention_slot',
+                  source: 'broker_b',
+                  sourceLabel: 'Broker B',
+                  destinationUse: 'reserve',
+                  destinationLabel: 'Reserve',
+                  urgency: 'standard',
+                  expectedBenefit: 'buffer',
+                  priority: -5,
+                  delayWeeks: -7,
+                  substitutionStatus: 'none',
+                },
+                {
+                  allocationId: 'alloc-malformed',
+                  resourceClass: 'licensed_handling_capacity',
+                  source: 'desk',
+                  sourceLabel: 'Desk',
+                  destinationUse: 'controlled_procurement',
+                  destinationLabel: 'Controlled procurement',
+                  urgency: 'standard',
+                  expectedBenefit: 'compliance',
+                  priority: 'urgent',
+                  delayWeeks: Number.NaN,
+                  substitutionStatus: 'none',
+                },
+                {
+                  allocationId: 'alloc-valid',
+                  resourceClass: 'licensed_handling_capacity',
+                  source: 'desk',
+                  sourceLabel: 'Desk',
+                  destinationUse: 'controlled_procurement',
+                  destinationLabel: 'Controlled procurement',
+                  urgency: 'contingency',
+                  expectedBenefit: 'compliance',
+                  priority: 2,
+                  delayWeeks: 1,
+                  substitutionStatus: 'degraded_substitute',
+                  substitutionSummary: 'substitute lane',
+                },
+              ],
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        allocation: expect.objectContaining({
+          allocationId: 'alloc-huge',
+          priority: 10,
+          delayWeeks: 52,
+        }),
+        allocations: [
+          expect.objectContaining({
+            allocationId: 'alloc-negative',
+            priority: 0,
+            delayWeeks: 0,
+          }),
+          expect.objectContaining({
+            allocationId: 'alloc-malformed',
+            priority: 0,
+            delayWeeks: 0,
+          }),
+          expect.objectContaining({
+            allocationId: 'alloc-valid',
+            priority: 2,
+            delayWeeks: 1,
             substitutionStatus: 'degraded_substitute',
           }),
         ],
@@ -9355,9 +10600,9 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(payload.reputationBefore).toBe(10)
       expect(payload.reputationAfter).toBe(100)
       expect(Number.isFinite(payload.reputationAfter!)).toBe(true)
-      expect(
-        payload.contactRelationshipAfter! - payload.contactRelationshipBefore!
-      ).toBe(payload.contactDelta)
+      expect(payload.contactRelationshipAfter! - payload.contactRelationshipBefore!).toBe(
+        payload.contactDelta
+      )
     })
 
     it('516 reconciles agency.containment_updated containment, funding, and clearance', () => {
@@ -9396,9 +10641,9 @@ describe('runTransfer import sanitization (326-332)', () => {
         fundingDelta?: number
       }
 
-      expect(
-        payload.containmentRatingAfter! - payload.containmentRatingBefore!
-      ).toBe(payload.containmentDelta)
+      expect(payload.containmentRatingAfter! - payload.containmentRatingBefore!).toBe(
+        payload.containmentDelta
+      )
       expect(payload.fundingAfter! - payload.fundingBefore!).toBe(payload.fundingDelta)
       expect(payload.clearanceLevelAfter! - payload.clearanceLevelBefore!).toBe(3)
     })
@@ -9462,7 +10707,9 @@ describe('runTransfer import sanitization (326-332)', () => {
             maxStage: 0,
             avgFatigue: 0,
             teamStatus: [],
-            notes: [{ id: 'note-future', content: 'future', timestamp: buildReportNoteTimestamp(99, 0) }],
+            notes: [
+              { id: 'note-future', content: 'future', timestamp: buildReportNoteTimestamp(99, 0) },
+            ],
           },
           {
             week: 2,
@@ -9478,7 +10725,9 @@ describe('runTransfer import sanitization (326-332)', () => {
             maxStage: 0,
             avgFatigue: 0,
             teamStatus: [],
-            notes: [{ id: 'note-week-2-a', content: 'first', timestamp: buildReportNoteTimestamp(2, 0) }],
+            notes: [
+              { id: 'note-week-2-a', content: 'first', timestamp: buildReportNoteTimestamp(2, 0) },
+            ],
           },
           {
             week: 4,
@@ -9494,7 +10743,13 @@ describe('runTransfer import sanitization (326-332)', () => {
             maxStage: 0,
             avgFatigue: 0,
             teamStatus: [],
-            notes: [{ id: 'note-week-4-a', content: 'week four a', timestamp: buildReportNoteTimestamp(4, 0) }],
+            notes: [
+              {
+                id: 'note-week-4-a',
+                content: 'week four a',
+                timestamp: buildReportNoteTimestamp(4, 0),
+              },
+            ],
           },
           {
             week: 4,
@@ -9510,7 +10765,13 @@ describe('runTransfer import sanitization (326-332)', () => {
             maxStage: 0,
             avgFatigue: 0,
             teamStatus: [],
-            notes: [{ id: 'note-week-4-b', content: 'week four b', timestamp: buildReportNoteTimestamp(4, 1) }],
+            notes: [
+              {
+                id: 'note-week-4-b',
+                content: 'week four b',
+                timestamp: buildReportNoteTimestamp(4, 1),
+              },
+            ],
           },
         ],
       })
@@ -9932,7 +11193,7 @@ describe('runTransfer import sanitization (326-332)', () => {
           caseId: 'case-infiltration',
           caseTitle: 'Covert Case',
           summary: 'Probe strain detected.',
-          infiltrationAwareness: 100,
+          infiltrationAwareness: 1,
           infiltrationProbeProgress: 0,
           infiltrationStage: 'exposed',
           probeAction: 'probe_access',
@@ -9942,6 +11203,84 @@ describe('runTransfer import sanitization (326-332)', () => {
           leaveBehindLabel: 'Courier cache',
         })
       }
+    })
+
+    it('527b migrates infiltration event awareness and progress to fractional scale', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 3,
+        events: [
+          {
+            id: 'evt-infiltration-fraction',
+            type: 'infiltration.awareness_complication',
+            timestamp: buildOperationEventTimestamp(3, 0),
+            payload: {
+              week: 3,
+              caseId: 'case-infiltration',
+              caseTitle: 'Covert Case',
+              summary: 'Fractional values.',
+              infiltrationAwareness: 0.25,
+              infiltrationProbeProgress: 1,
+            },
+          },
+          {
+            id: 'evt-infiltration-percent',
+            type: 'infiltration.weekly_encounter',
+            timestamp: buildOperationEventTimestamp(3, 1),
+            payload: {
+              week: 3,
+              caseId: 'case-infiltration',
+              caseTitle: 'Covert Case',
+              summary: 'Legacy percent values.',
+              infiltrationAwareness: 25,
+              infiltrationProbeProgress: 100,
+            },
+          },
+          {
+            id: 'evt-infiltration-negative',
+            type: 'infiltration.cover_strain',
+            timestamp: buildOperationEventTimestamp(3, 2),
+            payload: {
+              week: 3,
+              caseId: 'case-infiltration',
+              caseTitle: 'Covert Case',
+              summary: 'Negative values.',
+              infiltrationAwareness: -0.5,
+              infiltrationProbeProgress: -25,
+            },
+          },
+          {
+            id: 'evt-infiltration-malformed',
+            type: 'infiltration.leave_behind_tradeoff',
+            timestamp: buildOperationEventTimestamp(3, 3),
+            payload: {
+              week: 3,
+              caseId: 'case-infiltration',
+              caseTitle: 'Covert Case',
+              summary: 'Malformed values.',
+              infiltrationAwareness: '25%',
+              infiltrationProbeProgress: '0.5',
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        infiltrationAwareness: 0.25,
+        infiltrationProbeProgress: 1,
+      })
+      expect(hydrated.events[1]?.payload).toMatchObject({
+        infiltrationAwareness: 0.25,
+        infiltrationProbeProgress: 1,
+      })
+      expect(hydrated.events[2]?.payload).toMatchObject({
+        infiltrationAwareness: 0,
+        infiltrationProbeProgress: 0,
+      })
+      expect(hydrated.events[3]?.payload).not.toHaveProperty('infiltrationAwareness')
+      expect(hydrated.events[3]?.payload).not.toHaveProperty('infiltrationProbeProgress')
     })
 
     it('528 hydrates concealment.activated with trimmed strings and clamped confidence', () => {
@@ -10032,6 +11371,34 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
 
       expect(hydrated.events[0]?.payload.teamIds).toEqual(['team-a', 'team-b'])
+    })
+
+    it('530b preserves stale case event teamIds while trimming and deduping', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 2,
+        events: [
+          {
+            id: 'evt-failed-530b',
+            type: 'case.failed',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              caseId: 'case-001',
+              caseTitle: 'Failed',
+              mode: 'threshold',
+              kind: 'case',
+              fromStage: 1,
+              toStage: 2,
+              teamIds: [' team-stale-1 ', 'team-stale-1', 'team-known-a'],
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload.teamIds).toEqual(['team-stale-1', 'team-known-a'])
     })
 
     it('531 caps assignment.team_assigned assignedTeamCount to maxTeams', () => {
@@ -11232,7 +12599,10 @@ describe('runTransfer import sanitization (326-332)', () => {
       notes: [] as const,
     }
 
-    const minimalMissionResultPayload = (caseId: string, outcome: 'success' | 'partial' | 'fail' | 'unresolved') => ({
+    const minimalMissionResultPayload = (
+      caseId: string,
+      outcome: 'success' | 'partial' | 'fail' | 'unresolved'
+    ) => ({
       caseId,
       caseTitle: caseId,
       teamsUsed: [],
@@ -12218,7 +13588,7 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
 
       expect(hydrated.events[0]?.payload).toMatchObject({ revealLevel: 2 })
-      expect(hydrated.events[1]?.payload).toMatchObject({ revealLevel: 0 })
+      expect(hydrated.events[1]?.payload).toMatchObject({ revealLevel: 1 })
     })
 
     it('598 bounds system count events as audit-only counts', () => {
@@ -12274,10 +13644,7 @@ describe('runTransfer import sanitization (326-332)', () => {
       }
     }
 
-    function makeHydrationCase(
-      id: string,
-      overrides: Partial<CaseInstance> = {}
-    ): CaseInstance {
+    function makeHydrationCase(id: string, overrides: Partial<CaseInstance> = {}): CaseInstance {
       const fallback = createStartingState()
       const seed = fallback.cases['case-001']!
 
@@ -12760,7 +14127,10 @@ describe('runTransfer import sanitization (326-332)', () => {
               progressData: 9,
               progressMaterials: 5,
               requiredResearchIds: ['proj-a', 'phantom', 'proj-b'],
-              unlocks: [{ id: '', label: 'Bad' }, { id: 'unlock-1', label: 'Valid', category: 'intel_tool' }],
+              unlocks: [
+                { id: '', label: 'Bad' },
+                { id: 'unlock-1', label: 'Valid', category: 'intel_tool' },
+              ],
             },
             'proj-b': {
               projectId: 'proj-b',
@@ -13537,9 +14907,9 @@ describe('runTransfer import sanitization (326-332)', () => {
       ).toBe(false)
       expect(mission?.routingState).not.toBe('bogus')
       expect(mission?.routingBlockers).not.toContain('not-a-blocker')
-      expect(
-        hydrated.missionRouting?.nextGeneratedSequence
-      ).toBeGreaterThanOrEqual((hydrated.missionRouting?.orderedMissionIds.length ?? 0) + 1)
+      expect(hydrated.missionRouting?.nextGeneratedSequence).toBeGreaterThanOrEqual(
+        (hydrated.missionRouting?.orderedMissionIds.length ?? 0) + 1
+      )
     })
 
     it('629 keeps explicit replacementPressureState on hydrateGame; recomputeAttrition rebuilds derived scalars', () => {
@@ -13871,7 +15241,9 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
 
       expect(hydrated.runtimeState?.progressClocks['story.clock-complete']?.completedAtWeek).toBe(5)
-      expect(hydrated.runtimeState?.progressClocks['story.clock-open']?.completedAtWeek).toBeUndefined()
+      expect(
+        hydrated.runtimeState?.progressClocks['story.clock-open']?.completedAtWeek
+      ).toBeUndefined()
     })
   })
 
@@ -14395,4 +15767,3 @@ describe('runTransfer import sanitization (326-332)', () => {
     })
   })
 })
-

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -10,7 +10,7 @@ import {
   productionMaterialCatalog,
   type ProductionRecipe,
 } from '../../data/production'
-import { getTrainingProgram } from '../../data/training'
+import { getTrainingProgram, trainingCatalog } from '../../data/training'
 import { createDefaultAgentAssignmentState } from '../../domain/agentDefaults'
 import { normalizeAgent, reconcileAgentAssignmentAgainstGame } from '../../domain/agent/normalize'
 import { recomputeAttritionDerivedState } from '../../domain/agent/attritionReset'
@@ -41,6 +41,7 @@ import { sanitizeProgressionUnlockIds } from '../../domain/agencyProgression'
 import { normalizeRuntimeState, reconcileRuntimeUiSelections } from '../../domain/gameStateManager'
 import { normalizeCaseInstance } from '../../domain/case/normalizeCase'
 import { sanitizeDistrictScheduleState } from '../../domain/districtSchedule'
+import { sanitizeDamagedEquipmentQueue } from '../../domain/equipmentRecovery'
 import { normalizeMissionIntelRecord } from '../../domain/intel'
 import {
   reconcileHydratedMissionRoutingTriage,
@@ -275,6 +276,27 @@ export interface RunExportPayload {
   game: PersistedGame
 }
 
+const IMPORT_TIMESTAMP_FUTURE_SKEW_MS = 5 * 60 * 1000
+
+export function validateImportTimestampMetadata(
+  value: unknown,
+  fieldName: 'exportedAt' | 'savedAt',
+  payloadLabel = 'Run payload'
+) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${payloadLabel} ${fieldName} timestamp is missing or invalid.`)
+  }
+
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${payloadLabel} ${fieldName} timestamp is missing or invalid.`)
+  }
+
+  if (timestamp > Date.now() + IMPORT_TIMESTAMP_FUTURE_SKEW_MS) {
+    throw new Error(`${payloadLabel} ${fieldName} timestamp is from the future.`)
+  }
+}
+
 /** Hydration allowlist — derived from `OperationEventPayloadMap` + legacy import-only types. */
 export const OPERATION_EVENT_TYPES = [
   ...(Object.keys(operationEventPayloadSchemas) as OperationEventType[]),
@@ -313,6 +335,14 @@ const RECRUIT_CATEGORIES = [
 ] as const
 const STAT_KEYS = ['combat', 'investigation', 'utility', 'social'] as const
 const EXACT_POTENTIAL_TIERS = ['F', 'D', 'C', 'B', 'A', 'S'] as const
+/** Hydration 575-576: weekly report snapshot kind/mode allowlists. */
+const CASE_KINDS = ['case', 'raid', 'standard', 'anomaly'] as const satisfies readonly CaseKind[]
+const CASE_MODES = [
+  'threshold',
+  'probability',
+  'standard',
+  'anomaly',
+] as const satisfies readonly CaseMode[]
 const SCOUT_CONFIDENCES = ['low', 'medium', 'high', 'confirmed'] as const
 const MARKET_TRANSACTION_ACTIONS = ['buy', 'sell', 'favor_exchange', 'callable_obligation'] as const
 const MARKET_TRANSACTION_CATEGORIES = ['equipment', 'component', 'material'] as const
@@ -321,6 +351,8 @@ const MARKET_TRANSACTION_RESOURCE_CLASSES = [
   'reagent_stock',
   'licensed_handling_capacity',
 ] as const
+const MARKET_PROCUREMENT_ALLOCATION_PRIORITY_MAX = 10
+const MARKET_PROCUREMENT_ALLOCATION_DELAY_WEEKS_MAX = 52
 const FACTION_STANDING_MIN = -9999
 const FACTION_STANDING_MAX = 9999
 const FACTION_REPUTATION_MIN = -100
@@ -863,9 +895,13 @@ function hasRequiredOperationEventIdentity(
     return true
   }
 
-  return requiredFields.every(
-    (field) => typeof payload[field] === 'string' && payload[field].length > 0
-  )
+  return requiredFields.every((field) => {
+    if (typeof payload[field] !== 'string') {
+      return false
+    }
+
+    return payload[field].trim().length > 0
+  })
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -931,10 +967,14 @@ function sanitizeInteger(value: number | undefined, fallback: number, min: numbe
   return Math.max(min, Math.trunc(finiteValue))
 }
 
-function sanitizeDecimal(value: number | undefined, fallback: number, min: number, max?: number) {
+function sanitizeFiniteDecimalPreservePrecision(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max?: number
+) {
   const finiteValue = typeof value === 'number' && Number.isFinite(value) ? value : fallback
-  const rounded = Number(finiteValue.toFixed(2))
-  return max === undefined ? Math.max(min, rounded) : clamp(rounded, min, max)
+  return max === undefined ? Math.max(min, finiteValue) : clamp(finiteValue, min, max)
 }
 
 function sanitizeFiniteNumber(value: unknown, fallback: number) {
@@ -955,6 +995,49 @@ function sanitizeFiniteNumber(value: unknown, fallback: number) {
   }
 
   return fallback
+}
+
+function reconcileTrainingEventProgram(
+  trainingIdValue: unknown,
+  trainingNameValue: unknown
+): { trainingId: string; trainingName: string; fundingCost: number } {
+  const trainingIdCandidate = typeof trainingIdValue === 'string' ? trainingIdValue : undefined
+  const trainingNameCandidate =
+    typeof trainingNameValue === 'string' && trainingNameValue.trim().length > 0
+      ? trainingNameValue.trim()
+      : undefined
+
+  const matchedProgramById =
+    trainingIdCandidate && getTrainingProgram(trainingIdCandidate)
+      ? getTrainingProgram(trainingIdCandidate)
+      : undefined
+  const matchedProgramByName = trainingNameCandidate
+    ? trainingCatalog.find((program) => program.name === trainingNameCandidate)
+    : undefined
+  const fallbackProgram = trainingCatalog[0]
+  const program = matchedProgramById ?? matchedProgramByName ?? fallbackProgram
+
+  if (!program) {
+    return {
+      trainingId: 'combat-drills',
+      trainingName: trainingNameCandidate ?? 'Close-Quarters Drills',
+      fundingCost: 0,
+    }
+  }
+
+  return {
+    trainingId: program.trainingId,
+    trainingName: program.name,
+    fundingCost: program.fundingCost,
+  }
+}
+
+function sanitizeRelationshipValue(value: unknown, fallback: number) {
+  return clamp(sanitizeFiniteNumber(value, fallback), -2, 2)
+}
+
+function reconcileRelationshipDelta(previousValue: number, nextValue: number) {
+  return Math.round((nextValue - previousValue) * 100) / 100
 }
 
 const ALLOWED_GAME_OVER_REASONS = new Set<string>(Object.values(GAME_OVER_REASONS))
@@ -1115,8 +1198,12 @@ function resolveImportedEntityId(
   legacyFallback: string,
   allowLegacySyntheticRepair: boolean
 ): string | null {
-  if (typeof value === 'string' && value.length > 0) {
-    return value
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (trimmed.length > 0) {
+      return trimmed
+    }
   }
 
   return allowLegacySyntheticRepair ? legacyFallback : null
@@ -1276,6 +1363,38 @@ function reconcileMarketTotalPrice(
   return sanitized === expected ? sanitized : expected
 }
 
+function reconcileProductionEventRecipeOutput(
+  recipeIdValue: unknown,
+  outputIdValue: unknown,
+  outputNameValue: unknown
+): { recipeId: string; outputId: string; outputName: string } {
+  const recipeById =
+    typeof recipeIdValue === 'string' && getProductionRecipe(recipeIdValue)
+      ? getProductionRecipe(recipeIdValue)
+      : undefined
+  const recipe = recipeById ?? undefined
+
+  if (!recipe) {
+    const fallbackOutputId = typeof outputIdValue === 'string' ? outputIdValue : 'output-1'
+    const fallbackOutputName =
+      typeof outputNameValue === 'string' && outputNameValue.trim().length > 0
+        ? outputNameValue.trim()
+        : (inventoryItemLabels[fallbackOutputId] ?? 'Output 1')
+
+    return {
+      recipeId: typeof recipeIdValue === 'string' ? recipeIdValue : 'recipe-1',
+      outputId: fallbackOutputId,
+      outputName: fallbackOutputName,
+    }
+  }
+
+  return {
+    recipeId: recipe.recipeId,
+    outputId: recipe.outputItemId,
+    outputName: recipe.outputItemName,
+  }
+}
+
 function sanitizeOperationEventMarketProcurementAllocation(value: unknown) {
   if (!isRecord(value)) {
     return undefined
@@ -1323,8 +1442,16 @@ function sanitizeOperationEventMarketProcurementAllocation(value: unknown) {
     destinationLabel,
     urgency: value.urgency === 'contingency' ? 'contingency' : 'standard',
     expectedBenefit,
-    priority: sanitizeInteger(value.priority as number | undefined, 0, 0),
-    delayWeeks: sanitizeInteger(value.delayWeeks as number | undefined, 0, 0),
+    priority: clamp(
+      sanitizeInteger(value.priority as number | undefined, 0, 0),
+      0,
+      MARKET_PROCUREMENT_ALLOCATION_PRIORITY_MAX
+    ),
+    delayWeeks: clamp(
+      sanitizeInteger(value.delayWeeks as number | undefined, 0, 0),
+      0,
+      MARKET_PROCUREMENT_ALLOCATION_DELAY_WEEKS_MAX
+    ),
     ...(typeof value.displacedAlternativeUse === 'string' &&
     value.displacedAlternativeUse.trim().length > 0
       ? { displacedAlternativeUse: value.displacedAlternativeUse.trim() }
@@ -1342,18 +1469,33 @@ function sanitizeOperationEventMarketListingResourceStatuses(value: unknown) {
     return undefined
   }
 
+  const sanitizeCapacityValue = (raw: unknown) =>
+    typeof raw === 'number' && Number.isFinite(raw) ? Math.max(0, Math.trunc(raw)) : undefined
+
   const sanitized = value
     .filter((entry): entry is Record<string, unknown> => isRecord(entry))
     .map((entry) => {
       const resourceClass = isOneOf(entry.resourceClass, MARKET_TRANSACTION_RESOURCE_CLASSES)
         ? entry.resourceClass
         : 'supplier_attention_slot'
-      const allocations = Array.isArray(entry.allocations)
-        ? entry.allocations.filter(
-            (allocationId): allocationId is string =>
-              typeof allocationId === 'string' && allocationId.trim().length > 0
-          )
+      const allocationIds = Array.isArray(entry.allocations)
+        ? [
+            ...new Set(
+              entry.allocations
+                .filter(
+                  (allocationId): allocationId is string =>
+                    typeof allocationId === 'string' && allocationId.trim().length > 0
+                )
+                .map((allocationId) => allocationId.trim())
+            ),
+          ].sort((left, right) => left.localeCompare(right))
         : undefined
+      const capacity = sanitizeCapacityValue(entry.capacity)
+      const available = sanitizeCapacityValue(entry.available)
+      const boundedAvailable =
+        available !== undefined && capacity !== undefined
+          ? Math.min(available, capacity)
+          : available
 
       return stripUndefinedFields({
         resourceClass,
@@ -1363,13 +1505,9 @@ function sanitizeOperationEventMarketListingResourceStatuses(value: unknown) {
         ...(typeof entry.label === 'string' && entry.label.trim().length > 0
           ? { label: entry.label.trim() }
           : {}),
-        ...(typeof entry.available === 'number' && Number.isFinite(entry.available)
-          ? { available: Math.trunc(entry.available) }
-          : {}),
-        ...(typeof entry.capacity === 'number' && Number.isFinite(entry.capacity)
-          ? { capacity: Math.trunc(entry.capacity) }
-          : {}),
-        ...(allocations && allocations.length > 0 ? { allocations } : {}),
+        ...(boundedAvailable !== undefined ? { available: boundedAvailable } : {}),
+        ...(capacity !== undefined ? { capacity } : {}),
+        ...(allocationIds && allocationIds.length > 0 ? { allocations: allocationIds } : {}),
       })
     })
 
@@ -1549,16 +1687,16 @@ function sanitizeInfiltrationProbeEventPayload(
   importEntityId: (value: unknown, legacyFallback: string) => string | undefined
 ) {
   const caseId = importEntityId(payload.caseId, `case-${index + 1}`) ?? `case-${index + 1}`
-  const infiltrationAwareness =
-    typeof payload.infiltrationAwareness === 'number' &&
-    Number.isFinite(payload.infiltrationAwareness)
-      ? clamp(payload.infiltrationAwareness, 0, 100)
-      : undefined
-  const infiltrationProbeProgress =
-    typeof payload.infiltrationProbeProgress === 'number' &&
-    Number.isFinite(payload.infiltrationProbeProgress)
-      ? clamp(payload.infiltrationProbeProgress, 0, 100)
-      : undefined
+  const sanitizeInfiltrationFraction = (value: unknown) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return undefined
+    }
+
+    const normalizedValue = value > 1 ? value / 100 : value
+    return clamp(normalizedValue, 0, 1)
+  }
+  const infiltrationAwareness = sanitizeInfiltrationFraction(payload.infiltrationAwareness)
+  const infiltrationProbeProgress = sanitizeInfiltrationFraction(payload.infiltrationProbeProgress)
   const infiltrationStage = isOneOf(payload.infiltrationStage, INFILTRATION_PROBE_STAGES)
     ? payload.infiltrationStage
     : undefined
@@ -2124,7 +2262,7 @@ export function sanitizeGameConfig(
   }
 
   if (config.stageScalar !== undefined) {
-    nextConfig.stageScalar = sanitizeDecimal(
+    nextConfig.stageScalar = sanitizeFiniteDecimalPreservePrecision(
       config.stageScalar as number,
       fallback.stageScalar,
       0.05,
@@ -2150,7 +2288,7 @@ export function sanitizeGameConfig(
   }
 
   if (config.probabilityK !== undefined) {
-    nextConfig.probabilityK = sanitizeDecimal(
+    nextConfig.probabilityK = sanitizeFiniteDecimalPreservePrecision(
       config.probabilityK as number,
       fallback.probabilityK,
       0.05,
@@ -2159,7 +2297,7 @@ export function sanitizeGameConfig(
   }
 
   if (config.raidCoordinationPenaltyPerExtraTeam !== undefined) {
-    nextConfig.raidCoordinationPenaltyPerExtraTeam = sanitizeDecimal(
+    nextConfig.raidCoordinationPenaltyPerExtraTeam = sanitizeFiniteDecimalPreservePrecision(
       config.raidCoordinationPenaltyPerExtraTeam as number,
       fallback.raidCoordinationPenaltyPerExtraTeam,
       0,
@@ -2348,15 +2486,6 @@ const CASE_PRIORITIES = [
   'low',
 ] as const satisfies readonly CasePriority[]
 
-/** Hydration 575–576: weekly report snapshot kind/mode allowlists. */
-const CASE_KINDS = ['case', 'raid', 'standard', 'anomaly'] as const satisfies readonly CaseKind[]
-const CASE_MODES = [
-  'threshold',
-  'probability',
-  'deterministic',
-  'standard',
-] as const satisfies readonly CaseMode[]
-
 /** Hydration 583–584: case operation event kind/mode allowlists (aligned with 575–576). */
 function sanitizeOperationEventCaseKind(value: unknown): CaseKind {
   return isOneOf(value, CASE_KINDS) ? value : 'case'
@@ -2384,7 +2513,7 @@ function reconcileMarketShiftedFields(
       ? payload.featuredRecipeName.trim()
       : catalogName
   const canonicalCostMultiplier = getCanonicalMarketCostMultiplier(pressure)
-  const boundedCostMultiplier = sanitizeDecimal(
+  const boundedCostMultiplier = sanitizeFiniteDecimalPreservePrecision(
     payload.costMultiplier as number | undefined,
     canonicalCostMultiplier,
     0.5,
@@ -2666,6 +2795,17 @@ function sanitizeRevealLevel(value: unknown): CandidateRevealLevel {
   }
 
   return 0
+}
+
+function reconcileRecruitmentEventRevealLevel(
+  stage: CandidateScoutStage,
+  revealLevel: CandidateRevealLevel
+): CandidateRevealLevel {
+  if (stage >= 2) {
+    return 2
+  }
+
+  return Math.max(1, revealLevel) as CandidateRevealLevel
 }
 
 function sanitizeCandidateCostEstimate(value: unknown): CandidateCostEstimate | undefined {
@@ -4882,7 +5022,7 @@ const KNOWN_PRODUCTION_MATERIAL_IDS = new Set(
   productionMaterialCatalog.map((material) => material.materialId)
 )
 
-/** Hydration 510: operation-event material rows follow recipe catalog or strip unknown ids. */
+/** Hydration 510: operation-event material rows follow recipe catalog and drop stale unknown ids. */
 function sanitizeOperationEventProductionInputMaterials(
   payload: Record<string, unknown>
 ): ProductionMaterialRequirement[] {
@@ -4906,22 +5046,35 @@ function sanitizeProductionInputMaterials(
 
   const sanitized = entry.inputMaterials
     .filter((material): material is Record<string, unknown> => isRecord(material))
-    .map((material) => ({
-      materialId: typeof material.materialId === 'string' ? material.materialId.trim() : '',
-      materialName:
-        typeof material.materialName === 'string' && material.materialName.length > 0
-          ? material.materialName
-          : typeof material.materialId === 'string'
-            ? material.materialId
-            : '',
-      quantity: Math.max(0, sanitizeInteger(material.quantity as number | undefined, 0, 0)),
-    }))
+    .map((material) => {
+      const materialId = typeof material.materialId === 'string' ? material.materialId.trim() : ''
+      const catalogMaterialName = inventoryItemLabels[materialId]
+      const materialName =
+        typeof catalogMaterialName === 'string' && catalogMaterialName.trim().length > 0
+          ? catalogMaterialName.trim()
+          : typeof material.materialName === 'string'
+            ? material.materialName.trim()
+            : ''
+      const quantity =
+        typeof material.quantity === 'number' &&
+        Number.isFinite(material.quantity) &&
+        Number.isInteger(material.quantity) &&
+        material.quantity >= 0
+          ? material.quantity
+          : -1
+
+      return {
+        materialId,
+        materialName,
+        quantity,
+      }
+    })
     .filter(
       (material) =>
         material.materialId.length > 0 &&
         material.materialName.length > 0 &&
         KNOWN_PRODUCTION_MATERIAL_IDS.has(material.materialId) &&
-        material.quantity > 0
+        material.quantity >= 0
     )
 
   return sanitized.length > 0 ? sanitized : undefined
@@ -5108,7 +5261,7 @@ function sanitizeTrainingQueue(
           : undefined,
       relationshipDelta:
         typeof entry.relationshipDelta === 'number'
-          ? sanitizeDecimal(
+          ? sanitizeFiniteDecimalPreservePrecision(
               entry.relationshipDelta,
               program?.relationshipDelta ?? 0,
               RELATIONSHIP_VALUE_MIN,
@@ -5945,6 +6098,37 @@ function sanitizePersistedGlobalFlags(value: unknown): Record<string, GameFlagVa
 }
 
 /** SPE-441: normalize agency.fundingState at hydrate; top-level mirrors win over stale agency copies. */
+function sanitizeHydratedFundingValue(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  return sanitizeInteger(value, 0, 0)
+}
+
+function resolveHydratedFunding(game: Record<string, unknown>, fallback: GameState): number {
+  const topLevelFunding = sanitizeHydratedFundingValue(game.funding)
+  if (topLevelFunding !== undefined) {
+    return topLevelFunding
+  }
+
+  if (isRecord(game.agency)) {
+    const agencyFunding = sanitizeHydratedFundingValue(game.agency.funding)
+    if (agencyFunding !== undefined) {
+      return agencyFunding
+    }
+
+    if (isRecord(game.agency.fundingState)) {
+      const fundingStateFunding = sanitizeHydratedFundingValue(game.agency.fundingState.funding)
+      if (fundingStateFunding !== undefined) {
+        return fundingStateFunding
+      }
+    }
+  }
+
+  return sanitizeInteger(fallback.funding, 0, 0)
+}
+
 function sanitizeAgencyState(
   raw: unknown,
   mirrors: {
@@ -6280,7 +6464,9 @@ function applyHydratedFacilityResearchScalars(
       return product
     }
 
-    return product * sanitizeDecimal(raw, 1, 0.1, MAX_RESEARCH_SPEED_MULTIPLIER)
+    return (
+      product * sanitizeFiniteDecimalPreservePrecision(raw, 1, 0.1, MAX_RESEARCH_SPEED_MULTIPLIER)
+    )
   }, 1)
 
   if (bonusSlots === 0 && speedMultiplier === 1) {
@@ -6291,7 +6477,7 @@ function applyHydratedFacilityResearchScalars(
     ...state,
     researchSlots: Math.max(1, state.researchSlots + bonusSlots),
     researchSpeedMultiplier: clamp(
-      sanitizeDecimal(
+      sanitizeFiniteDecimalPreservePrecision(
         state.researchSpeedMultiplier * speedMultiplier,
         state.researchSpeedMultiplier,
         0.1,
@@ -6341,7 +6527,7 @@ function sanitizeResearchState(
       MAX_RESEARCH_SLOTS
     ),
     researchSpeedMultiplier: clamp(
-      sanitizeDecimal(
+      sanitizeFiniteDecimalPreservePrecision(
         value.researchSpeedMultiplier as number | undefined,
         base.researchSpeedMultiplier,
         0.1,
@@ -6392,7 +6578,7 @@ function sanitizeFacilityEffect(value: unknown): FacilityEffect {
       continue
     }
 
-    next[key] = sanitizeDecimal(raw, 0, 0, 100)
+    next[key] = sanitizeFiniteDecimalPreservePrecision(raw, 0, 0, 100)
   }
 
   return next
@@ -6432,12 +6618,18 @@ function sanitizeFacilityInstance(
     typeof value.upgradeCompleteWeek === 'number' && Number.isFinite(value.upgradeCompleteWeek)
       ? clamp(Math.round(value.upgradeCompleteWeek), 1, campaignWeek + 52)
       : undefined
+  const pendingEffectDeltas = sanitizeFacilityEffect(value.pendingEffectDeltas)
 
   const normalizedUpgradeInProgress =
     upgradeInProgress &&
     upgradeStartedWeek !== undefined &&
     upgradeCompleteWeek !== undefined &&
     upgradeCompleteWeek >= upgradeStartedWeek
+  const normalizedStatus = normalizedUpgradeInProgress
+    ? 'upgrading'
+    : status === 'upgrading'
+      ? 'inactive'
+      : status
 
   return stripUndefinedFields({
     facilityId,
@@ -6447,7 +6639,7 @@ function sanitizeFacilityInstance(
         : facilityId,
     level,
     maxLevel,
-    status: normalizedUpgradeInProgress ? 'upgrading' : status,
+    status: normalizedStatus,
     effects: sanitizeFacilityEffect(value.effects),
     ...(normalizedUpgradeInProgress
       ? {
@@ -6457,8 +6649,8 @@ function sanitizeFacilityInstance(
             upgradeCompleteWeek >= upgradeStartedWeek ? upgradeCompleteWeek : upgradeStartedWeek,
         }
       : {}),
-    ...(value.pendingEffectDeltas
-      ? { pendingEffectDeltas: sanitizeFacilityEffect(value.pendingEffectDeltas) }
+    ...(normalizedUpgradeInProgress && Object.keys(pendingEffectDeltas).length > 0
+      ? { pendingEffectDeltas }
       : {}),
   }) as FacilityInstance
 }
@@ -6518,7 +6710,7 @@ function sanitizeRelationshipSnapshot(
     campaignWeek
   )
   const snapshotValue = clamp(
-    sanitizeDecimal(
+    sanitizeFiniteDecimalPreservePrecision(
       value.value as number | undefined,
       0,
       RELATIONSHIP_VALUE_MIN,
@@ -6531,7 +6723,7 @@ function sanitizeRelationshipSnapshot(
   const trustDamage =
     typeof value.trustDamage === 'number' && Number.isFinite(value.trustDamage)
       ? clamp(
-          sanitizeDecimal(value.trustDamage, 0, 0, RELATIONSHIP_VALUE_MAX),
+          sanitizeFiniteDecimalPreservePrecision(value.trustDamage, 0, 0, RELATIONSHIP_VALUE_MAX),
           0,
           RELATIONSHIP_VALUE_MAX
         )
@@ -6570,7 +6762,10 @@ function sanitizeRelationshipHistory(
   return next.length > 0 ? next : fallback
 }
 
-function sanitizeHubOpportunity(value: unknown): HubState['opportunities'][number] | null {
+function sanitizeHubOpportunity(
+  value: unknown,
+  factionIds: ReadonlySet<string>
+): HubState['opportunities'][number] | null {
   if (!isRecord(value)) {
     return null
   }
@@ -6580,7 +6775,7 @@ function sanitizeHubOpportunity(value: unknown): HubState['opportunities'][numbe
   const detail = typeof value.detail === 'string' ? value.detail.trim() : ''
   const factionId = typeof value.factionId === 'string' ? value.factionId.trim() : ''
 
-  if (!id || !label || !detail || !factionId) {
+  if (!id || !label || !detail || !factionIds.has(factionId)) {
     return null
   }
 
@@ -6589,8 +6784,12 @@ function sanitizeHubOpportunity(value: unknown): HubState['opportunities'][numbe
     label,
     detail,
     factionId,
-    confidence: clamp(sanitizeDecimal(value.confidence as number | undefined, 0.5, 0, 1), 0, 1),
-    ...(value.misleading === true ? { misleading: true } : {}),
+    confidence: clamp(
+      sanitizeFiniteDecimalPreservePrecision(value.confidence as number | undefined, 0.5, 0, 1),
+      0,
+      1
+    ),
+    ...(typeof value.misleading === 'boolean' ? { misleading: value.misleading } : {}),
     ...(isOneOf(value.requiredSanctionLevel, HUB_SANCTION_LEVELS)
       ? { requiredSanctionLevel: value.requiredSanctionLevel }
       : {}),
@@ -6618,20 +6817,31 @@ function sanitizeHubRumor(value: unknown): HubState['rumors'][number] | null {
     id,
     label,
     detail,
-    confidence: clamp(sanitizeDecimal(value.confidence as number | undefined, 0.5, 0, 1), 0, 1),
-    ...(value.misleading === true ? { misleading: true } : {}),
-    ...(value.filtered === true ? { filtered: true } : {}),
+    confidence: clamp(
+      sanitizeFiniteDecimalPreservePrecision(value.confidence as number | undefined, 0.5, 0, 1),
+      0,
+      1
+    ),
+    ...(typeof value.misleading === 'boolean' ? { misleading: value.misleading } : {}),
+    ...(typeof value.filtered === 'boolean' ? { filtered: value.filtered } : {}),
   }) as HubState['rumors'][number]
 }
 
 /** SPE-428: bounded HubState sanitizer; strip payloads that do not match the hub model. */
-function sanitizeHubState(value: unknown): HubState | undefined {
+function sanitizeHubState(value: unknown, factions?: GameState['factions']): HubState | undefined {
   if (!isRecord(value)) {
     return undefined
   }
 
+  const factionIds = new Set(Object.keys(factions ?? {}))
+  if (factionIds.size === 0) {
+    for (const factionId of KNOWN_FACTION_IDS) {
+      factionIds.add(factionId)
+    }
+  }
+
   const districtKey =
-    typeof value.districtKey === 'string' && value.districtKey.trim().length > 0
+    typeof value.districtKey === 'string' && isOneOf(value.districtKey.trim(), HUB_DISTRICT_KEYS)
       ? value.districtKey.trim()
       : HUB_DISTRICT_KEYS[0]
 
@@ -6639,12 +6849,13 @@ function sanitizeHubState(value: unknown): HubState | undefined {
 
   if (isRecord(value.factionPresence)) {
     for (const [factionId, standing] of Object.entries(value.factionPresence)) {
-      if (typeof factionId !== 'string' || factionId.trim().length === 0) {
+      const normalizedFactionId = factionId.trim()
+      if (!factionIds.has(normalizedFactionId)) {
         continue
       }
 
-      factionPresence[factionId] = clamp(
-        sanitizeDecimal(standing as number | undefined, 0, -100, 100),
+      factionPresence[normalizedFactionId] = clamp(
+        sanitizeFiniteDecimalPreservePrecision(standing as number | undefined, 0, -100, 100),
         -100,
         100
       )
@@ -6653,7 +6864,7 @@ function sanitizeHubState(value: unknown): HubState | undefined {
 
   const opportunities = Array.isArray(value.opportunities)
     ? value.opportunities
-        .map((entry) => sanitizeHubOpportunity(entry))
+        .map((entry) => sanitizeHubOpportunity(entry, factionIds))
         .filter((entry): entry is HubState['opportunities'][number] => entry !== null)
         .slice(0, 8)
     : []
@@ -7390,111 +7601,127 @@ function sanitizeOperationEvents(
         break
 
       case 'agent.training_started':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('agent.training_started'),
-            payload: {
-              week,
-              queueId: typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
-              agentId: typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
-              agentName:
-                typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-              trainingId:
-                typeof payload.trainingId === 'string'
-                  ? payload.trainingId
-                  : `training-${index + 1}`,
-              trainingName:
-                typeof payload.trainingName === 'string'
-                  ? payload.trainingName
-                  : `Training ${index + 1}`,
-              teamName: typeof payload.teamName === 'string' ? payload.teamName : undefined,
-              etaWeeks: sanitizeInteger(payload.etaWeeks as number | undefined, 1, 1),
-              fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
-            },
-          })
-        )
+        {
+          const trainingProgram = reconcileTrainingEventProgram(
+            payload.trainingId,
+            payload.trainingName
+          )
+
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase('agent.training_started'),
+              payload: {
+                week,
+                queueId:
+                  typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
+                agentId:
+                  typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
+                agentName:
+                  typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
+                trainingId: trainingProgram.trainingId,
+                trainingName: trainingProgram.trainingName,
+                teamName: typeof payload.teamName === 'string' ? payload.teamName : undefined,
+                etaWeeks: sanitizeInteger(payload.etaWeeks as number | undefined, 1, 1),
+                fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
+              },
+            })
+          )
+        }
         break
 
       case 'agent.training_completed':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('agent.training_completed'),
-            payload: {
-              week,
-              queueId: typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
-              agentId: typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
-              agentName:
-                typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-              trainingId:
-                typeof payload.trainingId === 'string'
-                  ? payload.trainingId
-                  : `training-${index + 1}`,
-              trainingName:
-                typeof payload.trainingName === 'string'
-                  ? payload.trainingName
-                  : `Training ${index + 1}`,
-            },
-          })
-        )
+        {
+          const trainingProgram = reconcileTrainingEventProgram(
+            payload.trainingId,
+            payload.trainingName
+          )
+
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase('agent.training_completed'),
+              payload: {
+                week,
+                queueId:
+                  typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
+                agentId:
+                  typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
+                agentName:
+                  typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
+                trainingId: trainingProgram.trainingId,
+                trainingName: trainingProgram.trainingName,
+              },
+            })
+          )
+        }
         break
 
       case 'agent.training_cancelled':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('agent.training_cancelled'),
-            payload: {
-              week,
-              agentId: typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
-              agentName:
-                typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-              trainingId:
-                typeof payload.trainingId === 'string'
-                  ? payload.trainingId
-                  : `training-${index + 1}`,
-              trainingName:
-                typeof payload.trainingName === 'string'
-                  ? payload.trainingName
-                  : `Training ${index + 1}`,
-              refund: sanitizeInteger(payload.refund as number | undefined, 0, 0),
-            },
-          })
-        )
+        {
+          const trainingProgram = reconcileTrainingEventProgram(
+            payload.trainingId,
+            payload.trainingName
+          )
+
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase('agent.training_cancelled'),
+              payload: {
+                week,
+                agentId:
+                  typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
+                agentName:
+                  typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
+                trainingId: trainingProgram.trainingId,
+                trainingName: trainingProgram.trainingName,
+                refund: Math.min(
+                  sanitizeInteger(payload.refund as number | undefined, 0, 0),
+                  trainingProgram.fundingCost
+                ),
+              },
+            })
+          )
+        }
         break
 
       case 'agent.relationship_changed':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('agent.relationship_changed'),
-            payload: {
-              week,
-              agentId:
-                importEntityId(payload.agentId, `agent-${index + 1}`) ?? `agent-${index + 1}`,
-              agentName:
-                typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-              counterpartId:
-                importEntityId(payload.counterpartId, `counterpart-${index + 1}`) ??
-                `counterpart-${index + 1}`,
-              counterpartName:
-                typeof payload.counterpartName === 'string'
-                  ? payload.counterpartName
-                  : `Counterpart ${index + 1}`,
-              previousValue: sanitizeFiniteNumber(payload.previousValue, 0),
-              nextValue: sanitizeFiniteNumber(payload.nextValue, 0),
-              delta: sanitizeFiniteNumber(payload.delta, 0),
-              reason:
-                payload.reason === 'mission_success' ||
-                payload.reason === 'mission_partial' ||
-                payload.reason === 'mission_fail' ||
-                payload.reason === 'passive_drift' ||
-                payload.reason === 'external_event' ||
-                payload.reason === 'reconciliation' ||
-                payload.reason === 'spontaneous_event' ||
-                payload.reason === 'betrayal'
-                  ? payload.reason
-                  : 'passive_drift',
-            },
-          })
-        )
+        {
+          const previousValue = sanitizeRelationshipValue(payload.previousValue, 0)
+          const nextValue = sanitizeRelationshipValue(payload.nextValue, 0)
+
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase('agent.relationship_changed'),
+              payload: {
+                week,
+                agentId:
+                  importEntityId(payload.agentId, `agent-${index + 1}`) ?? `agent-${index + 1}`,
+                agentName:
+                  typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
+                counterpartId:
+                  importEntityId(payload.counterpartId, `counterpart-${index + 1}`) ??
+                  `counterpart-${index + 1}`,
+                counterpartName:
+                  typeof payload.counterpartName === 'string'
+                    ? payload.counterpartName
+                    : `Counterpart ${index + 1}`,
+                previousValue,
+                nextValue,
+                delta: reconcileRelationshipDelta(previousValue, nextValue),
+                reason:
+                  payload.reason === 'mission_success' ||
+                  payload.reason === 'mission_partial' ||
+                  payload.reason === 'mission_fail' ||
+                  payload.reason === 'passive_drift' ||
+                  payload.reason === 'external_event' ||
+                  payload.reason === 'reconciliation' ||
+                  payload.reason === 'spontaneous_event' ||
+                  payload.reason === 'betrayal'
+                    ? payload.reason
+                    : 'passive_drift',
+              },
+            })
+          )
+        }
         break
 
       case 'agent.instructor_assigned':
@@ -7756,100 +7983,128 @@ function sanitizeOperationEvents(
       case 'recruitment.scouting_initiated':
       case 'recruitment.scouting_refined':
       case 'recruitment.intel_confirmed':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase(eventType),
-            payload: {
-              week,
-              candidateId:
-                typeof payload.candidateId === 'string' ? payload.candidateId : `cand-${index + 1}`,
-              candidateName:
-                typeof payload.candidateName === 'string'
-                  ? payload.candidateName
-                  : `Candidate ${index + 1}`,
-              fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
-              stage: clamp(sanitizeInteger(payload.stage as number | undefined, 1, 1), 1, 3) as
-                | 1
-                | 2
-                | 3,
-              projectedTier: isOneOf(payload.projectedTier, EXACT_POTENTIAL_TIERS)
-                ? payload.projectedTier
-                : 'C',
-              confidence: isOneOf(payload.confidence, SCOUT_CONFIDENCES)
-                ? payload.confidence
-                : 'low',
-              previousProjectedTier: isOneOf(payload.previousProjectedTier, EXACT_POTENTIAL_TIERS)
-                ? payload.previousProjectedTier
-                : undefined,
-              previousConfidence: isOneOf(payload.previousConfidence, SCOUT_CONFIDENCES)
-                ? payload.previousConfidence
-                : undefined,
-              confirmedTier: isOneOf(payload.confirmedTier, EXACT_POTENTIAL_TIERS)
-                ? payload.confirmedTier
-                : undefined,
-              revealLevel: sanitizeRevealLevel(payload.revealLevel),
-              sourceFactionId:
-                typeof payload.sourceFactionId === 'string' ? payload.sourceFactionId : undefined,
-              sourceFactionName:
-                typeof payload.sourceFactionName === 'string'
-                  ? payload.sourceFactionName
+        {
+          const stage = clamp(sanitizeInteger(payload.stage as number | undefined, 1, 1), 1, 3) as
+            | 1
+            | 2
+            | 3
+          const revealLevel = reconcileRecruitmentEventRevealLevel(
+            stage,
+            sanitizeRevealLevel(payload.revealLevel)
+          )
+          const projectedTier = isOneOf(payload.projectedTier, EXACT_POTENTIAL_TIERS)
+            ? payload.projectedTier
+            : 'C'
+
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase(eventType),
+              payload: {
+                week,
+                candidateId:
+                  typeof payload.candidateId === 'string'
+                    ? payload.candidateId
+                    : `cand-${index + 1}`,
+                candidateName:
+                  typeof payload.candidateName === 'string'
+                    ? payload.candidateName
+                    : `Candidate ${index + 1}`,
+                fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
+                stage,
+                projectedTier,
+                confidence: isOneOf(payload.confidence, SCOUT_CONFIDENCES)
+                  ? payload.confidence
+                  : 'low',
+                previousProjectedTier: isOneOf(payload.previousProjectedTier, EXACT_POTENTIAL_TIERS)
+                  ? payload.previousProjectedTier
                   : undefined,
-              sourceContactId:
-                typeof payload.sourceContactId === 'string' ? payload.sourceContactId : undefined,
-              sourceContactName:
-                typeof payload.sourceContactName === 'string'
-                  ? payload.sourceContactName
+                previousConfidence: isOneOf(payload.previousConfidence, SCOUT_CONFIDENCES)
+                  ? payload.previousConfidence
                   : undefined,
-            },
-          })
-        )
+                confirmedTier:
+                  eventType === 'recruitment.intel_confirmed'
+                    ? isOneOf(payload.confirmedTier, EXACT_POTENTIAL_TIERS)
+                      ? payload.confirmedTier
+                      : projectedTier
+                    : isOneOf(payload.confirmedTier, EXACT_POTENTIAL_TIERS)
+                      ? payload.confirmedTier
+                      : undefined,
+                revealLevel,
+                sourceFactionId:
+                  typeof payload.sourceFactionId === 'string' ? payload.sourceFactionId : undefined,
+                sourceFactionName:
+                  typeof payload.sourceFactionName === 'string'
+                    ? payload.sourceFactionName
+                    : undefined,
+                sourceContactId:
+                  typeof payload.sourceContactId === 'string' ? payload.sourceContactId : undefined,
+                sourceContactName:
+                  typeof payload.sourceContactName === 'string'
+                    ? payload.sourceContactName
+                    : undefined,
+              },
+            })
+          )
+        }
         break
 
       case 'production.queue_started':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('production.queue_started'),
-            payload: {
-              week,
-              queueId: typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
-              queueName:
-                typeof payload.queueName === 'string' ? payload.queueName : `Queue ${index + 1}`,
-              recipeId:
-                typeof payload.recipeId === 'string' ? payload.recipeId : `recipe-${index + 1}`,
-              outputId:
-                typeof payload.outputId === 'string' ? payload.outputId : `output-${index + 1}`,
-              outputName:
-                typeof payload.outputName === 'string' ? payload.outputName : `Output ${index + 1}`,
-              outputQuantity: sanitizeInteger(payload.outputQuantity as number | undefined, 1, 1),
-              etaWeeks: sanitizeInteger(payload.etaWeeks as number | undefined, 1, 0),
-              fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
-              inputMaterials: sanitizeOperationEventProductionInputMaterials(payload),
-            },
-          })
-        )
+        {
+          const productionOutput = reconcileProductionEventRecipeOutput(
+            payload.recipeId,
+            payload.outputId,
+            payload.outputName
+          )
+
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase('production.queue_started'),
+              payload: {
+                week,
+                queueId:
+                  typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
+                queueName:
+                  typeof payload.queueName === 'string' ? payload.queueName : `Queue ${index + 1}`,
+                recipeId: productionOutput.recipeId,
+                outputId: productionOutput.outputId,
+                outputName: productionOutput.outputName,
+                outputQuantity: sanitizeInteger(payload.outputQuantity as number | undefined, 1, 1),
+                etaWeeks: sanitizeInteger(payload.etaWeeks as number | undefined, 1, 0),
+                fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
+                inputMaterials: sanitizeOperationEventProductionInputMaterials(payload),
+              },
+            })
+          )
+        }
         break
 
       case 'production.queue_completed':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('production.queue_completed'),
-            payload: {
-              week,
-              queueId: typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
-              queueName:
-                typeof payload.queueName === 'string' ? payload.queueName : `Queue ${index + 1}`,
-              recipeId:
-                typeof payload.recipeId === 'string' ? payload.recipeId : `recipe-${index + 1}`,
-              outputId:
-                typeof payload.outputId === 'string' ? payload.outputId : `output-${index + 1}`,
-              outputName:
-                typeof payload.outputName === 'string' ? payload.outputName : `Output ${index + 1}`,
-              outputQuantity: sanitizeInteger(payload.outputQuantity as number | undefined, 1, 1),
-              fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
-              inputMaterials: sanitizeOperationEventProductionInputMaterials(payload),
-            },
-          })
-        )
+        {
+          const productionOutput = reconcileProductionEventRecipeOutput(
+            payload.recipeId,
+            payload.outputId,
+            payload.outputName
+          )
+
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase('production.queue_completed'),
+              payload: {
+                week,
+                queueId:
+                  typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
+                queueName:
+                  typeof payload.queueName === 'string' ? payload.queueName : `Queue ${index + 1}`,
+                recipeId: productionOutput.recipeId,
+                outputId: productionOutput.outputId,
+                outputName: productionOutput.outputName,
+                outputQuantity: sanitizeInteger(payload.outputQuantity as number | undefined, 1, 1),
+                fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
+                inputMaterials: sanitizeOperationEventProductionInputMaterials(payload),
+              },
+            })
+          )
+        }
         break
 
       case 'market.shifted': {
@@ -8883,7 +9138,7 @@ export function hydrateGame(
     teams,
     squadKitTemplates
   )
-  const hydrationFunding = sanitizeInteger(game.funding as number | undefined, fallback.funding, 0)
+  const hydrationFunding = resolveHydratedFunding(game, fallback)
   const hydrationContainmentRating = sanitizeInteger(
     game.containmentRating as number | undefined,
     fallback.containmentRating,
@@ -8949,6 +9204,12 @@ export function hydrateGame(
   })
   const events = reconcileHydratedOperationEventRefs(sanitizedEvents)
   const market = sanitizeMarket(game.market, fallback.market, week)
+  const inventory = sanitizeInventory(game.inventory, fallback.inventory)
+  const damagedEquipmentQueue = sanitizeDamagedEquipmentQueue(
+    game.damagedEquipmentQueue,
+    inventory,
+    fallback.damagedEquipmentQueue
+  )
 
   const hydratedBase = stripUndefinedFields({
     ...fallback,
@@ -9019,7 +9280,8 @@ export function hydrateGame(
     caseQueue: sanitizeCaseQueueState(game.caseQueue, normalizedCases, fallback.caseQueue),
     reports,
     events,
-    inventory: sanitizeInventory(game.inventory, fallback.inventory),
+    inventory,
+    damagedEquipmentQueue,
     runtimeState,
     globalFlags,
     researchState: sanitizeResearchState(
@@ -9035,8 +9297,8 @@ export function hydrateGame(
       agents,
       fallback.relationshipHistory
     ),
-    hubState: sanitizeHubState(game.hubState),
-    prevHubState: sanitizeHubState(game.prevHubState),
+    hubState: sanitizeHubState(game.hubState, factions),
+    prevHubState: sanitizeHubState(game.prevHubState, factions),
     squadMetadata: sanitizeSquadMetadataMap(game.squadMetadata, teams, agents),
     squadKitTemplates,
     squadKitAssignments,
@@ -9241,6 +9503,8 @@ export function parseRunExport(raw: string, fallback = createStartingState()): G
   ) {
     throw new Error('Run payload version is not supported by this build.')
   }
+
+  validateImportTimestampMetadata(parsed.exportedAt, 'exportedAt')
 
   return hydrateGame(parsed.game, fallback, { allowLegacySyntheticRepair: true })
 }

--- a/src/app/store/saveSystem.test.ts
+++ b/src/app/store/saveSystem.test.ts
@@ -40,6 +40,56 @@ describe('saveSystem', () => {
     expect(payload.state).not.toHaveProperty('templates')
   })
 
+  it('rejects saves with missing, invalid, or future savedAt metadata', () => {
+    const fallback = createStartingState()
+    const basePayload = {
+      kind: GAME_SAVE_KIND,
+      version: GAME_SAVE_VERSION,
+      state: {
+        ...fallback,
+        week: 3,
+      },
+    }
+
+    expect(() => loadGameSave(JSON.stringify(basePayload))).toThrow(
+      'Save payload savedAt timestamp is missing or invalid.'
+    )
+    expect(() =>
+      loadGameSave(
+        JSON.stringify({
+          ...basePayload,
+          savedAt: 'not-a-date',
+        })
+      )
+    ).toThrow('Save payload savedAt timestamp is missing or invalid.')
+    expect(() =>
+      loadGameSave(
+        JSON.stringify({
+          ...basePayload,
+          savedAt: '2999-01-01T00:00:00.000Z',
+        })
+      )
+    ).toThrow('Save payload savedAt timestamp is from the future.')
+  })
+
+  it('accepts saves with valid savedAt metadata', () => {
+    const fallback = createStartingState()
+
+    const loaded = loadGameSave(
+      JSON.stringify({
+        kind: GAME_SAVE_KIND,
+        version: GAME_SAVE_VERSION,
+        savedAt: '2026-01-01T00:00:00.000Z',
+        state: {
+          ...fallback,
+          week: 4,
+        },
+      })
+    )
+
+    expect(loaded.week).toBe(4)
+  })
+
   it('round-trips authored runtime state, inventory, and breadcrumbs through save serialization', () => {
     let game = createStartingState()
 

--- a/src/app/store/saveSystem.ts
+++ b/src/app/store/saveSystem.ts
@@ -5,6 +5,7 @@ import {
   hydrateGame,
   parseRunExport,
   stripGameTemplates,
+  validateImportTimestampMetadata,
   type PersistedGame,
 } from './runTransfer'
 
@@ -52,6 +53,8 @@ export function hydrateGameSavePayload(payload: unknown, fallback = createStarti
   if (typeof payload.version !== 'number' || payload.version > GAME_SAVE_VERSION) {
     throw new Error('Save payload version is not supported by this build.')
   }
+
+  validateImportTimestampMetadata(payload.savedAt, 'savedAt', 'Save payload')
 
   return hydrateGame(payload.state, fallback)
 }

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -30,6 +30,7 @@ const startingStateTemplate: GameState = {
   reports: [],
   events: [],
   inventory: createStartingInventory(),
+  damagedEquipmentQueue: [],
   caseQueue: {
     queuedCaseIds: [],
     priorities: {},

--- a/src/domain/equipmentRecovery.ts
+++ b/src/domain/equipmentRecovery.ts
@@ -1,0 +1,37 @@
+import { getEquipmentDefinition } from './equipment'
+
+export const MAX_DAMAGED_EQUIPMENT_QUEUE_LENGTH = 64
+
+export function sanitizeDamagedEquipmentQueue(
+  value: unknown,
+  inventory: Record<string, number>,
+  fallback: readonly string[] = []
+): string[] {
+  const source = Array.isArray(value) ? value : fallback
+  const seen = new Set<string>()
+  const queue: string[] = []
+
+  for (const entry of source) {
+    if (typeof entry !== 'string') {
+      continue
+    }
+
+    const itemId = entry.trim()
+    if (!itemId || seen.has(itemId)) {
+      continue
+    }
+
+    if (!getEquipmentDefinition(itemId) || (inventory[itemId] ?? 0) <= 0) {
+      continue
+    }
+
+    seen.add(itemId)
+    queue.push(itemId)
+
+    if (queue.length >= MAX_DAMAGED_EQUIPMENT_QUEUE_LENGTH) {
+      break
+    }
+  }
+
+  return queue
+}

--- a/src/domain/funding.test.ts
+++ b/src/domain/funding.test.ts
@@ -341,6 +341,198 @@ describe('Funding, Procurement, & Budget Pressure System', () => {
     })
   })
 
+  it('sanitizes procurement backlog chronology and stale references during normalize', () => {
+    const longRequestId = `req-${'x'.repeat(160)}`
+    const longBlockedReason = `blocked-${'y'.repeat(160)}`
+    const normalized = normalizeFundingState(
+      500,
+      {
+        fundingBasePerWeek: basePerWeek,
+        fundingPerResolution: perResolution,
+        fundingPenaltyPerFail: penaltyPerFail,
+        fundingPenaltyPerUnresolved: penaltyPerUnresolved,
+      },
+      {
+        ...createInitialFundingState(
+          basePerWeek,
+          perResolution,
+          penaltyPerFail,
+          penaltyPerUnresolved,
+          500
+        ),
+        procurementBacklog: [
+          {
+            requestId: ' req-fulfilled-before ',
+            itemId: ' medkits ',
+            quantity: 2.9,
+            status: 'fulfilled',
+            requestedWeek: 4,
+            fulfilledWeek: 2,
+            cost: 12.345,
+            blockedReason: longBlockedReason,
+          },
+          {
+            requestId: 'req-future',
+            itemId: 'medkits',
+            quantity: 1,
+            status: 'pending',
+            requestedWeek: 99,
+            cost: 4,
+          },
+          {
+            requestId: 'req-invalid-status',
+            itemId: 'medkits',
+            quantity: 1,
+            status: 'lost' as 'pending',
+            requestedWeek: 3,
+            cost: 4,
+          },
+          {
+            requestId: 'req-unknown-item',
+            itemId: 'unknown_widget',
+            quantity: 1,
+            status: 'pending',
+            requestedWeek: 3,
+            cost: 7,
+          },
+          {
+            requestId: 'req-negative-cost',
+            itemId: 'medkits',
+            quantity: 1,
+            status: 'pending',
+            requestedWeek: 3,
+            cost: -9,
+          },
+          {
+            requestId: longRequestId,
+            itemId: 'medkits',
+            quantity: 1,
+            status: 'pending',
+            requestedWeek: 3,
+            cost: 8,
+            listingId: 'gear:field_plate',
+            delayWeeks: 2.8,
+          },
+          {
+            requestId: 'req-valid-delay',
+            itemId: 'medkits',
+            quantity: 1,
+            status: 'pending',
+            requestedWeek: 3,
+            cost: 8,
+            listingId: 'med-kits',
+            delayWeeks: 2,
+          },
+        ],
+      },
+      5
+    )
+
+    expect(normalized.procurementBacklog).toEqual([
+      {
+        requestId: 'req-negative-cost',
+        itemId: 'medkits',
+        quantity: 1,
+        requestedWeek: 3,
+        cost: 0,
+        status: 'pending',
+      },
+      {
+        requestId: 'req-unknown-item',
+        itemId: 'unknown_widget',
+        quantity: 1,
+        requestedWeek: 3,
+        cost: 7,
+        status: 'cancelled',
+        fulfilledWeek: 3,
+        blockedReason: 'unknown_item',
+      },
+      {
+        requestId: 'req-valid-delay',
+        itemId: 'medkits',
+        quantity: 1,
+        requestedWeek: 3,
+        cost: 8,
+        status: 'pending',
+        listingId: 'med-kits',
+        delayWeeks: 2,
+      },
+      {
+        requestId: longRequestId.slice(0, 120),
+        itemId: 'medkits',
+        quantity: 1,
+        requestedWeek: 3,
+        cost: 8,
+        status: 'cancelled',
+        fulfilledWeek: 3,
+        blockedReason: 'stale_listing',
+        delayWeeks: 2,
+      },
+      {
+        requestId: 'req-fulfilled-before',
+        itemId: 'medkits',
+        quantity: 2,
+        requestedWeek: 4,
+        cost: 12.35,
+        status: 'fulfilled',
+        fulfilledWeek: 4,
+        blockedReason: longBlockedReason.slice(0, 120),
+      },
+      {
+        requestId: 'req-future',
+        itemId: 'medkits',
+        quantity: 1,
+        requestedWeek: 5,
+        cost: 4,
+        status: 'pending',
+      },
+    ])
+  })
+
+  it('sanitizes funding history audit rows during normalize', () => {
+    const longReason = `custom-${'x'.repeat(120)}`
+    const longSourceId = `source-${'y'.repeat(160)}`
+    const normalized = normalizeFundingState(
+      500,
+      {
+        fundingBasePerWeek: basePerWeek,
+        fundingPerResolution: perResolution,
+        fundingPenaltyPerFail: penaltyPerFail,
+        fundingPenaltyPerUnresolved: penaltyPerUnresolved,
+      },
+      {
+        ...createInitialFundingState(
+          basePerWeek,
+          perResolution,
+          penaltyPerFail,
+          penaltyPerUnresolved,
+          500
+        ),
+        fundingHistory: [
+          { week: week + 99, delta: 12.345, reason: ' weekly_income ', sourceId: ' source-a ' },
+          { week: 2, delta: Number.NaN, reason: 'resolution_reward' },
+          { week: 3, delta: 9, reason: '   ' },
+          { week: 4, delta: 10, reason: longReason, sourceId: longSourceId },
+          { week: 4, delta: 11, reason: longReason, sourceId: longSourceId },
+          { week: 5, delta: -9_999_999, reason: 'failure_penalty' },
+          { week: 5, delta: 4, reason: 'market_transaction', sourceId: 'missing-request' },
+        ],
+      },
+      5
+    )
+
+    expect(normalized.fundingHistory).toEqual([
+      {
+        week: 4,
+        delta: 10,
+        reason: longReason.slice(0, 80),
+        sourceId: longSourceId.slice(0, 120),
+      },
+      { week: 5, delta: -1_000_000, reason: 'failure_penalty' },
+      { week: 5, delta: 12.35, reason: 'weekly_income', sourceId: 'source-a' },
+    ])
+  })
+
   it('throws on invalid status transitions', () => {
     let state = createInitialFundingState(basePerWeek, perResolution, penaltyPerFail, penaltyPerUnresolved, 100)
     state = placeProcurementOrder(state, {

--- a/src/domain/funding.ts
+++ b/src/domain/funding.ts
@@ -21,8 +21,18 @@ import { FUNDING_CALIBRATION } from './sim/calibration'
 import { hasCompromisedAuthorityProcurementDiversionSignals } from './sim/compromisedAuthority'
 
 const PROCUREMENT_SOURCE_REASONS = new Set<string>(['market_transaction'])
+const FUNDING_HISTORY_DELTA_LIMIT = 1_000_000
+const FUNDING_HISTORY_REASON_MAX_LENGTH = 80
+const FUNDING_HISTORY_SOURCE_ID_MAX_LENGTH = 120
+const PROCUREMENT_BACKLOG_REQUEST_ID_MAX_LENGTH = 120
+const PROCUREMENT_BACKLOG_BLOCKED_REASON_MAX_LENGTH = 120
+const PROCUREMENT_BACKLOG_LISTING_ID_MAX_LENGTH = 120
+const PROCUREMENT_BACKLOG_COST_LIMIT = 1_000_000
+const PROCUREMENT_BACKLOG_QUANTITY_LIMIT = 999
+const PROCUREMENT_BACKLOG_DELAY_WEEKS_LIMIT = 52
 
 let knownProcurementItemIdsCache: Set<string> | undefined
+let knownProcurementListingItemIdsCache: Map<string, string> | undefined
 
 export function getKnownProcurementItemIds(): Set<string> {
   if (!knownProcurementItemIdsCache) {
@@ -35,6 +45,24 @@ export function getKnownProcurementItemIds(): Set<string> {
   }
 
   return knownProcurementItemIdsCache
+}
+
+function getKnownProcurementListingItemIds(): Map<string, string> {
+  if (!knownProcurementListingItemIdsCache) {
+    knownProcurementListingItemIdsCache = new Map([
+      ...productionCatalog.map(
+        (recipe) => [recipe.recipeId, recipe.outputItemId] as const
+      ),
+      ...productionMaterialCatalog.map(
+        (material) => [`material:${material.materialId}`, material.materialId] as const
+      ),
+      ...getEquipmentCatalogEntries().map(
+        (definition) => [`gear:${definition.id}`, definition.id] as const
+      ),
+    ])
+  }
+
+  return knownProcurementListingItemIdsCache
 }
 
 type FundingConfig = Pick<
@@ -178,6 +206,26 @@ function isFundingHistorySourceIdValid(
   return sourceId.trim().length > 0
 }
 
+function sanitizeFundingHistoryReason(value: string) {
+  return value.trim().slice(0, FUNDING_HISTORY_REASON_MAX_LENGTH)
+}
+
+function sanitizeFundingHistorySourceId(value: unknown) {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const sourceId = value.trim().slice(0, FUNDING_HISTORY_SOURCE_ID_MAX_LENGTH)
+  return sourceId.length > 0 ? sourceId : undefined
+}
+
+function sanitizeFundingHistoryDelta(value: number) {
+  return Math.max(
+    -FUNDING_HISTORY_DELTA_LIMIT,
+    Math.min(FUNDING_HISTORY_DELTA_LIMIT, Number(value.toFixed(2)))
+  )
+}
+
 function sanitizeFundingHistory(
   value: FundingState['fundingHistory'] | undefined,
   campaignWeek: number,
@@ -201,11 +249,8 @@ function sanitizeFundingHistory(
     )
     .map((entry) => {
       const week = clampCampaignWeek(entry.week, cappedWeek, cappedWeek)
-      const reason = entry.reason.trim() as FundingCategory
-      const sourceId =
-        typeof entry.sourceId === 'string' && entry.sourceId.trim().length > 0
-          ? entry.sourceId.trim()
-          : undefined
+      const reason = sanitizeFundingHistoryReason(entry.reason) as FundingCategory
+      const sourceId = sanitizeFundingHistorySourceId(entry.sourceId)
 
       if (!isFundingHistorySourceIdValid(reason, sourceId, procurementRequestIds)) {
         return null
@@ -213,7 +258,7 @@ function sanitizeFundingHistory(
 
       return {
         week,
-        delta: Number(entry.delta.toFixed(2)),
+        delta: sanitizeFundingHistoryDelta(entry.delta),
         reason,
         ...(sourceId ? { sourceId } : {}),
       }
@@ -236,39 +281,92 @@ function sanitizeFundingHistory(
 
       return left.delta - right.delta
     })
+    .filter((entry, index, entries) => {
+      const key = `${entry.week}:${entry.reason}:${entry.sourceId ?? ''}`
+      return (
+        entries.findIndex(
+          (candidate) =>
+            `${candidate.week}:${candidate.reason}:${candidate.sourceId ?? ''}` === key
+        ) === index
+      )
+    })
+}
+
+function sanitizeProcurementBacklogRequestId(value: string) {
+  return value.trim().slice(0, PROCUREMENT_BACKLOG_REQUEST_ID_MAX_LENGTH)
+}
+
+function sanitizeProcurementBacklogBlockedReason(value: unknown) {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const blockedReason = value.trim().slice(0, PROCUREMENT_BACKLOG_BLOCKED_REASON_MAX_LENGTH)
+  return blockedReason.length > 0 ? blockedReason : undefined
+}
+
+function sanitizeProcurementBacklogListingId(value: unknown) {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const listingId = value.trim().slice(0, PROCUREMENT_BACKLOG_LISTING_ID_MAX_LENGTH)
+  return listingId.length > 0 ? listingId : undefined
+}
+
+function sanitizeProcurementBacklogCost(value: number) {
+  return Math.max(0, Math.min(PROCUREMENT_BACKLOG_COST_LIMIT, Number(value.toFixed(2))))
 }
 
 function sanitizeProcurementBacklogEntry(
   entry: ProcurementBacklogEntry,
   campaignWeek: number,
-  knownItemIds: Set<string>
+  knownItemIds: Set<string>,
+  knownListingItemIds: Map<string, string>
 ): ProcurementBacklogEntry | null {
   const cappedWeek = Math.max(1, Math.trunc(campaignWeek))
+  const requestId = sanitizeProcurementBacklogRequestId(entry.requestId)
+  const itemId = entry.itemId.trim()
+  if (requestId.length === 0 || itemId.length === 0) {
+    return null
+  }
+
   if (typeof entry.quantity !== 'number' || !Number.isFinite(entry.quantity) || entry.quantity < 1) {
     return null
   }
 
-  const quantity = Math.max(1, Math.trunc(entry.quantity))
+  const quantity = Math.min(
+    PROCUREMENT_BACKLOG_QUANTITY_LIMIT,
+    Math.max(1, Math.trunc(entry.quantity))
+  )
 
   const requestedWeek = clampCampaignWeek(entry.requestedWeek, cappedWeek, 1)
   let status = entry.status
+  const originalStatus = status
   let fulfilledWeek =
     typeof entry.fulfilledWeek === 'number' && Number.isFinite(entry.fulfilledWeek)
       ? clampCampaignWeek(entry.fulfilledWeek, cappedWeek, requestedWeek)
       : undefined
-  let blockedReason =
-    typeof entry.blockedReason === 'string' && entry.blockedReason.trim().length > 0
-      ? entry.blockedReason.trim()
-      : undefined
+  let blockedReason = sanitizeProcurementBacklogBlockedReason(entry.blockedReason)
 
-  const itemKnown = knownItemIds.has(entry.itemId)
+  const itemKnown = knownItemIds.has(itemId)
 
   if (!itemKnown) {
+    status = 'cancelled'
+    fulfilledWeek = originalStatus === 'pending' ? requestedWeek : (fulfilledWeek ?? requestedWeek)
+    blockedReason = blockedReason ?? 'unknown_item'
+  }
+
+  const listingId = sanitizeProcurementBacklogListingId(entry.listingId)
+  const knownListingItemId = listingId ? knownListingItemIds.get(listingId) : undefined
+  const staleListing = Boolean(listingId && knownListingItemId !== itemId)
+
+  if (staleListing) {
     if (status === 'pending') {
       status = 'cancelled'
       fulfilledWeek = requestedWeek
-      blockedReason = blockedReason ?? 'unknown_item'
     }
+    blockedReason = blockedReason ?? 'stale_listing'
   }
 
   if (status === 'pending') {
@@ -280,25 +378,24 @@ function sanitizeProcurementBacklogEntry(
     }
   }
 
-  const listingId =
-    typeof entry.listingId === 'string' && entry.listingId.trim().length > 0
-      ? entry.listingId.trim()
-      : undefined
   const delayWeeks =
     typeof entry.delayWeeks === 'number' && Number.isFinite(entry.delayWeeks)
-      ? Math.max(0, Math.trunc(entry.delayWeeks))
+      ? Math.min(
+          PROCUREMENT_BACKLOG_DELAY_WEEKS_LIMIT,
+          Math.max(0, Math.trunc(entry.delayWeeks))
+        )
       : undefined
 
   return {
-    requestId: entry.requestId,
-    itemId: entry.itemId,
+    requestId,
+    itemId,
     quantity,
     requestedWeek,
-    cost: sanitizeInteger(entry.cost, 0, 0),
+    cost: sanitizeProcurementBacklogCost(entry.cost),
     status,
     ...(fulfilledWeek !== undefined ? { fulfilledWeek } : {}),
     ...(blockedReason ? { blockedReason } : {}),
-    ...(listingId ? { listingId } : {}),
+    ...(listingId && !staleListing ? { listingId } : {}),
     ...(delayWeeks !== undefined ? { delayWeeks } : {}),
   }
 }
@@ -316,9 +413,9 @@ function sanitizeProcurementBacklog(
     .filter(
       (entry): entry is ProcurementBacklogEntry =>
         typeof entry?.requestId === 'string' &&
-        entry.requestId.length > 0 &&
+        entry.requestId.trim().length > 0 &&
         typeof entry.itemId === 'string' &&
-        entry.itemId.length > 0 &&
+        entry.itemId.trim().length > 0 &&
         typeof entry.quantity === 'number' &&
         Number.isFinite(entry.quantity) &&
         typeof entry.requestedWeek === 'number' &&
@@ -327,7 +424,14 @@ function sanitizeProcurementBacklog(
         Number.isFinite(entry.cost) &&
         (entry.status === 'pending' || entry.status === 'fulfilled' || entry.status === 'cancelled')
     )
-    .map((entry) => sanitizeProcurementBacklogEntry(entry, campaignWeek, knownItemIds))
+    .map((entry) =>
+      sanitizeProcurementBacklogEntry(
+        entry,
+        campaignWeek,
+        knownItemIds,
+        getKnownProcurementListingItemIds()
+      )
+    )
     .filter((entry): entry is ProcurementBacklogEntry => entry !== null)
     .sort((left, right) => {
       if (left.requestedWeek !== right.requestedWeek) {

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -2570,6 +2570,11 @@ export interface GameState {
   /** Historical snapshots of relationship values for trend analysis and chemistry prediction. */
   relationshipHistory?: RelationshipSnapshot[]
   inventory: Record<string, number>
+  /**
+   * Canonical weekly maintenance backlog of damaged equipment item IDs.
+   * Hydration and weekly recovery keep this bounded to unique, owned equipment-catalog entries.
+   */
+  damagedEquipmentQueue?: Id[]
   caseQueue?: CaseQueueState
   trainingQueue: TrainingQueueEntry[]
   productionQueue: ProductionQueueEntry[]

--- a/src/domain/protocols.ts
+++ b/src/domain/protocols.ts
@@ -235,7 +235,8 @@ export function sanitizePersistedAgencyProtocols(
   const catalog = new Set(PROTOCOL_CATALOG_IDS)
   const selectionLimit = resolvePersistedProtocolSelectionLimit(record, clearanceLevel)
   const hasLimitField =
-    typeof record.protocolSelectionLimit === 'number' && Number.isFinite(record.protocolSelectionLimit)
+    typeof record.protocolSelectionLimit === 'number' &&
+    Number.isFinite(record.protocolSelectionLimit)
   const hasActiveField = Array.isArray(record.activeProtocolIds)
 
   if (!hasLimitField && !hasActiveField) {
@@ -245,8 +246,11 @@ export function sanitizePersistedAgencyProtocols(
   const activeProtocolIds = hasActiveField
     ? [
         ...new Set(
-          record.activeProtocolIds!
-            .filter((id): id is string => typeof id === 'string' && id.length > 0)
+          record
+            .activeProtocolIds!.filter(
+              (id): id is string => typeof id === 'string' && id.trim().length > 0
+            )
+            .map((id) => id.trim())
             .filter((id) => catalog.has(id))
         ),
       ].slice(0, selectionLimit)

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -61,13 +61,10 @@ function getMissionResultHiddenStateFields(
 // SPE-94: Maintenance Specialist Bottleneck for Equipment Recovery
 /**
  * Returns a deterministic queue of damaged equipment item IDs for recovery.
- * For this implementation, we assume a field state.damagedEquipmentQueue: string[] exists or is derived.
- * In a real system, this would be derived from agent/equipment state each week.
+ * Queue entries are persisted as item IDs and sanitized against owned catalog equipment.
  */
 function getDamagedEquipmentQueue(state: GameState): string[] {
-  const { damagedEquipmentQueue } = state as AdvanceWeekState
-
-  return Array.isArray(damagedEquipmentQueue) ? [...damagedEquipmentQueue] : []
+  return sanitizeDamagedEquipmentQueue(state.damagedEquipmentQueue, state.inventory)
 }
 
 /**
@@ -345,6 +342,7 @@ import { listQueuedRuntimeEvents } from '../eventQueue'
 import { advanceRecoveryAgentsForWeek } from './recoveryPipeline'
 import { resolveDowntimeSlotForAgent } from './downtimeSlot'
 import { advanceRecoveryDowntimeForWeek, type DowntimeActivity } from './recoveryDowntime'
+import { sanitizeDamagedEquipmentQueue } from '../equipmentRecovery'
 import {
   applyWeeklyInventoryHoldingCostToFundingState,
   applyWeeklyOperatingCostToFundingState,
@@ -385,7 +383,6 @@ import { applyDwell } from './weirdRoom'
 import { previewResolutionForTeamIds } from './resolve'
 
 type AdvanceWeekState = GameState & {
-  damagedEquipmentQueue?: string[]
   id?: string
   neighborhoodPackets?: readonly NeighborhoodIncidentPacket[]
   civicConsequencePackets?: readonly CompactCivicAuthorityConsequencePacket[]
@@ -3867,11 +3864,7 @@ function advanceQueues(context: WeeklyExecutionContext) {
   const maintenanceCapacity = context.nextState.agency?.maintenanceSpecialistsAvailable ?? 0
   const { recovered, delayed } = applyEquipmentRecoveryBottleneck(damagedQueue, maintenanceCapacity)
 
-  // For demo: remove recovered items from damagedEquipmentQueue, leave delayed for next week
-  const nextStateWithExtras = context.nextState as AdvanceWeekState
-  if (nextStateWithExtras.damagedEquipmentQueue) {
-    nextStateWithExtras.damagedEquipmentQueue = [...delayed]
-  }
+  context.nextState.damagedEquipmentQueue = [...delayed]
 
   // Surface bottleneck/help signals in report notes
   if (damagedQueue.length > 0) {
@@ -4566,7 +4559,7 @@ export function advanceWeek(
   // SPE-854 slice 4: accumulate weekly corroboration/contradiction on persisted intake reports.
   const intakeCorroborationWeek = sourceState.week
 
-  // Patch: preserve unknown fields from input state for testability (e.g., damagedEquipmentQueue)
+  // Patch: preserve unknown fields from input state for testability.
   const stateWithUnknownFields = state as unknown as Record<string, unknown>
   const resultWithUnknownFields = result as unknown as Record<string, unknown>
   for (const key of Object.keys(stateWithUnknownFields)) {

--- a/src/test/sim.equipmentRecoveryBottleneck.test.ts
+++ b/src/test/sim.equipmentRecoveryBottleneck.test.ts
@@ -2,63 +2,94 @@ import { describe, it, expect } from 'vitest'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { createStartingState } from '../data/startingState'
 
-type RuntimeStateWithDamagedQueue = ReturnType<typeof createStartingState> & {
-  damagedEquipmentQueue?: string[]
-}
-
 describe('SPE-94: Equipment Recovery Bottleneck', () => {
-
   it('recovers up to maintenanceSpecialistsAvailable damaged items per week, delaying the rest (player-facing)', () => {
     const state = createStartingState()
-    ;(state as RuntimeStateWithDamagedQueue).damagedEquipmentQueue = [
-      'itemA', 'itemB', 'itemC', 'itemD', 'itemE'
+    state.inventory.medkits = 1
+    state.inventory.ward_seals = 1
+    state.inventory.silver_rounds = 1
+    state.inventory.signal_jammers = 1
+    state.inventory.emf_sensors = 1
+    state.damagedEquipmentQueue = [
+      'medkits',
+      'ward_seals',
+      'silver_rounds',
+      'signal_jammers',
+      'emf_sensors',
     ]
     state.agency!.maintenanceSpecialistsAvailable = 2
 
     const next = advanceWeek(state)
     const report = next.reports[0]
-    const recoveryNote = report.notes.find((note) =>
-      note.type === 'system.equipment_recovered'
-    )
+    const recoveryNote = report.notes.find((note) => note.type === 'system.equipment_recovered')
     expect(recoveryNote).toBeDefined()
     expect(recoveryNote?.metadata?.recoveredCount).toBe(2)
     expect(recoveryNote?.metadata?.delayedCount).toBe(3)
     expect(recoveryNote?.metadata?.maintenanceCapacity).toBe(2)
     expect(recoveryNote?.metadata?.damagedCount).toBe(5)
+    expect(next.damagedEquipmentQueue).toEqual(['silver_rounds', 'signal_jammers', 'emf_sensors'])
   })
-
 
   it('recovers all items if capacity >= queue length (player-facing)', () => {
     const state = createStartingState()
-    ;(state as RuntimeStateWithDamagedQueue).damagedEquipmentQueue = ['itemA', 'itemB']
+    state.inventory.medkits = 1
+    state.inventory.ward_seals = 1
+    state.damagedEquipmentQueue = ['medkits', 'ward_seals']
     state.agency!.maintenanceSpecialistsAvailable = 5
 
     const next = advanceWeek(state)
     const report = next.reports[0]
-    const recoveryNote = report.notes.find((note) =>
-      note.type === 'system.equipment_recovered'
-    )
+    const recoveryNote = report.notes.find((note) => note.type === 'system.equipment_recovered')
     expect(recoveryNote).toBeDefined()
     expect(recoveryNote?.metadata?.recoveredCount).toBe(2)
     expect(recoveryNote?.metadata?.delayedCount).toBe(0)
     expect(recoveryNote?.metadata?.maintenanceCapacity).toBe(5)
     expect(recoveryNote?.metadata?.damagedCount).toBe(2)
+    expect(next.damagedEquipmentQueue).toEqual([])
   })
 
   it('delays all items if capacity is zero (player-facing)', () => {
     const state = createStartingState()
-    ;(state as RuntimeStateWithDamagedQueue).damagedEquipmentQueue = ['itemA', 'itemB', 'itemC']
+    state.inventory.medkits = 1
+    state.inventory.ward_seals = 1
+    state.inventory.silver_rounds = 1
+    state.damagedEquipmentQueue = ['medkits', 'ward_seals', 'silver_rounds']
     state.agency!.maintenanceSpecialistsAvailable = 0
 
     const next = advanceWeek(state)
     const report = next.reports[0]
-    const recoveryNote = report.notes.find((note) =>
-      note.type === 'system.equipment_recovered'
-    )
+    const recoveryNote = report.notes.find((note) => note.type === 'system.equipment_recovered')
     expect(recoveryNote).toBeDefined()
     expect(recoveryNote?.metadata?.recoveredCount).toBe(0)
     expect(recoveryNote?.metadata?.delayedCount).toBe(3)
     expect(recoveryNote?.metadata?.maintenanceCapacity).toBe(0)
     expect(recoveryNote?.metadata?.damagedCount).toBe(3)
+    expect(next.damagedEquipmentQueue).toEqual(['medkits', 'ward_seals', 'silver_rounds'])
+  })
+
+  it('ignores malformed, duplicate, unknown, and unowned damaged queue entries before recovery', () => {
+    const state = createStartingState()
+    state.inventory.medkits = 1
+    state.inventory.ward_seals = 1
+    state.inventory.silver_rounds = 0
+    ;(state as unknown as { damagedEquipmentQueue: unknown[] }).damagedEquipmentQueue = [
+      ' medkits ',
+      'medkits',
+      '',
+      'unknown_equipment',
+      'silver_rounds',
+      'ward_seals',
+    ]
+    state.agency!.maintenanceSpecialistsAvailable = 1
+
+    const next = advanceWeek(state)
+    const report = next.reports[0]
+    const recoveryNote = report.notes.find((note) => note.type === 'system.equipment_recovered')
+
+    expect(recoveryNote).toBeDefined()
+    expect(recoveryNote?.metadata?.recovered).toEqual(['medkits'])
+    expect(recoveryNote?.metadata?.delayed).toEqual(['ward_seals'])
+    expect(recoveryNote?.metadata?.damagedCount).toBe(2)
+    expect(next.damagedEquipmentQueue).toEqual(['ward_seals'])
   })
 })


### PR DESCRIPTION
## Summary
- add hydration sanitizers for hub snapshots, damaged equipment recovery queue, agency protocol fields, funding mirrors/history/procurement backlog, facility upgrade timing, market audit payloads, infiltration fractions, decimal precision, and save/export timestamps
- model `damagedEquipmentQueue` as canonical GameState and sanitize it against catalog/inventory state
- keep durable audit data where useful, dropping or repairing stale/malformed IDs and impossible chronology during import

## Linear
- SPE-2547
- SPE-2548
- SPE-2549
- SPE-2550
- SPE-2551
- SPE-2552
- SPE-2553
- SPE-2554
- SPE-2555

## Tests
- `npm run test:run -- src/app/store/runTransfer.test.ts`
- `npm run test:run -- src/app/store/saveSystem.test.ts src/app/store/gameStore.test.ts`
- `npm run test:run -- src/domain/funding.test.ts src/test/sim.equipmentRecoveryBottleneck.test.ts`
- `npm run test:run -- src/app/App.test.tsx`
- `npm run test:run`