### PR TITLE
SPE-2647: wire resolveSpe956IncidentBaselines into EXAMPLE path builder

### DIFF
--- a/planning/spe-2647-example-incident-path-baseline-resolve-wire-slice-1.md
+++ b/planning/spe-2647-example-incident-path-baseline-resolve-wire-slice-1.md
@@ -8,7 +8,7 @@ One-page implementation plan. Linear: [SPE-2647](https://linear.app/spectranoir/
 | **Status**           | **In progress**                                                                                                                         |
 | **Parent / related** | [SPE-956](https://linear.app/spectranoir/issue/SPE-956) — remains **Done**; this issue does not reopen AC                              |
 | **Branch**           | `spe-2647-example-incident-path-baseline-resolve-wire-slice-1`                                                                          |
-| **Base `main` SHA**  | TBD after SPE-2649 handoff merge                                                                                                        |
+| **Base `main` SHA**  | `af276547`                                                                                                                              |
 
 ## Goal
 
@@ -34,10 +34,10 @@ Thin-wire `resolveSpe956IncidentBaselines` into EXAMPLE incident-path input buil
 
 ## Acceptance
 
-- [ ] EXAMPLE builders prefer persisted baselines when resolve returns a record
-- [ ] Missing baselines fall back to existing EXAMPLE fixtures
-- [ ] `applySpe956ParticipatoryChannelsToIncident` unchanged
-- [ ] Targeted Vitest green; lint green
+- [x] EXAMPLE builders prefer persisted baselines when resolve returns a record
+- [x] Missing baselines fall back to existing EXAMPLE fixtures
+- [x] `applySpe956ParticipatoryChannelsToIncident` unchanged
+- [x] Targeted Vitest green; lint green
 - [ ] Child Done only after merge
 
 ## Deferred

--- a/src/domain/spe956IncidentBaselinePersistence.ts
+++ b/src/domain/spe956IncidentBaselinePersistence.ts
@@ -26,12 +26,14 @@ import {
   tryNormalizeHotlineGuidanceBaseline,
   type HotlineGuidanceBaseline,
 } from './hotlineChannel'
-import { SPE_956_EXAMPLE_INCIDENT_ID } from './spe956ParticipatoryChannelIncidentPath'
 import {
   EXAMPLE_SURVIVOR_REGISTRY_BASELINE,
   tryNormalizeSurvivorSupportBaseline,
   type SurvivorSupportBaseline,
 } from './survivorInformalRegistry'
+
+/** Shared riverside incident id for the authored SPE-956 EXAMPLE path. */
+export const SPE_956_EXAMPLE_INCIDENT_ID = 'incident:riverside-site-breach' as const
 
 export interface Spe956PersistedIncidentBaselines {
   readonly incidentId: string

--- a/src/domain/spe956ParticipatoryChannelIncidentPath.ts
+++ b/src/domain/spe956ParticipatoryChannelIncidentPath.ts
@@ -47,6 +47,11 @@ import {
   EXAMPLE_HOTLINE_CHANNEL,
   EXAMPLE_HOTLINE_GUIDANCE_BASELINE,
 } from './hotlineChannel'
+import {
+  resolveSpe956IncidentBaselines,
+  SPE_956_EXAMPLE_INCIDENT_ID,
+  type Spe956IncidentBaselineGameStateLike,
+} from './spe956IncidentBaselinePersistence'
 import type { Spe956ParticipatoryChannelGameStateLike } from './spe956ParticipatoryChannelPersistence'
 import {
   evaluateAsyncDiscussionSessionFromGameState,
@@ -66,8 +71,7 @@ import {
   EXAMPLE_SURVIVOR_REGISTRY_SIGNAL,
 } from './survivorInformalRegistry'
 
-/** Shared riverside incident id for the authored SPE-956 EXAMPLE path. */
-export const SPE_956_EXAMPLE_INCIDENT_ID = 'incident:riverside-site-breach' as const
+export { SPE_956_EXAMPLE_INCIDENT_ID }
 
 export interface Spe956AdvisoryIncidentLaneInput {
   readonly bodyId: string
@@ -398,3 +402,46 @@ export const EXAMPLE_SPE_956_INCIDENT_PATH_INPUT: Spe956ParticipatoryChannelInci
       baseline: EXAMPLE_MEMORY_STABILIZATION_BASELINE,
     }),
   })
+
+/**
+ * Build EXAMPLE incident-path input, preferring persisted baselines from GameState when present.
+ * Falls back to authored EXAMPLE fixtures when resolve returns null or omits a lane baseline.
+ */
+export function buildExampleSpe956IncidentPathInputFromGameState(
+  game: Spe956IncidentBaselineGameStateLike | null | undefined,
+  incidentId: string = SPE_956_EXAMPLE_INCIDENT_ID
+): Spe956ParticipatoryChannelIncidentPathInput {
+  const persisted = resolveSpe956IncidentBaselines(game, incidentId)
+
+  return Object.freeze({
+    incidentId,
+    advisory: Object.freeze({
+      bodyId: EXAMPLE_COMMUNITY_ADVISORY_BODY.id,
+      signal: EXAMPLE_SUPPORT_ROUTING_SIGNAL,
+      baseline: persisted?.advisory ?? EXAMPLE_INCIDENT_BASELINE,
+    }),
+    hotline: Object.freeze({
+      channelId: EXAMPLE_HOTLINE_CHANNEL.id,
+      call: EXAMPLE_HOTLINE_CALL,
+      baseline: persisted?.hotline ?? EXAMPLE_HOTLINE_GUIDANCE_BASELINE,
+    }),
+    asyncDiscussion: Object.freeze({
+      incidentId,
+      surfaceId: EXAMPLE_DISCUSSION_SURFACE.id,
+      session: EXAMPLE_DISCUSSION_SESSION,
+      baseline: persisted?.asyncDiscussion ?? EXAMPLE_DISCUSSION_BASELINE,
+    }),
+    survivorRegistry: Object.freeze({
+      incidentId,
+      registryId: EXAMPLE_SURVIVOR_REGISTRY.id,
+      signal: EXAMPLE_SURVIVOR_REGISTRY_SIGNAL,
+      baseline: persisted?.survivorSupport ?? EXAMPLE_SURVIVOR_REGISTRY_BASELINE,
+    }),
+    collectiveMemory: Object.freeze({
+      incidentId,
+      channelId: EXAMPLE_MEMORY_STABILIZATION_CHANNEL.id,
+      signal: EXAMPLE_MEMORY_STABILIZATION_SIGNAL,
+      baseline: persisted?.collectiveMemory ?? EXAMPLE_MEMORY_STABILIZATION_BASELINE,
+    }),
+  })
+}

--- a/src/test/spe956ParticipatoryChannelIncidentPath.test.ts
+++ b/src/test/spe956ParticipatoryChannelIncidentPath.test.ts
@@ -22,9 +22,11 @@ import {
 } from '../domain/hotlineChannel'
 import {
   applySpe956ParticipatoryChannelsToIncident,
+  buildExampleSpe956IncidentPathInputFromGameState,
   EXAMPLE_SPE_956_INCIDENT_PATH_INPUT,
   SPE_956_EXAMPLE_INCIDENT_ID,
 } from '../domain/spe956ParticipatoryChannelIncidentPath'
+import { SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS } from '../domain/spe956IncidentBaselinePersistence'
 import {
   SPE_956_EXAMPLE_ASYNC_DISCUSSION_SURFACE_RECORDS,
   SPE_956_EXAMPLE_COLLECTIVE_MEMORY_CHANNEL_RECORDS,
@@ -301,5 +303,71 @@ describe('spe956ParticipatoryChannelIncidentPath (SPE-2639 / SPE-2640 / SPE-956)
     expect(fromNull.materialInfluence).toBe(false)
     expect(fromUndefined.reasonCodes).toEqual(['no_material_influence', 'no_participatory_lanes'])
     expect(fromNull.reasonCodes).toEqual(['no_material_influence', 'no_participatory_lanes'])
+  })
+})
+
+describe('buildExampleSpe956IncidentPathInputFromGameState (SPE-2647)', () => {
+  it('falls back to EXAMPLE fixtures when GameState has no persisted baselines', () => {
+    const built = buildExampleSpe956IncidentPathInputFromGameState({})
+
+    expect(built).toEqual(EXAMPLE_SPE_956_INCIDENT_PATH_INPUT)
+    expect(Object.isFrozen(built)).toBe(true)
+  })
+
+  it('prefers persisted baselines when resolve returns EXAMPLE records', () => {
+    const game = Object.freeze({
+      spe956IncidentBaselineRecords: SPE_956_EXAMPLE_INCIDENT_BASELINE_RECORDS,
+    })
+    const built = buildExampleSpe956IncidentPathInputFromGameState(game)
+
+    expect(built.advisory?.baseline).toEqual(EXAMPLE_INCIDENT_BASELINE)
+    expect(built.hotline?.baseline).toEqual(EXAMPLE_HOTLINE_GUIDANCE_BASELINE)
+    expect(built.asyncDiscussion?.baseline).toEqual(EXAMPLE_DISCUSSION_BASELINE)
+    expect(built.survivorRegistry?.baseline).toEqual(EXAMPLE_SURVIVOR_REGISTRY_BASELINE)
+    expect(built.collectiveMemory?.baseline).toEqual(EXAMPLE_MEMORY_STABILIZATION_BASELINE)
+    expect(built).toEqual(EXAMPLE_SPE_956_INCIDENT_PATH_INPUT)
+  })
+
+  it('uses persisted lane baselines when they differ from EXAMPLE fixtures', () => {
+    const customAdvisoryBaseline = {
+      ...EXAMPLE_INCIDENT_BASELINE,
+      supportRouting: 'persisted_advisory_routing',
+    }
+    const game = Object.freeze({
+      spe956IncidentBaselineRecords: Object.freeze({
+        [SPE_956_EXAMPLE_INCIDENT_ID]: Object.freeze({
+          incidentId: SPE_956_EXAMPLE_INCIDENT_ID,
+          advisory: customAdvisoryBaseline,
+        }),
+      }),
+    })
+
+    const built = buildExampleSpe956IncidentPathInputFromGameState(game)
+
+    expect(built.advisory?.baseline.supportRouting).toBe('persisted_advisory_routing')
+    expect(built.hotline?.baseline).toEqual(EXAMPLE_HOTLINE_GUIDANCE_BASELINE)
+    expect(built.asyncDiscussion?.baseline).toEqual(EXAMPLE_DISCUSSION_BASELINE)
+  })
+
+  it('wires persisted baselines through applySpe956ParticipatoryChannelsToIncident', () => {
+    const customAdvisoryBaseline = {
+      ...EXAMPLE_INCIDENT_BASELINE,
+      supportRouting: 'community_liaison_first',
+      framing: 'persisted_framing',
+    }
+    const game = Object.freeze({
+      ...EXAMPLE_GAME,
+      spe956IncidentBaselineRecords: Object.freeze({
+        [SPE_956_EXAMPLE_INCIDENT_ID]: Object.freeze({
+          incidentId: SPE_956_EXAMPLE_INCIDENT_ID,
+          advisory: customAdvisoryBaseline,
+        }),
+      }),
+    })
+    const input = buildExampleSpe956IncidentPathInputFromGameState(game)
+    const result = applySpe956ParticipatoryChannelsToIncident(game, input)
+
+    expect(result.advisory?.resolved.framing).toBe('persisted_framing')
+    expect(result.advisory?.resolved.supportRouting).toBe('community_liaison_first')
   })
 })


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2647 — https://linear.app/spectranoir/issue/SPE-2647
- **Parent issue (if any):** SPE-956 — https://linear.app/spectranoir/issue/SPE-956 (remains Done)
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Add `buildExampleSpe956IncidentPathInputFromGameState` to prefer persisted GameState baselines via `resolveSpe956IncidentBaselines` with EXAMPLE fixture fallback per lane
- Move `SPE_956_EXAMPLE_INCIDENT_ID` to persistence module to avoid circular imports (re-exported from incident path)
- Vitest coverage for fixture fallback, persisted EXAMPLE records, custom persisted baselines, and apply integration

## Docs updated

- `planning/spe-2647-example-incident-path-baseline-resolve-wire-slice-1.md`
- Includes SPE-2649 handoff docs (stacked on handoff branch until #3207 merges)

## Parent status

- SPE-956 remains **Done** — does not reopen AC

## Scope boundary

- EXAMPLE path-input builder only; `applySpe956ParticipatoryChannelsToIncident` signature unchanged
- No evaluator / week-close / composer expansion

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/spe956ParticipatoryChannelIncidentPath.test.ts src/test/spe956IncidentBaselinePersistence.test.ts`
- [x] Lint: `npm run lint`

## Screenshots (UI only)

<!-- Omit for domain-only changes -->

## Follow-ups

- None in SPE-2647 boundary

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue