### PR TITLE
SPE-2657: Harden agent training event validation

### DIFF
--- a/planning/spe-2657-harden-agent-training-event-validation-slice.md
+++ b/planning/spe-2657-harden-agent-training-event-validation-slice.md
@@ -1,0 +1,36 @@
+# SPE-2657 — Harden agent training event validation
+
+**Linear:** [SPE-2657](https://linear.app/spectranoir/issue/SPE-2657/harden-agenttraining-started-training-completed-training-cancelled)  
+**Branch:** `jamesdyedbq/spe-2657-harden-agenttraining_started-training_completed`
+
+## Goal
+
+Reject inconsistent `agent.training_started` / `agent.training_completed` / `agent.training_cancelled` payloads at the operation-event validation boundary so `etaWeeks` / `fundingCost` / `refund` and training program ids cannot drift past producers.
+
+## Scope
+
+- Harden the three training schemas in `src/domain/events/eventValidation.ts`
+- Shared `reconcileTrainingEventProgram` + started/completed/cancelled field helpers (SPE-2651–2656 pattern); hydrate + agent-history sanitize reconcile before validate
+- Add targeted validation + history preservation tests
+
+## Out of scope
+
+- `agent.instructor_assigned` / `instructor_unassigned` / `relationship_changed` / `betrayed` / `promoted` / `progression.xp_gained` (SPE-2651 / 2652 / 2654 / 2655 / 2656 — shipped)
+- Broader event-schema hardening for unrelated types
+- UI / feed rendering
+
+## Acceptance
+
+- Finite positive integer `etaWeeks` (>= 1) on started
+- Finite nonnegative integer `fundingCost` on started
+- Finite nonnegative integer `refund` on cancelled
+- Reject non-finite / negative / fractional numerics
+- Program id reconcile preserves unknown/legacy training ids via catalog match (hydrate + history)
+- Invalid cases fail; valid training and minimal/producer fixtures pass
+- Legacy history/hydrate training events preserved when reconcile runs first
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| — | — | None this slice |

--- a/planning/spe-2657-harden-agent-training-event-validation-slice.md
+++ b/planning/spe-2657-harden-agent-training-event-validation-slice.md
@@ -33,4 +33,4 @@ Reject inconsistent `agent.training_started` / `agent.training_completed` / `age
 
 | Item | Owner | Why deferred |
 | --- | --- | --- |
-| — | — | None this slice |
+| Catalog membership / id↔name consistency at validate | follow-on if needed | Acceptance is numerics + nonblank ids; hydrate/history reconcile already resolves unknown programs. Producer catalog checks would couple schema to `trainingCatalog`. |

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -1593,7 +1593,7 @@ describe('runTransfer helpers', () => {
     })
   })
 
-  it('sanitizes legacy unknown training event payloads to catalog-backed IDs/names and bounded refund', () => {
+  it('sanitizes legacy unknown training event payloads to catalog-backed IDs/names and nonnegative refund', () => {
     const fallback = createStartingState()
     const imported = parseRunExport(
       JSON.stringify({
@@ -1651,7 +1651,7 @@ describe('runTransfer helpers', () => {
       payload: {
         trainingId: 'combat-drills',
         trainingName: 'Close-Quarters Drills',
-        refund: 10,
+        refund: 999,
       },
     })
   })

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -10,7 +10,12 @@ import {
   productionMaterialCatalog,
   type ProductionRecipe,
 } from '../../data/production'
-import { getTrainingProgram, trainingCatalog } from '../../data/training'
+import { getTrainingProgram } from '../../data/training'
+import {
+  reconcileAgentTrainingCancelledFields,
+  reconcileAgentTrainingCompletedFields,
+  reconcileAgentTrainingStartedFields,
+} from '../../domain/sim/training'
 import { createDefaultAgentAssignmentState } from '../../domain/agentDefaults'
 import { normalizeAgent, reconcileAgentAssignmentAgainstGame } from '../../domain/agent/normalize'
 import { recomputeAttritionDerivedState } from '../../domain/agent/attritionReset'
@@ -1053,41 +1058,6 @@ function sanitizeFiniteNumber(value: unknown, fallback: number) {
   }
 
   return fallback
-}
-
-function reconcileTrainingEventProgram(
-  trainingIdValue: unknown,
-  trainingNameValue: unknown
-): { trainingId: string; trainingName: string; fundingCost: number } {
-  const trainingIdCandidate = typeof trainingIdValue === 'string' ? trainingIdValue : undefined
-  const trainingNameCandidate =
-    typeof trainingNameValue === 'string' && trainingNameValue.trim().length > 0
-      ? trainingNameValue.trim()
-      : undefined
-
-  const matchedProgramById =
-    trainingIdCandidate && getTrainingProgram(trainingIdCandidate)
-      ? getTrainingProgram(trainingIdCandidate)
-      : undefined
-  const matchedProgramByName = trainingNameCandidate
-    ? trainingCatalog.find((program) => program.name === trainingNameCandidate)
-    : undefined
-  const fallbackProgram = trainingCatalog[0]
-  const program = matchedProgramById ?? matchedProgramByName ?? fallbackProgram
-
-  if (!program) {
-    return {
-      trainingId: 'combat-drills',
-      trainingName: trainingNameCandidate ?? 'Close-Quarters Drills',
-      fundingCost: 0,
-    }
-  }
-
-  return {
-    trainingId: program.trainingId,
-    trainingName: program.name,
-    fundingCost: program.fundingCost,
-  }
 }
 
 const ALLOWED_GAME_OVER_REASONS = new Set<string>(Object.values(GAME_OVER_REASONS))
@@ -7611,10 +7581,7 @@ function sanitizeOperationEvents(
 
       case 'agent.training_started':
         {
-          const trainingProgram = reconcileTrainingEventProgram(
-            payload.trainingId,
-            payload.trainingName
-          )
+          const training = reconcileAgentTrainingStartedFields(payload)
 
           nextEvents.push(
             migrateOperationEventToCurrentSchema({
@@ -7627,11 +7594,11 @@ function sanitizeOperationEvents(
                   typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
                 agentName:
                   typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-                trainingId: trainingProgram.trainingId,
-                trainingName: trainingProgram.trainingName,
+                trainingId: training.trainingId,
+                trainingName: training.trainingName,
                 teamName: typeof payload.teamName === 'string' ? payload.teamName : undefined,
-                etaWeeks: sanitizeInteger(payload.etaWeeks as number | undefined, 1, 1),
-                fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
+                etaWeeks: training.etaWeeks,
+                fundingCost: training.fundingCost,
               },
             })
           )
@@ -7640,10 +7607,7 @@ function sanitizeOperationEvents(
 
       case 'agent.training_completed':
         {
-          const trainingProgram = reconcileTrainingEventProgram(
-            payload.trainingId,
-            payload.trainingName
-          )
+          const training = reconcileAgentTrainingCompletedFields(payload)
 
           nextEvents.push(
             migrateOperationEventToCurrentSchema({
@@ -7656,8 +7620,8 @@ function sanitizeOperationEvents(
                   typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
                 agentName:
                   typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-                trainingId: trainingProgram.trainingId,
-                trainingName: trainingProgram.trainingName,
+                trainingId: training.trainingId,
+                trainingName: training.trainingName,
               },
             })
           )
@@ -7666,10 +7630,7 @@ function sanitizeOperationEvents(
 
       case 'agent.training_cancelled':
         {
-          const trainingProgram = reconcileTrainingEventProgram(
-            payload.trainingId,
-            payload.trainingName
-          )
+          const training = reconcileAgentTrainingCancelledFields(payload)
 
           nextEvents.push(
             migrateOperationEventToCurrentSchema({
@@ -7680,12 +7641,9 @@ function sanitizeOperationEvents(
                   typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
                 agentName:
                   typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
-                trainingId: trainingProgram.trainingId,
-                trainingName: trainingProgram.trainingName,
-                refund: Math.min(
-                  sanitizeInteger(payload.refund as number | undefined, 0, 0),
-                  trainingProgram.fundingCost
-                ),
+                trainingId: training.trainingId,
+                trainingName: training.trainingName,
+                refund: training.refund,
               },
             })
           )

--- a/src/domain/agent/normalize.ts
+++ b/src/domain/agent/normalize.ts
@@ -34,6 +34,11 @@ import {
 } from '../sim/betrayal'
 import { reconcileAgentInstructorAssignmentFields } from '../sim/instructorAssignment'
 import { reconcileAgentRelationshipChangedFields } from '../sim/relationshipProjection'
+import {
+  reconcileAgentTrainingCancelledFields,
+  reconcileAgentTrainingCompletedFields,
+  reconcileAgentTrainingStartedFields,
+} from '../sim/training'
 import { ATTRITION_CALIBRATION } from '../sim/calibration'
 import { getTrainingProgram, trainingCatalog } from '../../data/training'
 import { getCertificationDefinitions } from '../sim/training-compat'
@@ -1211,7 +1216,22 @@ function sanitizeAgentHistoryLog(entry: unknown): OperationEvent | null {
                   ...entry.payload,
                   ...reconcileAgentInstructorAssignmentFields(entry.payload),
                 }
-              : entry.payload
+              : eventType === 'agent.training_started'
+                ? {
+                    ...entry.payload,
+                    ...reconcileAgentTrainingStartedFields(entry.payload),
+                  }
+                : eventType === 'agent.training_completed'
+                  ? {
+                      ...entry.payload,
+                      ...reconcileAgentTrainingCompletedFields(entry.payload),
+                    }
+                  : eventType === 'agent.training_cancelled'
+                    ? {
+                        ...entry.payload,
+                        ...reconcileAgentTrainingCancelledFields(entry.payload),
+                      }
+                    : entry.payload
   const validation = validateOperationEventPayload(eventType, payload)
 
   if (!validation.success) {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -230,14 +230,20 @@ const intelReportGeneratedSchema = z
   })
   .strict()
 
+const trimmedNonblankStringSchema = z
+  .string()
+  .refine((value) => value.length > 0 && value === value.trim(), {
+    message: 'must be a trimmed nonblank string',
+  })
+
 const agentTrainingStartedSchema = z
   .object({
     week: weekSchema,
     queueId: idSchema,
     agentId: idSchema,
     agentName: z.string(),
-    trainingId: z.string().min(1),
-    trainingName: z.string().min(1),
+    trainingId: trimmedNonblankStringSchema,
+    trainingName: trimmedNonblankStringSchema,
     teamName: z.string().optional(),
     etaWeeks: finitePositiveIntSchema,
     fundingCost: finiteNonNegativeIntSchema,
@@ -250,8 +256,8 @@ const agentTrainingCompletedSchema = z
     queueId: idSchema,
     agentId: idSchema,
     agentName: z.string(),
-    trainingId: z.string().min(1),
-    trainingName: z.string().min(1),
+    trainingId: trimmedNonblankStringSchema,
+    trainingName: trimmedNonblankStringSchema,
   })
   .strict()
 
@@ -260,8 +266,8 @@ const agentTrainingCancelledSchema = z
     week: weekSchema,
     agentId: idSchema,
     agentName: z.string(),
-    trainingId: z.string().min(1),
-    trainingName: z.string().min(1),
+    trainingId: trimmedNonblankStringSchema,
+    trainingName: trimmedNonblankStringSchema,
     refund: finiteNonNegativeIntSchema,
   })
   .strict()

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -7,6 +7,7 @@ const idSchema = z.string().min(1)
 const weekSchema = z.number().int().min(1)
 const nonNegativeIntSchema = z.number().int().min(0)
 const finiteNonNegativeIntSchema = z.number().finite().int().min(0)
+const finitePositiveIntSchema = z.number().finite().int().min(1)
 const finiteNonNegativeNumberSchema = z.number().finite().min(0)
 const finiteNumberSchema = z.number().finite()
 const finiteChemistryValueSchema = z.number().finite().min(-2).max(2)
@@ -235,11 +236,11 @@ const agentTrainingStartedSchema = z
     queueId: idSchema,
     agentId: idSchema,
     agentName: z.string(),
-    trainingId: z.string(),
-    trainingName: z.string(),
+    trainingId: z.string().min(1),
+    trainingName: z.string().min(1),
     teamName: z.string().optional(),
-    etaWeeks: z.number(),
-    fundingCost: z.number(),
+    etaWeeks: finitePositiveIntSchema,
+    fundingCost: finiteNonNegativeIntSchema,
   })
   .strict()
 
@@ -249,8 +250,8 @@ const agentTrainingCompletedSchema = z
     queueId: idSchema,
     agentId: idSchema,
     agentName: z.string(),
-    trainingId: z.string(),
-    trainingName: z.string(),
+    trainingId: z.string().min(1),
+    trainingName: z.string().min(1),
   })
   .strict()
 
@@ -259,9 +260,9 @@ const agentTrainingCancelledSchema = z
     week: weekSchema,
     agentId: idSchema,
     agentName: z.string(),
-    trainingId: z.string(),
-    trainingName: z.string(),
-    refund: z.number(),
+    trainingId: z.string().min(1),
+    trainingName: z.string().min(1),
+    refund: finiteNonNegativeIntSchema,
   })
   .strict()
 
@@ -358,8 +359,6 @@ const agentResignedSchema = z
     counterpartName: z.string().optional(),
   })
   .strict()
-
-const finitePositiveIntSchema = z.number().finite().int().min(1)
 
 const agentPromotedSchema = z
   .object({

--- a/src/domain/sim/training.ts
+++ b/src/domain/sim/training.ts
@@ -102,16 +102,18 @@ export function reconcileTrainingEventProgram(
   trainingIdValue: unknown,
   trainingNameValue: unknown
 ): { trainingId: string; trainingName: string; fundingCost: number } {
-  const trainingIdCandidate = typeof trainingIdValue === 'string' ? trainingIdValue : undefined
+  const trainingIdCandidate =
+    typeof trainingIdValue === 'string' && trainingIdValue.trim().length > 0
+      ? trainingIdValue.trim()
+      : undefined
   const trainingNameCandidate =
     typeof trainingNameValue === 'string' && trainingNameValue.trim().length > 0
       ? trainingNameValue.trim()
       : undefined
 
-  const matchedProgramById =
-    trainingIdCandidate && getTrainingProgram(trainingIdCandidate)
-      ? getTrainingProgram(trainingIdCandidate)
-      : undefined
+  const matchedProgramById = trainingIdCandidate
+    ? getTrainingProgram(trainingIdCandidate)
+    : undefined
   const matchedProgramByName = trainingNameCandidate
     ? trainingCatalog.find((program) => program.name === trainingNameCandidate)
     : undefined
@@ -163,22 +165,18 @@ export function reconcileAgentTrainingCompletedFields(payload: {
   }
 }
 
-/** Hydration / history: catalog program + refund clamped to program fundingCost. */
+/** Hydration / history: catalog program + nonnegative int refund (no catalog cost cap; team drills scale). */
 export function reconcileAgentTrainingCancelledFields(payload: {
   trainingId?: unknown
   trainingName?: unknown
   refund?: unknown
 }) {
   const program = reconcileTrainingEventProgram(payload.trainingId, payload.trainingName)
-  const refund = Math.min(
-    Math.max(0, Math.trunc(coerceFiniteNumber(payload.refund, 0))),
-    program.fundingCost
-  )
 
   return {
     trainingId: program.trainingId,
     trainingName: program.trainingName,
-    refund,
+    refund: Math.max(0, Math.trunc(coerceFiniteNumber(payload.refund, 0))),
   }
 }
 

--- a/src/domain/sim/training.ts
+++ b/src/domain/sim/training.ts
@@ -55,7 +55,7 @@ import {
   BASE_STAT_MAX,
 } from '../models'
 import { applyBoundedDelta } from '../shared/modifiers'
-import { getTrainingProgram } from '../../data/training'
+import { getTrainingProgram, trainingCatalog } from '../../data/training'
 
 /**
  * Primary stat affinity per agent role. Training the affinity stat grants +1 extra statDelta.
@@ -76,6 +76,111 @@ export {
   reviewCertification,
   transitionCertification,
 } from './training-compat'
+
+function coerceFiniteNumber(value: unknown, fallback: number) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed)
+
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return fallback
+}
+
+/** Hydration / history: resolve trainingId/name against catalog (id, then name, then fallback). */
+export function reconcileTrainingEventProgram(
+  trainingIdValue: unknown,
+  trainingNameValue: unknown
+): { trainingId: string; trainingName: string; fundingCost: number } {
+  const trainingIdCandidate = typeof trainingIdValue === 'string' ? trainingIdValue : undefined
+  const trainingNameCandidate =
+    typeof trainingNameValue === 'string' && trainingNameValue.trim().length > 0
+      ? trainingNameValue.trim()
+      : undefined
+
+  const matchedProgramById =
+    trainingIdCandidate && getTrainingProgram(trainingIdCandidate)
+      ? getTrainingProgram(trainingIdCandidate)
+      : undefined
+  const matchedProgramByName = trainingNameCandidate
+    ? trainingCatalog.find((program) => program.name === trainingNameCandidate)
+    : undefined
+  const fallbackProgram = trainingCatalog[0]
+  const program = matchedProgramById ?? matchedProgramByName ?? fallbackProgram
+
+  if (!program) {
+    return {
+      trainingId: 'combat-drills',
+      trainingName: trainingNameCandidate ?? 'Close-Quarters Drills',
+      fundingCost: 0,
+    }
+  }
+
+  return {
+    trainingId: program.trainingId,
+    trainingName: program.name,
+    fundingCost: program.fundingCost,
+  }
+}
+
+/** Hydration / history: catalog program + finite positive etaWeeks + nonnegative fundingCost. */
+export function reconcileAgentTrainingStartedFields(payload: {
+  trainingId?: unknown
+  trainingName?: unknown
+  etaWeeks?: unknown
+  fundingCost?: unknown
+}) {
+  const program = reconcileTrainingEventProgram(payload.trainingId, payload.trainingName)
+
+  return {
+    trainingId: program.trainingId,
+    trainingName: program.trainingName,
+    etaWeeks: Math.max(1, Math.trunc(coerceFiniteNumber(payload.etaWeeks, 1))),
+    fundingCost: Math.max(0, Math.trunc(coerceFiniteNumber(payload.fundingCost, 0))),
+  }
+}
+
+/** Hydration / history: catalog program ids/names only. */
+export function reconcileAgentTrainingCompletedFields(payload: {
+  trainingId?: unknown
+  trainingName?: unknown
+}) {
+  const program = reconcileTrainingEventProgram(payload.trainingId, payload.trainingName)
+
+  return {
+    trainingId: program.trainingId,
+    trainingName: program.trainingName,
+  }
+}
+
+/** Hydration / history: catalog program + refund clamped to program fundingCost. */
+export function reconcileAgentTrainingCancelledFields(payload: {
+  trainingId?: unknown
+  trainingName?: unknown
+  refund?: unknown
+}) {
+  const program = reconcileTrainingEventProgram(payload.trainingId, payload.trainingName)
+  const refund = Math.min(
+    Math.max(0, Math.trunc(coerceFiniteNumber(payload.refund, 0))),
+    program.fundingCost
+  )
+
+  return {
+    trainingId: program.trainingId,
+    trainingName: program.trainingName,
+    refund,
+  }
+}
 
 export function getTrainingAptitudeBonus(agentRole: AgentRole, targetStat: StatKey): number {
   if (agentRole === 'field_recon' && (targetStat === 'investigation' || targetStat === 'utility')) {

--- a/src/test/agentHistory.training.reconciliation.test.ts
+++ b/src/test/agentHistory.training.reconciliation.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest'
+import { createAgent } from '../domain/agent/factory'
+import { normalizeAgent } from '../domain/agent/normalize'
+
+describe('agent history training event reconciliation', () => {
+  it('preserves legacy agent.training_started logs by reconciling program and numerics before validation', () => {
+    const agent = createAgent({
+      id: 'a_training_started_legacy',
+      name: 'Legacy Started',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-training-started-legacy',
+            schemaVersion: 1,
+            type: 'agent.training_started',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              queueId: 'queue-legacy',
+              agentId: agent.id,
+              agentName: agent.name,
+              trainingId: 'legacy-unknown-program',
+              trainingName: 'Legacy Course Name',
+              etaWeeks: -2.7,
+              fundingCost: Number.NaN,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.training_started',
+      payload: {
+        trainingId: 'combat-drills',
+        trainingName: 'Close-Quarters Drills',
+        etaWeeks: 1,
+        fundingCost: 0,
+      },
+    })
+  })
+
+  it('preserves legacy agent.training_completed logs by reconciling program before validation', () => {
+    const agent = createAgent({
+      id: 'a_training_completed_legacy',
+      name: 'Legacy Completed',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-training-completed-legacy',
+            schemaVersion: 1,
+            type: 'agent.training_completed',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              queueId: 'queue-legacy',
+              agentId: agent.id,
+              agentName: agent.name,
+              trainingId: 'legacy-unknown-program',
+              trainingName: 'Analysis Lab',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.training_completed',
+      payload: {
+        trainingId: 'analysis-lab',
+        trainingName: 'Analysis Lab',
+      },
+    })
+  })
+
+  it('preserves legacy agent.training_cancelled logs by clamping refund to program fundingCost', () => {
+    const agent = createAgent({
+      id: 'a_training_cancelled_legacy',
+      name: 'Legacy Cancelled',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-training-cancelled-legacy',
+            schemaVersion: 1,
+            type: 'agent.training_cancelled',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              trainingId: 'combat-drills',
+              trainingName: 'Close-Quarters Drills',
+              refund: 999.8,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(1)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.training_cancelled',
+      payload: {
+        trainingId: 'combat-drills',
+        trainingName: 'Close-Quarters Drills',
+        refund: 10,
+      },
+    })
+  })
+
+  it('preserves numeric-string training fields when reconciling before validation', () => {
+    const agent = createAgent({
+      id: 'a_training_string',
+      name: 'String Training',
+      role: 'investigator',
+      baseStats: { combat: 20, investigation: 50, utility: 30, social: 25 },
+      abilities: [],
+      tags: [],
+      relationships: {},
+      fatigue: 0,
+      status: 'active',
+    })
+
+    const normalized = normalizeAgent({
+      ...agent,
+      history: {
+        ...agent.history!,
+        logs: [
+          {
+            id: 'evt-training-started-string',
+            schemaVersion: 1,
+            type: 'agent.training_started',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.000Z',
+            payload: {
+              week: 2,
+              queueId: 'queue-string',
+              agentId: agent.id,
+              agentName: agent.name,
+              trainingId: 'combat-drills',
+              trainingName: 'Close-Quarters Drills',
+              etaWeeks: '2.9',
+              fundingCost: '7.1',
+            },
+          },
+          {
+            id: 'evt-training-cancelled-string',
+            schemaVersion: 1,
+            type: 'agent.training_cancelled',
+            sourceSystem: 'agent',
+            timestamp: '2042-01-08T00:00:00.001Z',
+            payload: {
+              week: 2,
+              agentId: agent.id,
+              agentName: agent.name,
+              trainingId: 'combat-drills',
+              trainingName: 'Close-Quarters Drills',
+              refund: '4.8',
+            },
+          },
+        ],
+      },
+    })
+
+    expect(normalized.history?.logs).toHaveLength(2)
+    expect(normalized.history?.logs[0]).toMatchObject({
+      type: 'agent.training_started',
+      payload: {
+        etaWeeks: 2,
+        fundingCost: 7,
+      },
+    })
+    expect(normalized.history?.logs[1]).toMatchObject({
+      type: 'agent.training_cancelled',
+      payload: {
+        refund: 4,
+      },
+    })
+  })
+})

--- a/src/test/agentHistory.training.reconciliation.test.ts
+++ b/src/test/agentHistory.training.reconciliation.test.ts
@@ -101,7 +101,7 @@ describe('agent history training event reconciliation', () => {
     })
   })
 
-  it('preserves legacy agent.training_cancelled logs by clamping refund to program fundingCost', () => {
+  it('preserves legacy agent.training_cancelled logs with refund above catalog base fundingCost', () => {
     const agent = createAgent({
       id: 'a_training_cancelled_legacy',
       name: 'Legacy Cancelled',
@@ -144,7 +144,7 @@ describe('agent history training event reconciliation', () => {
       payload: {
         trainingId: 'combat-drills',
         trainingName: 'Close-Quarters Drills',
-        refund: 10,
+        refund: 999,
       },
     })
   })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -641,4 +641,129 @@ describe('event payload validation coverage', () => {
       expect(validation.success).toBe(false)
     }
   )
+
+  it('accepts consistent agent.training_started payloads', () => {
+    const validation = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+    })
+
+    expect(validation.success).toBe(true)
+  })
+
+  it('accepts consistent agent.training_completed payloads', () => {
+    const validation = validateOperationEventPayload('agent.training_completed', {
+      ...minimalOperationEventPayloads['agent.training_completed'],
+    })
+
+    expect(validation.success).toBe(true)
+  })
+
+  it('accepts consistent agent.training_cancelled payloads', () => {
+    const validation = validateOperationEventPayload('agent.training_cancelled', {
+      ...minimalOperationEventPayloads['agent.training_cancelled'],
+    })
+
+    expect(validation.success).toBe(true)
+  })
+
+  it('rejects agent.training_started payloads with non-finite numerics', () => {
+    const nanEta = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      etaWeeks: Number.NaN,
+    })
+    const infiniteFunding = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      fundingCost: Number.POSITIVE_INFINITY,
+    })
+
+    expect(nanEta.success).toBe(false)
+    expect(infiniteFunding.success).toBe(false)
+  })
+
+  it('rejects agent.training_started payloads with negative or zero etaWeeks', () => {
+    const negative = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      etaWeeks: -1,
+    })
+    const zero = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      etaWeeks: 0,
+    })
+
+    expect(negative.success).toBe(false)
+    expect(zero.success).toBe(false)
+  })
+
+  it('rejects agent.training_started payloads with negative fundingCost', () => {
+    const validation = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      fundingCost: -1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.training_started payloads with fractional numerics', () => {
+    const fractionalEta = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      etaWeeks: 1.5,
+    })
+    const fractionalFunding = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      fundingCost: 2.5,
+    })
+
+    expect(fractionalEta.success).toBe(false)
+    expect(fractionalFunding.success).toBe(false)
+  })
+
+  it('rejects agent.training_started payloads with blank trainingId', () => {
+    const validation = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      trainingId: '',
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.training_cancelled payloads with non-finite refund', () => {
+    const nanRefund = validateOperationEventPayload('agent.training_cancelled', {
+      ...minimalOperationEventPayloads['agent.training_cancelled'],
+      refund: Number.NaN,
+    })
+    const infiniteRefund = validateOperationEventPayload('agent.training_cancelled', {
+      ...minimalOperationEventPayloads['agent.training_cancelled'],
+      refund: Number.POSITIVE_INFINITY,
+    })
+
+    expect(nanRefund.success).toBe(false)
+    expect(infiniteRefund.success).toBe(false)
+  })
+
+  it('rejects agent.training_cancelled payloads with negative refund', () => {
+    const validation = validateOperationEventPayload('agent.training_cancelled', {
+      ...minimalOperationEventPayloads['agent.training_cancelled'],
+      refund: -1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.training_cancelled payloads with fractional refund', () => {
+    const validation = validateOperationEventPayload('agent.training_cancelled', {
+      ...minimalOperationEventPayloads['agent.training_cancelled'],
+      refund: 1.5,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects agent.training_completed payloads with blank trainingName', () => {
+    const validation = validateOperationEventPayload('agent.training_completed', {
+      ...minimalOperationEventPayloads['agent.training_completed'],
+      trainingName: '',
+    })
+
+    expect(validation.success).toBe(false)
+  })
 })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -726,6 +726,25 @@ describe('event payload validation coverage', () => {
     expect(validation.success).toBe(false)
   })
 
+  it('rejects agent.training_started payloads with whitespace-only trainingId or trainingName', () => {
+    const blankId = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      trainingId: '   ',
+    })
+    const blankName = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      trainingName: '   ',
+    })
+    const untrimmedId = validateOperationEventPayload('agent.training_started', {
+      ...minimalOperationEventPayloads['agent.training_started'],
+      trainingId: ' combat-drills ',
+    })
+
+    expect(blankId.success).toBe(false)
+    expect(blankName.success).toBe(false)
+    expect(untrimmedId.success).toBe(false)
+  })
+
   it('rejects agent.training_cancelled payloads with non-finite refund', () => {
     const nanRefund = validateOperationEventPayload('agent.training_cancelled', {
       ...minimalOperationEventPayloads['agent.training_cancelled'],


### PR DESCRIPTION
﻿## Linear

- **Slice issue:** SPE-2657 — https://linear.app/spectranoir/issue/SPE-2657/harden-agenttraining-started-training-completed-training-cancelled
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened agent.training_started / training_completed / training_cancelled schemas (finite int etaWeeks/fundingCost/refund; nonblank trainingId/name)
- Moved reconcileTrainingEventProgram + started/completed/cancelled field helpers into domain; hydrate + agent-history sanitize reconcile before validate
- Validation + history reconciliation tests; slice doc

## Docs updated

- planning/spe-2657-harden-agent-training-event-validation-slice.md

## Parent status

- none (standalone follow-on)

## Scope boundary

- Strict schema + tests only for those three training event types; no UI/feed; no other event schemas

## Validation

- [x] Targeted tests: events.validation.test.ts, agentHistory.training.reconciliation.test.ts, runTransfer training hydrate cases
- [x] Lint / verify: npm run lint --quiet

## Screenshots (UI only)

<!-- Omit for domain-only changes -->

## Follow-ups

<!-- Remaining slices or known gaps -->

## Linear updated

- [ ] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)
