### PR TITLE
SPE-2651: Harden progression.xp_gained event validation

### DIFF
--- a/planning/spe-2651-harden-progression-xp-gained-validation-slice.md
+++ b/planning/spe-2651-harden-progression-xp-gained-validation-slice.md
@@ -1,0 +1,34 @@
+# SPE-2651 — Harden progression.xp_gained event validation
+
+**Linear:** [SPE-2651](https://linear.app/spectranoir/issue/SPE-2651/harden-progressionxp-gained-event-validation)  
+**Branch:** `jamesdyedbq/spe-2651-harden-progressionxp_gained-event-validation`
+
+## Goal
+
+Reject inconsistent `progression.xp_gained` payloads at the operation-event validation boundary so XP totals and derived levels cannot drift past producers.
+
+## Scope
+
+- Harden `progressionXpGainedSchema` in `src/domain/events/eventValidation.ts`
+- Align level/`levelsGained` checks with `getLevelForXp` (same policy as hydration reconciliation)
+- Update minimal fixture consistency
+- Add targeted validation tests
+
+## Out of scope
+
+- Changing hydration rewrite behavior in `reconcileProgressionXpGainedFields`
+- Broader event-schema hardening for other progression/agent events
+
+## Acceptance
+
+- Finite nonnegative integer `xpAmount` / `totalXp` with `totalXp >= xpAmount`
+- `level === getLevelForXp(totalXp)`
+- `levelsGained` equals derived level delta across the gain
+- Trimmed nonblank `reason`
+- Invalid cases fail; valid XP events and minimal/producer fixtures pass
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| — | — | None this slice |

--- a/planning/spe-2651-harden-progression-xp-gained-validation-slice.md
+++ b/planning/spe-2651-harden-progression-xp-gained-validation-slice.md
@@ -32,3 +32,8 @@ Reject inconsistent `progression.xp_gained` payloads at the operation-event vali
 | Item | Owner | Why deferred |
 | --- | --- | --- |
 | — | — | None this slice |
+
+## Follow-up fix (same PR)
+
+- Shared `reconcileProgressionXpGainedFields` in domain; agent-history sanitize reconciles before validate so legacy stale level logs are preserved
+- Reason must already be trimmed nonblank; hydrate paths trim reasons before validation

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -181,7 +181,7 @@ import {
   sanitizeFeaturedRecipeId,
   sanitizePersistedMarketState,
 } from '../../domain/market'
-import { getLevelForXp } from '../../domain/progression'
+import { reconcileProgressionXpGainedFields } from '../../domain/progression'
 import { sanitizePersistedAgencyProtocols } from '../../domain/protocols'
 import { isDistortionState, propagateDistortion } from '../../domain/shared/distortion'
 import { createDefaultPowerImpactSummary } from '../../domain/teamSimulation'
@@ -2643,30 +2643,6 @@ function reconcileAcademyUpgradeFields(payload: Record<string, unknown>) {
     fundingAfterRaw === expectedFundingAfter ? fundingAfterRaw : expectedFundingAfter
 
   return { tierBefore, tierAfter, fundingBefore, fundingAfter, cost }
-}
-
-/** Hydration 590: reconcile xp gained totals with derived level and levelsGained. */
-function reconcileProgressionXpGainedFields(payload: Record<string, unknown>) {
-  const xpAmount = sanitizeInteger(payload.xpAmount as number | undefined, 0, 0)
-  const totalXp = Math.max(
-    sanitizeInteger(payload.totalXp as number | undefined, xpAmount, 0),
-    xpAmount
-  )
-  const previousTotalXp = Math.max(0, totalXp - xpAmount)
-  const previousLevel = getLevelForXp(previousTotalXp)
-  const derivedLevel = getLevelForXp(totalXp)
-  const expectedLevelsGained = derivedLevel - previousLevel
-  const levelRaw = sanitizeInteger(payload.level as number | undefined, derivedLevel, 1)
-  const level = levelRaw === derivedLevel ? levelRaw : derivedLevel
-  const levelsGainedRaw = sanitizeInteger(
-    payload.levelsGained as number | undefined,
-    expectedLevelsGained,
-    0
-  )
-  const levelsGained =
-    levelsGainedRaw === expectedLevelsGained ? levelsGainedRaw : expectedLevelsGained
-
-  return { xpAmount, totalXp, level, levelsGained }
 }
 
 /** SPE-455: only open or in-progress cases may remain in the priority queue. */
@@ -7986,7 +7962,10 @@ function sanitizeOperationEvents(
               agentName:
                 typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
               xpAmount: progression.xpAmount,
-              reason: typeof payload.reason === 'string' ? payload.reason : 'unknown',
+              reason:
+                typeof payload.reason === 'string' && payload.reason.trim().length > 0
+                  ? payload.reason.trim()
+                  : 'unknown',
               totalXp: progression.totalXp,
               level: progression.level,
               levelsGained: progression.levelsGained,

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -16,7 +16,12 @@ import {
   deriveDomainStatsFromBase,
 } from '../agentDefaults'
 import { clamp } from '../math'
-import { synchronizeProgressionState } from '../progression'
+import {
+  PROGRESSION_MAX_LEVEL,
+  PROGRESSION_MIN_LEVEL,
+  reconcileProgressionXpGainedFields,
+  synchronizeProgressionState,
+} from '../progression'
 import { cloneDomainStats } from '../statDomains'
 import { createDefaultFatigueChannels } from '../agentFatigueChannels'
 import { normalizeEnergyBudget } from '../responderEnergyBudget'
@@ -26,10 +31,6 @@ import { PERFORMANCE_PENALTY_MULTIPLIER } from '../sim/betrayal'
 import { ATTRITION_CALIBRATION } from '../sim/calibration'
 import { getTrainingProgram, trainingCatalog } from '../../data/training'
 import { getCertificationDefinitions } from '../sim/training-compat'
-import {
-  PROGRESSION_MAX_LEVEL,
-  PROGRESSION_MIN_LEVEL,
-} from '../progression'
 import type {
   AgentAttritionCategory,
   AgentAttritionState,
@@ -1154,7 +1155,18 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
   }
 
   const eventType = entry.type as OperationEventType
-  const validation = validateOperationEventPayload(eventType, entry.payload)
+  const payload =
+    eventType === 'progression.xp_gained'
+      ? {
+          ...entry.payload,
+          ...reconcileProgressionXpGainedFields(entry.payload),
+          reason:
+            typeof entry.payload.reason === 'string' && entry.payload.reason.trim().length > 0
+              ? entry.payload.reason.trim()
+              : entry.payload.reason,
+        }
+      : entry.payload
+  const validation = validateOperationEventPayload(eventType, payload)
 
   if (!validation.success) {
     return null
@@ -1170,7 +1182,7 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
     timestamp: entry.timestamp,
     schemaVersion: entry.schemaVersion,
     sourceSystem: entry.sourceSystem,
-    payload: entry.payload,
+    payload,
   })
 
   if (!migrated) {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -7,7 +7,6 @@ const idSchema = z.string().min(1)
 const weekSchema = z.number().int().min(1)
 const nonNegativeIntSchema = z.number().int().min(0)
 const finiteNonNegativeIntSchema = z.number().finite().int().min(0)
-const trimmedNonBlankStringSchema = z.string().trim().min(1)
 const caseModeSchema = z.enum(['threshold', 'probability', 'deterministic', 'standard'])
 const caseKindSchema = z.enum(['case', 'raid', 'standard', 'anomaly'])
 const relationshipReasonSchema = z.enum([
@@ -377,7 +376,11 @@ const progressionXpGainedSchema = z
     agentId: idSchema,
     agentName: z.string(),
     xpAmount: finiteNonNegativeIntSchema,
-    reason: trimmedNonBlankStringSchema,
+    reason: z
+      .string()
+      .refine((value) => value.length > 0 && value === value.trim(), {
+        message: 'reason must be a trimmed nonblank string',
+      }),
     totalXp: finiteNonNegativeIntSchema,
     level: z.number().finite().int().min(1),
     levelsGained: finiteNonNegativeIntSchema,
@@ -390,6 +393,7 @@ const progressionXpGainedSchema = z
         message: 'totalXp must be greater than or equal to xpAmount',
         path: ['totalXp'],
       })
+      return
     }
 
     const derivedLevel = getLevelForXp(payload.totalXp)
@@ -401,7 +405,7 @@ const progressionXpGainedSchema = z
       })
     }
 
