### PR TITLE
SPE-2616: Persisted commercialization-actor map + advanceWeek tick wire (slice 1)

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -168,6 +168,7 @@ Optional SPE-2577 week-close fields: `weeklyViewDelta`, `weeklyUptimeState`, `la
 Weekly tick: `src/domain/spe947EvaluatorWeeklyOrchestration.ts` (wired from `advanceWeek`).
 Optional SPE-2602 SPE-2111 registry bindings: `spe947VisualTriggerHazardBindings` (id-only links; compose in `spe947VisualTriggerHazardLinkage.ts`).
 Optional SPE-2610 media-economy continuity maps: `spe947MediaEconomyWeights` / `spe947MediaEconomyContinuityBindings` (sanitize in `spe947MediaEconomyContinuity.ts`; round-trip only).
+Optional SPE-2616 commercialization-actor map: `spe947MediaEconomyCommercializationActors` + `spe947MediaEconomyLastWeeklyTickWeek` (sanitize in `spe947MediaEconomySimulator.ts`; week-close tick via `advanceWeek`).
 
 **Current version**: `spe-947-evaluator.v1` — exported as `SPE_947_EVALUATOR_PERSISTENCE_SCHEMA_VERSION`
 
@@ -188,10 +189,12 @@ Optional SPE-2610 media-economy continuity maps: `spe947MediaEconomyWeights` / `
 | `spe947VisualTriggerHazardBindings` | SPE-2602            | Authored `entityKind` + `entityId` → `visualTriggerHazardId`; read/compose only against `visualTriggerHazardRecords`                                                               |
 | `spe947MediaEconomyWeights` | SPE-2609 / SPE-2610 | Authored continuity weights (`continuityFactor` + optional incentive peers); sanitize in `spe947MediaEconomyContinuity.ts` |
 | `spe947MediaEconomyContinuityBindings` | SPE-2609 / SPE-2610 | Authored case → economy-weight bindings (optional `mediaArtifactId`); round-trip only |
+| `spe947MediaEconomyCommercializationActors` | SPE-2611–2615 / SPE-2616 | Authored commercialization actors keyed by actor id; sanitize in `spe947MediaEconomySimulator.ts` |
+| `spe947MediaEconomyLastWeeklyTickWeek` | SPE-2615 / SPE-2616 | Week-close idempotency stamp for media-economy orchestration tick |
 
 ### Hydration
 
