### PR TITLE
SPE-2692: validate faction unlock event references

### DIFF
--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -15,6 +15,12 @@ const finitePositiveIntSchema = z.number().finite().int().min(1)
 const finiteNonNegativeNumberSchema = z.number().finite().min(0)
 const finiteNumberSchema = z.number().finite()
 const finiteChemistryValueSchema = z.number().finite().min(-2).max(2)
+const trimmedNonblankTextSchema = z
+  .string()
+  .min(1)
+  .refine((value) => value === value.trim(), {
+    message: 'must be a trimmed nonblank string',
+  })
 const caseModeSchema = z.enum(['threshold', 'probability', 'deterministic', 'standard'])
 const caseKindSchema = z.enum(['case', 'raid', 'standard', 'anomaly'])
 const relationshipReasonSchema = z.enum([
@@ -879,11 +885,11 @@ const factionUnlockAvailableSchema = z
   .object({
     week: weekSchema,
     factionId: factionIdSchema,
-    factionName: z.string().trim().min(1),
+    factionName: trimmedNonblankTextSchema,
     contactId: idSchema.optional(),
-    contactName: z.string().trim().min(1).optional(),
-    label: z.string().trim().min(1).max(120),
-    summary: z.string().trim().min(1).max(500),
+    contactName: trimmedNonblankTextSchema.optional(),
+    label: trimmedNonblankTextSchema.max(120),
+    summary: trimmedNonblankTextSchema.max(500),
     disposition: z.enum(['supportive', 'adversarial']),
   })
   .superRefine((payload, context) => {

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -5,6 +5,7 @@ import { getCanonicalMarketCostMultiplier, sanitizeFeaturedRecipeId } from '../m
 import { getEmergencyWaiverFalloutPrecedentPenaltyMultiplier } from '../procurementEmergencyFallout'
 import { normalizeInstitutionKeyForAudit } from '../procurementEmergencyInstitution'
 import { getLevelForXp } from '../progression'
+import { createInitialFactionState, FACTION_DEFINITIONS } from '../factions'
 import type { OperationEventType } from './types'
 
 const idSchema = z.string().min(1)
@@ -26,6 +27,18 @@ const relationshipReasonSchema = z.enum([
   'spontaneous_event',
   'betrayal',
 ])
+const knownFactionDefinitionsById = new Map(
+  FACTION_DEFINITIONS.map((faction) => [faction.id, faction] as const)
+)
+const knownFactionContactsByFactionId = new Map(
+  Object.entries(createInitialFactionState()).map(([factionId, faction]) => [
+    factionId,
+    new Map((faction.contacts ?? []).map((contact) => [contact.id, contact] as const)),
+  ])
+)
+const factionIdSchema = idSchema.refine((factionId) => knownFactionDefinitionsById.has(factionId), {
+  message: 'factionId must reference a known faction',
+})
 
 const scoutingConfidenceSchema = z.enum(['low', 'medium', 'high', 'confirmed'])
 const externalChemistryConsequenceSchema = z.enum([
@@ -374,11 +387,9 @@ const agentPromotedSchema = z
     week: weekSchema,
     agentId: idSchema,
     agentName: z.string(),
-    newRole: z
-      .string()
-      .refine((value) => value.length > 0 && value === value.trim(), {
-        message: 'newRole must be a trimmed nonblank string',
-      }),
+    newRole: z.string().refine((value) => value.length > 0 && value === value.trim(), {
+      message: 'newRole must be a trimmed nonblank string',
+    }),
     previousLevel: finitePositiveIntSchema,
     newLevel: finitePositiveIntSchema,
     levelsGained: finiteNonNegativeIntSchema,
@@ -425,11 +436,9 @@ const progressionXpGainedSchema = z
     agentId: idSchema,
     agentName: z.string(),
     xpAmount: finiteNonNegativeIntSchema,
-    reason: z
-      .string()
-      .refine((value) => value.length > 0 && value === value.trim(), {
-        message: 'reason must be a trimmed nonblank string',
-      }),
+    reason: z.string().refine((value) => value.length > 0 && value === value.trim(), {
+      message: 'reason must be a trimmed nonblank string',
+    }),
     totalXp: finiteNonNegativeIntSchema,
     level: z.number().finite().int().min(1),
     levelsGained: finiteNonNegativeIntSchema,
@@ -512,9 +521,7 @@ function refineProductionQueueCatalogMembership(
   context: z.RefinementCtx
 ) {
   // Reuse sanitizeFeaturedRecipeId membership (same PRODUCTION_RECIPE_IDS set as market.shifted).
-  if (
-    sanitizeFeaturedRecipeId(payload.recipeId, payload.recipeId) !== payload.recipeId
-  ) {
+  if (sanitizeFeaturedRecipeId(payload.recipeId, payload.recipeId) !== payload.recipeId) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
       message: 'recipeId must be a production catalog recipe id',
@@ -603,10 +610,7 @@ const marketShiftedSchema = z
       })
     } else {
       const catalogName = getProductionRecipe(payload.featuredRecipeId)?.name
-      if (
-        typeof catalogName === 'string' &&
-        payload.featuredRecipeName.trim() !== catalogName
-      ) {
+      if (typeof catalogName === 'string' && payload.featuredRecipeName.trim() !== catalogName) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
           message: `featuredRecipeName must match catalog name for featuredRecipeId (${catalogName})`,
@@ -831,8 +835,9 @@ const marketEmergencyGrayMarketFalloutTickSchema = z
       })
     }
 
-    const expectedMultiplier =
-      getEmergencyWaiverFalloutPrecedentPenaltyMultiplier(payload.waiverPrecedentCount)
+    const expectedMultiplier = getEmergencyWaiverFalloutPrecedentPenaltyMultiplier(
+      payload.waiverPrecedentCount
+    )
     if (payload.precedentPenaltyMultiplier !== expectedMultiplier) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
@@ -873,13 +878,54 @@ const factionStandingChangedSchema = z
 const factionUnlockAvailableSchema = z
   .object({
     week: weekSchema,
-    factionId: z.string(),
-    factionName: z.string(),
-    contactId: z.string().optional(),
-    contactName: z.string().optional(),
-    label: z.string(),
-    summary: z.string(),
+    factionId: factionIdSchema,
+    factionName: z.string().trim().min(1),
+    contactId: idSchema.optional(),
+    contactName: z.string().trim().min(1).optional(),
+    label: z.string().trim().min(1).max(120),
+    summary: z.string().trim().min(1).max(500),
     disposition: z.enum(['supportive', 'adversarial']),
+  })
+  .superRefine((payload, context) => {
+    const definition = knownFactionDefinitionsById.get(payload.factionId)
+    if (!definition) return
+
+    if (payload.factionName !== definition.name && payload.factionName !== definition.label) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['factionName'],
+        message: 'factionName must match the catalog name or label for factionId',
+      })
+    }
+
+    if (!payload.contactId) {
+      if (payload.contactName) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['contactName'],
+          message: 'contactName requires contactId',
+        })
+      }
+      return
+    }
+
+    const contact = knownFactionContactsByFactionId.get(payload.factionId)?.get(payload.contactId)
+    if (!contact) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['contactId'],
+        message: 'contactId must reference a known contact for factionId',
+      })
+      return
+    }
+
+    if (payload.contactName && contact.name && payload.contactName !== contact.name) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['contactName'],
+        message: 'contactName must match the catalog contact name for contactId',
+      })
+    }
   })
   .strict()
 

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -308,41 +308,32 @@ describe('event payload validation coverage', () => {
 
   it('rejects market.emergency_gray_market_fallout_tick with a risk transition that contradicts the outcome', () => {
     const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
-    const validation = validateOperationEventPayload(
-      'market.emergency_gray_market_fallout_tick',
-      {
-        ...base,
-        outcome: 'escalated_pending_oversight',
-        falloutRiskBefore: 'costly',
-        falloutRiskAfter: 'none',
-      }
-    )
+    const validation = validateOperationEventPayload('market.emergency_gray_market_fallout_tick', {
+      ...base,
+      outcome: 'escalated_pending_oversight',
+      falloutRiskBefore: 'costly',
+      falloutRiskAfter: 'none',
+    })
 
     expect(validation.success).toBe(false)
   })
 
   it('rejects market.emergency_gray_market_fallout_tick when funding increases on a penalty tick', () => {
     const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
-    const validation = validateOperationEventPayload(
-      'market.emergency_gray_market_fallout_tick',
-      {
-        ...base,
-        fundingAfter: base.fundingBefore + 1,
-      }
-    )
+    const validation = validateOperationEventPayload('market.emergency_gray_market_fallout_tick', {
+      ...base,
+      fundingAfter: base.fundingBefore + 1,
+    })
 
     expect(validation.success).toBe(false)
   })
 
   it('rejects market.emergency_gray_market_fallout_tick when containment increases on a penalty tick', () => {
     const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
-    const validation = validateOperationEventPayload(
-      'market.emergency_gray_market_fallout_tick',
-      {
-        ...base,
-        containmentRatingAfter: base.containmentRatingBefore + 1,
-      }
-    )
+    const validation = validateOperationEventPayload('market.emergency_gray_market_fallout_tick', {
+      ...base,
+      containmentRatingAfter: base.containmentRatingBefore + 1,
+    })
 
     expect(validation.success).toBe(false)
   })
@@ -367,14 +358,11 @@ describe('event payload validation coverage', () => {
 
   it('rejects market.emergency_gray_market_fallout_tick with a multiplier not derived from precedent count', () => {
     const base = minimalOperationEventPayloads['market.emergency_gray_market_fallout_tick']
-    const validation = validateOperationEventPayload(
-      'market.emergency_gray_market_fallout_tick',
-      {
-        ...base,
-        waiverPrecedentCount: 3,
-        precedentPenaltyMultiplier: 1.06,
-      }
-    )
+    const validation = validateOperationEventPayload('market.emergency_gray_market_fallout_tick', {
+      ...base,
+      waiverPrecedentCount: 3,
+      precedentPenaltyMultiplier: 1.06,
+    })
 
     expect(validation.success).toBe(false)
   })
@@ -569,10 +557,13 @@ describe('event payload validation coverage', () => {
       residueCount: 0,
       budgetPressure: 2,
     })
-    const hydrateFloorFundingDelta = validateOperationEventPayload('agency.front_business.resolved', {
-      ...minimalOperationEventPayloads['agency.front_business.resolved'],
-      fundingDelta: -10_000,
-    })
+    const hydrateFloorFundingDelta = validateOperationEventPayload(
+      'agency.front_business.resolved',
+      {
+        ...minimalOperationEventPayloads['agency.front_business.resolved'],
+        fundingDelta: -10_000,
+      }
+    )
     const academy = validateOperationEventPayload(
       'system.academy_upgraded',
       minimalOperationEventPayloads['system.academy_upgraded']
@@ -637,10 +628,13 @@ describe('event payload validation coverage', () => {
       ...base,
       lockoutCount: -1,
     })
-    const fractionalBudgetPressure = validateOperationEventPayload('agency.front_business.resolved', {
-      ...base,
-      budgetPressure: 1.5,
-    })
+    const fractionalBudgetPressure = validateOperationEventPayload(
+      'agency.front_business.resolved',
+      {
+        ...base,
+        budgetPressure: 1.5,
+      }
+    )
     const infiniteResidueCount = validateOperationEventPayload('agency.front_business.resolved', {
       ...base,
       residueCount: Number.POSITIVE_INFINITY,
@@ -1880,10 +1874,13 @@ describe('event payload validation coverage', () => {
       ...base,
       allocation: { ...base.allocation, priority: Number.NaN },
     })
-    const allocationsPriorityTooHigh = validateOperationEventPayload('market.transaction_recorded', {
-      ...base,
-      allocations: [{ ...base.allocation, allocationId: 'alloc-bad', priority: 99 }],
-    })
+    const allocationsPriorityTooHigh = validateOperationEventPayload(
+      'market.transaction_recorded',
+      {
+        ...base,
+        allocations: [{ ...base.allocation, allocationId: 'alloc-bad', priority: 99 }],
+      }
+    )
 
     expect(priorityTooHigh.success).toBe(false)
     expect(delayTooHigh.success).toBe(false)
@@ -1919,5 +1916,87 @@ describe('event payload validation coverage', () => {
     expect(negativeAvailable.success).toBe(false)
     expect(fractionalCapacity.success).toBe(false)
     expect(nanAvailable.success).toBe(false)
+  })
+
+  it('rejects faction.unlock_available payloads with unknown faction references', () => {
+    const validation = validateOperationEventPayload('faction.unlock_available', {
+      week: 3,
+      factionId: 'unknown-faction',
+      factionName: 'Unknown Faction',
+      label: 'Unknown channel',
+      summary: 'An unknown channel became available.',
+      disposition: 'supportive',
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects faction.unlock_available payloads with stale contacts', () => {
+    const validation = validateOperationEventPayload('faction.unlock_available', {
+      week: 3,
+      factionId: 'institutions',
+      factionName: 'Academic Institutions',
+      contactId: 'institutions-retired-contact',
+      contactName: 'Retired Contact',
+      label: 'Archive referral',
+      summary: 'A stale archive referral became available.',
+      disposition: 'supportive',
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects faction.unlock_available payloads with blank labels', () => {
+    const validation = validateOperationEventPayload('faction.unlock_available', {
+      week: 3,
+      factionId: 'institutions',
+      factionName: 'Academic Institutions',
+      label: '   ',
+      summary: 'A research channel became available.',
+      disposition: 'supportive',
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects faction.unlock_available payloads with overlong summaries', () => {
+    const validation = validateOperationEventPayload('faction.unlock_available', {
+      week: 3,
+      factionId: 'institutions',
+      factionName: 'Academic Institutions',
+      label: 'Research fellowship',
+      summary: 'x'.repeat(501),
+      disposition: 'supportive',
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('rejects faction.unlock_available payloads with invalid dispositions', () => {
+    const validation = validateOperationEventPayload('faction.unlock_available', {
+      week: 3,
+      factionId: 'institutions',
+      factionName: 'Academic Institutions',
+      label: 'Research fellowship',
+      summary: 'A research fellowship became available.',
+      disposition: 'neutral',
+    })
+
+    expect(validation.success).toBe(false)
+  })
+
+  it('accepts a valid faction.unlock_available payload', () => {
+    const validation = validateOperationEventPayload('faction.unlock_available', {
+      week: 3,
+      factionId: 'institutions',
+      factionName: 'Academic Institutions',
+      contactId: 'institutions-halden',
+      contactName: 'Miren Halden',
+      label: 'Research fellowship',
+      summary: 'A fellowship referral channel is available through Halden.',
+      disposition: 'supportive',
+    })
+
+    expect(validation.success).toBe(true)
   })
 })

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -1959,6 +1959,30 @@ describe('event payload validation coverage', () => {
     expect(validation.success).toBe(false)
   })
 
+  it('rejects faction.unlock_available payloads with padded labels or summaries', () => {
+    const base = {
+      week: 3,
+      factionId: 'institutions',
+      factionName: 'Academic Institutions',
+      label: 'Research fellowship',
+      summary: 'A research fellowship became available.',
+      disposition: 'supportive' as const,
+    }
+
+    expect(
+      validateOperationEventPayload('faction.unlock_available', {
+        ...base,
+        label: '  Research fellowship  ',
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('faction.unlock_available', {
+        ...base,
+        summary: '  A research fellowship became available.  ',
+      }).success
+    ).toBe(false)
+  })
+
   it('rejects faction.unlock_available payloads with overlong summaries', () => {
     const validation = validateOperationEventPayload('faction.unlock_available', {
       week: 3,

--- a/src/test/fixtures/minimalOperationEventPayloads.ts
+++ b/src/test/fixtures/minimalOperationEventPayloads.ts
@@ -407,8 +407,10 @@ export const minimalOperationEventPayloads = {
   },
   'faction.unlock_available': {
     week: WEEK,
-    factionId: 'faction-min',
-    factionName: 'Minimal Faction',
+    factionId: 'institutions',
+    factionName: 'Academic Institutions',
+    contactId: 'institutions-halden',
+    contactName: 'Miren Halden',
     label: 'Minimal unlock',
     summary: 'Minimal unlock summary.',
     disposition: 'supportive',


### PR DESCRIPTION
## Summary

- validate `faction.unlock_available` faction IDs and catalog-derived names
- validate optional contacts against the referenced faction's canonical contact catalog
- require trimmed, nonblank labels and summaries with 120/500 character bounds
- preserve the `supportive | adversarial` disposition enum
- add invalid-reference/text-boundary coverage and a valid catalog-backed event fixture

## Why

The event payload previously accepted arbitrary strings, allowing unknown factions, stale contacts, blank labels, and unbounded summaries into canonical operation history.

## Historical policy

Current faction/contact catalogs are authoritative during hydration. Historical unlock events whose faction or contact has been removed are rejected by the existing event sanitizer. Dynamic contact activation, relationship, and faction-tier eligibility remain producer-time checks in `getFactionRecruitUnlocks`, because payload validation does not receive a historical runtime-state snapshot.

## Validation

- `npm exec vitest -- run src/test/events.validation.test.ts src/test/events.producerValidation.test.ts src/domain/events/eventMigration.test.ts` — 178 tests passed
- scoped ESLint passed
- scoped Prettier check passed
- `git diff --check` passed

Linear: https://linear.app/spectranoir/issue/SPE-2692/validate-factionunlock-available-references-and-text-bounds