### PR TITLE
SPE-2622: fix propagation graph hydration and unsafe map-key regressions

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -240,6 +240,9 @@ Tick wired from `advanceWeek` via `applyWeeklySpe956PropagationGraphTick`. Graph
 - Sanitize via `sanitizeSpe956PropagationGraphRecords` in `spe956PropagationGraphPersistence.ts`
 - Wired in `hydrateGame` (`src/app/store/runTransfer.ts`)
 - Invalid graphs, duplicate ids, unknown node kinds, dangling edges, and missing seed nodes are dropped without throw
+- Explicit authored `{}` hydrates as empty canonical map (does not fall back to prior graphs); non-record input still uses fallback
+- Unsafe graph ids (`__proto__`, `constructor`, `prototype`) are rejected; result map uses null prototype
+- `resolvePersistedPropagationGraph` resolves own properties only (SPE-2622)
 - Default starting state: empty `{}` map in `createStartingState`
 
 ### Versioning

--- a/src/domain/spe956PropagationGraphPersistence.ts
+++ b/src/domain/spe956PropagationGraphPersistence.ts
@@ -60,6 +60,10 @@ function isNonNegativeFinite(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0
 }
 
+function isSafeMapKey(id: string): boolean {
+  return id !== '__proto__' && id !== 'constructor' && id !== 'prototype'
+}
+
 function sanitizePositiveIntegerWeek(value: unknown): number | undefined {
   if (
     typeof value !== 'number' ||
@@ -154,7 +158,7 @@ function sanitizeSpe956PropagationGraphEntry(
   const id = normalizeId(value.id, '')
   const label = normalizeLabel(value.label, id)
   const seedNodeId = normalizeId(value.seedNodeId, '')
-  if (id.length === 0 || label.length === 0 || seedNodeId.length === 0) {
+  if (id.length === 0 || !isSafeMapKey(id) || label.length === 0 || seedNodeId.length === 0) {
     return null
   }
 
@@ -237,7 +241,7 @@ export function sanitizeSpe956PropagationGraphRecords(
     return fallback
   }
 
-  const next: Spe956PropagationGraphRecordsMap = {}
+  const next = Object.create(null) as Spe956PropagationGraphRecordsMap
   const seenIds = new Set<string>()
 
   for (const entry of Object.values(value)) {
@@ -250,7 +254,9 @@ export function sanitizeSpe956PropagationGraphRecords(
     next[record.id] = record
   }
 
-  return Object.keys(next).length > 0 ? next : fallback
+  // Plain-record input (including authored `{}`) wins over fallback so cleared
+  // maps survive Zustand rehydration when current state still holds records.
+  return next
 }
 
 export function extractSpe956PropagationGraphRecords(
@@ -263,7 +269,12 @@ export function resolvePersistedPropagationGraph(
   game: Partial<{ spe956PropagationGraphRecords?: Spe956PropagationGraphRecordsMap }>,
   graphId: string
 ): Spe956PersistedPropagationGraph | null {
-  return extractSpe956PropagationGraphRecords(game)[graphId] ?? null
+  const records = extractSpe956PropagationGraphRecords(game)
+  if (!Object.prototype.hasOwnProperty.call(records, graphId)) {
+    return null
+  }
+
+  return records[graphId] ?? null
 }
 
 export interface Spe956PropagationGraphGameStateLike {

--- a/src/test/spe956PropagationGraphPersistence.test.ts
+++ b/src/test/spe956PropagationGraphPersistence.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../domain/spe956PropagationGraph'
 import {
   composeSpe956PropagationGraphFromGameState,
+  resolvePersistedPropagationGraph,
   sanitizeSpe956PropagationGraphRecords,
   SPE_956_EXAMPLE_PROPAGATION_GRAPH_RECORDS,
 } from '../domain/spe956PropagationGraphPersistence'
@@ -27,6 +28,106 @@ import { BACKGROUND_FRAGMENT_LATENT_FIXTURE } from '../domain/visualTriggerHazar
 describe('spe956PropagationGraphPersistence (SPE-2621 / SPE-956 slice 2)', () => {
   it('defaults starting state to empty spe956PropagationGraphRecords', () => {
     expect(createStartingState().spe956PropagationGraphRecords).toEqual({})
+  })
+
+  it('returns explicit empty map instead of fallback during sanitize (SPE-2622)', () => {
+    const fallback = SPE_956_EXAMPLE_PROPAGATION_GRAPH_RECORDS
+
+    expect(sanitizeSpe956PropagationGraphRecords({}, fallback)).toEqual({})
+    expect(sanitizeSpe956PropagationGraphRecords({}, fallback)).not.toBe(fallback)
+  })
+
+  it('returns fallback only for non-record input during sanitize (SPE-2622)', () => {
+    const fallback = SPE_956_EXAMPLE_PROPAGATION_GRAPH_RECORDS
+
+    expect(sanitizeSpe956PropagationGraphRecords(null, fallback)).toBe(fallback)
+    expect(sanitizeSpe956PropagationGraphRecords(undefined, fallback)).toBe(fallback)
+    expect(sanitizeSpe956PropagationGraphRecords('not-a-record', fallback)).toBe(fallback)
+  })
+
+  it('rejects unsafe graph ids and preserves valid records in mixed input (SPE-2622)', () => {
+    const unsafeIds = ['__proto__', 'constructor', 'prototype'] as const
+
+    for (const unsafeId of unsafeIds) {
+      const polluted = sanitizeSpe956PropagationGraphRecords({
+        polluted: {
+          id: unsafeId,
+          label: 'Unsafe graph id',
+          seedNodeId: 'node:unsafe',
+          nodes: [
+            {
+              id: 'node:unsafe',
+              label: 'Unsafe',
+              kind: 'artifact',
+              entityId: 'artifact:unsafe',
+            },
+          ],
+          edges: [],
+        },
+      })
+
+      expect(Object.prototype.hasOwnProperty.call(polluted, unsafeId)).toBe(false)
+      expect(Object.keys(polluted)).toEqual([])
+    }
+
+    const mixed = sanitizeSpe956PropagationGraphRecords({
+      valid: SPE_956_EXAMPLE_PROPAGATION_GRAPH,
+      polluted: {
+        id: '__proto__',
+        label: 'Proto pollution attempt',
+        seedNodeId: 'node:artifact-leak',
+        nodes: SPE_956_EXAMPLE_PROPAGATION_GRAPH.nodes,
+        edges: [],
+      },
+    })
+
+    expect(mixed[SPE_956_EXAMPLE_PROPAGATION_GRAPH.id]).toEqual(
+      SPE_956_EXAMPLE_PROPAGATION_GRAPH
+    )
+    expect(Object.prototype.hasOwnProperty.call(mixed, '__proto__')).toBe(false)
+    expect(Object.keys(mixed)).toEqual([SPE_956_EXAMPLE_PROPAGATION_GRAPH.id])
+  })
+
+  it('resolvePersistedPropagationGraph ignores inherited keys (SPE-2622)', () => {
+    const inheritedGraphId = 'graph:inherited'
+    const records = Object.create(null) as Record<string, unknown>
+    records[inheritedGraphId] = SPE_956_EXAMPLE_PROPAGATION_GRAPH
+    Object.setPrototypeOf(records, {
+      [inheritedGraphId]: SPE_956_EXAMPLE_PROPAGATION_GRAPH,
+    })
+
+    expect(resolvePersistedPropagationGraph({ spe956PropagationGraphRecords: records }, inheritedGraphId)).toEqual(
+      SPE_956_EXAMPLE_PROPAGATION_GRAPH
+    )
+
+    const prototypeOnlyId = 'graph:prototype-only'
+    const prototypeBacked = Object.create({
+      [prototypeOnlyId]: SPE_956_EXAMPLE_PROPAGATION_GRAPH,
+    }) as Record<string, unknown>
+
+    expect(
+      resolvePersistedPropagationGraph(
+        { spe956PropagationGraphRecords: prototypeBacked },
+        prototypeOnlyId
+      )
+    ).toBeNull()
+  })
+
+  it('hydrates explicit empty graph records over fallback during import (SPE-2622)', () => {
+    const fallback = createStartingState()
+    Object.assign(fallback, {
+      spe956PropagationGraphRecords: SPE_956_EXAMPLE_PROPAGATION_GRAPH_RECORDS,
+    })
+
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        spe956PropagationGraphRecords: {},
+      },
+      fallback
+    )
+
+    expect(hydrated.spe956PropagationGraphRecords).toEqual({})
   })
 
   it('drops invalid and duplicate graph entries during sanitize without throwing', () => {


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2622 — https://linear.app/spectranoir/issue/SPE-2622/fix-spe-956-propagation-graph-hydration-and-unsafe-map-key-regressions
- **Parent issue (if any):** SPE-956 — https://linear.app/spectranoir/issue/SPE-956/advisory-groups-hotlines-and-participatory-decision-channels
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- `sanitizeSpe956PropagationGraphRecords` returns canonical empty map for explicit `{}` input instead of falling back to prior graphs
- Rejects unsafe graph ids (`__proto__`, `constructor`, `prototype`) and builds null-prototype result map
- `resolvePersistedPropagationGraph` resolves own properties only
- Regression tests for empty-map hydration, non-record fallback, unsafe ids, mixed input, and inherited-key rejection

## Docs updated

- `SCHEMA_REGISTRY.md` — SPE-956 hydration section (SPE-2622 notes)

## Parent status

- Parent SPE-956 remains open — bugfix slice only

## Scope boundary

- No changes to compose semantics, weekly orchestration tick, evaluator contracts, store/UI/mirror

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/spe956PropagationGraphPersistence.test.ts`
- [x] Lint / verify: `npm run lint`

## Screenshots (UI only)

<!-- Omit for domain-only changes -->

## Follow-ups

- SPE-956 store/UI/mirror surfacing for propagation graphs (deferred from slices 1–3)

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)
