### PR TITLE
SPE-2656: Harden instructor assignment event validation

### DIFF
--- a/planning/spe-2656-harden-agent-instructor-assignment-validation-slice.md
+++ b/planning/spe-2656-harden-agent-instructor-assignment-validation-slice.md
@@ -1,0 +1,35 @@
+# SPE-2656 — Harden agent.instructor_assigned / instructor_unassigned bonus+specialty validation
+
+**Linear:** [SPE-2656](https://linear.app/spectranoir/issue/SPE-2656/harden-agentinstructor-assigned-instructor-unassigned-bonusspecialty)  
+**Branch:** `jamesdyedbq/spe-2656-harden-agentinstructor_assigned-instructor_unassigned`
+
+## Goal
+
+Reject inconsistent `agent.instructor_assigned` / `agent.instructor_unassigned` payloads at the operation-event validation boundary so `bonus` and `instructorSpecialty` cannot drift past producers.
+
+## Scope
+
+- Harden shared instructor assignment schema in `src/domain/events/eventValidation.ts`
+- Shared `reconcileAgentInstructorAssignmentFields` (SPE-2655 pattern); hydrate + agent-history sanitize reconcile before validate
+- Add targeted validation + history preservation tests
+
+## Out of scope
+
+- `agent.relationship_changed` / `agent.betrayed` / `agent.promoted` / `progression.xp_gained` (SPE-2651 / 2652 / 2654 / 2655 — shipped)
+- Training events (separate slice)
+- Broader event-schema hardening for unrelated types
+- UI / feed rendering
+
+## Acceptance
+
+- Finite nonnegative integer `bonus` (reject non-finite / negative / fractional)
+- `instructorSpecialty` StatKey allowlist (`combat` | `investigation` | `utility` | `social`)
+- Assigned and unassigned schemas stay aligned (shared fields schema)
+- Invalid cases fail; valid instructor and minimal/producer fixtures pass
+- Legacy history/hydrate instructor events preserved when reconcile runs first
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| — | — | None this slice |

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -920,6 +920,62 @@ describe('runTransfer helpers', () => {
     expect(roundTripped.events).toHaveLength(game.events.length)
   })
 
+  it('reconciles instructor assignment bonus and specialty on import hydration', () => {
+    const fallback = createStartingState()
+    const hydrated = hydrateGame({
+      ...stripGameTemplates(fallback),
+      events: [
+        {
+          id: 'evt-instructor-assigned-raw',
+          type: 'agent.instructor_assigned',
+          timestamp: buildOperationEventTimestamp(2, 0),
+          payload: {
+            week: 2,
+            staffId: 'staff-instructor-01',
+            instructorName: 'Iris Vale',
+            agentId: 'a_mina',
+            agentName: 'Mina Park',
+            instructorSpecialty: 'not-a-stat',
+            bonus: -1.5,
+          },
+        },
+        {
+          id: 'evt-instructor-unassigned-raw',
+          type: 'agent.instructor_unassigned',
+          timestamp: buildOperationEventTimestamp(2, 1),
+          payload: {
+            week: 2,
+            staffId: 'staff-instructor-01',
+            instructorName: 'Iris Vale',
+            agentId: 'a_mina',
+            agentName: 'Mina Park',
+            instructorSpecialty: 'utility',
+            bonus: '3.2',
+          },
+        },
+      ],
+    })
+
+    expect(hydrated.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent.instructor_assigned',
+          payload: expect.objectContaining({
+            instructorSpecialty: 'combat',
+            bonus: 0,
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent.instructor_unassigned',
+          payload: expect.objectContaining({
+            instructorSpecialty: 'utility',
+            bonus: 3,
+          }),
+        }),
+      ])
+    )
+  })
+
   it('assigns deterministic migrated ids for legacy events missing ids', () => {
     const fallback = createStartingState()
     const imported = parseRunExport(

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -186,6 +186,7 @@ import {
   reconcileProgressionXpGainedFields,
 } from '../../domain/progression'
 import { reconcileAgentBetrayedFields } from '../../domain/sim/betrayal'
+import { reconcileAgentInstructorAssignmentFields } from '../../domain/sim/instructorAssignment'
 import { reconcileAgentRelationshipChangedFields } from '../../domain/sim/relationshipProjection'
 import { sanitizePersistedAgencyProtocols } from '../../domain/protocols'
 import { isDistortionState, propagateDistortion } from '../../domain/shared/distortion'
@@ -7722,49 +7723,32 @@ function sanitizeOperationEvents(
         break
 
       case 'agent.instructor_assigned':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('agent.instructor_assigned'),
-            payload: {
-              week,
-              staffId: typeof payload.staffId === 'string' ? payload.staffId : `staff-${index + 1}`,
-              instructorName:
-                typeof payload.instructorName === 'string'
-                  ? payload.instructorName
-                  : `Instructor ${index + 1}`,
-              agentId: typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
-              agentName:
-                typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-              instructorSpecialty: isOneOf(payload.instructorSpecialty, STAT_KEYS)
-                ? payload.instructorSpecialty
-                : 'combat',
-              bonus: sanitizeInteger(payload.bonus as number | undefined, 0, 0),
-            },
-          })
-        )
-        break
-
       case 'agent.instructor_unassigned':
-        nextEvents.push(
-          migrateOperationEventToCurrentSchema({
-            ...createBase('agent.instructor_unassigned'),
-            payload: {
-              week,
-              staffId: typeof payload.staffId === 'string' ? payload.staffId : `staff-${index + 1}`,
-              instructorName:
-                typeof payload.instructorName === 'string'
-                  ? payload.instructorName
-                  : `Instructor ${index + 1}`,
-              agentId: typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
-              agentName:
-                typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-              instructorSpecialty: isOneOf(payload.instructorSpecialty, STAT_KEYS)
-                ? payload.instructorSpecialty
-                : 'combat',
-              bonus: sanitizeInteger(payload.bonus as number | undefined, 0, 0),
-            },
-          })
-        )
+        {
+          const instructor = reconcileAgentInstructorAssignmentFields(payload)
+          nextEvents.push(
+            migrateOperationEventToCurrentSchema({
+              ...createBase(eventType),
+              payload: {
+                week,
+                staffId:
+                  typeof payload.staffId === 'string' ? payload.staffId : `staff-${index + 1}`,
+                instructorName:
+                  typeof payload.instructorName === 'string'
+                    ? payload.instructorName
+                    : `Instructor ${index + 1}`,
+                agentId:
+                  typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
+                agentName:
+                  typeof payload.agentName === 'string'
+                    ? payload.agentName
+                    : `Agent ${index + 1}`,
+                instructorSpecialty: instructor.instructorSpecialty,
+                bonus: instructor.bonus,
+              },
+            })
+          )
+        }
         break
 
       case 'agent.injured':

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -32,6 +32,7 @@ import {
   PERFORMANCE_PENALTY_MULTIPLIER,
   reconcileAgentBetrayedFields,
 } from '../sim/betrayal'
+import { reconcileAgentInstructorAssignmentFields } from '../sim/instructorAssignment'
 import { reconcileAgentRelationshipChangedFields } from '../sim/relationshipProjection'
 import { ATTRITION_CALIBRATION } from '../sim/calibration'
 import { getTrainingProgram, trainingCatalog } from '../../data/training'
@@ -1204,7 +1205,13 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
                 ...entry.payload,
                 ...reconcileAgentRelationshipChangedFields(entry.payload),
               }
