### PR TITLE
SPE-2644: persist SPE-956 incident-lane baselines on GameState

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -263,12 +263,12 @@ Tick wired from `advanceWeek` via `applyWeeklySpe956PropagationGraphTick`. Graph
 Documents compact GameState maps for authored SPE-956 participatory channel envelopes
 (SPE-2632 slice 1 survivor registry; SPE-2633 slice 2 collective memory channel;
 SPE-2634 slice 3 hotline channel; SPE-2635 slice 4 async discussion surface;
-SPE-2636 slice 5 community advisory body).
+SPE-2636 slice 5 community advisory body) plus SPE-2644 incident-lane baseline map.
 No evaluator contract changes.
 
 **Current version**: `spe-956-participatory-channel.v1` — exported as `SPE_956_PARTICIPATORY_CHANNEL_PERSISTENCE_SCHEMA_VERSION`
 
-**Location**: `src/domain/spe956ParticipatoryChannelPersistence.ts` (evaluator contracts: `survivorInformalRegistry.ts`, `collectiveMemoryStabilization.ts`, `hotlineChannel.ts`, `asyncDiscussionSurface.ts`, `communityAdvisoryDecisionInfluence.ts`; SPE-2638 `evaluate*FromGameState` helpers; SPE-2639 incident path: `spe956ParticipatoryChannelIncidentPath.ts`)
+**Location**: `src/domain/spe956ParticipatoryChannelPersistence.ts` (evaluator contracts: `survivorInformalRegistry.ts`, `collectiveMemoryStabilization.ts`, `hotlineChannel.ts`, `asyncDiscussionSurface.ts`, `communityAdvisoryDecisionInfluence.ts`; SPE-2638 `evaluate*FromGameState` helpers; SPE-2639 incident path: `spe956ParticipatoryChannelIncidentPath.ts`; SPE-2644 baselines: `spe956IncidentBaselinePersistence.ts`)
 
 ### GameState fields
 
@@ -279,17 +279,19 @@ No evaluator contract changes.
 | `spe956HotlineChannelRecords`           | Authored channel id + unit intervals + boolean + unanswered/anger enums + escalation rules string |
 | `spe956AsyncDiscussionSurfaceRecords`   | Authored surface id + nested participation window + retention/widening enums + memoryStabilization |
 | `spe956CommunityAdvisoryBodyRecords`    | Authored body id + mission/membership/criteria strings + stakeholder string array + scope enums + positive unit-interval influenceThreshold |
+| `spe956IncidentBaselineRecords`         | SPE-2644: authored incident-lane baselines keyed by incident id; optional advisory / hotline / asyncDiscussion / survivorSupport / collectiveMemory |
 
 ### Hydration
 
-- Sanitize via `sanitizeSpe956SurvivorInformalRegistryRecords`, `sanitizeSpe956CollectiveMemoryChannelRecords`, `sanitizeSpe956HotlineChannelRecords`, `sanitizeSpe956AsyncDiscussionSurfaceRecords`, and `sanitizeSpe956CommunityAdvisoryBodyRecords` in `spe956ParticipatoryChannelPersistence.ts`
+- Sanitize via `sanitizeSpe956SurvivorInformalRegistryRecords`, `sanitizeSpe956CollectiveMemoryChannelRecords`, `sanitizeSpe956HotlineChannelRecords`, `sanitizeSpe956AsyncDiscussionSurfaceRecords`, `sanitizeSpe956CommunityAdvisoryBodyRecords`, and `sanitizeSpe956IncidentBaselineRecords`
 - Wired in `hydrateGame` (`src/app/store/runTransfer.ts`)
 - Invalid entries, duplicate ids, and incomplete enum/field sets are dropped without throw
 - Nested `participationWindow` requires non-negative integer `startWeek`/`endWeek` with `startWeek <= endWeek`
 - Community advisory bodies require non-empty mission/membership/criteria strings; non-empty trimmed `representedStakeholderClasses` string array; non-empty `authorizedDecisionScopes` enum array (any invalid enum drops the entry); positive unit-interval `influenceThreshold` (`> 0` and `<= 1`)
