### PR TITLE
docs: require independent PR review during babysit

### DIFF
--- a/.cursor/rules/implementation-lite.mdc
+++ b/.cursor/rules/implementation-lite.mdc
@@ -100,7 +100,12 @@ Run the ship loop only **after** pre-ship audit completion criteria are met:
 2. **Push** the branch to `origin` (`git push -u origin HEAD` when the remote branch is new).
 3. **Open a PR** against `main` with the PR mapping body below.
 4. **Linear:** comment the PR URL on the **slice** issue; keep the slice **In Progress** until merge (then **Done** + merge comment per `linear-always-update.mdc`).
-5. **Babysit → merge (same session, mandatory):** after the PR opens, babysit until CI is clean and the PR is mergeable — triage review comments, fix in-boundary failures, push, re-watch `gh pr checks` until green. Then **merge** the PR (`gh pr merge`). Do **not** end the session or write a next-issue plan while the PR is still open.
+5. **Babysit → merge (same session, mandatory):** after the PR opens, babysit until CI is clean and the PR is mergeable. **Do not** rely only on existing PR comments — run a full independent review first, then triage external feedback and CI. Sub-steps (in order):
+   - **Independent review (mandatory):** review the full branch diff against `main` from scratch — slice doc, Linear acceptance, edge cases, regressions, tests, docs. Use `code-reviewer` and/or `bugbot` subagents on non-trivial diffs. Record findings (critical / warning / note).
+   - **Fix in-boundary findings** from the independent review; push.
+   - **Triage external review comments** (humans, Bugbot, Copilot); fix valid in-scope requests; explain or defer out-of-scope items on the PR.
+   - **CI loop:** fix in-boundary failures; merge `main` when the branch is behind; push; re-watch `gh pr checks` until green and mergeable.
+   - **Merge** the PR (`gh pr merge`). Do **not** end the session or write a next-issue plan while the PR is still open.
 6. **Sync `main`:** `git checkout main` && `git pull origin main`. Confirm the merge commit is on local `main`.
 
 Do **not** end an implementation session with only local files, uncommitted work, an open unmerged PR, or "say if you want a PR."
@@ -137,7 +142,7 @@ If Linear tooling is unavailable, report the exact status/comment update that sh
 
 ## Session closeout (mandatory)
 
-**Order:** ship loop → babysit CI → merge → `checkout main` && pull → **then** closeout. **Do not** produce a next-issue plan until merge and local `main` sync are complete.
+**Order:** ship loop → babysit (independent review + comment triage + CI) → merge → `checkout main` && pull → **then** closeout. **Do not** produce a next-issue plan until merge and local `main` sync are complete.
 
 ### Phase A — PR open, babysit blocked (interim only)
 

--- a/.cursor/rules/implementation-lite.mdc
+++ b/.cursor/rules/implementation-lite.mdc
@@ -116,7 +116,9 @@ Repo ship loop overrides a generic "commit only when asked" preference for Conta
 
 ## PR mapping
 
-When opening or updating a PR, the PR body must name:
+When opening or updating a PR, use `.github/pull_request_template.md` as the body scaffold. The **Summary** section includes `@coderabbitai summary` — CodeRabbit replaces that placeholder on review; fill the remaining sections before merge.
+
+The PR body must name:
 
 - the canonical Linear issue
 - any parent issue
@@ -127,6 +129,46 @@ When opening or updating a PR, the PR body must name:
 - whether the parent remains open
 
 If the PR satisfies a child issue, do not reference only the parent.
+
+**Agent `gh pr create` body** (fill placeholders; keep template section order):
+
+```markdown
+## Linear
+
+- **Slice issue:** SPE-___ — <url>
+- **Parent issue (if any):** <!-- or none -->
+- **Child issues covered:** <!-- or slice only -->
+
+## Summary
+
+@coderabbitai summary
+
+## What shipped
+
+- 
+
+## Docs updated
+
+- 
+
+## Parent status
+
+- 
+
+## Scope boundary
+
+- 
+
+## Validation
+
+- [ ] Targeted tests: 
+- [ ] Lint / verify: 
+
+## Linear updated
+
+- [ ] Slice issue linked in PR body
+- [ ] PR URL on slice issue
+```
 
 ## Linear updates
 

