### PR TITLE
SPE-2652: Harden agent.promoted event validation

### DIFF
--- a/planning/spe-2652-harden-agent-promoted-validation-slice.md
+++ b/planning/spe-2652-harden-agent-promoted-validation-slice.md
@@ -1,0 +1,34 @@
+# SPE-2652 — Harden agent.promoted event validation
+
+**Linear:** [SPE-2652](https://linear.app/spectranoir/issue/SPE-2652/harden-agentpromoted-event-validation)  
+**Branch:** `jamesdyedbq/spe-2652-harden-agentpromoted-event-validation`
+
+## Goal
+
+Reject inconsistent `agent.promoted` payloads at the operation-event validation boundary so level and skill-point fields cannot drift past producers.
+
+## Scope
+
+- Harden `agentPromotedSchema` in `src/domain/events/eventValidation.ts`
+- Shared `reconcileAgentPromotedFields` (SPE-2651 pattern); hydrate + agent-history sanitize reconcile before validate
+- Add targeted validation + history preservation tests
+
+## Out of scope
+
+- Progression XP schema (SPE-2651)
+- Broader event-schema hardening for unrelated types
+- UI / feed rendering
+
+## Acceptance
+
+- Finite nonnegative integer `levelsGained` / `skillPointsGranted`; levels are finite ints ≥ 1
+- `newLevel >= previousLevel` and `levelsGained === newLevel - previousLevel`
+- Trimmed nonblank `newRole`
+- Invalid cases fail; valid promotions and minimal/producer fixtures pass
+- Legacy history/hydrate promoted events preserved when reconcile runs first
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| — | — | None this slice |

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -10686,6 +10686,39 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
     })
 
