### PR TITLE
SPE-2654: Harden agent.betrayed trust-damage event validation

### DIFF
--- a/planning/spe-2654-harden-agent-betrayed-validation-slice.md
+++ b/planning/spe-2654-harden-agent-betrayed-validation-slice.md
@@ -1,0 +1,33 @@
+# SPE-2654 — Harden agent.betrayed trust-damage event validation
+
+**Linear:** [SPE-2654](https://linear.app/spectranoir/issue/SPE-2654/harden-agentbetrayed-trust-damage-event-validation)  
+**Branch:** `jamesdyedbq/spe-2654-harden-agentbetrayed-trust-damage-event-validation`
+
+## Goal
+
+Reject inconsistent `agent.betrayed` payloads at the operation-event validation boundary so `trustDamageDelta` / `trustDamageTotal` cannot drift past producers.
+
+## Scope
+
+- Harden `agentBetrayedSchema` in `src/domain/events/eventValidation.ts`
+- Shared `reconcileAgentBetrayedFields` (SPE-2652 pattern); hydrate + agent-history sanitize reconcile before validate
+- Add targeted validation + history preservation tests
+
+## Out of scope
+
+- `agent.promoted` / `progression.xp_gained` (SPE-2651 / SPE-2652 — shipped)
+- Broader event-schema hardening for unrelated types
+- UI / feed rendering
+
+## Acceptance
+
+- Finite nonnegative `trustDamageDelta` / `trustDamageTotal` (fractional damage allowed)
+- `trustDamageTotal >= trustDamageDelta`
+- Invalid cases fail; valid betrayal and minimal/producer fixtures pass
+- Legacy history/hydrate betrayed events preserved when reconcile runs first
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| — | — | None this slice |

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -10719,6 +10719,67 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
     })
 