--- a/.cursor/rules/linear-always-update.mdc
+++ b/.cursor/rules/linear-always-update.mdc
@@ -17,7 +17,7 @@ Linear is the **system of record** for issue state, scope, and closure. GitHub P
 | **During work** | Harvest triage: **`docs/harvest-candidate-triage-agent.md`**; owner comments with full mechanic + boundary + fold-in vs child reasoning (**`docs/harvest-fold-in-linear-comments.md`**, not one-liners); owner map QA **`docs/harvest-mirror-owner-map-qa.md`**; SPE-2110 intake same session; comment on slice issue when scope or blockers change materially. |
 | **Slice ready** | **Commit**, **push**, and **open PR** on the named branch before claiming the slice complete locally (`implementation-lite.mdc` ship loop). |
 | **PR opened** | Link the **slice** issue in the PR body (not only the parent epic); comment PR URL on the slice issue. |
-| **Babysit → merge** | Same session: babysit CI until green, merge PR, then `git checkout main` && `git pull origin main` (`implementation-lite.mdc`). |
+| **Babysit → merge** | Same session: independent review + comment triage + CI until green, merge PR, then `git checkout main` && `git pull origin main` (`implementation-lite.mdc`). |
 | **PR merged** | Set slice issue **Done**; parent **Done** only if full parent scope shipped, else return parent to **Backlog**. |
 | **After merge** | Short comment on the slice issue: PR URL + what shipped. |
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,35 @@
 ## Linear
 
-- **Slice issue:** <!-- SPE-___ URL — canonical scope and acceptance -->
+- **Slice issue:** <!-- SPE-___ + URL — canonical scope and acceptance -->
 - **Parent issue (if any):** <!-- leave blank when none -->
+- **Child issues covered:** <!-- list each child this branch satisfies, or "slice only" -->
+
+## Summary
+
+@coderabbitai summary
+
+<!-- CodeRabbit replaces the line above on review. Add slice-specific bullets below only when needed. -->
+
+## What shipped
+
+<!-- 1–3 bullets: behavior, files, acceptance satisfied -->
+
+## Docs updated
+
+<!-- paths, or "none" -->
+
+## Parent status
+
+<!-- e.g. Parent remains open — child slice only / Parent can close — full umbrella shipped -->
 
 ## Scope boundary
 
 <!-- What this PR deliberately does *not* change -->
 
-## Summary
-
-<!-- What shipped in 1–3 bullets -->
-
-## Files changed
-
-<!-- High-signal paths only -->
-
 ## Validation
 
 - [ ] Targeted tests: <!-- command(s) run -->
-- [ ] Lint / verify scripts (if touched): <!-- e.g. npm run verify:audits-index -->
+- [ ] Lint / verify scripts (if touched): <!-- e.g. npm run lint, npm run verify:audits-index -->
 
 ## Screenshots (UI only)
 
@@ -26,9 +37,10 @@
 
 ## Follow-ups
 
-<!-- Remaining slices or known gaps -->
+<!-- Remaining slices or known gaps; match slice doc ## Deferred when applicable -->
 
 ## Linear updated
 
-- [ ] Issue moved to accurate status
-- [ ] Merge comment added with PR URL and validation
+- [ ] Slice issue linked in this PR body (not parent only)
+- [ ] PR URL commented on slice issue
+- [ ] Accurate status through merge (Done only when full child boundary ships)

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ remaining-subset.json
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+*.code-workspace
 .idea
 
 # Cursor-local agent config (solo dev; environment.json stays tracked)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,49 @@ All scripts are documented in `README.md` under the **Scripts** section and in `
 - **Session closeout:** phase A after PR open (audit closeout only — **no** next-issue plan); phase B after merge (next-issue plan only). Formats in `docs/agent-session-closeout.md`; User Rules paste: `docs/cursor-session-closeout-user-rules-snippet.md`.
 - **Deferred work:** same session — slice doc `## Deferred` + Linear parent/child comment; see `docs/agent-session-closeout.md` § Deferred work recording and `.cursor/rules/implementation-lite.mdc`.
 - **Backlog hygiene passes:** paste from `docs/cursor-backlog-hygiene-user-rules-snippet.md` (optional local `.cursor/rules/backlog-hygiene.mdc`; grooming only, not implementation).
