### PR TITLE
SPE-2693: reconcile recovered event validation changes

### DIFF
--- a/src/domain/agentPotential.ts
+++ b/src/domain/agentPotential.ts
@@ -14,7 +14,7 @@ import {
 
 export type LivePotentialTier = ExactPotentialTier
 
-const LIVE_POTENTIAL_TIERS = [
+export const EXACT_POTENTIAL_TIERS = [
   'F',
   'D',
   'C',
@@ -54,11 +54,11 @@ const PROFILE_RANK_ADJUSTMENTS: Record<string, readonly number[]> = {
 }
 
 function isLivePotentialTier(value: string | undefined): value is LivePotentialTier {
-  return LIVE_POTENTIAL_TIERS.includes(value as LivePotentialTier)
+  return EXACT_POTENTIAL_TIERS.includes(value as LivePotentialTier)
 }
 
 function getPotentialTierIndex(tier: LivePotentialTier) {
-  return LIVE_POTENTIAL_TIERS.indexOf(tier)
+  return EXACT_POTENTIAL_TIERS.indexOf(tier)
 }
 
 function normalizePotentialIntelConfidence(
@@ -189,8 +189,8 @@ export function scoreToExactPotentialTier(score: number): LivePotentialTier {
 export function shiftPotentialTier(tier: LivePotentialTier, offset: number): LivePotentialTier {
   const currentIndex = getPotentialTierIndex(tier)
   return (
-    LIVE_POTENTIAL_TIERS[
-      clamp(currentIndex + Math.trunc(offset), 0, LIVE_POTENTIAL_TIERS.length - 1)
+    EXACT_POTENTIAL_TIERS[
+      clamp(currentIndex + Math.trunc(offset), 0, EXACT_POTENTIAL_TIERS.length - 1)
     ] ?? tier
   )
 }
@@ -206,7 +206,7 @@ export function stepPotentialTierToward(
     return current
   }
 
-  return LIVE_POTENTIAL_TIERS[currentIndex + Math.sign(targetIndex - currentIndex)] ?? target
+  return EXACT_POTENTIAL_TIERS[currentIndex + Math.sign(targetIndex - currentIndex)] ?? target
 }
 
 export function normalizePotentialIntel(

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -954,11 +954,38 @@ const factionStandingChangedSchema = z
     contactDelta: z.number().finite().int().optional(),
   })
   .superRefine((payload, context) => {
-    if (payload.delta !== payload.standingAfter - payload.standingBefore) {
+    const deltaMatchesTransition = (
+      before: number,
+      after: number,
+      delta: number,
+      minimum: number,
+      maximum: number
+    ) => after === Math.min(maximum, Math.max(minimum, before + delta))
+
+    const deltaMatches =
+      payload.reason === 'recruitment.hired' &&
+      payload.reputationBefore !== undefined &&
+      payload.reputationAfter !== undefined
+        ? deltaMatchesTransition(
+            payload.reputationBefore,
+            payload.reputationAfter,
+            payload.delta,
+            -100,
+            100
+          )
+        : deltaMatchesTransition(
+            payload.standingBefore,
+            payload.standingAfter,
+            payload.delta,
+            -20,
+            20
+          )
+
+    if (!deltaMatches) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['delta'],
-        message: 'delta must equal standingAfter - standingBefore',
+        message: 'delta must produce the bounded standing or reputation transition',
       })
     }
 
@@ -980,12 +1007,19 @@ const factionStandingChangedSchema = z
     if (
       payload.contactRelationshipBefore !== undefined &&
       payload.contactRelationshipAfter !== undefined &&
-      payload.contactDelta !== payload.contactRelationshipAfter - payload.contactRelationshipBefore
+      payload.contactDelta !== undefined &&
+      !deltaMatchesTransition(
+        payload.contactRelationshipBefore,
+        payload.contactRelationshipAfter,
+        payload.contactDelta,
+        -100,
+        100
+      )
     ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['contactDelta'],
-        message: 'contactDelta must equal contactRelationshipAfter - contactRelationshipBefore',
+        message: 'contactDelta must produce the bounded contact relationship transition',
       })
     }
   })

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -6,6 +6,8 @@ import { getEmergencyWaiverFalloutPrecedentPenaltyMultiplier } from '../procurem
 import { normalizeInstitutionKeyForAudit } from '../procurementEmergencyInstitution'
 import { getLevelForXp } from '../progression'
 import { createInitialFactionState, FACTION_DEFINITIONS } from '../factions'
+import { EXACT_POTENTIAL_TIERS } from '../agentPotential'
+import { CASE_KINDS, CASE_MODES } from '../models'
 import type { OperationEventType } from './types'
 
 const idSchema = z.string().min(1)