+    it('SPE-2654 reconciles agent.betrayed trust damage on hydrate', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-betrayed-2654',
+            type: 'agent.betrayed',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              betrayerId: Object.keys(fallback.agents)[0]!,
+              betrayerName: 'Agent',
+              betrayedId: Object.keys(fallback.agents)[1] ?? 'a_counterpart',
+              betrayedName: 'Counterpart',
+              trustDamageDelta: -0.4,
+              trustDamageTotal: 0.1,
+              triggeredConsequences: ['benching'],
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        trustDamageDelta: 0,
+        trustDamageTotal: 0.1,
+        triggeredConsequences: ['benching'],
+      })
+    })
+
+    it('SPE-2654 lifts agent.betrayed trustDamageTotal to trustDamageDelta on hydrate', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-betrayed-total-2654',
+            type: 'agent.betrayed',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              betrayerId: Object.keys(fallback.agents)[0]!,
+              betrayerName: 'Agent',
+              betrayedId: Object.keys(fallback.agents)[1] ?? 'a_counterpart',
+              betrayedName: 'Counterpart',
+              trustDamageDelta: 0.9,
+              trustDamageTotal: 0.2,
+              triggeredConsequences: [],
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        trustDamageDelta: 0.9,
+        trustDamageTotal: 0.9,
+      })
+    })
+
     it('518 sorts weekly reports, dedupes by week, and drops out-of-range weeks', () => {
       const fallback = createStartingState()
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -185,6 +185,7 @@ import {
   reconcileAgentPromotedFields,
   reconcileProgressionXpGainedFields,
 } from '../../domain/progression'
+import { reconcileAgentBetrayedFields } from '../../domain/sim/betrayal'
 import { sanitizePersistedAgencyProtocols } from '../../domain/protocols'
 import { isDistortionState, propagateDistortion } from '../../domain/shared/distortion'
 import { createDefaultPowerImpactSummary } from '../../domain/teamSimulation'
@@ -7816,7 +7817,8 @@ function sanitizeOperationEvents(
         )
         break
 
-      case 'agent.betrayed':
+      case 'agent.betrayed': {
+        const betrayal = reconcileAgentBetrayedFields(payload)
         nextEvents.push(
           migrateOperationEventToCurrentSchema({
             ...createBase('agent.betrayed'),
@@ -7836,8 +7838,8 @@ function sanitizeOperationEvents(
                 typeof payload.betrayedName === 'string'
                   ? payload.betrayedName
                   : `Counterpart ${index + 1}`,
-              trustDamageDelta: sanitizeFiniteNumber(payload.trustDamageDelta, 0),
-              trustDamageTotal: sanitizeFiniteNumber(payload.trustDamageTotal, 0),
+              trustDamageDelta: betrayal.trustDamageDelta,
+              trustDamageTotal: betrayal.trustDamageTotal,
               triggeredConsequences: Array.isArray(payload.triggeredConsequences)
                 ? payload.triggeredConsequences.filter(
                     (
@@ -7857,6 +7859,7 @@ function sanitizeOperationEvents(
           })
         )
         break
+      }
 
       case 'agent.resigned':
         nextEvents.push(

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -28,7 +28,10 @@ import { createDefaultFatigueChannels } from '../agentFatigueChannels'
 import { normalizeEnergyBudget } from '../responderEnergyBudget'
 import { isAgentAttritionUnavailable } from './attrition'
 import { getEquipmentCatalogEntries } from '../equipment'
-import { PERFORMANCE_PENALTY_MULTIPLIER } from '../sim/betrayal'
+import {
+  PERFORMANCE_PENALTY_MULTIPLIER,
+  reconcileAgentBetrayedFields,
+} from '../sim/betrayal'
 import { ATTRITION_CALIBRATION } from '../sim/calibration'
 import { getTrainingProgram, trainingCatalog } from '../../data/training'
 import { getCertificationDefinitions } from '../sim/training-compat'
@@ -1175,7 +1178,27 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
                 ? entry.payload.newRole.trim()
                 : entry.payload.newRole,
           }
-        : entry.payload
+        : eventType === 'agent.betrayed'
+          ? {
+              ...entry.payload,
+              ...reconcileAgentBetrayedFields(entry.payload),
+              triggeredConsequences: Array.isArray(entry.payload.triggeredConsequences)
+                ? entry.payload.triggeredConsequences.filter(
+                    (
+                      consequence
+                    ): consequence is
+                      | 'benching'
+                      | 'performance_penalty'
+                      | 'disciplinary'
+                      | 'resignation' =>
+                      consequence === 'benching' ||
+                      consequence === 'performance_penalty' ||
+                      consequence === 'disciplinary' ||
+                      consequence === 'resignation'
+                  )
+                : entry.payload.triggeredConsequences,
+            }
+          : entry.payload
   const validation = validateOperationEventPayload(eventType, payload)
 
   if (!validation.success) {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -7,6 +7,7 @@ const idSchema = z.string().min(1)
 const weekSchema = z.number().int().min(1)
 const nonNegativeIntSchema = z.number().int().min(0)
 const finiteNonNegativeIntSchema = z.number().finite().int().min(0)
+const finiteNonNegativeNumberSchema = z.number().finite().min(0)
 const caseModeSchema = z.enum(['threshold', 'probability', 'deterministic', 'standard'])
 const caseKindSchema = z.enum(['case', 'raid', 'standard', 'anomaly'])
 const relationshipReasonSchema = z.enum([
@@ -326,11 +327,20 @@ const agentBetrayedSchema = z
     betrayerName: z.string(),
     betrayedId: idSchema,
     betrayedName: z.string(),
-    trustDamageDelta: z.number(),
-    trustDamageTotal: z.number(),
+    trustDamageDelta: finiteNonNegativeNumberSchema,
+    trustDamageTotal: finiteNonNegativeNumberSchema,
     triggeredConsequences: z.array(externalChemistryConsequenceSchema),
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.trustDamageTotal < payload.trustDamageDelta) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'trustDamageTotal must be greater than or equal to trustDamageDelta',
+        path: ['trustDamageTotal'],
+      })
+    }
+  })
 
 const agentResignedSchema = z
   .object({

--- a/src/domain/sim/betrayal.ts
+++ b/src/domain/sim/betrayal.ts
@@ -80,17 +80,34 @@ export function reconcileAgentBetrayedFields(payload: {
   trustDamageDelta?: unknown
   trustDamageTotal?: unknown
 }) {
-  const trustDamageDelta =
-    typeof payload.trustDamageDelta === 'number' && Number.isFinite(payload.trustDamageDelta)
-      ? Math.max(0, payload.trustDamageDelta)
-      : 0
-  const trustDamageTotalRaw =
-    typeof payload.trustDamageTotal === 'number' && Number.isFinite(payload.trustDamageTotal)
-      ? Math.max(0, payload.trustDamageTotal)
-      : trustDamageDelta
+  const trustDamageDelta = Math.max(0, coerceFiniteNumber(payload.trustDamageDelta, 0))
+  const trustDamageTotalRaw = Math.max(
+    0,
+    coerceFiniteNumber(payload.trustDamageTotal, trustDamageDelta)
+  )
   const trustDamageTotal = Math.max(trustDamageTotalRaw, trustDamageDelta)
 
   return { trustDamageDelta, trustDamageTotal }
+}
+
+function coerceFiniteNumber(value: unknown, fallback: number) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed)
+
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return fallback
 }
 
 function toDirectedPairKey(fromId: string, toId: string) {

--- a/src/domain/sim/betrayal.ts
+++ b/src/domain/sim/betrayal.ts
@@ -75,6 +75,24 @@ function roundToTwo(value: number) {
   return Math.round(value * 100) / 100
 }
 
+/** Hydration: reconcile agent.betrayed trust-damage fields to finite nonnegative totals. */
+export function reconcileAgentBetrayedFields(payload: {
+  trustDamageDelta?: unknown
+  trustDamageTotal?: unknown
+}) {
+  const trustDamageDelta =
+    typeof payload.trustDamageDelta === 'number' && Number.isFinite(payload.trustDamageDelta)
+      ? Math.max(0, payload.trustDamageDelta)
+      : 0
+  const trustDamageTotalRaw =
+    typeof payload.trustDamageTotal === 'number' && Number.isFinite(payload.trustDamageTotal)
+      ? Math.max(0, payload.trustDamageTotal)
+      : trustDamageDelta
+  const trustDamageTotal = Math.max(trustDamageTotalRaw, trustDamageDelta)
+
+  return { trustDamageDelta, trustDamageTotal }
+}
+
 function toDirectedPairKey(fromId: string, toId: string) {
   return `${fromId}->${toId}`
 }

--- a/src/test/agentHistory.betrayed.reconciliation.test.ts
+++ b/src/test/agentHistory.betrayed.reconciliation.test.ts
@@ -101,4 +101,53 @@ describe('agent history agent.betrayed reconciliation', () => {
       },
     })
   })
+
+  it('preserves numeric-string trust damage when reconciling before validation', () => {
+    const agent = createAgent({
+      id: 'a_betrayed_string',
+      name: 'String Damage',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-betrayed-string',
+            schemaVersion: 1,
+            type: 'agent.betrayed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              betrayerId: agent.id,
+              betrayerName: agent.name,
+              betrayedId: 'a_counterpart',
+              betrayedName: 'Counterpart',
+              trustDamageDelta: '0.35',
+              trustDamageTotal: '1.10',
+              triggeredConsequences: [],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.betrayed',
+      payload: {
+        trustDamageDelta: 0.35,
+        trustDamageTotal: 1.1,
+      },
+    })
+  })
 })