+
+---
+
+## Review guidelines
+
+Codex (`@codex review`), Copilot code review, Gemini Code Assist, CharlieHelps, and other PR reviewers should enforce the same bar. Read the PR description for the Linear slice issue, `planning/*-slice.md`, and stated boundary before commenting.
+
+### Severity
+
+- **P0 / P1 (flag):** correctness bugs, determinism breaks, persistence/hydration gaps, layer-boundary violations, week-close ordering errors, hidden-state leaks through UI, event schema/migration regressions, missing tests when acceptance requires coverage, security issues.
+- **Do not flag:** style-only nits, drive-by refactors, scope expansion suggestions, or pre-existing `npm run build` baseline TS drift unless this PR makes it worse (see caveats above).
+
+### Architecture
+
+Per `docs/dependency-boundaries.md` and `src/test/boundary-enforcement.test.ts`:
+
+- **Domain** (`src/domain/**`): pure simulation; no store/projection/UI imports.
+- **Store** (`src/app/store/**`): orchestration; may import domain only.
+- **Projections** (`src/features/*View.ts`): pure selectors; no UI or cross-feature imports.
+- **UI** (`src/features/**`): presentational; use projections. Do not re-derive canonical domain summaries when a domain helper or projection already owns them.
+- **Vite 8:** type-only imports must use `import type { ... }` in dev-server-loaded files.
+
+### Simulation and state
+
+- Outcomes must be reproducible (seeded RNG; no hidden randomness or silent mutation).
+- Week-close hooks belong on week-close — flag mid-week mutations that should run at close as P0.
+- New persisted fields need normalization defaults and event schema/migration updates per `SCHEMA_REGISTRY.md`.
+
+### Scope discipline
+
+- PR must match linked Linear/slice acceptance; flag scope creep as P1.
+- Do not request unrelated refactors, renames, or parallel subsystems.
+- Do not duplicate feedback already fixed in the same PR unless the fix is wrong.
+
+### Tests and docs
+
+- New domain or user-visible behavior needs targeted Vitest coverage; flag missing tests P1 when acceptance implies it.
+- In-boundary docs, fixtures, and schemas must stay current; typos in touched docs are P1.
+- Validation expectation: most specific tests first, then lint; full suite `npm run test:run` on non-trivial sim changes.
+
+### Review process
+
+1. Review the **full diff against `main`**, not isolated hunks.
+2. Cite file paths; explain **why** something fails acceptance.
+3. Prefer the smallest in-boundary fix when suggesting changes.
+4. Do not weaken tests, CI, or lint rules to pass.

--- a/docs/cursor-implementation-lite-user-rules-snippet.md
+++ b/docs/cursor-implementation-lite-user-rules-snippet.md
@@ -74,17 +74,9 @@ Repo ship loop overrides a generic "commit only when asked" preference for Conta
 
 ### PR mapping
 
-When opening or updating a PR, the PR body must name:
+When opening or updating a PR, use `.github/pull_request_template.md`. Put `@coderabbitai summary` under **Summary** (CodeRabbit replaces it on review); fill Linear, what shipped, docs, parent status, validation, and scope boundary.
 
-- the canonical Linear issue
-- any parent issue
-- each child issue covered by the branch
-- what shipped
-- validation run
-- docs updated
-- whether the parent remains open
-
-If the PR satisfies a child issue, do not reference only the parent.
+The PR body must name: canonical Linear slice issue; parent (if any); each child covered; what shipped; validation run; docs updated; whether the parent remains open. If the PR satisfies a child issue, do not reference only the parent.
 
 ### Linear updates
 