+    it('SPE-2652 trims agent.promoted newRole before role allowlist on hydrate', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-promoted-role-trim',
+            type: 'agent.promoted',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              agentId: Object.keys(fallback.agents)[0]!,
+              agentName: 'Agent',
+              newRole: ' medic ',
+              previousLevel: 2,
+              newLevel: 3,
+              levelsGained: 1,
+              skillPointsGranted: 1,
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        newRole: 'medic',
+        previousLevel: 2,
+        newLevel: 3,
+        levelsGained: 1,
+        skillPointsGranted: 1,
+      })
+    })
+
     it('518 sorts weekly reports, dedupes by week, and drops out-of-range weeks', () => {
       const fallback = createStartingState()
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -181,7 +181,10 @@ import {
   sanitizeFeaturedRecipeId,
   sanitizePersistedMarketState,
 } from '../../domain/market'
-import { reconcileProgressionXpGainedFields } from '../../domain/progression'
+import {
+  reconcileAgentPromotedFields,
+  reconcileProgressionXpGainedFields,
+} from '../../domain/progression'
 import { sanitizePersistedAgencyProtocols } from '../../domain/protocols'
 import { isDistortionState, propagateDistortion } from '../../domain/shared/distortion'
 import { createDefaultPowerImpactSummary } from '../../domain/teamSimulation'
@@ -1352,23 +1355,6 @@ function reconcileContactRelationshipFields(
     contactRelationshipBefore: before,
     contactRelationshipAfter: reconciledAfter,
     contactDelta: reconciledDelta,
-  }
-}
-
-function reconcilePromotionLevels(
-  previousLevel: unknown,
-  newLevel: unknown,
-  levelsGained: unknown
-) {
-  const previous = sanitizeInteger(previousLevel as number | undefined, 1, 1)
-  const next = Math.max(previous, sanitizeInteger(newLevel as number | undefined, previous, 1))
-  const expectedGained = next - previous
-  const gained = sanitizeInteger(levelsGained as number | undefined, expectedGained, 0)
-
-  return {
-    previousLevel: previous,
-    newLevel: next,
-    levelsGained: gained === expectedGained ? gained : expectedGained,
   }
 }
 
@@ -7892,11 +7878,7 @@ function sanitizeOperationEvents(
         break
 
       case 'agent.promoted': {
-        const promotion = reconcilePromotionLevels(
-          payload.previousLevel,
-          payload.newLevel,
-          payload.levelsGained
-        )
+        const promotion = reconcileAgentPromotedFields(payload)
 
         nextEvents.push(
           migrateOperationEventToCurrentSchema({
@@ -7919,11 +7901,7 @@ function sanitizeOperationEvents(
               previousLevel: promotion.previousLevel,
               newLevel: promotion.newLevel,
               levelsGained: promotion.levelsGained,
-              skillPointsGranted: sanitizeInteger(
-                payload.skillPointsGranted as number | undefined,
-                0,
-                0
-              ),
+              skillPointsGranted: promotion.skillPointsGranted,
             },
           })
         )

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -7879,6 +7879,8 @@ function sanitizeOperationEvents(
 
       case 'agent.promoted': {
         const promotion = reconcileAgentPromotedFields(payload)
+        const trimmedNewRole =
+          typeof payload.newRole === 'string' ? payload.newRole.trim() : ''
 
         nextEvents.push(
           migrateOperationEventToCurrentSchema({
@@ -7889,14 +7891,15 @@ function sanitizeOperationEvents(
               agentName:
                 typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
               newRole:
-                payload.newRole === 'occultist' ||
-                payload.newRole === 'investigator' ||
-                payload.newRole === 'field_recon' ||
-                payload.newRole === 'medium' ||
-                payload.newRole === 'tech' ||
-                payload.newRole === 'medic' ||
-                payload.newRole === 'negotiator'
-                  ? payload.newRole
+                trimmedNewRole === 'occultist' ||
+                trimmedNewRole === 'investigator' ||
+                trimmedNewRole === 'field_recon' ||
+                trimmedNewRole === 'medium' ||
+                trimmedNewRole === 'tech' ||
+                trimmedNewRole === 'medic' ||
+                trimmedNewRole === 'negotiator' ||
+                trimmedNewRole === 'hunter'
+                  ? trimmedNewRole
                   : 'hunter',
               previousLevel: promotion.previousLevel,
               newLevel: promotion.newLevel,

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -19,6 +19,7 @@ import { clamp } from '../math'
 import {
   PROGRESSION_MAX_LEVEL,
   PROGRESSION_MIN_LEVEL,
+  reconcileAgentPromotedFields,
   reconcileProgressionXpGainedFields,
   synchronizeProgressionState,
 } from '../progression'
@@ -1165,7 +1166,16 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
               ? entry.payload.reason.trim()
               : entry.payload.reason,
         }
-      : entry.payload
+      : eventType === 'agent.promoted'
+        ? {
+            ...entry.payload,
+            ...reconcileAgentPromotedFields(entry.payload),
+            newRole:
+              typeof entry.payload.newRole === 'string' && entry.payload.newRole.trim().length > 0
+                ? entry.payload.newRole.trim()
+                : entry.payload.newRole,
+          }
+        : entry.payload
   const validation = validateOperationEventPayload(eventType, payload)
 
   if (!validation.success) {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -343,18 +343,43 @@ const agentResignedSchema = z
   })
   .strict()
 
+const finitePositiveIntSchema = z.number().finite().int().min(1)
+
 const agentPromotedSchema = z
   .object({
     week: weekSchema,
     agentId: idSchema,
     agentName: z.string(),
-    newRole: z.string(),
-    previousLevel: z.number(),
-    newLevel: z.number(),
-    levelsGained: z.number(),
-    skillPointsGranted: z.number(),
+    newRole: z
+      .string()
+      .refine((value) => value.length > 0 && value === value.trim(), {
+        message: 'newRole must be a trimmed nonblank string',
+      }),
+    previousLevel: finitePositiveIntSchema,
+    newLevel: finitePositiveIntSchema,
+    levelsGained: finiteNonNegativeIntSchema,
+    skillPointsGranted: finiteNonNegativeIntSchema,
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.newLevel < payload.previousLevel) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'newLevel must be greater than or equal to previousLevel',
+        path: ['newLevel'],
+      })
+      return
+    }
+
+    const expectedLevelsGained = payload.newLevel - payload.previousLevel
+    if (payload.levelsGained !== expectedLevelsGained) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `levelsGained must equal newLevel - previousLevel (${expectedLevelsGained})`,
+        path: ['levelsGained'],
+      })
+    }
+  })
 
 const agentHiredSchema = z
   .object({

--- a/src/domain/progression.ts
+++ b/src/domain/progression.ts
@@ -255,6 +255,37 @@ export function reconcileProgressionXpGainedFields(payload: {
   return { xpAmount, totalXp, level, levelsGained }
 }
 
+/** Hydration: reconcile agent.promoted level fields and skill points granted. */
+export function reconcileAgentPromotedFields(payload: {
+  previousLevel?: unknown
+  newLevel?: unknown
+  levelsGained?: unknown
+  skillPointsGranted?: unknown
+}) {
+  const previousLevel =
+    typeof payload.previousLevel === 'number' && Number.isFinite(payload.previousLevel)
+      ? Math.max(PROGRESSION_MIN_LEVEL, Math.trunc(payload.previousLevel))
+      : PROGRESSION_MIN_LEVEL
+  const newLevelRaw =
+    typeof payload.newLevel === 'number' && Number.isFinite(payload.newLevel)
+      ? Math.max(PROGRESSION_MIN_LEVEL, Math.trunc(payload.newLevel))
+      : previousLevel
+  const newLevel = Math.max(previousLevel, newLevelRaw)
+  const expectedLevelsGained = newLevel - previousLevel
+  const levelsGainedRaw =
+    typeof payload.levelsGained === 'number' && Number.isFinite(payload.levelsGained)
+      ? Math.max(0, Math.trunc(payload.levelsGained))
+      : expectedLevelsGained
+  const levelsGained =
+    levelsGainedRaw === expectedLevelsGained ? levelsGainedRaw : expectedLevelsGained
+  const skillPointsGranted =
+    typeof payload.skillPointsGranted === 'number' && Number.isFinite(payload.skillPointsGranted)
+      ? Math.max(0, Math.trunc(payload.skillPointsGranted))
+      : 0
+
+  return { previousLevel, newLevel, levelsGained, skillPointsGranted }
+}
+
 export function synchronizeProgressionState(
   progression: AgentProgression,
   fallbackLevel = 1

--- a/src/test/agentHistory.promoted.reconciliation.test.ts
+++ b/src/test/agentHistory.promoted.reconciliation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { createAgent } from '../domain/agent/factory'
+import { normalizeAgent } from '../domain/agent/normalize'
+
+describe('agent history agent.promoted reconciliation', () => {
+  it('preserves legacy promoted logs by reconciling level fields before validation', () => {
+    const agent = createAgent({
+      id: 'a_promoted_legacy',
+      name: 'Legacy Promoted',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-promoted-legacy',
+            schemaVersion: 1,
+            type: 'agent.promoted',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              newRole: ' medic ',
+              previousLevel: 4,
+              newLevel: 2,
+              levelsGained: 9,
+              skillPointsGranted: -1.5,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.promoted',
+      payload: {
+        newRole: 'medic',
+        previousLevel: 4,
+        newLevel: 4,
+        levelsGained: 0,
+        skillPointsGranted: 0,
+      },
+    })
+  })
+})

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -391,6 +391,24 @@ describe('event payload validation coverage', () => {
     expect(validation.success).toBe(false)
   })
 
+  it('rejects agent.promoted payloads with zero previousLevel', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      previousLevel: 0,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.promoted payloads with negative skillPointsGranted', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      skillPointsGranted: -1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
   it('rejects agent.promoted payloads with fractional levels', () => {
     const fractionalPrevious = validateOperationEventPayload('agent.promoted', {
       ...minimalOperationEventPayloads['agent.promoted'],

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -369,4 +369,79 @@ describe('event payload validation coverage', () => {
 
     expect(validation.success).toBe(false)
   })
+
+  it('accepts consistent agent.promoted payloads', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      previousLevel: 2,
+      newLevel: 4,
+      levelsGained: 2,
+      skillPointsGranted: 2,
+    })
+
+    expect(validation.success, validation.error).toBe(true)
+  })
+
+  it('rejects agent.promoted payloads with negative levels', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      previousLevel: -1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.promoted payloads with fractional levels', () => {
+    const fractionalPrevious = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      previousLevel: 1.5,
+    })
+    const fractionalSkillPoints = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      skillPointsGranted: 0.5,
+    })
+
+    expect(fractionalPrevious.success).toBe(false)
+    expect(fractionalSkillPoints.success).toBe(false)
+  })
+
+  it('rejects agent.promoted payloads when newLevel is below previousLevel', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      previousLevel: 4,
+      newLevel: 2,
+      levelsGained: 0,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.promoted payloads with levelsGained mismatch', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      previousLevel: 2,
+      newLevel: 4,
+      levelsGained: 1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.promoted payloads with blank newRole', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      newRole: '   ',
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.promoted payloads with untrimmed newRole', () => {
+    const validation = validateOperationEventPayload('agent.promoted', {
+      ...minimalOperationEventPayloads['agent.promoted'],
+      newRole: ' medic ',
+    })
+
+    expect(validation.success).toBe(false)
+  })
 })

