### PR TITLE
SPE-2663: Align hydrate reconcileMarketTotalPrice with producer unitPrice*quantity

### DIFF
--- a/planning/spe-2662-harden-market-transaction-validation-slice.md
+++ b/planning/spe-2662-harden-market-transaction-validation-slice.md
@@ -39,6 +39,6 @@ Hydrate `reconcileMarketTotalPrice` still uses `unitPrice * quantity * bundleCou
 
 | Item | Owner | Why deferred |
 | --- | --- | --- |
-| Align hydrate `reconcileMarketTotalPrice` with producer `unitPrice * quantity` | follow-on if needed | Validate-only slice; hydrate rewrite policy unchanged. |
+| Align hydrate `reconcileMarketTotalPrice` with producer `unitPrice * quantity` | [SPE-2663](https://linear.app/spectranoir/issue/SPE-2663/align-hydrate-reconcilemarkettotalprice-with-producer) | Validate-only slice; hydrate rewrite policy deferred to SPE-2663. |
 | Catalog membership on `production.queue_*` recipeId | follow-on if needed | Alternate SPE-2661 Deferred; production schemas remain opaque-id tolerant. |
 | Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this numeric/consistency slice. |

--- a/planning/spe-2663-align-hydrate-reconcile-market-total-price-slice.md
+++ b/planning/spe-2663-align-hydrate-reconcile-market-total-price-slice.md
@@ -1,0 +1,36 @@
+# SPE-2663 — Align hydrate reconcileMarketTotalPrice with producer unitPrice*quantity
+
+**Linear:** [SPE-2663](https://linear.app/spectranoir/issue/SPE-2663/align-hydrate-reconcilemarkettotalprice-with-producer)  
+**Branch:** `jamesdyedbq/spe-2663-align-hydrate-reconcilemarkettotalprice-with-producer`  
+**Status:** In progress
+
+## Goal
+
+Align hydrate `reconcileMarketTotalPrice` with producer semantics so multi-bundle `market.transaction_recorded` rows are not rewritten using `unitPrice * quantity * bundleCount`.
+
+## Scope
+
+- Fix `reconcileMarketTotalPrice` in `src/app/store/runTransfer.ts` to match producers: expected total ≈ `unitPrice * quantity` with integer-cent drift `|round(total*100) - round(unit*qty*100)| <= max(1, bundleCount)` (SPE-2662 validate policy)
+- Preserve cent `unitPrice` on hydrate (do not integer-truncate before reconcile)
+- Update hydrate case 512 / mismatch tests for multi-bundle + cent unitPrice
+- Keep validate harden from SPE-2662 unchanged
+
+## Out of scope
+
+- Catalog membership on `production.queue_*`
+- Allocation / listing-resource-status validate bounds
+- UI / feed
+- SCHEMA_REGISTRY expansion
+
+## Acceptance
+
+- Hydrate preserves producer-valid multi-bundle + cent-rounded totals (does not rewrite 30→90 or 75→truncated product)
+- Case 512 still forces positive qty/bundle and reconciles grossly mismatched totals
+- Targeted hydrate tests; no SCHEMA_REGISTRY expansion
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Catalog membership on `production.queue_*` recipeId | follow-on if needed | Alternate SPE-2661/2662 Deferred; production schemas remain opaque-id tolerant. |
+| Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this hydrate-formula slice. |

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -10648,6 +10648,80 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
     })
 
+    it('512 preserves producer multi-bundle totalPrice (unitPrice*quantity, not *bundleCount)', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-market-txn-512-multi',
+            type: 'market.transaction_recorded',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              marketWeek: 2,
+              transactionId: 'market-2-512-multi',
+              action: 'buy',
+              listingId: 'mat:binding_agent',
+              itemId: 'binding_agent',
+              itemName: 'Binding Agent',
+              category: 'material',
+              quantity: 3,
+              bundleCount: 3,
+              unitPrice: 10,
+              totalPrice: 30,
+              remainingAvailability: 1,
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        quantity: 3,
+        bundleCount: 3,
+        unitPrice: 10,
+        totalPrice: 30,
+      })
+    })
+
+    it('512 preserves cent unitPrice totals within bundle drift', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-market-txn-512-cents',
+            type: 'market.transaction_recorded',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              marketWeek: 2,
+              transactionId: 'market-2-512-cents',
+              action: 'buy',
+              listingId: 'mat:binding_agent',
+              itemId: 'binding_agent',
+              itemName: 'Binding Agent',
+              category: 'material',
+              quantity: 9,
+              bundleCount: 3,
+              unitPrice: 8.33,
+              totalPrice: 75,
+              remainingAvailability: 1,
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        quantity: 9,
+        bundleCount: 3,
+        unitPrice: 8.33,
+        totalPrice: 75,
+      })
+    })
+
     it('513 clamps emergency waiver accountability waiverGrantWeek below event week', () => {
       const fallback = createStartingState()
 

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -10722,6 +10722,43 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
     })
 
+    it('512 rewrites overflowed unitPrice*quantity product to finite zero totalPrice', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        events: [
+          {
+            id: 'evt-market-txn-512-overflow',
+            type: 'market.transaction_recorded',
+            timestamp: buildOperationEventTimestamp(2, 0),
+            payload: {
+              week: 2,
+              marketWeek: 2,
+              transactionId: 'market-2-512-overflow',
+              action: 'buy',
+              listingId: 'mat:binding_agent',
+              itemId: 'binding_agent',
+              itemName: 'Binding Agent',
+              category: 'material',
+              quantity: 2,
+              bundleCount: 1,
+              unitPrice: 1e307,
+              totalPrice: 1e307,
+              remainingAvailability: 1,
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events[0]?.payload).toMatchObject({
+        quantity: 2,
+        bundleCount: 1,
+        unitPrice: 1e307,
+        totalPrice: 0,
+      })
+    })
+
     it('513 clamps emergency waiver accountability waiverGrantWeek below event week', () => {
       const fallback = createStartingState()
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -1365,6 +1365,10 @@ function reconcileMarketTotalPrice(
   // per-item (cents allowed). Match SPE-2662 validate: keep totalPrice when within
   // ~1¢/bundle of unitPrice*quantity; otherwise rewrite to the cent-rounded product.
   const productCents = Math.round(unitPrice * quantity * 100)
+  // Overflow can yield Infinity; do not hydrate a non-finite totalPrice (validate rejects).
+  if (!Number.isFinite(productCents)) {
+    return 0
+  }
   const expected = Math.max(0, productCents / 100)
   const candidate =
     typeof totalPrice === 'number' && Number.isFinite(totalPrice) && totalPrice >= 0
@@ -1372,7 +1376,7 @@ function reconcileMarketTotalPrice(
       : expected
   const totalCents = Math.round(candidate * 100)
 
-  if (!Number.isFinite(productCents) || !Number.isFinite(totalCents)) {
+  if (!Number.isFinite(totalCents)) {
     return expected
   }
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -1361,10 +1361,27 @@ function reconcileMarketTotalPrice(
   bundleCount: number,
   totalPrice: unknown
 ) {
-  const expected = Math.max(0, Math.trunc(unitPrice * quantity * bundleCount))
-  const sanitized = sanitizeInteger(totalPrice as number | undefined, expected, 0)
+  // Producer semantics (sim/market): quantity already includes bundles; unitPrice is
+  // per-item (cents allowed). Match SPE-2662 validate: keep totalPrice when within
+  // ~1¢/bundle of unitPrice*quantity; otherwise rewrite to the cent-rounded product.
+  const productCents = Math.round(unitPrice * quantity * 100)
+  const expected = Math.max(0, productCents / 100)
+  const candidate =
+    typeof totalPrice === 'number' && Number.isFinite(totalPrice) && totalPrice >= 0
+      ? totalPrice
+      : expected
+  const totalCents = Math.round(candidate * 100)
 
-  return sanitized === expected ? sanitized : expected
+  if (!Number.isFinite(productCents) || !Number.isFinite(totalCents)) {
+    return expected
+  }
+
+  const maxDriftCents = Math.max(1, bundleCount)
+  if (Math.abs(totalCents - productCents) <= maxDriftCents) {
+    return candidate
+  }
+
+  return expected
 }
 
 function sanitizeOperationEventMarketProcurementAllocation(value: unknown) {
@@ -7996,7 +8013,12 @@ function sanitizeOperationEvents(
       case 'market.transaction_recorded': {
         const quantity = sanitizeInteger(payload.quantity as number | undefined, 1, 1)
         const bundleCount = sanitizeInteger(payload.bundleCount as number | undefined, 1, 1)
-        const unitPrice = sanitizeInteger(payload.unitPrice as number | undefined, 0, 0)
+        // SPE-2663: preserve cent unitPrice (producers round buyPrice/bundleQuantity).
+        const unitPrice = sanitizeFiniteDecimalPreservePrecision(
+          payload.unitPrice as number | undefined,
+          0,
+          0
+        )
         const totalPrice = reconcileMarketTotalPrice(
           unitPrice,
           quantity,


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2663 — https://linear.app/spectranoir/issue/SPE-2663/align-hydrate-reconcilemarkettotalprice-with-producer
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Hydrate `reconcileMarketTotalPrice` now expects `unitPrice * quantity` with SPE-2662 integer-cent / bundle drift (no longer multiplies by `bundleCount`)
- Preserve cent `unitPrice` on hydrate so producer-valid multi-bundle totals (30, 75) are not rewritten
- Case 512 still forces positive qty/bundle and rewrites grossly mismatched totals; added multi-bundle + cent hydrate tests

## Docs updated

- `planning/spe-2663-align-hydrate-reconcile-market-total-price-slice.md`
- `planning/spe-2662-harden-market-transaction-validation-slice.md` Deferred owner → SPE-2663

## Parent status

- No parent — slice-only follow-on from SPE-2662 Deferred

## Scope boundary

- Does not change validate schemas (SPE-2662 remains as shipped)
- Does not touch production.queue catalog, UI/feed, or allocation validate bounds
- No SCHEMA_REGISTRY expansion

## Validation

- [x] Targeted tests: `npx vitest run src/app/store/runTransfer.test.ts -t 512` (3 passed); `-t 328` (1 passed)
- [x] Lint / verify: `npx eslint src/app/store/runTransfer.ts src/app/store/runTransfer.test.ts`

## Follow-ups

- Catalog membership on `production.queue_*` recipeId (SPE-2661/2662 Deferred)
- Allocation / listing-resource-status validate bounds (hydrate already clamps)

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)