### PR TITLE
SPE-2664: Harden production.queue_* catalog membership at validate

### DIFF
--- a/planning/spe-2661-harden-market-shifted-catalog-validation-slice.md
+++ b/planning/spe-2661-harden-market-shifted-catalog-validation-slice.md
@@ -34,4 +34,4 @@ Reject inconsistent `market.shifted` payloads at the operation-event validation 
 | Item | Owner | Why deferred |
 | --- | --- | --- |
 | Broader `market.transaction_*` schema hardening | follow-on if needed | Out of slice boundary; backlog primary remains none. |
-| Catalog membership on production.queue_* recipeId | follow-on if needed | Out of slice; production schemas remain opaque-id tolerant. |
+| Catalog membership on production.queue_* recipeId | [SPE-2664](https://linear.app/spectranoir/issue/SPE-2664/harden-productionqueue-started-queue-completed-catalog-membership-for) | Out of slice; owned by SPE-2664 validate harden. |

--- a/planning/spe-2662-harden-market-transaction-validation-slice.md
+++ b/planning/spe-2662-harden-market-transaction-validation-slice.md
@@ -40,5 +40,5 @@ Hydrate `reconcileMarketTotalPrice` still uses `unitPrice * quantity * bundleCou
 | Item | Owner | Why deferred |
 | --- | --- | --- |
 | Align hydrate `reconcileMarketTotalPrice` with producer `unitPrice * quantity` | [SPE-2663](https://linear.app/spectranoir/issue/SPE-2663/align-hydrate-reconcilemarkettotalprice-with-producer) | Validate-only slice; hydrate rewrite policy deferred to SPE-2663. |
-| Catalog membership on `production.queue_*` recipeId | follow-on if needed | Alternate SPE-2661 Deferred; production schemas remain opaque-id tolerant. |
+| Catalog membership on `production.queue_*` recipeId | [SPE-2664](https://linear.app/spectranoir/issue/SPE-2664/harden-productionqueue-started-queue-completed-catalog-membership-for) | Alternate SPE-2661 Deferred; owned by SPE-2664 validate harden. |
 | Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this numeric/consistency slice. |

--- a/planning/spe-2663-align-hydrate-reconcile-market-total-price-slice.md
+++ b/planning/spe-2663-align-hydrate-reconcile-market-total-price-slice.md
@@ -32,5 +32,5 @@ Align hydrate `reconcileMarketTotalPrice` with producer semantics so multi-bundl
 
 | Item | Owner | Why deferred |
 | --- | --- | --- |
-| Catalog membership on `production.queue_*` recipeId | follow-on if needed | Alternate SPE-2661/2662 Deferred; production schemas remain opaque-id tolerant. |
+| Catalog membership on `production.queue_*` recipeId | [SPE-2664](https://linear.app/spectranoir/issue/SPE-2664/harden-productionqueue-started-queue-completed-catalog-membership-for) | Alternate SPE-2661/2662 Deferred; owned by SPE-2664 validate harden. |
 | Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this hydrate-formula slice. |

--- a/planning/spe-2664-harden-production-queue-catalog-validation-slice.md
+++ b/planning/spe-2664-harden-production-queue-catalog-validation-slice.md
@@ -1,0 +1,39 @@
+# SPE-2664 — Harden production.queue_* catalog membership for recipeId (+ output id↔name)
+
+**Linear:** [SPE-2664](https://linear.app/spectranoir/issue/SPE-2664/harden-productionqueue-started-queue-completed-catalog-membership-for)  
+**Branch:** `jamesdyedbq/spe-2664-harden-productionqueue_started-queue_completed-catalog`
+
+## Goal
+
+Reject unknown `production.queue_started` / `production.queue_completed` payloads at the operation-event validation boundary when `recipeId` is not in `productionCatalog`, or when `outputId` / `outputName` do not match the catalog product fields for a known recipe.
+
+## Scope
+
+- Harden `productionQueueStartedSchema` / `productionQueueCompletedSchema` in `src/domain/events/eventValidation.ts`
+- Reuse SPE-2661 membership via `sanitizeFeaturedRecipeId` + `getProductionRecipe` for catalog output fields
+- Producer contract: `outputId` = `outputItemId`, `outputName` = `outputItemName` (not recipe id / recipe name)
+- Intentional fixture update: minimal queue payloads use catalog `ward-seals` / `ward_seals` / `Ward Seals` (not opaque `recipe-min`)
+- Targeted validation tests; hydrate opaque-id reconcile unchanged (reconcile-before-validate)
+
+## Out of scope
+
+- Hydrate rewrite policy / `reconcileProductionEventRecipeOutput` changes
+- `market.transaction_*` / `market.shifted`
+- UI / feed rendering
+- Allocation priority/delayWeeks + listing resource available/capacity at validate
+- SCHEMA_REGISTRY expansion
+
+## Acceptance
+
+- Reject unknown `recipeId` (not in `productionCatalog`)
+- When `recipeId` is catalog-known: reject `outputId` / `outputName` that do not match catalog `outputItemId` / `outputItemName`
+- Accept catalog-valid queue_started / queue_completed payloads (trimmed `outputName` allowed)
+- Hydrate still preserves / reconciles opaque recipe ids as today
+- Minimal/producer fixtures pass after intentional fixture update
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this production-queue catalog slice. |
+| Hydrate rewrite of opaque production queue recipe ids | keep current | This slice is validate-only; hydrate reconcile stays opaque-id tolerant. |

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -505,6 +505,46 @@ const recruitmentScoutingSchema = z
   })
   .strict()
 
+/** SPE-2664: catalog recipeId membership + outputId/outputName vs catalog product fields. */
+function refineProductionQueueCatalogMembership(
+  payload: { recipeId: string; outputId: string; outputName: string },
+  context: z.RefinementCtx
+) {
+  // Reuse sanitizeFeaturedRecipeId membership (same PRODUCTION_RECIPE_IDS set as market.shifted).
+  if (
+    sanitizeFeaturedRecipeId(payload.recipeId, payload.recipeId) !== payload.recipeId
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'recipeId must be a production catalog recipe id',
+      path: ['recipeId'],
+    })
+    return
+  }
+
+  const recipe = getProductionRecipe(payload.recipeId)
+  if (!recipe) {
+    return
+  }
+
+  // Producer contract: outputId/outputName are catalog outputItemId/outputItemName (not recipe id/name).
+  if (payload.outputId !== recipe.outputItemId) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `outputId must match catalog outputItemId for recipeId (${recipe.outputItemId})`,
+      path: ['outputId'],
+    })
+  }
+
+  if (payload.outputName.trim() !== recipe.outputItemName) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `outputName must match catalog outputItemName for recipeId (${recipe.outputItemName})`,
+      path: ['outputName'],
+    })
+  }
+}
+
 const productionQueueStartedSchema = z
   .object({
     week: weekSchema,
@@ -519,6 +559,9 @@ const productionQueueStartedSchema = z
     inputMaterials: z.array(materialRequirementSchema),
   })
   .strict()
+  .superRefine((payload, context) => {
+    refineProductionQueueCatalogMembership(payload, context)
+  })
 
 const productionQueueCompletedSchema = z
   .object({
@@ -533,6 +576,9 @@ const productionQueueCompletedSchema = z
     inputMaterials: z.array(materialRequirementSchema),
   })
   .strict()
+  .superRefine((payload, context) => {
+    refineProductionQueueCatalogMembership(payload, context)
+  })
 
 const marketShiftedSchema = z
   .object({

--- a/src/test/eventFeedView.exhaustiveness.test.ts
+++ b/src/test/eventFeedView.exhaustiveness.test.ts
@@ -61,7 +61,7 @@ describe('event feed search surfaces', () => {
     expect(views).toHaveLength(1)
     expect(views[0]?.event.id).toBe('evt-production-search')
 
-    const payloadPhrase = 'recipe-min'
+    const payloadPhrase = 'ward-seals'
     expect(queryEvents(index, { query: payloadPhrase })).toHaveLength(1)
     expect(views.filter((view) => view.searchText.includes(payloadPhrase))).toHaveLength(1)
   })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -802,6 +802,92 @@ describe('event payload validation coverage', () => {
     expect(validation.success).toBe(true)
   })
 
+  it('rejects production.queue_started payloads with unknown recipeId', () => {
+    const unknown = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      recipeId: 'phantom-recipe',
+      outputId: 'phantom-output',
+      outputName: 'Phantom Output',
+    })
+
+    expect(unknown.success).toBe(false)
+  })
+
+  it('rejects production.queue_completed payloads with unknown recipeId', () => {
+    const unknown = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      recipeId: 'phantom-recipe',
+      outputId: 'phantom-output',
+      outputName: 'Phantom Output',
+    })
+
+    expect(unknown.success).toBe(false)
+  })
+
+  it('rejects production.queue_started payloads with outputId/outputName mismatch', () => {
+    const wrongOutputId = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      recipeId: 'ward-seals',
+      outputId: 'wrong-output',
+      outputName: 'Ward Seals',
+    })
+    const wrongOutputName = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      recipeId: 'ward-seals',
+      outputId: 'ward_seals',
+      outputName: 'Wrong Label',
+    })
+    // outputId must be catalog outputItemId — not the recipe id itself.
+    const recipeIdAsOutput = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      recipeId: 'ward-seals',
+      outputId: 'ward-seals',
+      outputName: 'Ward Seals',
+    })
+
+    expect(wrongOutputId.success).toBe(false)
+    expect(wrongOutputName.success).toBe(false)
+    expect(recipeIdAsOutput.success).toBe(false)
+  })
+
+  it('rejects production.queue_completed payloads with outputId/outputName mismatch', () => {
+    const wrongOutputId = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      recipeId: 'med-kits',
+      outputId: 'wrong-output',
+      outputName: 'Emergency Medkits',
+    })
+    const wrongOutputName = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      recipeId: 'med-kits',
+      outputId: 'medkits',
+      outputName: 'Wrong Label',
+    })
+
+    expect(wrongOutputId.success).toBe(false)
+    expect(wrongOutputName.success).toBe(false)
+  })
+
+  it('accepts production.queue_* payloads with catalog-valid recipe and output fields', () => {
+    const started = validateOperationEventPayload('production.queue_started', {
+      ...minimalOperationEventPayloads['production.queue_started'],
+      recipeId: 'med-kits',
+      outputId: 'medkits',
+      outputName: 'Emergency Medkits',
+      queueName: 'Emergency Medkits',
+    })
+    const completedTrimmed = validateOperationEventPayload('production.queue_completed', {
+      ...minimalOperationEventPayloads['production.queue_completed'],
+      recipeId: 'med-kits',
+      outputId: 'medkits',
+      outputName: '  Emergency Medkits  ',
+      queueName: 'Emergency Medkits',
+    })
+
+    expect(started.success).toBe(true)
+    expect(completedTrimmed.success).toBe(true)
+  })
+
   it('rejects production.queue_started payloads with non-finite numerics', () => {
     const nanEta = validateOperationEventPayload('production.queue_started', {
       ...minimalOperationEventPayloads['production.queue_started'],

--- a/src/test/fixtures/minimalOperationEventPayloads.ts
+++ b/src/test/fixtures/minimalOperationEventPayloads.ts
@@ -304,10 +304,12 @@ export const minimalOperationEventPayloads = {
   'production.queue_started': {
     week: WEEK,
     queueId: 'queue-min',
-    queueName: 'Minimal Queue',
-    recipeId: 'recipe-min',
-    outputId: 'output-min',
-    outputName: 'Minimal Output',
+    queueName: 'Ward Seal Batch',
+    // SPE-2664: validate requires productionCatalog membership (not opaque recipe-min).
+    // Producer: outputId/outputName = catalog outputItemId/outputItemName (not recipe id/name).
+    recipeId: 'ward-seals',
+    outputId: 'ward_seals',
+    outputName: 'Ward Seals',
     outputQuantity: 1,
     etaWeeks: 1,
     fundingCost: 10,
@@ -322,10 +324,11 @@ export const minimalOperationEventPayloads = {
   'production.queue_completed': {
     week: WEEK,
     queueId: 'queue-min',
-    queueName: 'Minimal Queue',
-    recipeId: 'recipe-min',
-    outputId: 'output-min',
-    outputName: 'Minimal Output',
+    queueName: 'Ward Seal Batch',
+    // SPE-2664: validate requires productionCatalog membership (not opaque recipe-min).
+    recipeId: 'ward-seals',
+    outputId: 'ward_seals',
+    outputName: 'Ward Seals',
     outputQuantity: 1,
     fundingCost: 10,
     inputMaterials: [


### PR DESCRIPTION
## Linear

- **Slice issue:** [SPE-2664](https://linear.app/spectranoir/issue/SPE-2664/harden-productionqueue-started-queue-completed-catalog-membership-for)
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Harden `production.queue_started` / `production.queue_completed` validate schemas: reject unknown `recipeId` (not in `productionCatalog`)
- When recipe is known, require `outputId` / `outputName` match catalog `outputItemId` / `outputItemName` (producer contract; not recipe id/name)
- Intentional minimal fixture update to catalog `ward-seals` / `ward_seals` / `Ward Seals`
- Targeted validation tests; hydrate opaque-id reconcile unchanged

## Docs updated

- `planning/spe-2664-harden-production-queue-catalog-validation-slice.md`
- SPE-2661 / SPE-2662 / SPE-2663 Deferred owners → SPE-2664

## Parent status

- No parent — standalone validate harden from SPE-2661/2662/2663 Deferred

## Scope boundary

- Does **not** change hydrate rewrite / `reconcileProductionEventRecipeOutput`
- Does **not** change `market.transaction_*` / `market.shifted`
- Does **not** change UI/feed or allocation validate bounds
- No SCHEMA_REGISTRY expansion

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/test/events.producerValidation.test.ts src/test/eventFeedView.exhaustiveness.test.ts src/test/sim.production.test.ts src/test/events.coverage.test.ts`
- [x] Lint: eslint on touched source/test files

## Follow-ups

- Allocation priority/delayWeeks + listing resource available/capacity at validate (hydrate SPE-2551/2552 already clamp)
- Hydrate rewrite of opaque production queue recipe ids remains intentionally unchanged

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)
