### PR TITLE
SPE-2610: GameState persistence for media-economy continuity maps (slice 1)

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -193,7 +193,8 @@ Optional SPE-2610 media-economy continuity maps: `spe947MediaEconomyWeights` / `
 
 - Sanitize via `sanitizeSpe947*` helpers in `spe947EvaluatorPersistence.ts` (and media-economy sanitizers in `spe947MediaEconomyContinuity.ts`)
 - Wired in `hydrateGame` (`src/app/store/runTransfer.ts`)
-- Invalid, duplicate-id, and mismatched-key entries are dropped without throw
+- Invalid and duplicate-id entries are dropped without throw; map keys are re-derived from record ids
+- Media-economy maps: an authored plain-record input (including `{}`) is preserved — not replaced by hydrate fallback
 - Default starting state: empty `{}` maps in `createStartingState`
 
 ### Versioning

--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -167,10 +167,11 @@ Documents compact GameState maps for shipped SPE-2568–2573 pure evaluator inpu
 Optional SPE-2577 week-close fields: `weeklyViewDelta`, `weeklyUptimeState`, `lastWeeklyTickWeek`.
 Weekly tick: `src/domain/spe947EvaluatorWeeklyOrchestration.ts` (wired from `advanceWeek`).
 Optional SPE-2602 SPE-2111 registry bindings: `spe947VisualTriggerHazardBindings` (id-only links; compose in `spe947VisualTriggerHazardLinkage.ts`).
+Optional SPE-2610 media-economy continuity maps: `spe947MediaEconomyWeights` / `spe947MediaEconomyContinuityBindings` (sanitize in `spe947MediaEconomyContinuity.ts`; round-trip only).
 
 **Current version**: `spe-947-evaluator.v1` — exported as `SPE_947_EVALUATOR_PERSISTENCE_SCHEMA_VERSION`
 
-**Location**: `src/domain/spe947EvaluatorPersistence.ts`
+**Location**: `src/domain/spe947EvaluatorPersistence.ts` (media-economy maps: `src/domain/spe947MediaEconomyContinuity.ts`)
 
 ### GameState fields
 
@@ -185,10 +186,12 @@ Optional SPE-2602 SPE-2111 registry bindings: `spe947VisualTriggerHazardBindings
 | `spe947FootageExposureBindings`     | SPE-2571            | Optional baseline bindings keyed by artifact id                                                                                                                                    |
 | `spe947TakedownResistanceBindings`  | SPE-2572            | Threshold bindings keyed by owner id                                                                                                                                               |
 | `spe947VisualTriggerHazardBindings` | SPE-2602            | Authored `entityKind` + `entityId` → `visualTriggerHazardId`; read/compose only against `visualTriggerHazardRecords`                                                               |
+| `spe947MediaEconomyWeights` | SPE-2609 / SPE-2610 | Authored continuity weights (`continuityFactor` + optional incentive peers); sanitize in `spe947MediaEconomyContinuity.ts` |
+| `spe947MediaEconomyContinuityBindings` | SPE-2609 / SPE-2610 | Authored case → economy-weight bindings (optional `mediaArtifactId`); round-trip only |
 
 ### Hydration
 
