### PR TITLE
SPE-2655: Harden agent.relationship_changed numeric consistency validation

### DIFF
--- a/planning/spe-2655-harden-agent-relationship-changed-validation-slice.md
+++ b/planning/spe-2655-harden-agent-relationship-changed-validation-slice.md
@@ -1,0 +1,33 @@
+# SPE-2655 — Harden agent.relationship_changed numeric consistency validation
+
+**Linear:** [SPE-2655](https://linear.app/spectranoir/issue/SPE-2655/harden-agentrelationship-changed-numeric-consistency-validation)  
+**Branch:** `jamesdyedbq/spe-2655-harden-agentrelationship_changed-numeric-consistency`
+
+## Goal
+
+Reject inconsistent `agent.relationship_changed` payloads at the operation-event validation boundary so `previousValue` / `nextValue` / `delta` cannot drift past producers.
+
+## Scope
+
+- Harden `agentRelationshipChangedSchema` in `src/domain/events/eventValidation.ts`
+- Shared `reconcileAgentRelationshipChangedFields` (SPE-2654 pattern); hydrate + agent-history sanitize reconcile before validate
+- Add targeted validation + history preservation tests
+
+## Out of scope
+
+- `agent.betrayed` / `agent.promoted` / `progression.xp_gained` (SPE-2651 / 2652 / 2654 — shipped)
+- Broader event-schema hardening for unrelated types
+- UI / feed rendering
+
+## Acceptance
+
+- Finite chemistry values in range `[-2, 2]` for `previousValue` / `nextValue`
+- Finite `delta` with `delta === round(nextValue - previousValue, 2)`
+- Invalid cases fail; valid relationship and minimal/producer fixtures pass
+- Legacy history/hydrate relationship events preserved when reconcile runs first
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| — | — | None this slice |

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -7714,17 +7714,7 @@ function sanitizeOperationEvents(
                 previousValue: relationship.previousValue,
                 nextValue: relationship.nextValue,
                 delta: relationship.delta,
-                reason:
-                  payload.reason === 'mission_success' ||
-                  payload.reason === 'mission_partial' ||
-                  payload.reason === 'mission_fail' ||
-                  payload.reason === 'passive_drift' ||
-                  payload.reason === 'external_event' ||
-                  payload.reason === 'reconciliation' ||
-                  payload.reason === 'spontaneous_event' ||
-                  payload.reason === 'betrayal'
-                    ? payload.reason
-                    : 'passive_drift',
+                reason: relationship.reason,
               },
             })
           )

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -186,6 +186,7 @@ import {
   reconcileProgressionXpGainedFields,
 } from '../../domain/progression'
 import { reconcileAgentBetrayedFields } from '../../domain/sim/betrayal'
+import { reconcileAgentRelationshipChangedFields } from '../../domain/sim/relationshipProjection'
 import { sanitizePersistedAgencyProtocols } from '../../domain/protocols'
 import { isDistortionState, propagateDistortion } from '../../domain/shared/distortion'
 import { createDefaultPowerImpactSummary } from '../../domain/teamSimulation'
@@ -1086,14 +1087,6 @@ function reconcileTrainingEventProgram(
     trainingName: program.name,
     fundingCost: program.fundingCost,
   }
-}
-
-function sanitizeRelationshipValue(value: unknown, fallback: number) {
-  return clamp(sanitizeFiniteNumber(value, fallback), -2, 2)
-}
-
-function reconcileRelationshipDelta(previousValue: number, nextValue: number) {
-  return Math.round((nextValue - previousValue) * 100) / 100
 }
 
 const ALLOWED_GAME_OVER_REASONS = new Set<string>(Object.values(GAME_OVER_REASONS))
