### PR TITLE
SPE-2662: Harden market.transaction_recorded numeric consistency at validate

### DIFF
--- a/planning/spe-2662-harden-market-transaction-validation-slice.md
+++ b/planning/spe-2662-harden-market-transaction-validation-slice.md
@@ -11,7 +11,7 @@ Reject inconsistent `market.transaction_recorded` payloads at the operation-even
 
 - Harden `marketTransactionRecordedSchema` in `src/domain/events/eventValidation.ts`
 - Finite positive ints for `quantity` / `bundleCount`; finite nonnegative for `unitPrice` / `totalPrice` (cents allowed); finite nonnegative int for `remainingAvailability`
-- `superRefine` consistency: `|totalPrice - unitPrice * quantity| <= 0.01` (quantity already includes bundles; do not multiply by `bundleCount`)
+- `superRefine` consistency: integer-cent drift `|round(totalPrice*100) - round(unitPrice*quantity*100)| <= bundleCount` (quantity already includes bundles; ~1¢/bundle rounding)
 - Keep hydrate reconcile-before-validate; do not change sanitize rewrite policy this slice
 - Targeted validation tests (multi-bundle, cent unitPrice, zero-price favor/obligation)
 
@@ -30,7 +30,7 @@ Hydrate `reconcileMarketTotalPrice` still uses `unitPrice * quantity * bundleCou
 ## Acceptance
 
 - Reject non-finite, negative, zero-quantity/bundle, and fractional qty/bundle/remainingAvailability
-- Reject `totalPrice` outside 1 cent of `unitPrice * quantity`
+- Reject `totalPrice` outside `bundleCount` cents of `unitPrice * quantity` (integer-cent compare)
 - Accept producer-valid multi-bundle and cent-`unitPrice` payloads; zero-price favor / obligation rows
 - Hydrate still runs before validate (runTransfer case 512 policy preserved this slice)
 - Do not break minimal/producer fixtures without intentional fixture update

--- a/planning/spe-2662-harden-market-transaction-validation-slice.md
+++ b/planning/spe-2662-harden-market-transaction-validation-slice.md
@@ -1,0 +1,39 @@
+# SPE-2662 — Harden market.transaction_* numeric + consistency validation
+
+**Linear:** [SPE-2662](https://linear.app/spectranoir/issue/SPE-2662/harden-markettransaction-numeric-consistency-validation)  
+**Branch:** `jamesdyedbq/spe-2662-harden-markettransaction-numeric-consistency-validation`
+
+## Goal
+
+Reject inconsistent `market.transaction_recorded` payloads at the operation-event validation boundary so quantity / bundle / price numerics cannot drift past producers, and `totalPrice` cannot disagree with `unitPrice * quantity * bundleCount`.
+
+## Scope
+
+- Harden `marketTransactionRecordedSchema` in `src/domain/events/eventValidation.ts`
+- Finite positive ints for `quantity` / `bundleCount`; finite nonnegative ints for `unitPrice` / `totalPrice` / `remainingAvailability`
+- `superRefine` consistency: `totalPrice === unitPrice * quantity * bundleCount` (matches hydrate `reconcileMarketTotalPrice` product)
+- Keep hydrate reconcile-before-validate; do not change sanitize rewrite policy
+- Targeted validation tests; hydrate runTransfer case 512 (zero qty/bundle + mismatched total) remains unchanged
+
+## Out of scope
+
+- Catalog membership on `production.queue_*` recipeId
+- Broader allocation / listing-resource-status numeric bounds at validate (hydrate SPE-2551/2552 already clamp)
+- Production / training / agent event types
+- UI / feed rendering
+- SPE-2658-style history sanitize (already shipped)
+
+## Acceptance
+
+- Reject non-finite, negative, zero-quantity/bundle, and fractional transaction numerics
+- Reject `totalPrice` that does not equal `unitPrice * quantity * bundleCount`
+- Accept producer-valid / minimal fixture payloads (including zero-price favor / obligation rows)
+- Hydrate still reconciles zero/mismatched totals before validate (runTransfer case 512 policy preserved)
+- Do not break minimal/producer fixtures without intentional fixture update
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Catalog membership on `production.queue_*` recipeId | follow-on if needed | Alternate SPE-2661 Deferred; production schemas remain opaque-id tolerant. |
+| Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this numeric/consistency slice. |

--- a/planning/spe-2662-harden-market-transaction-validation-slice.md
+++ b/planning/spe-2662-harden-market-transaction-validation-slice.md
@@ -5,15 +5,19 @@
 
 ## Goal
 
-Reject inconsistent `market.transaction_recorded` payloads at the operation-event validation boundary so quantity / bundle / price numerics cannot drift past producers, and `totalPrice` cannot disagree with `unitPrice * quantity * bundleCount`.
+Reject inconsistent `market.transaction_recorded` payloads at the operation-event validation boundary so quantity / bundle / price numerics cannot drift past producers, and `totalPrice` cannot disagree with producer semantics (`unitPrice * quantity` within 1 cent).
 
 ## Scope
 
 - Harden `marketTransactionRecordedSchema` in `src/domain/events/eventValidation.ts`
-- Finite positive ints for `quantity` / `bundleCount`; finite nonnegative ints for `unitPrice` / `totalPrice` / `remainingAvailability`
-- `superRefine` consistency: `totalPrice === unitPrice * quantity * bundleCount` (matches hydrate `reconcileMarketTotalPrice` product)
-- Keep hydrate reconcile-before-validate; do not change sanitize rewrite policy
-- Targeted validation tests; hydrate runTransfer case 512 (zero qty/bundle + mismatched total) remains unchanged
+- Finite positive ints for `quantity` / `bundleCount`; finite nonnegative for `unitPrice` / `totalPrice` (cents allowed); finite nonnegative int for `remainingAvailability`
+- `superRefine` consistency: `|totalPrice - unitPrice * quantity| <= 0.01` (quantity already includes bundles; do not multiply by `bundleCount`)
+- Keep hydrate reconcile-before-validate; do not change sanitize rewrite policy this slice
+- Targeted validation tests (multi-bundle, cent unitPrice, zero-price favor/obligation)
+
+## Deferred note on hydrate
+
+Hydrate `reconcileMarketTotalPrice` still uses `unitPrice * quantity * bundleCount`. That can disagree with multi-bundle producers; fixing hydrate formula is out of this validate-only slice.
 
 ## Out of scope
 
@@ -25,15 +29,16 @@ Reject inconsistent `market.transaction_recorded` payloads at the operation-even
 
 ## Acceptance
 
-- Reject non-finite, negative, zero-quantity/bundle, and fractional transaction numerics
-- Reject `totalPrice` that does not equal `unitPrice * quantity * bundleCount`
-- Accept producer-valid / minimal fixture payloads (including zero-price favor / obligation rows)
-- Hydrate still reconciles zero/mismatched totals before validate (runTransfer case 512 policy preserved)
+- Reject non-finite, negative, zero-quantity/bundle, and fractional qty/bundle/remainingAvailability
+- Reject `totalPrice` outside 1 cent of `unitPrice * quantity`
+- Accept producer-valid multi-bundle and cent-`unitPrice` payloads; zero-price favor / obligation rows
+- Hydrate still runs before validate (runTransfer case 512 policy preserved this slice)
 - Do not break minimal/producer fixtures without intentional fixture update
 
 ## Deferred
 
 | Item | Owner | Why deferred |
 | --- | --- | --- |
+| Align hydrate `reconcileMarketTotalPrice` with producer `unitPrice * quantity` | follow-on if needed | Validate-only slice; hydrate rewrite policy unchanged. |
 | Catalog membership on `production.queue_*` recipeId | follow-on if needed | Alternate SPE-2661 Deferred; production schemas remain opaque-id tolerant. |
 | Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this numeric/consistency slice. |

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -625,11 +625,11 @@ const marketTransactionRecordedSchema = z
     itemId: z.string(),
     itemName: z.string(),
     category: z.enum(['equipment', 'component', 'material']),
-    // SPE-2662: finite nonnegative/positive ints; hydrate reconciles before validate.
+    // SPE-2662: qty/bundle positive ints; prices finite nonnegative (cents allowed).
     quantity: finitePositiveIntSchema,
     bundleCount: finitePositiveIntSchema,
-    unitPrice: finiteNonNegativeIntSchema,
-    totalPrice: finiteNonNegativeIntSchema,
+    unitPrice: finiteNonNegativeNumberSchema,
+    totalPrice: finiteNonNegativeNumberSchema,
     remainingAvailability: finiteNonNegativeIntSchema,
     favorExchangeFactionId: z.string().optional(),
     favorExchangeFavorId: z.string().optional(),
@@ -643,12 +643,14 @@ const marketTransactionRecordedSchema = z
   })
   .strict()
   .superRefine((payload, context) => {
-    // Match hydrate reconcileMarketTotalPrice expected product (nonnegative ints).
-    const expectedTotalPrice = payload.unitPrice * payload.quantity * payload.bundleCount
-    if (payload.totalPrice !== expectedTotalPrice) {
+    // Producer semantics (sim/market): quantity already includes bundles; unitPrice is
+    // per-item (may be cents). totalPrice ≈ unitPrice * quantity within 1 cent.
+    // Do not multiply by bundleCount again.
+    const product = payload.unitPrice * payload.quantity
+    if (Math.abs(payload.totalPrice - product) > 0.01) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `totalPrice must equal unitPrice * quantity * bundleCount (${expectedTotalPrice})`,
+        message: `totalPrice must equal unitPrice * quantity within 1 cent (expected ~${product})`,
         path: ['totalPrice'],
       })
     }

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -644,13 +644,15 @@ const marketTransactionRecordedSchema = z
   .strict()
   .superRefine((payload, context) => {
     // Producer semantics (sim/market): quantity already includes bundles; unitPrice is
-    // per-item (may be cents). totalPrice ≈ unitPrice * quantity within 1 cent.
-    // Do not multiply by bundleCount again.
-    const product = payload.unitPrice * payload.quantity
-    if (Math.abs(payload.totalPrice - product) > 0.01) {
+    // per-item rounded to cents. Rounding can accumulate ~1¢ per bundle vs totalPrice.
+    // Compare in integer cents to avoid float edge cases (e.g. 8.33 * 9).
+    const productCents = Math.round(payload.unitPrice * payload.quantity * 100)
+    const totalCents = Math.round(payload.totalPrice * 100)
+    const maxDriftCents = Math.max(1, payload.bundleCount)
+    if (Math.abs(totalCents - productCents) > maxDriftCents) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `totalPrice must equal unitPrice * quantity within 1 cent (expected ~${product})`,
+        message: `totalPrice must equal unitPrice * quantity within ${maxDriftCents} cent(s) (expected ~${productCents / 100})`,
         path: ['totalPrice'],
       })
     }

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -648,6 +648,15 @@ const marketTransactionRecordedSchema = z
     // Compare in integer cents to avoid float edge cases (e.g. 8.33 * 9).
     const productCents = Math.round(payload.unitPrice * payload.quantity * 100)
     const totalCents = Math.round(payload.totalPrice * 100)
+    // Finite schema fields can still overflow the cent product to Infinity.
+    if (!Number.isFinite(productCents) || !Number.isFinite(totalCents)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'totalPrice / unitPrice*quantity must stay within finite cent precision',
+        path: ['totalPrice'],
+      })
+      return
+    }
     const maxDriftCents = Math.max(1, payload.bundleCount)
     if (Math.abs(totalCents - productCents) > maxDriftCents) {
       context.addIssue({

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -625,11 +625,12 @@ const marketTransactionRecordedSchema = z
     itemId: z.string(),
     itemName: z.string(),
     category: z.enum(['equipment', 'component', 'material']),
-    quantity: z.number(),
-    bundleCount: z.number(),
-    unitPrice: z.number(),
-    totalPrice: z.number(),
-    remainingAvailability: z.number(),
+    // SPE-2662: finite nonnegative/positive ints; hydrate reconciles before validate.
+    quantity: finitePositiveIntSchema,
+    bundleCount: finitePositiveIntSchema,
+    unitPrice: finiteNonNegativeIntSchema,
+    totalPrice: finiteNonNegativeIntSchema,
+    remainingAvailability: finiteNonNegativeIntSchema,
     favorExchangeFactionId: z.string().optional(),
     favorExchangeFavorId: z.string().optional(),
     favorExchangeLabel: z.string().optional(),
@@ -641,6 +642,17 @@ const marketTransactionRecordedSchema = z
     allocations: z.array(procurementAllocationSchema).optional(),
   })
   .strict()
+  .superRefine((payload, context) => {
+    // Match hydrate reconcileMarketTotalPrice expected product (nonnegative ints).
+    const expectedTotalPrice = payload.unitPrice * payload.quantity * payload.bundleCount
+    if (payload.totalPrice !== expectedTotalPrice) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `totalPrice must equal unitPrice * quantity * bundleCount (${expectedTotalPrice})`,
+        path: ['totalPrice'],
+      })
+    }
+  })
 
 const marketEmergencyGrayMarketWaiverGrantedSchema = z
   .object({

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1024,4 +1024,89 @@ describe('event payload validation coverage', () => {
     expect(valid.success).toBe(true)
     expect(trimmedName.success).toBe(true)
   })
+
+  it('accepts consistent market.transaction_recorded payloads', () => {
+    const validation = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+    })
+    const zeroPrice = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      action: 'favor_exchange',
+      unitPrice: 0,
+      totalPrice: 0,
+      favorExchangeFactionId: 'faction-min',
+      favorExchangeFavorId: 'favor-min',
+      favorExchangeLabel: 'Minimal favor',
+    })
+
+    expect(validation.success).toBe(true)
+    expect(zeroPrice.success).toBe(true)
+  })
+
+  it('rejects market.transaction_recorded payloads with non-finite or invalid numerics', () => {
+    const base = minimalOperationEventPayloads['market.transaction_recorded']
+    const nanQuantity = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      quantity: Number.NaN,
+    })
+    const infiniteUnitPrice = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      unitPrice: Number.POSITIVE_INFINITY,
+      totalPrice: Number.POSITIVE_INFINITY,
+    })
+    const negativeRemaining = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      remainingAvailability: -1,
+    })
+    const zeroQuantity = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      quantity: 0,
+      totalPrice: 0,
+    })
+    const zeroBundle = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      bundleCount: 0,
+      totalPrice: 0,
+    })
+    const fractionalQuantity = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      quantity: 1.5,
+      totalPrice: 15,
+    })
+    const negativeUnitPrice = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      unitPrice: -1,
+      totalPrice: -1,
+    })
+
+    expect(nanQuantity.success).toBe(false)
+    expect(infiniteUnitPrice.success).toBe(false)
+    expect(negativeRemaining.success).toBe(false)
+    expect(zeroQuantity.success).toBe(false)
+    expect(zeroBundle.success).toBe(false)
+    expect(fractionalQuantity.success).toBe(false)
+    expect(negativeUnitPrice.success).toBe(false)
+  })
+
+  it('rejects market.transaction_recorded payloads with totalPrice inconsistency', () => {
+    const mismatch = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      unitPrice: 10,
+      quantity: 1,
+      bundleCount: 1,
+      totalPrice: 999,
+    })
+    const productMismatch = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      unitPrice: 5,
+      quantity: 2,
+      bundleCount: 3,
+      totalPrice: 20,
+    })
+
+    expect(mismatch.success).toBe(false)
+    expect(mismatch.error).toMatch(/totalPrice must equal/)
+    expect(productMismatch.success).toBe(false)
+    expect(productMismatch.error).toMatch(/totalPrice must equal/)
+  })
 })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1029,7 +1029,7 @@ describe('event payload validation coverage', () => {
     const validation = validateOperationEventPayload('market.transaction_recorded', {
       ...minimalOperationEventPayloads['market.transaction_recorded'],
     })
-    const zeroPrice = validateOperationEventPayload('market.transaction_recorded', {
+    const zeroFavor = validateOperationEventPayload('market.transaction_recorded', {
       ...minimalOperationEventPayloads['market.transaction_recorded'],
       action: 'favor_exchange',
       unitPrice: 0,
@@ -1038,9 +1038,37 @@ describe('event payload validation coverage', () => {
       favorExchangeFavorId: 'favor-min',
       favorExchangeLabel: 'Minimal favor',
     })
+    const zeroObligation = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      action: 'callable_obligation',
+      unitPrice: 0,
+      totalPrice: 0,
+      callableObligationFactionId: 'faction-min',
+      callableObligationFavorId: 'favor-min',
+      callableObligationLabel: 'Minimal obligation',
+    })
+    // Producer multi-bundle: quantity already includes bundles; do not * bundleCount.
+    const multiBundle = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      quantity: 3,
+      bundleCount: 3,
+      unitPrice: 10,
+      totalPrice: 30,
+    })
+    // Producer cent unitPrice with listing buyPrice not divisible by bundleQuantity.
+    const centUnitPrice = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      quantity: 3,
+      bundleCount: 1,
+      unitPrice: 8.33,
+      totalPrice: 25,
+    })
 
     expect(validation.success).toBe(true)
-    expect(zeroPrice.success).toBe(true)
+    expect(zeroFavor.success).toBe(true)
+    expect(zeroObligation.success).toBe(true)
+    expect(multiBundle.success).toBe(true)
+    expect(centUnitPrice.success).toBe(true)
   })
 
   it('rejects market.transaction_recorded payloads with non-finite or invalid numerics', () => {
@@ -1058,6 +1086,10 @@ describe('event payload validation coverage', () => {
       ...base,
       remainingAvailability: -1,
     })
+    const fractionalRemaining = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      remainingAvailability: 1.5,
+    })
     const zeroQuantity = validateOperationEventPayload('market.transaction_recorded', {
       ...base,
       quantity: 0,
@@ -1073,6 +1105,11 @@ describe('event payload validation coverage', () => {
       quantity: 1.5,
       totalPrice: 15,
     })
+    const fractionalBundle = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      bundleCount: 1.5,
+      totalPrice: 15,
+    })
     const negativeUnitPrice = validateOperationEventPayload('market.transaction_recorded', {
       ...base,
       unitPrice: -1,
@@ -1082,9 +1119,11 @@ describe('event payload validation coverage', () => {
     expect(nanQuantity.success).toBe(false)
     expect(infiniteUnitPrice.success).toBe(false)
     expect(negativeRemaining.success).toBe(false)
+    expect(fractionalRemaining.success).toBe(false)
     expect(zeroQuantity.success).toBe(false)
     expect(zeroBundle.success).toBe(false)
     expect(fractionalQuantity.success).toBe(false)
+    expect(fractionalBundle.success).toBe(false)
     expect(negativeUnitPrice.success).toBe(false)
   })
 
@@ -1096,17 +1135,18 @@ describe('event payload validation coverage', () => {
       bundleCount: 1,
       totalPrice: 999,
     })
-    const productMismatch = validateOperationEventPayload('market.transaction_recorded', {
+    // Double-counting bundles would wrongly accept this if * bundleCount were used.
+    const doubleCounted = validateOperationEventPayload('market.transaction_recorded', {
       ...minimalOperationEventPayloads['market.transaction_recorded'],
-      unitPrice: 5,
-      quantity: 2,
+      unitPrice: 10,
+      quantity: 3,
       bundleCount: 3,
-      totalPrice: 20,
+      totalPrice: 90,
     })
 
     expect(mismatch.success).toBe(false)
     expect(mismatch.error).toMatch(/totalPrice must equal/)
-    expect(productMismatch.success).toBe(false)
-    expect(productMismatch.error).toMatch(/totalPrice must equal/)
+    expect(doubleCounted.success).toBe(false)
+    expect(doubleCounted.error).toMatch(/totalPrice must equal/)
   })
 })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1063,12 +1063,21 @@ describe('event payload validation coverage', () => {
       unitPrice: 8.33,
       totalPrice: 25,
     })
+    // Multi-bundle + cent unitPrice: 3¢ drift from 8.33*9 vs bundles*buyPrice.
+    const multiBundleCents = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      quantity: 9,
+      bundleCount: 3,
+      unitPrice: 8.33,
+      totalPrice: 75,
+    })
 
     expect(validation.success).toBe(true)
     expect(zeroFavor.success).toBe(true)
     expect(zeroObligation.success).toBe(true)
     expect(multiBundle.success).toBe(true)
     expect(centUnitPrice.success).toBe(true)
+    expect(multiBundleCents.success).toBe(true)
   })
 
   it('rejects market.transaction_recorded payloads with non-finite or invalid numerics', () => {

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1158,4 +1158,17 @@ describe('event payload validation coverage', () => {
     expect(doubleCounted.success).toBe(false)
     expect(doubleCounted.error).toMatch(/totalPrice must equal/)
   })
+
+  it('rejects market.transaction_recorded payloads whose cent product overflows', () => {
+    const overflow = validateOperationEventPayload('market.transaction_recorded', {
+      ...minimalOperationEventPayloads['market.transaction_recorded'],
+      unitPrice: 1e307,
+      quantity: 2,
+      bundleCount: 1,
+      totalPrice: 1e307,
+    })
+
+    expect(overflow.success).toBe(false)
+    expect(overflow.error).toMatch(/finite cent precision/)
+  })
 })


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2662 — https://linear.app/spectranoir/issue/SPE-2662/harden-markettransaction-numeric-consistency-validation
- **Parent issue (if any):** none (follow-on from SPE-2661 Deferred)
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hardened `marketTransactionRecordedSchema` with finite positive ints for `quantity` / `bundleCount` and finite nonnegative ints for `unitPrice` / `totalPrice` / `remainingAvailability`
- Added `superRefine` so `totalPrice` must equal `unitPrice * quantity * bundleCount` (matches hydrate `reconcileMarketTotalPrice` product)
- Targeted accept/reject Vitest coverage; hydrate reconcile-before-validate unchanged

## Docs updated

- `planning/spe-2662-harden-market-transaction-validation-slice.md`

## Parent status

- No parent umbrella; SPE-2661 remains Done. Validation-chain follow-ons continue via Deferred.

## Scope boundary

- Does not add catalog membership on `production.queue_*`
- Does not harden allocation/listing-resource-status numerics at validate
- No UI / feed / SCHEMA_REGISTRY changes

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts`; producer + hydrate case 512 filter
- [x] Lint / verify: `npx eslint src/domain/events/eventValidation.ts src/test/events.validation.test.ts`

## Follow-ups

- Catalog membership on `production.queue_*` recipeId (alternate SPE-2661 Deferred)
- Allocation priority/delayWeeks + listing resource available/capacity at validate (hydrate SPE-2551/2552 already clamp)

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)