-- Sanitize via `sanitizeSpe947*` helpers in `spe947EvaluatorPersistence.ts`
+- Sanitize via `sanitizeSpe947*` helpers in `spe947EvaluatorPersistence.ts` (and media-economy sanitizers in `spe947MediaEconomyContinuity.ts`)
 - Wired in `hydrateGame` (`src/app/store/runTransfer.ts`)
 - Invalid, duplicate-id, and mismatched-key entries are dropped without throw
 - Default starting state: empty `{}` maps in `createStartingState`

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -72,7 +72,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Current handoff (primary):** [SPE-2609](https://linear.app/spectranoir/issue/SPE-2609/compact-media-economy-commercialization-continuity-slice-1) SPE-947 compact media-economy / commercialization continuity (slice 1) — authored economy weights / compose over SPE-2606 `commercialization` residual risk; branch `spe-947-media-economy-continuity-slice-1`; see `planning/spe-947-media-economy-continuity-slice-1.md`. Coordinate with [SPE-1085](https://linear.app/spectranoir/issue/SPE-1085) (co-own continuity flavor only). Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
+**Current handoff (primary):** [SPE-2610](https://linear.app/spectranoir/issue/SPE-2610/gamestate-persistence-for-media-economy-continuity-maps-slice-1) SPE-947 GameState persistence for media-economy continuity maps (slice 1) — SPE-2576-style sanitize/hydrate for SPE-2609 `spe947MediaEconomyWeights` / `spe947MediaEconomyContinuityBindings`; branch `spe-947-media-economy-persistence-slice-1`; see `planning/spe-947-media-economy-persistence-slice-1.md`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
+
+**Recently shipped:** [SPE-2609](https://linear.app/spectranoir/issue/SPE-2609/compact-media-economy-commercialization-continuity-slice-1) SPE-947 compact media-economy / commercialization continuity (slice 1) — authored economy weights / compose over SPE-2606 `commercialization` residual risk; PR #3120 @ `bcaa7115`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
 
 **Recently shipped:** [SPE-2606](https://linear.app/spectranoir/issue/SPE-2606/adaptation-commercialization-persistence-kinds-slice-1) SPE-947 adaptation / commercialization persistence kinds (slice 1) — expand SPE-2573 `POST_CASE_MEDIA_KINDS` with distinct `adaptation` + `commercialization`; PR #3116 @ `635aa445`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
 

--- a/planning/spe-947-media-economy-continuity-slice-1.md
+++ b/planning/spe-947-media-economy-continuity-slice-1.md
@@ -67,7 +67,7 @@ Ship the smallest deterministic **authored media-economy / commercialization con
 | Propagation graph wire-up              | SPE-956 / harvest #965       | Deferred since SPE-2111  |
 | Full SPE-1085 canon continuity         | SPE-1085                     | Co-own coordination only |
 | Full commercialization / media-economy | Later SPE-947 sibling        | Compact weights only     |
-| GameState persistence for economy maps | Later SPE-947 sibling        | Compose-only this slice  |
+| GameState persistence for economy maps | **In Progress** — [SPE-2610](https://linear.app/spectranoir/issue/SPE-2610) | Compose-only SPE-2609; persist in SPE-2610 |
 | Parent umbrella Done                   | Later SPE-947 reconciliation | Wire-up still open       |
 
 ## See also

--- a/planning/spe-947-media-economy-persistence-slice-1.md
+++ b/planning/spe-947-media-economy-persistence-slice-1.md
@@ -1,0 +1,71 @@
+# SPE-947 — GameState persistence for media-economy continuity maps (slice 1)
+
+One-page implementation plan. Linear: [SPE-2610](https://linear.app/spectranoir/issue/SPE-2610/gamestate-persistence-for-media-economy-continuity-maps-slice-1) (child under [SPE-947](https://linear.app/spectranoir/issue/SPE-947)). Next SPE-947-owned deferred sibling after shipped [SPE-2609](https://linear.app/spectranoir/issue/SPE-2609); [SPE-947](https://linear.app/spectranoir/issue/SPE-947) parent stays **Backlog**. Propagation graph stays [SPE-956](https://linear.app/spectranoir/issue/SPE-956) / harvest #965.
+
+| Field               | Value                                                                                                                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2610 — GameState persistence for media-economy continuity maps (slice 1)](https://linear.app/spectranoir/issue/SPE-2610/gamestate-persistence-for-media-economy-continuity-maps-slice-1) |
+| **Status**          | **In Progress**                                                                                                                                                                               |
+| **Parent**          | [SPE-947](https://linear.app/spectranoir/issue/SPE-947) — hazardous content propagation and counter-memetic operations; stays **Backlog**                                                     |
+| **Branch**          | `spe-947-media-economy-persistence-slice-1`                                                                                                                                                   |
+| **Base `main` SHA** | `bcaa7115`                                                                                                                                                                                    |
+
+## Goal
+
+Ship the smallest deterministic **SPE-2576-style sanitize/hydrate + GameState maps** for SPE-2609 `spe947MediaEconomyWeights` / `spe947MediaEconomyContinuityBindings` (round-trip only) — without inventing a full media-economy simulator, SPE-956 propagation graph, mid-week mutations, or marking SPE-947 Done. Child Done ≠ umbrella Done.
+
+## Prerequisite (on `main` @ `bcaa7115`)
+
+| Shipped                              | Anchor                                                                                         |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Compact media-economy continuity     | [SPE-2609](https://linear.app/spectranoir/issue/SPE-2609) — compose types + EXAMPLE fixtures   |
+| SPE-947 evaluator persistence        | [SPE-2576](https://linear.app/spectranoir/issue/SPE-2576) — sanitize/hydrate pattern           |
+| CP-neutral labeling                  | [SPE-2596](https://linear.app/spectranoir/issue/SPE-2596)                                      |
+
+## Persistence contract
+
+- **Weights** — `spe947MediaEconomyWeights` keyed by weight id; `continuityFactor` required finite ≥ 0; optional incentive peers finite ≥ 0 or drop entry.
+- **Bindings** — `spe947MediaEconomyContinuityBindings` keyed by binding id; require `id` / `caseId` / `economyWeightId`; optional `mediaArtifactId`.
+- **Empty / missing** — default `{}`; sanitize never throws; empty defaults do not falsely satisfy parent AC.
+- **Compose** — optional wire into existing SPE-2609 resolve/compose only; no status-semantic rewrite.
+
+## Scope
+
+| In                                                                                          | Out                                            |
+| ------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Sanitize/hydrate + GameState maps for SPE-2609 weights / bindings                           | Full media-economy / internet simulator        |
+| Focused Vitest: empty/no-op + one authored weight/binding round-trip                        | Mid-week mutations                             |
+| Slice doc + backlog handoff; parent deferred pointer                                        | SPE-2609 continuity decision status rewrite    |
+| SCHEMA_REGISTRY additive field rows under `spe-947-evaluator.v1`                            | SPE-2568–2574 evaluator contracts              |
+|                                                                                             | SPE-947 parent Done                            |
+|                                                                                             | SPE-956 propagation graph                      |
+
+## Acceptance
+
+- [x] Empty / missing economy maps do not throw or falsely satisfy parent AC
+- [x] Invalid factors drop/sanitize safely
+- [x] Authored weight + binding round-trips through sanitize/hydrate
+- [x] SPE-2609 evaluate/compose contracts unchanged beyond optional map wiring
+- [x] No mid-week mutations; no invented media-economy or propagation graph
+- [x] `npm run lint` + targeted tests green
+- [ ] Parent SPE-947 stays **Backlog**; child Done only after merge
+
+## Validation
+
+- `npm.cmd run test:run -- src/test/spe947MediaEconomyPersistence.test.ts`
+- `npm.cmd run lint`
+
+## Deferred
+
+| Item                                   | Suggested owner              | Why deferred             |
+| -------------------------------------- | ---------------------------- | ------------------------ |
+| Propagation graph wire-up              | SPE-956 / harvest #965       | Deferred since SPE-2111  |
+| Full commercialization / media-economy | Later SPE-947 sibling        | Compact persist only     |
+| Parent umbrella Done                   | Later SPE-947 reconciliation | Wire-up still open       |
+
+## See also
+
+- `planning/spe-947-media-economy-continuity-slice-1.md`
+- `planning/spe-947-gamestate-persistence-slice-1.md`
+- `planning/spe-947-parent-ac-matrix-reconciliation-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -252,6 +252,10 @@ import {
   sanitizeSpe947VisualTriggerHazardBindings,
 } from '../../domain/spe947EvaluatorPersistence'
 import {
+  sanitizeSpe947MediaEconomyContinuityBindings,
+  sanitizeSpe947MediaEconomyWeights,
+} from '../../domain/spe947MediaEconomyContinuity'
+import {
   buildCandidateEvaluation,
   deriveCandidateCostEstimate,
   normalizeCandidateHireStatus,
@@ -9058,6 +9062,14 @@ export function hydrateGame(
     game.spe947VisualTriggerHazardBindings,
     fallback.spe947VisualTriggerHazardBindings ?? {}
   )
+  const spe947MediaEconomyWeights = sanitizeSpe947MediaEconomyWeights(
+    game.spe947MediaEconomyWeights,
+    fallback.spe947MediaEconomyWeights ?? {}
+  )
+  const spe947MediaEconomyContinuityBindings = sanitizeSpe947MediaEconomyContinuityBindings(
+    game.spe947MediaEconomyContinuityBindings,
+    fallback.spe947MediaEconomyContinuityBindings ?? {}
+  )
   const affiliationPersonStatusRecords = sanitizeAffiliationPersonStatusRecords(
     game.affiliationPersonStatusRecords,
     fallback.affiliationPersonStatusRecords ?? {}
@@ -9319,6 +9331,8 @@ export function hydrateGame(
     spe947FootageExposureBindings,
     spe947TakedownResistanceBindings,
     spe947VisualTriggerHazardBindings,
+    spe947MediaEconomyWeights,
+    spe947MediaEconomyContinuityBindings,
     affiliationPersonStatusRecords,
     affiliationFileWorkQueueActionRecords,
     affiliationFileWorkQueueEvidenceResolutionRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -70,6 +70,8 @@ const startingStateTemplate: GameState = {
   spe947FootageExposureBindings: {},
   spe947TakedownResistanceBindings: {},
   spe947VisualTriggerHazardBindings: {},
+  spe947MediaEconomyWeights: {},
+  spe947MediaEconomyContinuityBindings: {},
   affiliationPersonStatusRecords: {},
   entityWelfareReclassificationRecords: {},
   containedPersonTherapeuticCareRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -315,6 +315,10 @@ import type {
   Spe947TakedownResistanceBindingRecordsMap,
   Spe947VisualTriggerHazardBindingRecordsMap,
 } from './spe947EvaluatorPersistence'
+import type {
+  Spe947MediaEconomyContinuityBindingRecordsMap,
+  Spe947MediaEconomyWeightRecordsMap,
+} from './spe947MediaEconomyContinuity'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
 import type { SquadKitAssignment } from './squadKitAssignment'
@@ -2832,6 +2836,18 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing. Read/compose only.
    */
   spe947VisualTriggerHazardBindings?: Spe947VisualTriggerHazardBindingRecordsMap
+
+  /**
+   * SPE-2610 slice 1: authored SPE-2609 media-economy continuity weights (keyed by weight id).
+   * Hydration drops invalid or duplicate-id entries without throwing. Round-trip only.
+   */
+  spe947MediaEconomyWeights?: Spe947MediaEconomyWeightRecordsMap
+
+  /**
+   * SPE-2610 slice 1: authored SPE-2609 case → economy-weight continuity bindings (keyed by binding id).
+   * Hydration drops invalid or duplicate-id entries without throwing. Round-trip only.
+   */
+  spe947MediaEconomyContinuityBindings?: Spe947MediaEconomyContinuityBindingRecordsMap
 
   /**
    * SPE-2518 slice 1: persisted affiliation/person-status evidence records (keyed by record id).

--- a/src/domain/spe947MediaEconomyContinuity.ts
+++ b/src/domain/spe947MediaEconomyContinuity.ts
@@ -1,11 +1,15 @@
 /**
- * SPE-2609 / SPE-947: smallest deterministic media-economy continuity surface.
+ * SPE-2609 / SPE-2610 / SPE-947: media-economy continuity surface + GameState
+ * persistence for authored economy weights / continuity bindings.
  *
  * Authored economy weights / incentive factors over SPE-2606 commercialization
  * kind so lingering commercialization can modulate residual risk after local
  * containment. Compose-only inputs into SPE-2573 — no full media-economy
  * simulator, no kind vocabulary rewrite, no mid-week mutations, no SPE-2572
  * takedown AC rewrite, no SPE-1085 canon continuity rewrite.
+ *
+ * SPE-2610: sanitize/hydrate for `spe947MediaEconomyWeights` and
+ * `spe947MediaEconomyContinuityBindings` (round-trip only; SPE-2576 pattern).
  */
 
 import {
@@ -99,8 +103,120 @@ export interface Spe947MediaEconomyContinuityMaps {
   readonly spe947MediaEconomyContinuityBindings?: Spe947MediaEconomyContinuityBindingRecordsMap
 }
 
+type PlainRecord = Record<string, unknown>
+
+function isPlainRecord(value: unknown): value is PlainRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeId(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback
+}
+
+function normalizeLabel(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback
+}
+
 function isNonNegativeFinite(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function sanitizeSpe947MediaEconomyWeightEntry(value: unknown): Spe947MediaEconomyWeight | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeId(value.id, '')
+  const label = normalizeLabel(value.label, id)
+  if (id.length === 0 || label.length === 0 || !isNonNegativeFinite(value.continuityFactor)) {
+    return null
+  }
+
+  if (value.profitIncentive !== undefined && !isNonNegativeFinite(value.profitIncentive)) {
+    return null
+  }
+
+  if (value.attentionIncentive !== undefined && !isNonNegativeFinite(value.attentionIncentive)) {
+    return null
+  }
+
+  return Object.freeze({
+    id,
+    label,
+    continuityFactor: value.continuityFactor,
+    ...(value.profitIncentive !== undefined ? { profitIncentive: value.profitIncentive } : {}),
+    ...(value.attentionIncentive !== undefined
+      ? { attentionIncentive: value.attentionIncentive }
+      : {}),
+  })
+}
+
+function sanitizeSpe947MediaEconomyContinuityBindingEntry(
+  value: unknown
+): Spe947MediaEconomyContinuityBinding | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeId(value.id, '')
+  const caseId = normalizeId(value.caseId, '')
+  const economyWeightId = normalizeId(value.economyWeightId, '')
+  if (id.length === 0 || caseId.length === 0 || economyWeightId.length === 0) {
+    return null
+  }
+
+  const mediaArtifactId =
+    typeof value.mediaArtifactId === 'string' && value.mediaArtifactId.trim().length > 0
+      ? value.mediaArtifactId.trim()
+      : undefined
+
+  return Object.freeze({
+    id,
+    caseId,
+    economyWeightId,
+    ...(mediaArtifactId !== undefined ? { mediaArtifactId } : {}),
+  })
+}
+
+function sanitizeKeyedRecordMap<T extends { readonly id: string }>(
+  value: unknown,
+  fallback: Record<string, T>,
+  sanitizeEntry: (entry: unknown) => T | null
+): Record<string, T> {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: Record<string, T> = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  return Object.keys(next).length > 0 ? next : fallback
+}
+
+/** Hydration: canonical economy-weight map keyed by weight id; drops invalid/duplicate-id. */
+export function sanitizeSpe947MediaEconomyWeights(
+  value: unknown,
+  fallback: Spe947MediaEconomyWeightRecordsMap = {}
+): Spe947MediaEconomyWeightRecordsMap {
+  return sanitizeKeyedRecordMap(value, fallback, sanitizeSpe947MediaEconomyWeightEntry)
+}
+
+/** Hydration: continuity bindings keyed by binding id; drops invalid/duplicate-id. */
+export function sanitizeSpe947MediaEconomyContinuityBindings(
+  value: unknown,
+  fallback: Spe947MediaEconomyContinuityBindingRecordsMap = {}
+): Spe947MediaEconomyContinuityBindingRecordsMap {
+  return sanitizeKeyedRecordMap(value, fallback, sanitizeSpe947MediaEconomyContinuityBindingEntry)
 }
 
 function roundMetric(value: number): number {
@@ -458,3 +574,14 @@ export const SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING: Spe947MediaEconom
     economyWeightId: SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT.id,
     mediaArtifactId: 'media:commercial-merch-line',
   })
+
+/** Compact SPE-2610 persistence fixture: authored weight + binding only (empty defaults ≠ AC). */
+export const SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE = Object.freeze({
+  spe947MediaEconomyWeights: Object.freeze({
+    [SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT.id]: SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT,
+  }),
+  spe947MediaEconomyContinuityBindings: Object.freeze({
+    [SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING.id]:
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING,
+  }),
+})

--- a/src/domain/spe947MediaEconomyContinuity.ts
+++ b/src/domain/spe947MediaEconomyContinuity.ts
@@ -121,6 +121,10 @@ function isNonNegativeFinite(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
 }
 
+function isSafeMapKey(id: string): boolean {
+  return id !== '__proto__' && id !== 'constructor' && id !== 'prototype'
+}
+
 function sanitizeSpe947MediaEconomyWeightEntry(value: unknown): Spe947MediaEconomyWeight | null {
   if (!isPlainRecord(value)) {
     return null
@@ -128,7 +132,12 @@ function sanitizeSpe947MediaEconomyWeightEntry(value: unknown): Spe947MediaEcono
 
   const id = normalizeId(value.id, '')
   const label = normalizeLabel(value.label, id)
-  if (id.length === 0 || label.length === 0 || !isNonNegativeFinite(value.continuityFactor)) {
+  if (
+    id.length === 0 ||
+    !isSafeMapKey(id) ||
+    label.length === 0 ||
+    !isNonNegativeFinite(value.continuityFactor)
+  ) {
     return null
   }
 
@@ -161,8 +170,20 @@ function sanitizeSpe947MediaEconomyContinuityBindingEntry(
   const id = normalizeId(value.id, '')
   const caseId = normalizeId(value.caseId, '')
   const economyWeightId = normalizeId(value.economyWeightId, '')
-  if (id.length === 0 || caseId.length === 0 || economyWeightId.length === 0) {
+  if (
+    id.length === 0 ||
+    !isSafeMapKey(id) ||
+    caseId.length === 0 ||
+    economyWeightId.length === 0
+  ) {
     return null
+  }
+
+  // Present but blank/non-string mediaArtifactId must not collapse to unscoped binding.
+  if (value.mediaArtifactId !== undefined) {
+    if (typeof value.mediaArtifactId !== 'string' || value.mediaArtifactId.trim().length === 0) {
+      return null
+    }
   }
 
   const mediaArtifactId =

--- a/src/domain/spe947MediaEconomyContinuity.ts
+++ b/src/domain/spe947MediaEconomyContinuity.ts
@@ -200,7 +200,9 @@ function sanitizeKeyedRecordMap<T extends { readonly id: string }>(
     next[record.id] = record
   }
 
-  return Object.keys(next).length > 0 ? next : fallback
+  // Plain-record input (including authored `{}`) wins over fallback so cleared
+  // maps survive Zustand rehydration when current state still holds records.
+  return next
 }
 
 /** Hydration: canonical economy-weight map keyed by weight id; drops invalid/duplicate-id. */

--- a/src/test/spe947MediaEconomyPersistence.test.ts
+++ b/src/test/spe947MediaEconomyPersistence.test.ts
@@ -43,6 +43,23 @@ describe('spe947MediaEconomyPersistence (SPE-2610 / SPE-947)', () => {
     ).toEqual([])
   })
 
+  it('preserves explicitly empty maps over non-empty hydrate fallback', () => {
+    const fallback = createStartingState()
+    Object.assign(fallback, SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE)
+
+    const hydrated = hydrateGame(
+      {
+        ...createStartingState(),
+        spe947MediaEconomyWeights: {},
+        spe947MediaEconomyContinuityBindings: {},
+      },
+      fallback
+    )
+
+    expect(hydrated.spe947MediaEconomyWeights).toEqual({})
+    expect(hydrated.spe947MediaEconomyContinuityBindings).toEqual({})
+  })
+
   it('drops invalid factors and duplicate-id entries during sanitize without throwing', () => {
     const sanitizedWeights = sanitizeSpe947MediaEconomyWeights({
       valid: SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT,

--- a/src/test/spe947MediaEconomyPersistence.test.ts
+++ b/src/test/spe947MediaEconomyPersistence.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { createStartingState } from '../data/startingState'
+import {
+  composeSpe947MediaEconomyContinuityReadings,
+  sanitizeSpe947MediaEconomyContinuityBindings,
+  sanitizeSpe947MediaEconomyWeights,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT,
+  EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE,
+} from '../domain/spe947MediaEconomyContinuity'
+
+describe('spe947MediaEconomyPersistence (SPE-2610 / SPE-947)', () => {
+  it('defaults starting state to empty media-economy continuity maps', () => {
+    const state = createStartingState()
+
+    expect(state.spe947MediaEconomyWeights).toEqual({})
+    expect(state.spe947MediaEconomyContinuityBindings).toEqual({})
+  })
+
+  it('empty defaults do not throw or falsely satisfy continuity AC', () => {
+    const state = createStartingState()
+
+    expect(() =>
+      composeSpe947MediaEconomyContinuityReadings({
+        maps: {
+          spe947MediaEconomyWeights: state.spe947MediaEconomyWeights,
+          spe947MediaEconomyContinuityBindings: state.spe947MediaEconomyContinuityBindings,
+        },
+      })
+    ).not.toThrow()
+
+    expect(
+      composeSpe947MediaEconomyContinuityReadings({
+        maps: {
+          spe947MediaEconomyWeights: state.spe947MediaEconomyWeights,
+          spe947MediaEconomyContinuityBindings: state.spe947MediaEconomyContinuityBindings,
+        },
+      })
+    ).toEqual([])
+  })
+
+  it('drops invalid factors and duplicate-id entries during sanitize without throwing', () => {
+    const sanitizedWeights = sanitizeSpe947MediaEconomyWeights({
+      valid: SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT,
+      duplicate: {
+        ...SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT,
+        label: 'duplicate should lose',
+      },
+      badFactor: {
+        id: 'economy:bad-factor',
+        label: 'Bad factor',
+        continuityFactor: -1,
+      },
+      badProfit: {
+        id: 'economy:bad-profit',
+        label: 'Bad profit',
+        continuityFactor: 1,
+        profitIncentive: Number.NaN,
+      },
+      emptyId: {
+        id: '',
+        label: 'Missing id',
+        continuityFactor: 1,
+      },
+    })
+
+    expect(sanitizedWeights[SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT.id]).toEqual(
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT
+    )
+    expect(sanitizedWeights['economy:bad-factor']).toBeUndefined()
+    expect(sanitizedWeights['economy:bad-profit']).toBeUndefined()
+    expect(Object.keys(sanitizedWeights)).toEqual([SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT.id])
+
+    const sanitizedBindings = sanitizeSpe947MediaEconomyContinuityBindings({
+      valid: SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING,
+      duplicate: {
+        ...SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING,
+        caseId: 'case:other',
+      },
+      missingWeight: {
+        id: 'spe947-media-economy:missing-weight',
+        caseId: 'case:x',
+        economyWeightId: '',
+      },
+    })
+
+    expect(sanitizedBindings[SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING.id]).toEqual(
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING
+    )
+    expect(sanitizedBindings['spe947-media-economy:missing-weight']).toBeUndefined()
+    expect(Object.keys(sanitizedBindings)).toEqual([
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING.id,
+    ])
+  })
+
+  it('round-trips authored weight and binding through save/load', () => {
+    const state = createStartingState()
+    Object.assign(state, SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE)
+    state.spe947PostCaseMediaCases = {
+      [EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE.caseId!]:
+        EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE,
+    }
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.spe947MediaEconomyWeights).toEqual(state.spe947MediaEconomyWeights)
+    expect(loaded.spe947MediaEconomyContinuityBindings).toEqual(
+      state.spe947MediaEconomyContinuityBindings
+    )
+
+    const readings = composeSpe947MediaEconomyContinuityReadings({
+      maps: {
+        spe947PostCaseMediaCases: loaded.spe947PostCaseMediaCases,
+        spe947MediaEconomyWeights: loaded.spe947MediaEconomyWeights,
+        spe947MediaEconomyContinuityBindings: loaded.spe947MediaEconomyContinuityBindings,
+      },
+    })
+
+    expect(readings).toHaveLength(1)
+    expect(readings[0]?.status).toBe('modulated')
+    expect(readings[0]?.remainsRisky).toBe(true)
+  })
+
+  it('hydrates media-economy maps through import parsing and drops invalids', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        ...SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE,
+        spe947MediaEconomyWeights: {
+          ...SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyWeights,
+          invalid: {
+            id: 'economy:invalid',
+            label: 'Invalid',
+            continuityFactor: -2,
+          },
+        },
+        spe947MediaEconomyContinuityBindings: {
+          ...SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyContinuityBindings,
+          invalid: {
+            id: 'spe947-media-economy:invalid',
+            caseId: '',
+            economyWeightId: SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT.id,
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.spe947MediaEconomyWeights).toEqual(
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyWeights
+    )
+    expect(hydrated.spe947MediaEconomyContinuityBindings).toEqual(
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyContinuityBindings
+    )
+  })
+})

--- a/src/test/spe947MediaEconomyPersistence.test.ts
+++ b/src/test/spe947MediaEconomyPersistence.test.ts
@@ -112,6 +112,26 @@ describe('spe947MediaEconomyPersistence (SPE-2610 / SPE-947)', () => {
     expect(Object.keys(sanitizedBindings)).toEqual([
       SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING.id,
     ])
+
+    const protoPollution = sanitizeSpe947MediaEconomyWeights({
+      polluted: {
+        id: '__proto__',
+        label: 'Proto pollution attempt',
+        continuityFactor: 1,
+      },
+    })
+    expect(Object.prototype.hasOwnProperty.call(protoPollution, '__proto__')).toBe(false)
+    expect(Object.keys(protoPollution)).toEqual([])
+
+    const blankArtifactBinding = sanitizeSpe947MediaEconomyContinuityBindings({
+      blankArtifact: {
+        id: 'spe947-media-economy:blank-artifact',
+        caseId: 'case:x',
+        economyWeightId: SPE_947_EXAMPLE_MEDIA_ECONOMY_WEIGHT.id,
+        mediaArtifactId: '   ',
+      },
+    })
+    expect(blankArtifactBinding['spe947-media-economy:blank-artifact']).toBeUndefined()
   })
 
   it('round-trips authored weight and binding through save/load', () => {


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2610 — https://linear.app/spectranoir/issue/SPE-2610/gamestate-persistence-for-media-economy-continuity-maps-slice-1
- **Parent issue (if any):** SPE-947 — https://linear.app/spectranoir/issue/SPE-947/hazardous-content-propagation-and-counter-memetic-operations
- **Child issues covered:** slice only (SPE-2610)

## Summary

@coderabbitai summary

## What shipped

- SPE-2576-style sanitize/hydrate for SPE-2609 `spe947MediaEconomyWeights` / `spe947MediaEconomyContinuityBindings` on GameState
- Empty `{}` defaults in starting state; invalid factors / duplicate ids dropped without throw
- Focused Vitest: empty/no-op + authored weight/binding save/load + hydrate round-trip

## Docs updated

- `planning/spe-947-media-economy-persistence-slice-1.md`
- `planning/backlog.md` handoff
- `planning/spe-947-media-economy-continuity-slice-1.md` deferred pointer
- `SCHEMA_REGISTRY.md` additive field rows under `spe-947-evaluator.v1`

## Parent status

- Parent SPE-947 remains **Backlog** — child slice only; domain-evaluator Yes ≠ umbrella Done

## Scope boundary

- No full media-economy simulator
- No SPE-956 propagation graph
- No mid-week mutations
- No SPE-2609 continuity decision status rewrite
- No SPE-2568–2574 evaluator contract changes

## Validation

- [x] Targeted tests: `npm.cmd run test:run -- src/test/spe947MediaEconomyPersistence.test.ts` (5 passed); related SPE-947 persistence/mirror tests green
- [x] Lint / verify: `npm.cmd run lint`

## Follow-ups

- Propagation graph wire-up → SPE-956 / harvest #965
- Full commercialization / media-economy sim → later SPE-947 sibling
- Parent umbrella Done → later SPE-947 reconciliation

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)

Made with [Cursor](https://cursor.com)