### PR TITLE
SPE-2690: Validate accountability closure chronology

### DIFF
--- a/planning/spe-2690-emergency-gray-market-accountability-closure-chronology-slice.md
+++ b/planning/spe-2690-emergency-gray-market-accountability-closure-chronology-slice.md
@@ -1,0 +1,35 @@
+# SPE-2690 — Emergency gray-market accountability closure chronology
+
+**Linear:** [SPE-2690](https://linear.app/spectranoir/issue/SPE-2690/validate-emergency-gray-market-accountability-closure-chronology)  
+**Branch:** `spe-2690-accountability-closure-chronology`
+
+## Goal
+
+Keep emergency gray-market accountability closure records canonical: the closure posts exactly one campaign week after the waiver grant and carries a normalized institution audit key.
+
+## Scope
+
+- Require positive integer `week` and `waiverGrantWeek`.
+- Require `week === waiverGrantWeek + 1`.
+- Require a nonblank institution key that already matches `normalizeInstitutionKeyForAudit`.
+- Preserve the existing producer, which already emits the canonical next-week relationship.
+- Reconcile older loose closure records during hydration by setting `waiverGrantWeek` to `week - 1`.
+- Drop an impossible closure recorded in campaign week 1 after canonical validation; do not invent a later closure week.
+- Add focused validation and hydration tests.
+
+## Boundary
+
+- No waiver eligibility, grant, fallout, procurement-access, or UI behavior changes.
+- No changes to unrelated market event schemas.
+- No schema-version bump: hydration already performs per-event canonicalization before current-schema validation.
+
+## Acceptance
+
+- Closure before grant, in the grant week, or later than the next-week window fails validation.
+- Invalid, blank, or noncanonical institution keys fail validation.
+- The canonical next-week closure passes validation.
+- Legacy loose grant weeks hydrate to the prior campaign week.
+
+## Deferred
+
+None.

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -10803,7 +10803,11 @@ describe('runTransfer import sanitization (326-332)', () => {
       })
     })
 
