### PR TITLE
SPE-2669: Harden agency.front_business.* + system.academy_upgraded soft numerics at validate

### DIFF
--- a/planning/spe-2668-harden-agency-containment-updated-soft-numerics-validate-slice.md
+++ b/planning/spe-2668-harden-agency-containment-updated-soft-numerics-validate-slice.md
@@ -40,4 +40,4 @@ Reject non-finite / invalid soft numerics on `agency.containment_updated` at the
 | Item | Owner | Why deferred |
 | --- | --- | --- |
 | Opaque production hydrate rewrite of queue recipe ids | keep current (SPE-2664 Deferred) | Validate-only; hydrate reconcile stays opaque-id tolerant. |
-| Agency front-business / academy soft numerics at validate | follow-on (unnamed) | Out of this slice; same validate-harden pattern when prioritized. |
+| Agency front-business / academy soft numerics at validate | [SPE-2669](https://linear.app/spectranoir/issue/SPE-2669/harden-agencyfront-business-systemacademy-upgraded-soft-numerics-at) | Out of this slice; same validate-harden pattern when prioritized. |

--- a/planning/spe-2669-harden-agency-front-business-academy-soft-numerics-validate-slice.md
+++ b/planning/spe-2669-harden-agency-front-business-academy-soft-numerics-validate-slice.md
@@ -1,0 +1,45 @@
+# SPE-2669 — Harden agency.front_business.* + system.academy_upgraded soft numerics at validate
+
+**Linear:** [SPE-2669](https://linear.app/spectranoir/issue/SPE-2669/harden-agencyfront-business-systemacademy-upgraded-soft-numerics-at)  
+**Branch:** `jamesdyedbq/spe-2669-harden-agencyfront_business-systemacademy_upgraded-soft`
+
+## Goal
+
+Reject non-finite / invalid soft numerics on `agency.front_business.opened`, `agency.front_business.resolved`, and `system.academy_upgraded` at the validation boundary, matching hydrate sanitize floors without changing hydrate rewrite policy.
+
+Follow-on from SPE-2668 Deferred (agency front-business / academy soft numerics).
+
+## Scope
+
+- Harden inline front-business schemas + `systemAcademyUpgradedSchema` in `src/domain/events/eventValidation.ts`
+- **Opened:** `startupCost` finite nonnegative int; `fundingBefore` / `fundingAfter` finite numerics
+- **Resolved:** `fundingDelta` finite signed (hydrate min -10_000); `riskScore` / `lockoutCount` / `residueCount` / `budgetPressure` finite nonnegative ints
+- **Academy:** `fundingBefore` / `fundingAfter` finite; `cost` / `tierBefore` / `tierAfter` finite nonnegative ints
+- Do **not** change hydrate sanitize/reconcile rewrite (`runTransfer.ts` cases ~8387–8448 / `reconcileAcademyUpgradeFields`)
+- Targeted validation tests; fixture update only if needed
+
+## Out of scope
+
+- Hydrate sanitize / reconcile rewrite policy
+- `staff.side_work` / infiltration soft numerics (not scoped in same pass)
+- `agency.containment_updated` (done SPE-2668)
+- `market.*` / `production.queue_*` already-hardened events (SPE-2659–2666)
+- Opaque production hydrate rewrite (SPE-2664 Deferred keep-current)
+- UI / feed rendering
+- SCHEMA_REGISTRY expansion
+- SPE-2667 delayed market order hydration (separate open PR #3245)
+
+## Acceptance
+
+- Reject non-finite funding/cost/score fields (NaN, Infinity) on front-business opened/resolved and academy_upgraded
+- Reject invalid nonnegative-int fields where hydrate floors require (NaN, Infinity, negative, fractional)
+- Accept producer-aligned fixtures including negative `fundingDelta` on resolved
+- Leave unrelated agency / staff / infiltration events alone
+- Hydrate rewrite policy unchanged
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Opaque production hydrate rewrite of queue recipe ids | keep current (SPE-2664 Deferred) | Validate-only; hydrate reconcile stays opaque-id tolerant. |
+| `staff.side_work.resolved` / infiltration soft numerics at validate | follow-on (unnamed) | Out of this slice; same validate-harden pattern when prioritized. |

--- a/planning/spe-2669-harden-agency-front-business-academy-soft-numerics-validate-slice.md
+++ b/planning/spe-2669-harden-agency-front-business-academy-soft-numerics-validate-slice.md
@@ -13,7 +13,7 @@ Follow-on from SPE-2668 Deferred (agency front-business / academy soft numerics)
 
 - Harden inline front-business schemas + `systemAcademyUpgradedSchema` in `src/domain/events/eventValidation.ts`
 - **Opened:** `startupCost` finite nonnegative int; `fundingBefore` / `fundingAfter` finite numerics
-- **Resolved:** `fundingDelta` finite signed (hydrate min -10_000); `riskScore` / `lockoutCount` / `residueCount` / `budgetPressure` finite nonnegative ints
+- **Resolved:** `fundingDelta` finite signed with hydrate min `-10_000`; `riskScore` / `lockoutCount` / `residueCount` / `budgetPressure` finite nonnegative ints
 - **Academy:** `fundingBefore` / `fundingAfter` finite; `cost` / `tierBefore` / `tierAfter` finite nonnegative ints
 - Do **not** change hydrate sanitize/reconcile rewrite (`runTransfer.ts` cases ~8387–8448 / `reconcileAcademyUpgradeFields`)
 - Targeted validation tests; fixture update only if needed

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -7,7 +7,6 @@ import type { OperationEventType } from './types'
 
 const idSchema = z.string().min(1)
 const weekSchema = z.number().int().min(1)
-const nonNegativeIntSchema = z.number().int().min(0)
 const finiteNonNegativeIntSchema = z.number().finite().int().min(0)
 const finitePositiveIntSchema = z.number().finite().int().min(1)
 const finiteNonNegativeNumberSchema = z.number().finite().min(0)
@@ -879,11 +878,11 @@ const concealmentActivatedEventSchema = z
 const systemAcademyUpgradedSchema = z
   .object({
     week: weekSchema,
-    tierBefore: nonNegativeIntSchema,
-    tierAfter: nonNegativeIntSchema,
-    fundingBefore: z.number(),
-    fundingAfter: z.number(),
-    cost: z.number(),
+    tierBefore: finiteNonNegativeIntSchema,
+    tierAfter: finiteNonNegativeIntSchema,
+    fundingBefore: finiteNumberSchema,
+    fundingAfter: finiteNumberSchema,
+    cost: finiteNonNegativeIntSchema,
   })
   .strict()
 
@@ -930,20 +929,20 @@ export const operationEventPayloadSchemas = {
   'agency.front_business.opened': z.object({
     week: z.number(),
     kind: z.literal('courierShell'),
-    startupCost: z.number(),
-    fundingBefore: z.number(),
-    fundingAfter: z.number(),
+    startupCost: finiteNonNegativeIntSchema,
+    fundingBefore: finiteNumberSchema,
+    fundingAfter: finiteNumberSchema,
   }),
   'agency.front_business.resolved': z.object({
     week: z.number(),
     kind: z.literal('courierShell'),
     statusBefore: z.enum(['active', 'strained', 'collapsed']),
     statusAfter: z.enum(['active', 'strained', 'collapsed']),
-    fundingDelta: z.number(),
-    riskScore: z.number(),
-    lockoutCount: z.number(),
-    residueCount: z.number(),
-    budgetPressure: z.number(),
+    fundingDelta: finiteNumberSchema,
+    riskScore: finiteNonNegativeIntSchema,
+    lockoutCount: finiteNonNegativeIntSchema,
+    residueCount: finiteNonNegativeIntSchema,
+    budgetPressure: finiteNonNegativeIntSchema,
   }),
   'directive.applied': directiveAppliedSchema,
   'support.shortfall': supportShortfallSchema,

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -938,7 +938,7 @@ export const operationEventPayloadSchemas = {
     kind: z.literal('courierShell'),
     statusBefore: z.enum(['active', 'strained', 'collapsed']),
     statusAfter: z.enum(['active', 'strained', 'collapsed']),
-    fundingDelta: finiteNumberSchema,
+    fundingDelta: finiteNumberSchema.min(-10_000),
     riskScore: finiteNonNegativeIntSchema,
     lockoutCount: finiteNonNegativeIntSchema,
     residueCount: finiteNonNegativeIntSchema,

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -393,6 +393,137 @@ describe('event payload validation coverage', () => {
     expect(fractionalClearance.success).toBe(false)
   })
 
+  it('accepts agency.front_business.* and system.academy_upgraded producer-aligned payloads including negative funding deltas', () => {
+    const opened = validateOperationEventPayload(
+      'agency.front_business.opened',
+      minimalOperationEventPayloads['agency.front_business.opened']
+    )
+    const resolved = validateOperationEventPayload(
+      'agency.front_business.resolved',
+      minimalOperationEventPayloads['agency.front_business.resolved']
+    )
+    const negativeFundingDelta = validateOperationEventPayload('agency.front_business.resolved', {
+      week: 3,
+      kind: 'courierShell',
+      statusBefore: 'active',
+      statusAfter: 'strained',
+      fundingDelta: -250,
+      riskScore: 3,
+      lockoutCount: 1,
+      residueCount: 0,
+      budgetPressure: 2,
+    })
+    const academy = validateOperationEventPayload(
+      'system.academy_upgraded',
+      minimalOperationEventPayloads['system.academy_upgraded']
+    )
+
+    expect(opened.success).toBe(true)
+    expect(resolved.success).toBe(true)
+    expect(negativeFundingDelta.success).toBe(true)
+    expect(academy.success).toBe(true)
+  })
+
+  it('rejects agency.front_business.opened payloads with non-finite funding or invalid startupCost', () => {
+    const base = minimalOperationEventPayloads['agency.front_business.opened']
+    const nanFunding = validateOperationEventPayload('agency.front_business.opened', {
+      ...base,
+      fundingBefore: Number.NaN,
+    })
+    const infiniteFundingAfter = validateOperationEventPayload('agency.front_business.opened', {
+      ...base,
+      fundingAfter: Number.POSITIVE_INFINITY,
+    })
+    const nanStartupCost = validateOperationEventPayload('agency.front_business.opened', {
+      ...base,
+      startupCost: Number.NaN,
+    })
+    const negativeStartupCost = validateOperationEventPayload('agency.front_business.opened', {
+      ...base,
+      startupCost: -1,
+    })
+    const fractionalStartupCost = validateOperationEventPayload('agency.front_business.opened', {
+      ...base,
+      startupCost: 1.5,
+    })
+
+    expect(nanFunding.success).toBe(false)
+    expect(infiniteFundingAfter.success).toBe(false)
+    expect(nanStartupCost.success).toBe(false)
+    expect(negativeStartupCost.success).toBe(false)
+    expect(fractionalStartupCost.success).toBe(false)
+  })
+
+  it('rejects agency.front_business.resolved payloads with non-finite fundingDelta or invalid score fields', () => {
+    const base = minimalOperationEventPayloads['agency.front_business.resolved']
+    const nanFundingDelta = validateOperationEventPayload('agency.front_business.resolved', {
+      ...base,
+      fundingDelta: Number.NaN,
+    })
+    const infiniteFundingDelta = validateOperationEventPayload('agency.front_business.resolved', {
+      ...base,
+      fundingDelta: Number.NEGATIVE_INFINITY,
+    })
+    const nanRiskScore = validateOperationEventPayload('agency.front_business.resolved', {
+      ...base,
+      riskScore: Number.NaN,
+    })
+    const negativeLockoutCount = validateOperationEventPayload('agency.front_business.resolved', {
+      ...base,
+      lockoutCount: -1,
+    })
+    const fractionalBudgetPressure = validateOperationEventPayload('agency.front_business.resolved', {
+      ...base,
+      budgetPressure: 1.5,
+    })
+    const infiniteResidueCount = validateOperationEventPayload('agency.front_business.resolved', {
+      ...base,
+      residueCount: Number.POSITIVE_INFINITY,
+    })
+
+    expect(nanFundingDelta.success).toBe(false)
+    expect(infiniteFundingDelta.success).toBe(false)
+    expect(nanRiskScore.success).toBe(false)
+    expect(negativeLockoutCount.success).toBe(false)
+    expect(fractionalBudgetPressure.success).toBe(false)
+    expect(infiniteResidueCount.success).toBe(false)
+  })
+
+  it('rejects system.academy_upgraded payloads with non-finite funding or invalid cost/tier fields', () => {
+    const base = minimalOperationEventPayloads['system.academy_upgraded']
+    const nanFunding = validateOperationEventPayload('system.academy_upgraded', {
+      ...base,
+      fundingBefore: Number.NaN,
+    })
+    const infiniteFundingAfter = validateOperationEventPayload('system.academy_upgraded', {
+      ...base,
+      fundingAfter: Number.POSITIVE_INFINITY,
+    })
+    const nanCost = validateOperationEventPayload('system.academy_upgraded', {
+      ...base,
+      cost: Number.NaN,
+    })
+    const negativeCost = validateOperationEventPayload('system.academy_upgraded', {
+      ...base,
+      cost: -1,
+    })
+    const fractionalTier = validateOperationEventPayload('system.academy_upgraded', {
+      ...base,
+      tierAfter: 1.5,
+    })
+    const infiniteTier = validateOperationEventPayload('system.academy_upgraded', {
+      ...base,
+      tierBefore: Number.POSITIVE_INFINITY,
+    })
+
+    expect(nanFunding.success).toBe(false)
+    expect(infiniteFundingAfter.success).toBe(false)
+    expect(nanCost.success).toBe(false)
+    expect(negativeCost.success).toBe(false)
+    expect(fractionalTier.success).toBe(false)
+    expect(infiniteTier.success).toBe(false)
+  })
+
   it('rejects case.aggregate_battle payloads missing battleId', () => {
     const payload: Record<string, unknown> = {
       ...minimalOperationEventPayloads['case.aggregate_battle'],

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -413,6 +413,10 @@ describe('event payload validation coverage', () => {
       residueCount: 0,
       budgetPressure: 2,
     })
+    const hydrateFloorFundingDelta = validateOperationEventPayload('agency.front_business.resolved', {
+      ...minimalOperationEventPayloads['agency.front_business.resolved'],
+      fundingDelta: -10_000,
+    })
     const academy = validateOperationEventPayload(
       'system.academy_upgraded',
       minimalOperationEventPayloads['system.academy_upgraded']
@@ -421,6 +425,7 @@ describe('event payload validation coverage', () => {
     expect(opened.success).toBe(true)
     expect(resolved.success).toBe(true)
     expect(negativeFundingDelta.success).toBe(true)
+    expect(hydrateFloorFundingDelta.success).toBe(true)
     expect(academy.success).toBe(true)
   })
 
@@ -464,6 +469,10 @@ describe('event payload validation coverage', () => {
       ...base,
       fundingDelta: Number.NEGATIVE_INFINITY,
     })
+    const belowHydrateFloor = validateOperationEventPayload('agency.front_business.resolved', {
+      ...base,
+      fundingDelta: -10_001,
+    })
     const nanRiskScore = validateOperationEventPayload('agency.front_business.resolved', {
       ...base,
       riskScore: Number.NaN,
@@ -483,6 +492,7 @@ describe('event payload validation coverage', () => {
 
     expect(nanFundingDelta.success).toBe(false)
     expect(infiniteFundingDelta.success).toBe(false)
+    expect(belowHydrateFloor.success).toBe(false)
     expect(nanRiskScore.success).toBe(false)
     expect(negativeLockoutCount.success).toBe(false)
     expect(fractionalBudgetPressure.success).toBe(false)


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2669 — https://linear.app/spectranoir/issue/SPE-2669/harden-agencyfront-business-systemacademy-upgraded-soft-numerics-at
- **Parent issue (if any):** none (follow-on from SPE-2668 Deferred)
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Harden validate schemas for `agency.front_business.opened`, `agency.front_business.resolved`, and `system.academy_upgraded` using `finiteNumberSchema` / `finiteNonNegativeIntSchema`
- Reject non-finite funding/cost/score fields and invalid nonnegative ints (NaN, Infinity, negative, fractional) where hydrate floors require
- Accept producer-aligned fixtures including negative `fundingDelta` on resolved
- Remove unused `nonNegativeIntSchema` after academy tiers moved to finite nonnegative int
- Hydrate rewrite policy unchanged

## Docs updated

- `planning/spe-2669-harden-agency-front-business-academy-soft-numerics-validate-slice.md`
- `planning/spe-2668-harden-agency-containment-updated-soft-numerics-validate-slice.md` Deferred row → SPE-2669

## Parent status

- No parent umbrella; SPE-2668 remains Done. Validate-harden chain continues via Deferred follow-ons (`staff.side_work` / infiltration not in this PR).

## Scope boundary

- Validate-only; no hydrate sanitize/reconcile rewrite changes
- Does not harden `staff.side_work` / infiltration
- Does not touch `agency.containment_updated` (SPE-2668), market/production already-hardened events, opaque production hydrate rewrite (SPE-2664 Deferred), UI/feed, or SCHEMA_REGISTRY
- SPE-2667 (#3245) left alone

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/test/minimalOperationEventPayloads.test.ts src/test/events.producerValidation.test.ts`
- [x] Lint: `npx eslint src/domain/events/eventValidation.ts src/test/events.validation.test.ts`

## Follow-ups

- `staff.side_work.resolved` / infiltration soft numerics at validate (Deferred)
- Opaque production hydrate rewrite (SPE-2664 Deferred keep-current)

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)

Made with [Cursor](https://cursor.com)