### PR TITLE
SPE-2659: Harden production.queue_started / queue_completed numeric validation

### DIFF
--- a/planning/spe-2659-harden-production-queue-event-validation-slice.md
+++ b/planning/spe-2659-harden-production-queue-event-validation-slice.md
@@ -1,0 +1,36 @@
+# SPE-2659 — Harden production.queue_started / queue_completed numeric consistency validation
+
+**Linear:** [SPE-2659](https://linear.app/spectranoir/issue/SPE-2659/harden-productionqueue-started-queue-completed-numeric-consistency)  
+**Branch:** `jamesdyedbq/spe-2659-harden-productionqueue_started-queue_completed-numeric`
+
+## Goal
+
+Reject inconsistent `production.queue_started` / `production.queue_completed` payloads at the operation-event validation boundary so `etaWeeks` / `fundingCost` / `outputQuantity` cannot drift past producers.
+
+## Scope
+
+- Harden the two production queue schemas in `src/domain/events/eventValidation.ts`
+- Shared `reconcileProductionQueueStartedFields` / `reconcileProductionQueueCompletedFields` (SPE-2651–2657 pattern); hydrate sanitize reconciles before validate
+- Add targeted validation + hydrate preservation tests
+
+## Out of scope
+
+- `agent.training_*` / `instructor_*` / `relationship_changed` / `betrayed` / `promoted` / `progression.xp_gained` (SPE-2651–2657 — shipped)
+- Broader event-schema hardening for unrelated types
+- UI / feed rendering
+- Catalog membership at validate (deferred from SPE-2657 — optional/low priority)
+
+## Acceptance
+
+- Finite positive integer `etaWeeks` (>= 1) on started
+- Finite nonnegative integer `fundingCost` on started and completed
+- Finite positive integer `outputQuantity` (>= 1) on started and completed
+- Reject non-finite / negative / fractional numerics
+- Invalid cases fail; valid production and minimal/producer fixtures pass
+- Legacy hydrate production events preserved when reconcile runs first (scaled fundingCost not rewritten to catalog/market bands)
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Catalog membership / id↔name consistency at validate | follow-on if needed | Acceptance is numerics; hydrate already reconciles known recipes. Producer catalog checks would couple schema to `productionCatalog`. |

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -10229,6 +10229,68 @@ describe('runTransfer import sanitization (326-332)', () => {
       ).toBe(false)
     })
 
+    it('SPE-2659 reconciles production queue numerics and preserves scaled fundingCost', () => {
+      const fallback = createStartingState()
+      const recipe = getProductionRecipe('ward-seals')!
+      const scaledFundingCost = recipe.baseFundingCost * 3
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-production-started-2659',
+            type: 'production.queue_started',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              queueId: 'q-2659',
+              queueName: 'Queue',
+              recipeId: 'ward-seals',
+              outputId: 'stale-output',
+              outputName: 'Stale Output',
+              outputQuantity: -2.7,
+              etaWeeks: 0,
+              fundingCost: scaledFundingCost,
+              inputMaterials: [],
+            },
+          },
+          {
+            id: 'evt-production-completed-2659',
+            type: 'production.queue_completed',
+            timestamp: buildOperationEventTimestamp(2, 1),
+            payload: {
+              week: 2,
+              queueId: 'q-2659',
+              queueName: 'Queue',
+              recipeId: 'ward-seals',
+              outputId: 'stale-output',
+              outputName: 'Stale Output',
+              outputQuantity: Number.NaN,
+              fundingCost: Number.NaN,
+              inputMaterials: [],
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events).toHaveLength(2)
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        recipeId: 'ward-seals',
+        outputId: recipe.outputItemId,
+        outputName: recipe.outputItemName,
+        outputQuantity: 1,
+        etaWeeks: 1,
+        fundingCost: scaledFundingCost,
+      })
+      expect(hydrated.events[1]?.payload).toMatchObject({
+        recipeId: 'ward-seals',
+        outputId: recipe.outputItemId,
+        outputName: recipe.outputItemName,
+        outputQuantity: 1,
+        fundingCost: 0,
+      })
+    })
+
     it('510b keeps only catalog-backed nonnegative integer material rows for legacy unknown-recipe production events', () => {
       const fallback = createStartingState()
 

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -10266,7 +10266,7 @@ describe('runTransfer import sanitization (326-332)', () => {
               outputId: 'stale-output',
               outputName: 'Stale Output',
               outputQuantity: Number.NaN,
-              fundingCost: Number.NaN,
+              fundingCost: scaledFundingCost,
               inputMaterials: [],
             },
           },
@@ -10287,7 +10287,7 @@ describe('runTransfer import sanitization (326-332)', () => {
         outputId: recipe.outputItemId,
         outputName: recipe.outputItemName,
         outputQuantity: 1,
-        fundingCost: 0,
+        fundingCost: scaledFundingCost,
       })
     })
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -12,6 +12,10 @@ import {
 } from '../../data/production'
 import { getTrainingProgram } from '../../data/training'
 import {
+  reconcileProductionQueueCompletedFields,
+  reconcileProductionQueueStartedFields,
+} from '../../domain/sim/production'
+import {
   reconcileAgentTrainingCancelledFields,
   reconcileAgentTrainingCompletedFields,
   reconcileAgentTrainingStartedFields,
@@ -1364,38 +1368,6 @@ function reconcileMarketTotalPrice(
   const sanitized = sanitizeInteger(totalPrice as number | undefined, expected, 0)
 
   return sanitized === expected ? sanitized : expected
-}
-
-function reconcileProductionEventRecipeOutput(
-  recipeIdValue: unknown,
-  outputIdValue: unknown,
-  outputNameValue: unknown
-): { recipeId: string; outputId: string; outputName: string } {
-  const recipeById =
-    typeof recipeIdValue === 'string' && getProductionRecipe(recipeIdValue)
-      ? getProductionRecipe(recipeIdValue)
-      : undefined
-  const recipe = recipeById ?? undefined
-
-  if (!recipe) {
-    const fallbackOutputId = typeof outputIdValue === 'string' ? outputIdValue : 'output-1'
-    const fallbackOutputName =
-      typeof outputNameValue === 'string' && outputNameValue.trim().length > 0
-        ? outputNameValue.trim()
-        : (inventoryItemLabels[fallbackOutputId] ?? 'Output 1')
-
-    return {
-      recipeId: typeof recipeIdValue === 'string' ? recipeIdValue : 'recipe-1',
-      outputId: fallbackOutputId,
-      outputName: fallbackOutputName,
-    }
-  }
-
-  return {
-    recipeId: recipe.recipeId,
-    outputId: recipe.outputItemId,
-    outputName: recipe.outputItemName,
-  }
 }
 
 function sanitizeOperationEventMarketProcurementAllocation(value: unknown) {
@@ -7989,11 +7961,7 @@ function sanitizeOperationEvents(
 
       case 'production.queue_started':
         {
-          const productionOutput = reconcileProductionEventRecipeOutput(
-            payload.recipeId,
-            payload.outputId,
-            payload.outputName
-          )
+          const production = reconcileProductionQueueStartedFields(payload)
 
           nextEvents.push(
             migrateOperationEventToCurrentSchema({
@@ -8004,12 +7972,12 @@ function sanitizeOperationEvents(
                   typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
                 queueName:
                   typeof payload.queueName === 'string' ? payload.queueName : `Queue ${index + 1}`,
-                recipeId: productionOutput.recipeId,
-                outputId: productionOutput.outputId,
-                outputName: productionOutput.outputName,
-                outputQuantity: sanitizeInteger(payload.outputQuantity as number | undefined, 1, 1),
-                etaWeeks: sanitizeInteger(payload.etaWeeks as number | undefined, 1, 0),
-                fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
+                recipeId: production.recipeId,
+                outputId: production.outputId,
+                outputName: production.outputName,
+                outputQuantity: production.outputQuantity,
+                etaWeeks: production.etaWeeks,
+                fundingCost: production.fundingCost,
                 inputMaterials: sanitizeOperationEventProductionInputMaterials(payload),
               },
             })
@@ -8019,11 +7987,7 @@ function sanitizeOperationEvents(
 
       case 'production.queue_completed':
         {
-          const productionOutput = reconcileProductionEventRecipeOutput(
-            payload.recipeId,
-            payload.outputId,
-            payload.outputName
-          )
+          const production = reconcileProductionQueueCompletedFields(payload)
 
           nextEvents.push(
             migrateOperationEventToCurrentSchema({
@@ -8034,11 +7998,11 @@ function sanitizeOperationEvents(
                   typeof payload.queueId === 'string' ? payload.queueId : `queue-${index + 1}`,
                 queueName:
                   typeof payload.queueName === 'string' ? payload.queueName : `Queue ${index + 1}`,
-                recipeId: productionOutput.recipeId,
-                outputId: productionOutput.outputId,
-                outputName: productionOutput.outputName,
-                outputQuantity: sanitizeInteger(payload.outputQuantity as number | undefined, 1, 1),
-                fundingCost: sanitizeInteger(payload.fundingCost as number | undefined, 0, 0),
+                recipeId: production.recipeId,
+                outputId: production.outputId,
+                outputName: production.outputName,
+                outputQuantity: production.outputQuantity,
+                fundingCost: production.fundingCost,
                 inputMaterials: sanitizeOperationEventProductionInputMaterials(payload),
               },
             })

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -511,9 +511,9 @@ const productionQueueStartedSchema = z
     recipeId: z.string(),
     outputId: z.string(),
     outputName: z.string(),
-    outputQuantity: z.number(),
-    etaWeeks: z.number(),
-    fundingCost: z.number(),
+    outputQuantity: finitePositiveIntSchema,
+    etaWeeks: finitePositiveIntSchema,
+    fundingCost: finiteNonNegativeIntSchema,
     inputMaterials: z.array(materialRequirementSchema),
   })
   .strict()
@@ -526,8 +526,8 @@ const productionQueueCompletedSchema = z
     recipeId: z.string(),
     outputId: z.string(),
     outputName: z.string(),
-    outputQuantity: z.number(),
-    fundingCost: z.number(),
+    outputQuantity: finitePositiveIntSchema,
+    fundingCost: finiteNonNegativeIntSchema,
     inputMaterials: z.array(materialRequirementSchema),
   })
   .strict()

--- a/src/domain/sim/production.ts
+++ b/src/domain/sim/production.ts
@@ -18,11 +18,119 @@ import {
   hasRecipeMaterialStock,
   getProductionRecipe,
   getMarketPressureLabel,
+  inventoryItemLabels,
   rollNextMarket,
 } from '../../data/production'
 
 function nextQueueId(state: GameState) {
   return `queue-${state.week}-${state.productionQueue.length + 1}-${state.events.length + 1}`
+}
+
+function coerceFiniteNumber(value: unknown, fallback: number) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed)
+
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+    }
+  }
+
+  return fallback
+}
+
+/** Hydration: resolve recipeId/output against catalog (id match, else preserve legacy ids/names). */
+export function reconcileProductionEventRecipeOutput(
+  recipeIdValue: unknown,
+  outputIdValue: unknown,
+  outputNameValue: unknown
+): { recipeId: string; outputId: string; outputName: string } {
+  const recipeById =
+    typeof recipeIdValue === 'string' && getProductionRecipe(recipeIdValue)
+      ? getProductionRecipe(recipeIdValue)
+      : undefined
+  const recipe = recipeById ?? undefined
+
+  if (!recipe) {
+    const fallbackOutputId = typeof outputIdValue === 'string' ? outputIdValue : 'output-1'
+    const fallbackOutputName =
+      typeof outputNameValue === 'string' && outputNameValue.trim().length > 0
+        ? outputNameValue.trim()
+        : (inventoryItemLabels[fallbackOutputId] ?? 'Output 1')
+
+    return {
+      recipeId: typeof recipeIdValue === 'string' ? recipeIdValue : 'recipe-1',
+      outputId: fallbackOutputId,
+      outputName: fallbackOutputName,
+    }
+  }
+
+  return {
+    recipeId: recipe.recipeId,
+    outputId: recipe.outputItemId,
+    outputName: recipe.outputItemName,
+  }
+}
+
+/**
+ * Hydration: catalog recipe output + finite positive etaWeeks/outputQuantity + nonnegative fundingCost.
+ * Does not rewrite fundingCost to catalog/market bands (scaled costs must survive).
+ */
+export function reconcileProductionQueueStartedFields(payload: {
+  recipeId?: unknown
+  outputId?: unknown
+  outputName?: unknown
+  outputQuantity?: unknown
+  etaWeeks?: unknown
+  fundingCost?: unknown
+}) {
+  const productionOutput = reconcileProductionEventRecipeOutput(
+    payload.recipeId,
+    payload.outputId,
+    payload.outputName
+  )
+
+  return {
+    recipeId: productionOutput.recipeId,
+    outputId: productionOutput.outputId,
+    outputName: productionOutput.outputName,
+    outputQuantity: Math.max(1, Math.trunc(coerceFiniteNumber(payload.outputQuantity, 1))),
+    etaWeeks: Math.max(1, Math.trunc(coerceFiniteNumber(payload.etaWeeks, 1))),
+    fundingCost: Math.max(0, Math.trunc(coerceFiniteNumber(payload.fundingCost, 0))),
+  }
+}
+
+/**
+ * Hydration: catalog recipe output + finite positive outputQuantity + nonnegative fundingCost.
+ * Does not rewrite fundingCost to catalog/market bands (scaled costs must survive).
+ */
+export function reconcileProductionQueueCompletedFields(payload: {
+  recipeId?: unknown
+  outputId?: unknown
+  outputName?: unknown
+  outputQuantity?: unknown
+  fundingCost?: unknown
+}) {
+  const productionOutput = reconcileProductionEventRecipeOutput(
+    payload.recipeId,
+    payload.outputId,
+    payload.outputName
+  )
+
+  return {
+    recipeId: productionOutput.recipeId,
+    outputId: productionOutput.outputId,
+    outputName: productionOutput.outputName,
+    outputQuantity: Math.max(1, Math.trunc(coerceFiniteNumber(payload.outputQuantity, 1))),
+    fundingCost: Math.max(0, Math.trunc(coerceFiniteNumber(payload.fundingCost, 0))),
+  }
 }
 
 export function queueFabrication(state: GameState, recipeId: string): GameState {

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -785,4 +785,119 @@ describe('event payload validation coverage', () => {
 
     expect(validation.success).toBe(false)
   })
+
+  it('accepts consistent production.queue_started payloads', () => {
+    const validation = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+    })
+
+    expect(validation.success).toBe(true)
+  })
+
+  it('accepts consistent production.queue_completed payloads', () => {
+    const validation = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+    })
+
+    expect(validation.success).toBe(true)
+  })
+
+  it('rejects production.queue_started payloads with non-finite numerics', () => {
+    const nanEta = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      etaWeeks: Number.NaN,
+    })
+    const infiniteFunding = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      fundingCost: Number.POSITIVE_INFINITY,
+    })
+    const nanQuantity = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      outputQuantity: Number.NaN,
+    })
+
+    expect(nanEta.success).toBe(false)
+    expect(infiniteFunding.success).toBe(false)
+    expect(nanQuantity.success).toBe(false)
+  })
+
+  it('rejects production.queue_started payloads with negative or zero etaWeeks', () => {
+    const negative = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      etaWeeks: -1,
+    })
+    const zero = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      etaWeeks: 0,
+    })
+
+    expect(negative.success).toBe(false)
+    expect(zero.success).toBe(false)
+  })
+
+  it('rejects production.queue_started payloads with negative fundingCost', () => {
+    const validation = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      fundingCost: -1,
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects production.queue_started payloads with zero or negative outputQuantity', () => {
+    const zero = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      outputQuantity: 0,
+    })
+    const negative = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      outputQuantity: -2,
+    })
+
+    expect(zero.success).toBe(false)
+    expect(negative.success).toBe(false)
+  })
+
+  it('rejects production.queue_started payloads with fractional numerics', () => {
+    const fractionalEta = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      etaWeeks: 1.5,
+    })
+    const fractionalFunding = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      fundingCost: 2.5,
+    })
+    const fractionalQuantity = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      outputQuantity: 1.25,
+    })
+
+    expect(fractionalEta.success).toBe(false)
+    expect(fractionalFunding.success).toBe(false)
+    expect(fractionalQuantity.success).toBe(false)
+  })
+
+  it('rejects production.queue_completed payloads with non-finite or invalid numerics', () => {
+    const nanFunding = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      fundingCost: Number.NaN,
+    })
+    const negativeFunding = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      fundingCost: -1,
+    })
+    const fractionalQuantity = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      outputQuantity: 0.5,
+    })
+    const zeroQuantity = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      outputQuantity: 0,
+    })
+
+    expect(nanFunding.success).toBe(false)
+    expect(negativeFunding.success).toBe(false)
+    expect(fractionalQuantity.success).toBe(false)
+    expect(zeroQuantity.success).toBe(false)
+  })
 })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -882,9 +882,17 @@ describe('event payload validation coverage', () => {
       ...minimalOperationEventPayloads['production.queue_completed'],
       fundingCost: Number.NaN,
     })
