### PR TITLE
SPE-2695: validate directive.applied payloads

### DIFF
--- a/src/app/store/runTransfer.test.ts
+++ b/src/app/store/runTransfer.test.ts
@@ -1598,6 +1598,59 @@ describe('runTransfer helpers', () => {
     })
   })
 
+  it('repairs legacy directive.applied events but drops invalid current-schema events', () => {
+    const fallback = createStartingState()
+    const imported = parseRunExport(
+      JSON.stringify({
+        kind: RUN_EXPORT_KIND,
+        version: GAME_STORE_VERSION,
+        exportedAt: new Date().toISOString(),
+        game: {
+          ...fallback,
+          week: 2,
+          events: [
+            {
+              id: 'evt-legacy-directive',
+              schemaVersion: 1,
+              type: 'directive.applied',
+              sourceSystem: 'system',
+              timestamp: '2042-01-08T00:00:00.001Z',
+              payload: {
+                week: 2,
+                directiveId: 'retired-directive',
+                directiveLabel: 'Retired Directive',
+              },
+            },
+            {
+              id: 'evt-current-directive-mismatch',
+              schemaVersion: 2,
+              type: 'directive.applied',
+              sourceSystem: 'system',
+              timestamp: '2042-01-08T00:00:00.002Z',
+              payload: {
+                week: 2,
+                directiveId: 'intel-surge',
+                directiveLabel: 'Recovery Rotation',
+              },
+            },
+          ],
+        },
+      })
+    )
+
+    expect(imported.events).toHaveLength(1)
+    expect(imported.events[0]).toMatchObject({
+      id: 'evt-legacy-directive',
+      schemaVersion: 2,
+      type: 'directive.applied',
+      payload: {
+        week: 2,
+        directiveId: 'intel-surge',
+        directiveLabel: 'Intel Surge',
+      },
+    })
+  })
+
   it('sanitizes sparse agent.training_cancelled payloads with fallback defaults', () => {
     const fallback = createStartingState()
     const imported = parseRunExport(

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -31,6 +31,7 @@ import {
 } from '../../domain/agent/deploymentMomentum'
 import {
   createDefaultWeeklyDirectiveState,
+  getWeeklyDirectiveDefinition,
   getWeeklyDirectiveDefinitions,
   isWeeklyDirectiveId,
 } from '../../domain/directives'
@@ -8343,23 +8344,35 @@ function sanitizeOperationEvents(
         break
       }
 
-      case 'directive.applied':
+      case 'directive.applied': {
+        const isLegacyEvent = schemaVersion === 1
+        const directiveId = isWeeklyDirectiveId(payload.directiveId)
+          ? payload.directiveId
+          : isLegacyEvent
+            ? FALLBACK_WEEKLY_DIRECTIVE_ID
+            : null
+        const definition = getWeeklyDirectiveDefinition(directiveId)
+
+        if (
+          !directiveId ||
+          !definition ||
+          (!isLegacyEvent && payload.directiveLabel !== definition.label)
+        ) {
+          break
+        }
+
         nextEvents.push(
           migrateOperationEventToCurrentSchema({
             ...createBase('directive.applied'),
             payload: {
               week,
-              directiveId: isWeeklyDirectiveId(payload.directiveId)
-                ? payload.directiveId
-                : FALLBACK_WEEKLY_DIRECTIVE_ID,
-              directiveLabel:
-                typeof payload.directiveLabel === 'string'
-                  ? payload.directiveLabel
-                  : 'Directive applied',
+              directiveId,
+              directiveLabel: definition.label,
             },
           })
         )
         break
+      }
 
       case 'support.shortfall':
         nextEvents.push(

--- a/src/domain/events/eventValidation.ts
+++ b/src/domain/events/eventValidation.ts
@@ -7,6 +7,7 @@ import { normalizeInstitutionKeyForAudit } from '../procurementEmergencyInstitut
 import { getLevelForXp } from '../progression'
 import { createInitialFactionState, FACTION_DEFINITIONS } from '../factions'
 import { EXACT_POTENTIAL_TIERS } from '../agentPotential'
+import { getWeeklyDirectiveDefinition, isWeeklyDirectiveId } from '../directives'
 import { CASE_KINDS, CASE_MODES } from '../models'
 import type { OperationEventType } from './types'
 
@@ -1096,8 +1097,27 @@ const agencyContainmentUpdatedSchema = z
 const directiveAppliedSchema = z
   .object({
     week: weekSchema,
-    directiveId: z.string(),
-    directiveLabel: z.string(),
+    directiveId: trimmedNonblankTextSchema,
+    directiveLabel: trimmedNonblankTextSchema,
+  })
+  .superRefine((payload, context) => {
+    if (!isWeeklyDirectiveId(payload.directiveId)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['directiveId'],
+        message: 'directiveId must reference a known weekly directive',
+      })
+      return
+    }
+
+    const definition = getWeeklyDirectiveDefinition(payload.directiveId)
+    if (payload.directiveLabel !== definition?.label) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['directiveLabel'],
+        message: 'directiveLabel must match the catalog label for directiveId',
+      })
+    }
   })
   .strict()
 

