### PR TITLE
SPE-2691: Validate fallout tick consistency

### DIFF
--- a/planning/spe-2691-emergency-gray-market-fallout-tick-consistency-slice.md
+++ b/planning/spe-2691-emergency-gray-market-fallout-tick-consistency-slice.md
@@ -1,0 +1,37 @@
+# SPE-2691 — Emergency gray-market fallout tick consistency
+
+**Linear:** [SPE-2691](https://linear.app/spectranoir/issue/SPE-2691/validate-emergency-gray-market-fallout-tick-consistency)  
+**Branch:** `spe-2691-fallout-tick-consistency`
+
+## Goal
+
+Keep emergency gray-market fallout tick records internally consistent with the canonical two-phase fallout lifecycle and precedent-pressure policy.
+
+## Scope
+
+- Require `escalated_pending_oversight` to record `risk → costly`.
+- Require `resolved_closed` to record `costly → none`.
+- Require finite, nonnegative funding and containment before/after values.
+- Require positive funding and containment to decrease on a penalty tick; zero remains zero.
+- Derive the persisted multiplier from precedent count using the named capped policy: `1 + 0.06 × min(count - 1, 6)`, rounded to three decimals.
+- Require a normalized, nonblank institution audit key.
+- Reconcile older loose records during hydration to the canonical risk transition, non-increasing metrics, bounded precedent count, derived multiplier, and normalized institution key.
+
+## Boundary
+
+- No changes to waiver eligibility, fallout probability, penalty magnitudes, procurement access, or UI behavior.
+- No changes to unrelated market event schemas.
+- No schema-version bump; event hydration already canonicalizes persisted fallout tick fields.
+
+## Acceptance
+
+- Risk/outcome mismatches fail validation.
+- Funding or containment increases fail validation.
+- Negative or non-finite funding/containment fail validation.
+- A multiplier inconsistent with precedent count fails validation.
+- Invalid institution keys fail validation.
+- Producer-aligned fallout ticks pass validation.
+
+## Deferred
+
+None.

--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -13514,18 +13514,22 @@ describe('runTransfer import sanitization (326-332)', () => {
         falloutRiskBefore: 'risk',
         falloutRiskAfter: 'costly',
         fundingBefore: 500,
-        fundingAfter: 500,
+        fundingAfter: 499,
         containmentRatingBefore: 60,
-        containmentRatingAfter: 60,
+        containmentRatingAfter: 59,
+        waiverPrecedentCount: 1,
+        precedentPenaltyMultiplier: 1,
       })
       expect(hydrated.events[1]?.payload).toMatchObject({
         outcome: 'resolved_closed',
         falloutRiskBefore: 'costly',
         falloutRiskAfter: 'none',
         fundingBefore: 400,
-        fundingAfter: 400,
+        fundingAfter: 399,
         containmentRatingBefore: 55,
-        containmentRatingAfter: 55,
+        containmentRatingAfter: 54,
+        waiverPrecedentCount: 2,
+        precedentPenaltyMultiplier: 1.06,
       })
     })
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -183,6 +183,7 @@ import {
   AUTHORITY_ROUTE_CRISIS_DIRECTOR_SELF,
   LEGACY_WAIVER_AUTHORITY_BASIS_MIGRATION,
 } from '../../domain/procurementEmergencyAuthority'
