### PR TITLE
docs: add CLAUDE.md for Claude Code (SPE-2560)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ All scripts are documented in `README.md` under the **Scripts** section and in `
 
 Codex (`@codex review`), **Greptile** (`@greptileai`), **CodeRabbit**, **Amazon Q Developer** (`/q review`), Copilot code review, Gemini Code Assist, CharlieHelps, and other PR reviewers should enforce the same bar. Read the PR description for the Linear slice issue, `planning/*-slice.md`, and stated boundary before commenting.
 
-AI review repo config: `.greptile/` (`config.json`, `rules.md`, `files.json`), `.amazonq/rules/*.md`, `.coderabbit.yaml`. Dashboard or marketplace settings may also apply; in-repo files are version-controlled and reviewed in PRs.
+AI review repo config: `.greptile/` (`config.json`, `rules.md`, `files.json`), `.amazonq/rules/*.md`, `.coderabbit.yaml`, `CLAUDE.md` (Claude Code). Dashboard or marketplace settings may also apply; in-repo files are version-controlled and reviewed in PRs.
 
 ### Severity
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Client-only React/TypeScript SPA. Pure sim in `src/domain/`; Zustand in `src/app
 
 Same as `AGENTS.md` Review guidelines. Flag P0/P1: correctness, determinism, hydration, layer boundaries, week-close order, hidden UI truth, migrations, missing required tests, security. Do not flag style nits, drive-by refactors, scope expansion, or pre-existing `build` TS drift unless this change worsens it.
 
-AI review config also lives in: `.greptile/`, `.amazonq/rules/`, `.coderabbit.yaml`.
+AI review config also lives in: `.greptile/`, `.amazonq/rules/`, `.coderabbit.yaml`, and this file (`CLAUDE.md`).
 
 ## Do not
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# Containment Protocol — Claude Code
+
+Canonical agent policy: **`AGENTS.md`**. Linear is the system of record. Implementation: `.cursor/rules/implementation-lite.mdc`.
+
+## Stack
+
+Client-only React/TypeScript SPA. Pure sim in `src/domain/`; Zustand in `src/app/store/`; projections in `src/features/*View.ts`; UI in `src/features/**/*.tsx`. No backend, DB, or required env vars. Node 22.
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Dev | `npm run dev` |
+| Lint | `npm run lint` |
+| Tests | `npm run test:run` |
+| Format | `npm run format:check` |
+| Audit index | `npm run verify:audits-index` |
+| Theme contracts | `npm run verify:theme-contracts` |
+
+`npm run build` has known baseline TS drift — do not treat as a green deployment gate; do not expand that drift in-slice.
+
+## Architecture (hard)
+
+- **Domain** (`src/domain/**`): pure; no React/store/features imports; seeded RNG only.
+- **Store** (`src/app/store/**`): orchestration; domain only.
+- **Projections** (`*View.ts` / `*Selectors.ts`): pure; no UI or cross-feature imports.
+- **UI**: presentational; use projections.
+- **Vite 8:** `import type { ... }` for type-only imports in files the dev server loads.
+- Week-close hooks belong on week-close (`src/domain/sim`). Mid-week mutations that should run at close are P0.
+- New persisted fields need normalization + event schema/migration per `SCHEMA_REGISTRY.md`.
+
+## Scope and ship
+
+1. One Linear slice (`SPE-####`) + `planning/*-slice.md` when present. Do not expand scope.
+2. Pre-ship audit: `docs/agent-pre-ship-audit.md` (six passes) before commit.
+3. Ship loop: commit → push → PR (`.github/pull_request_template.md`) → babysit (independent review + Greptile/CodeRabbit/Amazon Q/bot triage + CI) → merge → `git checkout main` && `git pull origin main`.
+4. Linear: In Progress before work; PR URL on slice issue; Done + merge comment after merge. Parent stays open unless full parent scope shipped.
+5. Deferred work: same session — slice doc `## Deferred` + Linear parent/child comment.
+
+## Review bar
+
+Same as `AGENTS.md` Review guidelines. Flag P0/P1: correctness, determinism, hydration, layer boundaries, week-close order, hidden UI truth, migrations, missing required tests, security. Do not flag style nits, drive-by refactors, scope expansion, or pre-existing `build` TS drift unless this change worsens it.
+
+AI review config also lives in: `.greptile/`, `.amazonq/rules/`, `.coderabbit.yaml`.
+
+## Do not
+
+- Parallel subsystems or unrelated refactors
+- Weaken CI, lint, or tests to pass
+- Skip Linear because GitHub has a bot linkback
+- End an implementation session with only local files or an open unmerged PR (unless user says no commit / no PR / do not merge)


### PR DESCRIPTION
## Linear

- **Slice issue:** [SPE-2560](https://linear.app/spectranoir/issue/SPE-2560/add-claudemd-for-claude-code)
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Root \CLAUDE.md\ for Claude Code (stack, commands, architecture, ship loop, review bar)
- \AGENTS.md\ AI review config pointer includes \CLAUDE.md\

## Docs updated

- \CLAUDE.md\ (new)
- \AGENTS.md\

## Parent status

- N/A

## Scope boundary

- Docs only; no runtime code

## Validation

- [x] Docs-only review

## Screenshots (UI only)

- N/A

## Follow-ups

- Optional: install Claude GitHub app if using Claude Code PR review

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Claude Code guidance for the repository. The main changes are:

- Added a root `CLAUDE.md` with stack, commands, architecture, ship loop, Linear, and review guidance.
- Updated `AGENTS.md` to list `CLAUDE.md` with the in-repo AI review configuration.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge from a code correctness perspective.

The changes are documentation-only and align with the existing repo guidance. No runtime behavior, dependency, persistence, or security surface changes were introduced.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Saved the docs-only validation logs for the before and after states.
- Validated the post-validation state by confirming AGENTS.md and CLAUDE.md exist.
- Detected formatting issues by running prettier --check on AGENTS.md and CLAUDE.md, which exited with code 1.

<a href="https://app.greptile.com/trex/runs/14050926/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Updates the AI review config pointer to include `CLAUDE.md`; no issues found. |
| CLAUDE.md | Adds a Claude Code guide mirroring stack, commands, architecture, ship loop, Linear, and review expectations; no issues found. |

<sub>Reviews (2): Last reviewed commit: ["docs: include CLAUDE.md in its AI review..."](https://github.com/jamesjedi420/containment-protocol/commit/a4a2e0bc24a91a454269987a22870103d7ffa4e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43427395)</sub>

<!-- /greptile_comment -->