@@ -15,14 +17,18 @@ const finitePositiveIntSchema = z.number().finite().int().min(1)
 const finiteNonNegativeNumberSchema = z.number().finite().min(0)
 const finiteNumberSchema = z.number().finite()
 const finiteChemistryValueSchema = z.number().finite().min(-2).max(2)
+const factionStandingValueSchema = z.number().finite().int().min(-20).max(20)
+const factionReputationValueSchema = z.number().finite().int().min(-100).max(100)
 const trimmedNonblankTextSchema = z
   .string()
   .min(1)
   .refine((value) => value === value.trim(), {
     message: 'must be a trimmed nonblank string',
   })
-const caseModeSchema = z.enum(['threshold', 'probability', 'deterministic', 'standard'])
-const caseKindSchema = z.enum(['case', 'raid', 'standard', 'anomaly'])
+const caseModeSchema = z.enum(CASE_MODES)
+const caseKindSchema = z.enum(CASE_KINDS)
+const caseStageSchema = finitePositiveIntSchema
+const caseTeamIdsSchema = z.array(idSchema).transform((teamIds) => [...new Set(teamIds)])
 const relationshipReasonSchema = z.enum([
   'mission_success',
   'mission_partial',
@@ -47,6 +53,7 @@ const factionIdSchema = idSchema.refine((factionId) => knownFactionDefinitionsBy
 })
 
 const scoutingConfidenceSchema = z.enum(['low', 'medium', 'high', 'confirmed'])
+const potentialTierSchema = z.enum(EXACT_POTENTIAL_TIERS)
 const externalChemistryConsequenceSchema = z.enum([
   'benching',
   'performance_penalty',
@@ -70,8 +77,17 @@ const assignmentTeamAssignedSchema = z
     caseKind: z.string(),
     teamId: idSchema,
     teamName: z.string(),
-    assignedTeamCount: z.number(),
-    maxTeams: z.number(),
+    assignedTeamCount: finiteNonNegativeIntSchema,
+    maxTeams: finitePositiveIntSchema,
+  })
+  .superRefine((payload, context) => {
+    if (payload.assignedTeamCount > payload.maxTeams) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['assignedTeamCount'],
+        message: 'assignedTeamCount must be less than or equal to maxTeams',
+      })
+    }
   })
   .strict()
 
@@ -82,7 +98,7 @@ const assignmentTeamUnassignedSchema = z
     caseTitle: z.string(),
     teamId: idSchema,
     teamName: z.string(),
-    remainingTeamCount: z.number(),
+    remainingTeamCount: finiteNonNegativeIntSchema,
   })
   .strict()
 
@@ -91,10 +107,10 @@ const caseResolvedSchema = z
     week: weekSchema,
     caseId: idSchema,
     caseTitle: z.string(),
-    mode: z.string(),
-    kind: z.string(),
-    stage: z.number(),
-    teamIds: z.array(idSchema),
+    mode: caseModeSchema,
+    kind: caseKindSchema,
+    stage: caseStageSchema,
+    teamIds: caseTeamIdsSchema,
     performanceSummary: z.unknown().optional(),
     rewardBreakdown: z.unknown().optional(),
   })
@@ -105,44 +121,72 @@ const casePartiallyResolvedSchema = z
     week: weekSchema,
     caseId: idSchema,
     caseTitle: z.string(),
