### PR TITLE
SPE-2700: Standing-shaped forgiveness on external-support reliability drift

### DIFF
--- a/architecture/external-support-reliability-trust.md
+++ b/architecture/external-support-reliability-trust.md
@@ -24,6 +24,11 @@ Reports and debug surfaces must distinguish **success**, **degraded success**, a
 
 Repeated verification, payments, shared danger, or betrayals move trust along **deterministic curves**; reliability may lag until competence is proven.
 
+**SPE-2700:** negative reliability drift magnitudes are scaled by ranking-derived rival comparative
+pressure (`trustFailureDriftScale`). High agency standing forgives weak outputs longer; low standing
+accelerates trust collapse for the same failure/partial/idle trigger. Positive drift is unscaled.
+No separate persisted forgiveness field.
+
 ## Non-roster semantics
 
 These assets **do not** consume normal barracks capacity but may consume **contract slots**, **legitimacy**, or **secrecy budget**. Mishandling them can trigger **SPE-87** civic pressure or **SPE-79** integrity hits.

--- a/planning/spe-2699-rival-comparative-pressure-slice.md
+++ b/planning/spe-2699-rival-comparative-pressure-slice.md
@@ -42,7 +42,7 @@ Peer baseline = ranking base score (50). Pressure inverts ranking delta; multipl
 
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
-| Forgiveness thresholds from standing | SPE-39 child | Separate AC; posture math |
+| Forgiveness thresholds from standing | SPE-2700 | Shipped: trustFailureDriftScale → SPE-93 negative drift |
 | Cross-jurisdiction coordination packets | SPE-39 + SPE-854 | Intake pairing |
 | Hidden-cell strategic interference | SPE-39 child | Larger adversary layer |
 | Protective-coercive rival posture after exposure | SPE-39 child | Harvest fold-in C23/C26 |

