### PR TITLE
SPE-2661: Harden market.shifted catalog membership at validate

### DIFF
--- a/planning/spe-2660-harden-market-shifted-validation-slice.md
+++ b/planning/spe-2660-harden-market-shifted-validation-slice.md
@@ -32,5 +32,5 @@ Reject inconsistent `market.shifted` payloads at the operation-event validation 
 
 | Item | Owner | Why deferred |
 | --- | --- | --- |
-| Catalog membership / featuredRecipeId↔name consistency at validate | follow-on if needed | Acceptance is numerics + pressure↔multiplier; hydrate already reconciles catalog ids/names. Producer catalog checks would couple schema to `productionCatalog`. |
+| Catalog membership / featuredRecipeId↔name consistency at validate | [SPE-2661](https://linear.app/spectranoir/issue/SPE-2661/harden-marketshifted-catalog-membership-featuredrecipeidname) | Deferred from SPE-2660 numerics slice; follow-on owns strict membership + id↔name at validate. |
 | Broader `market.transaction_*` schema hardening | follow-on if needed | Out of slice boundary; backlog primary remains none. |

--- a/planning/spe-2661-harden-market-shifted-catalog-validation-slice.md
+++ b/planning/spe-2661-harden-market-shifted-catalog-validation-slice.md
@@ -1,0 +1,37 @@
+# SPE-2661 — Harden market.shifted catalog membership + featuredRecipeId↔name consistency
+
+**Linear:** [SPE-2661](https://linear.app/spectranoir/issue/SPE-2661/harden-marketshifted-catalog-membership-featuredrecipeidname)  
+**Branch:** `jamesdyedbq/spe-2661-harden-marketshifted-catalog-membership-featuredrecipeidname`
+
+## Goal
+
+Reject inconsistent `market.shifted` payloads at the operation-event validation boundary when `featuredRecipeId` is not in `productionCatalog`, or when `featuredRecipeName` does not match the catalog name for that id.
+
+## Scope
+
+- Harden `marketShiftedSchema` in `src/domain/events/eventValidation.ts` for catalog membership + id↔name consistency
+- Reuse `sanitizeFeaturedRecipeId` membership check + `getProductionRecipe` for catalog name
+- Intentional fixture update: minimal `market.shifted` uses catalog `ward-seals` (not opaque `recipe-min`)
+- Targeted validation tests; hydrate 586 phantom reconcile remains unchanged (reconcile-before-validate)
+
+## Out of scope
+
+- `market.transaction_*` schemas
+- Production / training / agent event types
+- UI / feed rendering
+- Broader catalog enforcement elsewhere
+
+## Acceptance
+
+- Reject unknown `featuredRecipeId` (not in `productionCatalog`)
+- Reject id/name mismatch when id is known (`featuredRecipeName.trim()` must equal catalog name)
+- Accept catalog-valid `market.shifted` payloads
+- Hydrate still reconciles phantoms as today (reconcile runs before validate)
+- Minimal/producer fixtures pass after intentional `market.shifted` fixture update
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Broader `market.transaction_*` schema hardening | follow-on if needed | Out of slice boundary; backlog primary remains none. |
+| Catalog membership on production.queue_* recipeId | follow-on if needed | Out of slice; production schemas remain opaque-id tolerant. |

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -1,6 +1,7 @@
 // Zod schemas for OperationEvent payloads and event validation utilities.
 import { z } from 'zod'
-import { getCanonicalMarketCostMultiplier } from '../market'
+import { getProductionRecipe } from '../../data/production'
+import { getCanonicalMarketCostMultiplier, sanitizeFeaturedRecipeId } from '../market'
 import { getLevelForXp } from '../progression'
 import type { OperationEventType } from './types'
 
@@ -543,6 +544,30 @@ const marketShiftedSchema = z
   })
   .strict()
   .superRefine((payload, context) => {
+    // SPE-2661: catalog membership + id↔name (reuse sanitizeFeaturedRecipeId membership).
+    if (
+      sanitizeFeaturedRecipeId(payload.featuredRecipeId, payload.featuredRecipeId) !==
+      payload.featuredRecipeId
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'featuredRecipeId must be a production catalog recipe id',
+        path: ['featuredRecipeId'],
+      })
+    } else {
+      const catalogName = getProductionRecipe(payload.featuredRecipeId)?.name
+      if (
+        typeof catalogName === 'string' &&
+        payload.featuredRecipeName.trim() !== catalogName
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `featuredRecipeName must match catalog name for featuredRecipeId (${catalogName})`,
+          path: ['featuredRecipeName'],
+        })
+      }
+    }
+
     const canonicalCostMultiplier = getCanonicalMarketCostMultiplier(payload.pressure)
     if (payload.costMultiplier !== canonicalCostMultiplier) {
       context.addIssue({

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -984,4 +984,36 @@ describe('event payload validation coverage', () => {
     expect(discountedMismatch.success).toBe(false)
     expect(outOfBand.success).toBe(false)
   })
+
+  it('rejects market.shifted payloads with unknown featuredRecipeId', () => {
+    const unknown = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      featuredRecipeId: 'phantom-recipe',
+      featuredRecipeName: 'Phantom Recipe',
+    })
+
+    expect(unknown.success).toBe(false)
+  })
+
+  it('rejects market.shifted payloads with featuredRecipeId/name mismatch', () => {
+    const mismatch = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      featuredRecipeId: 'ward-seals',
+      featuredRecipeName: 'Wrong Label',
+    })
+
+    expect(mismatch.success).toBe(false)
+  })
+
+  it('accepts market.shifted payloads with catalog-valid featured recipe id and name', () => {
+    const valid = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      featuredRecipeId: 'med-kits',
+      featuredRecipeName: 'Emergency Medkits',
+      pressure: 'stable',
+      costMultiplier: 1,
+    })
+
+    expect(valid.success).toBe(true)
+  })
 })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1013,7 +1013,15 @@ describe('event payload validation coverage', () => {
       pressure: 'stable',
       costMultiplier: 1,
     })