-    mode: z.string(),
-    kind: z.string(),
-    fromStage: z.number(),
-    toStage: z.number(),
-    teamIds: z.array(idSchema),
+    mode: caseModeSchema,
+    kind: caseKindSchema,
+    fromStage: caseStageSchema,
+    toStage: caseStageSchema,
+    teamIds: caseTeamIdsSchema,
     performanceSummary: z.unknown().optional(),
     rewardBreakdown: z.unknown().optional(),
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.toStage < payload.fromStage) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['toStage'],
+        message: 'toStage must be greater than or equal to fromStage',
+      })
+    }
+  })
 
 const caseFailedSchema = z
   .object({
     week: weekSchema,
     caseId: idSchema,
     caseTitle: z.string(),
-    mode: z.string(),
-    kind: z.string(),
-    fromStage: z.number(),
-    toStage: z.number(),
-    teamIds: z.array(idSchema),
+    mode: caseModeSchema,
+    kind: caseKindSchema,
+    fromStage: caseStageSchema,
+    toStage: caseStageSchema,
+    teamIds: caseTeamIdsSchema,
     performanceSummary: z.unknown().optional(),
     rewardBreakdown: z.unknown().optional(),
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.toStage < payload.fromStage) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['toStage'],
+        message: 'toStage must be greater than or equal to fromStage',
+      })
+    }
+  })
 
 const caseEscalatedSchema = z
   .object({
     week: weekSchema,
     caseId: idSchema,
     caseTitle: z.string(),
-    fromStage: z.number(),
-    toStage: z.number(),
+    fromStage: caseStageSchema,
+    toStage: caseStageSchema,
     trigger: z.enum(['deadline', 'failure']),
-    deadlineRemaining: z.number(),
+    deadlineRemaining: finiteNonNegativeIntSchema,
     convertedToRaid: z.boolean(),
+    neighborhoodPressureAuditTag: trimmedNonblankTextSchema.max(200).optional(),
     rewardBreakdown: z.unknown().optional(),
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.toStage < payload.fromStage) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['toStage'],
+        message: 'toStage must be greater than or equal to fromStage',
+      })
+    }
+  })
 
 const caseSpawnedSchema = z
   .object({
@@ -151,7 +195,7 @@ const caseSpawnedSchema = z
     caseTitle: z.string(),
     templateId: z.string(),
     kind: z.string(),
-    stage: z.number(),
+    stage: caseStageSchema,
     trigger: z.enum([
       'failure',
       'unresolved',
@@ -174,10 +218,19 @@ const caseRaidConvertedSchema = z
     week: weekSchema,
     caseId: idSchema,
     caseTitle: z.string(),
-    stage: z.number(),
+    stage: caseStageSchema,
     trigger: z.enum(['deadline', 'failure']),
-    minTeams: z.number(),
-    maxTeams: z.number(),
+    minTeams: finitePositiveIntSchema,
+    maxTeams: finitePositiveIntSchema,
+  })
+  .superRefine((payload, context) => {
+    if (payload.maxTeams < payload.minTeams) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['maxTeams'],
+        message: 'maxTeams must be greater than or equal to minTeams',
+      })
+    }
   })
   .strict()
 
@@ -506,20 +559,41 @@ const recruitmentScoutingSchema = z
     week: weekSchema,
     candidateId: idSchema,
     candidateName: z.string(),
-    fundingCost: z.number(),
+    fundingCost: finiteNonNegativeIntSchema,
     stage: z.number().int().min(1).max(3),
-    projectedTier: z.string(),
+    projectedTier: potentialTierSchema,
     confidence: scoutingConfidenceSchema,
-    previousProjectedTier: z.string().optional(),
+    previousProjectedTier: potentialTierSchema.optional(),
     previousConfidence: scoutingConfidenceSchema.optional(),
-    confirmedTier: z.string().optional(),
-    revealLevel: z.number(),
+    confirmedTier: potentialTierSchema.optional(),
+    revealLevel: z.number().finite().int().min(0).max(2),
     sourceFactionId: z.string().optional(),
     sourceFactionName: z.string().optional(),
     sourceContactId: z.string().optional(),
     sourceContactName: z.string().optional(),
   })
   .strict()
+  .superRefine((payload, context) => {
+    if (payload.stage === 1 && payload.revealLevel < 1) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['revealLevel'],
+        message: 'revealLevel must be at least 1 when stage is 1',
+      })
+    }
+
+    if (payload.stage >= 2 && payload.revealLevel !== 2) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['revealLevel'],
+        message: 'revealLevel must be 2 when stage is 2 or 3',
+      })
+    }
+  })
+
+const recruitmentIntelConfirmedSchema = recruitmentScoutingSchema.safeExtend({
+  confirmedTier: potentialTierSchema,
+})
 
 /** SPE-2664: catalog recipeId membership + outputId/outputName vs catalog product fields. */
 function refineProductionQueueCatalogMembership(
@@ -856,13 +930,13 @@ const marketEmergencyGrayMarketFalloutTickSchema = z
 const factionStandingChangedSchema = z
   .object({
     week: weekSchema,
-    factionId: z.string(),
+    factionId: factionIdSchema,
     factionName: z.string(),
-    delta: z.number(),
-    standingBefore: z.number(),
-    standingAfter: z.number(),
-    reputationBefore: z.number().optional(),
-    reputationAfter: z.number().optional(),
+    delta: z.number().finite().int(),
+    standingBefore: factionStandingValueSchema,
+    standingAfter: factionStandingValueSchema,
+    reputationBefore: factionReputationValueSchema.optional(),
+    reputationAfter: factionReputationValueSchema.optional(),
     reason: z.enum([
       'case.resolved',
       'case.partially_resolved',
@@ -875,9 +949,45 @@ const factionStandingChangedSchema = z
     interactionLabel: z.string().optional(),
     contactId: z.string().optional(),
     contactName: z.string().optional(),
-    contactRelationshipBefore: z.number().optional(),
-    contactRelationshipAfter: z.number().optional(),
-    contactDelta: z.number().optional(),
+    contactRelationshipBefore: factionReputationValueSchema.optional(),
+    contactRelationshipAfter: factionReputationValueSchema.optional(),
+    contactDelta: z.number().finite().int().optional(),
+  })
+  .superRefine((payload, context) => {
+    if (payload.delta !== payload.standingAfter - payload.standingBefore) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['delta'],
+        message: 'delta must equal standingAfter - standingBefore',
+      })
+    }
+
+    const contactValues = [
+      payload.contactRelationshipBefore,
+      payload.contactRelationshipAfter,
+      payload.contactDelta,
+    ]
+    const providedContactValues = contactValues.filter((value) => value !== undefined)
+    if (providedContactValues.length > 0 && providedContactValues.length < contactValues.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['contactDelta'],
+        message: 'contact relationship fields must all be present together',
+      })
+      return
+    }
+
+    if (
+      payload.contactRelationshipBefore !== undefined &&
+      payload.contactRelationshipAfter !== undefined &&
+      payload.contactDelta !== payload.contactRelationshipAfter - payload.contactRelationshipBefore
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['contactDelta'],
+        message: 'contactDelta must equal contactRelationshipAfter - contactRelationshipBefore',
+      })
+    }
   })
   .strict()
 