--- a/src/test/progression.test.ts
+++ b/src/test/progression.test.ts
@@ -10,6 +10,7 @@ import {
   getXpThresholdForLevel,
   getXpToNextLevel,
   PROGRESSION_MAX_LEVEL,
+  reconcileAgentPromotedFields,
   reconcileProgressionXpGainedFields,
   synchronizeProgressionState,
 } from '../domain/progression'
@@ -51,6 +52,22 @@ describe('progression helpers', () => {
       totalXp,
       level: expectedLevel,
       levelsGained: expectedLevelsGained,
+    })
+  })
+
+  it('reconciles agent.promoted level fields to non-decreasing levels', () => {
+    expect(
+      reconcileAgentPromotedFields({
+        previousLevel: 4,
+        newLevel: 2,
+        levelsGained: 9,
+        skillPointsGranted: -1.5,
+      })
+    ).toEqual({
+      previousLevel: 4,
+      newLevel: 4,
+      levelsGained: 0,
+      skillPointsGranted: 0,
     })
   })
 


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2652 — https://linear.app/spectranoir/issue/SPE-2652/harden-agentpromoted-event-validation
- **Parent issue (if any):** none — same-class follow-on after SPE-2651; backlog primary was none after SPE-956 follow-ons
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened `agentPromotedSchema` for finite int levels/skill points, level delta consistency, and trimmed nonblank `newRole`
- Shared `reconcileAgentPromotedFields` used by hydrate (`sanitizeOperationEvents`) and agent-history sanitize so legacy promoted logs survive stricter validation
- Targeted validation + history reconciliation tests; slice doc

## Docs updated

- `planning/spe-2652-harden-agent-promoted-validation-slice.md`

## Parent status

- No parent umbrella — slice stands alone (related to SPE-2651 pattern)

## Scope boundary

- Does not change progression.xp_gained schema, unrelated event types, or UI/feed rendering

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/test/agentHistory.promoted.reconciliation.test.ts src/test/progression.test.ts` and runTransfer `517 enforces`
- [x] Lint / verify: `npm run lint`

## Screenshots (UI only)

<!-- Omit for domain-only changes -->

## Follow-ups

- None this slice

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)