+- Incident baselines (SPE-2644): map key must equal `incidentId`; advisory/hotline lanes require `baseline.incidentId === entry.incidentId`; invalid lanes dropped; entries with zero surviving lanes dropped; uses exported `tryNormalize*Baseline` helpers from evaluator modules
 - Explicit authored `{}` hydrates as empty canonical map (does not fall back to prior records); non-record input still uses fallback
 - Unsafe ids (`__proto__`, `constructor`, `prototype`) are rejected; maps built from plain-record input use null prototype (non-record input returns the caller `fallback` unchanged)
-- `resolvePersistedSurvivorInformalRegistry` / `resolvePersistedCollectiveMemoryChannel` / `resolvePersistedHotlineChannel` / `resolvePersistedAsyncDiscussionSurface` / `resolvePersistedCommunityAdvisoryBody` resolve own properties only and reject unsafe ids
+- `resolvePersistedSurvivorInformalRegistry` / `resolvePersistedCollectiveMemoryChannel` / `resolvePersistedHotlineChannel` / `resolvePersistedAsyncDiscussionSurface` / `resolvePersistedCommunityAdvisoryBody` / `resolveSpe956IncidentBaselines` resolve own properties only and reject unsafe ids
 - Default starting state: empty `{}` maps in `createStartingState`
 
 ### Optional weekly orchestration fields (SPE-2643)
@@ -304,8 +306,9 @@ Tick wired from `advanceWeek` via `applyWeeklySpe956ParticipatoryChannelTick` ov
 
 ### Deferred (optional post-Done siblings)
 
-- GameState incident baseline persistence; weekly report-note surfacing; SPE-1046 file-content release delivery slice 2 (separate successor)
-- UI / planning mirror shipped (SPE-2637); compose helpers shipped (SPE-2638); incident path shipped (SPE-2639/2640); umbrella Done (SPE-2642)
+- Weekly report-note surfacing (optional sibling)
+- Backend file-byte transport remains out of SPE-2542 ledger boundary (slice 2 already shipped)
+- UI / planning mirror shipped (SPE-2637); compose helpers shipped (SPE-2638); incident path shipped (SPE-2639/2640); week-close tick shipped (SPE-2643); incident baselines shipped (SPE-2644); umbrella Done (SPE-2642)
 
 ### Versioning
 

