### PR TITLE
SPE-2660: Harden market.shifted numeric + pressure/multiplier consistency

### DIFF
--- a/planning/spe-2660-harden-market-shifted-validation-slice.md
+++ b/planning/spe-2660-harden-market-shifted-validation-slice.md
@@ -1,0 +1,36 @@
+# SPE-2660 — Harden market.shifted numeric + pressure/multiplier consistency validation
+
+**Linear:** [SPE-2660](https://linear.app/spectranoir/issue/SPE-2660/harden-marketshifted-numeric-pressuremultiplier-consistency-validation)  
+**Branch:** `jamesdyedbq/spe-2660-harden-marketshifted-numeric-pressuremultiplier-consistency`
+
+## Goal
+
+Reject inconsistent `market.shifted` payloads at the operation-event validation boundary so `costMultiplier` cannot drift from the stated `pressure` band (canonical multipliers).
+
+## Scope
+
+- Harden `marketShiftedSchema` in `src/domain/events/eventValidation.ts`
+- Shared `reconcileMarketShiftedFields` in `src/domain/market.ts` (SPE-2651–2659 reconcile-before-validate); hydrate sanitize reconciles before validate
+- Add targeted validation + hydrate preservation tests
+
+## Out of scope
+
+- `production.queue_*` / `agent.training_*` / instructor / relationship / betrayal / promoted / progression (SPE-2651–2659 — shipped)
+- Broader `market.transaction_*` schemas
+- UI / feed rendering
+- Catalog membership at validate (SPE-2657/2659 deferred — optional/low priority)
+
+## Acceptance
+
+- Finite nonnegative `costMultiplier`
+- `costMultiplier` equals canonical multiplier for `pressure` (`tight` → 1.15, `stable` → 1, `discounted` → 0.9)
+- Reject non-finite / negative / out-of-band / pressure-inconsistent multipliers
+- Invalid cases fail; valid market.shifted and minimal/producer fixtures pass
+- Legacy hydrate market.shifted events preserved/reconciled when reconcile runs first (same policy as today)
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Catalog membership / featuredRecipeId↔name consistency at validate | follow-on if needed | Acceptance is numerics + pressure↔multiplier; hydrate already reconciles catalog ids/names. Producer catalog checks would couple schema to `productionCatalog`. |
+| Broader `market.transaction_*` schema hardening | follow-on if needed | Out of slice boundary; backlog primary remains none. |

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -152,7 +152,6 @@ import {
   type GameConfig,
   type GameState,
   type Id,
-  type MarketPressure,
   type MarketState,
   type MissionResolutionKind,
   type MissionRewardBreakdown,
@@ -186,8 +185,7 @@ import {
 } from '../../domain/procurementEmergencyAuthority'
 import { normalizeInstitutionKeyForAudit } from '../../domain/procurementEmergencyInstitution'
 import {
-  getCanonicalMarketCostMultiplier,
-  sanitizeFeaturedRecipeId,
+  reconcileMarketShiftedFields,
   sanitizePersistedMarketState,
 } from '../../domain/market'
 import {
@@ -367,7 +365,6 @@ const INFILTRATION_COVER_ROLES = [
   'official_inspector',
 ] as const
 const CONCEALMENT_MODES = ['hidden', 'displaced'] as const
-const MARKET_PRESSURES: MarketPressure[] = ['discounted', 'stable', 'tight']
 const RECRUIT_CATEGORIES = [
   'agent',
   'staff',
@@ -2468,38 +2465,6 @@ function sanitizeOperationEventCaseKind(value: unknown): CaseKind {
 
 function sanitizeOperationEventCaseMode(value: unknown): CaseMode {
   return isOneOf(value, CASE_MODES) ? value : 'threshold'
-}
-
-/** Hydration 586–587: market.shifted catalog + canonical pressure multiplier (aligned with 454). */
-function reconcileMarketShiftedFields(
-  payload: Record<string, unknown>,
-  fallbackFeaturedRecipeId: string
-) {
-  const pressure = isOneOf(payload.pressure, MARKET_PRESSURES) ? payload.pressure : 'stable'
-  const featuredRecipeId = sanitizeFeaturedRecipeId(
-    payload.featuredRecipeId,
-    fallbackFeaturedRecipeId
-  )
-  const recipe = getProductionRecipe(featuredRecipeId)
-  const catalogName = recipe?.name ?? featuredRecipeId
-  const featuredRecipeName =
-    typeof payload.featuredRecipeName === 'string' &&
-    payload.featuredRecipeName.trim() === catalogName
-      ? payload.featuredRecipeName.trim()
-      : catalogName
-  const canonicalCostMultiplier = getCanonicalMarketCostMultiplier(pressure)
-  const boundedCostMultiplier = sanitizeFiniteDecimalPreservePrecision(
-    payload.costMultiplier as number | undefined,
-    canonicalCostMultiplier,
-    0.5,
-    2
-  )
-  const costMultiplier =
-    boundedCostMultiplier === canonicalCostMultiplier
-      ? boundedCostMultiplier
-      : canonicalCostMultiplier
-
-  return { featuredRecipeId, featuredRecipeName, pressure, costMultiplier }
 }
 
 /** Hydration 588: reconcile fallout tick outcome with risk and before/after metrics. */

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -1,5 +1,6 @@
 // Zod schemas for OperationEvent payloads and event validation utilities.
 import { z } from 'zod'
+import { getCanonicalMarketCostMultiplier } from '../market'
 import { getLevelForXp } from '../progression'
 import type { OperationEventType } from './types'
 
@@ -538,9 +539,19 @@ const marketShiftedSchema = z
     featuredRecipeId: z.string(),
     featuredRecipeName: z.string(),
     pressure: z.enum(['tight', 'stable', 'discounted']),
-    costMultiplier: z.number(),
+    costMultiplier: finiteNonNegativeNumberSchema,
   })
   .strict()
+  .superRefine((payload, context) => {
+    const canonicalCostMultiplier = getCanonicalMarketCostMultiplier(payload.pressure)
+    if (payload.costMultiplier !== canonicalCostMultiplier) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `costMultiplier must equal canonical multiplier for pressure (${canonicalCostMultiplier})`,
+        path: ['costMultiplier'],
+      })
+    }
+  })
 
 const marketTransactionListingResourceStatusSchema = z
   .object({

--- a/src/domain/market.ts
+++ b/src/domain/market.ts
@@ -1517,6 +1517,46 @@ export function sanitizeFeaturedRecipeId(value: unknown, fallbackRecipeId: strin
 }
 
 /**
+ * Hydration 586–587 / SPE-2660: catalog featured recipe + canonical pressure multiplier.
+ * Aligns with sanitizePersistedMarketState (SPE-454) and validateOperationEventPayload.
+ */
+export function reconcileMarketShiftedFields(
+  payload: {
+    featuredRecipeId?: unknown
+    featuredRecipeName?: unknown
+    pressure?: unknown
+    costMultiplier?: unknown
+  },
+  fallbackFeaturedRecipeId: string
+) {
+  const pressure = isMarketPressure(payload.pressure) ? payload.pressure : 'stable'
+  const featuredRecipeId = sanitizeFeaturedRecipeId(
+    payload.featuredRecipeId,
+    fallbackFeaturedRecipeId
+  )
+  const recipe = getProductionRecipe(featuredRecipeId)
+  const catalogName = recipe?.name ?? featuredRecipeId
+  const featuredRecipeName =
+    typeof payload.featuredRecipeName === 'string' &&
+    payload.featuredRecipeName.trim() === catalogName
+      ? payload.featuredRecipeName.trim()
+      : catalogName
+  const canonicalCostMultiplier = getCanonicalMarketCostMultiplier(pressure)
+  const boundedCostMultiplier = sanitizeMarketDecimal(
+    typeof payload.costMultiplier === 'number' ? payload.costMultiplier : undefined,
+    canonicalCostMultiplier,
+    0.5,
+    2
+  )
+  const costMultiplier =
+    boundedCostMultiplier === canonicalCostMultiplier
+      ? boundedCostMultiplier
+      : canonicalCostMultiplier
+
+  return { featuredRecipeId, featuredRecipeName, pressure, costMultiplier }
+}
+
+/**
  * SPE-446–448: normalize persisted market snapshots on import.
  * `listings` are derived at read time — strip any persisted copy (SPE-448).
  */

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -915,4 +915,73 @@ describe('event payload validation coverage', () => {
     expect(zeroQuantity.success).toBe(false)
     expect(negativeQuantity.success).toBe(false)
   })
+
+  it('accepts consistent market.shifted payloads for each pressure band', () => {
+    const stable = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      pressure: 'stable',
+      costMultiplier: 1,
+    })
+    const tight = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      pressure: 'tight',
+      costMultiplier: 1.15,
+    })
+    const discounted = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      pressure: 'discounted',
+      costMultiplier: 0.9,
+    })
+
+    expect(stable.success).toBe(true)
+    expect(tight.success).toBe(true)
+    expect(discounted.success).toBe(true)
+  })
+
+  it('rejects market.shifted payloads with non-finite or negative costMultiplier', () => {
+    const nan = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      costMultiplier: Number.NaN,
+    })
+    const infinite = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      costMultiplier: Number.POSITIVE_INFINITY,
+    })
+    const negative = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      costMultiplier: -0.1,
+    })
+
+    expect(nan.success).toBe(false)
+    expect(infinite.success).toBe(false)
+    expect(negative.success).toBe(false)
+  })
+
+  it('rejects market.shifted payloads with pressure-inconsistent costMultiplier', () => {
+    const stableMismatch = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      pressure: 'stable',
+      costMultiplier: 1.15,
+    })
+    const tightMismatch = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      pressure: 'tight',
+      costMultiplier: 0.9,
+    })
+    const discountedMismatch = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      pressure: 'discounted',
+      costMultiplier: 1,
+    })
+    const outOfBand = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      pressure: 'stable',
+      costMultiplier: 1.75,
+    })
+
+    expect(stableMismatch.success).toBe(false)
+    expect(tightMismatch.success).toBe(false)
+    expect(discountedMismatch.success).toBe(false)
+    expect(outOfBand.success).toBe(false)
+  })
 })


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2660 — https://linear.app/spectranoir/issue/SPE-2660/harden-marketshifted-numeric-pressuremultiplier-consistency-validation
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened `marketShiftedSchema`: finite nonnegative `costMultiplier` plus superRefine requiring canonical multiplier for `pressure` (tight 1.15 / stable 1 / discounted 0.9)
- Extracted shared `reconcileMarketShiftedFields` to `src/domain/market.ts`; hydrate still reconciles before validate
- Targeted validation tests for accept/reject cases; existing hydrate 586/587 coverage retained
- Slice doc `planning/spe-2660-harden-market-shifted-validation-slice.md`

## Docs updated

- `planning/spe-2660-harden-market-shifted-validation-slice.md`

## Parent status

- No parent; backlog primary remains none

## Scope boundary

- Strict schema + tests only for `market.shifted`
- Did not expand to `market.transaction_*`, production/training/agent event types, or UI/feed
- Catalog membership at validate deferred (SPE-2657/2659 optional/low)

## Validation

- [x] Targeted tests: `events.validation.test.ts` (market.shifted cases), `runTransfer.test.ts` hydrate 586/587, `sim.market.test.ts`
- [x] Lint: eslint on touched source files

## Follow-ups

- Catalog membership / featuredRecipeId↔name at validate (optional/low)
- Broader `market.transaction_*` schema hardening if needed later

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)