--- a/docs/cursor-implementation-lite-user-rules-snippet.md
+++ b/docs/cursor-implementation-lite-user-rules-snippet.md
@@ -63,7 +63,7 @@ Run only **after** pre-ship audit passes:
 2. **Push** the branch to `origin` (`git push -u origin HEAD` when the remote branch is new).
 3. **Open a PR** against `main` with the PR mapping body below.
 4. **Linear:** comment the PR URL on the **slice** issue; keep the slice **In Progress** until merge (then **Done** + merge comment).
-5. **Babysit → merge (same session):** watch CI (`gh pr checks`), triage comments, fix in-boundary failures, push until green; merge when mergeable. Do **not** end the session or write a next-issue plan while the PR is still open.
+5. **Babysit → merge (same session):** after the PR opens — **independent review** of full diff vs `main` from scratch (slice doc + Linear acceptance; use `code-reviewer` / `bugbot` on non-trivial diffs); fix in-boundary findings and push; **triage external comments**; **CI loop** (`gh pr checks`) until green; merge when mergeable. Do **not** rely only on existing PR comments. Do **not** end the session or write a next-issue plan while the PR is still open.
 6. **Sync `main`:** `git checkout main` && `git pull origin main`.
 
 Do **not** end an implementation session with only local files, uncommitted work, an open unmerged PR, or "say if you want a PR."
@@ -100,4 +100,4 @@ If Linear tooling is unavailable, report the exact status/comment update that sh
 
 ### Session closeout (mandatory)
 
-**Order:** ship loop → babysit CI → merge → `checkout main` && pull → closeout. **Phase B (after merge):** slice Done + merge comment — next-issue plan only. **Phase A (interim):** only when babysit/merge is blocked in-session. Formats: `docs/agent-session-closeout.md`. Paste: `docs/cursor-session-closeout-user-rules-snippet.md`.
+**Order:** ship loop → babysit (independent review + comment triage + CI) → merge → `checkout main` && pull → closeout. **Phase B (after merge):** slice Done + merge comment — next-issue plan only. **Phase A (interim):** only when babysit/merge is blocked in-session. Formats: `docs/agent-session-closeout.md`. Paste: `docs/cursor-session-closeout-user-rules-snippet.md`.

--- a/docs/cursor-session-closeout-user-rules-snippet.md
+++ b/docs/cursor-session-closeout-user-rules-snippet.md
@@ -14,7 +14,7 @@ End using the **phase A** structure in `docs/agent-session-closeout.md`.
 
 ## Phase B — After merge (normal session end)
 
-After babysit → merge, slice **Done**, merge comment on Linear, and **`git checkout main` && `git pull origin main`**:
+After babysit (independent review + comment triage + CI) → merge, slice **Done**, merge comment on Linear, and **`git checkout main` && `git pull origin main`**:
 
 Do not implement the next issue unless the user explicitly asks. Prepare a **next-issue implementation plan** only.
 

--- a/docs/cursor-user-rules-snippet.md
+++ b/docs/cursor-user-rules-snippet.md
@@ -12,7 +12,7 @@ Copy the standing-workflow block below into **Cursor → Settings → Rules → 
 
 ## Containment Protocol — standing workflow
 
-- **Git exception:** For Containment Protocol **implementation slices**, follow repo **`implementation-lite` ship loop** (commit → push → open PR → **babysit CI until green → merge** → `checkout main` && pull) even when another rule says "only commit when requested." Do **not** plan the next slice until merge and local `main` sync complete. Tracked repo rules: `.cursor/rules/implementation-lite.mdc` and `.cursor/rules/linear-always-update.mdc` (`alwaysApply: true`). Honor explicit **no commit** / **no PR** / **local only** / **do not merge** only when the user says so in that session.
+- **Git exception:** For Containment Protocol **implementation slices**, follow repo **`implementation-lite` ship loop** (commit → push → open PR → **babysit: independent review + comment triage + CI until green → merge** → `checkout main` && pull) even when another rule says "only commit when requested." Do **not** plan the next slice until merge and local `main` sync complete. Tracked repo rules: `.cursor/rules/implementation-lite.mdc` and `.cursor/rules/linear-always-update.mdc` (`alwaysApply: true`). Honor explicit **no commit** / **no PR** / **local only** / **do not merge** only when the user says so in that session.
 - **Linear is mandatory on every agent session** (implementation, harvest, PR babysit, review): In Progress before work, **commit + push + open PR** before claiming an implementation slice complete, slice issue linked in PR, Done + comment on merge. Never skip because GitHub has a bot linkback. Repo rules: `.cursor/rules/linear-always-update.mdc`, `.cursor/rules/implementation-lite.mdc`; detail in **`AGENTS.md`**. Harvest triage: post **rich** owner comments (mechanic + boundary + fold-in vs child) per **`docs/harvest-fold-in-linear-comments.md`** — not one-line notes.
 - After a PR **merges**: run `git checkout main` and `git pull origin main`, then **start a new agent chat** for the next slice. Do not continue the old thread—it keeps stale branches, CI context, and failed "Move to local" branch names.
 - During an **open PR** on one branch: one agent session is fine until merge.
