### PR TITLE
SPE-2701: Protective-coercive rival posture after public exposure

### DIFF
--- a/planning/spe-2701-post-exposure-rival-posture-slice.md
+++ b/planning/spe-2701-post-exposure-rival-posture-slice.md
@@ -1,0 +1,54 @@
+# SPE-2701 — Protective-coercive rival posture after public exposure
+
+**Linear:** [SPE-2701](https://linear.app/spectranoir/issue/SPE-2701/spe-39-protective-coercive-rival-posture-after-public-exposure)  
+**Parent:** [SPE-39](https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer) (stays **Backlog**/open after merge)  
+**Branch:** `jamesdyedbq/spe-2701-spe-39-protective-coercive-rival-posture-after-public`  
+**Base:** `main` @ `614454327703470f7a394447afffb76789b8a60b`
+
+## Goal
+
+One deterministic post-exposure comparative-pressure / protective-coercive rival-posture shift from agency standing/ranking into public-disclosure regional trust → cooperation bands, without reopening standing-award math, SPE-2699 contract/recruit multipliers, or SPE-2700 forgiveness-scale formula.
+
+## Acceptance (this slice)
+
+- [x] Identical standing + exposure inputs → identical `postExposureTrustDelta` and trust/cooperation outcomes
+- [x] High standing vs low standing diverge after comparable public exposure (protective vs coercive)
+- [x] No active exposure → no post-exposure comparative trust shift (`rivalPosture` inactive; delta applied 0)
+- [x] Agency + rival-pressure summary + disclosure report notes expose posture/pressure signal
+- [x] SPE-2699 `contractRewardMultiplier` / `recruitQualityDelta` and SPE-2700 `trustFailureDriftScale` unchanged for same ranking inputs
+- [x] No new persisted fields; SCHEMA_REGISTRY unchanged
+- [x] Standing award / ranking-accumulator math untouched
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Domain | `src/domain/rivalPressure.ts` — `postExposureTrustDelta` + `postExposurePosture` on `RivalPressureView` |
+| Trust surface | `src/domain/publicDisclosureTrustOutcomeProjection.ts` — apply delta only when awareness ≠ secrecy_intact |
+| Week-close notes | `publicDisclosureTrustOutcomeWeeklyReportNotes` + `advanceWeek` pass delta from `buildRivalPressure` |
+| Agency / UI | `buildAgencySummary`, `reportView` summary line |
+| Docs | `systems/hub-simulation.md`, `systems/factions-legitimacy.md` |
+| Tests | `src/test/rivalPressure.test.ts`, `src/test/publicDisclosureTrustOutcomeProjection.test.ts` |
+
+Delta derives from ranking vs peer baseline (same inputs as SPE-2699/2700 pressure). High rank → positive trust delta (protective). Low rank → negative (coercive). Peer baseline → 0 / neutral. Application is projection-time only.
+
+## Out of scope
+
+- SPE-2696/2697 standing awards, repeats, hydration
+- SPE-2699 contract/recruit multiplier formula changes
+- SPE-2700 `trustFailureDriftScale` formula changes
+- Cross-jurisdiction liaison packets; hidden-cell interference; SPE-542 / SPE-430 rival sims
+- Emergency-waiver legitimacy fallout tick standing scale
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Cross-jurisdiction coordination packets | SPE-39 + SPE-854 | Intake pairing |
+| Hidden-cell strategic interference | SPE-39 child | Larger adversary layer |
+| Legitimacy fallout tick standing scale | SPE-39 / procurement follow-up | Alternate fallout surface; disclosure trust path chosen |
+
+## Validation
+
+- `npm run test:run -- src/test/rivalPressure.test.ts src/test/publicDisclosureTrustOutcomeProjection.test.ts src/test/agency.test.ts src/test/agencyStanding.test.ts`
+- `npm run lint`

--- a/planning/spe-2701-post-exposure-rival-posture-slice.md
+++ b/planning/spe-2701-post-exposure-rival-posture-slice.md
@@ -50,5 +50,5 @@ Delta derives from ranking vs peer baseline (same inputs as SPE-2699/2700 pressu
 
 ## Validation
 
-- `npm run test:run -- src/test/rivalPressure.test.ts src/test/publicDisclosureTrustOutcomeProjection.test.ts src/test/agency.test.ts src/test/agencyStanding.test.ts`
+- `npm run test:run -- src/test/rivalPressure.test.ts src/test/publicDisclosureTrustOutcomeProjection.test.ts src/test/publicDisclosureSegmentedTrustOutcomeProjection.test.ts src/test/publicDisclosureCampaignView.test.ts src/test/publicDisclosurePostureChoice.test.ts src/test/agency.test.ts`
 - `npm run lint`

--- a/src/domain/agency.ts
+++ b/src/domain/agency.ts
@@ -8,7 +8,7 @@ import { buildFactionStates } from './factions'
 import { buildLogisticsOverview } from './logistics'
 import { buildMajorIncidentProfile } from './majorIncidents'
 import { buildAgencyRanking, type AgencyRankingTier } from './rankings'
-import { buildRivalPressure, type RivalPressureBand } from './rivalPressure'
+import { buildRivalPressure, type RivalPressureBand, type RivalPostExposurePosture } from './rivalPressure'
 import { getTeamAssignedCaseId, getTeamMemberIds } from './teamSimulation'
 
 const DEFAULT_AGENCY_NAME = 'Containment Protocol'
@@ -84,6 +84,8 @@ export interface AgencySummary {
     contractRewardMultiplier: number
     recruitQualityDelta: number
     trustFailureDriftScale: number
+    postExposureTrustDelta: number
+    postExposurePosture: RivalPostExposurePosture
   }
   report: AgencyReportSummary
   // Commercial Chokepoint Statecraft & Council Power (issue #187)
@@ -371,6 +373,8 @@ export function buildAgencySummary(game: GameState): AgencySummary {
       contractRewardMultiplier: rivalPressure.contractRewardMultiplier,
       recruitQualityDelta: rivalPressure.recruitQualityDelta,
       trustFailureDriftScale: rivalPressure.trustFailureDriftScale,
+      postExposureTrustDelta: rivalPressure.postExposureTrustDelta,
+      postExposurePosture: rivalPressure.postExposurePosture,
     },
     report: buildAgencyReportSummary(game),
     chokepointLeverage,

--- a/src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts
+++ b/src/domain/publicDisclosureSegmentedTrustOutcomeProjection.ts
@@ -15,7 +15,11 @@ import {
   type PublicDisclosureRecord,
   type PublicDisclosureRecordsMap,
 } from './publicDisclosureStateRegistry'
-import type { PublicDisclosureTrustOutcomeAttentionTone } from './publicDisclosureTrustOutcomeProjection'
+import {
+  applyPostExposureComparativeTrustAdjustment,
+  type PublicDisclosureTrustOutcomeAttentionTone,
+} from './publicDisclosureTrustOutcomeProjection'
+import { buildRivalPressure } from './rivalPressure'
 
 export type PublicDisclosureTrustSegmentKind = 'population' | 'channel'
 
@@ -274,9 +278,14 @@ function resolveFrontDeskDivergenceTone(
 /** Projects population / channel trust divergence from hydrated disclosure records. */
 export function projectPublicDisclosureSegmentedTrustOutcome(
   records: PublicDisclosureRecordsMap | null | undefined,
-  postureChoices?: PublicDisclosurePostureChoicesMap | null
+  postureChoices?: PublicDisclosurePostureChoicesMap | null,
+  options?: { readonly postExposureTrustDelta?: number } | null
 ): PublicDisclosureSegmentedTrustOutcomeProjection {
-  const effectiveRecords = applyPublicDisclosurePostureTrustAdjustment(records, postureChoices)
+  const postureAdjusted = applyPublicDisclosurePostureTrustAdjustment(records, postureChoices)
+  const effectiveRecords = applyPostExposureComparativeTrustAdjustment(
+    postureAdjusted,
+    options?.postExposureTrustDelta ?? 0
+  )
   const persistedRecords = listPersistedRecords(effectiveRecords)
   const activeRecords = persistedRecords.filter((record) => record.awarenessLevel !== 'secrecy_intact')
   const aggregate = collectSegmentTrustScores(activeRecords)
@@ -306,11 +315,15 @@ export function projectPublicDisclosureSegmentedTrustOutcome(
 }
 
 export function projectPublicDisclosureSegmentedTrustOutcomeFromGame(
-  game: Pick<GameState, 'publicDisclosureRecords' | 'publicDisclosurePostureChoices'>
+  game: Pick<
+    GameState,
+    'publicDisclosureRecords' | 'publicDisclosurePostureChoices' | 'reports' | 'events'
+  >
 ): PublicDisclosureSegmentedTrustOutcomeProjection {
   return projectPublicDisclosureSegmentedTrustOutcome(
     game.publicDisclosureRecords,
-    game.publicDisclosurePostureChoices
+    game.publicDisclosurePostureChoices,
+    { postExposureTrustDelta: buildRivalPressure(game).postExposureTrustDelta }
   )
 }
 

--- a/src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts
+++ b/src/domain/publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes.ts
@@ -17,13 +17,15 @@ import { createDeterministicReportNote } from './reportNotes'
 export function buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes(input: {
   nextRecords: PublicDisclosureRecordsMap | null | undefined
   postureChoices?: PublicDisclosurePostureChoicesMap | null
+  postExposureTrustDelta?: number
   week: number
   sequenceStart: number
   baseTimestamp?: number
 }): ReportNote[] {
   const projection = projectPublicDisclosureSegmentedTrustOutcome(
     input.nextRecords,
-    input.postureChoices
+    input.postureChoices,
+    { postExposureTrustDelta: input.postExposureTrustDelta ?? 0 }
   )
 
   if (projection.isInactive || !projection.hasDivergence) {

--- a/src/domain/publicDisclosureTrustOutcomeProjection.ts
+++ b/src/domain/publicDisclosureTrustOutcomeProjection.ts
@@ -16,6 +16,11 @@ import {
   type PublicDisclosureRecord,
   type PublicDisclosureRecordsMap,
 } from './publicDisclosureStateRegistry'
+import {
+  buildRivalPressure,
+  resolveRivalPostExposurePosture,
+  type RivalPostExposurePosture,
+} from './rivalPressure'
 
 const AWARENESS_SEVERITY_ORDER: readonly AwarenessLevel[] = [
   'secrecy_intact',
@@ -42,6 +47,14 @@ export interface PublicDisclosureTrustOutcomeProjection {
   readonly cooperationBandLabel: string
   readonly frontDeskAttentionTone: PublicDisclosureTrustOutcomeAttentionTone
   readonly frontDeskAttentionSummary: string
+  /** Standing-shaped trust delta applied only when exposure is active (SPE-2701). */
+  readonly postExposureTrustDeltaApplied: number
+  /** Protective / coercive / neutral when exposure active; inactive otherwise. */
+  readonly rivalPosture: RivalPostExposurePosture | 'inactive'
+}
+
+export interface ProjectPublicDisclosureTrustOutcomeOptions {
+  readonly postExposureTrustDelta?: number
 }
 
 const COOPERATION_BAND_LABELS: Record<PublicDisclosureCooperationBand, string> = {
@@ -204,23 +217,89 @@ function formatRegionalTrustBandLabel(
   return `${band.charAt(0).toUpperCase()}${band.slice(1)} regional trust`
 }
 
+function clampTrustScore(score: number): number {
+  const clamped = Math.min(1, Math.max(0, score))
+  return Math.round(clamped * 100) / 100
+}
+
+/**
+ * Applies standing-shaped post-exposure comparative trust only to active exposure campaigns.
+ * Secrecy-intact / empty maps are unchanged. Does not mutate persisted registry records.
+ */
+export function applyPostExposureComparativeTrustAdjustment(
+  records: PublicDisclosureRecordsMap | null | undefined,
+  postExposureTrustDelta: number
+): PublicDisclosureRecordsMap {
+  const sourceRecords = records ?? {}
+  const delta = Number.isFinite(postExposureTrustDelta) ? postExposureTrustDelta : 0
+
+  if (delta === 0 || Object.keys(sourceRecords).length === 0) {
+    return sourceRecords
+  }
+
+  let changed = false
+  const nextRecords: PublicDisclosureRecordsMap = {}
+
+  for (const [recordId, record] of Object.entries(sourceRecords).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    if (
+      record.awarenessLevel === 'secrecy_intact' ||
+      !record.trustByRegion ||
+      record.trustByRegion.length === 0
+    ) {
+      nextRecords[recordId] = record
+      continue
+    }
+
+    changed = true
+    nextRecords[recordId] = Object.freeze({
+      ...record,
+      trustByRegion: Object.freeze(
+        record.trustByRegion.map((entry) =>
+          Object.freeze({
+            ...entry,
+            trustScore: clampTrustScore(entry.trustScore + delta),
+          })
+        )
+      ),
+    })
+  }
+
+  return changed ? nextRecords : sourceRecords
+}
+
 function buildFrontDeskAttentionSummary(input: {
   activeCampaignCount: number
   dominantAwarenessBandLabel: string
   cooperationBandLabel: string
   aggregateRegionalTrustBand: PublicDisclosureRegionalTrustBand | null
+  rivalPosture: RivalPostExposurePosture | 'inactive'
+  postExposureTrustDeltaApplied: number
 }): string {
   const trustLabel = formatRegionalTrustBandLabel(input.aggregateRegionalTrustBand)
+  const postureNote =
+    input.rivalPosture === 'inactive'
+      ? 'rival posture inactive'
+      : `rival posture ${input.rivalPosture} (trust ${
+          input.postExposureTrustDeltaApplied > 0 ? '+' : ''
+        }${input.postExposureTrustDeltaApplied})`
 
-  return `${input.activeCampaignCount} active disclosure campaign(s); dominant awareness band: ${input.dominantAwarenessBandLabel}; ${input.cooperationBandLabel.toLowerCase()}; ${trustLabel.toLowerCase()}.`
+  return `${input.activeCampaignCount} active disclosure campaign(s); dominant awareness band: ${input.dominantAwarenessBandLabel}; ${input.cooperationBandLabel.toLowerCase()}; ${trustLabel.toLowerCase()}; ${postureNote}.`
 }
 
 /** Projects compliance/cooperation bands from hydrated disclosure records. */
 export function projectPublicDisclosureTrustOutcome(
   records: PublicDisclosureRecordsMap | null | undefined,
-  postureChoices?: PublicDisclosurePostureChoicesMap | null
+  postureChoices?: PublicDisclosurePostureChoicesMap | null,
+  options?: ProjectPublicDisclosureTrustOutcomeOptions | null
 ): PublicDisclosureTrustOutcomeProjection {
-  const effectiveRecords = applyPublicDisclosurePostureTrustAdjustment(records, postureChoices)
+  const postureAdjusted = applyPublicDisclosurePostureTrustAdjustment(records, postureChoices)
+  const requestedDelta = options?.postExposureTrustDelta ?? 0
+  const effectiveRecords = applyPostExposureComparativeTrustAdjustment(
+    postureAdjusted,
+    requestedDelta
+  )
   const persistedRecords = listPersistedRecords(effectiveRecords)
   const activeCampaignCount = persistedRecords.filter(
     (record) => record.awarenessLevel !== 'secrecy_intact'
@@ -237,6 +316,12 @@ export function projectPublicDisclosureTrustOutcome(
     activeCampaignCount,
   })
   const cooperationBandLabel = COOPERATION_BAND_LABELS[cooperationBand]
+  const postExposureTrustDeltaApplied =
+    activeCampaignCount > 0 && Number.isFinite(requestedDelta) ? requestedDelta + 0 : 0
+  const rivalPosture: RivalPostExposurePosture | 'inactive' =
+    activeCampaignCount === 0
+      ? 'inactive'
+      : resolveRivalPostExposurePosture(postExposureTrustDeltaApplied)
 
   return Object.freeze({
     isEmpty: persistedRecords.length === 0,
@@ -252,16 +337,24 @@ export function projectPublicDisclosureTrustOutcome(
       dominantAwarenessBandLabel,
       cooperationBandLabel,
       aggregateRegionalTrustBand,
+      rivalPosture,
+      postExposureTrustDeltaApplied,
     }),
+    postExposureTrustDeltaApplied,
+    rivalPosture,
   })
 }
 
 export function projectPublicDisclosureTrustOutcomeFromGame(
-  game: Pick<GameState, 'publicDisclosureRecords' | 'publicDisclosurePostureChoices'>
+  game: Pick<
+    GameState,
+    'publicDisclosureRecords' | 'publicDisclosurePostureChoices' | 'reports' | 'events'
+  >
 ): PublicDisclosureTrustOutcomeProjection {
   return projectPublicDisclosureTrustOutcome(
     game.publicDisclosureRecords,
-    game.publicDisclosurePostureChoices
+    game.publicDisclosurePostureChoices,
+    { postExposureTrustDelta: buildRivalPressure(game).postExposureTrustDelta }
   )
 }
 
@@ -274,6 +367,12 @@ export function formatPublicDisclosureTrustOutcomeNoteContent(
   }
 
   const trustLabel = formatRegionalTrustBandLabel(projection.aggregateRegionalTrustBand)
+  const postureNote =
+    projection.rivalPosture === 'inactive'
+      ? 'rival posture inactive'
+      : `rival posture ${projection.rivalPosture} (trust ${
+          projection.postExposureTrustDeltaApplied > 0 ? '+' : ''
+        }${projection.postExposureTrustDeltaApplied})`
 
-  return `Public disclosure trust outcome — W${week}: ${projection.activeCampaignCount} active campaign(s); dominant awareness ${projection.dominantAwarenessBandLabel}; ${projection.cooperationBandLabel}; ${trustLabel}.`
+  return `Public disclosure trust outcome — W${week}: ${projection.activeCampaignCount} active campaign(s); dominant awareness ${projection.dominantAwarenessBandLabel}; ${projection.cooperationBandLabel}; ${trustLabel}; ${postureNote}.`
 }

--- a/src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts
+++ b/src/domain/publicDisclosureTrustOutcomeWeeklyReportNotes.ts
@@ -17,13 +17,15 @@ import { createDeterministicReportNote } from './reportNotes'
 export function buildWeeklyPublicDisclosureTrustOutcomeReportNotes(input: {
   nextRecords: PublicDisclosureRecordsMap | null | undefined
   postureChoices?: PublicDisclosurePostureChoicesMap | null
+  postExposureTrustDelta?: number
   week: number
   sequenceStart: number
   baseTimestamp?: number
 }): ReportNote[] {
   const projection = projectPublicDisclosureTrustOutcome(
     input.nextRecords,
-    input.postureChoices
+    input.postureChoices,
+    { postExposureTrustDelta: input.postExposureTrustDelta ?? 0 }
   )
 
   if (projection.activeCampaignCount === 0) {
@@ -42,6 +44,8 @@ export function buildWeeklyPublicDisclosureTrustOutcomeReportNotes(input: {
         dominantAwarenessLevel: projection.dominantAwarenessLevel,
         aggregateRegionalTrustBand: projection.aggregateRegionalTrustBand,
         cooperationBand: projection.cooperationBand,
+        postExposureTrustDeltaApplied: projection.postExposureTrustDeltaApplied,
+        rivalPosture: projection.rivalPosture,
         week: input.week,
       }
     ),

--- a/src/domain/rivalPressure.ts
+++ b/src/domain/rivalPressure.ts
@@ -7,6 +7,8 @@ export const RIVAL_PRESSURE_PEER_BASELINE = RANKING_BASE_SCORE
 
 export type RivalPressureBand = 'suppressed' | 'balanced' | 'competitive' | 'severe'
 
+export type RivalPostExposurePosture = 'protective' | 'coercive' | 'neutral'
+
 export interface RivalPressureView {
   /** 0–100 comparative pressure (higher = rivals look stronger). */
   score: number
@@ -22,6 +24,13 @@ export interface RivalPressureView {
    * <1 = standing-shaped forgiveness; >1 = accelerated trust collapse.
    */
   trustFailureDriftScale: number
+  /**
+   * Additive regional-trust delta after public exposure (SPE-2701).
+   * Applied only when disclosure awareness is active; high standing protective, low coercive.
+   */
+  postExposureTrustDelta: number
+  /** Protective / coercive / neutral label for the post-exposure trust delta. */
+  postExposurePosture: RivalPostExposurePosture
   summary: string
 }
 
@@ -48,21 +57,54 @@ function buildForgivenessNote(trustFailureDriftScale: number): string {
   return `external-support failure drift neutral (${trustFailureDriftScale}×).`
 }
 
+export function resolveRivalPostExposurePosture(
+  postExposureTrustDelta: number
+): RivalPostExposurePosture {
+  if (postExposureTrustDelta > 0) {
+    return 'protective'
+  }
+  if (postExposureTrustDelta < 0) {
+    return 'coercive'
+  }
+  return 'neutral'
+}
+
+function buildPostExposurePostureNote(
+  postExposurePosture: RivalPostExposurePosture,
+  postExposureTrustDelta: number
+): string {
+  switch (postExposurePosture) {
+    case 'protective':
+      return `post-exposure rival posture protective (trust ${postExposureTrustDelta > 0 ? '+' : ''}${postExposureTrustDelta}).`
+    case 'coercive':
+      return `post-exposure rival posture coercive (trust ${postExposureTrustDelta}).`
+    case 'neutral':
+      return `post-exposure rival posture neutral (trust ${postExposureTrustDelta}).`
+    default: {
+      const _exhaustive: never = postExposurePosture
+      return _exhaustive
+    }
+  }
+}
+
 function buildRivalPressureSummary(
   band: RivalPressureBand,
   rankingScore: number,
-  trustFailureDriftScale: number
+  trustFailureDriftScale: number,
+  postExposurePosture: RivalPostExposurePosture,
+  postExposureTrustDelta: number
 ): string {
   const forgiveness = buildForgivenessNote(trustFailureDriftScale)
+  const exposure = buildPostExposurePostureNote(postExposurePosture, postExposureTrustDelta)
   switch (band) {
     case 'suppressed':
-      return `Comparative pressure suppressed (rank ${rankingScore}): peer agencies lag; contract terms and recruit quality tilt favorable; ${forgiveness}`
+      return `Comparative pressure suppressed (rank ${rankingScore}): peer agencies lag; contract terms and recruit quality tilt favorable; ${forgiveness} ${exposure}`
     case 'balanced':
-      return `Comparative pressure balanced (rank ${rankingScore}): peer agencies track evenly; no rival payout or staffing skew; ${forgiveness}`
+      return `Comparative pressure balanced (rank ${rankingScore}): peer agencies track evenly; no rival payout or staffing skew; ${forgiveness} ${exposure}`
     case 'competitive':
-      return `Comparative pressure competitive (rank ${rankingScore}): peer agencies press for share; contract payouts and recruit quality tighten; ${forgiveness}`
+      return `Comparative pressure competitive (rank ${rankingScore}): peer agencies press for share; contract payouts and recruit quality tighten; ${forgiveness} ${exposure}`
     case 'severe':
-      return `Comparative pressure severe (rank ${rankingScore}): peer agencies dominate optics; contract payouts and recruit quality compress; ${forgiveness}`
+      return `Comparative pressure severe (rank ${rankingScore}): peer agencies dominate optics; contract payouts and recruit quality compress; ${forgiveness} ${exposure}`
     default: {
       const _exhaustive: never = band
       return _exhaustive
@@ -85,6 +127,9 @@ export function buildRivalPressureFromRankingScore(rankingScore: number): RivalP
   const recruitQualityDelta = clamp(Math.round(-deltaFromPeer * 0.12), -6, 4) + 0
   // High standing (negative deltaFromPeer) softens trust collapse; low standing hardens it.
   const trustFailureDriftScale = Number(clamp(1 + deltaFromPeer * 0.004, 0.7, 1.3).toFixed(3))
+  // High standing protects regional trust after exposure; low standing coerces it downward.
+  const postExposureTrustDelta = Number(clamp(-deltaFromPeer * 0.0025, -0.1, 0.1).toFixed(2)) + 0
+  const postExposurePosture = resolveRivalPostExposurePosture(postExposureTrustDelta)
 
   return {
     score,
@@ -94,7 +139,15 @@ export function buildRivalPressureFromRankingScore(rankingScore: number): RivalP
     contractRewardMultiplier,
     recruitQualityDelta,
     trustFailureDriftScale,
-    summary: buildRivalPressureSummary(band, clampedRanking, trustFailureDriftScale),
+    postExposureTrustDelta,
+    postExposurePosture,
+    summary: buildRivalPressureSummary(
+      band,
+      clampedRanking,
+      trustFailureDriftScale,
+      postExposurePosture,
+      postExposureTrustDelta
+    ),
   }
 }
 

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -325,6 +325,7 @@ import { composePopulationEmergenceNormalizationIntoDisclosureRecords } from '..
 import { applyWeeklyPublicDisclosureProgressionTick } from '../publicDisclosureWeeklyProgression'
 import { buildWeeklyPublicDisclosureTrustOutcomeReportNotes } from '../publicDisclosureTrustOutcomeWeeklyReportNotes'
 import { buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes } from '../publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes'
+import { buildRivalPressure } from '../rivalPressure'
 import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInformationWeeklyRetention'
 import { applyWeeklyMinorAnomalyItemDispositionTick } from '../minorAnomalyItemWeeklyDisposition'
 import { applyWeeklyUnexplainedLocationLifecycleTick } from '../unexplainedLocationWeeklyLifecycle'
@@ -5739,6 +5740,7 @@ export function advanceWeek(
     const trustOutcomeNotes = buildWeeklyPublicDisclosureTrustOutcomeReportNotes({
       nextRecords: nextPublicDisclosureRecordsForTrustOutcome,
       postureChoices: inputWeeklyState.publicDisclosurePostureChoices,
+      postExposureTrustDelta: buildRivalPressure(result).postExposureTrustDelta,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -5737,10 +5737,11 @@ export function advanceWeek(
     result.reports.length > 0
   ) {
     const lastWeeklyReport = result.reports[result.reports.length - 1]
+    const postExposureTrustDelta = buildRivalPressure(result).postExposureTrustDelta
     const trustOutcomeNotes = buildWeeklyPublicDisclosureTrustOutcomeReportNotes({
       nextRecords: nextPublicDisclosureRecordsForTrustOutcome,
       postureChoices: inputWeeklyState.publicDisclosurePostureChoices,
-      postExposureTrustDelta: buildRivalPressure(result).postExposureTrustDelta,
+      postExposureTrustDelta,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,
@@ -5751,6 +5752,7 @@ export function advanceWeek(
     const segmentedTrustNotes = buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes({
       nextRecords: nextPublicDisclosureRecordsForTrustOutcome,
       postureChoices: inputWeeklyState.publicDisclosurePostureChoices,
+      postExposureTrustDelta,
       week: result.week,
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + appendedDisclosureNotes.length + 1,
       baseTimestamp: noteBaseTimestamp,

--- a/src/features/operations/publicDisclosureCampaignView.ts
+++ b/src/features/operations/publicDisclosureCampaignView.ts
@@ -164,13 +164,17 @@ function resolveCoverNarrativeContextLabel(
   return null
 }
 
-function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDisclosureCampaignRecordView {
+function toRecordView(
+  game: GameState,
+  record: PublicDisclosureRecord,
+  postExposureTrustDelta: number
+): PublicDisclosureCampaignRecordView {
   const adjustedRecords = applyPostExposureComparativeTrustAdjustment(
     applyPublicDisclosurePostureTrustAdjustment(
       { [record.id]: record },
       game.publicDisclosurePostureChoices
     ),
-    buildRivalPressure(game).postExposureTrustDelta
+    postExposureTrustDelta
   )
   const effectiveRecord = adjustedRecords[record.id] ?? record
   const projection = projectDisclosureRegionalView(effectiveRecord, { redactUnknown: true })
@@ -234,6 +238,7 @@ function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDi
 /** Read-only player briefing over hydrated `publicDisclosureRecords`; does not mutate GameState. */
 export function getPublicDisclosureCampaignView(game: GameState): PublicDisclosureCampaignView {
   const records = listPersistedRecords(game)
+  const postExposureTrustDelta = buildRivalPressure(game).postExposureTrustDelta
   const trustOutcome = projectPublicDisclosureTrustOutcomeFromGame(game)
   const segmentedTrust = projectPublicDisclosureSegmentedTrustOutcomeFromGame(game)
 
@@ -263,6 +268,8 @@ export function getPublicDisclosureCampaignView(game: GameState): PublicDisclosu
       segmentTrustChips,
       week: game.week,
     }),
-    records: Object.freeze(records.map((record) => toRecordView(game, record))),
+    records: Object.freeze(
+      records.map((record) => toRecordView(game, record, postExposureTrustDelta))
+    ),
   })
 }

--- a/src/features/operations/publicDisclosureCampaignView.ts
+++ b/src/features/operations/publicDisclosureCampaignView.ts
@@ -5,15 +5,20 @@ import {
   type PublicDisclosureRecord,
 } from '../../domain/publicDisclosureStateRegistry'
 import { resolveTruthLayerDualIncidentPairing } from '../../domain/truthLayerCoverNarrativePairing'
-import { projectPublicDisclosureTrustOutcomeFromGame } from '../../domain/publicDisclosureTrustOutcomeProjection'
+import {
+  applyPostExposureComparativeTrustAdjustment,
+  projectPublicDisclosureTrustOutcomeFromGame,
+} from '../../domain/publicDisclosureTrustOutcomeProjection'
 import { projectPublicDisclosureSegmentedTrustOutcomeFromGame } from '../../domain/publicDisclosureSegmentedTrustOutcomeProjection'
 import {
+  applyPublicDisclosurePostureTrustAdjustment,
   canApplyPublicDisclosurePostureChoiceOnRecord,
   listPublicDisclosurePostureChoiceOptions,
   readPublicDisclosurePostureChoice,
   formatPublicDisclosurePostureChoiceLabel,
   type PublicDisclosurePostureChoice,
 } from '../../domain/publicDisclosurePostureChoice'
+import { buildRivalPressure } from '../../domain/rivalPressure'
 import { formatPublicDisclosureEnumLabel } from './publicDisclosureMirrorView'
 
 const AWARENESS_SEVERITY_ORDER: readonly AwarenessLevel[] = [
@@ -160,7 +165,15 @@ function resolveCoverNarrativeContextLabel(
 }
 
 function toRecordView(game: GameState, record: PublicDisclosureRecord): PublicDisclosureCampaignRecordView {
-  const projection = projectDisclosureRegionalView(record, { redactUnknown: true })
+  const adjustedRecords = applyPostExposureComparativeTrustAdjustment(
+    applyPublicDisclosurePostureTrustAdjustment(
+      { [record.id]: record },
+      game.publicDisclosurePostureChoices
+    ),
+    buildRivalPressure(game).postExposureTrustDelta
+  )
+  const effectiveRecord = adjustedRecords[record.id] ?? record
+  const projection = projectDisclosureRegionalView(effectiveRecord, { redactUnknown: true })
   const allowsPostureChoice = canApplyPublicDisclosurePostureChoiceOnRecord(record)
   const selectedPostureChoice = readPublicDisclosurePostureChoice(game, record.id) ?? null
   const postureChoiceOptions = allowsPostureChoice

--- a/src/features/report/reportView.ts
+++ b/src/features/report/reportView.ts
@@ -37,7 +37,9 @@ export function getReportPageView(game: GameState): ReportPageView {
     `${agencySummary.name}: reputation ${agencySummary.reputation}, ` +
     `pressure ${agencySummary.pressure.score} (${agencySummary.pressure.level}), ` +
     `rival pressure ${agencySummary.rivalPressure.score} (${agencySummary.rivalPressure.band}; ` +
-    `trust-failure drift ${agencySummary.rivalPressure.trustFailureDriftScale}×), ` +
+    `trust-failure drift ${agencySummary.rivalPressure.trustFailureDriftScale}×; ` +
+    `post-exposure ${agencySummary.rivalPressure.postExposurePosture} ` +
+    `${agencySummary.rivalPressure.postExposureTrustDelta > 0 ? '+' : ''}${agencySummary.rivalPressure.postExposureTrustDelta}), ` +
     `stability ${agencySummary.stability.score} (${agencySummary.stability.level}), ` +
     `chokepoint leverage ${agencySummary.chokepointLeverage}, ` +
     `council power [${councilPower}], ` +

--- a/src/test/publicDisclosureCampaignView.test.ts
+++ b/src/test/publicDisclosureCampaignView.test.ts
@@ -142,4 +142,57 @@ describe('publicDisclosureCampaignView (SPE-861 slice 1)', () => {
     expect(adjusted.records[0]?.selectedPostureChoiceLabel).toBe('Transparent posture')
     expect(adjusted.summary.cooperationBandLabel).toBe('Watchful compliance')
   })
+
+  it('aligns campaign regional bands with standing-shaped post-exposure trust (SPE-2701)', () => {
+    const game = createStartingState()
+    game.publicDisclosureRecords = {
+      [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE,
+    }
+    game.reports = [
+      {
+        week: 1,
+        rngStateBefore: 1,
+        rngStateAfter: 2,
+        newCases: [],
+        progressedCases: [],
+        resolvedCases: Array.from({ length: 10 }, (_, index) => `resolved-a-${index}`),
+        failedCases: [],
+        partialCases: [],
+        unresolvedTriggers: [],
+        spawnedCases: [],
+        maxStage: 1,
+        avgFatigue: 0,
+        teamStatus: [],
+        notes: [],
+      },
+      {
+        week: 2,
+        rngStateBefore: 2,
+        rngStateAfter: 3,
+        newCases: [],
+        progressedCases: [],
+        resolvedCases: Array.from({ length: 10 }, (_, index) => `resolved-b-${index}`),
+        failedCases: [],
+        partialCases: [],
+        unresolvedTriggers: [],
+        spawnedCases: [],
+        maxStage: 1,
+        avgFatigue: 0,
+        teamStatus: [],
+        notes: [],
+      },
+    ]
+
+    const view = getPublicDisclosureCampaignView(game)
+    const coastal = view.records[0]?.regionalBandViews.find(
+      (entry) => entry.regionLabel === 'Coastal Metro'
+    )
+    const coastalChip = view.summary.segmentTrustChips.find(
+      (entry) => entry.segmentLabel === 'Coastal Metro'
+    )
+
+    expect(view.summary.cooperationBandLabel).toBe('Watchful compliance')
+    expect(coastal?.trustBandLabel).toBe('Moderate')
+    expect(coastalChip?.trustBandLabel).toBe('Moderate')
+  })
 })

--- a/src/test/publicDisclosureSegmentedTrustOutcomeProjection.test.ts
+++ b/src/test/publicDisclosureSegmentedTrustOutcomeProjection.test.ts
@@ -143,4 +143,21 @@ describe('publicDisclosureSegmentedTrustOutcomeProjection (SPE-861 slice 3)', ()
 
     expect(first).toBe(second)
   })
+
+  it('applies post-exposure trust delta to segment bands (SPE-2701)', () => {
+    const records = { [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE }
+    const baseline = projectPublicDisclosureSegmentedTrustOutcome(records)
+    const protective = projectPublicDisclosureSegmentedTrustOutcome(records, null, {
+      postExposureTrustDelta: 0.08,
+    })
+    const coastalBaseline = baseline.segmentEntries.find(
+      (entry) => entry.segmentLabel === 'Coastal Metro'
+    )
+    const coastalProtective = protective.segmentEntries.find(
+      (entry) => entry.segmentLabel === 'Coastal Metro'
+    )
+
+    expect(coastalBaseline?.trustBandLabel).toBe('Low')
+    expect(coastalProtective?.trustBandLabel).toBe('Moderate')
+  })
 })

--- a/src/test/publicDisclosureTrustOutcomeProjection.test.ts
+++ b/src/test/publicDisclosureTrustOutcomeProjection.test.ts
@@ -80,7 +80,33 @@ describe('publicDisclosureTrustOutcomeProjection (SPE-861 slice 2)', () => {
     })
 
     expect(formatPublicDisclosureTrustOutcomeNoteContent(projection, 24)).toBe(
-      'Public disclosure trust outcome — W24: 1 active campaign(s); dominant awareness Official Disclosure; Opposed posture; Low regional trust.'
+      'Public disclosure trust outcome — W24: 1 active campaign(s); dominant awareness Official Disclosure; Opposed posture; Low regional trust; rival posture neutral (trust 0).'
+    )
+  })
+
+  it('applies standing-shaped post-exposure trust only when exposure is active (SPE-2701)', () => {
+    const records = { [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE }
+    const protective = projectPublicDisclosureTrustOutcome(records, null, {
+      postExposureTrustDelta: 0.08,
+    })
+    const coercive = projectPublicDisclosureTrustOutcome(records, null, {
+      postExposureTrustDelta: -0.08,
+    })
+    const inactive = projectPublicDisclosureTrustOutcome({}, null, {
+      postExposureTrustDelta: 0.08,
+    })
+
+    expect(protective.rivalPosture).toBe('protective')
+    expect(protective.postExposureTrustDeltaApplied).toBe(0.08)
+    expect(protective.aggregateRegionalTrustBand).toBe('moderate')
+    expect(protective.cooperationBand).toBe('watchful')
+    expect(coercive.rivalPosture).toBe('coercive')
+    expect(coercive.aggregateRegionalTrustBand).toBe('low')
+    expect(coercive.cooperationBand).toBe('opposed')
+    expect(inactive.rivalPosture).toBe('inactive')
+    expect(inactive.postExposureTrustDeltaApplied).toBe(0)
+    expect(formatPublicDisclosureTrustOutcomeNoteContent(protective, 7)).toContain(
+      'rival posture protective (trust +0.08)'
     )
   })
 

--- a/src/test/rivalPressure.test.ts
+++ b/src/test/rivalPressure.test.ts
@@ -10,6 +10,8 @@ import {
   buildRivalPressureFromRankingScore,
 } from '../domain/rivalPressure'
 import { applyAssetReliabilityDrift, createContractorAsset } from '../domain/externalSupport'
+import { DISCLOSURE_PROGRESSION_FIXTURE } from '../domain/publicDisclosureStateRegistry'
+import { projectPublicDisclosureTrustOutcome } from '../domain/publicDisclosureTrustOutcomeProjection'
 import { buildRecruitmentGenerationState } from '../domain/sim/candidateGenerator'
 import { getReportPageView } from '../features/report/reportView'
 import type { WeeklyReport } from '../domain/models'
@@ -50,19 +52,26 @@ describe('rival comparative pressure (SPE-2699)', () => {
     expect(balanced.contractRewardMultiplier).toBe(1)
     expect(balanced.recruitQualityDelta).toBe(0)
     expect(balanced.trustFailureDriftScale).toBe(1)
+    expect(balanced.postExposureTrustDelta).toBe(0)
+    expect(balanced.postExposurePosture).toBe('neutral')
     expect(Object.is(balanced.recruitQualityDelta, -0)).toBe(false)
+    expect(Object.is(balanced.postExposureTrustDelta, -0)).toBe(false)
 
     expect(weak.score).toBeGreaterThan(balanced.score)
     expect(weak.band).toBe('severe')
     expect(weak.contractRewardMultiplier).toBeLessThan(balanced.contractRewardMultiplier)
     expect(weak.recruitQualityDelta).toBeLessThan(balanced.recruitQualityDelta)
     expect(weak.trustFailureDriftScale).toBeGreaterThan(balanced.trustFailureDriftScale)
+    expect(weak.postExposureTrustDelta).toBeLessThan(balanced.postExposureTrustDelta)
+    expect(weak.postExposurePosture).toBe('coercive')
 
     expect(strong.score).toBeLessThan(balanced.score)
     expect(strong.band).toBe('suppressed')
     expect(strong.contractRewardMultiplier).toBeGreaterThan(balanced.contractRewardMultiplier)
     expect(strong.recruitQualityDelta).toBeGreaterThan(balanced.recruitQualityDelta)
     expect(strong.trustFailureDriftScale).toBeLessThan(balanced.trustFailureDriftScale)
+    expect(strong.postExposureTrustDelta).toBeGreaterThan(balanced.postExposureTrustDelta)
+    expect(strong.postExposurePosture).toBe('protective')
 
     expect(applyRivalPressureToContractScalar(1, weak)).toBeLessThan(
       applyRivalPressureToContractScalar(1, strong)
@@ -200,14 +209,64 @@ describe('rival comparative pressure (SPE-2699)', () => {
       contractRewardMultiplier: buildRivalPressure(game).contractRewardMultiplier,
       recruitQualityDelta: buildRivalPressure(game).recruitQualityDelta,
       trustFailureDriftScale: buildRivalPressure(game).trustFailureDriftScale,
+      postExposureTrustDelta: buildRivalPressure(game).postExposureTrustDelta,
+      postExposurePosture: buildRivalPressure(game).postExposurePosture,
     })
     expect(summary.rivalPressure.summary).toMatch(/Comparative pressure/)
     expect(summary.rivalPressure.summary).toMatch(/external-support failure drift/)
+    expect(summary.rivalPressure.summary).toMatch(/post-exposure rival posture/)
 
     const reportLine = getReportPageView(game).summary?.agencySummaryLine ?? ''
     expect(reportLine).toMatch(
       new RegExp(
-        `rival pressure ${summary.rivalPressure.score} \\(${summary.rivalPressure.band}; trust-failure drift ${summary.rivalPressure.trustFailureDriftScale}×\\)`
+        `rival pressure ${summary.rivalPressure.score} \\(${summary.rivalPressure.band}; trust-failure drift ${summary.rivalPressure.trustFailureDriftScale}×; post-exposure ${summary.rivalPressure.postExposurePosture} ${summary.rivalPressure.postExposureTrustDelta > 0 ? '\\+' : ''}${summary.rivalPressure.postExposureTrustDelta}\\)`
+      )
+    )
+  })
+
+  it('shifts public-disclosure cooperation after exposure by standing (SPE-2701)', () => {
+    const records = { [DISCLOSURE_PROGRESSION_FIXTURE.id]: DISCLOSURE_PROGRESSION_FIXTURE }
+    const weak = buildRivalPressureFromRankingScore(20)
+    const strong = buildRivalPressureFromRankingScore(80)
+    const baseline = projectPublicDisclosureTrustOutcome(records)
+    const weakExposure = projectPublicDisclosureTrustOutcome(records, null, {
+      postExposureTrustDelta: weak.postExposureTrustDelta,
+    })
+    const strongExposure = projectPublicDisclosureTrustOutcome(records, null, {
+      postExposureTrustDelta: strong.postExposureTrustDelta,
+    })
+    const secrecyOnly = projectPublicDisclosureTrustOutcome(
+      {
+        'disclosure:secret': {
+          ...DISCLOSURE_PROGRESSION_FIXTURE,
+          id: 'disclosure:secret',
+          awarenessLevel: 'secrecy_intact',
+        },
+      },
+      null,
+      { postExposureTrustDelta: strong.postExposureTrustDelta }
+    )
+
+    expect(weak.postExposureTrustDelta).toBeLessThan(0)
+    expect(strong.postExposureTrustDelta).toBeGreaterThan(0)
+    expect(weakExposure.postExposureTrustDeltaApplied).toBe(weak.postExposureTrustDelta)
+    expect(strongExposure.postExposureTrustDeltaApplied).toBe(strong.postExposureTrustDelta)
+    expect(weakExposure.rivalPosture).toBe('coercive')
+    expect(strongExposure.rivalPosture).toBe('protective')
+    expect(baseline.cooperationBand).toBe('opposed')
+    expect(weakExposure.cooperationBand).toBe('opposed')
+    expect(strongExposure.cooperationBand).not.toBe(weakExposure.cooperationBand)
+    expect(strongExposure.aggregateRegionalTrustBand).not.toBe(
+      weakExposure.aggregateRegionalTrustBand
+    )
+    expect(secrecyOnly.activeCampaignCount).toBe(0)
+    expect(secrecyOnly.postExposureTrustDeltaApplied).toBe(0)
+    expect(secrecyOnly.rivalPosture).toBe('inactive')
+    expect(JSON.stringify(weakExposure)).toBe(
+      JSON.stringify(
+        projectPublicDisclosureTrustOutcome(records, null, {
+          postExposureTrustDelta: weak.postExposureTrustDelta,
+        })
       )
     )
   })

--- a/systems/factions-legitimacy.md
+++ b/systems/factions-legitimacy.md
@@ -313,10 +313,12 @@ Examples:
 - weakness may embolden interference
 - successful intervention may change power posture in a region or district
 
-**Implemented hooks (SPE-2699 / SPE-2700):** ranking-derived comparative pressure (`buildRivalPressure`)
-adjusts contract payout scalars and recruit quality deltas, and scales negative external-support
-reliability drift (standing-shaped forgiveness). Abstract peer baseline only — no per-rival squad
-simulation. Standing award math remains separate.
+**Implemented hooks (SPE-2699 / SPE-2700 / SPE-2701):** ranking-derived comparative pressure
+(`buildRivalPressure`) adjusts contract payout scalars and recruit quality deltas, scales negative
+external-support reliability drift (standing-shaped forgiveness), and after public disclosure
+exposure applies a protective/coercive `postExposureTrustDelta` into regional trust → cooperation
+bands. Abstract peer baseline only — no per-rival squad simulation. Standing award math remains
+separate.
 
 ---
 

--- a/systems/hub-simulation.md
+++ b/systems/hub-simulation.md
@@ -164,8 +164,11 @@ Comparative rival pressure is a separate **read-time** derivation from agency ra
 an abstract peer baseline (`src/domain/rivalPressure.ts`). It does not mutate standing awards. Weak
 comparative rank compresses contract reward scalars and recruit overall quality; strong rank eases
 both. The same pressure also scales **negative** external-support reliability drift (SPE-93): high
-standing softens trust collapse after weak outputs; low standing accelerates it. Agency overview and
-report summary lines expose the pressure band and forgiveness scale for legibility.
+standing softens trust collapse after weak outputs; low standing accelerates it. After public
+disclosure exposure (awareness ≠ secrecy-intact), ranking also supplies a bounded
+`postExposureTrustDelta` into regional trust → cooperation bands: high standing is protective, low
+standing is coercive. Agency overview and report summary lines expose the pressure band, forgiveness
+scale, and post-exposure posture for legibility.
 
 ### Stage B — Build hub opportunity pools
 


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2701 — https://linear.app/spectranoir/issue/SPE-2701/spe-39-protective-coercive-rival-posture-after-public-exposure
- **Parent issue (if any):** SPE-39 — https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Read-time `postExposureTrustDelta` / `postExposurePosture` on `buildRivalPressure` (protective high standing, coercive low standing)
- Apply delta only when public-disclosure awareness is active into regional trust → cooperation bands
- Agency + report summary + disclosure trust-outcome notes expose the posture signal
- Week-close notes pass ranking-derived delta via `buildRivalPressure`

## Docs updated

- `systems/hub-simulation.md`
- `systems/factions-legitimacy.md`
- `planning/spe-2701-post-exposure-rival-posture-slice.md`

## Parent status

- Parent SPE-39 remains **Backlog** — liaison packets and hidden-cell interference still open; this closes the post-exposure half of the forgiveness/post-exposure AC (forgiveness shipped in SPE-2700)

## Scope boundary

- Does not reopen SPE-2696/2697 standing awards
- Does not change SPE-2699 contract/recruit multiplier formulas
- Does not change SPE-2700 `trustFailureDriftScale` formula
- No rival expedition / per-rival squad sim; no new persisted fields / SCHEMA_REGISTRY

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/rivalPressure.test.ts src/test/publicDisclosureTrustOutcomeProjection.test.ts src/test/publicDisclosurePostureChoice.test.ts src/test/agency.test.ts`
- [x] Lint / verify: `npm run lint`

## Follow-ups

- Cross-jurisdiction coordination packets (SPE-39 + SPE-854)
- Hidden-cell strategic interference (SPE-39 child)
- Legitimacy fallout tick standing scale (alternate surface)

## Linear updated

- [x] Slice issue linked in this PR body
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)

Made with [Cursor](https://cursor.com)