### PR TITLE
SPE-2665: Harden market.transaction_recorded allocation + listing resource bounds at validate

### DIFF
--- a/planning/spe-2662-harden-market-transaction-validation-slice.md
+++ b/planning/spe-2662-harden-market-transaction-validation-slice.md
@@ -41,4 +41,4 @@ Hydrate `reconcileMarketTotalPrice` still uses `unitPrice * quantity * bundleCou
 | --- | --- | --- |
 | Align hydrate `reconcileMarketTotalPrice` with producer `unitPrice * quantity` | [SPE-2663](https://linear.app/spectranoir/issue/SPE-2663/align-hydrate-reconcilemarkettotalprice-with-producer) | Validate-only slice; hydrate rewrite policy deferred to SPE-2663. |
 | Catalog membership on `production.queue_*` recipeId | [SPE-2664](https://linear.app/spectranoir/issue/SPE-2664/harden-productionqueue-started-queue-completed-catalog-membership-for) | Alternate SPE-2661 Deferred; owned by SPE-2664 validate harden. |
-| Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this numeric/consistency slice. |
+| Allocation priority/delayWeeks + listing resource available/capacity at validate | [SPE-2665](https://linear.app/spectranoir/issue/SPE-2665/harden-markettransaction-recorded-allocation-prioritydelayweeks) | Hydrate already clamps (SPE-2551/2552); owned by SPE-2665 validate harden. |

--- a/planning/spe-2663-align-hydrate-reconcile-market-total-price-slice.md
+++ b/planning/spe-2663-align-hydrate-reconcile-market-total-price-slice.md
@@ -33,4 +33,4 @@ Align hydrate `reconcileMarketTotalPrice` with producer semantics so multi-bundl
 | Item | Owner | Why deferred |
 | --- | --- | --- |
 | Catalog membership on `production.queue_*` recipeId | [SPE-2664](https://linear.app/spectranoir/issue/SPE-2664/harden-productionqueue-started-queue-completed-catalog-membership-for) | Alternate SPE-2661/2662 Deferred; owned by SPE-2664 validate harden. |
-| Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this hydrate-formula slice. |
+| Allocation priority/delayWeeks + listing resource available/capacity at validate | [SPE-2665](https://linear.app/spectranoir/issue/SPE-2665/harden-markettransaction-recorded-allocation-prioritydelayweeks) | Hydrate already clamps (SPE-2551/2552); owned by SPE-2665 validate harden. |

--- a/planning/spe-2664-harden-production-queue-catalog-validation-slice.md
+++ b/planning/spe-2664-harden-production-queue-catalog-validation-slice.md
@@ -35,5 +35,5 @@ Reject unknown `production.queue_started` / `production.queue_completed` payload
 
 | Item | Owner | Why deferred |
 | --- | --- | --- |
-| Allocation priority/delayWeeks + listing resource available/capacity at validate | follow-on if needed | Hydrate already clamps (SPE-2551/2552); out of this production-queue catalog slice. |
+| Allocation priority/delayWeeks + listing resource available/capacity at validate | [SPE-2665](https://linear.app/spectranoir/issue/SPE-2665/harden-markettransaction-recorded-allocation-prioritydelayweeks) | Hydrate already clamps (SPE-2551/2552); owned by SPE-2665 validate harden. |
 | Hydrate rewrite of opaque production queue recipe ids | keep current | This slice is validate-only; hydrate reconcile stays opaque-id tolerant. |

--- a/planning/spe-2665-harden-market-transaction-allocation-listing-bounds-slice.md
+++ b/planning/spe-2665-harden-market-transaction-allocation-listing-bounds-slice.md
@@ -1,0 +1,39 @@
+# SPE-2665 — Harden market.transaction_recorded allocation + listing resource numeric bounds at validate
+
+**Linear:** [SPE-2665](https://linear.app/spectranoir/issue/SPE-2665/harden-markettransaction-recorded-allocation-prioritydelayweeks)  
+**Branch:** `jamesdyedbq/spe-2665-harden-markettransaction_recorded-allocation`
+
+## Goal
+
+Reject out-of-bounds `market.transaction_recorded` allocation and listing-resource-status numerics at the operation-event validation boundary so priority/delayWeeks and available/capacity cannot drift past hydrate clamp maxima (SPE-2551/2552).
+
+## Scope
+
+- Harden `procurementAllocationSchema` and `marketTransactionListingResourceStatusSchema` in `src/domain/events/eventValidation.ts`
+- Finite nonnegative ints for allocation `priority` / `delayWeeks` within hydrate clamp maxima (`priority` 0–10, `delayWeeks` 0–52)
+- Finite nonnegative ints for listing resource `available` / `capacity`; when both present, `available <= capacity`
+- Keep hydrate SPE-2551/2552 clamps unchanged (validate-only; no sanitize rewrite policy change)
+- Targeted validation tests; fixture update only if needed
+- Update SPE-2662/2663/2664 Deferred owners to this issue
+
+## Out of scope
+
+- Hydrate clamp rewrite policy / sanitize changes
+- `production.queue_*` catalog membership (SPE-2664 shipped)
+- Opaque production hydrate rewrite (separate deferred on SPE-2664)
+- UI / feed rendering
+- SCHEMA_REGISTRY expansion
+
+## Acceptance
+
+- Reject non-finite, negative, fractional, and above-max `priority` / `delayWeeks`
+- Reject non-finite, negative, fractional `available` / `capacity`; reject `available > capacity` when both present
+- Accept hydrate-aligned valid rows (including available without capacity; clamp-edge priority/delayWeeks)
+- Do not break zero-price favor / obligation paths
+- Hydrate clamps remain unchanged
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Hydrate rewrite of opaque production queue recipe ids | keep current (SPE-2664 Deferred) | Validate-only; hydrate reconcile stays opaque-id tolerant. |

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -624,6 +624,11 @@ const marketShiftedSchema = z
     }
   })
 
+// SPE-2665: align with runTransfer hydrate clamps (SPE-2551/2552). Validate rejects;
+// hydrate still clamps — do not drift these maxima without updating both sites.
+const MARKET_PROCUREMENT_ALLOCATION_PRIORITY_MAX = 10
+const MARKET_PROCUREMENT_ALLOCATION_DELAY_WEEKS_MAX = 52
+
 const marketTransactionListingResourceStatusSchema = z
   .object({
     resourceClass: z.enum([
@@ -633,11 +638,24 @@ const marketTransactionListingResourceStatusSchema = z
     ]),
     sourceId: z.string().optional(),
     label: z.string().optional(),
-    available: z.number().optional(),
-    capacity: z.number().optional(),
+    available: finiteNonNegativeIntSchema.optional(),
+    capacity: finiteNonNegativeIntSchema.optional(),
     allocations: z.array(z.string()).optional(),
   })
   .passthrough()
+  .superRefine((payload, context) => {
+    if (
+      payload.available !== undefined &&
+      payload.capacity !== undefined &&
+      payload.available > payload.capacity
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'available must be <= capacity when both are present',
+        path: ['available'],
+      })
+    }
+  })
 
 const procurementAllocationSchema = z
   .object({
@@ -653,8 +671,8 @@ const procurementAllocationSchema = z
     destinationLabel: z.string(),
     urgency: z.enum(['standard', 'contingency']),
     expectedBenefit: z.string(),
-    priority: z.number(),
-    delayWeeks: z.number(),
+    priority: finiteNonNegativeIntSchema.max(MARKET_PROCUREMENT_ALLOCATION_PRIORITY_MAX),
+    delayWeeks: finiteNonNegativeIntSchema.max(MARKET_PROCUREMENT_ALLOCATION_DELAY_WEEKS_MAX),
     displacedAlternativeUse: z.string().optional(),
     substitutionStatus: z.enum(['none', 'degraded_substitute']),
     substitutionSummary: z.string().optional(),

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1257,4 +1257,104 @@ describe('event payload validation coverage', () => {
     expect(overflow.success).toBe(false)
     expect(overflow.error).toMatch(/finite cent precision/)
   })
+
+  it('accepts market.transaction_recorded allocation and listing bounds aligned with hydrate clamps', () => {
+    const base = minimalOperationEventPayloads['market.transaction_recorded']
+    const clampEdge = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      allocation: {
+        ...base.allocation,
+        priority: 10,
+        delayWeeks: 52,
+      },
+      allocations: [
+        {
+          ...base.allocation,
+          allocationId: 'alloc-edge',
+          priority: 0,
+          delayWeeks: 0,
+        },
+      ],
+      listingResourceStatuses: [
+        {
+          resourceClass: 'licensed_handling_capacity',
+          available: 0,
+          capacity: 0,
+        },
+        {
+          resourceClass: 'supplier_attention_slot',
+          available: 2,
+          capacity: 2,
+        },
+        // available without capacity is allowed (hydrate leaves available alone).
+        { resourceClass: 'reagent_stock', available: 10 },
+        { resourceClass: 'reagent_stock', capacity: 5 },
+      ],
+    })
+
+    expect(clampEdge.success).toBe(true)
+  })
+
+  it('rejects market.transaction_recorded payloads with out-of-bounds allocation priority or delayWeeks', () => {
+    const base = minimalOperationEventPayloads['market.transaction_recorded']
+    const priorityTooHigh = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      allocation: { ...base.allocation, priority: 11 },
+    })
+    const delayTooHigh = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      allocation: { ...base.allocation, delayWeeks: 53 },
+    })
+    const negativePriority = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      allocation: { ...base.allocation, priority: -1 },
+    })
+    const fractionalDelay = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      allocation: { ...base.allocation, delayWeeks: 1.5 },
+    })
+    const nanPriority = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      allocation: { ...base.allocation, priority: Number.NaN },
+    })
+    const allocationsPriorityTooHigh = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      allocations: [{ ...base.allocation, allocationId: 'alloc-bad', priority: 99 }],
+    })
+
+    expect(priorityTooHigh.success).toBe(false)
+    expect(delayTooHigh.success).toBe(false)
+    expect(negativePriority.success).toBe(false)
+    expect(fractionalDelay.success).toBe(false)
+    expect(nanPriority.success).toBe(false)
+    expect(allocationsPriorityTooHigh.success).toBe(false)
+  })
+
+  it('rejects market.transaction_recorded payloads with invalid listing available/capacity', () => {
+    const base = minimalOperationEventPayloads['market.transaction_recorded']
+    const availableOverCapacity = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      listingResourceStatuses: [
+        { resourceClass: 'supplier_attention_slot', available: 3, capacity: 2 },
+      ],
+    })
+    const negativeAvailable = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      listingResourceStatuses: [{ resourceClass: 'reagent_stock', available: -1 }],
+    })
+    const fractionalCapacity = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      listingResourceStatuses: [{ resourceClass: 'reagent_stock', capacity: 1.5 }],
+    })
+    const nanAvailable = validateOperationEventPayload('market.transaction_recorded', {
+      ...base,
+      listingResourceStatuses: [{ resourceClass: 'reagent_stock', available: Number.NaN }],
+    })
+
+    expect(availableOverCapacity.success).toBe(false)
+    expect(availableOverCapacity.error).toMatch(/available must be <= capacity/)
+    expect(negativeAvailable.success).toBe(false)
+    expect(fractionalCapacity.success).toBe(false)
+    expect(nanAvailable.success).toBe(false)
+  })
 })


### PR DESCRIPTION
﻿## Linear

- **Slice issue:** SPE-2665 — https://linear.app/spectranoir/issue/SPE-2665/harden-markettransaction-recorded-allocation-prioritydelayweeks
- **Parent issue (if any):** none — follow-on from SPE-2662/2663/2664 Deferred
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Validate-only: finite nonnegative ints for `market.transaction_recorded` allocation `priority`/`delayWeeks` within hydrate clamp maxima (0–10 / 0–52)
- Finite nonnegative ints for listing resource `available`/`capacity`; reject `available > capacity` when both present
- Targeted validation tests; SPE-2662/2663/2664 Deferred owners pointed at SPE-2665

## Docs updated

- `planning/spe-2665-harden-market-transaction-allocation-listing-bounds-slice.md`
- SPE-2662/2663/2664 Deferred owner rows

## Parent status

- No parent umbrella — SPE-2662/2663/2664 remain Done; Deferred owners updated to SPE-2665

## Scope boundary

- Does not change SPE-2551/2552 hydrate clamp rewrite policy
- Does not touch production.queue_* catalog (SPE-2664 shipped) or opaque production hydrate rewrite
- No UI/feed or SCHEMA_REGISTRY changes

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/test/minimalOperationEventPayloads.test.ts` (147 passed)
- [x] Lint / verify: `npm run lint`

## Follow-ups

- Hydrate rewrite of opaque production queue recipe ids remains deferred (SPE-2664 Deferred / keep current)

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)
