### PR TITLE
SPE-2620: Community advisory body decision influence (slice 1)

### DIFF
--- a/planning/backlog-handoff-manifest.json
+++ b/planning/backlog-handoff-manifest.json
@@ -1,8 +1,9 @@
 {
   "primary": "SPE-2620",
-  "inProgress": [],
+  "inProgress": ["SPE-2620"],
   "recentlyShipped": ["SPE-2626", "SPE-2625"],
   "sliceDocStatus": {
+    "planning/spe-956-community-advisory-decision-influence-slice-1.md": "In Progress",
     "planning/spe-2625-propagation-graph-counter-overflow-fix.md": "Shipped",
     "planning/spe-956-propagation-graph-surfacing-slice-4.md": "Shipped"
   }

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -72,9 +72,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Current handoff (primary):** [SPE-2620](https://linear.app/spectranoir/issue/SPE-2620) — community advisory body decision influence (slice 1); create the implementation slice doc before coding.
+**Current handoff (primary):** [SPE-2620](https://linear.app/spectranoir/issue/SPE-2620) — community advisory body decision influence (slice 1); slice doc `planning/spe-956-community-advisory-decision-influence-slice-1.md`.
 
-**In progress:** (none)
+**In progress:** [SPE-2620](https://linear.app/spectranoir/issue/SPE-2620) — community advisory body decision influence (slice 1); branch `spe-956-community-advisory-decision-influence-slice-1`.
 
 **Recently shipped:** [SPE-2626](https://linear.app/spectranoir/issue/SPE-2626) SPE-956 propagation graph mirror corrective pass — code-unit ordering, neutral enum formatting, explicit edge empty state, source-array totals, and trimmed entity ids. Parent [SPE-956](https://linear.app/spectranoir/issue/SPE-956) stays **Backlog**.
 
@@ -421,6 +421,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-947-counter-memetic-uptake-gate-slice-1.md`                          | **Shipped**     | [SPE-2570](https://linear.app/spectranoir/issue/SPE-2570) — pure counter-memetic lore + distributor + uptake gate evaluator (parent AC row 3); PR #3063 @ `e46115b2`; parent SPE-947 stays **Backlog**.                                                                                               |
 | `spe-947-platform-outage-degrade-slice-1.md`                              | **Shipped**     | [SPE-2569](https://linear.app/spectranoir/issue/SPE-2569) — pure platform outage / reach-failure degrade evaluator (parent AC row 4); PR #3061 @ `ee721082`; parent SPE-947 stays **Backlog**.                                                                                                        |
 | `spe-947-platform-reach-multiplier-slice-1.md`                            | **Shipped**     | [SPE-2568](https://linear.app/spectranoir/issue/SPE-2568) — pure platform reach-multiplier evaluator (parent AC row 1); PR #3059 @ `cc1ec1d4`; parent SPE-947 stays **Backlog**.                                                                                                                      |
+| `spe-956-community-advisory-decision-influence-slice-1.md`                | **In Progress** | [SPE-2620](https://linear.app/spectranoir/issue/SPE-2620) — pure community advisory body decision influence evaluator + authored incident fixture; parent SPE-956 stays **Backlog**.                                                                                                                    |
 | `spe-956-propagation-graph-wire-up-slice-1.md`                            | **Shipped**     | [SPE-2619](https://linear.app/spectranoir/issue/SPE-2619) — pure propagation graph compose over SPE-947 evaluators + SPE-2111 registry; PR #3140 @ `cbba01d4`; parent SPE-956 stays **Backlog**.                                                                                                      |
 | `spe-956-propagation-graph-persistence-slice-2.md`                        | **Shipped**     | [SPE-2621](https://linear.app/spectranoir/issue/SPE-2621) — GameState persistence for authored graphs; PR #3143 @ `dc2bf497`; parent SPE-956 stays **Backlog**.                                                                                                                                       |
 | `spe-956-propagation-graph-week-close-slice-3.md`                         | **Shipped**     | [SPE-2624](https://linear.app/spectranoir/issue/SPE-2624) — week-close graph tick; PR #3147 @ `62766f11`; parent SPE-956 stays **Backlog**.                                                                                                                                                           |

--- a/planning/spe-956-community-advisory-decision-influence-slice-1.md
+++ b/planning/spe-956-community-advisory-decision-influence-slice-1.md
@@ -31,12 +31,13 @@ Ship the smallest pure deterministic community-advisory surface: one authored ad
 - **Baseline:** incidentId + responseTiming / restrictionLevel / framing / supportRouting strings (single source of truth input).
 - **supportScore** = `SUPPORT_BAND_WEIGHT[supportBand] * confidence` (micro-rounded for display; compare with raw product).
 - **Disposition priority:**
-  1. Missing/invalid evaluation input, body, signal, or baseline → `deferred`, resolved === baseline, no adjustment.
+  1. Missing/invalid evaluation input, body, signal, or baseline (including partial baselines missing required fields) → `deferred`, resolved === baseline, no adjustment.
   2. bodyId mismatch → `rejected`, no adjustment.
   3. Recommendation scope ∉ authorizedDecisionScopes → `rejected` (`recommendation_out_of_scope`), no adjustment.
-  4. supportScore < influenceThreshold → `deferred` when urgency is `elevated`/`urgent`, else `rejected` (`below_influence_threshold`); no adjustment.
-  5. Meets threshold + conditions present → `modified`, apply proposed value, keep conditions inspectable.
-  6. Meets threshold + no conditions → `adopted`, apply proposed value.
+  4. Malformed `conditions` (non-array or non-string entries) → `deferred` (`invalid_advisory_conditions`), no adjustment.
+  5. supportScore < influenceThreshold → `deferred` when urgency is `elevated`/`urgent`, else `rejected` (`below_influence_threshold`); no adjustment.
+  6. Meets threshold + conditions present → `modified`, apply proposed value, keep conditions inspectable.
+  7. Meets threshold + no conditions → `adopted`, apply proposed value.
 - Result is frozen: disposition, baseline, resolved, proposedAdjustment | null, supportScore, influenceThreshold, bodyId, reasonCodes (unique sorted).
 - Never mutates baseline; never invents parallel policy maps.
 

--- a/planning/spe-956-community-advisory-decision-influence-slice-1.md
+++ b/planning/spe-956-community-advisory-decision-influence-slice-1.md
@@ -1,0 +1,89 @@
+# SPE-956 — Community advisory body decision influence (slice 1)
+
+One-page implementation plan. Linear: [SPE-2620](https://linear.app/spectranoir/issue/SPE-2620) (child under [SPE-956](https://linear.app/spectranoir/issue/SPE-956)). First participatory-decision boundary for the SPE-956 umbrella. Parent stays **Backlog**.
+
+| Field               | Value                                                                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2620 — Community advisory body decision influence (slice 1)](https://linear.app/spectranoir/issue/SPE-2620)                 |
+| **Status**          | **In Progress**                                                                                                                  |
+| **Parent**          | [SPE-956](https://linear.app/spectranoir/issue/SPE-956) — advisory groups / hotlines / participatory channels; stays **Backlog** |
+| **Branch**          | `spe-956-community-advisory-decision-influence-slice-1`                                                                          |
+| **Base `main` SHA** | `0c2d31ea`                                                                                                                       |
+
+## Goal
+
+Ship the smallest pure deterministic community-advisory surface: one authored advisory body with mission, membership rule, stakeholder classes, authorized scopes, and influence threshold can materially change an incident response choice via a frozen proposed-adjustment envelope — without UI, persistence, store, week-close wiring, or parallel policy state.
+
+## Prerequisite (on `main` @ `0c2d31ea`)
+
+| Shipped / pattern              | Anchor                                                                          |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| Frozen evaluator envelopes     | `contentOwnerTakedownResistance.ts`, `segmentedFeedbackWorkflow.ts`             |
+| Bounded proposed adjustments   | `authorityNegotiation.ts` adjustment pattern (reuse shape, not authority graph) |
+| Operational advisories (avoid) | `advisory.ts` — team arrangement / instability hints; **do not extend**         |
+| SPE-956 graph siblings         | SPE-2619–2626 propagation graph chain (orthogonal; do not rewrite)              |
+
+## Evaluation contract
+
+- **Module:** `src/domain/communityAdvisoryDecisionInfluence.ts` (distinct from operational `advisory.ts`).
+- **Body:** id, mission, membershipRule, representedStakeholderClasses, authorizedDecisionScopes, influenceThreshold, decisionCriteria.
+- **Signal:** bodyId, recommendation `{ scope, proposedValue }`, supportBand, confidence (0–1), urgency, optional conditions.
+- **Baseline:** incidentId + responseTiming / restrictionLevel / framing / supportRouting strings (single source of truth input).
+- **supportScore** = `SUPPORT_BAND_WEIGHT[supportBand] * confidence` (micro-rounded for display; compare with raw product).
+- **Disposition priority:**
+  1. Missing/invalid evaluation input, body, signal, or baseline → `deferred`, resolved === baseline, no adjustment.
+  2. bodyId mismatch → `rejected`, no adjustment.
+  3. Recommendation scope ∉ authorizedDecisionScopes → `rejected` (`recommendation_out_of_scope`), no adjustment.
+  4. supportScore < influenceThreshold → `deferred` when urgency is `elevated`/`urgent`, else `rejected` (`below_influence_threshold`); no adjustment.
+  5. Meets threshold + conditions present → `modified`, apply proposed value, keep conditions inspectable.
+  6. Meets threshold + no conditions → `adopted`, apply proposed value.
+- Result is frozen: disposition, baseline, resolved, proposedAdjustment | null, supportScore, influenceThreshold, bodyId, reasonCodes (unique sorted).
+- Never mutates baseline; never invents parallel policy maps.
+
+## Scope
+
+| In                                                               | Out                                                       |
+| ---------------------------------------------------------------- | --------------------------------------------------------- |
+| Compact body / signal / baseline types + pure evaluator          | Hotline intake / scripts / staffing (later SPE-956 child) |
+| Dispositions `adopted` \| `modified` \| `deferred` \| `rejected` | SPE-860 inquiry queues; SPE-911 notifications             |
+| One authored incident fixture where advisory changes routing     | SPE-875 worker governance; SPE-1682 survivor registry     |
+| Focused Vitest + slice doc + backlog handoff                     | UI / persistence / store / week-close                     |
+|                                                                  | Full deliberative-democracy / elections simulator         |
+|                                                                  | Edits to `advisory.ts` operational hints                  |
+
+## Acceptance
+
+- [x] One advisory body has explicit mission, membership rules, stakeholders, scope, and decision criteria.
+- [x] One authored advisory signal materially changes an incident response decision (`adopted`).
+- [x] At least one signal is `modified`, `deferred`, or `rejected` for scope exceed or threshold failure.
+- [x] Empty/missing advisory input is a deterministic no-op without throw.
+- [x] Focused tests cover adopted influence, bounded reject/defer/modify, stable reason codes, immutability.
+- [ ] SPE-956 remains **Backlog** after this child ships; child Done only after merge.
+
+## Validation
+
+- `npm.cmd run test:run -- src/test/communityAdvisoryDecisionInfluence.test.ts`
+- `npm.cmd run lint`
+- `npm.cmd run verify:backlog-handoff`
+- Direct Prettier check for touched files only.
+
+## Deferred
+
+| Item                                     | Suggested owner                                         | Why deferred                                      |
+| ---------------------------------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| Hotline intake / callback queues         | Later SPE-956 child; coordinate SPE-860                 | Parent participatory channel, not this boundary   |
+| Stakeholder notification duties          | [SPE-911](https://linear.app/spectranoir/issue/SPE-911) | Separate notification matrix                      |
+| Worker / contractor governance           | [SPE-875](https://linear.app/spectranoir/issue/SPE-875) | Out of advisory-body influence                    |
+| Survivor registry / recurrence           | Later SPE-956 child; SPE-860 / SPE-1682                 | Separate registry surface                         |
+| Persistence / store / week-close wire    | SPE-956 follow-up child                                 | Domain-only foundation this slice                 |
+| UI / planning mirror                     | SPE-956 follow-up child                                 | No presentational surface this slice              |
+| Compose with operational `getAdvisories` | Do not merge                                            | Distinct operational vs community advisory spaces |
+
+## See also
+
+- `src/domain/contentOwnerTakedownResistance.ts`
+- `src/domain/segmentedFeedbackWorkflow.ts`
+- `src/domain/authorityNegotiation.ts`
+- `src/domain/advisory.ts` (operational — do not extend)
+- `planning/spe-956-propagation-graph-wire-up-slice-1.md`
+- `planning/backlog.md`

--- a/src/domain/communityAdvisoryDecisionInfluence.ts
+++ b/src/domain/communityAdvisoryDecisionInfluence.ts
@@ -144,12 +144,29 @@ function normalizeToken(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
-function normalizeStringList(values: unknown): readonly string[] {
-  if (!Array.isArray(values)) {
-    return Object.freeze([])
+function tryNormalizeConditions(
+  values: unknown
+): { readonly ok: true; readonly conditions: readonly string[] } | { readonly ok: false } {
+  if (values === undefined) {
+    return { ok: true, conditions: Object.freeze([]) }
   }
 
-  return uniqueSorted(values.map((value) => normalizeToken(value)))
+  if (!Array.isArray(values)) {
+    return { ok: false }
+  }
+
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      return { ok: false }
+    }
+  }
+
+  return {
+    ok: true,
+    conditions: uniqueSorted(
+      values.map((value) => value.trim()).filter((value) => value.length > 0)
+    ),
+  }
 }
 
 function freezeBaseline(decision: IncidentResponseDecision): IncidentResponseDecision {
@@ -289,13 +306,27 @@ function isUrgency(value: unknown): value is CommunityAdvisoryUrgency {
   return typeof value === 'string' && URGENCY_SET.has(value)
 }
 
-function normalizeBaseline(value: IncidentResponseDecision): IncidentResponseDecision {
+function tryNormalizeBaseline(value: unknown): IncidentResponseDecision | null {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const incidentId = normalizeToken(value.incidentId)
+  const responseTiming = normalizeToken(value.responseTiming)
+  const restrictionLevel = normalizeToken(value.restrictionLevel)
+  const framing = normalizeToken(value.framing)
+  const supportRouting = normalizeToken(value.supportRouting)
+
+  if (!incidentId || !responseTiming || !restrictionLevel || !framing || !supportRouting) {
+    return null
+  }
+
   return freezeBaseline({
-    incidentId: normalizeToken(value.incidentId) || 'incident:unknown',
-    responseTiming: normalizeToken(value.responseTiming) || 'unchanged',
-    restrictionLevel: normalizeToken(value.restrictionLevel) || 'unchanged',
-    framing: normalizeToken(value.framing) || 'unchanged',
-    supportRouting: normalizeToken(value.supportRouting) || 'unchanged',
+    incidentId,
+    responseTiming,
+    restrictionLevel,
+    framing,
+    supportRouting,
   })
 }
 
@@ -324,7 +355,10 @@ export function evaluateCommunityAdvisoryDecisionInfluence(
     return emptyDeferredResult(['invalid_incident_baseline'])
   }
 
-  const baseline = normalizeBaseline(rawBaseline as IncidentResponseDecision)
+  const baseline = tryNormalizeBaseline(rawBaseline)
+  if (!baseline) {
+    return emptyDeferredResult(['invalid_incident_baseline'])
+  }
 
   const rawBody = input.body
   if (rawBody === null || rawBody === undefined) {
@@ -358,7 +392,14 @@ export function evaluateCommunityAdvisoryDecisionInfluence(
   const authorizedScopes = Array.isArray(body.authorizedDecisionScopes)
     ? body.authorizedDecisionScopes.filter(isDecisionScope)
     : []
-  const conditions = normalizeStringList(signal.conditions)
+  const normalizedConditions = tryNormalizeConditions(signal.conditions)
+  if (!normalizedConditions.ok) {
+    return emptyDeferredResult(['invalid_advisory_conditions'], baseline, {
+      bodyId,
+      influenceThreshold,
+    })
+  }
+  const conditions = normalizedConditions.conditions
 
   if (!bodyId) {
     return emptyDeferredResult(['missing_advisory_body_id'], baseline)

--- a/src/domain/communityAdvisoryDecisionInfluence.ts
+++ b/src/domain/communityAdvisoryDecisionInfluence.ts
@@ -1,0 +1,535 @@
+/**
+ * SPE-2620 / SPE-956 slice 1: community advisory body decision influence.
+ * Pure deterministic evaluator — returns a frozen proposed-adjustment envelope.
+ * Distinct from operational team advisories in `advisory.ts`.
+ * No GameState persistence, store, UI, or week-close coupling.
+ */
+
+export const COMMUNITY_ADVISORY_DECISION_SCOPES = [
+  'response_timing',
+  'restriction_level',
+  'framing',
+  'support_routing',
+] as const
+
+export type CommunityAdvisoryDecisionScope = (typeof COMMUNITY_ADVISORY_DECISION_SCOPES)[number]
+
+export const COMMUNITY_ADVISORY_SUPPORT_BANDS = ['low', 'moderate', 'strong', 'unanimous'] as const
+
+export type CommunityAdvisorySupportBand = (typeof COMMUNITY_ADVISORY_SUPPORT_BANDS)[number]
+
+export const COMMUNITY_ADVISORY_URGENCIES = ['routine', 'elevated', 'urgent'] as const
+
+export type CommunityAdvisoryUrgency = (typeof COMMUNITY_ADVISORY_URGENCIES)[number]
+
+export const COMMUNITY_ADVISORY_DISPOSITIONS = [
+  'adopted',
+  'modified',
+  'deferred',
+  'rejected',
+] as const
+
+export type CommunityAdvisoryDisposition = (typeof COMMUNITY_ADVISORY_DISPOSITIONS)[number]
+
+export const SUPPORT_BAND_WEIGHT: Readonly<Record<CommunityAdvisorySupportBand, number>> =
+  Object.freeze({
+    low: 0.25,
+    moderate: 0.5,
+    strong: 0.75,
+    unanimous: 1,
+  })
+
+export interface CommunityAdvisoryBody {
+  readonly id: string
+  readonly mission: string
+  readonly membershipRule: string
+  readonly representedStakeholderClasses: readonly string[]
+  readonly authorizedDecisionScopes: readonly CommunityAdvisoryDecisionScope[]
+  readonly influenceThreshold: number
+  readonly decisionCriteria: string
+}
+
+export interface CommunityAdvisoryRecommendation {
+  readonly scope: CommunityAdvisoryDecisionScope
+  readonly proposedValue: string
+}
+
+export interface CommunityAdvisorySignal {
+  readonly bodyId: string
+  readonly recommendation: CommunityAdvisoryRecommendation
+  readonly supportBand: CommunityAdvisorySupportBand
+  readonly confidence: number
+  readonly urgency: CommunityAdvisoryUrgency
+  readonly conditions?: readonly string[]
+}
+
+export interface IncidentResponseDecision {
+  readonly incidentId: string
+  readonly responseTiming: string
+  readonly restrictionLevel: string
+  readonly framing: string
+  readonly supportRouting: string
+}
+
+export interface CommunityAdvisoryProposedAdjustment {
+  readonly scope: CommunityAdvisoryDecisionScope
+  readonly fromValue: string
+  readonly toValue: string
+}
+
+export interface CommunityAdvisoryInfluenceEvaluationInput {
+  readonly body?: CommunityAdvisoryBody | null
+  readonly signal?: CommunityAdvisorySignal | null
+  readonly baseline?: IncidentResponseDecision | null
+}
+
+export interface CommunityAdvisoryInfluenceResult {
+  readonly disposition: CommunityAdvisoryDisposition
+  readonly bodyId: string | null
+  readonly baseline: IncidentResponseDecision
+  readonly resolved: IncidentResponseDecision
+  readonly proposedAdjustment: CommunityAdvisoryProposedAdjustment | null
+  readonly supportScore: number
+  readonly influenceThreshold: number
+  readonly conditions: readonly string[]
+  readonly reasonCodes: readonly string[]
+}
+
+const EMPTY_BASELINE: IncidentResponseDecision = Object.freeze({
+  incidentId: 'incident:unknown',
+  responseTiming: 'unchanged',
+  restrictionLevel: 'unchanged',
+  framing: 'unchanged',
+  supportRouting: 'unchanged',
+})
+
+const SCOPE_SET = new Set<string>(COMMUNITY_ADVISORY_DECISION_SCOPES)
+const SUPPORT_BAND_SET = new Set<string>(COMMUNITY_ADVISORY_SUPPORT_BANDS)
+const URGENCY_SET = new Set<string>(COMMUNITY_ADVISORY_URGENCIES)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function uniqueSorted(values: readonly string[]): readonly string[] {
+  return Object.freeze(
+    [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))].sort(
+      (left, right) => left.localeCompare(right)
+    )
+  )
+}
+
+function isUnitInterval(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 1
+}
+
+function isPositiveUnitInterval(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 && value <= 1
+}
+
+function roundMetric(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0
+  }
+
+  const scaled = value * 1_000_000
+  if (!Number.isFinite(scaled)) {
+    return value
+  }
+
+  return Math.round(scaled) / 1_000_000
+}
+
+function normalizeToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeStringList(values: unknown): readonly string[] {
+  if (!Array.isArray(values)) {
+    return Object.freeze([])
+  }
+
+  return uniqueSorted(values.map((value) => normalizeToken(value)))
+}
+
+function freezeBaseline(decision: IncidentResponseDecision): IncidentResponseDecision {
+  return Object.freeze({
+    incidentId: decision.incidentId,
+    responseTiming: decision.responseTiming,
+    restrictionLevel: decision.restrictionLevel,
+    framing: decision.framing,
+    supportRouting: decision.supportRouting,
+  })
+}
+
+function cloneBaseline(decision: IncidentResponseDecision): IncidentResponseDecision {
+  return freezeBaseline({ ...decision })
+}
+
+function freezeAdjustment(
+  adjustment: CommunityAdvisoryProposedAdjustment
+): CommunityAdvisoryProposedAdjustment {
+  return Object.freeze({ ...adjustment })
+}
+
+function freezeResult(result: CommunityAdvisoryInfluenceResult): CommunityAdvisoryInfluenceResult {
+  return Object.freeze({
+    disposition: result.disposition,
+    bodyId: result.bodyId,
+    baseline: freezeBaseline(result.baseline),
+    resolved: freezeBaseline(result.resolved),
+    proposedAdjustment: result.proposedAdjustment
+      ? freezeAdjustment(result.proposedAdjustment)
+      : null,
+    supportScore: result.supportScore,
+    influenceThreshold: result.influenceThreshold,
+    conditions: Object.freeze([...result.conditions]),
+    reasonCodes: uniqueSorted(result.reasonCodes),
+  })
+}
+
+function emptyDeferredResult(
+  reasonCodes: readonly string[],
+  baseline: IncidentResponseDecision = EMPTY_BASELINE,
+  extras: {
+    bodyId?: string | null
+    supportScore?: number
+    influenceThreshold?: number
+    conditions?: readonly string[]
+  } = {}
+): CommunityAdvisoryInfluenceResult {
+  const frozenBaseline = cloneBaseline(baseline)
+  return freezeResult({
+    disposition: 'deferred',
+    bodyId: extras.bodyId ?? null,
+    baseline: frozenBaseline,
+    resolved: cloneBaseline(frozenBaseline),
+    proposedAdjustment: null,
+    supportScore: extras.supportScore ?? 0,
+    influenceThreshold: extras.influenceThreshold ?? 0,
+    conditions: extras.conditions ?? Object.freeze([]),
+    reasonCodes,
+  })
+}
+
+function emptyRejectedResult(
+  reasonCodes: readonly string[],
+  baseline: IncidentResponseDecision,
+  extras: {
+    bodyId?: string | null
+    supportScore?: number
+    influenceThreshold?: number
+    conditions?: readonly string[]
+  } = {}
+): CommunityAdvisoryInfluenceResult {
+  const frozenBaseline = cloneBaseline(baseline)
+  return freezeResult({
+    disposition: 'rejected',
+    bodyId: extras.bodyId ?? null,
+    baseline: frozenBaseline,
+    resolved: cloneBaseline(frozenBaseline),
+    proposedAdjustment: null,
+    supportScore: extras.supportScore ?? 0,
+    influenceThreshold: extras.influenceThreshold ?? 0,
+    conditions: extras.conditions ?? Object.freeze([]),
+    reasonCodes,
+  })
+}
+
+function readScopeValue(
+  decision: IncidentResponseDecision,
+  scope: CommunityAdvisoryDecisionScope
+): string {
+  switch (scope) {
+    case 'response_timing':
+      return decision.responseTiming
+    case 'restriction_level':
+      return decision.restrictionLevel
+    case 'framing':
+      return decision.framing
+    case 'support_routing':
+      return decision.supportRouting
+    default: {
+      const _exhaustive: never = scope
+      return _exhaustive
+    }
+  }
+}
+
+function applyAdjustment(
+  decision: IncidentResponseDecision,
+  scope: CommunityAdvisoryDecisionScope,
+  toValue: string
+): IncidentResponseDecision {
+  switch (scope) {
+    case 'response_timing':
+      return freezeBaseline({ ...decision, responseTiming: toValue })
+    case 'restriction_level':
+      return freezeBaseline({ ...decision, restrictionLevel: toValue })
+    case 'framing':
+      return freezeBaseline({ ...decision, framing: toValue })
+    case 'support_routing':
+      return freezeBaseline({ ...decision, supportRouting: toValue })
+    default: {
+      const _exhaustive: never = scope
+      return _exhaustive
+    }
+  }
+}
+
+function isDecisionScope(value: unknown): value is CommunityAdvisoryDecisionScope {
+  return typeof value === 'string' && SCOPE_SET.has(value)
+}
+
+function isSupportBand(value: unknown): value is CommunityAdvisorySupportBand {
+  return typeof value === 'string' && SUPPORT_BAND_SET.has(value)
+}
+
+function isUrgency(value: unknown): value is CommunityAdvisoryUrgency {
+  return typeof value === 'string' && URGENCY_SET.has(value)
+}
+
+function normalizeBaseline(value: IncidentResponseDecision): IncidentResponseDecision {
+  return freezeBaseline({
+    incidentId: normalizeToken(value.incidentId) || 'incident:unknown',
+    responseTiming: normalizeToken(value.responseTiming) || 'unchanged',
+    restrictionLevel: normalizeToken(value.restrictionLevel) || 'unchanged',
+    framing: normalizeToken(value.framing) || 'unchanged',
+    supportRouting: normalizeToken(value.supportRouting) || 'unchanged',
+  })
+}
+
+/**
+ * Evaluates whether a community advisory signal may adjust an incident response
+ * decision. Returns a proposed adjustment / resolved snapshot — never a parallel
+ * policy store. Insufficient or missing signals are no-ops.
+ */
+export function evaluateCommunityAdvisoryDecisionInfluence(
+  input: CommunityAdvisoryInfluenceEvaluationInput | null | undefined
+): CommunityAdvisoryInfluenceResult {
+  if (input === null || input === undefined) {
+    return emptyDeferredResult(['missing_evaluation_input'])
+  }
+
+  if (!isRecord(input)) {
+    return emptyDeferredResult(['invalid_evaluation_input'])
+  }
+
+  const rawBaseline = input.baseline
+  if (rawBaseline === null || rawBaseline === undefined) {
+    return emptyDeferredResult(['missing_incident_baseline'])
+  }
+
+  if (!isRecord(rawBaseline)) {
+    return emptyDeferredResult(['invalid_incident_baseline'])
+  }
+
+  const baseline = normalizeBaseline(rawBaseline as IncidentResponseDecision)
+
+  const rawBody = input.body
+  if (rawBody === null || rawBody === undefined) {
+    return emptyDeferredResult(['missing_advisory_body'], baseline)
+  }
+
+  if (!isRecord(rawBody)) {
+    return emptyDeferredResult(['invalid_advisory_body'], baseline)
+  }
+
+  const rawSignal = input.signal
+  if (rawSignal === null || rawSignal === undefined) {
+    return emptyDeferredResult(['missing_advisory_signal'], baseline, {
+      bodyId: normalizeToken((rawBody as CommunityAdvisoryBody).id) || null,
+    })
+  }
+
+  if (!isRecord(rawSignal)) {
+    return emptyDeferredResult(['invalid_advisory_signal'], baseline, {
+      bodyId: normalizeToken((rawBody as CommunityAdvisoryBody).id) || null,
+    })
+  }
+
+  const body = rawBody as CommunityAdvisoryBody
+  const signal = rawSignal as CommunityAdvisorySignal
+  const bodyId = normalizeToken(body.id) || null
+  const signalBodyId = normalizeToken(signal.bodyId)
+  const influenceThreshold = isPositiveUnitInterval(body.influenceThreshold)
+    ? body.influenceThreshold
+    : 0
+  const authorizedScopes = Array.isArray(body.authorizedDecisionScopes)
+    ? body.authorizedDecisionScopes.filter(isDecisionScope)
+    : []
+  const conditions = normalizeStringList(signal.conditions)
+
+  if (!bodyId) {
+    return emptyDeferredResult(['missing_advisory_body_id'], baseline)
+  }
+
+  if (!isPositiveUnitInterval(body.influenceThreshold)) {
+    return emptyDeferredResult(['missing_or_invalid_influence_threshold'], baseline, {
+      bodyId,
+      conditions,
+    })
+  }
+
+  if (!signalBodyId || signalBodyId !== bodyId) {
+    return emptyRejectedResult(['advisory_rejected', 'body_signal_mismatch'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  const recommendation = signal.recommendation
+  if (!isRecord(recommendation) || !isDecisionScope(recommendation.scope)) {
+    return emptyDeferredResult(['missing_or_invalid_recommendation_scope'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  const proposedValue = normalizeToken(recommendation.proposedValue)
+  if (!proposedValue) {
+    return emptyDeferredResult(['missing_recommendation_value'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  if (!authorizedScopes.includes(recommendation.scope)) {
+    return emptyRejectedResult(['advisory_rejected', 'recommendation_out_of_scope'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  if (!isSupportBand(signal.supportBand)) {
+    return emptyDeferredResult(['missing_or_invalid_support_band'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  if (!isUnitInterval(signal.confidence)) {
+    return emptyDeferredResult(['missing_or_invalid_confidence'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  if (!isUrgency(signal.urgency)) {
+    return emptyDeferredResult(['missing_or_invalid_urgency'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  const rawSupportScore = SUPPORT_BAND_WEIGHT[signal.supportBand] * signal.confidence
+  const supportScore = roundMetric(rawSupportScore)
+
+  if (rawSupportScore < influenceThreshold) {
+    const deferForUrgency = signal.urgency === 'elevated' || signal.urgency === 'urgent'
+    if (deferForUrgency) {
+      return freezeResult({
+        disposition: 'deferred',
+        bodyId,
+        baseline,
+        resolved: cloneBaseline(baseline),
+        proposedAdjustment: null,
+        supportScore,
+        influenceThreshold,
+        conditions,
+        reasonCodes: ['advisory_deferred', 'below_influence_threshold'],
+      })
+    }
+
+    return emptyRejectedResult(['advisory_rejected', 'below_influence_threshold'], baseline, {
+      bodyId,
+      supportScore,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  const fromValue = readScopeValue(baseline, recommendation.scope)
+  const proposedAdjustment = freezeAdjustment({
+    scope: recommendation.scope,
+    fromValue,
+    toValue: proposedValue,
+  })
+  const resolved = applyAdjustment(baseline, recommendation.scope, proposedValue)
+
+  if (conditions.length > 0) {
+    return freezeResult({
+      disposition: 'modified',
+      bodyId,
+      baseline,
+      resolved,
+      proposedAdjustment,
+      supportScore,
+      influenceThreshold,
+      conditions,
+      reasonCodes: ['advisory_modified_with_conditions'],
+    })
+  }
+
+  return freezeResult({
+    disposition: 'adopted',
+    bodyId,
+    baseline,
+    resolved,
+    proposedAdjustment,
+    supportScore,
+    influenceThreshold,
+    conditions,
+    reasonCodes: ['advisory_adopted'],
+  })
+}
+
+/** Authored advisory body: riverside stakeholders with bounded incident influence. */
+export const EXAMPLE_COMMUNITY_ADVISORY_BODY: CommunityAdvisoryBody = Object.freeze({
+  id: 'advisory-body:riverside-stakeholders',
+  mission:
+    'Represent local residents and survivors when incident response framing, timing, or support routing affects the community.',
+  membershipRule:
+    'Two resident delegates, one survivor advocate, one municipal liaison; rotating chair by authored roster.',
+  representedStakeholderClasses: Object.freeze([
+    'local_residents',
+    'survivors',
+    'municipal_liaison',
+  ]),
+  authorizedDecisionScopes: Object.freeze([
+    'framing',
+    'response_timing',
+    'support_routing',
+  ] as const satisfies readonly CommunityAdvisoryDecisionScope[]),
+  influenceThreshold: 0.6,
+  decisionCriteria:
+    'Adopt when support band × confidence meets the authored influence threshold and the recommendation stays inside authorized scopes; otherwise defer or reject without changing the incident baseline.',
+})
+
+/** Authored incident baseline for the riverside advisory fixture. */
+export const EXAMPLE_INCIDENT_BASELINE: IncidentResponseDecision = Object.freeze({
+  incidentId: 'incident:riverside-site-breach',
+  responseTiming: 'immediate_deploy',
+  restrictionLevel: 'soft_perimeter',
+  framing: 'agency_first_brief',
+  supportRouting: 'standard_ops_desk',
+})
+
+/** Authored signal that materially changes support routing when adopted. */
+export const EXAMPLE_SUPPORT_ROUTING_SIGNAL: CommunityAdvisorySignal = Object.freeze({
+  bodyId: 'advisory-body:riverside-stakeholders',
+  recommendation: Object.freeze({
+    scope: 'support_routing' as const,
+    proposedValue: 'community_liaison_first',
+  }),
+  supportBand: 'strong',
+  confidence: 0.9,
+  urgency: 'elevated',
+})

--- a/src/domain/communityAdvisoryDecisionInfluence.ts
+++ b/src/domain/communityAdvisoryDecisionInfluence.ts
@@ -392,6 +392,39 @@ export function evaluateCommunityAdvisoryDecisionInfluence(
   const authorizedScopes = Array.isArray(body.authorizedDecisionScopes)
     ? body.authorizedDecisionScopes.filter(isDecisionScope)
     : []
+  const mission = normalizeToken(body.mission)
+  const membershipRule = normalizeToken(body.membershipRule)
+  const decisionCriteria = normalizeToken(body.decisionCriteria)
+  const stakeholderClasses = Array.isArray(body.representedStakeholderClasses)
+    ? body.representedStakeholderClasses
+        .map((value) => normalizeToken(value))
+        .filter((value) => value.length > 0)
+    : []
+
+  if (!bodyId) {
+    return emptyDeferredResult(['missing_advisory_body_id'], baseline)
+  }
+
+  if (!mission || !membershipRule || !decisionCriteria || stakeholderClasses.length === 0) {
+    return emptyDeferredResult(['incomplete_advisory_body'], baseline, {
+      bodyId,
+      influenceThreshold,
+    })
+  }
+
+  if (!isPositiveUnitInterval(body.influenceThreshold)) {
+    return emptyDeferredResult(['missing_or_invalid_influence_threshold'], baseline, {
+      bodyId,
+    })
+  }
+
+  if (authorizedScopes.length === 0) {
+    return emptyDeferredResult(['missing_authorized_decision_scopes'], baseline, {
+      bodyId,
+      influenceThreshold,
+    })
+  }
+
   const normalizedConditions = tryNormalizeConditions(signal.conditions)
   if (!normalizedConditions.ok) {
     return emptyDeferredResult(['invalid_advisory_conditions'], baseline, {
@@ -400,25 +433,6 @@ export function evaluateCommunityAdvisoryDecisionInfluence(
     })
   }
   const conditions = normalizedConditions.conditions
-
-  if (!bodyId) {
-    return emptyDeferredResult(['missing_advisory_body_id'], baseline)
-  }
-
-  if (!isPositiveUnitInterval(body.influenceThreshold)) {
-    return emptyDeferredResult(['missing_or_invalid_influence_threshold'], baseline, {
-      bodyId,
-      conditions,
-    })
-  }
-
-  if (!signalBodyId || signalBodyId !== bodyId) {
-    return emptyRejectedResult(['advisory_rejected', 'body_signal_mismatch'], baseline, {
-      bodyId,
-      influenceThreshold,
-      conditions,
-    })
-  }
 
   const recommendation = signal.recommendation
   if (!isRecord(recommendation) || !isDecisionScope(recommendation.scope)) {
@@ -432,14 +446,6 @@ export function evaluateCommunityAdvisoryDecisionInfluence(
   const proposedValue = normalizeToken(recommendation.proposedValue)
   if (!proposedValue) {
     return emptyDeferredResult(['missing_recommendation_value'], baseline, {
-      bodyId,
-      influenceThreshold,
-      conditions,
-    })
-  }
-
-  if (!authorizedScopes.includes(recommendation.scope)) {
-    return emptyRejectedResult(['advisory_rejected', 'recommendation_out_of_scope'], baseline, {
       bodyId,
       influenceThreshold,
       conditions,
@@ -464,6 +470,22 @@ export function evaluateCommunityAdvisoryDecisionInfluence(
 
   if (!isUrgency(signal.urgency)) {
     return emptyDeferredResult(['missing_or_invalid_urgency'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  if (!signalBodyId || signalBodyId !== bodyId) {
+    return emptyRejectedResult(['advisory_rejected', 'body_signal_mismatch'], baseline, {
+      bodyId,
+      influenceThreshold,
+      conditions,
+    })
+  }
+
+  if (!authorizedScopes.includes(recommendation.scope)) {
+    return emptyRejectedResult(['advisory_rejected', 'recommendation_out_of_scope'], baseline, {
       bodyId,
       influenceThreshold,
       conditions,

--- a/src/test/communityAdvisoryDecisionInfluence.test.ts
+++ b/src/test/communityAdvisoryDecisionInfluence.test.ts
@@ -209,6 +209,9 @@ describe('communityAdvisoryDecisionInfluence (SPE-2620 / SPE-956 slice 1)', () =
     expect(Object.isFrozen(result.reasonCodes)).toBe(true)
     expect(Object.isFrozen(result.resolved)).toBe(true)
     expect(Object.isFrozen(result.baseline)).toBe(true)
+    expect(Object.isFrozen(result.conditions)).toBe(true)
+    expect(result.proposedAdjustment).not.toBeNull()
+    expect(Object.isFrozen(result.proposedAdjustment)).toBe(true)
     expect(inputBaseline.supportRouting).toBe('standard_ops_desk')
     expect(result.resolved).not.toBe(inputBaseline)
     expect(result.baseline).not.toBe(inputBaseline)
@@ -280,5 +283,45 @@ describe('communityAdvisoryDecisionInfluence (SPE-2620 / SPE-956 slice 1)', () =
     expect(numericConditions.disposition).toBe('deferred')
     expect(numericConditions.reasonCodes).toEqual(['invalid_advisory_conditions'])
     expect(numericConditions.proposedAdjustment).toBeNull()
+  })
+
+  it('defers an incomplete advisory body before applying influence', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: {
+        id: 'advisory-body:incomplete',
+        mission: '',
+        membershipRule: 'rule',
+        representedStakeholderClasses: [],
+        authorizedDecisionScopes: ['support_routing'],
+        influenceThreshold: 0.6,
+        decisionCriteria: '',
+      },
+      signal: {
+        ...EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+        bodyId: 'advisory-body:incomplete',
+      },
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('deferred')
+    expect(result.reasonCodes).toEqual(['incomplete_advisory_body'])
+    expect(result.proposedAdjustment).toBeNull()
+    expect(result.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
+  })
+
+  it('defers malformed signal fields before rejecting a body mismatch', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: signal({
+        bodyId: 'advisory-body:other',
+        supportBand: 'invalid' as CommunityAdvisorySignal['supportBand'],
+      }),
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('deferred')
+    expect(result.reasonCodes).toEqual(['missing_or_invalid_support_band'])
+    expect(result.proposedAdjustment).toBeNull()
+    expect(result.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
   })
 })

--- a/src/test/communityAdvisoryDecisionInfluence.test.ts
+++ b/src/test/communityAdvisoryDecisionInfluence.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXAMPLE_COMMUNITY_ADVISORY_BODY,
+  EXAMPLE_INCIDENT_BASELINE,
+  EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+  evaluateCommunityAdvisoryDecisionInfluence,
+  type CommunityAdvisorySignal,
+  type IncidentResponseDecision,
+} from '../domain/communityAdvisoryDecisionInfluence'
+
+function signal(overrides: Partial<CommunityAdvisorySignal> = {}): CommunityAdvisorySignal {
+  return {
+    ...EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+    ...overrides,
+    recommendation: {
+      ...EXAMPLE_SUPPORT_ROUTING_SIGNAL.recommendation,
+      ...(overrides.recommendation ?? {}),
+    },
+  }
+}
+
+function baseline(overrides: Partial<IncidentResponseDecision> = {}): IncidentResponseDecision {
+  return {
+    ...EXAMPLE_INCIDENT_BASELINE,
+    ...overrides,
+  }
+}
+
+describe('communityAdvisoryDecisionInfluence (SPE-2620 / SPE-956 slice 1)', () => {
+  it('adopts an in-scope signal that meets the influence threshold and changes support routing', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('adopted')
+    expect(result.reasonCodes).toEqual(['advisory_adopted'])
+    expect(result.proposedAdjustment).toEqual({
+      scope: 'support_routing',
+      fromValue: 'standard_ops_desk',
+      toValue: 'community_liaison_first',
+    })
+    expect(result.resolved.supportRouting).toBe('community_liaison_first')
+    expect(result.resolved.responseTiming).toBe(EXAMPLE_INCIDENT_BASELINE.responseTiming)
+    expect(result.baseline).toEqual(EXAMPLE_INCIDENT_BASELINE)
+    expect(result.bodyId).toBe('advisory-body:riverside-stakeholders')
+  })
+
+  it('modifies when the signal meets the threshold but attaches conditions', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: signal({
+        recommendation: {
+          scope: 'framing',
+          proposedValue: 'survivor_centered_brief',
+        },
+        conditions: Object.freeze(['pending_survivor_consent']),
+      }),
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('modified')
+    expect(result.reasonCodes).toEqual(['advisory_modified_with_conditions'])
+    expect(result.proposedAdjustment).toEqual({
+      scope: 'framing',
+      fromValue: 'agency_first_brief',
+      toValue: 'survivor_centered_brief',
+    })
+    expect(result.resolved.framing).toBe('survivor_centered_brief')
+    expect(result.conditions).toEqual(['pending_survivor_consent'])
+  })
+
+  it('rejects when the recommendation exceeds authorized decision scope', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: signal({
+        recommendation: {
+          scope: 'restriction_level',
+          proposedValue: 'full_cordon',
+        },
+      }),
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('rejected')
+    expect(result.reasonCodes).toEqual(['advisory_rejected', 'recommendation_out_of_scope'])
+    expect(result.proposedAdjustment).toBeNull()
+    expect(result.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
+  })
+
+  it('rejects a routine signal that fails the influence threshold without changing the baseline', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: signal({
+        supportBand: 'low',
+        confidence: 0.4,
+        urgency: 'routine',
+      }),
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('rejected')
+    expect(result.reasonCodes).toEqual(['advisory_rejected', 'below_influence_threshold'])
+    expect(result.proposedAdjustment).toBeNull()
+    expect(result.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
+    expect(result.supportScore).toBeLessThan(result.influenceThreshold)
+  })
+
+  it('defers an elevated/urgent signal that fails the influence threshold without changing the baseline', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: signal({
+        supportBand: 'moderate',
+        confidence: 0.5,
+        urgency: 'urgent',
+      }),
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('deferred')
+    expect(result.reasonCodes).toEqual(['advisory_deferred', 'below_influence_threshold'])
+    expect(result.proposedAdjustment).toBeNull()
+    expect(result.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
+  })
+
+  it('returns a deterministic deferred no-op when evaluation input is missing', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence(undefined)
+
+    expect(result.disposition).toBe('deferred')
+    expect(result.reasonCodes).toEqual(['missing_evaluation_input'])
+    expect(result.proposedAdjustment).toBeNull()
+    expect(result.bodyId).toBeNull()
+    expect(result.resolved).toEqual(result.baseline)
+  })
+
+  it('returns a deferred no-op when body, signal, or baseline is missing', () => {
+    const missingBody = evaluateCommunityAdvisoryDecisionInfluence({
+      body: null,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+    expect(missingBody.disposition).toBe('deferred')
+    expect(missingBody.reasonCodes).toContain('missing_advisory_body')
+    expect(missingBody.proposedAdjustment).toBeNull()
+    expect(missingBody.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
+
+    const missingSignal = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: null,
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+    expect(missingSignal.disposition).toBe('deferred')
+    expect(missingSignal.reasonCodes).toContain('missing_advisory_signal')
+    expect(missingSignal.proposedAdjustment).toBeNull()
+
+    const missingBaseline = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: null,
+    })
+    expect(missingBaseline.disposition).toBe('deferred')
+    expect(missingBaseline.reasonCodes).toContain('missing_incident_baseline')
+    expect(missingBaseline.proposedAdjustment).toBeNull()
+  })
+
+  it('rejects when signal bodyId does not match the advisory body', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: signal({ bodyId: 'advisory-body:other' }),
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(result.disposition).toBe('rejected')
+    expect(result.reasonCodes).toEqual(['advisory_rejected', 'body_signal_mismatch'])
+    expect(result.proposedAdjustment).toBeNull()
+    expect(result.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
+  })
+
+  it('keeps reason codes unique and sorted across paths', () => {
+    const adopted = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+    const rejected = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: signal({
+        recommendation: { scope: 'restriction_level', proposedValue: 'full_cordon' },
+      }),
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+
+    expect(adopted.reasonCodes).toEqual([...adopted.reasonCodes].sort((a, b) => a.localeCompare(b)))
+    expect(rejected.reasonCodes).toEqual(
+      [...new Set(rejected.reasonCodes)].sort((a, b) => a.localeCompare(b))
+    )
+  })
+
+  it('freezes the result envelope and does not mutate the baseline input', () => {
+    const inputBaseline = baseline()
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: inputBaseline,
+    })
+
+    expect(Object.isFrozen(result)).toBe(true)
+    expect(Object.isFrozen(result.reasonCodes)).toBe(true)
+    expect(Object.isFrozen(result.resolved)).toBe(true)
+    expect(Object.isFrozen(result.baseline)).toBe(true)
+    expect(inputBaseline.supportRouting).toBe('standard_ops_desk')
+    expect(result.resolved).not.toBe(inputBaseline)
+    expect(result.baseline).not.toBe(inputBaseline)
+  })
+
+  it('returns byte-stable decisions for the same inputs', () => {
+    const input = {
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    }
+
+    const first = evaluateCommunityAdvisoryDecisionInfluence(input)
+    const second = evaluateCommunityAdvisoryDecisionInfluence(input)
+
+    expect(second).toEqual(first)
+  })
+
+  it('exposes an authored body with mission, membership, stakeholders, scope, and criteria', () => {
+    expect(EXAMPLE_COMMUNITY_ADVISORY_BODY.mission.length).toBeGreaterThan(0)
+    expect(EXAMPLE_COMMUNITY_ADVISORY_BODY.membershipRule.length).toBeGreaterThan(0)
+    expect(EXAMPLE_COMMUNITY_ADVISORY_BODY.decisionCriteria.length).toBeGreaterThan(0)
+    expect(EXAMPLE_COMMUNITY_ADVISORY_BODY.representedStakeholderClasses.length).toBeGreaterThan(0)
+    expect(EXAMPLE_COMMUNITY_ADVISORY_BODY.authorizedDecisionScopes).toEqual([
+      'framing',
+      'response_timing',
+      'support_routing',
+    ])
+    expect(EXAMPLE_COMMUNITY_ADVISORY_BODY.influenceThreshold).toBeGreaterThan(0)
+  })
+})

--- a/src/test/communityAdvisoryDecisionInfluence.test.ts
+++ b/src/test/communityAdvisoryDecisionInfluence.test.ts
@@ -239,4 +239,46 @@ describe('communityAdvisoryDecisionInfluence (SPE-2620 / SPE-956 slice 1)', () =
     ])
     expect(EXAMPLE_COMMUNITY_ADVISORY_BODY.influenceThreshold).toBeGreaterThan(0)
   })
+
+  it('defers a partial baseline instead of inventing missing decision fields', () => {
+    const result = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: {
+        incidentId: 'incident:partial',
+        responseTiming: 'now',
+      } as IncidentResponseDecision,
+    })
+
+    expect(result.disposition).toBe('deferred')
+    expect(result.reasonCodes).toEqual(['invalid_incident_baseline'])
+    expect(result.proposedAdjustment).toBeNull()
+  })
+
+  it('defers malformed condition payloads instead of adopting them', () => {
+    const objectConditions = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: {
+        ...EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+        conditions: {} as unknown as readonly string[],
+      },
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+    expect(objectConditions.disposition).toBe('deferred')
+    expect(objectConditions.reasonCodes).toEqual(['invalid_advisory_conditions'])
+    expect(objectConditions.proposedAdjustment).toBeNull()
+    expect(objectConditions.resolved).toEqual(EXAMPLE_INCIDENT_BASELINE)
+
+    const numericConditions = evaluateCommunityAdvisoryDecisionInfluence({
+      body: EXAMPLE_COMMUNITY_ADVISORY_BODY,
+      signal: {
+        ...EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+        conditions: [42] as unknown as readonly string[],
+      },
+      baseline: EXAMPLE_INCIDENT_BASELINE,
+    })
+    expect(numericConditions.disposition).toBe('deferred')
+    expect(numericConditions.reasonCodes).toEqual(['invalid_advisory_conditions'])
+    expect(numericConditions.proposedAdjustment).toBeNull()
+  })
 })


### PR DESCRIPTION
## Linear

- **Slice issue:** [SPE-2620](https://linear.app/spectranoir/issue/SPE-2620/community-advisory-body-decision-influence-slice-1)
- **Parent issue (if any):** [SPE-956](https://linear.app/spectranoir/issue/SPE-956/advisory-groups-hotlines-and-participatory-decision-channels)
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Pure `evaluateCommunityAdvisoryDecisionInfluence` with frozen `adopted` / `modified` / `deferred` / `rejected` envelopes and proposed adjustments
- Authored riverside advisory body + incident baseline + support-routing signal fixture
- Focused Vitest coverage for adoption, condition modification, scope/threshold failure, empty no-op, stable reason codes, and immutability

## Docs updated

- `planning/spe-956-community-advisory-decision-influence-slice-1.md`
- `planning/backlog.md` + `planning/backlog-handoff-manifest.json`

## Parent status

- Parent SPE-956 remains **Backlog** — child slice only (hotline, notifications, survivor registry, persistence/UI still deferred)

## Scope boundary

- No UI, persistence, store, or week-close wiring
- Does not extend operational `advisory.ts` team hints
- Does not touch hotline/inquiry, SPE-911 notifications, SPE-875 governance, or SPE-1682 survivor registry

## Validation

- [x] Targeted tests: `npm.cmd run test:run -- src/test/communityAdvisoryDecisionInfluence.test.ts` (12 passed)
- [x] Lint / verify: `npm.cmd run lint`, `npm.cmd run verify:backlog-handoff`

## Follow-ups

- Hotline / persistence / UI / week-close wire — later SPE-956 children (see slice doc ## Deferred)

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)