+    const trimmedName = validateOperationEventPayload('market.shifted', {
+      ...minimalOperationEventPayloads['market.shifted'],
+      featuredRecipeId: 'med-kits',
+      featuredRecipeName: '  Emergency Medkits  ',
+      pressure: 'stable',
+      costMultiplier: 1,
+    })
 
     expect(valid.success).toBe(true)
+    expect(trimmedName.success).toBe(true)
   })
 })

--- a/src/test/fixtures/minimalOperationEventPayloads.ts
+++ b/src/test/fixtures/minimalOperationEventPayloads.ts
@@ -338,8 +338,9 @@ export const minimalOperationEventPayloads = {
   },
   'market.shifted': {
     week: WEEK,
-    featuredRecipeId: 'recipe-min',
-    featuredRecipeName: 'Minimal Recipe',
+    // SPE-2661: validate requires productionCatalog membership (not opaque recipe-min).
+    featuredRecipeId: 'ward-seals',
+    featuredRecipeName: 'Ward Seal Batch',
     pressure: 'stable',
     costMultiplier: 1,
   },


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2661 — https://linear.app/spectranoir/issue/SPE-2661/harden-marketshifted-catalog-membership-featuredrecipeidname
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Harden `marketShiftedSchema`: reject unknown `featuredRecipeId` (not in `productionCatalog`) and reject `featuredRecipeName` when trim ≠ catalog name
- Reuse `sanitizeFeaturedRecipeId` membership + `getProductionRecipe` for name; hydrate reconcile-first unchanged
- Intentional minimal fixture update: `market.shifted` uses `ward-seals` / `Ward Seal Batch` (not opaque `recipe-min`)
- Validation tests for unknown id, name mismatch, and catalog-valid accept

## Docs updated

- `planning/spe-2661-harden-market-shifted-catalog-validation-slice.md` (new)
- `planning/spe-2660-harden-market-shifted-validation-slice.md` Deferred owner → SPE-2661

## Parent status

- No parent; backlog primary remains none

## Scope boundary

- Strict schema + tests only for `market.shifted` catalog checks
- Do not expand to `market.transaction_*` or production/training/agent schemas

## Validation

- [x] Targeted tests: `events.validation.test.ts`, `events.producerValidation.test.ts`, `eventFeedView.exhaustiveness.test.ts`, hydrate 586 market.shifted
- [x] Lint: eslint on touched sources

## Follow-ups

- Broader `market.transaction_*` schema hardening (deferred)
- Catalog membership on `production.queue_*` recipeId (deferred)
- Alternate high-priority outside validation chain: SPE-2658

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)

Made with [Cursor](https://cursor.com)