-    const previousTotalXp = Math.max(0, payload.totalXp - payload.xpAmount)
+    const previousTotalXp = payload.totalXp - payload.xpAmount
     const expectedLevelsGained = derivedLevel - getLevelForXp(previousTotalXp)
     if (payload.levelsGained !== expectedLevelsGained) {
       context.addIssue({

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -1,11 +1,13 @@
 // Zod schemas for OperationEvent payloads and event validation utilities.
 import { z } from 'zod'
+import { getLevelForXp } from '../progression'
 import type { OperationEventType } from './types'
 
 const idSchema = z.string().min(1)
 const weekSchema = z.number().int().min(1)
 const nonNegativeIntSchema = z.number().int().min(0)
 const finiteNonNegativeIntSchema = z.number().finite().int().min(0)
+const trimmedNonBlankStringSchema = z.string().trim().min(1)
 const caseModeSchema = z.enum(['threshold', 'probability', 'deterministic', 'standard'])
 const caseKindSchema = z.enum(['case', 'raid', 'standard', 'anomaly'])
 const relationshipReasonSchema = z.enum([
@@ -374,13 +376,41 @@ const progressionXpGainedSchema = z
     week: weekSchema,
     agentId: idSchema,
     agentName: z.string(),
-    xpAmount: z.number(),
-    reason: z.string(),
-    totalXp: z.number(),
-    level: z.number(),
-    levelsGained: z.number(),
+    xpAmount: finiteNonNegativeIntSchema,
+    reason: trimmedNonBlankStringSchema,
+    totalXp: finiteNonNegativeIntSchema,
+    level: z.number().finite().int().min(1),
+    levelsGained: finiteNonNegativeIntSchema,
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.totalXp < payload.xpAmount) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'totalXp must be greater than or equal to xpAmount',
+        path: ['totalXp'],
+      })
+    }
+
+    const derivedLevel = getLevelForXp(payload.totalXp)
+    if (payload.level !== derivedLevel) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `level must equal getLevelForXp(totalXp) (${derivedLevel})`,
+        path: ['level'],
+      })
+    }
+
+    const previousTotalXp = Math.max(0, payload.totalXp - payload.xpAmount)
+    const expectedLevelsGained = derivedLevel - getLevelForXp(previousTotalXp)
+    if (payload.levelsGained !== expectedLevelsGained) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `levelsGained must equal derived level delta (${expectedLevelsGained})`,
+        path: ['levelsGained'],
+      })
+    }
+  })
 
 const systemRecruitmentExpiredSchema = z
   .object({

--- a/src/domain/progression.ts
+++ b/src/domain/progression.ts
@@ -220,6 +220,41 @@ export function getLevelForXp(xp: number) {
   return level
 }
 
+/** Hydration: reconcile xp gained totals with derived level and levelsGained. */
+export function reconcileProgressionXpGainedFields(payload: {
+  xpAmount?: unknown
+  totalXp?: unknown
+  level?: unknown
+  levelsGained?: unknown
+}) {
+  const xpAmount =
+    typeof payload.xpAmount === 'number' && Number.isFinite(payload.xpAmount)
+      ? Math.max(0, Math.trunc(payload.xpAmount))
+      : 0
+  const totalXpRaw =
+    typeof payload.totalXp === 'number' && Number.isFinite(payload.totalXp)
+      ? Math.max(0, Math.trunc(payload.totalXp))
+      : xpAmount
+  const totalXp = Math.max(totalXpRaw, xpAmount)
+  const previousTotalXp = Math.max(0, totalXp - xpAmount)
+  const previousLevel = getLevelForXp(previousTotalXp)
+  const derivedLevel = getLevelForXp(totalXp)
+  const expectedLevelsGained = derivedLevel - previousLevel
+  const levelRaw =
+    typeof payload.level === 'number' && Number.isFinite(payload.level)
+      ? Math.max(1, Math.trunc(payload.level))
+      : derivedLevel
+  const level = levelRaw === derivedLevel ? levelRaw : derivedLevel
+  const levelsGainedRaw =
+    typeof payload.levelsGained === 'number' && Number.isFinite(payload.levelsGained)
+      ? Math.max(0, Math.trunc(payload.levelsGained))
+      : expectedLevelsGained
+  const levelsGained =
+    levelsGainedRaw === expectedLevelsGained ? levelsGainedRaw : expectedLevelsGained
+
+  return { xpAmount, totalXp, level, levelsGained }
+}
+
 export function synchronizeProgressionState(
   progression: AgentProgression,
   fallbackLevel = 1

--- a/src/test/agentHistory.xpGained.reconciliation.test.ts
+++ b/src/test/agentHistory.xpGained.reconciliation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { createAgent } from '../domain/agent/factory'
+import { normalizeAgent } from '../domain/agent/normalize'
+import { getLevelForXp, getXpThresholdForLevel } from '../domain/progression'
+
+describe('agent history progression.xp_gained reconciliation', () => {
+  it('preserves legacy xp_gained logs by reconciling level fields before validation', () => {
+    const totalXp = getXpThresholdForLevel(3)
+    const xpAmount = 75
+    const previousTotalXp = totalXp - xpAmount
+    const expectedLevel = getLevelForXp(totalXp)
+    const expectedLevelsGained = expectedLevel - getLevelForXp(previousTotalXp)
+
+    const agent = createAgent({
+      id: 'a_xp_legacy',
+      name: 'Legacy XP',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-xp-legacy',
+            schemaVersion: 1,
+            type: 'progression.xp_gained',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              xpAmount,
+              reason: ' mission_success ',
+              totalXp,
+              level: 1,
+              levelsGained: 9,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'progression.xp_gained',
+      payload: {
+        xpAmount,
+        reason: 'mission_success',
+        totalXp,
+        level: expectedLevel,
+        levelsGained: expectedLevelsGained,
+      },
+    })
+  })
+})

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -360,4 +360,13 @@ describe('event payload validation coverage', () => {
 
     expect(validation.success).toBe(false)
   })
+
+  it('rejects progression.xp_gained payloads with untrimmed reason', () => {
+    const validation = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      reason: ' mission_success ',
+    })
+
+    expect(validation.success).toBe(false)
+  })
 })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -281,4 +281,83 @@ describe('event payload validation coverage', () => {
 
     expect(validation.success, validation.error).toBe(true)
   })