+import { getEmergencyWaiverFalloutPrecedentPenaltyMultiplier } from '../../domain/procurementEmergencyFallout'
 import { normalizeInstitutionKeyForAudit } from '../../domain/procurementEmergencyInstitution'
 import {
   reconcileMarketShiftedFields,
@@ -2494,7 +2495,7 @@ function reconcileEmergencyGrayMarketFalloutTickFields(payload: Record<string, u
     fundingBefore,
     0
   )
-  const fundingAfter = Math.min(fundingAfterRaw, fundingBefore)
+  const fundingAfter = Math.min(fundingAfterRaw, Math.max(0, fundingBefore - 1))
   const containmentRatingBefore = sanitizeInteger(
     payload.containmentRatingBefore as number | undefined,
     0,
@@ -2505,7 +2506,17 @@ function reconcileEmergencyGrayMarketFalloutTickFields(payload: Record<string, u
     containmentRatingBefore,
     0
   )
-  const containmentRatingAfter = Math.min(containmentRatingAfterRaw, containmentRatingBefore)
+  const containmentRatingAfter = Math.min(
+    containmentRatingAfterRaw,
+    Math.max(0, containmentRatingBefore - 1)
+  )
+  const waiverPrecedentCount = clamp(
+    sanitizeInteger(payload.waiverPrecedentCount as number | undefined, 1, 1),
+    1,
+    50000
+  )
+  const precedentPenaltyMultiplier =
+    getEmergencyWaiverFalloutPrecedentPenaltyMultiplier(waiverPrecedentCount)
 
   return {
     outcome,
@@ -2515,6 +2526,8 @@ function reconcileEmergencyGrayMarketFalloutTickFields(payload: Record<string, u
     fundingAfter,
     containmentRatingBefore,
     containmentRatingAfter,
+    waiverPrecedentCount,
+    precedentPenaltyMultiplier,
   }
 }
 
@@ -8166,19 +8179,8 @@ function sanitizeOperationEvents(
               institutionKey: normalizeInstitutionKeyForAudit(
                 typeof payload.institutionKey === 'string' ? payload.institutionKey : undefined
               ),
-              waiverPrecedentCount: clamp(
-                sanitizeInteger(payload.waiverPrecedentCount as number | undefined, 1, 1),
-                1,
-                50000
-              ),
-              precedentPenaltyMultiplier: clamp(
-                typeof payload.precedentPenaltyMultiplier === 'number' &&
-                  Number.isFinite(payload.precedentPenaltyMultiplier)
-                  ? payload.precedentPenaltyMultiplier
-                  : 1,
-                1,
-                2
-              ),
+              waiverPrecedentCount: fallout.waiverPrecedentCount,
+              precedentPenaltyMultiplier: fallout.precedentPenaltyMultiplier,
             },
           })
         )

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod'
 import { getProductionRecipe } from '../../data/production'
 import { getCanonicalMarketCostMultiplier, sanitizeFeaturedRecipeId } from '../market'
+import { getEmergencyWaiverFalloutPrecedentPenaltyMultiplier } from '../procurementEmergencyFallout'
 import { normalizeInstitutionKeyForAudit } from '../procurementEmergencyInstitution'
 import { getLevelForXp } from '../progression'
 import type { OperationEventType } from './types'
@@ -776,15 +777,70 @@ const marketEmergencyGrayMarketFalloutTickSchema = z
     outcome: z.enum(['escalated_pending_oversight', 'resolved_closed']),
     falloutRiskBefore: z.enum(['risk', 'costly']),
     falloutRiskAfter: z.enum(['costly', 'none']),
-    fundingBefore: finiteNumberSchema,
-    fundingAfter: finiteNumberSchema,
-    containmentRatingBefore: finiteNumberSchema,
-    containmentRatingAfter: finiteNumberSchema,
+    fundingBefore: finiteNonNegativeNumberSchema,
+    fundingAfter: finiteNonNegativeNumberSchema,
+    containmentRatingBefore: finiteNonNegativeNumberSchema,
+    containmentRatingAfter: finiteNonNegativeNumberSchema,
     waiverPrecedentCount: z.number().int().min(1).max(50000),
-    precedentPenaltyMultiplier: z.number().min(1).max(2),
-    institutionKey: z.string().min(1),
+    precedentPenaltyMultiplier: z.number().finite(),
+    institutionKey: z
+      .string()
+      .min(1)
+      .refine((value) => value === normalizeInstitutionKeyForAudit(value), {
+        message: 'institutionKey must be a normalized nonblank audit key',
+      }),
   })
   .strict()
