### PR TITLE
SPE-2696: Risk-weighted agency-standing rewards

### DIFF
--- a/src/domain/missionResults.ts
+++ b/src/domain/missionResults.ts
@@ -3,6 +3,8 @@ import { getEquipmentDefinition } from './equipment'
 import { buildFactionRewardInfluence, FACTION_DEFINITIONS } from './factions'
 import type { WeakestLinkMissionResolutionResult } from './weakestLinkResolution'
 import type {
+  AgencyStandingAward,
+  AgencyStandingDangerBand,
   CaseInstance,
   GameConfig,
   GameState,
@@ -84,6 +86,18 @@ const RAID_VALUE_MULTIPLIER = 1.2
 const STAGE_VALUE_STEP = 0.14
 const DURATION_VALUE_STEP = 2
 const DEADLINE_PRESSURE_VALUE_STEP = 1.5
+const AGENCY_STANDING_BASE_POINTS = 6
+const AGENCY_STANDING_MAX_ABSOLUTE_POINTS = 24
+const AGENCY_STANDING_DURATION_STEP = 0.15
+const AGENCY_STANDING_MAX_DURATION_MULTIPLIER = 1.45
+const AGENCY_STANDING_MIN_REPEAT_MULTIPLIER = 0.2
+
+const AGENCY_STANDING_OUTCOME_MULTIPLIERS: Readonly<Record<MissionResolutionKind, number>> = {
+  success: 1,
+  partial: 0.55,
+  fail: -0.3,
+  unresolved: -0.45,
+}
 
 const REWARD_CASE_PROFILES: readonly RewardCaseProfile[] = [
   {
@@ -307,6 +321,127 @@ function buildOperationValueBreakdown(
     factors,
     operationValue:
       requiredScore + stageBonusValue + raidBonusValue + durationValue + deadlinePressureValue,
+  }
+}
+
+function getAgencyStandingDangerBand(dangerScore: number): {
+  band: AgencyStandingDangerBand
+  multiplier: number
+} {
+  if (dangerScore >= 90) {
+    return { band: 'extreme', multiplier: 1.9 }
+  }
+  if (dangerScore >= 65) {
+    return { band: 'high', multiplier: 1.55 }
+  }
+  if (dangerScore >= 40) {
+    return { band: 'elevated', multiplier: 1.25 }
+  }
+  return { band: 'routine', multiplier: 1 }
+}
+
+function getAgencyStandingRepeatKey(currentCase: CaseInstance) {
+  const contractTemplateId =
+    typeof currentCase.contract?.templateId === 'string'
+      ? currentCase.contract.templateId.trim()
+      : ''
+  return contractTemplateId || currentCase.templateId
+}
+
+function countPriorSimilarCompletions(repeatKey: string, game?: Pick<GameState, 'reports'>) {
+  if (!game) {
+    return 0
+  }
+
+  return game.reports.reduce(
+    (count, report) =>
+      count +
+      Object.values(report.caseSnapshots ?? {}).filter(
+        (snapshot) => snapshot.missionResult?.rewards.agencyStanding?.repeatKey === repeatKey
+      ).length,
+    0
+  )
+}
+
+export function buildAgencyStandingAward(
+  currentCase: CaseInstance,
+  outcome: MissionResolutionKind,
+  config: GameConfig,
+  game?: Pick<GameState, 'reports'>
+): AgencyStandingAward {
+  const operationValue = buildOperationValueBreakdown(currentCase, config)
+  const durationValue = currentCase.durationWeeks * DURATION_VALUE_STEP
+  const dangerScore = Math.max(0, Math.round(operationValue.operationValue - durationValue))
+  const danger = getAgencyStandingDangerBand(dangerScore)
+  const durationMultiplier = Math.min(
+    AGENCY_STANDING_MAX_DURATION_MULTIPLIER,
+    1 + Math.max(0, currentCase.durationWeeks - 1) * AGENCY_STANDING_DURATION_STEP
+  )
+  const repeatKey = getAgencyStandingRepeatKey(currentCase)
+  const priorSimilarCompletions = countPriorSimilarCompletions(repeatKey, game)
+  const repeatMultiplier = Math.max(
+    AGENCY_STANDING_MIN_REPEAT_MULTIPLIER,
+    1 / (priorSimilarCompletions + 1)
+  )
+  const outcomeMultiplier = AGENCY_STANDING_OUTCOME_MULTIPLIERS[outcome]
+  const rawPoints =
+    AGENCY_STANDING_BASE_POINTS *
+    danger.multiplier *
+    outcomeMultiplier *
+    durationMultiplier *
+    repeatMultiplier
+  const points = Math.max(
+    -AGENCY_STANDING_MAX_ABSOLUTE_POINTS,
+    Math.min(AGENCY_STANDING_MAX_ABSOLUTE_POINTS, Math.round(rawPoints))
+  )
+  const outcomeLabel =
+    outcome === 'success'
+      ? 'completed'
+      : outcome === 'partial'
+        ? 'partially completed'
+        : outcome === 'fail'
+          ? 'failed'
+          : 'withdrawn or abandoned'
+
+  return {
+    points,
+    rawPoints: Number(rawPoints.toFixed(3)),
+    basePoints: AGENCY_STANDING_BASE_POINTS,
+    dangerScore,
+    dangerBand: danger.band,
+    dangerMultiplier: danger.multiplier,
+    outcomeMultiplier,
+    durationMultiplier,
+    repeatMultiplier,
+    priorSimilarCompletions,
+    repeatKey,
+    factors: [
+      {
+        id: 'danger',
+        label: 'Operational danger',
+        multiplier: danger.multiplier,
+        detail: `${danger.band} danger (${dangerScore}) applies x${danger.multiplier.toFixed(2)}.`,
+      },
+      {
+        id: 'outcome',
+        label: 'Completion outcome',
+        multiplier: outcomeMultiplier,
+        detail: `${outcomeLabel} applies x${outcomeMultiplier.toFixed(2)}; danger alone never grants standing.`,
+      },
+      {
+        id: 'duration',
+        label: 'Expected commitment',
+        multiplier: durationMultiplier,
+        detail: `${Math.max(1, currentCase.durationWeeks)} expected week(s) applies bounded x${durationMultiplier.toFixed(2)}.`,
+      },
+      {
+        id: 'repeat',
+        label: 'Repeat normalization',
+        multiplier: repeatMultiplier,
+        detail: `${priorSimilarCompletions} prior similar completion(s) applies bounded x${repeatMultiplier.toFixed(2)}.`,
+      },
+    ],
+    summary: `${points >= 0 ? '+' : ''}${points} agency standing: ${danger.band} danger, ${outcomeLabel}, x${durationMultiplier.toFixed(2)} commitment, x${repeatMultiplier.toFixed(2)} repeat normalization.`,
   }
 }
 
@@ -633,6 +768,7 @@ function buildRewardReasons(
     | 'factionStanding'
     | 'containmentDelta'
     | 'factors'
+    | 'agencyStanding'
   >
 ) {
   const inventorySummary =
@@ -657,6 +793,7 @@ function buildRewardReasons(
   )
 
   return [
+    ...(breakdown.agencyStanding ? [breakdown.agencyStanding.summary] : []),
     `Operation value ${breakdown.operationValue} came from difficulty, escalation pressure, duration, and deadline pressure.`,
     `${breakdown.caseTypeLabel} routing applies the deterministic reward table for this incident family.`,
     factionInfluence
@@ -708,22 +845,31 @@ function buildPowerImpactNotes(powerImpact: PowerImpactSummary | undefined) {
 }
 
 export function buildMissionResult(input: MissionResultInput): MissionResult {
-    const explanationNotes: string[] = []
-    // --- Knowledge-state gating/risk: defeat-condition certainty check ---
-    if (input.knowledge && input.requiredDefeatCertainty && input.anomalyId && input.teamsUsed?.length) {
-      const teamId = input.teamsUsed[0]?.teamId ?? ''
-      const anomalyId = input.anomalyId
-      const key = Object.keys(input.knowledge).find(
-        (knowledgeKey) => knowledgeKey.includes(teamId) && knowledgeKey.includes(anomalyId)
+  const explanationNotes: string[] = []
+  // --- Knowledge-state gating/risk: defeat-condition certainty check ---
+  if (
+    input.knowledge &&
+    input.requiredDefeatCertainty &&
+    input.anomalyId &&
+    input.teamsUsed?.length
+  ) {
+    const teamId = input.teamsUsed[0]?.teamId ?? ''
+    const anomalyId = input.anomalyId
+    const key = Object.keys(input.knowledge).find(
+      (knowledgeKey) => knowledgeKey.includes(teamId) && knowledgeKey.includes(anomalyId)
+    )
+    const entry = key ? input.knowledge[key] : undefined
+    const order = ['unknown', 'suspected', 'family', 'exact']
+    const currentIdx =
+      entry && entry.defeatConditionCertainty ? order.indexOf(entry.defeatConditionCertainty) : -1
+    const requiredIdx = order.indexOf(input.requiredDefeatCertainty)
+    if (currentIdx < requiredIdx) {
+      appendUniqueNote(
+        explanationNotes,
+        `Insufficient defeat-condition certainty: required ${input.requiredDefeatCertainty}, found ${entry?.defeatConditionCertainty ?? 'none'}. Risk of mission failure or escalation.`
       )
-      const entry = key ? input.knowledge[key] : undefined
-      const order = ['unknown', 'suspected', 'family', 'exact']
-      const currentIdx = entry && entry.defeatConditionCertainty ? order.indexOf(entry.defeatConditionCertainty) : -1
-      const requiredIdx = order.indexOf(input.requiredDefeatCertainty)
-      if (currentIdx < requiredIdx) {
-        appendUniqueNote(explanationNotes, `Insufficient defeat-condition certainty: required ${input.requiredDefeatCertainty}, found ${entry?.defeatConditionCertainty ?? 'none'}. Risk of mission failure or escalation.`)
-      }
     }
+  }
   const performanceSummary = input.performanceSummary ?? EMPTY_PERFORMANCE_METRIC_SUMMARY
   const powerImpact = input.powerImpact
   const fatigueChanges = input.fatigueChanges ?? []
@@ -798,7 +944,9 @@ export function buildMissionResult(input: MissionResultInput): MissionResult {
     penalties: buildMissionPenaltyBreakdown(input.rewards),
     fatigueChanges: fatigueChanges.map((change) => ({ ...change })),
     injuries: injuries.map((injury) => ({ ...injury })),
-    ...(fatalities.length > 0 ? { fatalities: fatalities.map((fatality) => ({ ...fatality })) } : {}),
+    ...(fatalities.length > 0
+      ? { fatalities: fatalities.map((fatality) => ({ ...fatality })) }
+      : {}),
     spawnedConsequences: spawnedConsequences.map((consequence) => ({ ...consequence })),
     explanationNotes,
   }
@@ -842,6 +990,7 @@ export function buildMissionRewardBreakdown(
     outcome,
     operationValue.operationValue
   )
+  const agencyStanding = buildAgencyStandingAward(currentCase, outcome, config, game)
 
   const breakdown: MissionRewardBreakdown = {
     outcome,
@@ -878,6 +1027,7 @@ export function buildMissionRewardBreakdown(
       profile,
       factionRewardValue.modifierValue
     ),
+    agencyStanding,
     inventoryRewards,
     factionStanding,
     label: getOutcomeLabel(outcome),
@@ -888,11 +1038,7 @@ export function buildMissionRewardBreakdown(
   if (fieldBase) {
     const materialQuantityIncreased = inventoryRewards.some((grant, index) => {
       const raw = inventoryRewardsRaw[index]
-      return (
-        grant.kind === 'material' &&
-        raw?.kind === 'material' &&
-        grant.quantity > raw.quantity
-      )
+      return grant.kind === 'material' && raw?.kind === 'material' && grant.quantity > raw.quantity
     })
     if (fieldBase.quality.supply > 0 && materialQuantityIncreased) {
       fieldBaseReasons.push(FIELD_BASE_SUPPLY_TIER_MATERIAL_REASON)

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -23,7 +23,11 @@ export type DeploymentSoftRiskCode =
   | 'intel-uncertainty'
 
 export type DeploymentReadinessCategory =
-  'mission_ready' | 'conditional' | 'hard_blocked' | 'temporarily_blocked' | 'recovery_required'
+  | 'mission_ready'
+  | 'conditional'
+  | 'hard_blocked'
+  | 'temporarily_blocked'
+  | 'recovery_required'
 
 export type MissionCategory =
   | 'containment_breach'
@@ -115,7 +119,12 @@ export interface MissionRoutingState {
 }
 
 export type MissionIntakeSource =
-  'scripted' | 'escalation' | 'pressure' | 'faction' | 'contract' | 'tutorial'
+  | 'scripted'
+  | 'escalation'
+  | 'pressure'
+  | 'faction'
+  | 'contract'
+  | 'tutorial'
 
 export interface TeamDeploymentReadinessState {
   teamId: string
@@ -811,6 +820,31 @@ export interface MissionRewardFactionStanding {
   overlapTags: string[]
 }
 
+export type AgencyStandingDangerBand = 'routine' | 'elevated' | 'high' | 'extreme'
+
+export interface AgencyStandingFactor {
+  id: 'danger' | 'outcome' | 'duration' | 'repeat'
+  label: string
+  multiplier: number
+  detail: string
+}
+
+export interface AgencyStandingAward {
+  points: number
+  rawPoints: number
+  basePoints: number
+  dangerScore: number
+  dangerBand: AgencyStandingDangerBand
+  dangerMultiplier: number
+  outcomeMultiplier: number
+  durationMultiplier: number
+  repeatMultiplier: number
+  priorSimilarCompletions: number
+  repeatKey: string
+  factors: readonly AgencyStandingFactor[]
+  summary: string
+}
+
 export interface MissionRewardBreakdown {
   outcome: MissionResolutionKind
   caseType: string
@@ -828,6 +862,8 @@ export interface MissionRewardBreakdown {
   containmentDelta: number
   strategicValueDelta: number
   reputationDelta: number
+  /** Present on newly resolved operations; optional for legacy persisted reports. */
+  agencyStanding?: AgencyStandingAward
   inventoryRewards: readonly MissionRewardInventoryGrant[]
   factionStanding: readonly MissionRewardFactionStanding[]
   label: string
@@ -986,7 +1022,10 @@ export interface FieldBaseStagingPacket {
 
 /** SPE-99: deployed recovery-mode taxonomy derived from fieldBase staging quality. */
 export type ExpeditionRecoveryMode =
-  'unsafe_pause' | 'ordinary_rest' | 'active_recovery' | 'sanctuary_recovery'
+  | 'unsafe_pause'
+  | 'ordinary_rest'
+  | 'active_recovery'
+  | 'sanctuary_recovery'
 
 export const EXPEDITION_RECOVERY_MODES: readonly ExpeditionRecoveryMode[] = [
   'unsafe_pause',
@@ -1046,7 +1085,11 @@ export type ContractNextIntent =
   | 'answer-emergency'
 
 export type ContractDebriefChangedEntityKind =
-  'staff' | 'subject' | 'route' | 'evidence' | 'faction'
+  | 'staff'
+  | 'subject'
+  | 'route'
+  | 'evidence'
+  | 'faction'
 
 export interface ContractDebriefChangedEntity {
   kind: ContractDebriefChangedEntityKind
@@ -1342,7 +1385,9 @@ export interface CaseTemplate {
 
 /** SPE-1701: deterministic deployment carry-in stamped at team→case assignment. */
 export type DeploymentCarryInCode =
-  'residue-therapy-foregone' | 'well-rested-stable-energy' | 'off-books-courier-lockout'
+  | 'residue-therapy-foregone'
+  | 'well-rested-stable-energy'
+  | 'off-books-courier-lockout'
 
 export interface AgentDeploymentCarryInStamp {
   readinessDelta: number
@@ -1594,7 +1639,13 @@ export type ReportNoteType =
   | 'pattern_source_series.weekly_transition'
 
 export type ReportNoteMetadataValue =
-  string | number | boolean | null | readonly string[] | readonly number[] | readonly boolean[]
+  | string
+  | number
+  | boolean
+  | null
+  | readonly string[]
+  | readonly number[]
+  | readonly boolean[]
 
 export type ReportNoteMetadata = Record<string, ReportNoteMetadataValue>
 
@@ -1669,7 +1720,10 @@ export interface WeeklyReport {
 }
 
 export type WeeklyDirectiveId =
-  'intel-surge' | 'recovery-rotation' | 'procurement-push' | 'lockdown-protocol'
+  | 'intel-surge'
+  | 'recovery-rotation'
+  | 'procurement-push'
+  | 'lockdown-protocol'
 
 export interface WeeklyDirectiveHistoryEntry {
   week: number
@@ -1808,7 +1862,12 @@ export interface OneShotEventState {
 }
 
 export type EncounterRuntimeStatus =
-  'available' | 'active' | 'resolved' | 'locked' | 'hidden' | 'archived'
+  | 'available'
+  | 'active'
+  | 'resolved'
+  | 'locked'
+  | 'hidden'
+  | 'archived'
 export type EncounterResolutionOutcome = 'success' | 'partial' | 'failed' | 'failure' | 'dismissed'
 
 export interface EncounterRuntimeState {
@@ -2006,7 +2065,12 @@ export interface FundingState {
 }
 
 export type ResearchUnlockCategory =
-  'intel_tool' | 'facility' | 'training' | 'equipment' | 'contract' | (string & {})
+  | 'intel_tool'
+  | 'facility'
+  | 'training'
+  | 'equipment'
+  | 'contract'
+  | (string & {})
 
 export interface ResearchUnlock {
   id: string
@@ -2016,7 +2080,12 @@ export interface ResearchUnlock {
 }
 
 export type ResearchProjectStatus =
-  'locked' | 'available' | 'queued' | 'active' | 'completed' | 'blocked'
+  | 'locked'
+  | 'available'
+  | 'queued'
+  | 'active'
+  | 'completed'
+  | 'blocked'
 
 export interface ResearchProject {
   projectId: string
@@ -2053,7 +2122,11 @@ export interface ResearchState {
 
 export type AgentAttritionStatus = 'active' | 'at_risk' | 'temporarily_unavailable' | 'lost'
 export type AgentAttritionCategory =
-  'injury_exit' | 'burnout' | 'temporary_leave' | 'disciplinary' | 'unknown'
+  | 'injury_exit'
+  | 'burnout'
+  | 'temporary_leave'
+  | 'disciplinary'
+  | 'unknown'
 
 export interface AgentAttritionState {
   attritionStatus: AgentAttritionStatus
@@ -2100,7 +2173,12 @@ export interface SupportStaffSummary {
 }
 
 export type MajorIncidentStrategy =
-  'aggressive' | 'balanced' | 'cautious' | 'rapid_response' | 'containment_first' | 'risk_accepting'
+  | 'aggressive'
+  | 'balanced'
+  | 'cautious'
+  | 'rapid_response'
+  | 'containment_first'
+  | 'risk_accepting'
 export type MajorIncidentProvisionType = string
 export type RecruitmentFunnelStage = import('./recruitment/types').RecruitmentFunnelStage
 export type CertificationState = import('./agent/models').CertificationState
@@ -3064,11 +3142,18 @@ export interface GameState {
 
 /** The named stages a subject passes through in a custody pipeline. */
 export type CustodyStageKind =
-  'intake' | 'holding' | 'transfer_en_route' | 'handoff' | 'delivered' | 'released_hostile'
+  | 'intake'
+  | 'holding'
+  | 'transfer_en_route'
+  | 'handoff'
+  | 'delivered'
+  | 'released_hostile'
 
 /** Custody-specific distortion tags attached to a single stage record. */
 export type CustodyDistortionContext =
-  'custody_record_scrubbed' | 'forged_transfer_credentials' | 'vanished_file'
+  | 'custody_record_scrubbed'
+  | 'forged_transfer_credentials'
+  | 'vanished_file'
 
 /** One stage in the chain, with which institution owns it and any record-tampering context. */
 export interface CustodyStageRecord {
@@ -3117,7 +3202,9 @@ export interface CustodyChain {
 
 /** The type of corruption evidence surfaced by an investigation. */
 export type CustodyDiscoveryEventType =
-  'missing_record' | 'marker_revealed' | 'compromised_actor_identified'
+  | 'missing_record'
+  | 'marker_revealed'
+  | 'compromised_actor_identified'
 
 /** A single discovery produced by resolveCorruptionDiscovery(). */
 export interface CustodyDiscoveryEvent {

--- a/src/domain/rankings.ts
+++ b/src/domain/rankings.ts
@@ -22,6 +22,9 @@ export interface RankingProgressionFactor extends RankingScoreFactor {
 }
 
 export interface AgencyRankingBreakdown {
+  agencyStanding: RankingScoreFactor & {
+    awards: number
+  }
   casesResolved: RankingScoreFactor & {
     resolvedCases: number
     partialCases: number
@@ -55,6 +58,7 @@ export interface AgencyRankingHistoryEntry {
     unresolved: number
     reputationDelta: number
     progressionXp: number
+    agencyStanding: number
   }
 }
 
@@ -80,6 +84,8 @@ interface RankingAccumulator {
   reputationDelta: number
   progressionXp: number
   promotions: number
+  agencyStanding: number
+  standingAwards: number
 }
 
 const RANKING_BASE_SCORE = 50
@@ -106,6 +112,8 @@ function createEmptyAccumulator(): RankingAccumulator {
     reputationDelta: 0,
     progressionXp: 0,
     promotions: 0,
+    agencyStanding: 0,
+    standingAwards: 0,
   }
 }
 
@@ -140,6 +148,19 @@ function isMajorIncidentOutcome(
 }
 
 function accumulateRankingEvent(accumulator: RankingAccumulator, event: OperationEvent) {
+  if (
+    event.type === 'case.resolved' ||
+    event.type === 'case.partially_resolved' ||
+    event.type === 'case.failed' ||
+    event.type === 'case.escalated'
+  ) {
+    const award = event.payload.rewardBreakdown?.agencyStanding
+    if (award) {
+      accumulator.agencyStanding += award.points
+      accumulator.standingAwards += 1
+    }
+  }
+
   switch (event.type) {
     case 'case.resolved':
       accumulator.reputationDelta += event.payload.rewardBreakdown?.reputationDelta ?? 0
@@ -183,6 +204,13 @@ function buildAgencyRankingBreakdown(accumulator: RankingAccumulator): AgencyRan
   const unresolvedPenalty = accumulator.unresolvedCases * UNRESOLVED_PENALTY_POINTS
 
   return {
+    agencyStanding: {
+      label: 'Risk-weighted agency standing',
+      value: accumulator.agencyStanding,
+      awards: accumulator.standingAwards,
+      points: accumulator.agencyStanding,
+      detail: `${accumulator.standingAwards} operation award(s) combine authoritative danger, outcome, expected commitment, and repeat normalization.`,
+    },
     casesResolved: {
       label: 'Cases resolved',
       value: accumulator.resolvedCases + accumulator.partialCases,
@@ -243,12 +271,14 @@ function buildAgencyRankingFromAccumulator(
   const score = clamp(
     Math.round(
       RANKING_BASE_SCORE +
-        breakdown.casesResolved.points +
-        breakdown.majorIncidentsHandled.points +
+        (breakdown.agencyStanding.awards > 0
+          ? breakdown.agencyStanding.points
+          : breakdown.casesResolved.points + breakdown.majorIncidentsHandled.points) +
         breakdown.reputation.points +
         breakdown.progression.points -
-        breakdown.failures.penalty -
-        breakdown.unresolved.penalty
+        (breakdown.agencyStanding.awards > 0
+          ? 0
+          : breakdown.failures.penalty + breakdown.unresolved.penalty)
     ),
     0,
     100
@@ -311,6 +341,7 @@ export function buildAgencyRankingHistory(
         unresolved: accumulator.unresolvedCases,
         reputationDelta: accumulator.reputationDelta,
         progressionXp: accumulator.progressionXp,
+        agencyStanding: accumulator.agencyStanding,
       },
     })
   }

--- a/src/domain/reportNotes.ts
+++ b/src/domain/reportNotes.ts
@@ -690,6 +690,9 @@ function buildRewardMetadata(rewardBreakdown: MissionRewardBreakdown): ReportNot
     materialRewardCount: inventoryTotals.materials,
     equipmentRewardCount: inventoryTotals.equipment,
     factionStandingNet: getMissionRewardFactionStandingNet(rewardBreakdown),
+    ...(rewardBreakdown.agencyStanding
+      ? { agencyStandingDelta: rewardBreakdown.agencyStanding.points }
+      : {}),
   }
 }
 
@@ -698,6 +701,9 @@ function formatRewardSummary(rewardBreakdown: MissionRewardBreakdown) {
   const summaryParts = [
     `Funding ${formatSignedNumber(rewardBreakdown.fundingDelta)}`,
     `Reputation ${formatSignedNumber(rewardBreakdown.reputationDelta)}`,
+    ...(rewardBreakdown.agencyStanding
+      ? [`Agency standing ${formatSignedNumber(rewardBreakdown.agencyStanding.points)}`]
+      : []),
   ]
 
   if (inventoryTotals.materials > 0) {

--- a/src/features/rankings/RankingsPage.tsx
+++ b/src/features/rankings/RankingsPage.tsx
@@ -11,7 +11,8 @@ export default function RankingsPage() {
         <h2 className="text-lg font-semibold">Agency Rankings</h2>
         <p className="text-sm opacity-60">
           Standing is derived from contained operations, major-incident response, failure penalties,
-          agency reputation, and roster progression.
+          agency reputation, and roster progression. New operation awards are risk-weighted and
+          normalized for commitment and repeats.
         </p>
 
         <div className="grid gap-3 md:grid-cols-3">
@@ -24,6 +25,12 @@ export default function RankingsPage() {
       <article className="panel space-y-3">
         <h3 className="text-base font-semibold">Ranking breakdown</h3>
         <div className="grid gap-3 xl:grid-cols-2">
+          <FactorMetric
+            label={ranking.breakdown.agencyStanding.label}
+            value={`${ranking.breakdown.agencyStanding.awards} awards`}
+            impact={`${ranking.breakdown.agencyStanding.points >= 0 ? '+' : ''}${ranking.breakdown.agencyStanding.points}`}
+            detail={ranking.breakdown.agencyStanding.detail}
+          />
           <FactorMetric
             label={ranking.breakdown.casesResolved.label}
             value={`${ranking.breakdown.casesResolved.resolvedCases} resolved / ${ranking.breakdown.casesResolved.partialCases} partial`}
@@ -90,7 +97,9 @@ export default function RankingsPage() {
                   {entry.summary.majorIncidentsHandled}, failures {entry.summary.failures},
                   unresolved {entry.summary.unresolved}, reputation{' '}
                   {entry.summary.reputationDelta >= 0 ? '+' : ''}
-                  {entry.summary.reputationDelta}.
+                  {entry.summary.reputationDelta}, standing{' '}
+                  {entry.summary.agencyStanding >= 0 ? '+' : ''}
+                  {entry.summary.agencyStanding}.
                 </p>
               </li>
             ))}

--- a/src/test/agencyStanding.test.ts
+++ b/src/test/agencyStanding.test.ts
@@ -1,8 +1,203 @@
-import { buildAgencySummary } from '../domain/agency';
-import { buildAgencyRanking } from '../domain/rankings';
-import type { GameState } from '../domain/models';
+import { createStartingState } from '../data/startingState'
+import { buildAgencySummary } from '../domain/agency'
+import { buildAgencyStandingAward, buildMissionRewardBreakdown } from '../domain/missionResults'
+import { buildAgencyRanking } from '../domain/rankings'
+import type { GameState, MissionResolutionKind, WeeklyReport } from '../domain/models'
 
 describe('Agency Standing & Ranking', () => {
+  it('weights standing by authoritative operational danger', () => {
+    const state = createStartingState()
+    const routine = state.cases['case-001']
+    const dangerous = {
+      ...routine,
+      kind: 'raid' as const,
+      stage: 4,
+      difficulty: {
+        combat: routine.difficulty.combat + 8,
+        investigation: routine.difficulty.investigation + 8,
+        utility: routine.difficulty.utility + 8,
+        social: routine.difficulty.social + 8,
+      },
+    }
+
+    const routineAward = buildAgencyStandingAward(routine, 'success', state.config)
+    const dangerAward = buildAgencyStandingAward(dangerous, 'success', state.config)
+
+    expect(dangerAward.dangerScore).toBeGreaterThan(routineAward.dangerScore)
+    expect(dangerAward.dangerMultiplier).toBeGreaterThan(routineAward.dangerMultiplier)
+    expect(dangerAward.points).toBeGreaterThan(routineAward.points)
+  })
+
+  it.each<[MissionResolutionKind, number]>([
+    ['success', 1],
+    ['partial', 0.55],
+    ['fail', -0.3],
+    ['unresolved', -0.45],
+  ])('applies the bounded %s outcome modifier', (outcome, modifier) => {
+    const state = createStartingState()
+    const award = buildAgencyStandingAward(state.cases['case-001'], outcome, state.config)
+
+    expect(award.outcomeMultiplier).toBe(modifier)
+    expect(Math.abs(award.points)).toBeLessThanOrEqual(24)
+    if (outcome === 'success' || outcome === 'partial') {
+      expect(award.points).toBeGreaterThan(0)
+    } else {
+      expect(award.points).toBeLessThan(0)
+    }
+  })
+
+  it('is deterministic and normalizes expected duration and repeated operations', () => {
+    const state = createStartingState()
+    const shortCase = {
+      ...state.cases['case-001'],
+      durationWeeks: 1,
+      contract: { templateId: 'repeatable-short-operation' },
+    }
+    const longCase = { ...shortCase, durationWeeks: 4 }
+    const initial = buildAgencyStandingAward(shortCase, 'success', state.config)
+    const priorReport = {
+      week: 1,
+      caseSnapshots: {
+        prior: {
+          caseId: 'prior',
+          missionResult: {
+            rewards: { agencyStanding: initial },
+          },
+        },
+      },
+    } as unknown as WeeklyReport
+    const repeatedState = { reports: [priorReport, priorReport, priorReport] }
+
+    expect(buildAgencyStandingAward(shortCase, 'success', state.config)).toEqual(initial)
+    expect(buildAgencyStandingAward(longCase, 'success', state.config).durationMultiplier).toBe(
+      1.45
+    )
+    expect(buildAgencyStandingAward(longCase, 'success', state.config).points).toBeGreaterThan(
+      initial.points
+    )
+
+    const repeated = buildAgencyStandingAward(shortCase, 'success', state.config, repeatedState)
+    expect(repeated.priorSimilarCompletions).toBe(3)
+    expect(repeated.repeatMultiplier).toBeCloseTo(0.25)
+    expect(repeated.points).toBeLessThan(initial.points)
+  })
+
+  it('prevents a routine short-operation repeat sequence from outpacing dangerous commitment', () => {
+    const state = createStartingState()
+    const routine = {
+      ...state.cases['case-001'],
+      durationWeeks: 1,
+      contract: { templateId: 'farmable-routine' },
+    }
+    const dangerous = {
+      ...routine,
+      contract: { templateId: 'dangerous-commitment' },
+      kind: 'raid' as const,
+      stage: 4,
+      durationWeeks: 4,
+      difficulty: {
+        combat: routine.difficulty.combat + 8,
+        investigation: routine.difficulty.investigation + 8,
+        utility: routine.difficulty.utility + 8,
+        social: routine.difficulty.social + 8,
+      },
+    }
+    const priorAwards: WeeklyReport[] = []
+    let repeatedRoutineTotal = 0
+
+    for (let index = 0; index < 4; index += 1) {
+      const award = buildAgencyStandingAward(routine, 'success', state.config, {
+        reports: priorAwards,
+      })
+      repeatedRoutineTotal += award.points
+      priorAwards.push({
+        week: index + 1,
+        caseSnapshots: {
+          [`routine-${index}`]: {
+            caseId: `routine-${index}`,
+            missionResult: { rewards: { agencyStanding: award } },
+          },
+        },
+      } as unknown as WeeklyReport)
+    }
+
+    const dangerousAward = buildAgencyStandingAward(dangerous, 'success', state.config)
+    expect(repeatedRoutineTotal).toBeLessThanOrEqual(dangerousAward.points)
+  })
+
+  it('keeps standing independent from economics and momentum and emits explanations', () => {
+    const state = createStartingState()
+    const currentCase = state.cases['case-001']
+    const baseline = buildMissionRewardBreakdown(currentCase, 'success', state.config, state)
+    const economicallyChanged = buildMissionRewardBreakdown(currentCase, 'success', state.config, {
+      ...state,
+      funding: state.funding + 100_000,
+      agency: { ...state.agency, funding: state.agency.funding + 100_000 },
+      deploymentMomentum: {
+        enabled: true,
+        current: 99,
+        cap: 99,
+        lastUpdatedWeek: state.week,
+      },
+    } as typeof state)
+
+    expect(economicallyChanged.agencyStanding).toEqual(baseline.agencyStanding)
+    expect(baseline.agencyStanding!.factors.map((factor) => factor.id)).toEqual([
+      'danger',
+      'outcome',
+      'duration',
+      'repeat',
+    ])
+    expect(baseline.agencyStanding!.summary).toContain('agency standing')
+    expect(baseline.agencyStanding!.factors[1]?.detail).toContain(
+      'danger alone never grants standing'
+    )
+  })
+
+  it('projects completed standing awards into rankings and weekly history', () => {
+    const state = createStartingState()
+    const reward = buildMissionRewardBreakdown(
+      state.cases['case-001'],
+      'success',
+      state.config,
+      state
+    )
+    const ranking = buildAgencyRanking({
+      reports: [
+        {
+          week: 1,
+          resolvedCases: ['case-001'],
+          partialCases: [],
+          failedCases: [],
+          unresolvedTriggers: [],
+        } as unknown as WeeklyReport,
+      ],
+      events: [
+        {
+          id: 'evt-standing-case-001',
+          schemaVersion: 2,
+          type: 'case.resolved',
+          sourceSystem: 'incident',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          payload: {
+            week: 1,
+            caseId: 'case-001',
+            caseTitle: state.cases['case-001'].title,
+            mode: state.cases['case-001'].mode,
+            kind: state.cases['case-001'].kind,
+            stage: state.cases['case-001'].stage,
+            teamIds: [],
+            rewardBreakdown: reward,
+          },
+        },
+      ],
+    })
+
+    expect(ranking.breakdown.agencyStanding.awards).toBe(1)
+    expect(ranking.breakdown.agencyStanding.points).toBe(reward.agencyStanding!.points)
+    expect(ranking.history[0]?.summary.agencyStanding).toBe(reward.agencyStanding!.points)
+  })
+
   it('computes ranking tier and score deterministically from campaign state', () => {
     const game: GameState = {
       // Minimal stub for deterministic test
@@ -19,12 +214,12 @@ describe('Agency Standing & Ranking', () => {
       agents: {},
       productionQueue: [],
       inventory: {},
-    } as unknown as GameState;
-    const summary = buildAgencySummary(game);
-    const ranking = buildAgencyRanking(game);
-    expect(summary.ranking.score).toBe(ranking.score);
-    expect(['S', 'A', 'B', 'C', 'D']).toContain(summary.ranking.tier);
-  });
+    } as unknown as GameState
+    const summary = buildAgencySummary(game)
+    const ranking = buildAgencyRanking(game)
+    expect(summary.ranking.score).toBe(ranking.score)
+    expect(['S', 'A', 'B', 'C', 'D']).toContain(summary.ranking.tier)
+  })
 
   it('ranking penalizes unresolved and failed cases', () => {
     const game: GameState = {
@@ -51,9 +246,9 @@ describe('Agency Standing & Ranking', () => {
       agents: {},
       productionQueue: [],
       inventory: {},
-    } as unknown as GameState;
-    const summary = buildAgencySummary(game);
-    expect(summary.ranking.score).toBeLessThan(50);
-    expect(['C', 'D']).toContain(summary.ranking.tier);
-  });
-});
+    } as unknown as GameState
+    const summary = buildAgencySummary(game)
+    expect(summary.ranking.score).toBeLessThan(50)
+    expect(['C', 'D']).toContain(summary.ranking.tier)
+  })
+})

--- a/src/test/rankings.test.ts
+++ b/src/test/rankings.test.ts
@@ -182,6 +182,11 @@ describe('rankings', () => {
       partialReward.reputationDelta +
       failedReward.reputationDelta +
       unresolvedReward.reputationDelta
+    const expectedAgencyStanding =
+      successReward.agencyStanding!.points +
+      partialReward.agencyStanding!.points +
+      failedReward.agencyStanding!.points +
+      unresolvedReward.agencyStanding!.points
 
     expect(ranking).toEqual(secondRanking)
     expect(ranking.breakdown.casesResolved.points).toBe(6)
@@ -192,8 +197,9 @@ describe('rankings', () => {
     expect(ranking.breakdown.progression.points).toBe(5)
     expect(ranking.breakdown.failures.penalty).toBe(6)
     expect(ranking.breakdown.unresolved.penalty).toBe(8)
+    expect(ranking.breakdown.agencyStanding.points).toBe(expectedAgencyStanding)
     expect(ranking.score).toBe(
-      Math.max(0, Math.min(100, 50 + 6 + 8 + expectedReputation + 5 - 6 - 8))
+      Math.max(0, Math.min(100, 50 + expectedAgencyStanding + expectedReputation + 5))
     )
   })
 

--- a/systems/hub-simulation.md
+++ b/systems/hub-simulation.md
@@ -152,6 +152,14 @@ Hub simulation should read:
 
 This determines what the hub can plausibly surface.
 
+Agency standing awards are resolved separately from funding, salvage, faction standing, and
+tactical momentum. New operation results use a bounded deterministic contract: authoritative
+operation danger (difficulty, escalation, raid coordination, and deadline pressure), terminal
+outcome, expected-duration commitment, and prior completions of the same case/contract template.
+Success and partial completion can add standing; failure and withdrawal/abandonment remove it, so
+entering dangerous content never grants standing by itself. Campaign reward summaries retain the
+four multipliers used for each award.
+
 ### Stage B — Build hub opportunity pools
 
 Create possible output candidates based on:


### PR DESCRIPTION
## Summary
- add deterministic danger/outcome/commitment-weighted agency-standing awards
- normalize repeated operation templates and persist factor explanations in mission/report payloads
- project standing into rankings without changing economic, salvage, containment, or tactical-momentum rewards

## Validation
- npm run lint
- npm run test:run (740 files, 7,430 tests)
- npm run verify:audits-index
- npm run verify:backlog-handoff
- npm run verify:theme-contracts
- targeted Prettier on touched files (repo-wide format check has pre-existing baseline drift)

Linear: https://linear.app/spectranoir/issue/SPE-2696/risk-weighted-agency-standing-rewards