-    it('513 clamps emergency waiver accountability waiverGrantWeek below event week', () => {
+    it.each([
+      ['after the closure week', 99],
+      ['during the closure week', 5],
+      ['too early for the canonical window', 2],
+    ])('513 reconciles emergency waiver accountability grant week %s', (_case, waiverGrantWeek) => {
       const fallback = createStartingState()
 
       const hydrated = hydrateGame({
@@ -10816,7 +10820,7 @@ describe('runTransfer import sanitization (326-332)', () => {
             timestamp: buildOperationEventTimestamp(5, 0),
             payload: {
               week: 5,
-              waiverGrantWeek: 99,
+              waiverGrantWeek,
               institutionKey: 'containment_protocol',
             },
           },
@@ -10828,6 +10832,29 @@ describe('runTransfer import sanitization (326-332)', () => {
       expect(payload.waiverGrantWeek).toBeLessThan(payload.week ?? 0)
       expect(payload.waiverGrantWeek).toBeLessThanOrEqual(hydrated.week)
       expect(payload.waiverGrantWeek).toBe(4)
+    })
+
+    it('513 drops an emergency waiver accountability closure in campaign week one', () => {
+      const fallback = createStartingState()
+
+      const hydrated = hydrateGame({
+        ...stripGameTemplates(fallback),
+        week: 1,
+        events: [
+          {
+            id: 'evt-waiver-closed-513-impossible',
+            type: 'market.emergency_gray_market_waiver_accountability_closed',
+            timestamp: buildOperationEventTimestamp(1, 0),
+            payload: {
+              week: 1,
+              waiverGrantWeek: 1,
+              institutionKey: 'containment_protocol',
+            },
+          },
+        ],
+      })
+
+      expect(hydrated.events).toEqual([])
     })
 
     it('514-515 reconcile standing, reputation, and contact relationship deltas', () => {

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -1331,22 +1331,9 @@ function reconcileContactRelationshipFields(
   }
 }
 
-function clampEmergencyWaiverGrantWeek(
-  value: unknown,
-  eventWeek: number,
-  campaignWeek: number
-): number {
-  const cappedCampaignWeek = Math.max(1, Math.trunc(campaignWeek))
-  const cappedEventWeek = Math.max(1, Math.trunc(eventWeek))
-  const maxGrantWeek = Math.min(cappedEventWeek - 1, cappedCampaignWeek)
-
-  if (maxGrantWeek < 1) {
-    return 1
-  }
-
-  const fallback = Math.max(1, cappedEventWeek - 1)
-
-  return clamp(sanitizeInteger(value as number | undefined, fallback, 1), 1, maxGrantWeek)
+/** Hydration policy: legacy closure records always reconcile to the canonical next-week window. */
+function reconcileEmergencyWaiverClosureGrantWeek(eventWeek: number): number {
+  return Math.max(1, Math.trunc(eventWeek) - 1)
 }
 
 function reconcileBeforeAfterDelta(before: unknown, after: unknown, delta: unknown, min: number) {
@@ -7584,7 +7571,9 @@ function sanitizeOperationEvents(
                 agentId:
                   typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
                 agentName:
-                  typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
+                  typeof payload.agentName === 'string'
+                    ? payload.agentName
+                    : `Agent ${index + 1}`,
                 trainingId: training.trainingId,
                 trainingName: training.trainingName,
               },
@@ -7663,9 +7652,7 @@ function sanitizeOperationEvents(
                 agentId:
                   typeof payload.agentId === 'string' ? payload.agentId : `agent-${index + 1}`,
                 agentName:
-                  typeof payload.agentName === 'string'
-                    ? payload.agentName
-                    : `Agent ${index + 1}`,
+                  typeof payload.agentName === 'string' ? payload.agentName : `Agent ${index + 1}`,
                 instructorSpecialty: instructor.instructorSpecialty,
                 bonus: instructor.bonus,
               },
@@ -8143,16 +8130,16 @@ function sanitizeOperationEvents(
         break
 
       case 'market.emergency_gray_market_waiver_accountability_closed':
+        if (week === 1) {
+          break
+        }
+
         nextEvents.push(
           migrateOperationEventToCurrentSchema({
             ...createBase('market.emergency_gray_market_waiver_accountability_closed'),
             payload: {
               week,
-              waiverGrantWeek: clampEmergencyWaiverGrantWeek(
-                payload.waiverGrantWeek,
-                week,
-                cappedCampaignWeek
-              ),
+              waiverGrantWeek: reconcileEmergencyWaiverClosureGrantWeek(week),
               institutionKey: normalizeInstitutionKeyForAudit(
                 typeof payload.institutionKey === 'string' ? payload.institutionKey : undefined
               ),

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod'
 import { getProductionRecipe } from '../../data/production'
 import { getCanonicalMarketCostMultiplier, sanitizeFeaturedRecipeId } from '../market'
+import { normalizeInstitutionKeyForAudit } from '../procurementEmergencyInstitution'
 import { getLevelForXp } from '../progression'
 import type { OperationEventType } from './types'
 
@@ -751,9 +752,23 @@ const marketEmergencyGrayMarketWaiverAccountabilityClosedSchema = z
   .object({
     week: weekSchema,
     waiverGrantWeek: weekSchema,
-    institutionKey: z.string().min(1),
+    institutionKey: z
+      .string()
+      .min(1)
+      .refine((value) => value === normalizeInstitutionKeyForAudit(value), {
+        message: 'institutionKey must be a normalized nonblank audit key',
+      }),
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.week !== payload.waiverGrantWeek + 1) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'week must be exactly one campaign week after waiverGrantWeek',
+        path: ['week'],
+      })
+    }
+  })
 
 const marketEmergencyGrayMarketFalloutTickSchema = z
   .object({

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -236,6 +236,58 @@ describe('event payload validation coverage', () => {
     expect(validation.success).toBe(true)
   })
 
+  it.each([
+    ['before the grant', 4, 5],
+    ['during the grant week', 5, 5],
+    ['later than the canonical next-week window', 7, 5],
+  ])(
+    'rejects market.emergency_gray_market_waiver_accountability_closed %s',
+    (_case, week, waiverGrantWeek) => {
+      const validation = validateOperationEventPayload(
+        'market.emergency_gray_market_waiver_accountability_closed',
+        {
+          week,
+          waiverGrantWeek,
+          institutionKey: 'containment_protocol',
+        }
+      )
+
+      expect(validation.success).toBe(false)
+    }
+  )
+
+  it.each(['', '   ', ' Containment Protocol ', 'CONTAINMENT_PROTOCOL'])(
+    'rejects market.emergency_gray_market_waiver_accountability_closed with noncanonical institutionKey %j',
+    (institutionKey) => {
+      const validation = validateOperationEventPayload(
+        'market.emergency_gray_market_waiver_accountability_closed',
+        {
+          week: 6,
+          waiverGrantWeek: 5,
+          institutionKey,
+        }
+      )
+
+      expect(validation.success).toBe(false)
+    }
+  )
+
+  it.each([0, -1, 1.5])(
+    'rejects market.emergency_gray_market_waiver_accountability_closed with waiverGrantWeek %s',
+    (waiverGrantWeek) => {
+      const validation = validateOperationEventPayload(
+        'market.emergency_gray_market_waiver_accountability_closed',
+        {
+          week: 2,
+          waiverGrantWeek,
+          institutionKey: 'containment_protocol',
+        }
+      )
+
+      expect(validation.success).toBe(false)
+    }
+  )
+
   it('accepts market.emergency_gray_market_fallout_tick payloads', () => {
     const validation = validateOperationEventPayload('market.emergency_gray_market_fallout_tick', {
       week: 7,

--- a/src/test/fixtures/minimalOperationEventPayloads.ts
+++ b/src/test/fixtures/minimalOperationEventPayloads.ts
@@ -379,8 +379,8 @@ export const minimalOperationEventPayloads = {
     ruleConflictSignal: 'none',
   },
   'market.emergency_gray_market_waiver_accountability_closed': {
-    week: WEEK,
-    waiverGrantWeek: WEEK,
+    week: 2,
+    waiverGrantWeek: 1,
     institutionKey: 'containment_protocol',
   },
   'market.emergency_gray_market_fallout_tick': {


### PR DESCRIPTION
## Summary

- enforce canonical next-week chronology for `market.emergency_gray_market_waiver_accountability_closed`
- require positive integer grant weeks and normalized nonblank institution audit keys
- reconcile older loose closure records during hydration, dropping impossible campaign-week-one closures
- add focused validation, hydration, producer, and fixture coverage

## Root cause

The closure payload schema independently validated `week` and `waiverGrantWeek` as positive integers but did not validate their relationship. It also accepted any nonempty institution string. Hydration only clamped the grant week below the closure week, preserving noncanonical gaps.

## Impact

New closure events validate only when closure occurs exactly one week after grant. Older persisted closure records are deterministically canonicalized to `waiverGrantWeek = week - 1`; an impossible week-one closure is discarded rather than assigned invented chronology.

## Validation

- `npm run test:run` — 739 files / 7,395 tests passed
- `npm run lint` — passed
- `git diff --check` — passed
- `npm run format:check` — repository baseline remains red across 2,217 pre-existing files; no broad formatting rewrite included

Linear: [SPE-2690](https://linear.app/spectranoir/issue/SPE-2690/validate-emergency-gray-market-accountability-closure-chronology)