+    const infiniteQuantity = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      outputQuantity: Number.POSITIVE_INFINITY,
+    })
     const negativeFunding = validateOperationEventPayload('production.queue_completed', {
       ...minimalOperationEventPayloads['production.queue_completed'],
       fundingCost: -1,
+    })
+    const fractionalFunding = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      fundingCost: 2.5,
     })
     const fractionalQuantity = validateOperationEventPayload('production.queue_completed', {
       ...minimalOperationEventPayloads['production.queue_completed'],
@@ -894,10 +902,17 @@ describe('event payload validation coverage', () => {
       ...minimalOperationEventPayloads['production.queue_completed'],
       outputQuantity: 0,
     })
+    const negativeQuantity = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      outputQuantity: -3,
+    })
 
     expect(nanFunding.success).toBe(false)
+    expect(infiniteQuantity.success).toBe(false)
     expect(negativeFunding.success).toBe(false)
+    expect(fractionalFunding.success).toBe(false)
     expect(fractionalQuantity.success).toBe(false)
     expect(zeroQuantity.success).toBe(false)
+    expect(negativeQuantity.success).toBe(false)
   })
 })


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2659 — https://linear.app/spectranoir/issue/SPE-2659/harden-productionqueue-started-queue-completed-numeric-consistency
- **Parent issue (if any):** none — same-class follow-on after SPE-2657; backlog primary was none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened `production.queue_started` / `production.queue_completed` schemas: finite positive `etaWeeks` / `outputQuantity`, finite nonnegative `fundingCost`
- Shared `reconcileProductionQueueStartedFields` / `reconcileProductionQueueCompletedFields` used by hydrate sanitize (recipe output + numerics; scaled fundingCost preserved)
- Validation + hydrate preservation tests; slice doc

## Docs updated

- `planning/spe-2659-harden-production-queue-event-validation-slice.md`

## Parent status

- No parent umbrella — slice stands alone (related to SPE-2651–2657 pattern)

## Scope boundary

- Strict schema + tests only for those two production queue event types
- Does not harden training / instructor / relationship / betrayal / promoted / xp_gained (shipped)
- Does not expand catalog membership at validate (deferred, optional)

## Validation

- [x] Targeted tests: events.validation (production), events.producerValidation (production), runTransfer hydrate SPE-2659/510
- [x] Lint: eslint on touched source files

## Screenshots (UI only)

<!-- Omit for domain-only changes -->

## Follow-ups

- Catalog membership at validate remains optional/low priority (SPE-2657 deferred)

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)

Made with [Cursor](https://cursor.com)