@@ -7700,8 +7693,7 @@ function sanitizeOperationEvents(
 
       case 'agent.relationship_changed':
         {
-          const previousValue = sanitizeRelationshipValue(payload.previousValue, 0)
-          const nextValue = sanitizeRelationshipValue(payload.nextValue, 0)
+          const relationship = reconcileAgentRelationshipChangedFields(payload)
 
           nextEvents.push(
             migrateOperationEventToCurrentSchema({
@@ -7719,9 +7711,9 @@ function sanitizeOperationEvents(
                   typeof payload.counterpartName === 'string'
                     ? payload.counterpartName
                     : `Counterpart ${index + 1}`,
-                previousValue,
-                nextValue,
-                delta: reconcileRelationshipDelta(previousValue, nextValue),
+                previousValue: relationship.previousValue,
+                nextValue: relationship.nextValue,
+                delta: relationship.delta,
                 reason:
                   payload.reason === 'mission_success' ||
                   payload.reason === 'mission_partial' ||

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -1203,17 +1203,6 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
             ? {
                 ...entry.payload,
                 ...reconcileAgentRelationshipChangedFields(entry.payload),
-                reason:
-                  entry.payload.reason === 'mission_success' ||
-                  entry.payload.reason === 'mission_partial' ||
-                  entry.payload.reason === 'mission_fail' ||
-                  entry.payload.reason === 'passive_drift' ||
-                  entry.payload.reason === 'external_event' ||
-                  entry.payload.reason === 'reconciliation' ||
-                  entry.payload.reason === 'spontaneous_event' ||
-                  entry.payload.reason === 'betrayal'
-                    ? entry.payload.reason
-                    : 'passive_drift',
               }
             : entry.payload
   const validation = validateOperationEventPayload(eventType, payload)

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -32,6 +32,7 @@ import {
   PERFORMANCE_PENALTY_MULTIPLIER,
   reconcileAgentBetrayedFields,
 } from '../sim/betrayal'
+import { reconcileAgentRelationshipChangedFields } from '../sim/relationshipProjection'
 import { ATTRITION_CALIBRATION } from '../sim/calibration'
 import { getTrainingProgram, trainingCatalog } from '../../data/training'
 import { getCertificationDefinitions } from '../sim/training-compat'
@@ -1198,7 +1199,23 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
                   )
                 : entry.payload.triggeredConsequences,
             }
-          : entry.payload
+          : eventType === 'agent.relationship_changed'
+            ? {
+                ...entry.payload,
+                ...reconcileAgentRelationshipChangedFields(entry.payload),
+                reason:
+                  entry.payload.reason === 'mission_success' ||
+                  entry.payload.reason === 'mission_partial' ||
+                  entry.payload.reason === 'mission_fail' ||
+                  entry.payload.reason === 'passive_drift' ||
+                  entry.payload.reason === 'external_event' ||
+                  entry.payload.reason === 'reconciliation' ||
+                  entry.payload.reason === 'spontaneous_event' ||
+                  entry.payload.reason === 'betrayal'
+                    ? entry.payload.reason
+                    : 'passive_drift',
+              }
+            : entry.payload
   const validation = validateOperationEventPayload(eventType, payload)
 
   if (!validation.success) {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -8,6 +8,8 @@ const weekSchema = z.number().int().min(1)
 const nonNegativeIntSchema = z.number().int().min(0)
 const finiteNonNegativeIntSchema = z.number().finite().int().min(0)
 const finiteNonNegativeNumberSchema = z.number().finite().min(0)
+const finiteNumberSchema = z.number().finite()
+const finiteChemistryValueSchema = z.number().finite().min(-2).max(2)
 const caseModeSchema = z.enum(['threshold', 'probability', 'deterministic', 'standard'])
 const caseKindSchema = z.enum(['case', 'raid', 'standard', 'anomaly'])
 const relationshipReasonSchema = z.enum([
@@ -270,12 +272,23 @@ const agentRelationshipChangedSchema = z
     agentName: z.string(),
     counterpartId: idSchema,
     counterpartName: z.string(),
-    previousValue: z.number(),
-    nextValue: z.number(),
-    delta: z.number(),
+    previousValue: finiteChemistryValueSchema,
+    nextValue: finiteChemistryValueSchema,
+    delta: finiteNumberSchema,
     reason: relationshipReasonSchema,
   })
   .strict()
+  .superRefine((payload, context) => {
+    const expectedDelta = Math.round((payload.nextValue - payload.previousValue) * 100) / 100
+
+    if (payload.delta !== expectedDelta) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'delta must equal nextValue - previousValue (rounded to two decimals)',
+        path: ['delta'],
+      })
+    }
+  })
 
 const agentInstructorAssignedSchema = z
   .object({

--- a/src/domain/sim/relationshipProjection.ts
+++ b/src/domain/sim/relationshipProjection.ts
@@ -1,10 +1,58 @@
 import { clamp } from '../math'
 import type { Relationship } from '../models'
 
+export const RELATIONSHIP_VALUE_MIN = -2
+export const RELATIONSHIP_VALUE_MAX = 2
+
 export const STATE_HOSTILE_THRESHOLD = -0.5
 export const STATE_STRAINED_THRESHOLD = 0
 export const STATE_NEUTRAL_THRESHOLD = 0.5
 export const STATE_FRIENDLY_THRESHOLD = 1.2
+
+function coerceFiniteNumber(value: unknown, fallback: number) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed)
+
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return fallback
+}
+
+/** Round chemistry delta to two decimal places (producer / hydrate convention). */
+export function roundRelationshipDelta(value: number) {
+  return Math.round(value * 100) / 100
+}
+
+/** Hydration: clamp chemistry values to [-2, 2] and recompute finite delta. */
+export function reconcileAgentRelationshipChangedFields(payload: {
+  previousValue?: unknown
+  nextValue?: unknown
+}) {
+  const previousValue = clamp(
+    coerceFiniteNumber(payload.previousValue, 0),
+    RELATIONSHIP_VALUE_MIN,
+    RELATIONSHIP_VALUE_MAX
+  )
+  const nextValue = clamp(
+    coerceFiniteNumber(payload.nextValue, 0),
+    RELATIONSHIP_VALUE_MIN,
+    RELATIONSHIP_VALUE_MAX
+  )
+  const delta = roundRelationshipDelta(nextValue - previousValue)
+
+  return { previousValue, nextValue, delta }
+}
 
 /**
  * Compute relationship state based on value threshold.

--- a/src/domain/sim/relationshipProjection.ts
+++ b/src/domain/sim/relationshipProjection.ts
@@ -4,6 +4,19 @@ import type { Relationship } from '../models'
 export const RELATIONSHIP_VALUE_MIN = -2
 export const RELATIONSHIP_VALUE_MAX = 2
 
+export const RELATIONSHIP_CHANGED_REASONS = [
+  'mission_success',
+  'mission_partial',
+  'mission_fail',
+  'passive_drift',
+  'external_event',
+  'reconciliation',
+  'spontaneous_event',
+  'betrayal',
+] as const
+
+export type RelationshipChangedReason = (typeof RELATIONSHIP_CHANGED_REASONS)[number]
+
 export const STATE_HOSTILE_THRESHOLD = -0.5
 export const STATE_STRAINED_THRESHOLD = 0
 export const STATE_NEUTRAL_THRESHOLD = 0.5
@@ -29,15 +42,23 @@ function coerceFiniteNumber(value: unknown, fallback: number) {
   return fallback
 }
 
+function isRelationshipChangedReason(value: unknown): value is RelationshipChangedReason {
+  return (
+    typeof value === 'string' &&
+    (RELATIONSHIP_CHANGED_REASONS as readonly string[]).includes(value)
+  )
+}
+
 /** Round chemistry delta to two decimal places (producer / hydrate convention). */
 export function roundRelationshipDelta(value: number) {
   return Math.round(value * 100) / 100
 }
 
-/** Hydration: clamp chemistry values to [-2, 2] and recompute finite delta. */
+/** Hydration: clamp chemistry values to [-2, 2], recompute finite delta, sanitize reason. */
 export function reconcileAgentRelationshipChangedFields(payload: {
   previousValue?: unknown
   nextValue?: unknown
+  reason?: unknown
 }) {
   const previousValue = clamp(
     coerceFiniteNumber(payload.previousValue, 0),
@@ -50,8 +71,9 @@ export function reconcileAgentRelationshipChangedFields(payload: {
     RELATIONSHIP_VALUE_MAX
   )
   const delta = roundRelationshipDelta(nextValue - previousValue)
+  const reason = isRelationshipChangedReason(payload.reason) ? payload.reason : 'passive_drift'
 
-  return { previousValue, nextValue, delta }
+  return { previousValue, nextValue, delta, reason }
 }
 
 /**

--- a/src/test/agentHistory.relationshipChanged.reconciliation.test.ts
+++ b/src/test/agentHistory.relationshipChanged.reconciliation.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+import { createAgent } from '../domain/agent/factory'
+import { normalizeAgent } from '../domain/agent/normalize'
+
+describe('agent history agent.relationship_changed reconciliation', () => {
+  it('preserves legacy relationship logs by reconciling chemistry before validation', () => {
+    const agent = createAgent({
+      id: 'a_relationship_legacy',
+      name: 'Legacy Relationship',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-relationship-legacy',
+            schemaVersion: 1,
+            type: 'agent.relationship_changed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              counterpartId: 'a_counterpart',
+              counterpartName: 'Counterpart',
+              previousValue: 5,
+              nextValue: -3,
+              delta: 999,
+              reason: 'passive_drift',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.relationship_changed',
+      payload: {
+        previousValue: 2,
+        nextValue: -2,
+        delta: -4,
+        reason: 'passive_drift',
+      },
+    })
+  })
+
+  it('recomputes mismatched delta before validation', () => {
+    const agent = createAgent({
+      id: 'a_relationship_delta',
+      name: 'Delta Mismatch',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-relationship-delta',
+            schemaVersion: 1,
+            type: 'agent.relationship_changed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              counterpartId: 'a_counterpart',
+              counterpartName: 'Counterpart',
+              previousValue: 0.2,
+              nextValue: 0.4,
+              delta: 0.15,
+              reason: 'mission_success',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.relationship_changed',
+      payload: {
+        previousValue: 0.2,
+        nextValue: 0.4,
+        delta: 0.2,
+      },
+    })
+  })
+
+  it('preserves numeric-string chemistry when reconciling before validation', () => {
+    const agent = createAgent({
+      id: 'a_relationship_string',
+      name: 'String Chemistry',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-relationship-string',
+            schemaVersion: 1,
+            type: 'agent.relationship_changed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              counterpartId: 'a_counterpart',
+              counterpartName: 'Counterpart',
+              previousValue: '0.12',
+              nextValue: '0.28',
+              delta: 'bad',
+              reason: 'external_event',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.relationship_changed',
+      payload: {
+        previousValue: 0.12,
+        nextValue: 0.28,
+        delta: 0.16,
+        reason: 'external_event',
+      },
+    })
+  })
+
+  it('falls back invalid relationship reasons to passive_drift before validation', () => {
+    const agent = createAgent({
+      id: 'a_relationship_reason',
+      name: 'Reason Fallback',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-relationship-reason',
+            schemaVersion: 1,
+            type: 'agent.relationship_changed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              counterpartId: 'a_counterpart',
+              counterpartName: 'Counterpart',
+              previousValue: 0.1,
+              nextValue: 0.2,
+              delta: 0.1,
+              reason: 'unsupported_reason',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.relationship_changed',
+      payload: {
+        reason: 'passive_drift',
+      },
+    })
+  })
+})

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -47,6 +47,63 @@ describe('event payload validation coverage', () => {
     expect(validation.error).toBeTypeOf('string')
   })
 
+  it('accepts consistent agent.relationship_changed payloads', () => {
+    const validation = validateOperationEventPayload('agent.relationship_changed', {
+      ...minimalOperationEventPayloads['agent.relationship_changed'],
+    })
+
+    expect(validation.success).toBe(true)
+  })
+
+  it('rejects agent.relationship_changed payloads with non-finite chemistry values', () => {
+    const nanPrevious = validateOperationEventPayload('agent.relationship_changed', {
+      ...minimalOperationEventPayloads['agent.relationship_changed'],
+      previousValue: Number.NaN,
+    })
+    const infiniteNext = validateOperationEventPayload('agent.relationship_changed', {
+      ...minimalOperationEventPayloads['agent.relationship_changed'],
+      nextValue: Number.POSITIVE_INFINITY,
+    })
+    const infiniteDelta = validateOperationEventPayload('agent.relationship_changed', {
+      ...minimalOperationEventPayloads['agent.relationship_changed'],
+      delta: Number.NEGATIVE_INFINITY,
+    })
+
+    expect(nanPrevious.success).toBe(false)
+    expect(infiniteNext.success).toBe(false)
+    expect(infiniteDelta.success).toBe(false)
+  })
+
+  it('rejects agent.relationship_changed payloads with out-of-range chemistry values', () => {
+    const highPrevious = validateOperationEventPayload('agent.relationship_changed', {
+      ...minimalOperationEventPayloads['agent.relationship_changed'],
+      previousValue: 2.01,
+      nextValue: 2,
+      delta: -0.01,
+    })
+    const lowNext = validateOperationEventPayload('agent.relationship_changed', {
+      ...minimalOperationEventPayloads['agent.relationship_changed'],
+      previousValue: -2,
+      nextValue: -2.1,
+      delta: -0.1,
+    })
+
+    expect(highPrevious.success).toBe(false)
+    expect(lowNext.success).toBe(false)
+  })
+
+  it('rejects agent.relationship_changed payloads when delta mismatches nextValue - previousValue', () => {
+    const validation = validateOperationEventPayload('agent.relationship_changed', {
+      ...minimalOperationEventPayloads['agent.relationship_changed'],
+      previousValue: 0.2,
+      nextValue: 0.4,
+      delta: 0.15,
+    })
+
+    expect(validation.success).toBe(false)
+    expect(validation.error).toBeTypeOf('string')
+  })
+
   it('accepts recruitment intel confirmation payloads with confirmed confidence', () => {
     const validation = validateOperationEventPayload('recruitment.intel_confirmed', {
       week: 4,


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2655 — https://linear.app/spectranoir/issue/SPE-2655/harden-agentrelationship-changed-numeric-consistency-validation
- **Parent issue (if any):** none — same-class follow-on after SPE-2654; backlog primary was none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened `agentRelationshipChangedSchema` for finite chemistry in [-2, 2] and delta === round(next − previous, 2)
- Shared `reconcileAgentRelationshipChangedFields` used by hydrate sanitize and agent-history normalize before validate
- Validation + history preservation tests; slice doc

## Docs updated

- `planning/spe-2655-harden-agent-relationship-changed-validation-slice.md`

## Parent status

- No parent umbrella — slice stands alone (related to SPE-2651/2652/2654 pattern)

## Scope boundary

- Does not change agent.betrayed / agent.promoted / progression.xp_gained, unrelated event types, or UI/feed rendering

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/test/agentHistory.relationshipChanged.reconciliation.test.ts`
- [x] Hydrate regression: `npx vitest run src/app/store/runTransfer.test.ts -t "508 normalizes relationship|508b clamps legacy relationship"`
- [x] Producer validation: `npx vitest run src/test/events.producerValidation.test.ts`
- [x] Lint: eslint on touched files

## Follow-ups

- None this slice

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)