--- a/src/test/agentHistory.betrayed.reconciliation.test.ts
+++ b/src/test/agentHistory.betrayed.reconciliation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { createAgent } from '../domain/agent/factory'
+import { normalizeAgent } from '../domain/agent/normalize'
+
+describe('agent history agent.betrayed reconciliation', () => {
+  it('preserves legacy betrayed logs by reconciling trust damage before validation', () => {
+    const agent = createAgent({
+      id: 'a_betrayed_legacy',
+      name: 'Legacy Betrayed',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-betrayed-legacy',
+            schemaVersion: 1,
+            type: 'agent.betrayed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              betrayerId: agent.id,
+              betrayerName: agent.name,
+              betrayedId: 'a_counterpart',
+              betrayedName: 'Counterpart',
+              trustDamageDelta: -0.35,
+              trustDamageTotal: Number.NaN,
+              triggeredConsequences: ['benching', 'not-a-consequence'],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.betrayed',
+      payload: {
+        trustDamageDelta: 0,
+        trustDamageTotal: 0,
+        triggeredConsequences: ['benching'],
+      },
+    })
+  })
+
+  it('lifts trustDamageTotal up to trustDamageDelta before validation', () => {
+    const agent = createAgent({
+      id: 'a_betrayed_total',
+      name: 'Total Lift',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-betrayed-total',
+            schemaVersion: 1,
+            type: 'agent.betrayed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              betrayerId: agent.id,
+              betrayerName: agent.name,
+              betrayedId: 'a_counterpart',
+              betrayedName: 'Counterpart',
+              trustDamageDelta: 0.8,
+              trustDamageTotal: 0.2,
+              triggeredConsequences: [],
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.betrayed',
+      payload: {
+        trustDamageDelta: 0.8,
+        trustDamageTotal: 0.8,
+      },
+    })
+  })
+})

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -462,4 +462,62 @@ describe('event payload validation coverage', () => {
 
     expect(validation.success).toBe(false)
   })