--- a/planning/spe-956-gamestate-incident-baseline-persistence-slice-1.md
+++ b/planning/spe-956-gamestate-incident-baseline-persistence-slice-1.md
@@ -8,7 +8,7 @@ One-page implementation plan. Linear: [SPE-2644](https://linear.app/spectranoir/
 | **Status**           | **In progress**                                                                                                                         |
 | **Parent / related** | [SPE-956](https://linear.app/spectranoir/issue/SPE-956) — remains **Done**; this issue does not reopen AC                              |
 | **Branch**           | `spe-956-gamestate-incident-baseline-persistence-slice-1`                                                                               |
-| **Base `main` SHA**  | `fd0aed55` (update after SPE-2645 merges if needed)                                                                                     |
+| **Base `main` SHA**  | `6ac79281`                                                                                                                              |
 
 ## Goal
 
@@ -35,11 +35,11 @@ Persist authored SPE-956 incident-lane baselines on GameState (sanitize/hydrate)
 
 ## Acceptance
 
-- [ ] Empty/missing baseline persistence is a no-op without throw
-- [ ] Authored baselines sanitize/hydrate for all five lane kinds
-- [ ] Invalid / mismatched baselines are dropped
-- [ ] Incident path / evaluators / mirror / week-close unchanged unless a thin read helper is required
-- [ ] `npm run lint` + targeted tests green; `npm run verify:backlog-handoff` green
+- [x] Empty/missing baseline persistence is a no-op without throw
+- [x] Authored baselines sanitize/hydrate for all five lane kinds
+- [x] Invalid / mismatched baselines are dropped
+- [x] Incident path / evaluators / mirror / week-close unchanged unless a thin read helper is required
+- [x] `npm run lint` + targeted tests green; `npm run verify:backlog-handoff` green
 - [ ] Child Done only after merge
 
 ## Deferred

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -267,6 +267,7 @@ import {
   sanitizeSpe956HotlineChannelRecords,
   sanitizeSpe956SurvivorInformalRegistryRecords,
 } from '../../domain/spe956ParticipatoryChannelPersistence'
+import { sanitizeSpe956IncidentBaselineRecords } from '../../domain/spe956IncidentBaselinePersistence'
 import {
   buildCandidateEvaluation,
   deriveCandidateCostEstimate,
@@ -9115,6 +9116,10 @@ export function hydrateGame(
     game.spe956CommunityAdvisoryBodyRecords,
     fallback.spe956CommunityAdvisoryBodyRecords ?? {}
   )
+  const spe956IncidentBaselineRecords = sanitizeSpe956IncidentBaselineRecords(
+    game.spe956IncidentBaselineRecords,
+    fallback.spe956IncidentBaselineRecords ?? {}
+  )
   const affiliationPersonStatusRecords = sanitizeAffiliationPersonStatusRecords(
     game.affiliationPersonStatusRecords,
     fallback.affiliationPersonStatusRecords ?? {}
@@ -9386,6 +9391,7 @@ export function hydrateGame(
     spe956HotlineChannelRecords,
     spe956AsyncDiscussionSurfaceRecords,
     spe956CommunityAdvisoryBodyRecords,
+    spe956IncidentBaselineRecords,
     affiliationPersonStatusRecords,
     affiliationFileWorkQueueActionRecords,
     affiliationFileWorkQueueEvidenceResolutionRecords,
@@ -9578,8 +9584,8 @@ export function hydrateGame(
     }
   }
 
-  // Reapply SPE-956 participatory channel maps after stripUndefinedFields / spreads so
-  // per-entry Object.freeze (and nested windows/arrays) from sanitize survive hydrateGame.
+  // Reapply SPE-956 participatory channel + incident baseline maps after stripUndefinedFields /
+  // spreads so per-entry Object.freeze from sanitize survive hydrateGame.
   hydrated = {
     ...hydrated,
     spe956SurvivorInformalRegistryRecords,
@@ -9587,6 +9593,7 @@ export function hydrateGame(
     spe956HotlineChannelRecords,
     spe956AsyncDiscussionSurfaceRecords,
     spe956CommunityAdvisoryBodyRecords,
+    spe956IncidentBaselineRecords,
   }
 
   return hydrated

--- a/src/data/startingState.ts
+++ b/src/data/startingState.ts
@@ -79,6 +79,7 @@ const startingStateTemplate: GameState = {
   spe956HotlineChannelRecords: {},
   spe956AsyncDiscussionSurfaceRecords: {},
   spe956CommunityAdvisoryBodyRecords: {},
+  spe956IncidentBaselineRecords: {},
   affiliationPersonStatusRecords: {},
   entityWelfareReclassificationRecords: {},
   containedPersonTherapeuticCareRecords: {},

--- a/src/domain/asyncDiscussionSurface.ts
+++ b/src/domain/asyncDiscussionSurface.ts
@@ -227,7 +227,9 @@ function isSessionIntent(value: unknown): value is DiscussionSessionIntent {
   return typeof value === 'string' && INTENT_SET.has(value)
 }
 
-function tryNormalizeBaseline(value: unknown): DiscussionMemoryBaseline | null {
+export function tryNormalizeDiscussionMemoryBaseline(
+  value: unknown
+): DiscussionMemoryBaseline | null {
   if (!isRecord(value)) {
     return null
   }
@@ -285,7 +287,7 @@ export function evaluateAsyncDiscussionSession(
     return deferredResult(['invalid_discussion_baseline'])
   }
 
-  const baseline = tryNormalizeBaseline(rawBaseline)
+  const baseline = tryNormalizeDiscussionMemoryBaseline(rawBaseline)
   if (!baseline) {
     return deferredResult(['invalid_discussion_baseline'])
   }

--- a/src/domain/collectiveMemoryStabilization.ts
+++ b/src/domain/collectiveMemoryStabilization.ts
@@ -250,7 +250,9 @@ function isSignalIntent(value: unknown): value is MemorySignalIntent {
   return typeof value === 'string' && INTENT_SET.has(value)
 }
 
-function tryNormalizeBaseline(value: unknown): CollectiveMemoryBaseline | null {
+export function tryNormalizeCollectiveMemoryBaseline(
+  value: unknown
+): CollectiveMemoryBaseline | null {
   if (!isRecord(value)) {
     return null
   }
@@ -297,7 +299,7 @@ export function evaluateCollectiveMemoryStabilization(
     return deferredResult(['invalid_memory_baseline'])
   }
 
-  const baseline = tryNormalizeBaseline(rawBaseline)
+  const baseline = tryNormalizeCollectiveMemoryBaseline(rawBaseline)
   if (!baseline) {
     return deferredResult(['invalid_memory_baseline'])
   }

--- a/src/domain/communityAdvisoryDecisionInfluence.ts
+++ b/src/domain/communityAdvisoryDecisionInfluence.ts
@@ -306,7 +306,9 @@ function isUrgency(value: unknown): value is CommunityAdvisoryUrgency {
   return typeof value === 'string' && URGENCY_SET.has(value)
 }
 
-function tryNormalizeBaseline(value: unknown): IncidentResponseDecision | null {
+export function tryNormalizeIncidentResponseBaseline(
+  value: unknown
+): IncidentResponseDecision | null {
   if (!isRecord(value)) {
     return null
   }
@@ -355,7 +357,7 @@ export function evaluateCommunityAdvisoryDecisionInfluence(
     return emptyDeferredResult(['invalid_incident_baseline'])
   }
 
-  const baseline = tryNormalizeBaseline(rawBaseline)
+  const baseline = tryNormalizeIncidentResponseBaseline(rawBaseline)
   if (!baseline) {
     return emptyDeferredResult(['invalid_incident_baseline'])
   }

--- a/src/domain/hotlineChannel.ts
+++ b/src/domain/hotlineChannel.ts
@@ -221,7 +221,9 @@ function isAngerMode(value: unknown): value is HotlineAngerMode {
   return typeof value === 'string' && ANGER_MODE_SET.has(value)
 }
 
-function tryNormalizeBaseline(value: unknown): HotlineGuidanceBaseline | null {
+export function tryNormalizeHotlineGuidanceBaseline(
+  value: unknown
+): HotlineGuidanceBaseline | null {
   if (!isRecord(value)) {
     return null
   }
@@ -266,7 +268,7 @@ export function evaluateHotlineCall(
     return unansweredResult(['invalid_guidance_baseline'])
   }
 
-  const baseline = tryNormalizeBaseline(rawBaseline)
+  const baseline = tryNormalizeHotlineGuidanceBaseline(rawBaseline)
   if (!baseline) {
     return unansweredResult(['invalid_guidance_baseline'])
   }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -328,6 +328,7 @@ import type {
   Spe956HotlineChannelRecordsMap,
   Spe956SurvivorInformalRegistryRecordsMap,
 } from './spe956ParticipatoryChannelPersistence'
+import type { Spe956IncidentBaselineRecordsMap } from './spe956IncidentBaselinePersistence'
 import type { SquadMetadata } from './squadMetadata'
 import type { SquadKitTemplate } from './squadKitTemplate'
 import type { SquadKitAssignment } from './squadKitAssignment'
@@ -2904,6 +2905,13 @@ export interface GameState {
    * Hydration drops invalid or duplicate-id entries without throwing. Round-trip only.
    */
   spe956CommunityAdvisoryBodyRecords?: Spe956CommunityAdvisoryBodyRecordsMap
+
+  /**
+   * SPE-2644: authored SPE-956 incident-lane baselines (keyed by incident id).
+   * Optional advisory/hotline/async/survivor/memory lanes per incident.
+   * Hydration drops invalid, mismatched-key, and empty-lane entries without throwing.
+   */
+  spe956IncidentBaselineRecords?: Spe956IncidentBaselineRecordsMap
 
   /**
    * SPE-2518 slice 1: persisted affiliation/person-status evidence records (keyed by record id).

--- a/src/domain/spe956IncidentBaselinePersistence.ts
+++ b/src/domain/spe956IncidentBaselinePersistence.ts
@@ -1,0 +1,212 @@
+/**
+ * SPE-2644 / SPE-956: GameState persistence for authored incident-lane baselines.
+ *
+ * One map keyed by incident id with five optional lane baselines used by the
+ * SPE-2639/2640 incident path. Sanitize/hydrate + thin resolve only.
+ * Does not change evaluators, mirror, week-close, or expand the incident-path composer.
+ */
+
+import {
+  EXAMPLE_DISCUSSION_BASELINE,
+  tryNormalizeDiscussionMemoryBaseline,
+  type DiscussionMemoryBaseline,
+} from './asyncDiscussionSurface'
+import {
+  EXAMPLE_MEMORY_STABILIZATION_BASELINE,
+  tryNormalizeCollectiveMemoryBaseline,
+  type CollectiveMemoryBaseline,
+} from './collectiveMemoryStabilization'
+import {
+  EXAMPLE_INCIDENT_BASELINE,
+  tryNormalizeIncidentResponseBaseline,
+  type IncidentResponseDecision,
+} from './communityAdvisoryDecisionInfluence'
+import {
+  EXAMPLE_HOTLINE_GUIDANCE_BASELINE,
+  tryNormalizeHotlineGuidanceBaseline,
+  type HotlineGuidanceBaseline,
+} from './hotlineChannel'
+import { SPE_956_EXAMPLE_INCIDENT_ID } from './spe956ParticipatoryChannelIncidentPath'
+import {
+  EXAMPLE_SURVIVOR_REGISTRY_BASELINE,
+  tryNormalizeSurvivorSupportBaseline,
+  type SurvivorSupportBaseline,
+} from './survivorInformalRegistry'
+
+export interface Spe956PersistedIncidentBaselines {
+  readonly incidentId: string
+  readonly advisory?: IncidentResponseDecision
+  readonly hotline?: HotlineGuidanceBaseline
+  readonly asyncDiscussion?: DiscussionMemoryBaseline
+  readonly survivorSupport?: SurvivorSupportBaseline
+  readonly collectiveMemory?: CollectiveMemoryBaseline
+}
+
+export type Spe956IncidentBaselineRecordsMap = Record<string, Spe956PersistedIncidentBaselines>
+
+export interface Spe956IncidentBaselineGameStateLike {
+  readonly spe956IncidentBaselineRecords?: Spe956IncidentBaselineRecordsMap | null
+}
+
+type PlainRecord = Record<string, unknown>
+
+function isPlainRecord(value: unknown): value is PlainRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isSafeMapKey(id: string): boolean {
+  return id !== '__proto__' && id !== 'constructor' && id !== 'prototype'
+}
+
+function normalizeIncidentId(value: unknown): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : ''
+}
+
+function sanitizeSpe956IncidentBaselineEntry(
+  value: unknown,
+  mapKey: string
+): Spe956PersistedIncidentBaselines | null {
+  if (!isPlainRecord(value)) {
+    return null
+  }
+
+  const incidentId = normalizeIncidentId(value.incidentId)
+  if (
+    incidentId.length === 0 ||
+    !isSafeMapKey(incidentId) ||
+    !isSafeMapKey(mapKey) ||
+    incidentId !== mapKey
+  ) {
+    return null
+  }
+
+  let advisory: IncidentResponseDecision | undefined
+  if (value.advisory !== undefined) {
+    const normalized = tryNormalizeIncidentResponseBaseline(value.advisory)
+    if (normalized !== null && normalized.incidentId === incidentId) {
+      advisory = normalized
+    }
+  }
+
+  let hotline: HotlineGuidanceBaseline | undefined
+  if (value.hotline !== undefined) {
+    const normalized = tryNormalizeHotlineGuidanceBaseline(value.hotline)
+    if (normalized !== null && normalized.incidentId === incidentId) {
+      hotline = normalized
+    }
+  }
+
+  let asyncDiscussion: DiscussionMemoryBaseline | undefined
+  if (value.asyncDiscussion !== undefined) {
+    const normalized = tryNormalizeDiscussionMemoryBaseline(value.asyncDiscussion)
+    if (normalized !== null) {
+      asyncDiscussion = normalized
+    }
+  }
+
+  let survivorSupport: SurvivorSupportBaseline | undefined
+  if (value.survivorSupport !== undefined) {
+    const normalized = tryNormalizeSurvivorSupportBaseline(value.survivorSupport)
+    if (normalized !== null) {
+      survivorSupport = normalized
+    }
+  }
+
+  let collectiveMemory: CollectiveMemoryBaseline | undefined
+  if (value.collectiveMemory !== undefined) {
+    const normalized = tryNormalizeCollectiveMemoryBaseline(value.collectiveMemory)
+    if (normalized !== null) {
+      collectiveMemory = normalized
+    }
+  }
+
+  if (
+    advisory === undefined &&
+    hotline === undefined &&
+    asyncDiscussion === undefined &&
+    survivorSupport === undefined &&
+    collectiveMemory === undefined
+  ) {
+    return null
+  }
+
+  return Object.freeze({
+    incidentId,
+    ...(advisory !== undefined ? { advisory } : {}),
+    ...(hotline !== undefined ? { hotline } : {}),
+    ...(asyncDiscussion !== undefined ? { asyncDiscussion } : {}),
+    ...(survivorSupport !== undefined ? { survivorSupport } : {}),
+    ...(collectiveMemory !== undefined ? { collectiveMemory } : {}),
+  })
+}
+
+/** Hydration: canonical authored incident baseline map keyed by incident id. */
+export function sanitizeSpe956IncidentBaselineRecords(
+  value: unknown,
+  fallback: Spe956IncidentBaselineRecordsMap = {}
+): Spe956IncidentBaselineRecordsMap {
+  if (!isPlainRecord(value)) {
+    return fallback
+  }
+
+  const next = Object.create(null) as Spe956IncidentBaselineRecordsMap
+  const seenIds = new Set<string>()
+
+  for (const [mapKey, entry] of Object.entries(value)) {
+    if (!isSafeMapKey(mapKey)) {
+      continue
+    }
+
+    const record = sanitizeSpe956IncidentBaselineEntry(entry, mapKey)
+    if (record === null) {
+      continue
+    }
+
+    if (seenIds.has(record.incidentId)) {
+      continue
+    }
+
+    seenIds.add(record.incidentId)
+    next[record.incidentId] = record
+  }
+
+  return next
+}
+
+export function extractSpe956IncidentBaselineRecords(
+  game: Spe956IncidentBaselineGameStateLike | null | undefined
+): Spe956IncidentBaselineRecordsMap {
+  return sanitizeSpe956IncidentBaselineRecords(game?.spe956IncidentBaselineRecords, {})
+}
+
+/** Resolve own-property incident baselines; reject unsafe ids. */
+export function resolveSpe956IncidentBaselines(
+  game: Spe956IncidentBaselineGameStateLike | null | undefined,
+  incidentId: string
+): Spe956PersistedIncidentBaselines | null {
+  const trimmed = typeof incidentId === 'string' ? incidentId.trim() : ''
+  if (trimmed.length === 0 || !isSafeMapKey(trimmed)) {
+    return null
+  }
+
+  const records = extractSpe956IncidentBaselineRecords(game)
+  if (!Object.prototype.hasOwnProperty.call(records, trimmed)) {
+    return null
+  }
+
+  return records[trimmed] ?? null
+}
+
+export const SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS: Spe956IncidentBaselineRecordsMap =
+  Object.freeze(
+    Object.assign(Object.create(null), {
+      [SPE_956_EXAMPLE_INCIDENT_ID]: Object.freeze({
+        incidentId: SPE_956_EXAMPLE_INCIDENT_ID,
+        advisory: EXAMPLE_INCIDENT_BASELINE,
+        hotline: EXAMPLE_HOTLINE_GUIDANCE_BASELINE,
+        asyncDiscussion: EXAMPLE_DISCUSSION_BASELINE,
+        survivorSupport: EXAMPLE_SURVIVOR_REGISTRY_BASELINE,
+        collectiveMemory: EXAMPLE_MEMORY_STABILIZATION_BASELINE,
+      }),
+    })
+  ) as Spe956IncidentBaselineRecordsMap

--- a/src/domain/survivorInformalRegistry.ts
+++ b/src/domain/survivorInformalRegistry.ts
@@ -241,7 +241,9 @@ function isSignalIntent(value: unknown): value is RegistrySignalIntent {
   return typeof value === 'string' && INTENT_SET.has(value)
 }
 
-function tryNormalizeBaseline(value: unknown): SurvivorSupportBaseline | null {
+export function tryNormalizeSurvivorSupportBaseline(
+  value: unknown
+): SurvivorSupportBaseline | null {
   if (!isRecord(value)) {
     return null
   }
@@ -287,7 +289,7 @@ export function evaluateSurvivorInformalRegistrySignal(
     return deferredResult(['invalid_support_baseline'])
   }
 
-  const baseline = tryNormalizeBaseline(rawBaseline)
+  const baseline = tryNormalizeSurvivorSupportBaseline(rawBaseline)
   if (!baseline) {
     return deferredResult(['invalid_support_baseline'])
   }

--- a/src/test/spe956IncidentBaselinePersistence.test.ts
+++ b/src/test/spe956IncidentBaselinePersistence.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+
+import { hydrateGame } from '../app/store/runTransfer'
+import { loadGameSave, serializeGameSave } from '../app/store/saveSystem'
+import { createStartingState } from '../data/startingState'
+import { EXAMPLE_DISCUSSION_BASELINE } from '../domain/asyncDiscussionSurface'
+import { EXAMPLE_MEMORY_STABILIZATION_BASELINE } from '../domain/collectiveMemoryStabilization'
+import { EXAMPLE_INCIDENT_BASELINE } from '../domain/communityAdvisoryDecisionInfluence'
+import { EXAMPLE_HOTLINE_GUIDANCE_BASELINE } from '../domain/hotlineChannel'
+import { SPE_956_EXAMPLE_INCIDENT_ID } from '../domain/spe956ParticipatoryChannelIncidentPath'
+import {
+  resolveSpe956IncidentBaselines,
+  sanitizeSpe956IncidentBaselineRecords,
+  SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS,
+} from '../domain/spe956IncidentBaselinePersistence'
+import { EXAMPLE_SURVIVOR_REGISTRY_BASELINE } from '../domain/survivorInformalRegistry'
+
+describe('spe956IncidentBaselinePersistence (SPE-2644)', () => {
+  it('defaults starting state to empty spe956IncidentBaselineRecords', () => {
+    expect(createStartingState().spe956IncidentBaselineRecords).toEqual({})
+  })
+
+  it('returns explicit empty map instead of fallback during sanitize', () => {
+    const fallback = SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS
+
+    expect(sanitizeSpe956IncidentBaselineRecords({}, fallback)).toEqual({})
+    expect(sanitizeSpe956IncidentBaselineRecords({}, fallback)).not.toBe(fallback)
+    expect(Object.getPrototypeOf(sanitizeSpe956IncidentBaselineRecords({}, fallback))).toBeNull()
+  })
+
+  it('returns fallback only for non-record / missing input during sanitize', () => {
+    const fallback = SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS
+
+    expect(sanitizeSpe956IncidentBaselineRecords(null, fallback)).toBe(fallback)
+    expect(sanitizeSpe956IncidentBaselineRecords(undefined, fallback)).toBe(fallback)
+    expect(sanitizeSpe956IncidentBaselineRecords('not-a-record', fallback)).toBe(fallback)
+  })
+
+  it('rejects unsafe incident ids', () => {
+    for (const unsafeId of ['__proto__', 'constructor', 'prototype'] as const) {
+      const polluted = sanitizeSpe956IncidentBaselineRecords({
+        [unsafeId]: {
+          incidentId: unsafeId,
+          advisory: EXAMPLE_INCIDENT_BASELINE,
+        },
+      })
+
+      expect(Object.prototype.hasOwnProperty.call(polluted, unsafeId)).toBe(false)
+      expect(Object.keys(polluted)).toEqual([])
+    }
+  })
+
+  it('drops mismatched key, mismatched advisory incidentId, and empty-lane entries', () => {
+    const sanitized = sanitizeSpe956IncidentBaselineRecords({
+      [SPE_956_EXAMPLE_INCIDENT_ID]: {
+        incidentId: SPE_956_EXAMPLE_INCIDENT_ID,
+        advisory: EXAMPLE_INCIDENT_BASELINE,
+        hotline: EXAMPLE_HOTLINE_GUIDANCE_BASELINE,
+        asyncDiscussion: EXAMPLE_DISCUSSION_BASELINE,
+        survivorSupport: EXAMPLE_SURVIVOR_REGISTRY_BASELINE,
+        collectiveMemory: EXAMPLE_MEMORY_STABILIZATION_BASELINE,
+      },
+      'incident:wrong-key': {
+        incidentId: SPE_956_EXAMPLE_INCIDENT_ID,
+        advisory: EXAMPLE_INCIDENT_BASELINE,
+      },
+      'incident:mismatched-advisory': {
+        incidentId: 'incident:mismatched-advisory',
+        advisory: EXAMPLE_INCIDENT_BASELINE,
+        asyncDiscussion: EXAMPLE_DISCUSSION_BASELINE,
+      },
+      'incident:empty': {
+        incidentId: 'incident:empty',
+      },
+      'incident:bad-async': {
+        incidentId: 'incident:bad-async',
+        asyncDiscussion: { topicId: '', participation: 'x', institutionalMemory: 'y' },
+      },
+    })
+
+    expect(Object.keys(sanitized).sort()).toEqual(
+      [SPE_956_EXAMPLE_INCIDENT_ID, 'incident:mismatched-advisory'].sort()
+    )
+    expect(sanitized[SPE_956_EXAMPLE_INCIDENT_ID]?.advisory).toEqual(EXAMPLE_INCIDENT_BASELINE)
+    expect(sanitized['incident:mismatched-advisory']).toEqual({
+      incidentId: 'incident:mismatched-advisory',
+      asyncDiscussion: EXAMPLE_DISCUSSION_BASELINE,
+    })
+  })
+
+  it('keeps valid lanes when one lane is invalid', () => {
+    const sanitized = sanitizeSpe956IncidentBaselineRecords({
+      'incident:partial': {
+        incidentId: 'incident:partial',
+        advisory: EXAMPLE_INCIDENT_BASELINE,
+        asyncDiscussion: EXAMPLE_DISCUSSION_BASELINE,
+      },
+    })
+
+    // advisory dropped (EXAMPLE incidentId mismatch); async kept
+    expect(sanitized['incident:partial']).toEqual({
+      incidentId: 'incident:partial',
+      asyncDiscussion: EXAMPLE_DISCUSSION_BASELINE,
+    })
+  })
+
+  it('round-trips authored baselines through hydrateGame and save serialize/load', () => {
+    const base = createStartingState()
+    const withBaselines = {
+      ...base,
+      spe956IncidentBaselineRecords: SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS,
+    }
+
+    const hydrated = hydrateGame(withBaselines, base)
+    expect(hydrated.spe956IncidentBaselineRecords?.[SPE_956_EXAMPLE_INCIDENT_ID]).toEqual(
+      SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS[SPE_956_EXAMPLE_INCIDENT_ID]
+    )
+    expect(Object.isFrozen(hydrated.spe956IncidentBaselineRecords?.[SPE_956_EXAMPLE_INCIDENT_ID])).toBe(
+      true
+    )
+
+    const serialized = serializeGameSave(hydrated)
+    const loaded = loadGameSave(serialized)
+    expect(loaded?.spe956IncidentBaselineRecords?.[SPE_956_EXAMPLE_INCIDENT_ID]?.hotline).toEqual(
+      EXAMPLE_HOTLINE_GUIDANCE_BASELINE
+    )
+  })
+
+  it('resolveSpe956IncidentBaselines returns null for missing/unsafe and authored for EXAMPLE', () => {
+    const game = {
+      spe956IncidentBaselineRecords: SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS,
+    }
+
+    expect(resolveSpe956IncidentBaselines(game, SPE_956_EXAMPLE_INCIDENT_ID)?.advisory).toEqual(
+      EXAMPLE_INCIDENT_BASELINE
+    )
+    expect(resolveSpe956IncidentBaselines(game, 'incident:missing')).toBeNull()
+    expect(resolveSpe956IncidentBaselines(game, '__proto__')).toBeNull()
+    expect(resolveSpe956IncidentBaselines({}, SPE_956_EXAMPLE_INCIDENT_ID)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2644 — https://linear.app/spectranoir/issue/SPE-2644
- **Parent issue (if any):** SPE-956 (Done — related post-Done sibling; does not reopen AC)
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- GameState `spe956IncidentBaselineRecords` keyed by incident id (five optional lane baselines)
- Sanitize/hydrate + `resolveSpe956IncidentBaselines`
- Exported `tryNormalize*Baseline` helpers from five evaluator modules (no behavior change)
- Vitest coverage; SCHEMA_REGISTRY note

## Docs updated

- SCHEMA_REGISTRY.md
- planning/spe-956-gamestate-incident-baseline-persistence-slice-1.md

## Parent status

- SPE-956 remains Done (AC not reopened)

## Scope boundary

- Does not change incident-path composer, evaluators, mirror, or week-close tick
- Does not invent file-byte transport

## Validation

- [x] Targeted tests: spe956IncidentBaselinePersistence (+ participatory persistence / incident path regression)
- [x] Lint / verify: npm run lint; npm run verify:backlog-handoff

## Follow-ups

- Weekly report-note surfacing (optional sibling)

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue

Made with [Cursor](https://cursor.com)