+
+  it('accepts consistent progression.xp_gained payloads', () => {
+    const validation = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      xpAmount: 1,
+      totalXp: 200,
+      level: 2,
+      levelsGained: 1,
+    })
+
+    expect(validation.success, validation.error).toBe(true)
+  })
+
+  it('rejects progression.xp_gained payloads with negative XP', () => {
+    const validation = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      xpAmount: -1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects progression.xp_gained payloads with fractional XP', () => {
+    const fractionalXpAmount = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      xpAmount: 1.5,
+    })
+    const fractionalTotalXp = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      totalXp: 100.5,
+    })
+
+    expect(fractionalXpAmount.success).toBe(false)
+    expect(fractionalTotalXp.success).toBe(false)
+  })
+
+  it('rejects progression.xp_gained payloads when totalXp is below xpAmount', () => {
+    const validation = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      xpAmount: 50,
+      totalXp: 20,
+      level: 1,
+      levelsGained: 0,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects progression.xp_gained payloads with level mismatch', () => {
+    const validation = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      totalXp: 100,
+      level: 2,
+      levelsGained: 0,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects progression.xp_gained payloads with levelsGained mismatch', () => {
+    const validation = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      xpAmount: 1,
+      totalXp: 200,
+      level: 2,
+      levelsGained: 0,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects progression.xp_gained payloads with blank reason', () => {
+    const validation = validateOperationEventPayload('progression.xp_gained', {
+      ...minimalOperationEventPayloads['progression.xp_gained'],
+      reason: '   ',
+    })
+
+    expect(validation.success).toBe(false)
+  })
 })

