### PR TITLE
SPE-2645: post-SPE-2643 handoff; primary SPE-2644

### DIFF
--- a/planning/backlog-handoff-manifest.json
+++ b/planning/backlog-handoff-manifest.json
@@ -1,7 +1,9 @@
 {
-  "primary": "SPE-2643",
-  "inProgress": ["SPE-2643"],
+  "primary": "SPE-2644",
+  "inProgress": ["SPE-2644"],
   "recentlyShipped": [
+    "SPE-2645",
+    "SPE-2643",
     "SPE-2642",
     "SPE-2641",
     "SPE-2640",
@@ -11,11 +13,12 @@
     "SPE-2636",
     "SPE-2635",
     "SPE-2634",
-    "SPE-2633",
-    "SPE-2632"
+    "SPE-2633"
   ],
   "sliceDocStatus": {
-    "planning/spe-956-participatory-channel-week-close-slice-1.md": "In progress",
+    "planning/spe-2645-post-spe-2643-handoff-reconciliation-slice-1.md": "Shipped",
+    "planning/spe-956-gamestate-incident-baseline-persistence-slice-1.md": "In progress",
+    "planning/spe-956-participatory-channel-week-close-slice-1.md": "Shipped",
     "planning/spe-956-parent-umbrella-acceptance-slice-1.md": "Shipped",
     "planning/spe-956-parent-ac-matrix-reconciliation-slice-1.md": "Shipped",
     "planning/spe-956-parent-ac-incident-wire-up-slice-2.md": "Shipped",

--- a/planning/backlog.md
+++ b/planning/backlog.md
@@ -16,11 +16,11 @@ From `README.md` **Current design notes**:
 
 ## Active queue (highest leverage first — reorder as needed)
 
-**Recently shipped:** SPE-1046 file work queue release package handoff (slice 1) - persisted safe package handoff receipts after fulfillment on `main` @ `14b3f29a`; see `planning/spe-1046-file-work-queue-release-package-handoff-slice-1.md`. Parent [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) stays **Backlog**.
+**Recently shipped:** SPE-1046 file work queue release package handoff (slice 1) - persisted safe package handoff receipts after fulfillment on `main` @ `14b3f29a`; see `planning/spe-1046-file-work-queue-release-package-handoff-slice-1.md`. Parent [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) historical chain (now **Done**).
 
 **Recently shipped:** SPE-1046 file work queue file-content release delivery (slice 1) - persisted metadata-only file-release delivery receipts after safe package handoff; landed on `main` @ `97da46e3`; see `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`.
 
-**Next up (planning):** Actual file-content release delivery (slice 2) requires a new active Linear successor issue because [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) now reflects **Done**.
+**Recently shipped:** [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542) SPE-1046 file work queue actual file-content release delivery (slice 2) — ledger kind `actual_file_content_release_delivered` after metadata-only; PR #3021 @ `e28042c5`; see `planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md`. Backend file-byte transport remains deferred (not a duplicate ledger successor).
 
 Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **deferred** per `planning/infiltration-encounter-content-batch4plus-audit.md` (no eligible templates).
 
@@ -72,9 +72,13 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 ## Recommended next step (agent handoff)
 
-**Current handoff (primary):** [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643) — SPE-956 participatory channel week-close tick (post-Done follow-on); branch `spe-956-participatory-channel-week-close-slice-1`; see `planning/spe-956-participatory-channel-week-close-slice-1.md`. Parent [SPE-956](https://linear.app/spectranoir/issue/SPE-956) remains **Done** (does not reopen AC).
+**Current handoff (primary):** [SPE-2644](https://linear.app/spectranoir/issue/SPE-2644) — SPE-956 GameState incident baseline persistence (post-Done follow-on); branch `spe-956-gamestate-incident-baseline-persistence-slice-1`; see `planning/spe-956-gamestate-incident-baseline-persistence-slice-1.md`. Parent [SPE-956](https://linear.app/spectranoir/issue/SPE-956) remains **Done** (does not reopen AC).
 
-**In progress:** [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643)
+**In progress:** [SPE-2644](https://linear.app/spectranoir/issue/SPE-2644)
+
+**Recently shipped:** [SPE-2645](https://linear.app/spectranoir/issue/SPE-2645) post-SPE-2643 handoff reconciliation (docs) — week-close tick → Shipped; primary → GameState incident baseline persistence; SPE-2542 slice-2 status corrected; see `planning/spe-2645-post-spe-2643-handoff-reconciliation-slice-1.md`.
+
+**Recently shipped:** [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643) SPE-956 participatory channel week-close tick (post-Done follow-on) — pure `applyWeeklySpe956ParticipatoryChannelTick` + `advanceWeek` wire; PR #3196 @ `fd0aed55`; see `planning/spe-956-participatory-channel-week-close-slice-1.md`. Parent [SPE-956](https://linear.app/spectranoir/issue/SPE-956) remains **Done**.
 
 **Recently shipped:** [SPE-2642](https://linear.app/spectranoir/issue/SPE-2642) SPE-956 parent umbrella Done after SPE-2641 (owner acceptance) — Linear-only; PR #3194 @ `4133bb07`; see `planning/spe-956-parent-umbrella-acceptance-slice-1.md`. Parent [SPE-956](https://linear.app/spectranoir/issue/SPE-956) **Done**.
 
@@ -172,7 +176,7 @@ Mission triage full refresh remains **blocked**. SPE-2250 batch-4+ remains **def
 
 **Recently shipped:** [SPE-2568](https://linear.app/spectranoir/issue/SPE-2568/platform-reach-multiplier-from-view-count-slice-1) SPE-947 platform reach multiplier (slice 1) — pure `evaluatePlatformReachMultiplier`; PR #3059 @ `cc1ec1d4`. Parent [SPE-947](https://linear.app/spectranoir/issue/SPE-947) stays **Backlog**.
 
-**Secondary queue notes:** SPE-1046 file work queue file-content release delivery (slice 1) shipped on `main` @ `97da46e3` (`planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`); prepare actual file-content release delivery (slice 2) via `planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md` once a new Linear successor exists.
+**Secondary queue notes:** SPE-1046 file work queue file-content release delivery (slice 1) shipped on `main` @ `97da46e3` (`planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`); actual file-content release delivery (slice 2) shipped as [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542) / PR #3021 @ `e28042c5` (`planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md`). Backend file-byte transport remains deferred — do not open a duplicate ledger successor.
 
 **Recently shipped:** [SPE-2497](https://linear.app/spectranoir/issue/SPE-2497) pattern source series registry weekly transition surfacing (slice 5) — `pattern_source_series.weekly_transition` notes; PR #2914 @ `f5b91540`.
 
@@ -453,7 +457,9 @@ Git-visible implementation plans for agent sessions. **Linear issue state is aut
 | `spe-947-counter-memetic-uptake-gate-slice-1.md`                          | **Shipped**     | [SPE-2570](https://linear.app/spectranoir/issue/SPE-2570) — pure counter-memetic lore + distributor + uptake gate evaluator (parent AC row 3); PR #3063 @ `e46115b2`; parent SPE-947 stays **Backlog**.                                                                                               |
 | `spe-947-platform-outage-degrade-slice-1.md`                              | **Shipped**     | [SPE-2569](https://linear.app/spectranoir/issue/SPE-2569) — pure platform outage / reach-failure degrade evaluator (parent AC row 4); PR #3061 @ `ee721082`; parent SPE-947 stays **Backlog**.                                                                                                        |
 | `spe-947-platform-reach-multiplier-slice-1.md`                            | **Shipped**     | [SPE-2568](https://linear.app/spectranoir/issue/SPE-2568) — pure platform reach-multiplier evaluator (parent AC row 1); PR #3059 @ `cc1ec1d4`; parent SPE-947 stays **Backlog**.                                                                                                                      |
-| `spe-956-participatory-channel-week-close-slice-1.md`                     | **In progress** | [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643) — SPE-956 participatory channel week-close tick (post-Done follow-on; SPE-2624 pattern); parent SPE-956 remains **Done**.                                                                                                              |
+| `spe-2645-post-spe-2643-handoff-reconciliation-slice-1.md`                 | **Shipped**     | [SPE-2645](https://linear.app/spectranoir/issue/SPE-2645) — post-SPE-2643 handoff reconciliation (docs); primary → baseline persistence follow-on; SPE-2542 slice-2 status corrected.                                                                                                            |
+| `spe-956-gamestate-incident-baseline-persistence-slice-1.md`              | **In progress** | [SPE-2644](https://linear.app/spectranoir/issue/SPE-2644) — SPE-956 GameState incident baseline persistence (post-Done follow-on); parent SPE-956 remains **Done**.                                                                                                                              |
+| `spe-956-participatory-channel-week-close-slice-1.md`                     | **Shipped**     | [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643) — SPE-956 participatory channel week-close tick (post-Done follow-on; SPE-2624 pattern); PR #3196 @ `fd0aed55`; parent SPE-956 remains **Done**.                                                                                      |
 | `spe-956-parent-umbrella-acceptance-slice-1.md`                           | **Shipped**     | [SPE-2642](https://linear.app/spectranoir/issue/SPE-2642) — SPE-956 parent umbrella Done after SPE-2641 (owner acceptance; SPE-2618 pattern); parent SPE-956 **Done**; PR #3194 @ `4133bb07`.                                                                                                     |
 | `spe-956-parent-ac-matrix-reconciliation-slice-1.md`                      | **Shipped**     | [SPE-2641](https://linear.app/spectranoir/issue/SPE-2641) — parent AC matrix reconciliation after SPE-2639/2640; 7/7 Yes at incident-path / evaluator+EXAMPLE level; PR #3192 @ `e697dcbb`; parent SPE-956 umbrella Done via owner-acceptance child.                                                   |
 | `spe-956-parent-ac-incident-wire-up-slice-2.md`                           | **Shipped**     | [SPE-2640](https://linear.app/spectranoir/issue/SPE-2640) — parent AC incident wire-up async + survivor + memory lanes via SPE-2638 FromGameState helpers (slice 2); PR #3190 @ `0b99f42f`; parent SPE-956 stays **Backlog**.                                                                        |

--- a/planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md
+++ b/planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md
@@ -3,10 +3,10 @@
 One-page implementation plan. This slice follows metadata-only delivery receipts shipped in `planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md`.
 
 - **Linear:** [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542/file-work-queue-actual-file-content-release-delivery-slice-2)
-- **Status:** In Progress
-- **Parent context:** [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) historical chain
+- **Status:** Shipped
+- **Parent context:** [SPE-1046](https://linear.app/spectranoir/issue/SPE-1046) historical chain (parent **Done**; do not reopen)
 - **Branch:** `spe-file-work-queue-actual-file-content-release-delivery-slice-2`
-- **Base `main` SHA:** `b177998e`
+- **Base `main` SHA:** `b177998e` (merged PR #3021 @ `e28042c5`)
 
 ## Goal
 
@@ -26,12 +26,12 @@ Add a deterministic, durable actual file-content release delivery workflow on to
 
 ## Acceptance
 
-- [ ] A new release package or delivery mapping exists for actual file-content release and is deterministic.
-- [ ] Delivery id/ref format remains stable and sanitizer rejects malformed or mismatched records.
-- [ ] Store action only records delivery when prerequisites exist; otherwise no-op with no ledger mutation.
-- [ ] Existing metadata-only delivery behavior remains unchanged.
-- [ ] Operations mirror displays clear action availability and post-delivery status text for actual content release.
-- [ ] No mission routing/procurement/weekly progression/SPE-947 behavior changes occur.
+- [x] A new release package or delivery mapping exists for actual file-content release and is deterministic.
+- [x] Delivery id/ref format remains stable and sanitizer rejects malformed or mismatched records.
+- [x] Store action only records delivery when prerequisites exist; otherwise no-op with no ledger mutation.
+- [x] Existing metadata-only delivery behavior remains unchanged.
+- [x] Operations mirror displays clear action availability and post-delivery status text for actual content release.
+- [x] No mission routing/procurement/weekly progression/SPE-947 behavior changes occur.
 
 ## Validation
 

--- a/planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md
+++ b/planning/spe-1046-file-work-queue-file-release-delivery-slice-1.md
@@ -46,9 +46,12 @@ Persist a durable metadata-only file-release delivery receipt after safe package
 
 ## Deferred
 
-- **Actual file content release**
-  Owner: SPE-1046 follow-up child
-  Why: This slice records metadata-only delivery receipts, not file payload transport.
+- **Actual file content release (ledger)**
+  Owner: [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542) — **Done** (PR #3021)
+  Why: Metadata-only receipts deferred ledger kind; SPE-2542 shipped `actual_file_content_release_delivered`.
+- **Backend file-byte transport / storage**
+  Owner: dedicated infrastructure slice
+  Why: Still out of ledger boundary; do not invent file-byte I/O under SPE-1046 successors.
 - **Mission routing / procurement**
   Owner: SPE-1046 follow-up child
   Why: Existing routing/procurement gates remain separate from this receipt ledger.
@@ -56,11 +59,8 @@ Persist a durable metadata-only file-release delivery receipt after safe package
   Owner: SPE-947 child
   Why: Separate parent thread.
 - **SPE-1046 parent closure**
-  Owner: SPE-1046
-  Why: Broader parent acceptance remains open.
-- **Successor issue creation for actual file-content delivery**
-  Owner: Human / next agent
-  Why: Follow-up scope must be tracked under a new active successor issue.
+  Owner: SPE-1046 (historical; parent now **Done**)
+  Why: Broader parent acceptance was separate from this receipt ledger.
 
 ## See also
 

--- a/planning/spe-2645-post-spe-2643-handoff-reconciliation-slice-1.md
+++ b/planning/spe-2645-post-spe-2643-handoff-reconciliation-slice-1.md
@@ -30,7 +30,7 @@ Mark SPE-2643 **Shipped** in backlog/manifest, correct stale SPE-1046 actual fil
 - [x] SPE-2542 / actual file-content slice-2 docs no longer claim In Progress / “needs successor”
 - [x] `npm run verify:backlog-handoff` green
 - [x] No `src/` changes
-- [ ] Child Done only after merge
+- [x] Child Done only after merge (PR #3199)
 
 ## Status finding (binding)
 

--- a/planning/spe-2645-post-spe-2643-handoff-reconciliation-slice-1.md
+++ b/planning/spe-2645-post-spe-2643-handoff-reconciliation-slice-1.md
@@ -1,0 +1,55 @@
+# Post-SPE-2643 handoff reconciliation (docs)
+
+One-page hygiene plan. Linear: [SPE-2645](https://linear.app/spectranoir/issue/SPE-2645). Docs-only after [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643) merge.
+
+| Field                | Value                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------------- |
+| **Linear**           | [SPE-2645 — Post-SPE-2643 handoff reconciliation (docs)](https://linear.app/spectranoir/issue/SPE-2645) |
+| **Status**           | **Shipped**                                                                                |
+| **Parent / related** | [SPE-956](https://linear.app/spectranoir/issue/SPE-956) remains **Done**; [SPE-2644](https://linear.app/spectranoir/issue/SPE-2644) is next primary |
+| **Branch**           | `spe-2645-post-spe-2643-handoff-reconciliation`                                                 |
+| **Base `main` SHA**  | `fd0aed55`                                                                                     |
+
+## Goal
+
+Mark SPE-2643 **Shipped** in backlog/manifest, correct stale SPE-1046 actual file-content slice-2 notes (already shipped as [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542)), and set **primary** to [SPE-2644](https://linear.app/spectranoir/issue/SPE-2644) GameState incident baseline persistence.
+
+## Scope
+
+| In                                                                 | Out                                      |
+| ------------------------------------------------------------------ | ---------------------------------------- |
+| `planning/backlog.md` + `planning/backlog-handoff-manifest.json`    | Application / domain code (`src/`)       |
+| SPE-2643 slice doc → Shipped                                       | Implementing SPE-2644 baselines          |
+| SPE-2542 / slice-2 planning status → Shipped                       | Reopening SPE-956 or SPE-1046 AC         |
+| Primary → SPE-2644                                                 | Inventing file-byte transport            |
+
+## Acceptance
+
+- [x] SPE-2643 listed **Recently shipped**; not In Progress
+- [x] Primary points at SPE-2644
+- [x] SPE-2542 / actual file-content slice-2 docs no longer claim In Progress / “needs successor”
+- [x] `npm run verify:backlog-handoff` green
+- [x] No `src/` changes
+- [ ] Child Done only after merge
+
+## Status finding (binding)
+
+Preferred SPE-1046 file-content release delivery slice 2 **already shipped** as SPE-2542 (PR #3021 @ `e28042c5`). Do **not** open a duplicate Linear successor for that ledger work. Alternate sibling SPE-2644 is the correct primary.
+
+## Deferred
+
+| Item                                         | Suggested owner | Why deferred                                      |
+| -------------------------------------------- | --------------- | ------------------------------------------------- |
+| GameState incident baseline persistence      | SPE-2644        | This slice is docs handoff only                   |
+| Backend file-byte transport                  | Dedicated infra | Out of SPE-2542 ledger boundary by design         |
+
+## Validation
+
+- `npm.cmd run verify:backlog-handoff`
+- Confirm `git diff --stat` has no `src/` paths
+
+## See also
+
+- `planning/spe-956-participatory-channel-week-close-slice-1.md`
+- `planning/spe-1046-file-work-queue-actual-file-content-release-delivery-slice-2.md`
+- `planning/backlog.md`

--- a/planning/spe-956-gamestate-incident-baseline-persistence-slice-1.md
+++ b/planning/spe-956-gamestate-incident-baseline-persistence-slice-1.md
@@ -1,0 +1,64 @@
+# SPE-956 — GameState incident baseline persistence (post-Done follow-on)
+
+One-page implementation plan. Linear: [SPE-2644](https://linear.app/spectranoir/issue/SPE-2644) (post-Done follow-on related to [SPE-956](https://linear.app/spectranoir/issue/SPE-956); does **not** reopen parent AC). Follows shipped [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643) week-close tick; handoff via [SPE-2645](https://linear.app/spectranoir/issue/SPE-2645).
+
+| Field                | Value                                                                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Linear**           | [SPE-2644 — SPE-956 GameState incident baseline persistence (post-Done follow-on)](https://linear.app/spectranoir/issue/SPE-2644)     |
+| **Status**           | **In progress**                                                                                                                         |
+| **Parent / related** | [SPE-956](https://linear.app/spectranoir/issue/SPE-956) — remains **Done**; this issue does not reopen AC                              |
+| **Branch**           | `spe-956-gamestate-incident-baseline-persistence-slice-1`                                                                               |
+| **Base `main` SHA**  | `fd0aed55` (update after SPE-2645 merges if needed)                                                                                     |
+
+## Goal
+
+Persist authored SPE-956 incident-lane baselines on GameState (sanitize/hydrate) so the SPE-2639/2640 incident path can read baselines from persisted state instead of only EXAMPLE fixtures — without changing evaluator contracts, mirror UI, week-close tick, or the incident-path composer shape.
+
+## Prerequisite
+
+| Shipped                       | Anchor                                                                 | PR    |
+| ----------------------------- | ---------------------------------------------------------------------- | ----- |
+| Week-close channel tick       | [SPE-2643](https://linear.app/spectranoir/issue/SPE-2643)              | #3196 |
+| Parent umbrella Done          | [SPE-2642](https://linear.app/spectranoir/issue/SPE-2642)              | #3194 |
+| Incident path slices 1–2      | [SPE-2639](https://linear.app/spectranoir/issue/SPE-2639)–[SPE-2640](https://linear.app/spectranoir/issue/SPE-2640) | #3188–#3190 |
+| Five channel persistence maps | [SPE-2632](https://linear.app/spectranoir/issue/SPE-2632)–[SPE-2636](https://linear.app/spectranoir/issue/SPE-2636) | #3169–#3182 |
+
+## Scope
+
+| In                                                                 | Out                                        |
+| ------------------------------------------------------------------ | ------------------------------------------ |
+| Durable GameState persistence for five lane baseline kinds         | SPE-956 AC reopen / new AC rows            |
+| Sanitize + hydrate round-trip; empty/missing no-op                 | Evaluator / mirror rewrite                 |
+| Focused Vitest                                                     | Incident-path composer expansion           |
+| Slice doc + SCHEMA_REGISTRY note + backlog handoff                 | Week-close tick changes (SPE-2643)         |
+|                                                                    | SPE-1682 / 860 / 911 / 875; file-byte I/O  |
+
+## Acceptance
+
+- [ ] Empty/missing baseline persistence is a no-op without throw
+- [ ] Authored baselines sanitize/hydrate for all five lane kinds
+- [ ] Invalid / mismatched baselines are dropped
+- [ ] Incident path / evaluators / mirror / week-close unchanged unless a thin read helper is required
+- [ ] `npm run lint` + targeted tests green; `npm run verify:backlog-handoff` green
+- [ ] Child Done only after merge
+
+## Deferred
+
+| Item                              | Suggested owner | Why deferred                                      |
+| --------------------------------- | --------------- | ------------------------------------------------- |
+| Backend file-byte transport       | Infra slice     | SPE-2542 ledger already covers delivery receipts  |
+| SPE-1682 / 860 / 911 / 875        | Those parents   | Explicitly out of SPE-956 matrix boundary         |
+
+## Validation
+
+- Targeted Vitest for baseline persistence sanitize/hydrate
+- `npm.cmd run lint`
+- `npm.cmd run verify:backlog-handoff`
+
+## See also
+
+- `planning/spe-956-parent-ac-incident-wire-up-slice-1.md`
+- `planning/spe-956-parent-ac-incident-wire-up-slice-2.md`
+- `planning/spe-956-participatory-channel-persistence-slice-1.md`
+- `src/domain/spe956ParticipatoryChannelIncidentPath.ts` (inspect only)
+- `planning/backlog.md`

--- a/planning/spe-956-participatory-channel-week-close-slice-1.md
+++ b/planning/spe-956-participatory-channel-week-close-slice-1.md
@@ -5,7 +5,7 @@ One-page implementation plan. Linear: [SPE-2643](https://linear.app/spectranoir/
 | Field               | Value                                                                                                                                   |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | **Linear**          | [SPE-2643 — SPE-956 participatory channel week-close tick (post-Done follow-on)](https://linear.app/spectranoir/issue/SPE-2643)        |
-| **Status**          | **In progress**                                                                                                                         |
+| **Status**          | **Shipped**                                                                                                                             |
 | **Parent / related**| [SPE-956](https://linear.app/spectranoir/issue/SPE-956) — remains **Done**; this issue does not reopen AC                               |
 | **Branch**          | `spe-956-participatory-channel-week-close-slice-1`                                                                                      |
 | **Base `main` SHA** | `4133bb07`                                                                                                                              |
@@ -50,14 +50,14 @@ Wire persisted SPE-956 participatory channel maps into `advanceWeek` with a pure
 - [x] sanitize/hydrate round-trip preserves weekly fields
 - [x] `advanceWeek` integration covers no-op + authored-delta paths
 - [x] `npm run lint` + targeted tests green; `npm run verify:backlog-handoff` green
-- [ ] Child Done only after merge
+- [x] Child Done only after merge (PR #3196 @ `fd0aed55`)
 
 ## Deferred
 
 | Item                                    | Suggested owner                               | Why deferred                                                                 |
 | --------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------- |
-| GameState incident baseline persistence | Optional post-Done sibling                    | Baselines remain authored inputs on SPE-2639/2640 path                       |
-| SPE-1046 file-content release delivery slice 2 | New SPE-1046 successor (SPE-1046 Done) | Alternate handoff sibling; not this boundary                                 |
+| GameState incident baseline persistence | [SPE-2644](https://linear.app/spectranoir/issue/SPE-2644) | Baselines remain authored inputs on SPE-2639/2640 path; primary after SPE-2645 handoff |
+| SPE-1046 file-content release delivery slice 2 | [SPE-2542](https://linear.app/spectranoir/issue/SPE-2542) (already **Done**) | Ledger slice 2 shipped PR #3021; do not reopen duplicate successor           |
 | Weekly report-note surfacing            | Optional sibling                              | Out of week-close compose boundary                                           |
 | SPE-1682 / 860 / 911 / 875 expansions   | Those parents                                 | Explicitly out of SPE-956 matrix boundary                                    |
 


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2645 — https://linear.app/spectranoir/issue/SPE-2645
- **Parent issue (if any):** none (docs handoff; related SPE-956 remains Done)
- **Child issues covered:** slice only; points primary at SPE-2644

## Summary

@coderabbitai summary

## What shipped

- SPE-2643 → Shipped in backlog/manifest
- Primary → SPE-2644 (GameState incident baseline persistence)
- Corrected stale SPE-2542 / actual file-content slice-2 docs (already Done PR #3021)
- Stub slice doc for SPE-2644

## Docs updated

- planning/backlog.md, backlog-handoff-manifest.json
- planning/spe-2645-*, spe-956-* week-close + baseline stub, spe-1046 delivery slice docs

## Parent status

- SPE-956 remains Done (not reopened)
- SPE-1046 remains Done (not reopened)

## Scope boundary

- Docs-only; no src/ changes
- Does not implement SPE-2644

## Validation

- [x] Targeted tests: n/a (docs)
- [x] Lint / verify: npm run verify:backlog-handoff

## Follow-ups

- SPE-2644 implementation next session

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue