### PR TITLE
SPE-2686: Harden staff.side_work.resolved soft numerics at validate

### DIFF
--- a/planning/spe-2686-harden-staff-side-work-resolved-soft-numerics-validate-slice.md
+++ b/planning/spe-2686-harden-staff-side-work-resolved-soft-numerics-validate-slice.md
@@ -1,0 +1,45 @@
+# SPE-2686 — Harden staff.side_work.resolved soft numerics at validate
+
+**Linear:** [SPE-2686](https://linear.app/spectranoir/issue/SPE-2686/harden-staffside-workresolved-soft-numerics-at-validate)  
+**Branch:** `jamesdyedbq/spe-2686-harden-staffside_workresolved-soft-numerics-at-validate`
+
+> Note: Handoff named this follow-on SPE-2670; that id is already a canceled unrelated issue (Adventurer hover cards). This slice is SPE-2686.
+
+## Goal
+
+Reject non-finite / below-floor soft numerics on `staff.side_work.resolved` at the validation boundary, matching hydrate sanitize floors without changing hydrate rewrite policy.
+
+Follow-on from SPE-2669 Deferred (`staff.side_work.resolved` / infiltration soft numerics).
+
+## Scope
+
+- Harden `staff.side_work.resolved` schema in `src/domain/events/eventValidation.ts`
+- `fundingDelta` — finite signed with hydrate min `-10_000`
+- `fatigueDelta` — finite signed with hydrate min `-100`
+- Do **not** change hydrate sanitize rewrite (`runTransfer.ts` case ~8485–8505)
+- Targeted validation tests; fixture update only if needed
+
+## Out of scope
+
+- Hydrate sanitize / reconcile rewrite policy
+- Infiltration probe soft numerics (separate follow-on if prioritized)
+- `staff.coping.*` / concealment events
+- Already-hardened agency / market / production validate events (SPE-2659–2669)
+- UI / feed rendering
+- SCHEMA_REGISTRY expansion
+- SPE-2667 delayed market order hydration (separate open PR #3245)
+
+## Acceptance
+
+- Reject non-finite `fundingDelta` / `fatigueDelta` (NaN, Infinity)
+- Reject deltas below hydrate floors (`fundingDelta` < -10_000, `fatigueDelta` < -100)
+- Accept producer-aligned fixtures including negative deltas
+- Leave unrelated staff / agency / infiltration events alone
+- Hydrate rewrite policy unchanged
+
+## Deferred
+
+| Item | Owner | Why deferred |
+| --- | --- | --- |
+| Infiltration probe soft numerics at validate | follow-on (unnamed) | Out of this slice; same validate-harden pattern when prioritized. |
+| Opaque production hydrate rewrite of queue recipe ids | keep current (SPE-2664 Deferred) | Validate-only; hydrate reconcile stays opaque-id tolerant. |

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -972,8 +972,8 @@ export const operationEventPayloadSchemas = {
     agentId: z.string(),
     optionId: z.enum(['offBooksCourier', 'trustedCourier']),
     outcome: z.enum(['paid', 'lockout']),
-    fundingDelta: z.number(),
-    fatigueDelta: z.number(),
+    fundingDelta: finiteNumberSchema.min(-10_000),
+    fatigueDelta: finiteNumberSchema.min(-100),
   }),
 } satisfies Record<OperationEventType, z.ZodTypeAny>
 

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -534,6 +534,71 @@ describe('event payload validation coverage', () => {
     expect(infiniteTier.success).toBe(false)
   })
 