--- a/planning/spe-2700-standing-shaped-forgiveness-slice.md
+++ b/planning/spe-2700-standing-shaped-forgiveness-slice.md
@@ -1,0 +1,54 @@
+# SPE-2700 — Standing-shaped forgiveness on external-support reliability drift
+
+**Linear:** [SPE-2700](https://linear.app/spectranoir/issue/SPE-2700/spe-39-standing-shaped-forgiveness-on-external-support-reliability)  
+**Parent:** [SPE-39](https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer) (stays **Backlog**/open after merge)  
+**Branch:** `jamesdyedbq/spe-39-standing-shaped-forgiveness`  
+**Base:** `main` @ `b37e78ec`
+
+## Goal
+
+One deterministic standing-shaped forgiveness scale from agency ranking / rival pressure into external-support reliability drift (SPE-93 trust surface), without reopening SPE-2696/2697 standing awards or SPE-2699 contract/recruit multipliers.
+
+## Acceptance (this slice)
+
+- [x] Identical ranking inputs → identical `trustFailureDriftScale` and negative reliability deltas
+- [x] High standing vs low standing diverge on comparable failure/delay drift (high more forgiving; low harsher)
+- [x] Negative drift triggers (`support_failed`, `support_partial`, `week_idle`) use the scale; positive drift unchanged
+- [x] Agency summary + rival-pressure summary expose the forgiveness scale signal
+- [x] SPE-2699 `contractRewardMultiplier` / `recruitQualityDelta` unchanged for same ranking inputs
+- [x] No new persisted fields; SCHEMA_REGISTRY unchanged
+- [x] Standing award / ranking-accumulator math untouched
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Domain | `src/domain/rivalPressure.ts` — add `trustFailureDriftScale` on `RivalPressureView` |
+| Trust surface | `src/domain/externalSupport.ts` — scale negative deltas in `applyAssetReliabilityDrift` |
+| Hub write path | `src/domain/hub/supportActions.ts` — pass scale from `buildRivalPressure` |
+| Agency / UI | `buildAgencySummary`, `AgencyPage`, `reportView` (summary already carries rival pressure line) |
+| Docs | `systems/hub-simulation.md`, `systems/factions-legitimacy.md`, optional `architecture/external-support-reliability-trust.md` |
+| Tests | `src/test/rivalPressure.test.ts`, `src/test/externalSupport.test.ts` |
+
+Scale derives from ranking vs peer baseline (same inputs as SPE-2699 pressure). High rank → scale &lt; 1 (soften trust collapse). Low rank → scale &gt; 1 (accelerate collapse). Peer baseline → 1.0.
+
+## Out of scope
+
+- SPE-2696/2697 standing awards, repeats, hydration
+- SPE-2699 contract/recruit multiplier formula changes
+- Protective-coercive rival posture after public exposure
+- Cross-jurisdiction liaison packets; hidden-cell interference; SPE-542 / SPE-430 rival sims
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Protective-coercive rival posture after exposure | SPE-39 child | Separate AC half (post-exposure comparative pressure) |
+| Cross-jurisdiction coordination packets | SPE-39 + SPE-854 | Intake pairing |
+| Hidden-cell strategic interference | SPE-39 child | Larger adversary layer |
+| Legitimacy fallout tick standing scale | SPE-39 / procurement follow-up | Alternate fallout surface; trust path chosen for this AC |
+
+## Validation
+
+- `npm run test:run -- src/test/rivalPressure.test.ts src/test/externalSupport.test.ts src/test/agency.test.ts src/test/agencyStanding.test.ts`
+- `npm run lint`

--- a/src/domain/agency.ts
+++ b/src/domain/agency.ts
@@ -83,6 +83,7 @@ export interface AgencySummary {
     summary: string
     contractRewardMultiplier: number
     recruitQualityDelta: number
+    trustFailureDriftScale: number
   }
   report: AgencyReportSummary
   // Commercial Chokepoint Statecraft & Council Power (issue #187)
@@ -369,6 +370,7 @@ export function buildAgencySummary(game: GameState): AgencySummary {
       summary: rivalPressure.summary,
       contractRewardMultiplier: rivalPressure.contractRewardMultiplier,
       recruitQualityDelta: rivalPressure.recruitQualityDelta,
+      trustFailureDriftScale: rivalPressure.trustFailureDriftScale,
     },
     report: buildAgencyReportSummary(game),
     chokepointLeverage,

--- a/src/domain/externalSupport.ts
+++ b/src/domain/externalSupport.ts
@@ -2,6 +2,7 @@
 // Pure, deterministic functions. No side effects — all state mutation belongs in the store.
 
 import type { ExternalSupportAsset, ExternalAssetTrustBand } from './models'
+import { applyTrustFailureDriftScale } from './rivalPressure'
 
 // ---------------------------------------------------------------------------
 // Trust band derivation (read-time, never stored)
@@ -35,16 +36,24 @@ const DRIFT_TABLE: Record<AssetDriftTrigger, number> = {
   week_idle: -3,
 }
 
+export interface AssetReliabilityDriftOptions {
+  /** Standing-shaped scale from {@link buildRivalPressure}; defaults to 1 (neutral). */
+  trustFailureDriftScale?: number
+}
+
 /**
  * Returns an updated asset after applying a reliability drift trigger.
  * Deterministic — no RNG needed; trigger table drives the delta.
+ * Negative deltas may be scaled by agency standing forgiveness (SPE-2700).
  * Returns the updated asset and a human-readable reason fragment.
  */
 export function applyAssetReliabilityDrift(
   asset: ExternalSupportAsset,
-  trigger: AssetDriftTrigger
+  trigger: AssetDriftTrigger,
+  options?: AssetReliabilityDriftOptions
 ): { asset: ExternalSupportAsset; driftReason: string } {
-  const delta = DRIFT_TABLE[trigger]
+  const baseDelta = DRIFT_TABLE[trigger]
+  const delta = applyTrustFailureDriftScale(baseDelta, options?.trustFailureDriftScale ?? 1)
   const next = Math.max(0, Math.min(100, asset.reliability + delta))
   const prevBand = deriveAssetTrustBand(asset.reliability)
   const nextBand = deriveAssetTrustBand(next)

--- a/src/domain/hub/supportActions.ts
+++ b/src/domain/hub/supportActions.ts
@@ -4,11 +4,13 @@ import {
   resolveAssetSupportOutcome,
   applyAssetReliabilityDrift,
 } from '../externalSupport'
+import { buildRivalPressure } from '../rivalPressure'
 
 /**
  * Deterministic hub action: "Rally Support Staff" restores supportAvailable by a fixed amount.
  * If a contractor asset is present in externalSupportAssets, its reliability modifies the
  * amount restored and the asset's reliability drifts based on the outcome.
+ * Negative drift is standing-shaped via rival comparative pressure (SPE-2700).
  * Returns updated GameState and a note for reporting.
  */
 export function applyRallySupportStaffAction(state: GameState, amount: number = 2) {
@@ -27,7 +29,10 @@ export function applyRallySupportStaffAction(state: GameState, amount: number = 
     const outcome = resolveAssetSupportOutcome(contractor, amount)
     effectiveAmount = Math.max(0, outcome.modifiedScore)
     assetReason = outcome.outcomeReason
-    const drifted = applyAssetReliabilityDrift(contractor, outcome.driftTrigger)
+    const { trustFailureDriftScale } = buildRivalPressure(state)
+    const drifted = applyAssetReliabilityDrift(contractor, outcome.driftTrigger, {
+      trustFailureDriftScale,
+    })
     updatedAssets = { ...assets, [contractor.id]: drifted.asset }
   }
 

--- a/src/domain/rivalPressure.ts
+++ b/src/domain/rivalPressure.ts
@@ -17,6 +17,11 @@ export interface RivalPressureView {
   contractRewardMultiplier: number
   /** Additive delta applied to recruit overall quality. */
   recruitQualityDelta: number
+  /**
+   * Multiplier on negative external-support reliability drift (SPE-93).
+   * <1 = standing-shaped forgiveness; >1 = accelerated trust collapse.
+   */
+  trustFailureDriftScale: number
   summary: string
 }
 
@@ -33,16 +38,31 @@ function getRivalPressureBand(score: number): RivalPressureBand {
   return 'balanced'
 }
 
-function buildRivalPressureSummary(band: RivalPressureBand, rankingScore: number): string {
+function buildForgivenessNote(trustFailureDriftScale: number): string {
+  if (trustFailureDriftScale < 1) {
+    return `external-support failure drift softened (${trustFailureDriftScale}×).`
+  }
+  if (trustFailureDriftScale > 1) {
+    return `external-support failure drift hardened (${trustFailureDriftScale}×).`
+  }
+  return `external-support failure drift neutral (${trustFailureDriftScale}×).`
+}
+
+function buildRivalPressureSummary(
+  band: RivalPressureBand,
+  rankingScore: number,
+  trustFailureDriftScale: number
+): string {
+  const forgiveness = buildForgivenessNote(trustFailureDriftScale)
   switch (band) {
     case 'suppressed':
-      return `Comparative pressure suppressed (rank ${rankingScore}): peer agencies lag; contract terms and recruit quality tilt favorable.`
+      return `Comparative pressure suppressed (rank ${rankingScore}): peer agencies lag; contract terms and recruit quality tilt favorable; ${forgiveness}`
     case 'balanced':
-      return `Comparative pressure balanced (rank ${rankingScore}): peer agencies track evenly; no rival payout or staffing skew.`
+      return `Comparative pressure balanced (rank ${rankingScore}): peer agencies track evenly; no rival payout or staffing skew; ${forgiveness}`
     case 'competitive':
-      return `Comparative pressure competitive (rank ${rankingScore}): peer agencies press for share; contract payouts and recruit quality tighten.`
+      return `Comparative pressure competitive (rank ${rankingScore}): peer agencies press for share; contract payouts and recruit quality tighten; ${forgiveness}`
     case 'severe':
-      return `Comparative pressure severe (rank ${rankingScore}): peer agencies dominate optics; contract payouts and recruit quality compress.`
+      return `Comparative pressure severe (rank ${rankingScore}): peer agencies dominate optics; contract payouts and recruit quality compress; ${forgiveness}`
     default: {
       const _exhaustive: never = band
       return _exhaustive
@@ -63,6 +83,8 @@ export function buildRivalPressureFromRankingScore(rankingScore: number): RivalP
     clamp(1 - deltaFromPeer * 0.002, 0.88, 1.06).toFixed(3)
   )
   const recruitQualityDelta = clamp(Math.round(-deltaFromPeer * 0.12), -6, 4) + 0
+  // High standing (negative deltaFromPeer) softens trust collapse; low standing hardens it.
+  const trustFailureDriftScale = Number(clamp(1 + deltaFromPeer * 0.004, 0.7, 1.3).toFixed(3))
 
   return {
     score,
@@ -71,8 +93,21 @@ export function buildRivalPressureFromRankingScore(rankingScore: number): RivalP
     peerBaseline: RIVAL_PRESSURE_PEER_BASELINE,
     contractRewardMultiplier,
     recruitQualityDelta,
-    summary: buildRivalPressureSummary(band, clampedRanking),
+    trustFailureDriftScale,
+    summary: buildRivalPressureSummary(band, clampedRanking, trustFailureDriftScale),
   }
+}
+
+/** Scale a negative reliability drift by standing-shaped forgiveness; positive deltas pass through. */
+export function applyTrustFailureDriftScale(
+  baseDelta: number,
+  trustFailureDriftScale: number
+): number {
+  if (baseDelta >= 0) {
+    return baseDelta
+  }
+  const scale = clamp(trustFailureDriftScale, 0.7, 1.3)
+  return Math.round(baseDelta * scale)
 }
 
 /** Read-time rival/comparative pressure from agency ranking. No persisted fields. */

--- a/src/features/report/reportView.ts
+++ b/src/features/report/reportView.ts
@@ -36,7 +36,8 @@ export function getReportPageView(game: GameState): ReportPageView {
   const extendedSummaryLine =
     `${agencySummary.name}: reputation ${agencySummary.reputation}, ` +
     `pressure ${agencySummary.pressure.score} (${agencySummary.pressure.level}), ` +
-    `rival pressure ${agencySummary.rivalPressure.score} (${agencySummary.rivalPressure.band}), ` +
+    `rival pressure ${agencySummary.rivalPressure.score} (${agencySummary.rivalPressure.band}; ` +
+    `trust-failure drift ${agencySummary.rivalPressure.trustFailureDriftScale}×), ` +
     `stability ${agencySummary.stability.score} (${agencySummary.stability.level}), ` +
     `chokepoint leverage ${agencySummary.chokepointLeverage}, ` +
     `council power [${councilPower}], ` +

--- a/src/test/externalSupport.test.ts
+++ b/src/test/externalSupport.test.ts
@@ -98,10 +98,14 @@ describe('applyAssetReliabilityDrift', () => {
     const delivered = applyAssetReliabilityDrift(base, 'support_delivered', {
       trustFailureDriftScale: 1.12,
     })
+    const idleForgiven = applyAssetReliabilityDrift(base, 'week_idle', {
+      trustFailureDriftScale: 0.7,
+    })
 
     expect(forgiven.asset.reliability).toBe(32) // 50 + round(-20 * 0.88)
     expect(hardened.asset.reliability).toBe(28) // 50 + round(-20 * 1.12)
     expect(delivered.asset.reliability).toBe(62) // positive drift unscaled
+    expect(idleForgiven.asset.reliability).toBe(48) // 50 + round(-3 * 0.7) = 50 - 2
   })
 })
 

--- a/src/test/externalSupport.test.ts
+++ b/src/test/externalSupport.test.ts
@@ -86,6 +86,23 @@ describe('applyAssetReliabilityDrift', () => {
     expect(driftReason).toContain('moderate')
     expect(driftReason).toContain('degraded')
   })
+
+  it('SPE-2700: standing-shaped scale softens or hardens negative drift only', () => {
+    const base = createContractorAsset('c1', 'Local Contractor', 50)
+    const forgiven = applyAssetReliabilityDrift(base, 'support_failed', {
+      trustFailureDriftScale: 0.88,
+    })
+    const hardened = applyAssetReliabilityDrift(base, 'support_failed', {
+      trustFailureDriftScale: 1.12,
+    })
+    const delivered = applyAssetReliabilityDrift(base, 'support_delivered', {
+      trustFailureDriftScale: 1.12,
+    })
+
+    expect(forgiven.asset.reliability).toBe(32) // 50 + round(-20 * 0.88)
+    expect(hardened.asset.reliability).toBe(28) // 50 + round(-20 * 1.12)
+    expect(delivered.asset.reliability).toBe(62) // positive drift unscaled
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -206,5 +223,43 @@ describe('SPE-93: applyRallySupportStaffAction with contractor asset', () => {
     const r2 = applyRallySupportStaffAction(state, 2)
     expect(r1.nextState.agency?.supportAvailable).toBe(r2.nextState.agency?.supportAvailable)
     expect(r1.note?.content).toBe(r2.note?.content)
+  })
+
+  it('SPE-2700: high vs low standing diverges failed-contractor reliability drift', () => {
+    const asset = createContractorAsset('c-fail', 'Failed Contractor', 25)
+    const weakReports = [
+      {
+        week: 1,
+        resolvedCases: [],
+        partialCases: [],
+        failedCases: ['f1', 'f2', 'f3', 'f4', 'f5'],
+        unresolvedTriggers: ['u1', 'u2', 'u3', 'u4'],
+      },
+    ] as GameState['reports']
+    const strongReports = [
+      {
+        week: 1,
+        resolvedCases: Array.from({ length: 10 }, (_, i) => `r${i}`),
+        partialCases: [],
+        failedCases: [],
+        unresolvedTriggers: [],
+      },
+    ] as GameState['reports']
+
+    const weakState = { ...makeState(asset), reports: weakReports, events: [] as GameState['events'] }
+    const strongState = {
+      ...makeState(asset),
+      reports: strongReports,
+      events: [] as GameState['events'],
+    }
+
+    const weakNext = applyRallySupportStaffAction(weakState, 2)
+    const strongNext = applyRallySupportStaffAction(strongState, 2)
+
+    const weakReliability = weakNext.nextState.externalSupportAssets?.['c-fail']?.reliability
+    const strongReliability = strongNext.nextState.externalSupportAssets?.['c-fail']?.reliability
+
+    // degraded → support_partial (−6 base); high standing softens, low standing hardens
+    expect(strongReliability).toBeGreaterThan(weakReliability!)
   })
 })

--- a/src/test/rivalPressure.test.ts
+++ b/src/test/rivalPressure.test.ts
@@ -5,9 +5,11 @@ import { getContractOffers, refreshContractBoard } from '../domain/contracts'
 import {
   applyRivalPressureToContractScalar,
   applyRivalPressureToRecruitQuality,
+  applyTrustFailureDriftScale,
   buildRivalPressure,
   buildRivalPressureFromRankingScore,
 } from '../domain/rivalPressure'
+import { applyAssetReliabilityDrift, createContractorAsset } from '../domain/externalSupport'
 import { buildRecruitmentGenerationState } from '../domain/sim/candidateGenerator'
 import type { WeeklyReport } from '../domain/models'
 
@@ -46,17 +48,20 @@ describe('rival comparative pressure (SPE-2699)', () => {
     expect(balanced.band).toBe('balanced')
     expect(balanced.contractRewardMultiplier).toBe(1)
     expect(balanced.recruitQualityDelta).toBe(0)
+    expect(balanced.trustFailureDriftScale).toBe(1)
     expect(Object.is(balanced.recruitQualityDelta, -0)).toBe(false)
 
     expect(weak.score).toBeGreaterThan(balanced.score)
     expect(weak.band).toBe('severe')
     expect(weak.contractRewardMultiplier).toBeLessThan(balanced.contractRewardMultiplier)
     expect(weak.recruitQualityDelta).toBeLessThan(balanced.recruitQualityDelta)
+    expect(weak.trustFailureDriftScale).toBeGreaterThan(balanced.trustFailureDriftScale)
 
     expect(strong.score).toBeLessThan(balanced.score)
     expect(strong.band).toBe('suppressed')
     expect(strong.contractRewardMultiplier).toBeGreaterThan(balanced.contractRewardMultiplier)
     expect(strong.recruitQualityDelta).toBeGreaterThan(balanced.recruitQualityDelta)
+    expect(strong.trustFailureDriftScale).toBeLessThan(balanced.trustFailureDriftScale)
 
     expect(applyRivalPressureToContractScalar(1, weak)).toBeLessThan(
       applyRivalPressureToContractScalar(1, strong)
@@ -64,6 +69,37 @@ describe('rival comparative pressure (SPE-2699)', () => {
     expect(applyRivalPressureToRecruitQuality(50, weak)).toBeLessThan(
       applyRivalPressureToRecruitQuality(50, strong)
     )
+    expect(applyTrustFailureDriftScale(-20, weak.trustFailureDriftScale)).toBeLessThan(
+      applyTrustFailureDriftScale(-20, strong.trustFailureDriftScale)
+    )
+    expect(applyTrustFailureDriftScale(12, weak.trustFailureDriftScale)).toBe(12)
+    expect(applyTrustFailureDriftScale(12, strong.trustFailureDriftScale)).toBe(12)
+  })
+
+  it('softens negative reliability drift under high standing vs low standing', () => {
+    const contractor = createContractorAsset('c1', 'Local Contractor', 50)
+    const weak = buildRivalPressureFromRankingScore(20)
+    const strong = buildRivalPressureFromRankingScore(80)
+
+    const weakDrift = applyAssetReliabilityDrift(contractor, 'support_failed', {
+      trustFailureDriftScale: weak.trustFailureDriftScale,
+    })
+    const strongDrift = applyAssetReliabilityDrift(contractor, 'support_failed', {
+      trustFailureDriftScale: strong.trustFailureDriftScale,
+    })
+    const neutralDrift = applyAssetReliabilityDrift(contractor, 'support_failed')
+
+    expect(strongDrift.asset.reliability).toBeGreaterThan(neutralDrift.asset.reliability)
+    expect(weakDrift.asset.reliability).toBeLessThan(neutralDrift.asset.reliability)
+    expect(strongDrift.asset.reliability).toBeGreaterThan(weakDrift.asset.reliability)
+
+    const identicalA = applyAssetReliabilityDrift(contractor, 'support_partial', {
+      trustFailureDriftScale: weak.trustFailureDriftScale,
+    })
+    const identicalB = applyAssetReliabilityDrift(contractor, 'support_partial', {
+      trustFailureDriftScale: weak.trustFailureDriftScale,
+    })
+    expect(identicalA.asset.reliability).toBe(identicalB.asset.reliability)
   })
 
   it('compresses contract payouts under severe rival pressure vs suppressed', () => {
@@ -134,7 +170,9 @@ describe('rival comparative pressure (SPE-2699)', () => {
       summary: buildRivalPressure(game).summary,
       contractRewardMultiplier: buildRivalPressure(game).contractRewardMultiplier,
       recruitQualityDelta: buildRivalPressure(game).recruitQualityDelta,
+      trustFailureDriftScale: buildRivalPressure(game).trustFailureDriftScale,
     })
     expect(summary.rivalPressure.summary).toMatch(/Comparative pressure/)
+    expect(summary.rivalPressure.summary).toMatch(/external-support failure drift/)
   })
 })

--- a/src/test/rivalPressure.test.ts
+++ b/src/test/rivalPressure.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../domain/rivalPressure'
 import { applyAssetReliabilityDrift, createContractorAsset } from '../domain/externalSupport'
 import { buildRecruitmentGenerationState } from '../domain/sim/candidateGenerator'
+import { getReportPageView } from '../features/report/reportView'
 import type { WeeklyReport } from '../domain/models'
 
 function reportWithFailures(week: number, failures: number, unresolved: number): WeeklyReport {
@@ -93,10 +94,20 @@ describe('rival comparative pressure (SPE-2699)', () => {
     expect(weakDrift.asset.reliability).toBeLessThan(neutralDrift.asset.reliability)
     expect(strongDrift.asset.reliability).toBeGreaterThan(weakDrift.asset.reliability)
 
-    const identicalA = applyAssetReliabilityDrift(contractor, 'support_partial', {
+    const weakPartial = applyAssetReliabilityDrift(contractor, 'support_partial', {
       trustFailureDriftScale: weak.trustFailureDriftScale,
     })
-    const identicalB = applyAssetReliabilityDrift(contractor, 'support_partial', {
+    const strongPartial = applyAssetReliabilityDrift(contractor, 'support_partial', {
+      trustFailureDriftScale: strong.trustFailureDriftScale,
+    })
+    const neutralPartial = applyAssetReliabilityDrift(contractor, 'support_partial')
+    expect(strongPartial.asset.reliability).toBeGreaterThan(neutralPartial.asset.reliability)
+    expect(weakPartial.asset.reliability).toBeLessThan(neutralPartial.asset.reliability)
+
+    const identicalA = applyAssetReliabilityDrift(contractor, 'week_idle', {
+      trustFailureDriftScale: weak.trustFailureDriftScale,
+    })
+    const identicalB = applyAssetReliabilityDrift(contractor, 'week_idle', {
       trustFailureDriftScale: weak.trustFailureDriftScale,
     })
     expect(identicalA.asset.reliability).toBe(identicalB.asset.reliability)
@@ -162,6 +173,24 @@ describe('rival comparative pressure (SPE-2699)', () => {
 
   it('exposes rival pressure on agency summary for player-facing surfaces', () => {
     const game = createStartingState()
+    game.reports = [
+      {
+        week: 1,
+        rngStateBefore: 1,
+        rngStateAfter: 2,
+        newCases: [],
+        progressedCases: [],
+        resolvedCases: [],
+        failedCases: [],
+        partialCases: [],
+        unresolvedTriggers: [],
+        spawnedCases: [],
+        maxStage: 1,
+        avgFatigue: 0,
+        teamStatus: [],
+        notes: [],
+      },
+    ]
     const summary = buildAgencySummary(game)
 
     expect(summary.rivalPressure).toEqual({
@@ -174,5 +203,12 @@ describe('rival comparative pressure (SPE-2699)', () => {
     })
     expect(summary.rivalPressure.summary).toMatch(/Comparative pressure/)
     expect(summary.rivalPressure.summary).toMatch(/external-support failure drift/)
+
+    const reportLine = getReportPageView(game).summary?.agencySummaryLine ?? ''
+    expect(reportLine).toMatch(
+      new RegExp(
+        `rival pressure ${summary.rivalPressure.score} \\(${summary.rivalPressure.band}; trust-failure drift ${summary.rivalPressure.trustFailureDriftScale}×\\)`
+      )
+    )
   })
 })

--- a/systems/factions-legitimacy.md
+++ b/systems/factions-legitimacy.md
@@ -313,8 +313,9 @@ Examples:
 - weakness may embolden interference
 - successful intervention may change power posture in a region or district
 
-**Implemented hook (SPE-2699):** ranking-derived comparative pressure (`buildRivalPressure`) adjusts
-contract payout scalars and recruit quality deltas. Abstract peer baseline only — no per-rival squad
+**Implemented hooks (SPE-2699 / SPE-2700):** ranking-derived comparative pressure (`buildRivalPressure`)
+adjusts contract payout scalars and recruit quality deltas, and scales negative external-support
+reliability drift (standing-shaped forgiveness). Abstract peer baseline only — no per-rival squad
 simulation. Standing award math remains separate.
 
 ---

--- a/systems/hub-simulation.md
+++ b/systems/hub-simulation.md
@@ -163,7 +163,9 @@ four multipliers used for each award.
 Comparative rival pressure is a separate **read-time** derivation from agency ranking score versus
 an abstract peer baseline (`src/domain/rivalPressure.ts`). It does not mutate standing awards. Weak
 comparative rank compresses contract reward scalars and recruit overall quality; strong rank eases
-both. Agency overview and report summary lines expose the pressure band for legibility.
+both. The same pressure also scales **negative** external-support reliability drift (SPE-93): high
+standing softens trust collapse after weak outputs; low standing accelerates it. Agency overview and
+report summary lines expose the pressure band and forgiveness scale for legibility.
 
 ### Stage B — Build hub opportunity pools
 


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2700 — https://linear.app/spectranoir/issue/SPE-2700/spe-39-standing-shaped-forgiveness-on-external-support-reliability
- **Parent issue (if any):** SPE-39 — https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer
- **Child issues covered:** slice only (SPE-2700)

## Summary

@coderabbitai summary

## What shipped

- Derived `trustFailureDriftScale` from ranking / rival pressure (read-time; no new persisted fields)
- Scaled negative SPE-93 external-support reliability drift so high standing softens trust collapse and low standing hardens it
- Exposed the forgiveness signal on rival-pressure / agency summary lines
- Left SPE-2699 contract/recruit multipliers and SPE-2696/2697 standing award math unchanged

## Docs updated

- `systems/hub-simulation.md`
- `systems/factions-legitimacy.md`
- `architecture/external-support-reliability-trust.md`
- `planning/spe-2700-standing-shaped-forgiveness-slice.md`
- `planning/spe-2699-rival-comparative-pressure-slice.md` (deferred row → SPE-2700)

## Parent status

- Parent SPE-39 remains **Backlog**/open — forgiveness AC gap closed; post-exposure posture, liaison packets, and hidden-cell interference remain

## Scope boundary

- No standing-award reopen
- No SPE-2699 contract/recruit multiplier formula changes
- No rival expedition sim / protective-coercive exposure posture
- No SCHEMA_REGISTRY changes

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/rivalPressure.test.ts src/test/externalSupport.test.ts src/test/agency.test.ts src/test/agencyStanding.test.ts`
- [x] Lint / verify: `npm run lint`

## Follow-ups

- Protective-coercive rival posture after public exposure (SPE-39 child)
- Cross-jurisdiction coordination packets (SPE-39 + SPE-854)
- Hidden-cell strategic interference (SPE-39 child)

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)

Made with [Cursor](https://cursor.com)