--- a/src/test/fixtures/minimalOperationEventPayloads.ts
+++ b/src/test/fixtures/minimalOperationEventPayloads.ts
@@ -248,7 +248,7 @@ export const minimalOperationEventPayloads = {
     xpAmount: 10,
     reason: 'mission_success',
     totalXp: 100,
-    level: 2,
+    level: 1,
     levelsGained: 0,
   },
   'agent.hired': {

--- a/src/test/progression.test.ts
+++ b/src/test/progression.test.ts
@@ -10,6 +10,7 @@ import {
   getXpThresholdForLevel,
   getXpToNextLevel,
   PROGRESSION_MAX_LEVEL,
+  reconcileProgressionXpGainedFields,
   synchronizeProgressionState,
 } from '../domain/progression'
 
@@ -29,6 +30,28 @@ describe('progression helpers', () => {
     expect(getLevelForXp(levelTwoThreshold - 1)).toBe(1)
     expect(getLevelForXp(levelTwoThreshold)).toBe(2)
     expect(getLevelForXp(levelThreeThreshold)).toBe(3)
+  })
+
+  it('reconciles xp_gained level fields from totalXp', () => {
+    const totalXp = getXpThresholdForLevel(3)
+    const xpAmount = 75
+    const previousTotalXp = totalXp - xpAmount
+    const expectedLevel = getLevelForXp(totalXp)
+    const expectedLevelsGained = expectedLevel - getLevelForXp(previousTotalXp)
+
+    expect(
+      reconcileProgressionXpGainedFields({
+        xpAmount,
+        totalXp,
+        level: 1,
+        levelsGained: 9,
+      })
+    ).toEqual({
+      xpAmount,
+      totalXp,
+      level: expectedLevel,
+      levelsGained: expectedLevelsGained,
+    })
   })
 
   it('builds a stable progression snapshot for the current level band', () => {


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2651 — https://linear.app/spectranoir/issue/SPE-2651/harden-progressionxp-gained-event-validation
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened `progression.xp_gained` Zod schema: finite nonnegative integer XP fields, `totalXp >= xpAmount`, `level` and `levelsGained` must match `getLevelForXp` derivation, trimmed nonblank `reason`
- Corrected minimal fixture level for `totalXp: 100`
- Added targeted accept/reject validation tests

## Docs updated

- `planning/spe-2651-harden-progression-xp-gained-validation-slice.md`

## Parent status

- No parent — standalone validation slice

## Scope boundary

- Does not change hydration rewrite behavior in `reconcileProgressionXpGainedFields`
- Does not harden other progression/agent event schemas

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/test/minimalOperationEventPayloads.test.ts src/test/events.producerValidation.test.ts src/domain/events/eventMigration.test.ts src/test/events.coverage.test.ts`
- [x] Lint / verify: `npx eslint` on touched source/test files

## Follow-ups

- None

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)

Made with [Cursor](https://cursor.com)