### PR TITLE
SPE-2697: Fix standing reward hydration, ranking, and same-week repeats

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -86,6 +86,7 @@ Documents the versioned serialization format for the full game store state.
 - On load, the persisted payload version is checked against `GAME_STORE_VERSION`
 - Older payloads are migrated forward via `migratePersistedStore`
 - Missing or unrecognised version causes fallback to a fresh store
+- Optional `MissionRewardBreakdown.agencyStanding` on case-outcome event payloads and weekly `caseSnapshots` is sanitized by `sanitizeMissionRewardBreakdownSnapshot` / `sanitizeAgencyStandingAward` (SPE-2696 / SPE-2697); missing awards stay legacy-compatible
 
 ---
 

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -4464,8 +4464,7 @@ function sanitizeMissionResult(
   )
 
   const rewards =
-    sanitizeMissionRewardBreakdownSnapshot(value.rewards, fallback?.rewards) ??
-    fallback?.rewards ?? {
+    sanitizeMissionRewardBreakdownSnapshot(value.rewards, fallback?.rewards) ?? {
       outcome,
       caseType: 'general',
       caseTypeLabel: 'Operation',

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -154,6 +154,9 @@ import {
   type GameState,
   type Id,
   type MarketState,
+  type AgencyStandingAward,
+  type AgencyStandingDangerBand,
+  type AgencyStandingFactor,
   type MissionResolutionKind,
   type MissionRewardBreakdown,
   type MissionResult,
@@ -3928,6 +3931,109 @@ function sanitizePowerImpactSummary(value: unknown): PowerImpactSummary | undefi
   }
 }
 
+const AGENCY_STANDING_DANGER_BANDS = [
+  'routine',
+  'elevated',
+  'high',
+  'extreme',
+] as const satisfies readonly AgencyStandingDangerBand[]
+
+const AGENCY_STANDING_FACTOR_IDS = [
+  'danger',
+  'outcome',
+  'duration',
+  'repeat',
+] as const satisfies readonly AgencyStandingFactor['id'][]
+
+function sanitizeAgencyStandingAward(
+  value: unknown,
+  fallback?: AgencyStandingAward
+): AgencyStandingAward | undefined {
+  if (!isRecord(value)) {
+    return fallback
+  }
+
+  const dangerBand = isOneOf(value.dangerBand, AGENCY_STANDING_DANGER_BANDS)
+    ? value.dangerBand
+    : fallback?.dangerBand
+  const repeatKey =
+    typeof value.repeatKey === 'string' && value.repeatKey.trim().length > 0
+      ? value.repeatKey.trim()
+      : fallback?.repeatKey
+  const summary =
+    typeof value.summary === 'string' && value.summary.trim().length > 0
+      ? value.summary.trim()
+      : fallback?.summary
+
+  if (!dangerBand || !repeatKey || !summary) {
+    return fallback
+  }
+
+  const factors = Array.isArray(value.factors)
+    ? value.factors
+        .map((entry): AgencyStandingFactor | undefined => {
+          if (!isRecord(entry)) {
+            return undefined
+          }
+          const id = isOneOf(entry.id, AGENCY_STANDING_FACTOR_IDS) ? entry.id : undefined
+          const label = typeof entry.label === 'string' ? entry.label : undefined
+          const detail = typeof entry.detail === 'string' ? entry.detail : undefined
+          const multiplier =
+            typeof entry.multiplier === 'number' && Number.isFinite(entry.multiplier)
+              ? entry.multiplier
+              : undefined
+          if (!id || !label || !detail || multiplier === undefined) {
+            return undefined
+          }
+          return { id, label, multiplier, detail }
+        })
+        .filter((entry): entry is AgencyStandingFactor => entry !== undefined)
+    : (fallback?.factors ?? [])
+
+  return {
+    points: sanitizeInteger(value.points as number | undefined, fallback?.points ?? 0, -10_000),
+    rawPoints:
+      typeof value.rawPoints === 'number' && Number.isFinite(value.rawPoints)
+        ? value.rawPoints
+        : (fallback?.rawPoints ?? 0),
+    basePoints: sanitizeInteger(
+      value.basePoints as number | undefined,
+      fallback?.basePoints ?? 0,
+      0
+    ),
+    dangerScore: sanitizeInteger(
+      value.dangerScore as number | undefined,
+      fallback?.dangerScore ?? 0,
+      0
+    ),
+    dangerBand,
+    dangerMultiplier:
+      typeof value.dangerMultiplier === 'number' && Number.isFinite(value.dangerMultiplier)
+        ? value.dangerMultiplier
+        : (fallback?.dangerMultiplier ?? 1),
+    outcomeMultiplier:
+      typeof value.outcomeMultiplier === 'number' && Number.isFinite(value.outcomeMultiplier)
+        ? value.outcomeMultiplier
+        : (fallback?.outcomeMultiplier ?? 0),
+    durationMultiplier:
+      typeof value.durationMultiplier === 'number' && Number.isFinite(value.durationMultiplier)
+        ? value.durationMultiplier
+        : (fallback?.durationMultiplier ?? 1),
+    repeatMultiplier:
+      typeof value.repeatMultiplier === 'number' && Number.isFinite(value.repeatMultiplier)
+        ? value.repeatMultiplier
+        : (fallback?.repeatMultiplier ?? 1),
+    priorSimilarCompletions: sanitizeInteger(
+      value.priorSimilarCompletions as number | undefined,
+      fallback?.priorSimilarCompletions ?? 0,
+      0
+    ),
+    repeatKey,
+    factors,
+    summary,
+  }
+}
+
 function sanitizeMissionRewardBreakdownSnapshot(
   value: unknown,
   fallback?: MissionRewardBreakdown
@@ -3943,6 +4049,11 @@ function sanitizeMissionRewardBreakdownSnapshot(
   if (!outcome) {
     return fallback
   }
+
+  const agencyStanding = sanitizeAgencyStandingAward(
+    value.agencyStanding,
+    fallback?.agencyStanding
+  )
 
   return {
     outcome,
@@ -3982,6 +4093,7 @@ function sanitizeMissionRewardBreakdownSnapshot(
       fallback?.reputationDelta ?? 0,
       -10_000
     ),
+    ...(agencyStanding ? { agencyStanding } : {}),
     inventoryRewards: Array.isArray(value.inventoryRewards)
       ? value.inventoryRewards.filter((entry) => isRecord(entry))
       : (fallback?.inventoryRewards ?? []),
@@ -4351,73 +4463,23 @@ function sanitizeMissionResult(
     fallback?.weakestLink
   )
 
-  const rewards = isRecord(value.rewards)
-    ? {
-        ...(fallback?.rewards ?? {
-          outcome,
-          caseType: 'general',
-          caseTypeLabel: 'Operation',
-          operationValue: 0,
-          factors: [],
-          fundingDelta: 0,
-          containmentDelta: 0,
-          strategicValueDelta: 0,
-          reputationDelta: 0,
-          inventoryRewards: [],
-          factionStanding: [],
-          label: 'Mission',
-          reasons: [],
-        }),
-        ...value.rewards,
-        outcome: isOneOf(
-          (value.rewards as { outcome?: unknown }).outcome,
-          MISSION_RESOLUTION_OUTCOMES
-        )
-          ? (value.rewards as { outcome: MissionResolutionKind }).outcome
-          : outcome,
-        fundingDelta: sanitizeInteger(
-          (value.rewards as { fundingDelta?: number }).fundingDelta,
-          fallback?.rewards.fundingDelta ?? 0,
-          -10_000
-        ),
-        containmentDelta: sanitizeInteger(
-          (value.rewards as { containmentDelta?: number }).containmentDelta,
-          fallback?.rewards.containmentDelta ?? 0,
-          -10_000
-        ),
-        reputationDelta: sanitizeInteger(
-          (value.rewards as { reputationDelta?: number }).reputationDelta,
-          fallback?.rewards.reputationDelta ?? 0,
-          -10_000
-        ),
-        inventoryRewards: Array.isArray(
-          (value.rewards as { inventoryRewards?: unknown }).inventoryRewards
-        )
-          ? (value.rewards as { inventoryRewards: MissionResult['rewards']['inventoryRewards'] })
-              .inventoryRewards
-          : (fallback?.rewards.inventoryRewards ?? []),
-        factionStanding: Array.isArray(
-          (value.rewards as { factionStanding?: unknown }).factionStanding
-        )
-          ? (value.rewards as { factionStanding: MissionResult['rewards']['factionStanding'] })
-              .factionStanding
-          : (fallback?.rewards.factionStanding ?? []),
-      }
-    : (fallback?.rewards ?? {
-        outcome,
-        caseType: 'general',
-        caseTypeLabel: 'Operation',
-        operationValue: 0,
-        factors: [],
-        fundingDelta: 0,
-        containmentDelta: 0,
-        strategicValueDelta: 0,
-        reputationDelta: 0,
-        inventoryRewards: [],
-        factionStanding: [],
-        label: 'Mission',
-        reasons: [],
-      })
+  const rewards =
+    sanitizeMissionRewardBreakdownSnapshot(value.rewards, fallback?.rewards) ??
+    fallback?.rewards ?? {
+      outcome,
+      caseType: 'general',
+      caseTypeLabel: 'Operation',
+      operationValue: 0,
+      factors: [],
+      fundingDelta: 0,
+      containmentDelta: 0,
+      strategicValueDelta: 0,
+      reputationDelta: 0,
+      inventoryRewards: [],
+      factionStanding: [],
+      label: 'Mission',
+      reasons: [],
+    }
 
   const penalties = isRecord(value.penalties)
     ? {

--- a/src/domain/missionResults.ts
+++ b/src/domain/missionResults.ts
@@ -348,12 +348,17 @@ function getAgencyStandingRepeatKey(currentCase: CaseInstance) {
   return contractTemplateId || currentCase.templateId
 }
 
-function countPriorSimilarCompletions(repeatKey: string, game?: Pick<GameState, 'reports'>) {
+export type AgencyStandingGameContext = Pick<GameState, 'reports'> & {
+  /** Same-week awards already computed before the weekly report is appended. */
+  pendingAgencyStandingAwards?: readonly Pick<AgencyStandingAward, 'repeatKey'>[]
+}
+
+function countPriorSimilarCompletions(repeatKey: string, game?: AgencyStandingGameContext) {
   if (!game) {
     return 0
   }
 
-  return game.reports.reduce(
+  const fromReports = game.reports.reduce(
     (count, report) =>
       count +
       Object.values(report.caseSnapshots ?? {}).filter(
@@ -361,13 +366,18 @@ function countPriorSimilarCompletions(repeatKey: string, game?: Pick<GameState, 
       ).length,
     0
   )
+  const fromPending = (game.pendingAgencyStandingAwards ?? []).filter(
+    (award) => award.repeatKey === repeatKey
+  ).length
+
+  return fromReports + fromPending
 }
 
 export function buildAgencyStandingAward(
   currentCase: CaseInstance,
   outcome: MissionResolutionKind,
   config: GameConfig,
-  game?: Pick<GameState, 'reports'>
+  game?: AgencyStandingGameContext
 ): AgencyStandingAward {
   const operationValue = buildOperationValueBreakdown(currentCase, config)
   const durationValue = currentCase.durationWeeks * DURATION_VALUE_STEP
@@ -966,7 +976,8 @@ export function buildMissionRewardBreakdown(
     | 'reports'
     | 'market'
     | 'events'
-  >
+  > &
+    AgencyStandingGameContext
 ): MissionRewardBreakdown {
   const operationValue = buildOperationValueBreakdown(currentCase, config)
   const profile = classifyRewardCaseProfile(currentCase)

--- a/src/domain/rankings.ts
+++ b/src/domain/rankings.ts
@@ -81,6 +81,12 @@ interface RankingAccumulator {
   unresolvedCases: number
   majorResolvedIncidents: number
   majorPartialIncidents: number
+  legacyResolvedCases: number
+  legacyPartialCases: number
+  legacyFailedCases: number
+  legacyUnresolvedCases: number
+  legacyMajorResolvedIncidents: number
+  legacyMajorPartialIncidents: number
   reputationDelta: number
   progressionXp: number
   promotions: number
@@ -109,6 +115,12 @@ function createEmptyAccumulator(): RankingAccumulator {
     unresolvedCases: 0,
     majorResolvedIncidents: 0,
     majorPartialIncidents: 0,
+    legacyResolvedCases: 0,
+    legacyPartialCases: 0,
+    legacyFailedCases: 0,
+    legacyUnresolvedCases: 0,
+    legacyMajorResolvedIncidents: 0,
+    legacyMajorPartialIncidents: 0,
     reputationDelta: 0,
     progressionXp: 0,
     promotions: 0,
@@ -147,7 +159,11 @@ function isMajorIncidentOutcome(
   return payload.kind === 'raid' || stage >= 4
 }
 
-function accumulateRankingEvent(accumulator: RankingAccumulator, event: OperationEvent) {
+function accumulateRankingEvent(
+  accumulator: RankingAccumulator,
+  event: OperationEvent,
+  standingCoveredCaseIds: Set<string>
+) {
   if (
     event.type === 'case.resolved' ||
     event.type === 'case.partially_resolved' ||
@@ -158,6 +174,7 @@ function accumulateRankingEvent(accumulator: RankingAccumulator, event: Operatio
     if (award) {
       accumulator.agencyStanding += award.points
       accumulator.standingAwards += 1
+      standingCoveredCaseIds.add(event.payload.caseId)
     }
   }
 
@@ -166,12 +183,18 @@ function accumulateRankingEvent(accumulator: RankingAccumulator, event: Operatio
       accumulator.reputationDelta += event.payload.rewardBreakdown?.reputationDelta ?? 0
       if (isMajorIncidentOutcome(event.payload)) {
         accumulator.majorResolvedIncidents += 1
+        if (!event.payload.rewardBreakdown?.agencyStanding) {
+          accumulator.legacyMajorResolvedIncidents += 1
+        }
       }
       break
     case 'case.partially_resolved':
       accumulator.reputationDelta += event.payload.rewardBreakdown?.reputationDelta ?? 0
       if (isMajorIncidentOutcome(event.payload)) {
         accumulator.majorPartialIncidents += 1
+        if (!event.payload.rewardBreakdown?.agencyStanding) {
+          accumulator.legacyMajorPartialIncidents += 1
+        }
       }
       break
     case 'case.failed':
@@ -186,6 +209,36 @@ function accumulateRankingEvent(accumulator: RankingAccumulator, event: Operatio
       break
     default:
       break
+  }
+}
+
+function accumulateLegacyReportCounts(
+  accumulator: RankingAccumulator,
+  report: Pick<
+    GameState['reports'][number],
+    'resolvedCases' | 'partialCases' | 'failedCases' | 'unresolvedTriggers'
+  >,
+  standingCoveredCaseIds: Set<string>
+) {
+  for (const caseId of report.resolvedCases) {
+    if (!standingCoveredCaseIds.has(caseId)) {
+      accumulator.legacyResolvedCases += 1
+    }
+  }
+  for (const caseId of report.partialCases) {
+    if (!standingCoveredCaseIds.has(caseId)) {
+      accumulator.legacyPartialCases += 1
+    }
+  }
+  for (const caseId of report.failedCases) {
+    if (!standingCoveredCaseIds.has(caseId)) {
+      accumulator.legacyFailedCases += 1
+    }
+  }
+  for (const caseId of report.unresolvedTriggers) {
+    if (!standingCoveredCaseIds.has(caseId)) {
+      accumulator.legacyUnresolvedCases += 1
+    }
   }
 }
 
@@ -268,17 +321,24 @@ function buildAgencyRankingFromAccumulator(
   updatedThroughWeek: number | null
 ): Omit<AgencyRankingView, 'history'> {
   const breakdown = buildAgencyRankingBreakdown(accumulator)
+  const legacyCasePoints =
+    accumulator.legacyResolvedCases * RESOLVED_CASE_POINTS +
+    accumulator.legacyPartialCases * PARTIAL_CASE_POINTS
+  const legacyMajorPoints =
+    accumulator.legacyMajorResolvedIncidents * RESOLVED_MAJOR_INCIDENT_POINTS +
+    accumulator.legacyMajorPartialIncidents * PARTIAL_MAJOR_INCIDENT_POINTS
+  const legacyFailurePenalty = accumulator.legacyFailedCases * FAILURE_PENALTY_POINTS
+  const legacyUnresolvedPenalty = accumulator.legacyUnresolvedCases * UNRESOLVED_PENALTY_POINTS
   const score = clamp(
     Math.round(
       RANKING_BASE_SCORE +
-        (breakdown.agencyStanding.awards > 0
-          ? breakdown.agencyStanding.points
-          : breakdown.casesResolved.points + breakdown.majorIncidentsHandled.points) +
+        breakdown.agencyStanding.points +
+        legacyCasePoints +
+        legacyMajorPoints +
         breakdown.reputation.points +
         breakdown.progression.points -
-        (breakdown.agencyStanding.awards > 0
-          ? 0
-          : breakdown.failures.penalty + breakdown.unresolved.penalty)
+        legacyFailurePenalty -
+        legacyUnresolvedPenalty
     ),
     0,
     100
@@ -291,6 +351,24 @@ function buildAgencyRankingFromAccumulator(
     updatedThroughWeek,
     breakdown,
   }
+}
+
+function accumulateReportWeek(
+  accumulator: RankingAccumulator,
+  report: GameState['reports'][number],
+  weeklyEvents: OperationEvent[]
+) {
+  accumulator.reportsLogged += 1
+  accumulator.resolvedCases += report.resolvedCases.length
+  accumulator.partialCases += report.partialCases.length
+  accumulator.failedCases += report.failedCases.length
+  accumulator.unresolvedCases += report.unresolvedTriggers.length
+
+  const standingCoveredCaseIds = new Set<string>()
+  for (const event of weeklyEvents) {
+    accumulateRankingEvent(accumulator, event, standingCoveredCaseIds)
+  }
+  accumulateLegacyReportCounts(accumulator, report, standingCoveredCaseIds)
 }
 
 export function buildAgencyRankingHistory(
@@ -310,19 +388,10 @@ export function buildAgencyRankingHistory(
   const history: AgencyRankingHistoryEntry[] = []
 
   for (const report of reports) {
-    accumulator.reportsLogged += 1
-    accumulator.resolvedCases += report.resolvedCases.length
-    accumulator.partialCases += report.partialCases.length
-    accumulator.failedCases += report.failedCases.length
-    accumulator.unresolvedCases += report.unresolvedTriggers.length
-
     const weeklyEvents = [...(eventsByWeek.get(report.week) ?? [])].sort((left, right) =>
       left.id.localeCompare(right.id)
     )
-
-    for (const event of weeklyEvents) {
-      accumulateRankingEvent(accumulator, event)
-    }
+    accumulateReportWeek(accumulator, report, weeklyEvents)
 
     const ranking = buildAgencyRankingFromAccumulator(accumulator, report.week)
     const previousScore = history[history.length - 1]?.score ?? RANKING_BASE_SCORE
@@ -376,19 +445,10 @@ export function buildAgencyRanking(game: Pick<GameState, 'reports' | 'events'>):
       continue
     }
 
-    accumulator.reportsLogged += 1
-    accumulator.resolvedCases += report.resolvedCases.length
-    accumulator.partialCases += report.partialCases.length
-    accumulator.failedCases += report.failedCases.length
-    accumulator.unresolvedCases += report.unresolvedTriggers.length
-
     const weeklyEvents = [...(eventsByWeek.get(week) ?? [])].sort((left, right) =>
       left.id.localeCompare(right.id)
     )
-
-    for (const event of weeklyEvents) {
-      accumulateRankingEvent(accumulator, event)
-    }
+    accumulateReportWeek(accumulator, report, weeklyEvents)
   }
 
   return {

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -1691,6 +1691,21 @@ interface WeeklyCaseResolutionStrategy {
 
 type SeededRng = ReturnType<typeof createSeededRng>
 
+function buildMissionRewardGameContext(
+  nextState: GameState,
+  rewardByCaseId: Partial<Record<string, MissionRewardBreakdown>>
+) {
+  const pendingAgencyStandingAwards = Object.values(rewardByCaseId)
+    .map((reward) => reward?.agencyStanding)
+    .filter((award): award is NonNullable<typeof award> => award !== undefined)
+    .map((award) => ({ repeatKey: award.repeatKey }))
+
+  return {
+    ...nextState,
+    pendingAgencyStandingAwards,
+  }
+}
+
 interface WeeklyExecutionContext {
   sourceState: GameState
   nextState: GameState
@@ -2671,7 +2686,7 @@ function resolveAssignments(
         effectiveCase,
         'success',
         context.nextState.config,
-        context.nextState
+        buildMissionRewardGameContext(context.nextState, context.rewardByCaseId)
       )
 
       if (!willDegrade) {
@@ -2905,7 +2920,7 @@ function resolveAssignments(
       escalatedCase,
       outcome.result,
       context.nextState.config,
-      context.nextState
+      buildMissionRewardGameContext(context.nextState, context.rewardByCaseId)
     )
     context.rewardByCaseId[caseId] = rewardBreakdown
     const hiddenFields = getMissionResultHiddenStateFields(escalatedCase)
@@ -3072,7 +3087,7 @@ function downgradeResolvedCaseToPartial(
     downgradedCase,
     'partial',
     nextState.config,
-    nextState
+    buildMissionRewardGameContext(nextState, context.rewardByCaseId)
   )
   const instabilityObjectiveDrift = buildExecutionInstabilityObjectiveDriftConsequence(
     sourceCase,
@@ -3198,7 +3213,7 @@ function escalateCases(
       escalatedCase,
       'unresolved',
       context.nextState.config,
-      context.nextState
+      buildMissionRewardGameContext(context.nextState, context.rewardByCaseId)
     )
     context.nextState.cases[caseId] = escalatedCase
     context.rewardByCaseId[caseId] = rewardBreakdown

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -1693,10 +1693,12 @@ type SeededRng = ReturnType<typeof createSeededRng>
 
 function buildMissionRewardGameContext(
   nextState: GameState,
-  rewardByCaseId: Partial<Record<string, MissionRewardBreakdown>>
+  rewardByCaseId: Partial<Record<string, MissionRewardBreakdown>>,
+  excludeCaseId?: string
 ) {
-  const pendingAgencyStandingAwards = Object.values(rewardByCaseId)
-    .map((reward) => reward?.agencyStanding)
+  const pendingAgencyStandingAwards = Object.entries(rewardByCaseId)
+    .filter(([caseId]) => caseId !== excludeCaseId)
+    .map(([, reward]) => reward?.agencyStanding)
     .filter((award): award is NonNullable<typeof award> => award !== undefined)
     .map((award) => ({ repeatKey: award.repeatKey }))
 
@@ -2686,7 +2688,7 @@ function resolveAssignments(
         effectiveCase,
         'success',
         context.nextState.config,
-        buildMissionRewardGameContext(context.nextState, context.rewardByCaseId)
+        buildMissionRewardGameContext(context.nextState, context.rewardByCaseId, caseId)
       )
 
       if (!willDegrade) {
@@ -2920,7 +2922,7 @@ function resolveAssignments(
       escalatedCase,
       outcome.result,
       context.nextState.config,
-      buildMissionRewardGameContext(context.nextState, context.rewardByCaseId)
+      buildMissionRewardGameContext(context.nextState, context.rewardByCaseId, caseId)
     )
     context.rewardByCaseId[caseId] = rewardBreakdown
     const hiddenFields = getMissionResultHiddenStateFields(escalatedCase)
@@ -3087,7 +3089,7 @@ function downgradeResolvedCaseToPartial(
     downgradedCase,
     'partial',
     nextState.config,
-    buildMissionRewardGameContext(nextState, context.rewardByCaseId)
+    buildMissionRewardGameContext(nextState, context.rewardByCaseId, caseId)
   )
   const instabilityObjectiveDrift = buildExecutionInstabilityObjectiveDriftConsequence(
     sourceCase,
@@ -3213,7 +3215,7 @@ function escalateCases(
       escalatedCase,
       'unresolved',
       context.nextState.config,
-      buildMissionRewardGameContext(context.nextState, context.rewardByCaseId)
+      buildMissionRewardGameContext(context.nextState, context.rewardByCaseId, caseId)
     )
     context.nextState.cases[caseId] = escalatedCase
     context.rewardByCaseId[caseId] = rewardBreakdown

--- a/src/test/agencyStanding.test.ts
+++ b/src/test/agencyStanding.test.ts
@@ -1,4 +1,6 @@
+import { describe, expect, it } from 'vitest'
 import { createStartingState } from '../data/startingState'
+import { hydrateGame } from '../app/store/runTransfer'
 import { buildAgencySummary } from '../domain/agency'
 import { buildAgencyStandingAward, buildMissionRewardBreakdown } from '../domain/missionResults'
 import { buildAgencyRanking } from '../domain/rankings'
@@ -196,6 +198,185 @@ describe('Agency Standing & Ranking', () => {
     expect(ranking.breakdown.agencyStanding.awards).toBe(1)
     expect(ranking.breakdown.agencyStanding.points).toBe(reward.agencyStanding!.points)
     expect(ranking.history[0]?.summary.agencyStanding).toBe(reward.agencyStanding!.points)
+  })
+
+  it('preserves legacy failure penalties alongside new standing awards', () => {
+    const state = createStartingState()
+    const reward = buildMissionRewardBreakdown(
+      state.cases['case-001'],
+      'success',
+      state.config,
+      state
+    )
+    const ranking = buildAgencyRanking({
+      reports: [
+        {
+          week: 1,
+          resolvedCases: [],
+          partialCases: [],
+          failedCases: ['legacy-fail'],
+          unresolvedTriggers: ['legacy-unresolved'],
+        } as unknown as WeeklyReport,
+        {
+          week: 2,
+          resolvedCases: ['case-001'],
+          partialCases: [],
+          failedCases: [],
+          unresolvedTriggers: [],
+        } as unknown as WeeklyReport,
+      ],
+      events: [
+        {
+          id: 'evt-standing-case-001',
+          schemaVersion: 2,
+          type: 'case.resolved',
+          sourceSystem: 'incident',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          payload: {
+            week: 2,
+            caseId: 'case-001',
+            caseTitle: state.cases['case-001'].title,
+            mode: state.cases['case-001'].mode,
+            kind: state.cases['case-001'].kind,
+            stage: state.cases['case-001'].stage,
+            teamIds: [],
+            rewardBreakdown: reward,
+          },
+        },
+      ],
+    })
+
+    expect(ranking.breakdown.agencyStanding.awards).toBe(1)
+    expect(ranking.score).toBe(
+      Math.max(
+        0,
+        Math.min(
+          100,
+          50 +
+            reward.agencyStanding!.points +
+            reward.reputationDelta -
+            6 -
+            8
+        )
+      )
+    )
+  })
+
+  it('counts same-week pending awards for repeat normalization', () => {
+    const state = createStartingState()
+    const shortCase = {
+      ...state.cases['case-001'],
+      durationWeeks: 1,
+      contract: { templateId: 'same-week-repeat' },
+    }
+    const first = buildAgencyStandingAward(shortCase, 'success', state.config, {
+      reports: [],
+      pendingAgencyStandingAwards: [],
+    })
+    const second = buildAgencyStandingAward(shortCase, 'success', state.config, {
+      reports: [],
+      pendingAgencyStandingAwards: [{ repeatKey: first.repeatKey }],
+    })
+
+    expect(first.priorSimilarCompletions).toBe(0)
+    expect(second.priorSimilarCompletions).toBe(1)
+    expect(second.repeatMultiplier).toBeCloseTo(0.5)
+    expect(second.points).toBeLessThan(first.points)
+  })
+
+  it('round-trips agencyStanding through event and caseSnapshot hydration', () => {
+    const state = createStartingState()
+    const reward = buildMissionRewardBreakdown(
+      state.cases['case-001'],
+      'success',
+      state.config,
+      state
+    )
+    const withStanding: GameState = {
+      ...state,
+      reports: [
+        {
+          week: 1,
+          rngStateBefore: 1,
+          rngStateAfter: 2,
+          newCases: [],
+          progressedCases: [],
+          resolvedCases: ['case-001'],
+          failedCases: [],
+          partialCases: [],
+          unresolvedTriggers: [],
+          spawnedCases: [],
+          maxStage: 1,
+          avgFatigue: 0,
+          teamStatus: [],
+          notes: [],
+          caseSnapshots: {
+            'case-001': {
+              caseId: 'case-001',
+              rewardBreakdown: reward,
+              missionResult: {
+                caseId: 'case-001',
+                caseTitle: state.cases['case-001'].title,
+                teamsUsed: [],
+                outcome: 'success',
+                performanceSummary: {
+                  contribution: 0,
+                  threatHandled: 0,
+                  damageTaken: 0,
+                  healingPerformed: 0,
+                  evidenceGathered: 0,
+                  containmentActionsCompleted: 0,
+                },
+                rewards: reward,
+                penalties: {
+                  fundingLoss: 0,
+                  containmentLoss: 0,
+                  reputationLoss: 0,
+                  strategicLoss: 0,
+                },
+                fatigueChanges: [],
+                injuries: [],
+                spawnedConsequences: [],
+                explanationNotes: [],
+              },
+            },
+          },
+        } as unknown as WeeklyReport,
+      ],
+      events: [
+        {
+          id: 'evt-standing-hydrate',
+          schemaVersion: 2,
+          type: 'case.resolved',
+          sourceSystem: 'incident',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          payload: {
+            week: 1,
+            caseId: 'case-001',
+            caseTitle: state.cases['case-001'].title,
+            mode: state.cases['case-001'].mode,
+            kind: state.cases['case-001'].kind,
+            stage: state.cases['case-001'].stage,
+            teamIds: [],
+            rewardBreakdown: reward,
+          },
+        },
+      ],
+    }
+
+    const hydrated = hydrateGame(JSON.parse(JSON.stringify(withStanding)), createStartingState())
+    const hydratedEvent = hydrated.events.find((event) => event.id === 'evt-standing-hydrate')
+    const hydratedSnapshot = hydrated.reports[0]?.caseSnapshots?.['case-001']
+
+    expect(hydratedEvent && 'rewardBreakdown' in hydratedEvent.payload
+      ? hydratedEvent.payload.rewardBreakdown?.agencyStanding
+      : undefined).toEqual(reward.agencyStanding)
+    expect(hydratedSnapshot?.rewardBreakdown?.agencyStanding).toEqual(reward.agencyStanding)
+    expect(hydratedSnapshot?.missionResult?.rewards.agencyStanding).toEqual(reward.agencyStanding)
+
+    const ranking = buildAgencyRanking(hydrated)
+    expect(ranking.breakdown.agencyStanding.awards).toBe(1)
+    expect(ranking.breakdown.agencyStanding.points).toBe(reward.agencyStanding!.points)
   })
 
   it('computes ranking tier and score deterministically from campaign state', () => {

--- a/src/test/sim.coordinationFriction.test.ts
+++ b/src/test/sim.coordinationFriction.test.ts
@@ -80,7 +80,7 @@ describe('SPE-95: Command-coordination friction', () => {
     const baseAgent = createStartingState().agents.a_ava
     // 5 active cases, 0 support shortfall
     for (let i = 0; i < 5; ++i) {
-      state.cases['c' + i] = { id: 'c' + i, templateId: 't', title: 'C' + i, description: '', mode: 'deterministic', kind: 'case', status: 'in_progress', difficulty: { combat: 1, investigation: 1, utility: 1, social: 1 }, weights: { combat: 1, investigation: 1, utility: 1, social: 1 }, tags: [], requiredTags: [], preferredTags: [], stage: 1, durationWeeks: 1, deadlineWeeks: 1, deadlineRemaining: 1, assignedTeamIds: ['t' + i], onFail: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] }, onUnresolved: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] } }
+      state.cases['c' + i] = { id: 'c' + i, templateId: 't-' + i, title: 'C' + i, description: '', mode: 'deterministic', kind: 'case', status: 'in_progress', difficulty: { combat: 1, investigation: 1, utility: 1, social: 1 }, weights: { combat: 1, investigation: 1, utility: 1, social: 1 }, tags: [], requiredTags: [], preferredTags: [], stage: 1, durationWeeks: 1, deadlineWeeks: 1, deadlineRemaining: 1, assignedTeamIds: ['t' + i], onFail: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] }, onUnresolved: { stageDelta: 1, spawnCount: { min: 0, max: 0 }, spawnTemplateIds: [] } }
       state.agents['a' + i] = {
         ...baseAgent,
         id: 'a' + i,


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2697 — https://linear.app/spectranoir/issue/SPE-2697/spe-2696-follow-up-standing-reward-hydration-ranking-and-same-week
- **Parent issue (if any):** SPE-39
- **Child issues covered:** slice only (follow-up to merged SPE-2696 / PR #3284)

## Summary

@coderabbitai summary

## What shipped

- Round-trip `agencyStanding` through hydration sanitizers (events + caseSnapshots + missionResult rewards)
- Ranking combines standing awards with per-operation legacy contributions (no global `awards > 0` switch)
- Same-week repeat normalization via pending awards from `rewardByCaseId` in `advanceWeek`

## Docs updated

- none (behavior fix; hub-simulation docs already describe standing awards from SPE-2696)

## Parent status

- SPE-39 remains open
- SPE-2696 stays Done; this is a correctness follow-up

## Scope boundary

- Fixes three blocking review findings from PR #3284 only
- Does not reopen SPE-2696 product scope or ranking rebalance SPE-2682

## Validation

- [x] Targeted tests: `src/test/agencyStanding.test.ts`, `src/test/rankings.test.ts`
- [x] Lint / verify: eslint on touched files

## Follow-ups

- none in-boundary

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)