+  it('accepts staff.side_work.resolved producer-aligned payloads including negative deltas', () => {
+    const fixture = validateOperationEventPayload(
+      'staff.side_work.resolved',
+      minimalOperationEventPayloads['staff.side_work.resolved']
+    )
+    const negativeFunding = validateOperationEventPayload('staff.side_work.resolved', {
+      ...minimalOperationEventPayloads['staff.side_work.resolved'],
+      fundingDelta: -250,
+      fatigueDelta: -10,
+    })
+    const hydrateFloorFunding = validateOperationEventPayload('staff.side_work.resolved', {
+      ...minimalOperationEventPayloads['staff.side_work.resolved'],
+      fundingDelta: -10_000,
+    })
+    const hydrateFloorFatigue = validateOperationEventPayload('staff.side_work.resolved', {
+      ...minimalOperationEventPayloads['staff.side_work.resolved'],
+      fatigueDelta: -100,
+    })
+    const copingUnchanged = validateOperationEventPayload(
+      'staff.coping.misconduct',
+      minimalOperationEventPayloads['staff.coping.misconduct']
+    )
+
+    expect(fixture.success).toBe(true)
+    expect(negativeFunding.success).toBe(true)
+    expect(hydrateFloorFunding.success).toBe(true)
+    expect(hydrateFloorFatigue.success).toBe(true)
+    expect(copingUnchanged.success).toBe(true)
+  })
+
+  it('rejects staff.side_work.resolved payloads with non-finite or below-floor deltas', () => {
+    const base = minimalOperationEventPayloads['staff.side_work.resolved']
+    const nanFundingDelta = validateOperationEventPayload('staff.side_work.resolved', {
+      ...base,
+      fundingDelta: Number.NaN,
+    })
+    const infiniteFundingDelta = validateOperationEventPayload('staff.side_work.resolved', {
+      ...base,
+      fundingDelta: Number.NEGATIVE_INFINITY,
+    })
+    const belowFundingFloor = validateOperationEventPayload('staff.side_work.resolved', {
+      ...base,
+      fundingDelta: -10_001,
+    })
+    const nanFatigueDelta = validateOperationEventPayload('staff.side_work.resolved', {
+      ...base,
+      fatigueDelta: Number.NaN,
+    })
+    const infiniteFatigueDelta = validateOperationEventPayload('staff.side_work.resolved', {
+      ...base,
+      fatigueDelta: Number.POSITIVE_INFINITY,
+    })
+    const belowFatigueFloor = validateOperationEventPayload('staff.side_work.resolved', {
+      ...base,
+      fatigueDelta: -101,
+    })
+
+    expect(nanFundingDelta.success).toBe(false)
+    expect(infiniteFundingDelta.success).toBe(false)
+    expect(belowFundingFloor.success).toBe(false)
+    expect(nanFatigueDelta.success).toBe(false)
+    expect(infiniteFatigueDelta.success).toBe(false)
+    expect(belowFatigueFloor.success).toBe(false)
+  })
+
   it('rejects case.aggregate_battle payloads missing battleId', () => {
     const payload: Record<string, unknown> = {
       ...minimalOperationEventPayloads['case.aggregate_battle'],


### PR DESCRIPTION
﻿## Linear

- **Slice issue:** SPE-2686 — https://linear.app/spectranoir/issue/SPE-2686/harden-staffside-workresolved-soft-numerics-at-validate
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Validate-only finite soft-numeric harden for `staff.side_work.resolved`: `fundingDelta` finite with hydrate floor `.min(-10_000)`, `fatigueDelta` finite with hydrate floor `.min(-100)`
- Targeted accept/reject validation tests; producer fixture (negative fatigueDelta) unchanged
- Hydrate rewrite (`runTransfer.ts` sanitizeInteger floors) unchanged

## Docs updated

- `planning/spe-2686-harden-staff-side-work-resolved-soft-numerics-validate-slice.md`

## Parent status

- none — standalone follow-on from SPE-2669 Deferred (SPE-2669 remains Done)

## Scope boundary

- Does not change hydrate sanitize rewrite
- Does not harden infiltration probe soft numerics (deferred)
- Does not touch staff.coping / concealment, market, production, or SCHEMA_REGISTRY
- Does not babysit SPE-2667 (#3245)

## Validation

- [x] Targeted tests: `npx vitest run --config app.vite.config.ts --configLoader runner --environment jsdom --globals --pool vmThreads src/test/events.validation.test.ts` (102 passed)
- [x] Lint / verify: `npx eslint src/domain/events/eventValidation.ts src/test/events.validation.test.ts`

## Follow-ups

- Infiltration probe soft numerics at validate (SPE-2686 Deferred)
- Opaque production hydrate rewrite (SPE-2664 Deferred keep-current)
- SPE-2667 delayed market order hydration (#3245) remains separate

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)