-            : entry.payload
+            : eventType === 'agent.instructor_assigned' ||
+                eventType === 'agent.instructor_unassigned'
+              ? {
+                  ...entry.payload,
+                  ...reconcileAgentInstructorAssignmentFields(entry.payload),
+                }
+              : entry.payload
   const validation = validateOperationEventPayload(eventType, payload)
 
   if (!validation.success) {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -290,29 +290,22 @@ const agentRelationshipChangedSchema = z
     }
   })
 
-const agentInstructorAssignedSchema = z
+const instructorSpecialtySchema = z.enum(['combat', 'investigation', 'utility', 'social'])
+
+const agentInstructorAssignmentFieldsSchema = z
   .object({
     week: weekSchema,
     staffId: idSchema,
     instructorName: z.string(),
     agentId: idSchema,
     agentName: z.string(),
-    instructorSpecialty: z.string(),
-    bonus: z.number(),
+    instructorSpecialty: instructorSpecialtySchema,
+    bonus: finiteNonNegativeIntSchema,
   })
   .strict()
 
-const agentInstructorUnassignedSchema = z
-  .object({
-    week: weekSchema,
-    staffId: idSchema,
-    instructorName: z.string(),
-    agentId: idSchema,
-    agentName: z.string(),
-    instructorSpecialty: z.string(),
-    bonus: z.number(),
-  })
-  .strict()
+const agentInstructorAssignedSchema = agentInstructorAssignmentFieldsSchema
+const agentInstructorUnassignedSchema = agentInstructorAssignmentFieldsSchema
 
 const agentInjuredSchema = z
   .object({

--- a/src/domain/sim/instructorAssignment.ts
+++ b/src/domain/sim/instructorAssignment.ts
@@ -1,6 +1,55 @@
 import { type GameState, type InstructorData, type StatKey } from '../models'
 import { isAgentTraining } from './training'
 
+export const INSTRUCTOR_SPECIALTY_KEYS = [
+  'combat',
+  'investigation',
+  'utility',
+  'social',
+] as const satisfies readonly StatKey[]
+
+const DEFAULT_INSTRUCTOR_SPECIALTY: StatKey = 'combat'
+
+function coerceFiniteNumber(value: unknown, fallback: number) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed)
+
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return fallback
+}
+
+function isInstructorSpecialty(value: unknown): value is StatKey {
+  return (
+    typeof value === 'string' &&
+    (INSTRUCTOR_SPECIALTY_KEYS as readonly string[]).includes(value)
+  )
+}
+
+/** Hydration / history: nonnegative int bonus + StatKey specialty allowlist. */
+export function reconcileAgentInstructorAssignmentFields(payload: {
+  bonus?: unknown
+  instructorSpecialty?: unknown
+}) {
+  const bonus = Math.max(0, Math.trunc(coerceFiniteNumber(payload.bonus, 0)))
+  const instructorSpecialty = isInstructorSpecialty(payload.instructorSpecialty)
+    ? payload.instructorSpecialty
+    : DEFAULT_INSTRUCTOR_SPECIALTY
+
+  return { bonus, instructorSpecialty }
+}
+
 export function getInstructorBonus(efficiency: number): 0 | 1 | 2 {
   if (efficiency >= 90) return 2
   if (efficiency >= 70) return 1

--- a/src/test/agentHistory.instructorAssignment.reconciliation.test.ts
+++ b/src/test/agentHistory.instructorAssignment.reconciliation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { createAgent } from '../domain/agent/factory'
+import { normalizeAgent } from '../domain/agent/normalize'
+
+describe('agent history instructor assignment reconciliation', () => {
+  it.each(['agent.instructor_assigned', 'agent.instructor_unassigned'] as const)(
+    'preserves legacy %s logs by reconciling bonus and specialty before validation',
+    (eventType) => {
+      const agent = createAgent({
+        id: 'a_instructor_legacy',
+        name: 'Legacy Instructor',
+        role: 'investigator',
+        baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+        abilities: [],
+        tags: [],
+        relationships: {},
+        fatigue: 0,
+        status: 'active',
+      })
+
+      const normalized = normalizeAgent({
+        ...agent,
+        history: {
+          ...agent.history!,
+          logs: [
+            {
+              id: 'evt-instructor-legacy',
+              schemaVersion: 1,
+              type: eventType,
+              sourceSystem: 'agent',
+              timestamp: '2042-01-08T00:00:00.000Z',
+              payload: {
+                week: 2,
+                staffId: 'staff-instructor-01',
+                instructorName: 'Iris Vale',
+                agentId: agent.id,
+                agentName: agent.name,
+                instructorSpecialty: 'not-a-stat',
+                bonus: -3.7,
+              },
+            },
+          ],
+        },
+      })
+
+      expect(normalized.history?.logs).toHaveLength(1)
+      expect(normalized.history?.logs[0]).toMatchObject({
+        type: eventType,
+        payload: {
+          instructorSpecialty: 'combat',
+          bonus: 0,
+        },
+      })
+    }
+  )
+
+  it.each(['agent.instructor_assigned', 'agent.instructor_unassigned'] as const)(
+    'preserves numeric-string bonus for %s when reconciling before validation',
+    (eventType) => {
+      const agent = createAgent({
+        id: 'a_instructor_string',
+        name: 'String Bonus',
+        role: 'investigator',
+        baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+        abilities: [],
+        tags: [],
+        relationships: {},
+        fatigue: 0,
+        status: 'active',
+      })
+
+      const normalized = normalizeAgent({
+        ...agent,
+        history: {
+          ...agent.history!,
+          logs: [
+            {
+              id: 'evt-instructor-string',
+              schemaVersion: 1,
+              type: eventType,
+              sourceSystem: 'agent',
+              timestamp: '2042-01-08T00:00:00.000Z',
+              payload: {
+                week: 2,
+                staffId: 'staff-instructor-01',
+                instructorName: 'Iris Vale',
+                agentId: agent.id,
+                agentName: agent.name,
+                instructorSpecialty: 'investigation',
+                bonus: '2.9',
+              },
+            },
+          ],
+        },
+      })
+
+      expect(normalized.history?.logs).toHaveLength(1)
+      expect(normalized.history?.logs[0]).toMatchObject({
+        type: eventType,
+        payload: {
+          instructorSpecialty: 'investigation',
+          bonus: 2,
+        },
+      })
+    }
+  )
+})

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -577,4 +577,68 @@ describe('event payload validation coverage', () => {
 
     expect(validation.success).toBe(false)
   })
+
+  it.each(['agent.instructor_assigned', 'agent.instructor_unassigned'] as const)(
+    'accepts consistent %s payloads',
+    (eventType) => {
+      const validation = validateOperationEventPayload(eventType, {
+        ...minimalOperationEventPayloads[eventType],
+      })
+
+      expect(validation.success).toBe(true)
+    }
+  )
+
+  it.each(['agent.instructor_assigned', 'agent.instructor_unassigned'] as const)(
+    'rejects %s payloads with non-finite bonus',
+    (eventType) => {
+      const nanBonus = validateOperationEventPayload(eventType, {
+        ...minimalOperationEventPayloads[eventType],
+        bonus: Number.NaN,
+      })
+      const infiniteBonus = validateOperationEventPayload(eventType, {
+        ...minimalOperationEventPayloads[eventType],
+        bonus: Number.POSITIVE_INFINITY,
+      })
+
+      expect(nanBonus.success).toBe(false)
+      expect(infiniteBonus.success).toBe(false)
+    }
+  )
+
+  it.each(['agent.instructor_assigned', 'agent.instructor_unassigned'] as const)(
+    'rejects %s payloads with negative bonus',
+    (eventType) => {
+      const validation = validateOperationEventPayload(eventType, {
+        ...minimalOperationEventPayloads[eventType],
+        bonus: -1,
+      })
+
+      expect(validation.success).toBe(false)
+    }
+  )
+
+  it.each(['agent.instructor_assigned', 'agent.instructor_unassigned'] as const)(
+    'rejects %s payloads with fractional bonus',
+    (eventType) => {
+      const validation = validateOperationEventPayload(eventType, {
+        ...minimalOperationEventPayloads[eventType],
+        bonus: 1.5,
+      })
+
+      expect(validation.success).toBe(false)
+    }
+  )
+
+  it.each(['agent.instructor_assigned', 'agent.instructor_unassigned'] as const)(
+    'rejects %s payloads with invalid instructorSpecialty',
+    (eventType) => {
+      const validation = validateOperationEventPayload(eventType, {
+        ...minimalOperationEventPayloads[eventType],
+        instructorSpecialty: 'not-a-stat',
+      })
+
+      expect(validation.success).toBe(false)
+    }
+  )
 })


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2656 — https://linear.app/spectranoir/issue/SPE-2656/harden-agentinstructor-assigned-instructor-unassigned-bonusspecialty
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Shared strict schema for `agent.instructor_assigned` / `agent.instructor_unassigned`: finite nonnegative int `bonus` + StatKey `instructorSpecialty`
- `reconcileAgentInstructorAssignmentFields` used by hydrate (`runTransfer`) and agent-history normalize before validate
- Targeted validation, history reconciliation, and hydrate tests

## Docs updated

- `planning/spe-2656-harden-agent-instructor-assignment-validation-slice.md`

## Parent status

- No parent — standalone follow-on hardening slice

## Scope boundary

- Does not change relationship/betrayed/promoted/xp_gained (already shipped)
- Does not harden training events or UI/feed

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/test/agentHistory.instructorAssignment.reconciliation.test.ts -t instructor`; hydrate test in `runTransfer.test.ts`; producer/coverage fixtures
- [x] Lint: eslint on touched files

## Follow-ups

- Training event schema hardening (separate slice)

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)