+
+  it('accepts consistent agent.betrayed payloads', () => {
+    const validation = validateOperationEventPayload('agent.betrayed', {
+      ...minimalOperationEventPayloads['agent.betrayed'],
+      trustDamageDelta: 0.35,
+      trustDamageTotal: 1.1,
+      triggeredConsequences: ['benching'],
+    })
+
+    expect(validation.success).toBe(true)
+  })
+
+  it('rejects agent.betrayed payloads with negative trust damage', () => {
+    const negativeDelta = validateOperationEventPayload('agent.betrayed', {
+      ...minimalOperationEventPayloads['agent.betrayed'],
+      trustDamageDelta: -0.1,
+    })
+    const negativeTotal = validateOperationEventPayload('agent.betrayed', {
+      ...minimalOperationEventPayloads['agent.betrayed'],
+      trustDamageTotal: -1,
+    })
+
+    expect(negativeDelta.success).toBe(false)
+    expect(negativeTotal.success).toBe(false)
+  })
+
+  it('rejects agent.betrayed payloads with non-finite trust damage', () => {
+    const nanDelta = validateOperationEventPayload('agent.betrayed', {
+      ...minimalOperationEventPayloads['agent.betrayed'],
+      trustDamageDelta: Number.NaN,
+    })
+    const infiniteTotal = validateOperationEventPayload('agent.betrayed', {
+      ...minimalOperationEventPayloads['agent.betrayed'],
+      trustDamageTotal: Number.POSITIVE_INFINITY,
+    })
+
+    expect(nanDelta.success).toBe(false)
+    expect(infiniteTotal.success).toBe(false)
+  })
+
+  it('rejects agent.betrayed payloads when trustDamageTotal is below trustDamageDelta', () => {
+    const validation = validateOperationEventPayload('agent.betrayed', {
+      ...minimalOperationEventPayloads['agent.betrayed'],
+      trustDamageDelta: 1.2,
+      trustDamageTotal: 0.5,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.betrayed payloads with invalid consequence entries', () => {
+    const validation = validateOperationEventPayload('agent.betrayed', {
+      ...minimalOperationEventPayloads['agent.betrayed'],
+      triggeredConsequences: ['benching', 'not-a-consequence'],
+    })
+
+    expect(validation.success).toBe(false)
+  })
 })


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2654 — https://linear.app/spectranoir/issue/SPE-2654/harden-agentbetrayed-trust-damage-event-validation
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened `agentBetrayedSchema`: finite nonnegative `trustDamageDelta` / `trustDamageTotal`, `trustDamageTotal >= trustDamageDelta`
- Added `reconcileAgentBetrayedFields`; hydrate + agent-history sanitize reconcile (and filter invalid consequences) before validate
- Validation, hydrate, and agent-history preservation tests

## Docs updated

- `planning/spe-2654-harden-agent-betrayed-validation-slice.md`

## Parent status

- No parent — standalone follow-on from SPE-2651/2652 validation hardening

## Scope boundary

- Strict schema + tests only for `agent.betrayed`
- Does not change `agent.promoted` / `progression.xp_gained`, unrelated event types, or UI/feed rendering

## Validation

- [x] Targeted tests: vitest betrayed/SPE-2654/hydrate + related history/producer/coverage suites
- [x] Lint: eslint on touched files

## Follow-ups

- None this slice

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)
