### PR TITLE
SPE-2668: Harden agency.containment_updated soft numerics at validate

### DIFF
--- a/planning/spe-2668-harden-agency-containment-updated-soft-numerics-validate-slice.md
+++ b/planning/spe-2668-harden-agency-containment-updated-soft-numerics-validate-slice.md
@@ -1,0 +1,43 @@
+# SPE-2668 — Harden agency.containment_updated soft numerics at validate
+
+**Linear:** [SPE-2668](https://linear.app/spectranoir/issue/SPE-2668/harden-agencycontainment-updated-soft-numerics-at-validate)  
+**Branch:** `jamesdyedbq/spe-2668-harden-agencycontainment_updated-soft-numerics-at-validate`
+
+> Note: User request named this follow-on SPE-2667; that id was already assigned to delayed market order hydration. This slice is SPE-2668.
+
+## Goal
+
+Reject non-finite / invalid soft numerics on `agency.containment_updated` at the validation boundary, matching hydrate sanitize floors without changing hydrate rewrite policy.
+
+## Scope
+
+- Harden `agencyContainmentUpdatedSchema` in `src/domain/events/eventValidation.ts`
+- `containmentRatingBefore` / `containmentRatingAfter` / `containmentDelta` / `fundingBefore` / `fundingAfter` / `fundingDelta`: finite numerics (reject NaN/Infinity; signed deltas remain valid)
+- `clearanceLevelBefore` / `clearanceLevelAfter`: finite nonnegative ints (hydrate `sanitizeInteger` / `reconcileBeforeAfterDelta`)
+- Do **not** change hydrate sanitize/reconcile rewrite (`runTransfer.ts` `agency.containment_updated` case)
+- Do **not** require `delta == after − before` beyond what hydrate already reconciles
+- Targeted validation tests; fixture update only if needed
+
+## Out of scope
+
+- Hydrate sanitize / reconcile rewrite policy
+- Related agency front-business / academy events (not scoped in)
+- `market.transaction_*` / `market.shifted` / `market.emergency_gray_market_*` / `production.queue_*` (already hardened SPE-2659–2666)
+- Opaque production hydrate rewrite (SPE-2664 Deferred keep-current)
+- UI / feed rendering
+- SCHEMA_REGISTRY expansion
+
+## Acceptance
+
+- Reject non-finite containment/funding/delta fields (NaN, Infinity)
+- Reject non-finite / invalid clearanceLevel* (NaN, Infinity, negative, fractional)
+- Accept producer-aligned valid before/after/delta payloads (including negative funding/containment deltas)
+- Do not break related agency front-business / academy events in this pass
+- Hydrate rewrite policy unchanged
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Opaque production hydrate rewrite of queue recipe ids | keep current (SPE-2664 Deferred) | Validate-only; hydrate reconcile stays opaque-id tolerant. |
+| Agency front-business / academy soft numerics at validate | follow-on (unnamed) | Out of this slice; same validate-harden pattern when prioritized. |

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -816,14 +816,14 @@ const factionUnlockAvailableSchema = z
 const agencyContainmentUpdatedSchema = z
   .object({
     week: weekSchema,
-    containmentRatingBefore: z.number(),
-    containmentRatingAfter: z.number(),
-    containmentDelta: z.number(),
-    clearanceLevelBefore: z.number(),
-    clearanceLevelAfter: z.number(),
-    fundingBefore: z.number(),
-    fundingAfter: z.number(),
-    fundingDelta: z.number(),
+    containmentRatingBefore: finiteNumberSchema,
+    containmentRatingAfter: finiteNumberSchema,
+    containmentDelta: finiteNumberSchema,
+    clearanceLevelBefore: finiteNonNegativeIntSchema,
+    clearanceLevelAfter: finiteNonNegativeIntSchema,
+    fundingBefore: finiteNumberSchema,
+    fundingAfter: finiteNumberSchema,
+    fundingDelta: finiteNumberSchema,
   })
   .strict()
 

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -322,6 +322,77 @@ describe('event payload validation coverage', () => {
     expect(infiniteContainmentAfter.success).toBe(false)
   })
 
+  it('accepts agency.containment_updated producer-aligned payloads including negative deltas', () => {
+    const positive = validateOperationEventPayload(
+      'agency.containment_updated',
+      minimalOperationEventPayloads['agency.containment_updated']
+    )
+    const negativeDeltas = validateOperationEventPayload('agency.containment_updated', {
+      week: 3,
+      containmentRatingBefore: 60,
+      containmentRatingAfter: 55,
+      containmentDelta: -5,
+      clearanceLevelBefore: 2,
+      clearanceLevelAfter: 2,
+      fundingBefore: 200,
+      fundingAfter: 175,
+      fundingDelta: -25,
+    })
+
+    expect(positive.success).toBe(true)
+    expect(negativeDeltas.success).toBe(true)
+  })
+
+  it('rejects agency.containment_updated payloads with non-finite containment or funding fields', () => {
+    const base = minimalOperationEventPayloads['agency.containment_updated']
+    const nanContainment = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      containmentRatingBefore: Number.NaN,
+    })
+    const infiniteContainmentDelta = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      containmentDelta: Number.POSITIVE_INFINITY,
+    })
+    const nanFunding = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      fundingAfter: Number.NaN,
+    })
+    const infiniteFundingDelta = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      fundingDelta: Number.NEGATIVE_INFINITY,
+    })
+
+    expect(nanContainment.success).toBe(false)
+    expect(infiniteContainmentDelta.success).toBe(false)
+    expect(nanFunding.success).toBe(false)
+    expect(infiniteFundingDelta.success).toBe(false)
+  })
+
+  it('rejects agency.containment_updated payloads with invalid clearanceLevel fields', () => {
+    const base = minimalOperationEventPayloads['agency.containment_updated']
+    const nanClearance = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      clearanceLevelBefore: Number.NaN,
+    })
+    const infiniteClearance = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      clearanceLevelAfter: Number.POSITIVE_INFINITY,
+    })
+    const negativeClearance = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      clearanceLevelBefore: -1,
+    })
+    const fractionalClearance = validateOperationEventPayload('agency.containment_updated', {
+      ...base,
+      clearanceLevelAfter: 1.5,
+    })
+
+    expect(nanClearance.success).toBe(false)
+    expect(infiniteClearance.success).toBe(false)
+    expect(negativeClearance.success).toBe(false)
+    expect(fractionalClearance.success).toBe(false)
+  })
+
   it('rejects case.aggregate_battle payloads missing battleId', () => {
     const payload: Record<string, unknown> = {
       ...minimalOperationEventPayloads['case.aggregate_battle'],


### PR DESCRIPTION
## Linear

- **Slice issue:** [SPE-2668](https://linear.app/spectranoir/issue/SPE-2668/harden-agencycontainment-updated-soft-numerics-at-validate)
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Harden `agencyContainmentUpdatedSchema`: finite numerics for containment/funding/deltas; finite nonnegative ints for clearanceLevel*
- Reject NaN/Infinity (and invalid clearance) at validate; accept signed deltas and producer-aligned fixtures
- Slice doc: `planning/spe-2668-harden-agency-containment-updated-soft-numerics-validate-slice.md`

## Docs updated

- `planning/spe-2668-harden-agency-containment-updated-soft-numerics-validate-slice.md`

## Parent status

- No parent — standalone validate-harden follow-on from SPE-2659–2666

## Scope boundary

- Validate-only; hydrate `reconcileBeforeAfterDelta` / clearance sanitize rewrite unchanged
- No delta == after − before consistency gate beyond hydrate
- Does not touch agency front-business / academy, market/production already-hardened events, UI/feed, or SCHEMA_REGISTRY
- Opaque production hydrate rewrite remains deferred (SPE-2664)

## Validation

- [x] Targeted tests: `npx vitest run --config app.vite.config.ts --configLoader runner --environment jsdom --globals --pool vmThreads src/test/events.validation.test.ts` (96 passed)
- [x] Lint / verify: `npx eslint src/domain/events/eventValidation.ts src/test/events.validation.test.ts`

## Follow-ups

- Opaque production hydrate rewrite of queue recipe ids — keep current (SPE-2664 Deferred)
- Agency front-business / academy soft numerics at validate — unnamed follow-on when prioritized

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)