+  .superRefine((payload, context) => {
+    const expectedRisk =
+      payload.outcome === 'resolved_closed'
+        ? { before: 'costly', after: 'none' }
+        : { before: 'risk', after: 'costly' }
+
+    if (
+      payload.falloutRiskBefore !== expectedRisk.before ||
+      payload.falloutRiskAfter !== expectedRisk.after
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'fallout risk transition must match outcome',
+        path: ['falloutRiskAfter'],
+      })
+    }
+
+    if (
+      payload.fundingAfter > payload.fundingBefore ||
+      (payload.fundingBefore > 0 && payload.fundingAfter === payload.fundingBefore)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'fundingAfter must decrease when fundingBefore is positive',
+        path: ['fundingAfter'],
+      })
+    }
+
+    if (
+      payload.containmentRatingAfter > payload.containmentRatingBefore ||
+      (payload.containmentRatingBefore > 0 &&
+        payload.containmentRatingAfter === payload.containmentRatingBefore)
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'containmentRatingAfter must decrease when containmentRatingBefore is positive',
+        path: ['containmentRatingAfter'],
+      })
+    }
+
+    const expectedMultiplier =
+      getEmergencyWaiverFalloutPrecedentPenaltyMultiplier(payload.waiverPrecedentCount)
+    if (payload.precedentPenaltyMultiplier !== expectedMultiplier) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `precedentPenaltyMultiplier must equal ${expectedMultiplier} for waiverPrecedentCount`,
+        path: ['precedentPenaltyMultiplier'],
+      })
+    }
+  })
 
 const factionStandingChangedSchema = z
   .object({

--- a/src/domain/procurementEmergency.ts
+++ b/src/domain/procurementEmergency.ts
@@ -10,6 +10,7 @@ import {
   AUTHORITY_ROUTE_JOINT_OVERSIGHT_CLEARANCE_RATIFICATION,
   resolveEmergencyGrayMarketWaiverAuthority,
 } from './procurementEmergencyAuthority'
+import { getEmergencyWaiverFalloutPrecedentPenaltyMultiplier } from './procurementEmergencyFallout'
 import { getEmergencyProcurementInstitutionAuditKey } from './procurementEmergencyInstitution'
 import { buildMajorIncidentState } from './strategicState'
 import { normalizeGameState } from './teamSimulation'
@@ -120,18 +121,6 @@ export function invokeEmergencyGrayMarketWaiver(game: GameState): GameState {
   )
 }
 
-/** Max extra precedent steps that tighten fallout (beyond first waiver); caps abuse scaling (SPE-1184). */
-const FALLOUT_PRECEDENT_PRESSURE_MAX_EXTRA_STEPS = 6
-
-/** Per-step pressure on funding/containment penalty magnitude (+6% per step over baseline waiver). */
-const FALLOUT_PRECEDENT_PRESSURE_STEP = 0.06
-
-function emergencyWaiverFalloutPrecedentPressureMultiplier(precedentCount: number): number {
-  const baseline = clamp(precedentCount > 0 ? precedentCount : 1, 1, 50000)
-  const extraSteps = Math.min(Math.max(0, baseline - 1), FALLOUT_PRECEDENT_PRESSURE_MAX_EXTRA_STEPS)
-  return 1 + FALLOUT_PRECEDENT_PRESSURE_STEP * extraSteps
-}
-
 /**
  * Deterministic weekly fallout for emergency waiver legitimacy pressure (SPE-1184).
  * Phase 1: `risk` → `costly` with bounded funding + containment pressure.
@@ -151,10 +140,9 @@ export function applyEmergencyGrayMarketFalloutTick(
   const containmentBefore = nextStateDraft.containmentRating ?? 0
   const institutionKey = getEmergencyProcurementInstitutionAuditKey(nextStateDraft)
   const waiverPrecedentCount = clamp(nextStateDraft.emergencyGrayMarketWaiverPrecedentCount ?? 1, 1, 50000)
-  const precedentPenaltyMultiplier = emergencyWaiverFalloutPrecedentPressureMultiplier(
+  const precedentPenaltyMultiplier = getEmergencyWaiverFalloutPrecedentPenaltyMultiplier(
     waiverPrecedentCount
   )
-  const multiplierRounded = Math.round(precedentPenaltyMultiplier * 1000) / 1000
 
   const baseLegitimacy: LegitimacyState = {
     sanctionLevel: nextStateDraft.legitimacy?.sanctionLevel ?? 'tolerated',
@@ -187,7 +175,7 @@ export function applyEmergencyGrayMarketFalloutTick(
         containmentRatingBefore: containmentBefore,
         containmentRatingAfter: containmentAfter,
         waiverPrecedentCount,
-        precedentPenaltyMultiplier: multiplierRounded,
+        precedentPenaltyMultiplier,
         institutionKey,
       },
     }
@@ -229,7 +217,7 @@ export function applyEmergencyGrayMarketFalloutTick(
       containmentRatingBefore: containmentBefore,
       containmentRatingAfter: containmentAfter,
       waiverPrecedentCount,
-      precedentPenaltyMultiplier: multiplierRounded,
+      precedentPenaltyMultiplier,
       institutionKey,
     },
   }

--- a/src/domain/procurementEmergencyFallout.ts
+++ b/src/domain/procurementEmergencyFallout.ts
@@ -1,0 +1,21 @@
+import { clamp } from './math'
+
+/** Max extra precedent steps that tighten fallout beyond the first waiver. */
+export const EMERGENCY_WAIVER_FALLOUT_PRECEDENT_MAX_EXTRA_STEPS = 6
+
+/** Funding/containment penalty multiplier added per precedent step. */
+export const EMERGENCY_WAIVER_FALLOUT_PRECEDENT_MULTIPLIER_STEP = 0.06
+
+/** Canonical persisted multiplier for an emergency-waiver fallout tick. */
+export function getEmergencyWaiverFalloutPrecedentPenaltyMultiplier(
+  precedentCount: number
+): number {
+  const baseline = clamp(Math.trunc(precedentCount), 1, 50000)
+  const extraSteps = Math.min(
+    baseline - 1,
+    EMERGENCY_WAIVER_FALLOUT_PRECEDENT_MAX_EXTRA_STEPS
+  )
+  return Math.round(
+    (1 + EMERGENCY_WAIVER_FALLOUT_PRECEDENT_MULTIPLIER_STEP * extraSteps) * 1000
+  ) / 1000
+}

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -306,6 +306,94 @@ describe('event payload validation coverage', () => {
     expect(validation.success).toBe(true)
   })
 
+  it('rejects market.emergency_gray_market_fallout_tick with a risk transition that contradicts the outcome', () => {
+    const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
+    const validation = validateOperationEventPayload(
+      'market.emergency_gray_market_fallout_tick',
+      {
+        ...base,
+        outcome: 'escalated_pending_oversight',
+        falloutRiskBefore: 'costly',
+        falloutRiskAfter: 'none',
+      }
+    )
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects market.emergency_gray_market_fallout_tick when funding increases on a penalty tick', () => {
+    const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
+    const validation = validateOperationEventPayload(
+      'market.emergency_gray_market_fallout_tick',
+      {
+        ...base,
+        fundingAfter: base.fundingBefore + 1,
+      }
+    )
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects market.emergency_gray_market_fallout_tick when containment increases on a penalty tick', () => {
+    const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
+    const validation = validateOperationEventPayload(
+      'market.emergency_gray_market_fallout_tick',
+      {
+        ...base,
+        containmentRatingAfter: base.containmentRatingBefore + 1,
+      }
+    )
+
+    expect(validation.success).toBe(false)
+  })
+
+  it.each([
+    ['funding', { fundingAfter: 100 }],
+    ['containment', { containmentRatingAfter: 60 }],
+  ])(
+    'rejects market.emergency_gray_market_fallout_tick when positive %s does not decrease',
+    (_metric, override) => {
+      const validation = validateOperationEventPayload(
+        'market.emergency_gray_market_fallout_tick',
+        {
+          ...minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick'],
+          ...override,
+        }
+      )
+
+      expect(validation.success).toBe(false)
+    }
+  )
+
+  it('rejects market.emergency_gray_market_fallout_tick with a multiplier not derived from precedent count', () => {
+    const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
+    const validation = validateOperationEventPayload(
+      'market.emergency_gray_market_fallout_tick',
+      {
+        ...base,
+        waiverPrecedentCount: 3,
+        precedentPenaltyMultiplier: 1.06,
+      }
+    )
+
+    expect(validation.success).toBe(false)
+  })
+
+  it.each(['', '   ', ' Containment Protocol ', 'CONTAINMENT_PROTOCOL'])(
+    'rejects market.emergency_gray_market_fallout_tick with noncanonical institutionKey %j',
+    (institutionKey) => {
+      const validation = validateOperationEventPayload(
+        'market.emergency_gray_market_fallout_tick',
+        {
+          ...minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick'],
+          institutionKey,
+        }
+      )
+
+      expect(validation.success).toBe(false)
+    }
+  )
+
   it('rejects market.emergency_gray_market_waiver_granted payloads with invalid crisisPressureScore', () => {
     const base = minimalOperationEventPayloads['market.emergency_gray_market_waiver_granted']
     const nanScore = validateOperationEventPayload('market.emergency_gray_market_waiver_granted', {
@@ -367,11 +455,27 @@ describe('event payload validation coverage', () => {
         containmentRatingAfter: Number.NEGATIVE_INFINITY,
       }
     )
+    const negativeFunding = validateOperationEventPayload(
+      'market.emergency_gray_market_fallout_tick',
+      {
+        ...base,
+        fundingAfter: -1,
+      }
+    )
+    const negativeContainment = validateOperationEventPayload(
+      'market.emergency_gray_market_fallout_tick',
+      {
+        ...base,
+        containmentRatingBefore: -1,
+      }
+    )
 
     expect(nanFunding.success).toBe(false)
     expect(infiniteFundingAfter.success).toBe(false)
     expect(nanContainment.success).toBe(false)
     expect(infiniteContainmentAfter.success).toBe(false)
+    expect(negativeFunding.success).toBe(false)
+    expect(negativeContainment.success).toBe(false)
   })
 
   it('accepts agency.containment_updated producer-aligned payloads including negative deltas', () => {


### PR DESCRIPTION
## Linear

- **Slice issue:** [SPE-2691](https://linear.app/spectranoir/issue/SPE-2691/validate-emergency-gray-market-fallout-tick-consistency)
- **Parent issue:** [SPE-1524](https://linear.app/spectranoir/issue/SPE-1524)
- **Child issues covered:** SPE-2691 only

## Summary

@coderabbitai summary

## What shipped

- enforce canonical `risk → costly` and `costly → none` fallout transitions by outcome
- require finite nonnegative funding/containment with a decrease whenever the before value is positive
- centralize and validate the capped precedent multiplier policy (`1 + 0.06 × min(count - 1, 6)`)
- require normalized institution audit keys
- reconcile older loose persisted fallout ticks to the same canonical policy
- add focused schema and hydration regression coverage

## Docs updated

- `planning/spe-2691-emergency-gray-market-fallout-tick-consistency-slice.md`

## Parent status

- SPE-1524 remains unchanged; this child hardening slice does not establish completion of the entire parent scope.

## Scope boundary

- No changes to waiver eligibility, fallout probability, penalty magnitudes, procurement access, UI behavior, or unrelated market event schemas.

## Validation

- [x] Targeted tests: 607 passed across 4 files
- [x] Full tests: 7,405 passed across 739 files
- [x] Lint: passed
- [x] `npm run verify:backlog-handoff`: passed
- [x] `git diff --check`: passed

## Follow-ups

None.

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)