@@ -1037,7 +1147,7 @@ export const operationEventPayloadSchemas = {
   'system.party_cards_drawn': systemPartyCardsDrawnSchema,
   'recruitment.scouting_initiated': recruitmentScoutingSchema,
   'recruitment.scouting_refined': recruitmentScoutingSchema,
-  'recruitment.intel_confirmed': recruitmentScoutingSchema,
+  'recruitment.intel_confirmed': recruitmentIntelConfirmedSchema,
   'production.queue_started': productionQueueStartedSchema,
   'production.queue_completed': productionQueueCompletedSchema,
   'market.shifted': marketShiftedSchema,

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -328,7 +328,7 @@ export interface OperationEventPayloadMap {
     confidence: Exclude<PotentialIntelConfidence, 'unknown'>
     previousProjectedTier?: ExactPotentialTier
     previousConfidence?: Exclude<PotentialIntelConfidence, 'unknown'>
-    confirmedTier: ExactPotentialTier
+    confirmedTier?: ExactPotentialTier
     revealLevel: number
     sourceFactionId?: string
     sourceFactionName?: string
@@ -362,7 +362,7 @@ export interface OperationEventPayloadMap {
     confidence: Exclude<PotentialIntelConfidence, 'unknown'>
     previousProjectedTier?: ExactPotentialTier
     previousConfidence?: Exclude<PotentialIntelConfidence, 'unknown'>
-    confirmedTier?: ExactPotentialTier
+    confirmedTier: ExactPotentialTier
     revealLevel: number
     sourceFactionId?: string
     sourceFactionName?: string

--- a/src/domain/events/types.ts
+++ b/src/domain/events/types.ts
@@ -16,13 +16,7 @@ import type {
 } from '../models'
 
 export type OperationEventSourceSystem =
-  | 'assignment'
-  | 'incident'
-  | 'intel'
-  | 'agent'
-  | 'production'
-  | 'faction'
-  | 'system'
+  'assignment' | 'incident' | 'intel' | 'agent' | 'production' | 'faction' | 'system'
 
 export type CaseEscalationTrigger = 'deadline' | 'failure'
 export type CaseSpawnTrigger =
@@ -35,9 +29,7 @@ export type CaseSpawnTrigger =
   | 'pressure_threshold'
 
 export type MarketTransactionListingResourceClass =
-  | 'supplier_attention_slot'
-  | 'reagent_stock'
-  | 'licensed_handling_capacity'
+  'supplier_attention_slot' | 'reagent_stock' | 'licensed_handling_capacity'
 
 /** Listing-scoped procurement capacity recorded on a market transaction when allocations apply. */
 export interface MarketTransactionListingResourceStatus {
@@ -336,7 +328,7 @@ export interface OperationEventPayloadMap {
     confidence: Exclude<PotentialIntelConfidence, 'unknown'>
     previousProjectedTier?: ExactPotentialTier
     previousConfidence?: Exclude<PotentialIntelConfidence, 'unknown'>
-    confirmedTier?: ExactPotentialTier
+    confirmedTier: ExactPotentialTier
     revealLevel: number
     sourceFactionId?: string
     sourceFactionName?: string
@@ -430,10 +422,7 @@ export interface OperationEventPayloadMap {
     listingResourceStatuses?: readonly MarketTransactionListingResourceStatus[]
     allocation?: {
       allocationId: string
-      resourceClass:
-        | 'supplier_attention_slot'
-        | 'reagent_stock'
-        | 'licensed_handling_capacity'
+      resourceClass: 'supplier_attention_slot' | 'reagent_stock' | 'licensed_handling_capacity'
       source: string
       sourceLabel: string
       destinationUse: string
@@ -448,10 +437,7 @@ export interface OperationEventPayloadMap {
     }
     allocations?: Array<{
       allocationId: string
-      resourceClass:
-        | 'supplier_attention_slot'
-        | 'reagent_stock'
-        | 'licensed_handling_capacity'
+      resourceClass: 'supplier_attention_slot' | 'reagent_stock' | 'licensed_handling_capacity'
       source: string
       sourceLabel: string
       destinationUse: string

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -23,11 +23,7 @@ export type DeploymentSoftRiskCode =
   | 'intel-uncertainty'
 
 export type DeploymentReadinessCategory =
-  | 'mission_ready'
-  | 'conditional'
-  | 'hard_blocked'
-  | 'temporarily_blocked'
-  | 'recovery_required'
+  'mission_ready' | 'conditional' | 'hard_blocked' | 'temporarily_blocked' | 'recovery_required'
 
 export type MissionCategory =
   | 'containment_breach'
@@ -119,12 +115,7 @@ export interface MissionRoutingState {
 }
 
 export type MissionIntakeSource =
-  | 'scripted'
-  | 'escalation'
-  | 'pressure'
-  | 'faction'
-  | 'contract'
-  | 'tutorial'
+  'scripted' | 'escalation' | 'pressure' | 'faction' | 'contract' | 'tutorial'
 
 export interface TeamDeploymentReadinessState {
   teamId: string
@@ -478,8 +469,10 @@ export type StatBlock = Record<StatKey, number> & Record<string, number>
 export type WeightBlock = Record<StatKey, number> & Record<string, number>
 export const BASE_STAT_MAX = 100
 
-export type CaseMode = 'threshold' | 'probability' | 'deterministic' | 'standard'
-export type CaseKind = 'case' | 'raid' | 'standard' | 'anomaly'
+export const CASE_MODES = ['threshold', 'probability', 'deterministic', 'standard'] as const
+export type CaseMode = (typeof CASE_MODES)[number]
+export const CASE_KINDS = ['case', 'raid', 'standard', 'anomaly'] as const
+export type CaseKind = (typeof CASE_KINDS)[number]
 export type CaseStatus = 'open' | 'in_progress' | 'resolved'
 
 export type AgentAssignmentStateKind = 'idle' | 'assigned' | 'recovery' | 'training'
@@ -993,10 +986,7 @@ export interface FieldBaseStagingPacket {
 
 /** SPE-99: deployed recovery-mode taxonomy derived from fieldBase staging quality. */
 export type ExpeditionRecoveryMode =
-  | 'unsafe_pause'
-  | 'ordinary_rest'
-  | 'active_recovery'
-  | 'sanctuary_recovery'
+  'unsafe_pause' | 'ordinary_rest' | 'active_recovery' | 'sanctuary_recovery'
 
 export const EXPEDITION_RECOVERY_MODES: readonly ExpeditionRecoveryMode[] = [
   'unsafe_pause',
@@ -1056,11 +1046,7 @@ export type ContractNextIntent =
   | 'answer-emergency'
 
 export type ContractDebriefChangedEntityKind =
-  | 'staff'
-  | 'subject'
-  | 'route'
-  | 'evidence'
-  | 'faction'
+  'staff' | 'subject' | 'route' | 'evidence' | 'faction'
 
 export interface ContractDebriefChangedEntity {
   kind: ContractDebriefChangedEntityKind
@@ -1356,9 +1342,7 @@ export interface CaseTemplate {
 
 /** SPE-1701: deterministic deployment carry-in stamped at team→case assignment. */
 export type DeploymentCarryInCode =
-  | 'residue-therapy-foregone'
-  | 'well-rested-stable-energy'
-  | 'off-books-courier-lockout'
+  'residue-therapy-foregone' | 'well-rested-stable-energy' | 'off-books-courier-lockout'
 
 export interface AgentDeploymentCarryInStamp {
   readinessDelta: number
@@ -1610,13 +1594,7 @@ export type ReportNoteType =
   | 'pattern_source_series.weekly_transition'
 
 export type ReportNoteMetadataValue =
-  | string
-  | number
-  | boolean
-  | null
-  | readonly string[]
-  | readonly number[]
-  | readonly boolean[]
+  string | number | boolean | null | readonly string[] | readonly number[] | readonly boolean[]
 
 export type ReportNoteMetadata = Record<string, ReportNoteMetadataValue>
 
@@ -1691,10 +1669,7 @@ export interface WeeklyReport {
 }
 
 export type WeeklyDirectiveId =
-  | 'intel-surge'
-  | 'recovery-rotation'
-  | 'procurement-push'
-  | 'lockdown-protocol'
+  'intel-surge' | 'recovery-rotation' | 'procurement-push' | 'lockdown-protocol'
 
 export interface WeeklyDirectiveHistoryEntry {
   week: number
@@ -1833,12 +1808,7 @@ export interface OneShotEventState {
 }
 
 export type EncounterRuntimeStatus =
-  | 'available'
-  | 'active'
-  | 'resolved'
-  | 'locked'
-  | 'hidden'
-  | 'archived'
+  'available' | 'active' | 'resolved' | 'locked' | 'hidden' | 'archived'
 export type EncounterResolutionOutcome = 'success' | 'partial' | 'failed' | 'failure' | 'dismissed'
 
 export interface EncounterRuntimeState {
@@ -2036,12 +2006,7 @@ export interface FundingState {
 }
 
 export type ResearchUnlockCategory =
-  | 'intel_tool'
-  | 'facility'
-  | 'training'
-  | 'equipment'
-  | 'contract'
-  | (string & {})
+  'intel_tool' | 'facility' | 'training' | 'equipment' | 'contract' | (string & {})
 
 export interface ResearchUnlock {
   id: string
@@ -2051,12 +2016,7 @@ export interface ResearchUnlock {
 }
 
 export type ResearchProjectStatus =
-  | 'locked'
-  | 'available'
-  | 'queued'
-  | 'active'
-  | 'completed'
-  | 'blocked'
+  'locked' | 'available' | 'queued' | 'active' | 'completed' | 'blocked'
 
 export interface ResearchProject {
   projectId: string
@@ -2093,11 +2053,7 @@ export interface ResearchState {
 
 export type AgentAttritionStatus = 'active' | 'at_risk' | 'temporarily_unavailable' | 'lost'
 export type AgentAttritionCategory =
-  | 'injury_exit'
-  | 'burnout'
-  | 'temporary_leave'
-  | 'disciplinary'
-  | 'unknown'
+  'injury_exit' | 'burnout' | 'temporary_leave' | 'disciplinary' | 'unknown'
 
 export interface AgentAttritionState {
   attritionStatus: AgentAttritionStatus
@@ -2144,12 +2100,7 @@ export interface SupportStaffSummary {
 }
 
 export type MajorIncidentStrategy =
-  | 'aggressive'
-  | 'balanced'
-  | 'cautious'
-  | 'rapid_response'
-  | 'containment_first'
-  | 'risk_accepting'
+  'aggressive' | 'balanced' | 'cautious' | 'rapid_response' | 'containment_first' | 'risk_accepting'
 export type MajorIncidentProvisionType = string
 export type RecruitmentFunnelStage = import('./recruitment/types').RecruitmentFunnelStage
 export type CertificationState = import('./agent/models').CertificationState
@@ -3113,18 +3064,11 @@ export interface GameState {
 
 /** The named stages a subject passes through in a custody pipeline. */
 export type CustodyStageKind =
-  | 'intake'
-  | 'holding'
-  | 'transfer_en_route'
-  | 'handoff'
-  | 'delivered'
-  | 'released_hostile'
+  'intake' | 'holding' | 'transfer_en_route' | 'handoff' | 'delivered' | 'released_hostile'
 
 /** Custody-specific distortion tags attached to a single stage record. */
 export type CustodyDistortionContext =
-  | 'custody_record_scrubbed'
-  | 'forged_transfer_credentials'
-  | 'vanished_file'
+  'custody_record_scrubbed' | 'forged_transfer_credentials' | 'vanished_file'
 
 /** One stage in the chain, with which institution owns it and any record-tampering context. */
 export interface CustodyStageRecord {
@@ -3173,9 +3117,7 @@ export interface CustodyChain {
 
 /** The type of corruption evidence surfaced by an investigation. */
 export type CustodyDiscoveryEventType =
-  | 'missing_record'
-  | 'marker_revealed'
-  | 'compromised_actor_identified'
+  'missing_record' | 'marker_revealed' | 'compromised_actor_identified'
 
 /** A single discovery produced by resolveCorruptionDiscovery(). */
 export interface CustodyDiscoveryEvent {

--- a/src/domain/sim/recruitmentScouting.ts
+++ b/src/domain/sim/recruitmentScouting.ts
@@ -63,7 +63,10 @@ function createCandidateScoutEventDraft(
   }
 
   if (report.exactKnown) {
-    return createRecruitmentIntelConfirmedDraft(payload)
+    return createRecruitmentIntelConfirmedDraft({
+      ...payload,
+      confirmedTier: report.confirmedTier ?? report.projectedTier,
+    })
   }
 
   if (report.stage === 1) {
@@ -134,10 +137,10 @@ export function scoutCandidate(state: GameState, candidateId: Id): GameState {
       return candidate
     }
 
-    const revealedCandidate = revealCandidate(
-      candidate,
-      1 + scoutSupport.revealBoost
-    ) as Extract<GameState['candidates'][number], { category: 'agent' }>
+    const revealedCandidate = revealCandidate(candidate, 1 + scoutSupport.revealBoost) as Extract<
+      GameState['candidates'][number],
+      { category: 'agent' }
+    >
     const nextScoutReport = buildCandidateScoutReport(revealedCandidate, rng.next, {
       clearanceLevel: state.agency?.clearanceLevel ?? state.clearanceLevel,
       week: state.week,

--- a/src/test/events.recoveredValidation.test.ts
+++ b/src/test/events.recoveredValidation.test.ts
@@ -108,6 +108,51 @@ describe('recovered operation event validation', () => {
     expect(validateOperationEventPayload('faction.standing_changed', base).success).toBe(true)
   })
 
+  it('accepts bounded faction transitions and recruitment reputation deltas', () => {
+    const base = minimalOperationEventPayloads['faction.standing_changed']
+
+    expect(
+      validateOperationEventPayload('faction.standing_changed', {
+        ...base,
+        delta: 4,
+        standingBefore: 19,
+        standingAfter: 20,
+        contactRelationshipBefore: 98,
+        contactRelationshipAfter: 100,
+        contactDelta: 6,
+      }).success
+    ).toBe(true)
+    expect(
+      validateOperationEventPayload('faction.standing_changed', {
+        ...base,
+        reason: 'recruitment.hired',
+        delta: 4,
+        standingBefore: 0,
+        standingAfter: 1,
+        reputationBefore: 2,
+        reputationAfter: 6,
+      }).success
+    ).toBe(true)
+  })
+
+  it('preserves a valid recovered payload during v1 migration', () => {
+    const payload = minimalOperationEventPayloads['case.failed']
+    const migrated = migrateEventV1toV2({
+      id: 'recovered-valid-case-failed',
+      schemaVersion: 1,
+      type: 'case.failed',
+      timestamp: '2026-07-23T00:00:00.000Z',
+      sourceSystem: 'system',
+      payload,
+    })
+
+    expect(migrated).toMatchObject({
+      schemaVersion: 2,
+      type: 'case.failed',
+      payload,
+    })
+  })
+
   it('drops recovered invalid payload classes during v1 migration', () => {
     const invalidPayloads = [
       {

--- a/src/test/events.recoveredValidation.test.ts
+++ b/src/test/events.recoveredValidation.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { migrateEventV1toV2 } from '../domain/events/eventMigration'
+import { validateOperationEventPayload } from '../domain/events/eventValidation'
+import { minimalOperationEventPayloads } from './fixtures/minimalOperationEventPayloads'
+
+describe('recovered operation event validation', () => {
+  it('bounds assignment counts and rejects impossible assignments', () => {
+    const base = minimalOperationEventPayloads['assignment.team_assigned']
+
+    expect(
+      validateOperationEventPayload('assignment.team_assigned', {
+        ...base,
+        assignedTeamCount: -1,
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('assignment.team_assigned', {
+        ...base,
+        assignedTeamCount: 3,
+        maxTeams: 2,
+      }).success
+    ).toBe(false)
+    expect(validateOperationEventPayload('assignment.team_assigned', base).success).toBe(true)
+  })
+
+  it('validates case enums, stages, transitions, deadlines, and raid team bounds', () => {
+    const partial = minimalOperationEventPayloads['case.partially_resolved']
+    const escalated = minimalOperationEventPayloads['case.escalated']
+    const raid = minimalOperationEventPayloads['case.raid_converted']
+
+    expect(
+      validateOperationEventPayload('case.partially_resolved', {
+        ...partial,
+        mode: 'freeform',
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('case.partially_resolved', {
+        ...partial,
+        fromStage: 2,
+        toStage: 1,
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('case.escalated', {
+        ...escalated,
+        deadlineRemaining: -1,
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('case.raid_converted', {
+        ...raid,
+        minTeams: 3,
+        maxTeams: 2,
+      }).success
+    ).toBe(false)
+    expect(validateOperationEventPayload('case.partially_resolved', partial).success).toBe(true)
+  })
+
+  it('validates recruitment tiers, reveal gates, and confirmed-tier presence', () => {
+    const initiated = minimalOperationEventPayloads['recruitment.scouting_initiated']
+    const confirmed = minimalOperationEventPayloads['recruitment.intel_confirmed']
+
+    expect(
+      validateOperationEventPayload('recruitment.scouting_initiated', {
+        ...initiated,
+        projectedTier: 'legendary',
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('recruitment.scouting_refined', {
+        ...minimalOperationEventPayloads['recruitment.scouting_refined'],
+        revealLevel: 1,
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('recruitment.intel_confirmed', {
+        ...confirmed,
+        confirmedTier: undefined,
+      }).success
+    ).toBe(false)
+    expect(validateOperationEventPayload('recruitment.intel_confirmed', confirmed).success).toBe(
+      true
+    )
+  })
+
+  it('validates faction standing references, ranges, and delta arithmetic', () => {
+    const base = minimalOperationEventPayloads['faction.standing_changed']
+
+    expect(
+      validateOperationEventPayload('faction.standing_changed', {
+        ...base,
+        factionId: 'unknown-faction',
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('faction.standing_changed', {
+        ...base,
+        standingAfter: 21,
+      }).success
+    ).toBe(false)
+    expect(
+      validateOperationEventPayload('faction.standing_changed', {
+        ...base,
+        delta: 2,
+      }).success
+    ).toBe(false)
+    expect(validateOperationEventPayload('faction.standing_changed', base).success).toBe(true)
+  })
+
+  it('drops recovered invalid payload classes during v1 migration', () => {
+    const invalidPayloads = [
+      {
+        type: 'case.failed',
+        payload: {
+          ...minimalOperationEventPayloads['case.failed'],
+          fromStage: 2,
+          toStage: 1,
+        },
+      },
+      {
+        type: 'recruitment.intel_confirmed',
+        payload: {
+          ...minimalOperationEventPayloads['recruitment.intel_confirmed'],
+          confirmedTier: undefined,
+        },
+      },
+      {
+        type: 'faction.standing_changed',
+        payload: {
+          ...minimalOperationEventPayloads['faction.standing_changed'],
+          delta: 99,
+        },
+      },
+    ] as const
+
+    for (const [index, event] of invalidPayloads.entries()) {
+      expect(
+        migrateEventV1toV2({
+          id: `recovered-invalid-${index}`,
+          schemaVersion: 1,
+          type: event.type,
+          timestamp: '2026-07-23T00:00:00.000Z',
+          sourceSystem: 'system',
+          payload: event.payload,
+        })
+      ).toBeNull()
+    }
+  })
+})

--- a/src/test/fixtures/minimalOperationEventPayloads.ts
+++ b/src/test/fixtures/minimalOperationEventPayloads.ts
@@ -76,7 +76,7 @@ export const minimalOperationEventPayloads = {
     mode: 'threshold',
     kind: 'case',
     fromStage: 2,
-    toStage: 1,
+    toStage: 2,
     teamIds: ['team-min'],
   },
   'case.failed': {
@@ -398,8 +398,8 @@ export const minimalOperationEventPayloads = {
   },
   'faction.standing_changed': {
     week: WEEK,
-    factionId: 'faction-min',
-    factionName: 'Minimal Faction',
+    factionId: 'oversight',
+    factionName: 'Oversight Bureau',
     delta: 1,
     standingBefore: 0,
     standingAfter: 1,


### PR DESCRIPTION
## Summary

Reconcile the preserved dirty-main recovery branch without replaying stale history wholesale.

Retained changes:
- bound assignment counts and case enums/stages/transitions/deadlines/team limits
- validate recruitment scouting tiers, funding, reveal gates, and required confirmed tiers
- validate faction-standing catalog references, value ranges, paired contact fields, and delta arithmetic
- expose shared case/potential enum catalogs and keep the confirmed-scout producer type-safe
- add focused validation and v1 migration regression coverage

## Recovery disposition

- SPE-1046 non-mission file-access work already shipped as `4421d388` / PR #3022.
- Hydration/import, equipment recovery, funding, migration policy, production/training/market, faction unlock, and planning changes were already shipped or superseded on current `main`; they were not replayed.
- The original recovery branch remains intact at `4fc777b6`.

## Validation

- focused event validation/producer/migration: 184 tests passed
- full suite: 740 files / 7,417 tests passed
- full ESLint passed
- scoped Prettier passed
- `git diff --check` passed

Linear: https://linear.app/spectranoir/issue/SPE-2693/reconcile-preserved-dirty-main-recovery-branch