### PR TITLE
ci: skip coverage on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,8 @@ jobs:
       - name: Run tests (non-watch)
         run: npm run test:run:ci
 
+      # Coverage re-runs the full suite under instrumentation (~as long as the test
+      # step). Keep it on main pushes only so PR babysit stays one suite deep.
       - name: Coverage
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
         run: npm run coverage:ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ All simulation logic is pure TypeScript; state is managed via Zustand with `loca
 
 - **`npm run build` currently has baseline TS errors outside dev-environment setup.** Treat those as known type-contract drift, not as production-ignored failures; fix them in scoped follow-up changes before using `build` as a deployment gate. They do not block tests or the dev server because Vite transpiles TypeScript without strict type checking.
 - **This repo is pinned to Vite 8 (`vite` `^8.0.1`) with the native config loader.** Type-only exports are stripped at the ESM boundary. If you import an `interface` or `type` alias as a value import, the dev server will throw `SyntaxError: does not provide an export named '...'`. Always use `import type { ... }` for type-only imports in source files that the Vite dev server loads.
-- **Tests use `--pool vmThreads`** locally and the `jsdom` environment. The full suite runs in ~55s locally. CI PRs run `npm run test:run:ci` (`forks` pool) once; `npm run coverage:ci` runs only on pushes to `main` so PR babysit does not pay for a second instrumented suite.
+- **Tests use `--pool vmThreads`** locally and the `jsdom` environment. The full suite runs in ~55s locally. CI PRs run `npm run test:run:ci` (`forks` pool) once; `npm run coverage:ci` runs only on pushes to `main`/`master` (not on `pull_request`), so PR babysit does not pay for a second instrumented suite.
 - **No environment variables or secrets** are required. The only optional env var is `STRICT_TEST_CONSOLE=1` (used in CI to fail on console warnings in tests).
 - **Node.js 22** is required (matches CI configuration in `.github/workflows/test.yml`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ All simulation logic is pure TypeScript; state is managed via Zustand with `loca
 
 - **`npm run build` currently has baseline TS errors outside dev-environment setup.** Treat those as known type-contract drift, not as production-ignored failures; fix them in scoped follow-up changes before using `build` as a deployment gate. They do not block tests or the dev server because Vite transpiles TypeScript without strict type checking.
 - **This repo is pinned to Vite 8 (`vite` `^8.0.1`) with the native config loader.** Type-only exports are stripped at the ESM boundary. If you import an `interface` or `type` alias as a value import, the dev server will throw `SyntaxError: does not provide an export named '...'`. Always use `import type { ... }` for type-only imports in source files that the Vite dev server loads.
-- **Tests use `--pool vmThreads`** and the `jsdom` environment. The full suite runs in ~55s.
+- **Tests use `--pool vmThreads`** locally and the `jsdom` environment. The full suite runs in ~55s locally. CI PRs run `npm run test:run:ci` (`forks` pool) once; `npm run coverage:ci` runs only on pushes to `main` so PR babysit does not pay for a second instrumented suite.
 - **No environment variables or secrets** are required. The only optional env var is `STRICT_TEST_CONSOLE=1` (used in CI to fail on console warnings in tests).
 - **Node.js 22** is required (matches CI configuration in `.github/workflows/test.yml`).
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ No environment variables are required. CI sets `STRICT_TEST_CONSOLE=1` so unexpe
 | `npm run lint`                   | Run ESLint across the repository.                                                     |
 | `npm run test:run`               | Run the full Vitest suite once using the local `vmThreads` pool.                      |
 | `npm run test`                   | Run Vitest in watch mode. Pass a file path to narrow scope while iterating.           |
-| `npm run test:run:ci`            | Run the CI test command using the `forks` pool.                                       |
-| `npm run coverage`               | Run tests with coverage output.                                                       |
+| `npm run test:run:ci`            | Run the CI test command using the `forks` pool (PR and main).                         |
+| `npm run coverage`               | Run tests with coverage output (local `vmThreads` pool).                              |
+| `npm run coverage:ci`            | Coverage with the `forks` pool — CI runs this on pushes to `main` only, not on PRs.   |
 | `npm run format`                 | Rewrite files with Prettier.                                                          |
 | `npm run format:check`           | Check formatting without editing files.                                               |
 | `npm run verify:audits-index`    | Verify `docs/design-audits-index.md` matches top-level `docs/*audit*.md` files.       |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ npm run verify:backlog-handoff
 npm run verify:theme-contracts
 ```
 
-GitHub Actions runs lint, audit verification, theme-contract verification, tests, and coverage on pull requests.
+GitHub Actions on pull requests runs lint, audit verification, theme-contract verification, and tests. Coverage (`npm run coverage:ci`) runs on pushes to `main` / `master` after merge, not on every PR.
 
 ## Architecture
 


### PR DESCRIPTION
## Linear

- **Slice issue:** none — workflow/docs slice
- **Parent issue (if any):** none
- **Child issues covered:** none

## Summary

@coderabbitai summary

## What shipped

- Gate `coverage:ci` to pushes to `main`/`master` only in `.github/workflows/test.yml`
- Document the PR vs main CI split in `README.md` and `AGENTS.md`

## Docs updated

- `README.md` — scripts table for `coverage:ci`
- `AGENTS.md` — CI caveats for PR babysit timing

## Parent status

- none (workflow slice)

## Scope boundary

- CI timing only; does not change local scripts, thresholds, or weaken the PR test gate
- Coverage thresholds still enforced on main after merge

## Validation

- [x] Targeted tests: n/a (workflow/docs)
- [x] Lint / verify: workflow YAML review; docs wording only

## Follow-ups

- Optional later: try `vmThreads` on CI if forks overhead matters; Linear issue when MCP is back

## Linear updated

- [ ] Slice issue linked in PR body (none — workflow/docs; Linear MCP unavailable this session)
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)