-- Sanitize via `sanitizeSpe947*` helpers in `spe947EvaluatorPersistence.ts` (and media-economy sanitizers in `spe947MediaEconomyContinuity.ts`)
+- Sanitize via `sanitizeSpe947*` helpers in `spe947EvaluatorPersistence.ts` (media-economy weight/binding sanitizers in `spe947MediaEconomyContinuity.ts`; commercialization-actor sanitizers in `spe947MediaEconomySimulator.ts`)
 - Wired in `hydrateGame` (`src/app/store/runTransfer.ts`)
 - Invalid and duplicate-id entries are dropped without throw; map keys are re-derived from record ids
 - Media-economy maps: an authored plain-record input (including `{}`) is preserved — not replaced by hydrate fallback

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -72,7 +72,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Current handoff (primary):** [SPE-2615](https://linear.app/spectranoir/issue/SPE-2615/week-close-orchestration-hook-over-media-economy-aggregate-slice-1) SPE-947 week-close orchestration hook over media-economy aggregate (slice 1) — pure week-close compose over SPE-2613/2614 aggregate (SPE-2577 pattern); branch `spe-947-media-economy-week-close-orchestration-slice-1`; see `planning/spe-947-media-economy-week-close-orchestration-slice-1.md`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
+**Current handoff (primary):** [SPE-2616](https://linear.app/spectranoir/issue/SPE-2616/persisted-commercialization-actor-map-richer-advanceweek-delta) SPE-947 persisted commercialization-actor map + richer advanceWeek delta mutation (slice 1) — sanitize/hydrate actors on GameState + wire `advanceWeek` into SPE-2615 tick with `lastWeeklyTickWeek`; branch `spe-947-commercialization-actor-persistence-slice-1`; see `planning/spe-947-commercialization-actor-persistence-slice-1.md`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
+
+**Recently shipped:** [SPE-2615](https://linear.app/spectranoir/issue/SPE-2615/week-close-orchestration-hook-over-media-economy-aggregate-slice-1) SPE-947 week-close orchestration hook over media-economy aggregate (slice 1) — pure week-close compose over SPE-2613/2614 aggregate (SPE-2577 pattern); PR #3132 @ `cc05bf50`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
 
 **Recently shipped:** [SPE-2614](https://linear.app/spectranoir/issue/SPE-2614/further-media-economy-growth-third-commercial-path-week-close-wire) SPE-947 further media-economy growth (third commercial path) (slice 1) — third authored commercialization path + three-path aggregate over SPE-2613; PR #3130 @ `731d0af5`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
 

--- a/planning/spe-947-commercialization-actor-persistence-slice-1.md
+++ b/planning/spe-947-commercialization-actor-persistence-slice-1.md
@@ -1,0 +1,76 @@
+# SPE-947 — Persisted commercialization-actor map + richer advanceWeek delta mutation (slice 1)
+
+One-page implementation plan. Linear: [SPE-2616](https://linear.app/spectranoir/issue/SPE-2616/persisted-commercialization-actor-map-richer-advanceweek-delta) (child under [SPE-947](https://linear.app/spectranoir/issue/SPE-947)). Next SPE-947-owned deferred sibling after shipped [SPE-2615](https://linear.app/spectranoir/issue/SPE-2615); [SPE-956](https://linear.app/spectranoir/issue/SPE-956) stays out. Parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2616 — Persisted commercialization-actor map + richer advanceWeek delta mutation (slice 1)](https://linear.app/spectranoir/issue/SPE-2616/persisted-commercialization-actor-map-richer-advanceweek-delta) |
+| **Status**          | **In Progress**                                                                                                                                                                                       |
+| **Parent**          | [SPE-947](https://linear.app/spectranoir/issue/SPE-947) — hazardous content propagation and counter-memetic operations; stays **Backlog**                                                             |
+| **Branch**          | `spe-947-commercialization-actor-persistence-slice-1`                                                                                                                                                 |
+| **Base `main` SHA** | `cc05bf50`                                                                                                                                                                                            |
+
+## Goal
+
+Ship the smallest SPE-2576-style sanitize/hydrate for authored commercialization actors on GameState and wire `advanceWeek` to pass persisted actors into the SPE-2615 week-close tick with persisted `lastWeeklyTickWeek`. Authored weekly deltas only — no invent mid-week — without marking SPE-947 Done.
+
+## Prerequisite (on `main` @ `cc05bf50`)
+
+| Shipped                           | Anchor                                                                                    |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| Week-close orchestration          | [SPE-2615](https://linear.app/spectranoir/issue/SPE-2615) — aggregate tick over actors/maps |
+| Third commercial path             | [SPE-2614](https://linear.app/spectranoir/issue/SPE-2614) — three-path aggregate          |
+| Cross-path aggregate              | [SPE-2613](https://linear.app/spectranoir/issue/SPE-2613) — any/worse over multi-path     |
+| Multi-actor compose               | [SPE-2612](https://linear.app/spectranoir/issue/SPE-2612) — ≥2 paths                     |
+| Single-path sim                   | [SPE-2611](https://linear.app/spectranoir/issue/SPE-2611) — actor shape + EXAMPLE         |
+| GameState economy-map persistence | [SPE-2610](https://linear.app/spectranoir/issue/SPE-2610) — weight/binding sanitize        |
+
+## Week-close contract (slice 1)
+
+- **Persist actors** — `spe947MediaEconomyCommercializationActors` keyed map + `sanitizeSpe947MediaEconomyCommercializationActors`.
+- **Tick stamp** — `spe947MediaEconomyLastWeeklyTickWeek` on GameState; round-trip via hydrate.
+- **advanceWeek** — `listSpe947MediaEconomyCommercializationActors` feeds SPE-2615 tick; empty map ⇒ `empty_actors` no-op.
+- **No invent** — no mid-week actor creation; economy maps keep identity unless authored weekly delta exists (still none in slice 1).
+- **Idempotent** — same-week re-tick via persisted `lastWeeklyTickWeek` ⇒ `already_ticked`.
+
+## Scope
+
+| In                                                                                          | Out                                          |
+| ------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `sanitizeSpe947MediaEconomyCommercializationActors` + GameState field                       | Full internet / sprawling media-economy sim  |
+| `spe947MediaEconomyLastWeeklyTickWeek` idempotency stamp                                    | SPE-2610 weight/binding sanitize rewrite     |
+| `advanceWeek` reads persisted actors into SPE-2615 tick                                     | Mid-week mutations                           |
+| Focused Vitest: sanitize round-trip + empty/no-op + advanceWeek orchestrated + already_ticked | SPE-2611–2615 path/aggregate/tick rewrite    |
+| Slice doc + backlog handoff (SPE-2615 → Done)                                               | SPE-947 parent Done                          |
+|                                                                                             | SPE-956 propagation graph                    |
+|                                                                                             | Authored weekly economy-map delta fields     |
+
+## Acceptance
+
+- [ ] Empty/missing actor map must not falsely satisfy AC
+- [ ] Malformed actors drop like SPE-2610
+- [ ] No mid-week invent
+- [ ] Tick stamp round-trips for same-week idempotency
+- [ ] Actor order stays code-unit
+- [ ] Economy maps keep identity unless authored delta exists
+- [ ] `npm run lint` + targeted tests green
+- [ ] Parent SPE-947 stays **Backlog**; child Done only after merge
+
+## Validation
+
+- `npm.cmd run test:run -- src/test/spe947MediaEconomyCommercializationActorPersistence.test.ts src/test/advanceWeek.spe947Evaluator.integration.test.ts`
+- `npm.cmd run lint`
+
+## Deferred
+
+| Item                         | Suggested owner              | Why deferred                                      |
+| ---------------------------- | ---------------------------- | ------------------------------------------------- |
+| Authored weekly economy-map delta fields | Later SPE-947 sibling | `hasSpe947MediaEconomyWeeklyDelta` still false — maps identity-only |
+| Propagation graph wire-up    | SPE-956 / harvest 965        | Deferred since SPE-2111                           |
+| Parent umbrella Done         | Later SPE-947 reconciliation | Wire-up still open                                |
+
+## See also
+
+- `planning/spe-947-media-economy-week-close-orchestration-slice-1.md`
+- `planning/spe-947-media-economy-third-commercial-path-slice-1.md`
+- `planning/backlog.md`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -256,6 +256,10 @@ import {
   sanitizeSpe947MediaEconomyWeights,
 } from '../../domain/spe947MediaEconomyContinuity'
 import {
+  sanitizeSpe947MediaEconomyCommercializationActors,
+  sanitizeSpe947MediaEconomyLastWeeklyTickWeek,
+} from '../../domain/spe947MediaEconomySimulator'
+import {
   buildCandidateEvaluation,
   deriveCandidateCostEstimate,
   normalizeCandidateHireStatus,
@@ -9070,6 +9074,14 @@ export function hydrateGame(
     game.spe947MediaEconomyContinuityBindings,
     fallback.spe947MediaEconomyContinuityBindings ?? {}
   )
+  const spe947MediaEconomyCommercializationActors = sanitizeSpe947MediaEconomyCommercializationActors(
+    game.spe947MediaEconomyCommercializationActors,
+    fallback.spe947MediaEconomyCommercializationActors ?? {}
+  )
+  const spe947MediaEconomyLastWeeklyTickWeek = sanitizeSpe947MediaEconomyLastWeeklyTickWeek(
+    game.spe947MediaEconomyLastWeeklyTickWeek,
+    fallback.spe947MediaEconomyLastWeeklyTickWeek
+  )
   const affiliationPersonStatusRecords = sanitizeAffiliationPersonStatusRecords(
     game.affiliationPersonStatusRecords,
     fallback.affiliationPersonStatusRecords ?? {}
@@ -9333,6 +9345,8 @@ export function hydrateGame(
     spe947VisualTriggerHazardBindings,
     spe947MediaEconomyWeights,
     spe947MediaEconomyContinuityBindings,
+    spe947MediaEconomyCommercializationActors,
+    spe947MediaEconomyLastWeeklyTickWeek,
     affiliationPersonStatusRecords,
     affiliationFileWorkQueueActionRecords,
     affiliationFileWorkQueueEvidenceResolutionRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -72,6 +72,7 @@ const startingStateTemplate: GameState = {
   spe947VisualTriggerHazardBindings: {},
   spe947MediaEconomyWeights: {},
   spe947MediaEconomyContinuityBindings: {},
+  spe947MediaEconomyCommercializationActors: {},
   affiliationPersonStatusRecords: {},
   entityWelfareReclassificationRecords: {},
   containedPersonTherapeuticCareRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -319,6 +319,7 @@ import type {
   Spe947MediaEconomyContinuityBindingRecordsMap,
   Spe947MediaEconomyWeightRecordsMap,
 } from './spe947MediaEconomyContinuity'
+import type { Spe947MediaEconomyCommercializationActorRecordsMap } from './spe947MediaEconomySimulator'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
 import type { SquadKitAssignment } from './squadKitAssignment'
@@ -2848,6 +2849,17 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing. Round-trip only.
    */
   spe947MediaEconomyContinuityBindings?: Spe947MediaEconomyContinuityBindingRecordsMap
+
+  /**
+   * SPE-2616 slice 1: authored commercialization actors for SPE-2611–2615 media-economy paths (keyed by actor id).
+   * Hydration drops invalid or duplicate-id entries without throwing. Round-trip only.
+   */
+  spe947MediaEconomyCommercializationActors?: Spe947MediaEconomyCommercializationActorRecordsMap
+
+  /**
+   * SPE-2616 slice 1: last week the SPE-2615 media-economy week-close tick ran; idempotency marker.
+   */
+  spe947MediaEconomyLastWeeklyTickWeek?: number
 
   /**
    * SPE-2518 slice 1: persisted affiliation/person-status evidence records (keyed by record id).

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -270,6 +270,7 @@ import { applyWeeklySpe947EvaluatorTick } from '../spe947EvaluatorWeeklyOrchestr
 import { extractSpe947EvaluatorPersistenceMaps } from '../spe947EvaluatorPersistence'
 import { buildWeeklySpe947EvaluatorTransitionReportNotes } from '../spe947EvaluatorWeeklyReportNotes'
 import { applyWeeklySpe947MediaEconomyTick } from '../spe947MediaEconomyWeeklyOrchestration'
+import { listSpe947MediaEconomyCommercializationActors } from '../spe947MediaEconomySimulator'
 import { applyWeeklyNamingHazardDescriptorTick } from '../namingHazardDescriptorWeeklyOrchestration'
 import { applyWeeklyTherapeuticCareTick } from '../containedPersonTherapeuticCareWeeklyOrchestration'
 import { applyWeeklyCoerciveProtocolTick } from '../coerciveContainedPersonProtocolWeeklyOrchestration'
@@ -4978,11 +4979,13 @@ export function advanceWeek(
     outputWeeklyState.spe947CounterMemeticPlans = nextSpe947Maps.spe947CounterMemeticPlans
   }
 
-  // SPE-2615 slice 1: week-close media-economy aggregate orchestrate (SPE-2577 pattern peer).
-  // Commercialization actors are not GameState-persisted yet — empty actors ⇒ no-op (no invent).
-  // Shared economy maps mutate only when an authored weekly delta exists (none in slice 1).
+  // SPE-2615 / SPE-2616: week-close media-economy aggregate orchestrate (SPE-2577 pattern peer).
+  // Persisted commercialization actors feed the tick; empty actors ⇒ no-op (no invent).
+  // Shared economy maps mutate only when an authored weekly delta exists (none through SPE-2616).
   const mediaEconomyWeekClose = applyWeeklySpe947MediaEconomyTick({
-    actors: [],
+    actors: listSpe947MediaEconomyCommercializationActors(
+      outputWeeklyState.spe947MediaEconomyCommercializationActors
+    ),
     maps: {
       spe947PostCaseMediaCases: outputWeeklyState.spe947PostCaseMediaCases,
       spe947MediaEconomyWeights: outputWeeklyState.spe947MediaEconomyWeights,
@@ -4990,7 +4993,12 @@ export function advanceWeek(
         outputWeeklyState.spe947MediaEconomyContinuityBindings,
     },
     week: result.week,
+    lastWeeklyTickWeek: outputWeeklyState.spe947MediaEconomyLastWeeklyTickWeek,
   })
+  if (mediaEconomyWeekClose.lastWeeklyTickWeek !== undefined) {
+    outputWeeklyState.spe947MediaEconomyLastWeeklyTickWeek =
+      mediaEconomyWeekClose.lastWeeklyTickWeek
+  }
   if (mediaEconomyWeekClose.mapsMutated) {
     outputWeeklyState.spe947MediaEconomyWeights =
       mediaEconomyWeekClose.maps.spe947MediaEconomyWeights ?? {}

--- a/src/domain/spe947MediaEconomySimulator.ts
+++ b/src/domain/spe947MediaEconomySimulator.ts
@@ -167,7 +167,7 @@ export function listSpe947MediaEconomyCommercializationActors(
   const map = actors ?? {}
   return Object.freeze(
     Object.keys(map)
-      .sort((left, right) => left.localeCompare(right))
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
       .flatMap((actorId) => {
         const actor = map[actorId]
         return actor ? [actor] : []

--- a/src/domain/spe947MediaEconomySimulator.ts
+++ b/src/domain/spe947MediaEconomySimulator.ts
@@ -50,6 +50,131 @@ export interface Spe947MediaEconomyCommercializationActor {
   readonly actorWorsenFactor: number
 }
 
+export type Spe947MediaEconomyCommercializationActorRecordsMap = Record<
+  string,
+  Spe947MediaEconomyCommercializationActor
+>
+
+type PlainRecord = Record<string, unknown>
+
+function isPlainRecord(value: unknown): value is PlainRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeId(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback
+}
+
+function normalizeLabel(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback
+}
+
+function isSafeMapKey(id: string): boolean {
+  return id !== '__proto__' && id !== 'constructor' && id !== 'prototype'
+}
+
+function isValidActorWorsenFactor(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 1
+}
+
+function sanitizeSpe947MediaEconomyCommercializationActorEntry(
+  value: unknown
+): Spe947MediaEconomyCommercializationActor | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const id = normalizeId(value.id, '')
+  const label = normalizeLabel(value.label, id)
+  const continuityBindingId = normalizeId(value.continuityBindingId, '')
+  if (
+    id.length === 0 ||
+    !isSafeMapKey(id) ||
+    label.length === 0 ||
+    continuityBindingId.length === 0 ||
+    !isValidActorWorsenFactor(value.actorWorsenFactor)
+  ) {
+    return null
+  }
+
+  return Object.freeze({
+    id,
+    label,
+    continuityBindingId,
+    actorWorsenFactor: value.actorWorsenFactor,
+  })
+}
+
+function sanitizeKeyedRecordMap<T extends { readonly id: string }>(
+  value: unknown,
+  fallback: Record<string, T>,
+  sanitizeEntry: (entry: unknown) => T | null
+): Record<string, T> {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next: Record<string, T> = {}
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  // Plain-record input (including authored `{}`) wins over fallback so cleared
+  // maps survive Zustand rehydration when current state still holds records.
+  return next
+}
+
+/** Hydration: canonical commercialization-actor map keyed by actor id; drops invalid/duplicate-id. */
+export function sanitizeSpe947MediaEconomyCommercializationActors(
+  value: unknown,
+  fallback: Spe947MediaEconomyCommercializationActorRecordsMap = {}
+): Spe947MediaEconomyCommercializationActorRecordsMap {
+  return sanitizeKeyedRecordMap(value, fallback, sanitizeSpe947MediaEconomyCommercializationActorEntry)
+}
+
+/** Hydration: week-close idempotency stamp for SPE-2615 media-economy tick (SPE-2577 pattern). */
+export function sanitizeSpe947MediaEconomyLastWeeklyTickWeek(
+  value: unknown,
+  fallback: number | undefined = undefined
+): number | undefined {
+  if (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= 1 &&
+    value === Math.trunc(value)
+  ) {
+    return value
+  }
+
+  return fallback
+}
+
+/**
+ * Read persisted commercialization actors in deterministic code-unit id order.
+ * Empty / missing map → empty list (no invent).
+ */
+export function listSpe947MediaEconomyCommercializationActors(
+  actors: Spe947MediaEconomyCommercializationActorRecordsMap | null | undefined
+): readonly Spe947MediaEconomyCommercializationActor[] {
+  const map = actors ?? {}
+  return Object.freeze(
+    Object.keys(map)
+      .sort((left, right) => left.localeCompare(right))
+      .flatMap((actorId) => {
+        const actor = map[actorId]
+        return actor ? [actor] : []
+      })
+  )
+}
+
 export type Spe947MediaEconomySimStatus =
   | 'worsened'
   | 'continuity_only'
@@ -86,10 +211,6 @@ export interface Spe947MediaEconomySimReading {
   readonly simDecision: PostCaseMediaPersistenceDecision | null
   readonly remainsRisky: boolean
   readonly reasonCodes: readonly Spe947MediaEconomySimReasonCode[]
-}
-
-function isValidActorWorsenFactor(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 1
 }
 
 function persistedEconomyMapsAreEmpty(maps: Spe947MediaEconomyContinuityMaps): boolean {
@@ -659,6 +780,16 @@ export const SPE_947_EXAMPLE_MEDIA_ECONOMY_THREE_PATH_ACTORS: readonly Spe947Med
     SPE_947_EXAMPLE_MEDIA_ECONOMY_LIVESTREAM_ACTOR,
     SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR,
   ])
+
+/** Authored three-path EXAMPLE map keyed by actor id (SPE-2616 persistence fixture). */
+export const SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTORS_MAP: Spe947MediaEconomyCommercializationActorRecordsMap =
+  Object.freeze({
+    [SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR.id]:
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR,
+    [SPE_947_EXAMPLE_MEDIA_ECONOMY_LIVESTREAM_ACTOR.id]:
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_LIVESTREAM_ACTOR,
+    [SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR.id]: SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR,
+  })
 
 /** Shared persisted maps for single- and multi-actor EXAMPLE fixtures. */
 const SPE_947_EXAMPLE_MEDIA_ECONOMY_SIM_MAPS = Object.freeze({

--- a/src/test/spe947MediaEconomyCommercializationActorPersistence.test.ts
+++ b/src/test/spe947MediaEconomyCommercializationActorPersistence.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest'
+
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { createStartingState } from '../data/startingState'
+import {
+  EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE,
+} from '../domain/spe947MediaEconomyContinuity'
+import {
+  listSpe947MediaEconomyCommercializationActors,
+  sanitizeSpe947MediaEconomyCommercializationActors,
+  sanitizeSpe947MediaEconomyLastWeeklyTickWeek,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTORS_MAP,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_LIVESTREAM_ACTOR,
+  SPE_947_EXAMPLE_MEDIA_ECONOMY_THREE_PATH_AGGREGATE_FIXTURE,
+} from '../domain/spe947MediaEconomySimulator'
+import { applyWeeklySpe947MediaEconomyTick } from '../domain/spe947MediaEconomyWeeklyOrchestration'
+import { advanceWeek } from '../domain/sim/advanceWeek'
+
+function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) {
+  for (const currentCase of Object.values(state.cases)) {
+    currentCase.status = 'open'
+    currentCase.assignedTeamIds = []
+    currentCase.requiredTags = []
+    currentCase.preferredTags = []
+    currentCase.weeksRemaining = undefined
+  }
+}
+
+describe('spe947MediaEconomyCommercializationActorPersistence (SPE-2616 / SPE-947)', () => {
+  it('defaults starting state to empty commercialization-actor map', () => {
+    const state = createStartingState()
+
+    expect(state.spe947MediaEconomyCommercializationActors).toEqual({})
+    expect(state.spe947MediaEconomyLastWeeklyTickWeek).toBeUndefined()
+  })
+
+  it('empty defaults do not throw or falsely satisfy orchestration AC', () => {
+    const state = createStartingState()
+
+    expect(() =>
+      applyWeeklySpe947MediaEconomyTick({
+        actors: listSpe947MediaEconomyCommercializationActors(
+          state.spe947MediaEconomyCommercializationActors
+        ),
+        maps: SPE_947_EXAMPLE_MEDIA_ECONOMY_THREE_PATH_AGGREGATE_FIXTURE.maps,
+        week: 5,
+      })
+    ).not.toThrow()
+
+    const result = applyWeeklySpe947MediaEconomyTick({
+      actors: listSpe947MediaEconomyCommercializationActors(
+        state.spe947MediaEconomyCommercializationActors
+      ),
+      maps: SPE_947_EXAMPLE_MEDIA_ECONOMY_THREE_PATH_AGGREGATE_FIXTURE.maps,
+      week: 5,
+    })
+
+    expect(result.status).toBe('empty_actors')
+    expect(result.aggregate.anyRemainsRisky).toBe(false)
+  })
+
+  it('preserves explicitly empty actor map over non-empty hydrate fallback', () => {
+    const fallback = createStartingState()
+    fallback.spe947MediaEconomyCommercializationActors =
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTORS_MAP
+
+    const hydrated = hydrateGame(
+      {
+        ...createStartingState(),
+        spe947MediaEconomyCommercializationActors: {},
+      },
+      fallback
+    )
+
+    expect(hydrated.spe947MediaEconomyCommercializationActors).toEqual({})
+  })
+
+  it('drops invalid actors and duplicate-id entries during sanitize without throwing', () => {
+    const sanitized = sanitizeSpe947MediaEconomyCommercializationActors({
+      valid: SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR,
+      duplicate: {
+        ...SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR,
+        label: 'duplicate should lose',
+      },
+      badFactor: {
+        id: 'actor:bad-factor',
+        label: 'Bad factor',
+        continuityBindingId: SPE_947_EXAMPLE_MEDIA_ECONOMY_CONTINUITY_BINDING.id,
+        actorWorsenFactor: 0.5,
+      },
+      missingBinding: {
+        id: 'actor:missing-binding',
+        label: 'Missing binding',
+        continuityBindingId: '',
+        actorWorsenFactor: 2,
+      },
+    })
+
+    expect(Object.keys(sanitized)).toEqual([SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR.id])
+    expect(sanitized[SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR.id]).toEqual(
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR
+    )
+  })
+
+  it('drops proto-pollution keys during sanitize', () => {
+    const protoPollution = sanitizeSpe947MediaEconomyCommercializationActors({
+      __proto__: {
+        id: '__proto__',
+        label: 'Proto pollution',
+        continuityBindingId: 'bind:proto',
+        actorWorsenFactor: 2,
+      },
+      valid: SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR,
+    })
+
+    expect(Object.keys(protoPollution)).toEqual([SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR.id])
+  })
+
+  it('lists persisted actors in code-unit id order', () => {
+    const actors = listSpe947MediaEconomyCommercializationActors(
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTORS_MAP
+    )
+
+    expect(actors.map((actor) => actor.id)).toEqual([
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR.id,
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_LIVESTREAM_ACTOR.id,
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTOR.id,
+    ])
+  })
+
+  it('round-trips actor map and tick stamp through serialize/hydrate', () => {
+    const state = createStartingState()
+    state.spe947MediaEconomyCommercializationActors =
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTORS_MAP
+    state.spe947MediaEconomyLastWeeklyTickWeek = 6
+
+    const loaded = hydrateGame(loadGameSave(serializeGameSave(state)), createStartingState())
+
+    expect(loaded.spe947MediaEconomyCommercializationActors).toEqual(
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTORS_MAP
+    )
+    expect(loaded.spe947MediaEconomyLastWeeklyTickWeek).toBe(6)
+  })
+
+  it('sanitizeSpe947MediaEconomyLastWeeklyTickWeek rejects invalid stamps', () => {
+    expect(sanitizeSpe947MediaEconomyLastWeeklyTickWeek(0, 3)).toBe(3)
+    expect(sanitizeSpe947MediaEconomyLastWeeklyTickWeek(1.5, 3)).toBe(3)
+    expect(sanitizeSpe947MediaEconomyLastWeeklyTickWeek(Number.NaN, 3)).toBe(3)
+    expect(sanitizeSpe947MediaEconomyLastWeeklyTickWeek(8, 3)).toBe(8)
+  })
+})
+
+describe('advanceWeek SPE-947 media-economy persisted actors (SPE-2616)', () => {
+  it('orchestrates week-close over persisted actors without mutating economy maps', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 6
+    state.spe947PostCaseMediaCases = {
+      [EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE.caseId!]:
+        EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE,
+    }
+    state.spe947MediaEconomyWeights = {
+      ...SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyWeights,
+    }
+    state.spe947MediaEconomyContinuityBindings = {
+      ...SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyContinuityBindings,
+    }
+    state.spe947MediaEconomyCommercializationActors =
+      SPE_947_EXAMPLE_MEDIA_ECONOMY_COMMERCIALIZATION_ACTORS_MAP
+
+    const priorWeights = structuredClone(state.spe947MediaEconomyWeights)
+    const priorBindings = structuredClone(state.spe947MediaEconomyContinuityBindings)
+    const priorActors = structuredClone(state.spe947MediaEconomyCommercializationActors)
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.spe947MediaEconomyWeights).toEqual(priorWeights)
+    expect(nextState.spe947MediaEconomyContinuityBindings).toEqual(priorBindings)
+    expect(nextState.spe947MediaEconomyCommercializationActors).toEqual(priorActors)
+    expect(nextState.spe947MediaEconomyLastWeeklyTickWeek).toBe(7)
+  })
+
+  it('same-week re-tick is idempotent via persisted lastWeeklyTickWeek', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.week = 4
+    state.spe947PostCaseMediaCases = {
+      [EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE.caseId!]:
+        EXAMPLE_WEAK_COMMERCIALIZATION_CONTINUITY_CASE,
+    }
+    state.spe947MediaEconomyWeights = {
+      ...SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyWeights,
+    }
+    state.spe947MediaEconomyContinuityBindings = {
+      ...SPE_947_EXAMPLE_MEDIA_ECONOMY_PERSISTENCE_FIXTURE.spe947MediaEconomyContinuityBindings,
+    }
+    state.spe947MediaEconomyCommercializationActors = Object.freeze({
+      [SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR.id]: SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR,
+    })
+
+    const once = advanceWeek(state)
+    const retickInput = {
+      ...once,
+      week: 4,
+      spe947MediaEconomyCommercializationActors: once.spe947MediaEconomyCommercializationActors,
+      spe947MediaEconomyLastWeeklyTickWeek: once.spe947MediaEconomyLastWeeklyTickWeek,
+    }
+    const reticked = advanceWeek(retickInput)
+
+    expect(reticked.spe947MediaEconomyLastWeeklyTickWeek).toBe(once.spe947MediaEconomyLastWeeklyTickWeek)
+    expect(reticked.spe947MediaEconomyCommercializationActors).toEqual(
+      once.spe947MediaEconomyCommercializationActors
+    )
+  })
+
+  it('still no-ops without persisted actors even when economy maps exist', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.spe947MediaEconomyWeights = {
+      'weight:test': {
+        id: 'weight:test',
+        label: 'Test weight',
+        continuityFactor: 2,
+      },
+    }
+    state.spe947MediaEconomyContinuityBindings = {
+      'bind:test': {
+        id: 'bind:test',
+        caseId: 'case:test',
+        economyWeightId: 'weight:test',
+      },
+    }
+
+    const nextState = advanceWeek(state)
+
+    expect(nextState.spe947MediaEconomyLastWeeklyTickWeek).toBeUndefined()
+    expect(listSpe947MediaEconomyCommercializationActors(
+      nextState.spe947MediaEconomyCommercializationActors
+    )).toEqual([])
+  })
+})

--- a/src/test/spe947MediaEconomyCommercializationActorPersistence.test.ts
+++ b/src/test/spe947MediaEconomyCommercializationActorPersistence.test.ts
@@ -109,15 +109,16 @@ describe('spe947MediaEconomyCommercializationActorPersistence (SPE-2616 / SPE-94
 
   it('drops proto-pollution keys during sanitize', () => {
     const protoPollution = sanitizeSpe947MediaEconomyCommercializationActors({
-      __proto__: {
+      polluted: {
         id: '__proto__',
-        label: 'Proto pollution',
+        label: 'Proto pollution attempt',
         continuityBindingId: 'bind:proto',
         actorWorsenFactor: 2,
       },
       valid: SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR,
     })
 
+    expect(Object.prototype.hasOwnProperty.call(protoPollution, '__proto__')).toBe(false)
     expect(Object.keys(protoPollution)).toEqual([SPE_947_EXAMPLE_MEDIA_ECONOMY_CLIP_FARM_ACTOR.id])
   })
 


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2616 — https://linear.app/spectranoir/issue/SPE-2616/persisted-commercialization-actor-map-richer-advanceweek-delta
- **Parent issue (if any):** SPE-947 — https://linear.app/spectranoir/issue/SPE-947/hazardous-content-propagation-and-counter-memetic-operations
- **Child issues covered:** slice only (SPE-2616)

## Summary

@coderabbitai summary

## What shipped

- `sanitizeSpe947MediaEconomyCommercializationActors` + `sanitizeSpe947MediaEconomyLastWeeklyTickWeek` on GameState with hydrate wiring in `runTransfer.ts`
- `advanceWeek` passes persisted actors into `applyWeeklySpe947MediaEconomyTick` and persists `spe947MediaEconomyLastWeeklyTickWeek`
- Focused Vitest for sanitize round-trip, empty/no-op, orchestrated week-close, and same-week idempotency

## Docs updated

- `planning/spe-947-commercialization-actor-persistence-slice-1.md`
- `planning/backlog.md` (SPE-2615 → Done handoff; SPE-2616 primary)
- `SCHEMA_REGISTRY.md`

## Parent status

- SPE-947 parent remains **Backlog** — actor persistence slice only; propagation graph and umbrella reconciliation still deferred

## Scope boundary

- No SPE-2610 weight/binding sanitize rewrite
- No authored weekly economy-map delta fields (`hasSpe947MediaEconomyWeeklyDelta` still false)
- No SPE-956 propagation graph
- No SPE-947 parent Done

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/spe947MediaEconomyCommercializationActorPersistence.test.ts src/test/advanceWeek.spe947Evaluator.integration.test.ts`
- [x] Lint / verify: `npm run lint`

## Screenshots (UI only)

<!-- Omit for domain-only changes -->

## Follow-ups

- Authored weekly economy-map delta fields (later SPE-947 sibling)
- SPE-956 propagation graph wire-up
- Parent umbrella reconciliation

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)
