### PR TITLE
SPE-2699: Rival comparative pressure into contracts and recruitment

### DIFF
--- a/planning/spe-2699-rival-comparative-pressure-slice.md
+++ b/planning/spe-2699-rival-comparative-pressure-slice.md
@@ -1,0 +1,53 @@
+# SPE-2699 — Rival comparative pressure into contracts and recruitment
+
+**Linear:** [SPE-2699](https://linear.app/spectranoir/issue/SPE-2699/spe-39-rival-comparative-pressure-into-contracts-and-recruitment)  
+**Parent:** [SPE-39](https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer) (stays **Backlog**/open after merge)  
+**Branch:** `jamesdyedbq/spe-39-rival-comparative-pressure`  
+**Base:** `main` @ `2619f896`
+
+## Goal
+
+One deterministic rival/comparative-pressure hook from agency ranking into ≥2 downstream surfaces (contract payouts + recruit quality), without reopening SPE-2696/2697 standing award math.
+
+## Acceptance (this slice)
+
+- [x] Rival pressure score/band deterministic for identical ranking inputs
+- [x] Low ranking → lower contract funding than high ranking (same template)
+- [x] Low ranking → lower recruit quality delta than high ranking
+- [x] Agency summary + report summary expose band/summary
+- [x] No new persisted fields; SCHEMA_REGISTRY unchanged
+- [x] Standing award / ranking-accumulator math untouched
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Domain | `src/domain/rivalPressure.ts` — `buildRivalPressure`, scalar/quality helpers |
+| Contracts | `buildRewardPackage` in `src/domain/contracts.ts` |
+| Recruitment | `buildRecruitmentGenerationState` + qualityBias / faction-sponsored path in `candidateGenerator.ts` |
+| Agency / UI | `buildAgencySummary`, `AgencyPage`, `reportView` |
+| Docs | `systems/hub-simulation.md`, `systems/factions-legitimacy.md` |
+| Tests | `src/test/rivalPressure.test.ts` |
+
+Peer baseline = ranking base score (50). Pressure inverts ranking delta; multipliers bounded.
+
+## Out of scope
+
+- SPE-2696/2697 standing awards, repeats, hydration
+- Cross-jurisdiction liaison packets
+- Forgiveness thresholds / public-exposure posture
+- Hidden-cell interference; SPE-542 / SPE-430 rival sims
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Forgiveness thresholds from standing | SPE-39 child | Separate AC; posture math |
+| Cross-jurisdiction coordination packets | SPE-39 + SPE-854 | Intake pairing |
+| Hidden-cell strategic interference | SPE-39 child | Larger adversary layer |
+| Protective-coercive rival posture after exposure | SPE-39 child | Harvest fold-in C23/C26 |
+
+## Validation
+
+- `npm run test:run -- src/test/rivalPressure.test.ts src/test/agency.test.ts src/test/agencyStanding.test.ts src/test/contracts.test.ts src/test/recruitment.generator.test.ts`
+- `npm run lint`

--- a/src/domain/agency.ts
+++ b/src/domain/agency.ts
@@ -8,6 +8,7 @@ import { buildFactionStates } from './factions'
 import { buildLogisticsOverview } from './logistics'
 import { buildMajorIncidentProfile } from './majorIncidents'
 import { buildAgencyRanking, type AgencyRankingTier } from './rankings'
+import { buildRivalPressure, type RivalPressureBand } from './rivalPressure'
 import { getTeamAssignedCaseId, getTeamMemberIds } from './teamSimulation'
 
 const DEFAULT_AGENCY_NAME = 'Containment Protocol'
@@ -75,6 +76,13 @@ export interface AgencySummary {
   ranking: {
     score: number
     tier: AgencyRankingTier
+  }
+  rivalPressure: {
+    score: number
+    band: RivalPressureBand
+    summary: string
+    contractRewardMultiplier: number
+    recruitQualityDelta: number
   }
   report: AgencyReportSummary
   // Commercial Chokepoint Statecraft & Council Power (issue #187)
@@ -298,6 +306,7 @@ export function buildAgencySummary(game: GameState): AgencySummary {
   const pressure = buildAgencyPressureSummary(game)
   const stability = buildAgencyStabilitySummary(game, pressure, teams)
   const ranking = buildAgencyRanking(game)
+  const rivalPressure = buildRivalPressure(game)
   const averageFactionStanding = (() => {
     const factions = buildFactionStates(game)
     if (factions.length === 0) {
@@ -353,6 +362,13 @@ export function buildAgencySummary(game: GameState): AgencySummary {
     ranking: {
       score: ranking.score,
       tier: ranking.tier,
+    },
+    rivalPressure: {
+      score: rivalPressure.score,
+      band: rivalPressure.band,
+      summary: rivalPressure.summary,
+      contractRewardMultiplier: rivalPressure.contractRewardMultiplier,
+      recruitQualityDelta: rivalPressure.recruitQualityDelta,
     },
     report: buildAgencyReportSummary(game),
     chokepointLeverage,

--- a/src/domain/contracts.ts
+++ b/src/domain/contracts.ts
@@ -5,6 +5,7 @@ import { getFactionDefinition, inferFactionIdFromCaseTags } from './factions'
 import { sanitizePersistedFieldBasePacket } from './fieldBaseStaging'
 import { createMissionIntelState } from './intel'
 import { clamp, createSeededRng, normalizeSeed } from './math'
+import { applyRivalPressureToContractScalar, buildRivalPressure } from './rivalPressure'
 import { getCompletedResearchUnlockIds } from './research'
 import {
   buildContractInventoryRewards,
@@ -1596,7 +1597,8 @@ function buildRewardPackage(
   const rewardBonus = definition.modifiers
     .filter((modifier) => modifier.effect === 'reward_bonus')
     .reduce((sum, modifier) => sum + (modifier.value ?? 0), 0)
-  const scalar = clamp(rewardMultiplier + rewardBonus * 0.1, 0.6, 1.9)
+  const factionScalar = clamp(rewardMultiplier + rewardBonus * 0.1, 0.6, 1.9)
+  const scalar = applyRivalPressureToContractScalar(factionScalar, buildRivalPressure(state))
 
   return {
     funding: Math.max(0, Math.round(definition.baseRewards.funding * scalar)),

--- a/src/domain/rankings.ts
+++ b/src/domain/rankings.ts
@@ -94,7 +94,7 @@ interface RankingAccumulator {
   standingAwards: number
 }
 
-const RANKING_BASE_SCORE = 50
+export const RANKING_BASE_SCORE = 50
 const RESOLVED_CASE_POINTS = 4
 const PARTIAL_CASE_POINTS = 2
 const RESOLVED_MAJOR_INCIDENT_POINTS = 8

--- a/src/domain/rivalPressure.ts
+++ b/src/domain/rivalPressure.ts
@@ -1,9 +1,9 @@
 import { clamp } from './math'
 import type { GameState } from './models'
-import { buildAgencyRanking } from './rankings'
+import { buildAgencyRanking, RANKING_BASE_SCORE } from './rankings'
 
-/** Abstract peer baseline — matches ranking base score when no history exists. */
-export const RIVAL_PRESSURE_PEER_BASELINE = 50
+/** Abstract peer baseline — shared with ranking base score when no history exists. */
+export const RIVAL_PRESSURE_PEER_BASELINE = RANKING_BASE_SCORE
 
 export type RivalPressureBand = 'suppressed' | 'balanced' | 'competitive' | 'severe'
 

--- a/src/domain/rivalPressure.ts
+++ b/src/domain/rivalPressure.ts
@@ -1,0 +1,97 @@
+import { clamp } from './math'
+import type { GameState } from './models'
+import { buildAgencyRanking } from './rankings'
+
+/** Abstract peer baseline — matches ranking base score when no history exists. */
+export const RIVAL_PRESSURE_PEER_BASELINE = 50
+
+export type RivalPressureBand = 'suppressed' | 'balanced' | 'competitive' | 'severe'
+
+export interface RivalPressureView {
+  /** 0–100 comparative pressure (higher = rivals look stronger). */
+  score: number
+  band: RivalPressureBand
+  rankingScore: number
+  peerBaseline: number
+  /** Multiplier applied to contract reward scalars (funding / materials). */
+  contractRewardMultiplier: number
+  /** Additive delta applied to recruit overall quality. */
+  recruitQualityDelta: number
+  summary: string
+}
+
+function getRivalPressureBand(score: number): RivalPressureBand {
+  if (score >= 75) {
+    return 'severe'
+  }
+  if (score >= 55) {
+    return 'competitive'
+  }
+  if (score < 30) {
+    return 'suppressed'
+  }
+  return 'balanced'
+}
+
+function buildRivalPressureSummary(band: RivalPressureBand, rankingScore: number): string {
+  switch (band) {
+    case 'suppressed':
+      return `Comparative pressure suppressed (rank ${rankingScore}): peer agencies lag; contract terms and recruit quality tilt favorable.`
+    case 'balanced':
+      return `Comparative pressure balanced (rank ${rankingScore}): peer agencies track evenly; no rival payout or staffing skew.`
+    case 'competitive':
+      return `Comparative pressure competitive (rank ${rankingScore}): peer agencies press for share; contract payouts and recruit quality tighten.`
+    case 'severe':
+      return `Comparative pressure severe (rank ${rankingScore}): peer agencies dominate optics; contract payouts and recruit quality compress.`
+    default: {
+      const _exhaustive: never = band
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Pure ranking→pressure derivation. Prefer this in unit tests; gameplay uses
+ * {@link buildRivalPressure} so ranking history stays the single source of truth.
+ */
+export function buildRivalPressureFromRankingScore(rankingScore: number): RivalPressureView {
+  const clampedRanking = clamp(Math.round(rankingScore), 0, 100)
+  const deltaFromPeer = RIVAL_PRESSURE_PEER_BASELINE - clampedRanking
+  const score = clamp(Math.round(RIVAL_PRESSURE_PEER_BASELINE + deltaFromPeer), 0, 100)
+  const band = getRivalPressureBand(score)
+  const contractRewardMultiplier = Number(
+    clamp(1 - deltaFromPeer * 0.002, 0.88, 1.06).toFixed(3)
+  )
+  const recruitQualityDelta = clamp(Math.round(-deltaFromPeer * 0.12), -6, 4) + 0
+
+  return {
+    score,
+    band,
+    rankingScore: clampedRanking,
+    peerBaseline: RIVAL_PRESSURE_PEER_BASELINE,
+    contractRewardMultiplier,
+    recruitQualityDelta,
+    summary: buildRivalPressureSummary(band, clampedRanking),
+  }
+}
+
+/** Read-time rival/comparative pressure from agency ranking. No persisted fields. */
+export function buildRivalPressure(
+  game: Pick<GameState, 'reports' | 'events'>
+): RivalPressureView {
+  return buildRivalPressureFromRankingScore(buildAgencyRanking(game).score)
+}
+
+export function applyRivalPressureToContractScalar(
+  scalar: number,
+  pressure: Pick<RivalPressureView, 'contractRewardMultiplier'>
+): number {
+  return clamp(scalar * pressure.contractRewardMultiplier, 0.6, 1.9)
+}
+
+export function applyRivalPressureToRecruitQuality(
+  overallScore: number,
+  pressure: Pick<RivalPressureView, 'recruitQualityDelta'>
+): number {
+  return clamp(overallScore + pressure.recruitQualityDelta, 0, 100)
+}

--- a/src/domain/sim/candidateGenerator.ts
+++ b/src/domain/sim/candidateGenerator.ts
@@ -3,6 +3,10 @@ import { clamp, createSeededRng, randInt } from '../math'
 import { scoreToExactPotentialTier } from '../agentPotential'
 import { getFactionRecruitQualityModifier, getFactionRecruitUnlocks } from '../factions'
 import {
+  applyRivalPressureToRecruitQuality,
+  buildRivalPressure,
+} from '../rivalPressure'
+import {
   type AgentData,
   type Candidate,
   type CandidateRevealLevel,
@@ -138,6 +142,7 @@ interface RecruitmentGenerationSignals {
   activeAgentCount: number
   weekNumber: number
   reputationScore: number
+  rivalRecruitQualityDelta: number
 }
 
 export interface RecruitmentGenerationState {
@@ -151,6 +156,7 @@ export interface RecruitmentGenerationState {
   staff: GameState['staff']
   factions: GameState['factions']
   candidatePool: Candidate[]
+  rivalRecruitQualityDelta: number
 }
 
 export function buildRecruitmentGenerationState(
@@ -167,6 +173,8 @@ export function buildRecruitmentGenerationState(
     | 'staff'
     | 'factions'
     | 'candidates'
+    | 'reports'
+    | 'events'
   >
 ): RecruitmentGenerationState {
   return {
@@ -180,6 +188,7 @@ export function buildRecruitmentGenerationState(
     staff: state.staff,
     factions: state.factions ?? {},
     candidatePool: [...state.candidates],
+    rivalRecruitQualityDelta: buildRivalPressure(state).recruitQualityDelta,
   }
 }
 
@@ -270,6 +279,7 @@ function getRecruitmentGenerationSignals(
     activeAgentCount,
     weekNumber,
     reputationScore,
+    rivalRecruitQualityDelta: state.rivalRecruitQualityDelta,
   }
 }
 
@@ -576,7 +586,7 @@ function createFactionSponsoredAgentData(
 }
 
 function buildFactionSponsoredCandidate(
-  state: Pick<RecruitmentGenerationState, 'week' | 'factions'>,
+  state: Pick<RecruitmentGenerationState, 'week' | 'factions' | 'rivalRecruitQualityDelta'>,
   rng: () => number,
   usedIds: Set<string>
 ): Candidate | null {
@@ -613,7 +623,10 @@ function buildFactionSponsoredCandidate(
       contactId: unlock.contactId,
     }
   )
-  const boostedOverallScore = clamp(overallScore + recruitQualityBonus, 0, 100)
+  const boostedOverallScore = applyRivalPressureToRecruitQuality(
+    overallScore + recruitQualityBonus,
+    { recruitQualityDelta: state.rivalRecruitQualityDelta }
+  )
   const actualPotentialScore = clamp(boostedOverallScore + randInt(rng, 2, 10), 0, 100)
   const potentialTier = scoreToCandidatePotentialTier(actualPotentialScore)
 
@@ -705,7 +718,9 @@ function buildCandidate(
     state.week + randInt(rng, CANDIDATE_EXPIRY_MIN_WEEKS, CANDIDATE_EXPIRY_MAX_WEEKS)
   const normalizedCategory = normalizeCandidateCategory(category)
   const qualityBias =
-    Math.round((signals.reputationScore - 50) / 10) + Math.min(signals.weekNumber, 12) / 6
+    Math.round((signals.reputationScore - 50) / 10) +
+    Math.min(signals.weekNumber, 12) / 6 +
+    signals.rivalRecruitQualityDelta
 
   if (normalizedCategory === 'agent') {
     const agentData = generateAgentData(rng)

--- a/src/features/agency/AgencyPage.tsx
+++ b/src/features/agency/AgencyPage.tsx
@@ -72,6 +72,10 @@ export default function AgencyPage() {
               value={`${summary.pressure.score} (${summary.pressure.level})`}
             />
             <Metric
+              label="Rival pressure"
+              value={`${summary.rivalPressure.score} (${summary.rivalPressure.band})`}
+            />
+            <Metric
               label="Stability"
               value={`${summary.stability.score} (${summary.stability.level})`}
             />
@@ -95,6 +99,7 @@ export default function AgencyPage() {
               {summary.pressure.faction}, operations {summary.pressure.operations}, procurement{' '}
               {summary.pressure.market}
             </li>
+            <li>{summary.rivalPressure.summary}</li>
             <li>
               Stability split: containment {summary.stability.containment}, funding{' '}
               {summary.stability.funding}, readiness {summary.stability.readiness}, logistics{' '}

--- a/src/features/report/reportView.ts
+++ b/src/features/report/reportView.ts
@@ -36,6 +36,7 @@ export function getReportPageView(game: GameState): ReportPageView {
   const extendedSummaryLine =
     `${agencySummary.name}: reputation ${agencySummary.reputation}, ` +
     `pressure ${agencySummary.pressure.score} (${agencySummary.pressure.level}), ` +
+    `rival pressure ${agencySummary.rivalPressure.score} (${agencySummary.rivalPressure.band}), ` +
     `stability ${agencySummary.stability.score} (${agencySummary.stability.level}), ` +
     `chokepoint leverage ${agencySummary.chokepointLeverage}, ` +
     `council power [${councilPower}], ` +

--- a/src/test/rivalPressure.test.ts
+++ b/src/test/rivalPressure.test.ts
@@ -36,14 +36,17 @@ function reportWithResolutions(week: number, resolved: number): WeeklyReport {
 
 describe('rival comparative pressure (SPE-2699)', () => {
   it('derives deterministic pressure bands and surface deltas from ranking score', () => {
+    const empty = buildRivalPressure({ reports: [], events: [] })
     const balanced = buildRivalPressureFromRankingScore(50)
     const weak = buildRivalPressureFromRankingScore(20)
     const strong = buildRivalPressureFromRankingScore(80)
 
+    expect(empty).toEqual(balanced)
     expect(balanced).toEqual(buildRivalPressureFromRankingScore(50))
     expect(balanced.band).toBe('balanced')
     expect(balanced.contractRewardMultiplier).toBe(1)
     expect(balanced.recruitQualityDelta).toBe(0)
+    expect(Object.is(balanced.recruitQualityDelta, -0)).toBe(false)
 
     expect(weak.score).toBeGreaterThan(balanced.score)
     expect(weak.band).toBe('severe')

--- a/src/test/rivalPressure.test.ts
+++ b/src/test/rivalPressure.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { createStartingState } from '../data/startingState'
+import { buildAgencySummary } from '../domain/agency'
+import { getContractOffers, refreshContractBoard } from '../domain/contracts'
+import {
+  applyRivalPressureToContractScalar,
+  applyRivalPressureToRecruitQuality,
+  buildRivalPressure,
+  buildRivalPressureFromRankingScore,
+} from '../domain/rivalPressure'
+import { buildRecruitmentGenerationState } from '../domain/sim/candidateGenerator'
+import type { WeeklyReport } from '../domain/models'
+
+function reportWithFailures(week: number, failures: number, unresolved: number): WeeklyReport {
+  return {
+    week,
+    resolvedCases: [],
+    partialCases: [],
+    failedCases: Array.from({ length: failures }, (_, index) => `fail-${week}-${index}`),
+    unresolvedTriggers: Array.from(
+      { length: unresolved },
+      (_, index) => `unresolved-${week}-${index}`
+    ),
+  } as unknown as WeeklyReport
+}
+
+function reportWithResolutions(week: number, resolved: number): WeeklyReport {
+  return {
+    week,
+    resolvedCases: Array.from({ length: resolved }, (_, index) => `resolved-${week}-${index}`),
+    partialCases: [],
+    failedCases: [],
+    unresolvedTriggers: [],
+  } as unknown as WeeklyReport
+}
+
+describe('rival comparative pressure (SPE-2699)', () => {
+  it('derives deterministic pressure bands and surface deltas from ranking score', () => {
+    const balanced = buildRivalPressureFromRankingScore(50)
+    const weak = buildRivalPressureFromRankingScore(20)
+    const strong = buildRivalPressureFromRankingScore(80)
+
+    expect(balanced).toEqual(buildRivalPressureFromRankingScore(50))
+    expect(balanced.band).toBe('balanced')
+    expect(balanced.contractRewardMultiplier).toBe(1)
+    expect(balanced.recruitQualityDelta).toBe(0)
+
+    expect(weak.score).toBeGreaterThan(balanced.score)
+    expect(weak.band).toBe('severe')
+    expect(weak.contractRewardMultiplier).toBeLessThan(balanced.contractRewardMultiplier)
+    expect(weak.recruitQualityDelta).toBeLessThan(balanced.recruitQualityDelta)
+
+    expect(strong.score).toBeLessThan(balanced.score)
+    expect(strong.band).toBe('suppressed')
+    expect(strong.contractRewardMultiplier).toBeGreaterThan(balanced.contractRewardMultiplier)
+    expect(strong.recruitQualityDelta).toBeGreaterThan(balanced.recruitQualityDelta)
+
+    expect(applyRivalPressureToContractScalar(1, weak)).toBeLessThan(
+      applyRivalPressureToContractScalar(1, strong)
+    )
+    expect(applyRivalPressureToRecruitQuality(50, weak)).toBeLessThan(
+      applyRivalPressureToRecruitQuality(50, strong)
+    )
+  })
+
+  it('compresses contract payouts under severe rival pressure vs suppressed', () => {
+    const baseline = createStartingState()
+    const weakState = {
+      ...baseline,
+      reports: [reportWithFailures(1, 5, 4), reportWithFailures(2, 4, 3)],
+      events: [],
+    }
+    const strongState = {
+      ...baseline,
+      reports: [reportWithResolutions(1, 8), reportWithResolutions(2, 8)],
+      events: [],
+    }
+
+    const weakPressure = buildRivalPressure(weakState)
+    const strongPressure = buildRivalPressure(strongState)
+    expect(weakPressure.score).toBeGreaterThan(strongPressure.score)
+
+    const weakBoard = refreshContractBoard({ ...weakState, week: baseline.week + 1 })
+    const strongBoard = refreshContractBoard({ ...strongState, week: baseline.week + 1 })
+    const weakOffer = getContractOffers(weakBoard).find(
+      (offer) => offer.templateId === 'oversight-lockdown-retainer'
+    )
+    const strongOffer = getContractOffers(strongBoard).find(
+      (offer) => offer.templateId === 'oversight-lockdown-retainer'
+    )
+
+    expect(weakOffer).toBeDefined()
+    expect(strongOffer).toBeDefined()
+    expect(weakOffer!.rewards.funding).toBeLessThan(strongOffer!.rewards.funding)
+  })
+
+  it('passes recruit quality deltas through recruitment generation state', () => {
+    const baseline = createStartingState()
+    const weakState = {
+      ...baseline,
+      reports: [reportWithFailures(1, 5, 4)],
+      events: [],
+    }
+    const strongState = {
+      ...baseline,
+      reports: [reportWithResolutions(1, 10)],
+      events: [],
+    }
+
+    const weakRecruit = buildRecruitmentGenerationState(weakState)
+    const strongRecruit = buildRecruitmentGenerationState(strongState)
+
+    expect(weakRecruit.rivalRecruitQualityDelta).toBe(
+      buildRivalPressure(weakState).recruitQualityDelta
+    )
+    expect(strongRecruit.rivalRecruitQualityDelta).toBe(
+      buildRivalPressure(strongState).recruitQualityDelta
+    )
+    expect(weakRecruit.rivalRecruitQualityDelta).toBeLessThan(
+      strongRecruit.rivalRecruitQualityDelta
+    )
+  })
+
+  it('exposes rival pressure on agency summary for player-facing surfaces', () => {
+    const game = createStartingState()
+    const summary = buildAgencySummary(game)
+
+    expect(summary.rivalPressure).toEqual({
+      score: buildRivalPressure(game).score,
+      band: buildRivalPressure(game).band,
+      summary: buildRivalPressure(game).summary,
+      contractRewardMultiplier: buildRivalPressure(game).contractRewardMultiplier,
+      recruitQualityDelta: buildRivalPressure(game).recruitQualityDelta,
+    })
+    expect(summary.rivalPressure.summary).toMatch(/Comparative pressure/)
+  })
+})

--- a/systems/factions-legitimacy.md
+++ b/systems/factions-legitimacy.md
@@ -313,6 +313,10 @@ Examples:
 - weakness may embolden interference
 - successful intervention may change power posture in a region or district
 
+**Implemented hook (SPE-2699):** ranking-derived comparative pressure (`buildRivalPressure`) adjusts
+contract payout scalars and recruit quality deltas. Abstract peer baseline only — no per-rival squad
+simulation. Standing award math remains separate.
+
 ---
 
 ## 10. Faction and legitimacy outputs

--- a/systems/hub-simulation.md
+++ b/systems/hub-simulation.md
@@ -160,6 +160,11 @@ Success and partial completion can add standing; failure and withdrawal/abandonm
 entering dangerous content never grants standing by itself. Campaign reward summaries retain the
 four multipliers used for each award.
 
+Comparative rival pressure is a separate **read-time** derivation from agency ranking score versus
+an abstract peer baseline (`src/domain/rivalPressure.ts`). It does not mutate standing awards. Weak
+comparative rank compresses contract reward scalars and recruit overall quality; strong rank eases
+both. Agency overview and report summary lines expose the pressure band for legibility.
+
 ### Stage B — Build hub opportunity pools
 
 Create possible output candidates based on:


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2699 — https://linear.app/spectranoir/issue/SPE-2699/spe-39-rival-comparative-pressure-into-contracts-and-recruitment
- **Parent issue (if any):** SPE-39 — https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Read-time rival/comparative pressure from agency ranking (`src/domain/rivalPressure.ts`)
- Contract reward scalars compress under weak comparative standing; ease under strong standing
- Recruit quality deltas flow through recruitment generation (open-call + faction-sponsored)
- Agency overview + report summary expose pressure band/summary

## Docs updated

- `systems/hub-simulation.md`
- `systems/factions-legitimacy.md`
- `planning/spe-2699-rival-comparative-pressure-slice.md`

## Parent status

- SPE-39 remains open — child slice only (forgiveness, cross-jurisdiction, hidden-cell still deferred)

## Scope boundary

- Does not reopen SPE-2696/2697 standing award, repeat, or ranking-accumulator math
- No new persisted fields / SCHEMA_REGISTRY changes
- No rival-expedition or hunter-team simulation

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/rivalPressure.test.ts src/test/agency.test.ts src/test/contracts.test.ts src/test/agencyStanding.test.ts src/test/recruitment.generator.test.ts src/features/agency/AgencyPage.test.tsx`
- [x] Lint: `npm run lint`

## Follow-ups

- Forgiveness thresholds / public-exposure posture (SPE-39 child)
- Cross-jurisdiction liaison packets (SPE-39 + SPE-854)
- Hidden-cell strategic interference (SPE-39 child)

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)