### PR TITLE
SPE-2635: Participatory channel persistence — async discussion surface (slice 4)

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -262,12 +262,12 @@ Tick wired from `advanceWeek` via `applyWeeklySpe956PropagationGraphTick`. Graph
 
 Documents compact GameState maps for authored SPE-956 participatory channel envelopes
 (SPE-2632 slice 1 survivor registry; SPE-2633 slice 2 collective memory channel;
-SPE-2634 slice 3 hotline channel).
+SPE-2634 slice 3 hotline channel; SPE-2635 slice 4 async discussion surface).
 No evaluator contract changes.
 
 **Current version**: `spe-956-participatory-channel.v1` — exported as `SPE_956_PARTICIPATORY_CHANNEL_PERSISTENCE_SCHEMA_VERSION`
 
-**Location**: `src/domain/spe956ParticipatoryChannelPersistence.ts` (evaluator contracts: `survivorInformalRegistry.ts`, `collectiveMemoryStabilization.ts`, `hotlineChannel.ts`)
+**Location**: `src/domain/spe956ParticipatoryChannelPersistence.ts` (evaluator contracts: `survivorInformalRegistry.ts`, `collectiveMemoryStabilization.ts`, `hotlineChannel.ts`, `asyncDiscussionSurface.ts`)
 
 ### GameState fields
 
@@ -276,20 +276,22 @@ No evaluator contract changes.
 | `spe956SurvivorInformalRegistryRecords` | Authored registry id + recognition/catalog/band/ceiling enums; keyed by registry id                |
 | `spe956CollectiveMemoryChannelRecords`  | Authored channel id + narrative/recall/ceiling/rule enums; keyed by channel id                     |
 | `spe956HotlineChannelRecords`           | Authored channel id + unit intervals + boolean + unanswered/anger enums + escalation rules string |
+| `spe956AsyncDiscussionSurfaceRecords`   | Authored surface id + nested participation window + retention/widening enums + memoryStabilization |
 
 ### Hydration
 
-- Sanitize via `sanitizeSpe956SurvivorInformalRegistryRecords`, `sanitizeSpe956CollectiveMemoryChannelRecords`, and `sanitizeSpe956HotlineChannelRecords` in `spe956ParticipatoryChannelPersistence.ts`
+- Sanitize via `sanitizeSpe956SurvivorInformalRegistryRecords`, `sanitizeSpe956CollectiveMemoryChannelRecords`, `sanitizeSpe956HotlineChannelRecords`, and `sanitizeSpe956AsyncDiscussionSurfaceRecords` in `spe956ParticipatoryChannelPersistence.ts`
 - Wired in `hydrateGame` (`src/app/store/runTransfer.ts`)
 - Invalid entries, duplicate ids, and incomplete enum/field sets are dropped without throw
+- Nested `participationWindow` requires non-negative integer `startWeek`/`endWeek` with `startWeek <= endWeek`
 - Explicit authored `{}` hydrates as empty canonical map (does not fall back to prior records); non-record input still uses fallback
 - Unsafe ids (`__proto__`, `constructor`, `prototype`) are rejected; maps built from plain-record input use null prototype (non-record input returns the caller `fallback` unchanged)
-- `resolvePersistedSurvivorInformalRegistry` / `resolvePersistedCollectiveMemoryChannel` / `resolvePersistedHotlineChannel` resolve own properties only and reject unsafe ids
+- `resolvePersistedSurvivorInformalRegistry` / `resolvePersistedCollectiveMemoryChannel` / `resolvePersistedHotlineChannel` / `resolvePersistedAsyncDiscussionSurface` resolve own properties only and reject unsafe ids
 - Default starting state: empty `{}` maps in `createStartingState`
 
 ### Deferred (later SPE-956 children)
 
-- Advisory / async discussion channel maps
+- Community advisory body channel map
 - UI / planning mirror; week-close channel tick
 
 ### Versioning

--- a/planning/backlog-handoff-manifest.json
+++ b/planning/backlog-handoff-manifest.json
@@ -1,12 +1,13 @@
 {
-  "primary": "SPE-2635",
-  "inProgress": [],
+  "primary": null,
+  "inProgress": ["SPE-2635"],
   "recentlyShipped": [
     "SPE-2634",
     "SPE-2633",
     "SPE-2632"
   ],
   "sliceDocStatus": {
+    "planning/spe-956-participatory-channel-persistence-slice-4.md": "In progress",
     "planning/spe-956-participatory-channel-persistence-slice-3.md": "Shipped",
     "planning/spe-956-participatory-channel-persistence-slice-2.md": "Shipped",
     "planning/spe-956-participatory-channel-persistence-slice-1.md": "Shipped",

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -72,9 +72,9 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Current handoff (primary):** [SPE-2635](https://linear.app/spectranoir/issue/SPE-2635) — participatory channel persistence advisory/async maps (slice 4); create `planning/spe-956-participatory-channel-persistence-slice-4.md` before coding. Parent SPE-956 stays Backlog.
+**Current handoff (primary):** (none)
 
-**In progress:** (none)
+**In progress:** [SPE-2635](https://linear.app/spectranoir/issue/SPE-2635) — participatory channel persistence advisory/async maps (slice 4); async discussion surface GameState map; branch `spe-956-participatory-channel-persistence-slice-4`; see `planning/spe-956-participatory-channel-persistence-slice-4.md`. Parent SPE-956 stays Backlog.
 
 **Recently shipped:** [SPE-2634](https://linear.app/spectranoir/issue/SPE-2634) participatory channel persistence advisory/hotline/async maps (slice 3) — hotline channel GameState map; PR #3177; see `planning/spe-956-participatory-channel-persistence-slice-3.md`.
 
@@ -437,6 +437,7 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-947-counter-memetic-uptake-gate-slice-1.md`                          | **Shipped**     | [SPE-2570](https://linear.app/spectranoir/issue/SPE-2570) — pure counter-memetic lore + distributor + uptake gate evaluator (parent AC row 3); PR #3063 @ `e46115b2`; parent SPE-947 stays **Backlog**.                                                                                               |
 | `spe-947-platform-outage-degrade-slice-1.md`                              | **Shipped**     | [SPE-2569](https://linear.app/spectranoir/issue/SPE-2569) — pure platform outage / reach-failure degrade evaluator (parent AC row 4); PR #3061 @ `ee721082`; parent SPE-947 stays **Backlog**.                                                                                                        |
 | `spe-947-platform-reach-multiplier-slice-1.md`                            | **Shipped**     | [SPE-2568](https://linear.app/spectranoir/issue/SPE-2568) — pure platform reach-multiplier evaluator (parent AC row 1); PR #3059 @ `cc1ec1d4`; parent SPE-947 stays **Backlog**.                                                                                                                      |
+| `spe-956-participatory-channel-persistence-slice-4.md`                    | **In progress** | [SPE-2635](https://linear.app/spectranoir/issue/SPE-2635) — GameState persistence for SPE-956 async discussion surface envelopes (slice 4); parent SPE-956 stays **Backlog**.                                                                                                                                |
 | `spe-956-participatory-channel-persistence-slice-3.md`                    | **Shipped**     | [SPE-2634](https://linear.app/spectranoir/issue/SPE-2634) — GameState persistence for SPE-956 hotline channel envelopes (slice 3); PR #3177; parent SPE-956 stays **Backlog**.                                                                                                                                |
 | `spe-956-participatory-channel-persistence-slice-2.md`                    | **Shipped**     | [SPE-2633](https://linear.app/spectranoir/issue/SPE-2633) — GameState persistence for SPE-956 collective memory channel envelopes (slice 2); PR #3172; parent SPE-956 stays **Backlog**.                                                                                                              |
 | `spe-956-participatory-channel-persistence-slice-1.md`                    | **Shipped**     | [SPE-2632](https://linear.app/spectranoir/issue/SPE-2632) — GameState persistence for SPE-956 survivor informal registry channel envelopes; PR #3169; parent SPE-956 stays **Backlog**.                                                                                                                         |

--- a/planning/spe-956-participatory-channel-persistence-slice-4.md
+++ b/planning/spe-956-participatory-channel-persistence-slice-4.md
@@ -1,0 +1,75 @@
+# SPE-956 — Participatory channel persistence / advisory·async maps (slice 4)
+
+One-page implementation plan. Linear: [SPE-2635](https://linear.app/spectranoir/issue/SPE-2635) (child under [SPE-956](https://linear.app/spectranoir/issue/SPE-956)). Extends SPE-2632/2633/2634 sanitize/hydrate to one more already-shipped participatory channel envelope. Parent stays **Backlog**.
+
+| Field               | Value                                                                                                                                         |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**          | [SPE-2635 — Participatory channel persistence — advisory / async maps (slice 4)](https://linear.app/spectranoir/issue/SPE-2635)                 |
+| **Status**          | **In progress**                                                                                                                               |
+| **Parent**          | [SPE-956](https://linear.app/spectranoir/issue/SPE-956) — advisory groups / hotlines / participatory channels; stays **Backlog**              |
+| **Branch**          | `spe-956-participatory-channel-persistence-slice-4`                                                                                           |
+| **Base `main` SHA** | `2d20e9a6`                                                                                                                                    |
+
+## Goal
+
+Persist at least one additional already-shipped SPE-956 participatory channel envelope on GameState with sanitize/hydrate (SPE-2632–2634 pattern) — async discussion surface records — without evaluator contract changes, week-close coupling, or a full UI/planning mirror.
+
+## Prerequisite (on `main` @ `2d20e9a6`)
+
+| Shipped                        | Anchor                                                                                                  |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Survivor informal registry map | [SPE-2632](https://linear.app/spectranoir/issue/SPE-2632) — `spe956ParticipatoryChannelPersistence.ts` |
+| Collective memory channel map  | [SPE-2633](https://linear.app/spectranoir/issue/SPE-2633) — same module                                |
+| Hotline channel map            | [SPE-2634](https://linear.app/spectranoir/issue/SPE-2634) — same module                                |
+| Async discussion evaluator     | [SPE-2629](https://linear.app/spectranoir/issue/SPE-2629) — `asyncDiscussionSurface.ts`                |
+| Hydrate wiring                 | `runTransfer.ts` — `hydrateGame`                                                                        |
+
+## Channel choice (slice 4)
+
+| Choice                         | Rationale                                                                                                      |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| **Async discussion surface**   | Nested `participationWindow` `{startWeek,endWeek}` + two enums + boolean; smaller than advisory arrays/threshold |
+| Deferred sibling               | Community advisory body (string arrays + `authorizedDecisionScopes` enums + `influenceThreshold`) stays later  |
+
+## Scope
+
+| In                                                                   | Out                                               |
+| -------------------------------------------------------------------- | ------------------------------------------------- |
+| `spe956AsyncDiscussionSurfaceRecords` GameState map                  | Advisory body channel map                         |
+| Extend `spe956ParticipatoryChannelPersistence.ts` sanitize/hydrate   | SPE-2620/2628/2629/2630/2631 evaluator rewrites   |
+| `runTransfer` hydrate wiring + starting-state `{}`                   | Week-close tick; store actions; UI / mirror       |
+| Round-trip + empty/missing normalize tests                           | SPE-1682 / SPE-860 / SPE-911 / SPE-875 expansions |
+| Slice doc + SCHEMA_REGISTRY note + backlog handoff                   | Full SPE-956 parent AC                            |
+
+## Acceptance
+
+- [x] Empty default `{}` hydrates safely (legacy/missing saves no-op)
+- [x] Invalid async surface entries dropped without throw (bad window, enum, field)
+- [x] sanitize/hydrate round-trip through save/load and `hydrateGame`
+- [x] Hydrated channel shape is frozen / immutable for EXAMPLE fixture (incl. nested window)
+- [x] SPE-2629 evaluator contract unchanged
+- [x] SPE-956 remains **Backlog**
+- [x] `npm run lint` + targeted tests green
+
+## Deferred
+
+| Item                                              | Suggested owner | Why deferred                         |
+| ------------------------------------------------- | --------------- | ------------------------------------ |
+| Community advisory body channel map               | [SPE-2636](https://linear.app/spectranoir/issue/SPE-2636) | Arrays + threshold; after async map  |
+| UI / planning mirror                              | SPE-956 sibling | After persistence                    |
+| Week-close channel tick                           | SPE-956 sibling | Not required this slice              |
+| Compose/evaluate-from-GameState helpers (broader) | SPE-956 sibling | Optional read helpers                |
+
+## Validation
+
+- `npm.cmd run test:run -- src/test/spe956ParticipatoryChannelPersistence.test.ts`
+- `npm.cmd run lint`
+- `npm.cmd run verify:backlog-handoff`
+
+## See also
+
+- `planning/spe-956-participatory-channel-persistence-slice-1.md`
+- `planning/spe-956-participatory-channel-persistence-slice-2.md`
+- `planning/spe-956-participatory-channel-persistence-slice-3.md`
+- `planning/spe-956-async-discussion-surface-slice-1.md`
+- `SCHEMA_REGISTRY.md` — SPE-956 participatory channel persistence section

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -9572,6 +9572,16 @@ export function hydrateGame(
     }
   }
 
+  // Reapply SPE-956 participatory channel maps after stripUndefinedFields / spreads so
+  // per-entry Object.freeze (and nested windows) from sanitize survive hydrateGame.
+  hydrated = {
+    ...hydrated,
+    spe956SurvivorInformalRegistryRecords,
+    spe956CollectiveMemoryChannelRecords,
+    spe956HotlineChannelRecords,
+    spe956AsyncDiscussionSurfaceRecords,
+  }
+
   return hydrated
 }
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -261,6 +261,7 @@ import {
 } from '../../domain/spe947MediaEconomySimulator'
 import { sanitizeSpe956PropagationGraphRecords } from '../../domain/spe956PropagationGraphPersistence'
 import {
+  sanitizeSpe956AsyncDiscussionSurfaceRecords,
   sanitizeSpe956CollectiveMemoryChannelRecords,
   sanitizeSpe956HotlineChannelRecords,
   sanitizeSpe956SurvivorInformalRegistryRecords,
@@ -9105,6 +9106,10 @@ export function hydrateGame(
     game.spe956HotlineChannelRecords,
     fallback.spe956HotlineChannelRecords ?? {}
   )
+  const spe956AsyncDiscussionSurfaceRecords = sanitizeSpe956AsyncDiscussionSurfaceRecords(
+    game.spe956AsyncDiscussionSurfaceRecords,
+    fallback.spe956AsyncDiscussionSurfaceRecords ?? {}
+  )
   const affiliationPersonStatusRecords = sanitizeAffiliationPersonStatusRecords(
     game.affiliationPersonStatusRecords,
     fallback.affiliationPersonStatusRecords ?? {}
@@ -9374,6 +9379,7 @@ export function hydrateGame(
     spe956SurvivorInformalRegistryRecords,
     spe956CollectiveMemoryChannelRecords,
     spe956HotlineChannelRecords,
+    spe956AsyncDiscussionSurfaceRecords,
     affiliationPersonStatusRecords,
     affiliationFileWorkQueueActionRecords,
     affiliationFileWorkQueueEvidenceResolutionRecords,

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -77,6 +77,7 @@ const startingStateTemplate: GameState = {
   spe956SurvivorInformalRegistryRecords: {},
   spe956CollectiveMemoryChannelRecords: {},
   spe956HotlineChannelRecords: {},
+  spe956AsyncDiscussionSurfaceRecords: {},
   affiliationPersonStatusRecords: {},
   entityWelfareReclassificationRecords: {},
   containedPersonTherapeuticCareRecords: {},

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -322,6 +322,7 @@ import type {
 import type { Spe947MediaEconomyCommercializationActorRecordsMap } from './spe947MediaEconomySimulator'
 import type { Spe956PropagationGraphRecordsMap } from './spe956PropagationGraphPersistence'
 import type {
+  Spe956AsyncDiscussionSurfaceRecordsMap,
   Spe956CollectiveMemoryChannelRecordsMap,
   Spe956HotlineChannelRecordsMap,
   Spe956SurvivorInformalRegistryRecordsMap,
@@ -2890,6 +2891,12 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing. Round-trip only.
    */
   spe956HotlineChannelRecords?: Spe956HotlineChannelRecordsMap
+
+  /**
+   * SPE-2635 slice 4: authored SPE-956 async discussion surfaces (keyed by surface id).
+   * Hydration drops invalid or duplicate-id entries without throwing. Round-trip only.
+   */
+  spe956AsyncDiscussionSurfaceRecords?: Spe956AsyncDiscussionSurfaceRecordsMap
 
   /**
    * SPE-2518 slice 1: persisted affiliation/person-status evidence records (keyed by record id).

--- a/src/domain/spe956ParticipatoryChannelPersistence.ts
+++ b/src/domain/spe956ParticipatoryChannelPersistence.ts
@@ -1,11 +1,21 @@
 /**
- * SPE-2632 / SPE-2633 / SPE-2634 / SPE-956: GameState persistence for participatory channel envelopes.
+ * SPE-2632 / SPE-2633 / SPE-2634 / SPE-2635 / SPE-956: GameState persistence for participatory channel envelopes.
  * Slice 1 (SPE-2632): survivor informal registry (SPE-2630 evaluator).
  * Slice 2 (SPE-2633): collective memory channel (SPE-2631 evaluator).
  * Slice 3 (SPE-2634): hotline channel (SPE-2628 evaluator).
+ * Slice 4 (SPE-2635): async discussion surface (SPE-2629 evaluator).
  * Sanitize/hydrate follows SPE-2621 pattern. No evaluator contract changes.
  */
 
+import {
+  DISCUSSION_WIDENING_RULES,
+  EXAMPLE_DISCUSSION_SURFACE,
+  TRANSCRIPT_RETENTION_MODES,
+  type DiscussionParticipationWindow,
+  type DiscussionSurface,
+  type DiscussionWideningRule,
+  type TranscriptRetentionMode,
+} from './asyncDiscussionSurface'
 import {
   CREDIBILITY_CEILINGS as MEMORY_CREDIBILITY_CEILINGS,
   EXAMPLE_MEMORY_STABILIZATION_CHANNEL,
@@ -403,3 +413,137 @@ export function resolvePersistedHotlineChannel(
 export const SPE_956_EXAMPLE_HOTLINE_CHANNEL_RECORDS: Spe956HotlineChannelRecordsMap = Object.freeze({
   [EXAMPLE_HOTLINE_CHANNEL.id]: EXAMPLE_HOTLINE_CHANNEL,
 })
+
+/** Persisted async discussion surface: opaque authored SPE-2629 channel envelope. */
+export type Spe956PersistedAsyncDiscussionSurface = DiscussionSurface
+
+export type Spe956AsyncDiscussionSurfaceRecordsMap = Record<
+  string,
+  Spe956PersistedAsyncDiscussionSurface
+>
+
+function isNonNegativeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+}
+
+function isTranscriptRetentionMode(value: unknown): value is TranscriptRetentionMode {
+  return (
+    typeof value === 'string' && (TRANSCRIPT_RETENTION_MODES as readonly string[]).includes(value)
+  )
+}
+
+function isDiscussionWideningRule(value: unknown): value is DiscussionWideningRule {
+  return (
+    typeof value === 'string' && (DISCUSSION_WIDENING_RULES as readonly string[]).includes(value)
+  )
+}
+
+function sanitizeParticipationWindow(value: unknown): DiscussionParticipationWindow | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const { startWeek, endWeek } = value
+  if (!isNonNegativeInt(startWeek) || !isNonNegativeInt(endWeek) || startWeek > endWeek) {
+    return null
+  }
+
+  return Object.freeze({ startWeek, endWeek })
+}
+
+function sanitizeSpe956AsyncDiscussionSurfaceEntry(
+  value: unknown
+): Spe956PersistedAsyncDiscussionSurface | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const {
+    id: rawId,
+    participationWindow: rawWindow,
+    transcriptRetentionMode,
+    wideningRule,
+    memoryStabilization,
+  } = value
+
+  const id = normalizeId(rawId, '')
+  const participationWindow = sanitizeParticipationWindow(rawWindow)
+
+  if (
+    id.length === 0 ||
+    !isSafeMapKey(id) ||
+    participationWindow === null ||
+    !isTranscriptRetentionMode(transcriptRetentionMode) ||
+    !isDiscussionWideningRule(wideningRule) ||
+    typeof memoryStabilization !== 'boolean'
+  ) {
+    return null
+  }
+
+  return Object.freeze({
+    id,
+    participationWindow,
+    transcriptRetentionMode,
+    wideningRule,
+    memoryStabilization,
+  })
+}
+
+/** Hydration: canonical authored async discussion surface map keyed by surface id. */
+export function sanitizeSpe956AsyncDiscussionSurfaceRecords(
+  value: unknown,
+  fallback: Spe956AsyncDiscussionSurfaceRecordsMap = {}
+): Spe956AsyncDiscussionSurfaceRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next = Object.create(null) as Spe956AsyncDiscussionSurfaceRecordsMap
+  const seenIds = new Set<string>()
+
+  for (const entry of Object.values(value)) {
+    const record = sanitizeSpe956AsyncDiscussionSurfaceEntry(entry)
+    if (!record || seenIds.has(record.id)) {
+      continue
+    }
+
+    seenIds.add(record.id)
+    next[record.id] = record
+  }
+
+  // Plain-record input (including authored `{}`) wins over fallback so cleared
+  // maps survive Zustand rehydration when current state still holds records.
+  return next
+}
+
+export function extractSpe956AsyncDiscussionSurfaceRecords(
+  game: Partial<{
+    spe956AsyncDiscussionSurfaceRecords?: Spe956AsyncDiscussionSurfaceRecordsMap
+  }>
+): Spe956AsyncDiscussionSurfaceRecordsMap {
+  return game.spe956AsyncDiscussionSurfaceRecords ?? {}
+}
+
+export function resolvePersistedAsyncDiscussionSurface(
+  game: Partial<{
+    spe956AsyncDiscussionSurfaceRecords?: Spe956AsyncDiscussionSurfaceRecordsMap
+  }>,
+  surfaceId: string
+): Spe956PersistedAsyncDiscussionSurface | null {
+  if (!isSafeMapKey(surfaceId)) {
+    return null
+  }
+
+  const records = extractSpe956AsyncDiscussionSurfaceRecords(game)
+  if (!Object.prototype.hasOwnProperty.call(records, surfaceId)) {
+    return null
+  }
+
+  return records[surfaceId] ?? null
+}
+
+/** EXAMPLE persisted async discussion surface fixture (mirrors SPE-2629 authored surface). */
+export const SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS: Spe956AsyncDiscussionSurfaceRecordsMap =
+  Object.freeze({
+    [EXAMPLE_DISCUSSION_SURFACE.id]: EXAMPLE_DISCUSSION_SURFACE,
+  })

--- a/src/test/spe956ParticipatoryChannelPersistence.test.ts
+++ b/src/test/spe956ParticipatoryChannelPersistence.test.ts
@@ -3,16 +3,20 @@ import { describe, expect, it } from 'vitest'
 import { hydrateGame } from '../app/store/runTransfer'
 import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
 import { createStartingState } from '../data/startingState'
+import { EXAMPLE_DISCUSSION_SURFACE } from '../domain/asyncDiscussionSurface'
 import { EXAMPLE_MEMORY_STABILIZATION_CHANNEL } from '../domain/collectiveMemoryStabilization'
 import { EXAMPLE_HOTLINE_CHANNEL } from '../domain/hotlineChannel'
 import { EXAMPLE_SURVIVOR_REGISTRY } from '../domain/survivorInformalRegistry'
 import {
+  resolvePersistedAsyncDiscussionSurface,
   resolvePersistedCollectiveMemoryChannel,
   resolvePersistedHotlineChannel,
   resolvePersistedSurvivorInformalRegistry,
+  sanitizeSpe956AsyncDiscussionSurfaceRecords,
   sanitizeSpe956CollectiveMemoryChannelRecords,
   sanitizeSpe956HotlineChannelRecords,
   sanitizeSpe956SurvivorInformalRegistryRecords,
+  SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS,
   SPE_956_EXAMPLE_COLLECTIVE_MEMORY_CHANNEL_RECORDS,
   SPE_956_EXAMPLE_HOTLINE_CHANNEL_RECORDS,
   SPE_956_EXAMPLE_SURVIVOR_INFORMAL_REGISTRY_RECORDS,
@@ -605,5 +609,226 @@ describe('spe956ParticipatoryChannelPersistence (SPE-2634 / SPE-956 slice 3)', (
     )
 
     expect(hydrated.spe956HotlineChannelRecords).toEqual(SPE_956_EXAMPLE_HOTLINE_CHANNEL_RECORDS)
+  })
+})
+
+describe('spe956ParticipatoryChannelPersistence (SPE-2635 / SPE-956 slice 4)', () => {
+  it('defaults starting state to empty spe956AsyncDiscussionSurfaceRecords', () => {
+    expect(createStartingState().spe956AsyncDiscussionSurfaceRecords).toEqual({})
+  })
+
+  it('returns explicit empty map instead of fallback during sanitize', () => {
+    const fallback = SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS
+
+    expect(sanitizeSpe956AsyncDiscussionSurfaceRecords({}, fallback)).toEqual({})
+    expect(sanitizeSpe956AsyncDiscussionSurfaceRecords({}, fallback)).not.toBe(fallback)
+    expect(Object.getPrototypeOf(sanitizeSpe956AsyncDiscussionSurfaceRecords({}, fallback))).toBeNull()
+  })
+
+  it('returns fallback only for non-record / missing input during sanitize', () => {
+    const fallback = SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS
+
+    expect(sanitizeSpe956AsyncDiscussionSurfaceRecords(null, fallback)).toBe(fallback)
+    expect(sanitizeSpe956AsyncDiscussionSurfaceRecords(undefined, fallback)).toBe(fallback)
+    expect(sanitizeSpe956AsyncDiscussionSurfaceRecords('not-a-record', fallback)).toBe(fallback)
+  })
+
+  it('rejects unsafe surface ids and preserves valid records in mixed input', () => {
+    const unsafeIds = ['__proto__', 'constructor', 'prototype'] as const
+
+    for (const unsafeId of unsafeIds) {
+      const polluted = sanitizeSpe956AsyncDiscussionSurfaceRecords({
+        polluted: {
+          id: unsafeId,
+          participationWindow: { startWeek: 1, endWeek: 12 },
+          transcriptRetentionMode: 'session_bound',
+          wideningRule: 'open_async',
+          memoryStabilization: false,
+        },
+      })
+
+      expect(Object.prototype.hasOwnProperty.call(polluted, unsafeId)).toBe(false)
+      expect(Object.keys(polluted)).toEqual([])
+    }
+
+    const mixed = sanitizeSpe956AsyncDiscussionSurfaceRecords({
+      valid: EXAMPLE_DISCUSSION_SURFACE,
+      polluted: {
+        id: '__proto__',
+        participationWindow: { startWeek: 1, endWeek: 12 },
+        transcriptRetentionMode: 'session_bound',
+        wideningRule: 'open_async',
+        memoryStabilization: false,
+      },
+    })
+
+    expect(mixed[EXAMPLE_DISCUSSION_SURFACE.id]).toEqual(EXAMPLE_DISCUSSION_SURFACE)
+    expect(Object.prototype.hasOwnProperty.call(mixed, '__proto__')).toBe(false)
+    expect(Object.keys(mixed)).toEqual([EXAMPLE_DISCUSSION_SURFACE.id])
+  })
+
+  it('drops invalid and duplicate surface entries during sanitize without throwing', () => {
+    const sanitized = sanitizeSpe956AsyncDiscussionSurfaceRecords({
+      valid: EXAMPLE_DISCUSSION_SURFACE,
+      duplicate: {
+        ...EXAMPLE_DISCUSSION_SURFACE,
+        wideningRule: 'closed',
+      },
+      missingId: {
+        id: '',
+        participationWindow: { startWeek: 1, endWeek: 12 },
+        transcriptRetentionMode: 'session_bound',
+        wideningRule: 'open_async',
+        memoryStabilization: false,
+      },
+      badEnum: {
+        id: 'discussion:bad-enum',
+        participationWindow: { startWeek: 1, endWeek: 12 },
+        transcriptRetentionMode: 'not_a_mode',
+        wideningRule: 'open_async',
+        memoryStabilization: false,
+      },
+      invertedWindow: {
+        id: 'discussion:inverted-window',
+        participationWindow: { startWeek: 12, endWeek: 1 },
+        transcriptRetentionMode: 'session_bound',
+        wideningRule: 'open_async',
+        memoryStabilization: false,
+      },
+      badWindowField: {
+        id: 'discussion:bad-window',
+        participationWindow: { startWeek: 1.5, endWeek: 12 },
+        transcriptRetentionMode: 'session_bound',
+        wideningRule: 'open_async',
+        memoryStabilization: false,
+      },
+      missingWindow: {
+        id: 'discussion:missing-window',
+        participationWindow: null,
+        transcriptRetentionMode: 'session_bound',
+        wideningRule: 'open_async',
+        memoryStabilization: false,
+      },
+      badBoolean: {
+        id: 'discussion:bad-boolean',
+        participationWindow: { startWeek: 1, endWeek: 12 },
+        transcriptRetentionMode: 'session_bound',
+        wideningRule: 'open_async',
+        memoryStabilization: 'yes',
+      },
+      notRecord: 'skip-me',
+    })
+
+    expect(sanitized[EXAMPLE_DISCUSSION_SURFACE.id]).toEqual(EXAMPLE_DISCUSSION_SURFACE)
+    expect(sanitized['discussion:bad-enum']).toBeUndefined()
+    expect(sanitized['discussion:inverted-window']).toBeUndefined()
+    expect(sanitized['discussion:bad-window']).toBeUndefined()
+    expect(sanitized['discussion:missing-window']).toBeUndefined()
+    expect(sanitized['discussion:bad-boolean']).toBeUndefined()
+    expect(Object.keys(sanitized)).toEqual([EXAMPLE_DISCUSSION_SURFACE.id])
+  })
+
+  it('hydrated EXAMPLE async discussion surface shape is frozen', () => {
+    const sanitized = sanitizeSpe956AsyncDiscussionSurfaceRecords({
+      valid: {
+        ...EXAMPLE_DISCUSSION_SURFACE,
+        participationWindow: { ...EXAMPLE_DISCUSSION_SURFACE.participationWindow },
+      },
+    })
+    const record = sanitized[EXAMPLE_DISCUSSION_SURFACE.id]
+
+    expect(record).toEqual(EXAMPLE_DISCUSSION_SURFACE)
+    expect(Object.isFrozen(record)).toBe(true)
+    expect(Object.isFrozen(record?.participationWindow)).toBe(true)
+  })
+
+  it('resolvePersistedAsyncDiscussionSurface ignores inherited keys and unsafe ids', () => {
+    const surfaceId = EXAMPLE_DISCUSSION_SURFACE.id
+    const ownRecords = Object.create(null) as Record<string, unknown>
+    ownRecords[surfaceId] = EXAMPLE_DISCUSSION_SURFACE
+
+    expect(
+      resolvePersistedAsyncDiscussionSurface(
+        { spe956AsyncDiscussionSurfaceRecords: ownRecords },
+        surfaceId
+      )
+    ).toEqual(EXAMPLE_DISCUSSION_SURFACE)
+
+    const prototypeOnlyId = 'discussion:prototype-only'
+    const prototypeBacked = Object.create({
+      [prototypeOnlyId]: EXAMPLE_DISCUSSION_SURFACE,
+    }) as Record<string, unknown>
+
+    expect(
+      resolvePersistedAsyncDiscussionSurface(
+        { spe956AsyncDiscussionSurfaceRecords: prototypeBacked },
+        prototypeOnlyId
+      )
+    ).toBeNull()
+
+    for (const unsafeId of ['__proto__', 'constructor', 'prototype'] as const) {
+      const records = Object.create(null) as Record<string, unknown>
+      records[unsafeId] = EXAMPLE_DISCUSSION_SURFACE
+      expect(
+        resolvePersistedAsyncDiscussionSurface(
+          { spe956AsyncDiscussionSurfaceRecords: records },
+          unsafeId
+        )
+      ).toBeNull()
+    }
+  })
+
+  it('hydrates explicit empty async discussion surface records over fallback during import', () => {
+    const fallback = createStartingState()
+    Object.assign(fallback, {
+      spe956AsyncDiscussionSurfaceRecords: SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS,
+    })
+
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        spe956AsyncDiscussionSurfaceRecords: {},
+      },
+      fallback
+    )
+
+    expect(hydrated.spe956AsyncDiscussionSurfaceRecords).toEqual({})
+  })
+
+  it('round-trips EXAMPLE async discussion surface records through save/load', () => {
+    const state = createStartingState()
+    Object.assign(state, {
+      spe956AsyncDiscussionSurfaceRecords: SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS,
+    })
+
+    const loaded = loadGameSave(serializeGameSave(state))
+
+    expect(loaded.spe956AsyncDiscussionSurfaceRecords).toEqual(
+      SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS
+    )
+  })
+
+  it('hydrates persisted async discussion surface records through import parsing', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        spe956AsyncDiscussionSurfaceRecords: {
+          ...SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS,
+          invalid: {
+            id: 'discussion:invalid',
+            participationWindow: { startWeek: 1, endWeek: 12 },
+            transcriptRetentionMode: 'not_valid',
+            wideningRule: 'open_async',
+            memoryStabilization: false,
+          },
+        },
+      },
+      fallback
+    )
+
+    expect(hydrated.spe956AsyncDiscussionSurfaceRecords).toEqual(
+      SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS
+    )
   })
 })

--- a/src/test/spe956ParticipatoryChannelPersistence.test.ts
+++ b/src/test/spe956ParticipatoryChannelPersistence.test.ts
@@ -742,6 +742,27 @@ describe('spe956ParticipatoryChannelPersistence (SPE-2635 / SPE-956 slice 4)', (
     expect(Object.isFrozen(record?.participationWindow)).toBe(true)
   })
 
+  it('hydrateGame preserves frozen async discussion surface shape including nested window', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame(
+      {
+        ...fallback,
+        spe956AsyncDiscussionSurfaceRecords: {
+          valid: {
+            ...EXAMPLE_DISCUSSION_SURFACE,
+            participationWindow: { ...EXAMPLE_DISCUSSION_SURFACE.participationWindow },
+          },
+        },
+      },
+      fallback
+    )
+    const record = hydrated.spe956AsyncDiscussionSurfaceRecords?.[EXAMPLE_DISCUSSION_SURFACE.id]
+
+    expect(record).toEqual(EXAMPLE_DISCUSSION_SURFACE)
+    expect(Object.isFrozen(record)).toBe(true)
+    expect(Object.isFrozen(record?.participationWindow)).toBe(true)
+  })
+
   it('resolvePersistedAsyncDiscussionSurface ignores inherited keys and unsafe ids', () => {
     const surfaceId = EXAMPLE_DISCUSSION_SURFACE.id
     const ownRecords = Object.create(null) as Record<string, unknown>


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2635 — https://linear.app/spectranoir/issue/SPE-2635
- **Parent issue (if any):** SPE-956 — https://linear.app/spectranoir/issue/SPE-956
- **Child issues covered:** slice only (async discussion surface map); advisory deferred to SPE-2636

## Summary

@coderabbitai summary

## What shipped

- Persist `spe956AsyncDiscussionSurfaceRecords` on GameState with SPE-2632–2634 sanitize/hydrate pattern (nested `participationWindow`, retention/widening enums, `memoryStabilization`)
- Wire hydrate in `runTransfer`, empty `{}` in starting state, SCHEMA_REGISTRY + slice-4 doc + backlog handoff
- Focused Vitest: round-trip, empty/missing normalize, invalid window/enum/field drop, frozen nested shape

## Docs updated

- `planning/spe-956-participatory-channel-persistence-slice-4.md`
- `SCHEMA_REGISTRY.md`
- `planning/backlog.md` / `planning/backlog-handoff-manifest.json`

## Parent status

- Parent SPE-956 remains **Backlog** — child slice only; advisory map still open as SPE-2636

## Scope boundary

- No SPE-2620/2628/2629/2630/2631 evaluator rewrites
- No advisory body map (SPE-2636), UI mirror, or week-close tick
- No SPE-1682 / SPE-860 / SPE-911 / SPE-875 expansions

## Validation

- [x] Targeted tests: `npm.cmd run test:run -- src/test/spe956ParticipatoryChannelPersistence.test.ts` (40 passed)
- [x] Lint / verify: `npm.cmd run lint`; `npm.cmd run verify:backlog-handoff`

## Follow-ups

- SPE-2636 — community advisory body channel map (arrays + threshold)
- UI / planning mirror; week-close channel tick (SPE-956 siblings)

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)