--- a/src/test/events.validation.test.ts
+++ b/src/test/events.validation.test.ts
@@ -487,6 +487,34 @@ describe('event payload validation coverage', () => {
     expect(negativeDeltas.success).toBe(true)
   })
 
+  it('validates directive.applied against the weekly directive catalog', () => {
+    const valid = validateOperationEventPayload('directive.applied', {
+      week: 3,
+      directiveId: 'intel-surge',
+      directiveLabel: 'Intel Surge',
+    })
+    const unknownId = validateOperationEventPayload('directive.applied', {
+      week: 3,
+      directiveId: 'unknown-directive',
+      directiveLabel: 'Unknown Directive',
+    })
+    const blankLabel = validateOperationEventPayload('directive.applied', {
+      week: 3,
+      directiveId: 'intel-surge',
+      directiveLabel: '   ',
+    })
+    const mismatchedLabel = validateOperationEventPayload('directive.applied', {
+      week: 3,
+      directiveId: 'intel-surge',
+      directiveLabel: 'Recovery Rotation',
+    })
+
+    expect(valid.success).toBe(true)
+    expect(unknownId.success).toBe(false)
+    expect(blankLabel.success).toBe(false)
+    expect(mismatchedLabel.success).toBe(false)
+  })
+
   it('rejects agency.containment_updated payloads with non-finite containment or funding fields', () => {
     const base = minimalOperationEventPayloads['agency.containment_updated']
     const nanContainment = validateOperationEventPayload('agency.containment_updated', {


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2695 — https://linear.app/spectranoir/issue/SPE-2695/validate-directiveapplied-payloads-against-directive-registry
- **Parent issue (if any):** none
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Validates `directive.applied` IDs and labels against the weekly directive registry.
- Drops invalid current-schema events while canonically repairing explicit legacy v1 events.
- Adds schema and run-transfer coverage for valid, unknown, blank, mismatched, and legacy payloads.

## Docs updated

- none

## Parent status

- No parent issue.

## Scope boundary

- No directive mechanics, UI, persisted directive state, or schema version changes.

## Validation

- [x] Targeted tests: `npx vitest run src/test/events.validation.test.ts src/app/store/runTransfer.test.ts` (539 passed)
- [x] Full tests: `npm run test:run` (7,421 passed)
- [x] Lint: `npm run lint`
- [x] Touched-file formatting: `npx prettier --check src/domain/events/eventValidation.ts src/app/store/runTransfer.ts src/test/events.validation.test.ts src/app/store/runTransfer.test.ts`
- [ ] Repository format baseline: `npm run format:check` reports 2,194 pre-existing files

## Follow-ups

- none

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [x] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)