@@ -22,7 +22,7 @@ Copy the standing-workflow block below into **Cursor → Settings → Rules → 
 - When I merge, remind me to sync `main` and **switch to a new agent** before the next issue.
 - **Implementation lite:** `docs/cursor-implementation-lite-user-rules-snippet.md` (scope, **pre-ship audit**, **ship loop**, PR mapping, Linear).
 - **Pre-ship audit:** before commit/merge — six passes until clean; `docs/agent-pre-ship-audit.md`.
-- **Session closeout:** babysit → merge → sync `main`, then phase B (next-issue plan only). Phase A only if babysit blocked. Final reply per `docs/agent-session-closeout.md`.
+- **Session closeout:** babysit (independent review + comment triage + CI) → merge → sync `main`, then phase B (next-issue plan only). Phase A only if babysit blocked. Final reply per `docs/agent-session-closeout.md`.
 - **Backlog hygiene:** remind me to use the block from `docs/cursor-backlog-hygiene-user-rules-snippet.md` when running hygiene or grooming passes (not implementation).
 
 ---


### PR DESCRIPTION
## Summary

- Expand **babysit** in `implementation-lite.mdc` and mirrored cursor snippets so every implementation session runs a **full independent branch review** (slice doc + Linear acceptance) before triaging external comments and CI.
- Align `linear-always-update.mdc` babysit row with the same expectation.
- Add **`## Review guidelines`** to `AGENTS.md` for Codex (`@codex review`), Copilot, Gemini, CharlieHelps, and other PR reviewers.
- Update **`.github/pull_request_template.md`** with `<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development and review guidance with a more thorough PR review, comment-triage, CI, merge, and session closeout workflow.
  * Added clearer PR content requirements, including shipped work, documentation updates, validation, scope, parent status, and linked issues.
  * Expanded reviewer guidelines covering architecture boundaries, testing, documentation, and scope discipline.
  * Updated user-facing workflow snippets to reflect the revised process.

* **Chores**
  * Added workspace files to the ignored files list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->` and full PR mapping sections (Linear, what shipped, docs, parent status).
- Gitignore `*.code-workspace` and drop the redundant single-root workspace file.

## Linear

No slice issue — workflow/docs hygiene only.

## What shipped

| Area | Change |
|------|--------|
| `.cursor/rules/implementation-lite.mdc` | Babysit sub-steps + PR template / `gh pr create` scaffold |
| `.cursor/rules/linear-always-update.mdc` | Babysit table row updated |
| `docs/cursor-*-snippet.md` | Mirrored babysit + closeout + PR mapping |
| `AGENTS.md` | `## Review guidelines` for Codex and PR reviewers |
| `.github/pull_request_template.md` | CodeRabbit placeholder + slice PR mapping |
| `.gitignore` | Ignore `*.code-workspace` |

**Note:** `~/.cursor/skills-cursor/babysit/SKILL.md` was updated locally (outside repo).

## Validation

- Docs-only diff; no code or test changes required.

## Docs updated

- `implementation-lite.mdc`, `linear-always-update.mdc`, `AGENTS.md`, PR template, three cursor user-rules snippets, `.gitignore`.

## Parent remains open

N/A — no Linear parent/child scope.