### PR TITLE
SPE-2706: Hidden-cell strategic interference (research rollback)

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -87,6 +87,7 @@ Documents the versioned serialization format for the full game store state.
 - Older payloads are migrated forward via `migratePersistedStore`
 - Missing or unrecognised version causes fallback to a fresh store
 - Optional `MissionRewardBreakdown.agencyStanding` on case-outcome event payloads and weekly `caseSnapshots` is sanitized by `sanitizeMissionRewardBreakdownSnapshot` / `sanitizeAgencyStandingAward` (SPE-2696 / SPE-2697); missing awards stay legacy-compatible
+- Optional `ResearchState.lastHiddenCellRollbackWeek` / `lastHiddenCellRollbackProjectId` / `lastHiddenCellRollbackAmount` (SPE-2706) are sanitized in `sanitizeResearchState`; missing markers stay legacy-compatible (no rollback applied for that load)
 
 ---
 

--- a/docs/research-system-audit.md
+++ b/docs/research-system-audit.md
@@ -95,5 +95,5 @@ research-progress rollback through `src/domain/hiddenCellStrategicInterference.t
 
 ### Summary
 - **Files created:** `docs/research-system-audit.md`
-- **Runtime code changed:** No
-- **Overlap risks:** None; documentation-only, no symbol or logic changes, no test edits.
+- **Runtime code changed:** Yes (SPE-2706 research-rollback interference path; see §11)
+- **Overlap risks:** Hidden-cell rollback composes rival pressure only; does not merge research with funding or detection systems.

--- a/docs/research-system-audit.md
+++ b/docs/research-system-audit.md
@@ -73,7 +73,18 @@ Research is the **canonical unlock path**, not a flat tech tree checkbox.
 - Unclear prerequisites or unlocks.
 - Overlapping unlocks with other systems (gear, training, facilities).
 
-## 11. Open Questions
+## 11. Hidden-cell research rollback (SPE-2706 / SPE-39)
+
+When rival-pressure band is `competitive` or `severe`, week-close may apply one bounded
+research-progress rollback through `src/domain/hiddenCellStrategicInterference.ts`:
+
+- Target: lex-min `activeProjectIds` entry with `progressTime > 0` (never completed projects)
+- Amount: deterministic 1–2 weeks of `progressTime`, clamped to available progress
+- Idempotency: `ResearchState.lastHiddenCellRollbackWeek` (+ project id / amount markers)
+- Player-facing: `agency.hidden_cell_interference` note with `kind: research_rollback`
+- Independent of SPE-2704 funding theft; does not un-complete finished research
+
+## 12. Open Questions
 - Should research be cancelable or only pausable?
 - How are hybrid (occult + technical) projects handled for slot allocation?
 - Can research be accelerated by staff assignment or only by facilities?

--- a/planning/spe-2706-hidden-cell-research-rollback-slice.md
+++ b/planning/spe-2706-hidden-cell-research-rollback-slice.md
@@ -1,0 +1,56 @@
+# SPE-2706 — Hidden-cell strategic interference (research rollback)
+
+**Linear:** [SPE-2706](https://linear.app/spectranoir/issue/SPE-2706/spe-39-hidden-cell-strategic-interference-research-rollback)  
+**Parent:** [SPE-39](https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer) (stays **Backlog**/open after merge)  
+**Branch:** `jamesdyedbq/spe-2706-spe-39-hidden-cell-strategic-interference-research-rollback`  
+**Base:** `main` @ `27a31742b8bc925072439770c68d525917d8ad86`
+
+## Goal
+
+One deterministic bounded hidden-cell interference path from abstract rival/hidden-cell pressure into the existing **research/progression** surface (research rollback), with a player-legible week-close note — closes parent SPE-39 residual for XCOM-style research sabotage without a full adversary org sim or detection layer.
+
+## Acceptance (this slice)
+
+- [x] Identical ranking/pressure + research progress inputs → identical rollback outcome
+- [x] No research rollback when cell pressure inactive (rival band suppressed/balanced)
+- [x] Active path reduces bounded `progressTime` on a deterministically selected active project; idempotent per closed week
+- [x] Does not un-complete finished projects; rollback reversible-friendly (progress only)
+- [x] Weekly report note + agency/report summary expose a legible interference signal
+- [x] SPE-2704 funding-theft path unchanged for the same pressure + funding inputs
+- [x] SPE-2699–2705 rival-pressure formula outputs unchanged for same ranking inputs
+- [x] Detection / scans / covert confrontation ops out of slice
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Domain | `src/domain/hiddenCellStrategicInterference.ts` — reuse cell-pressure gate; research rollback resolve + apply |
+| Research state | `ResearchState` active project `progressTime`; optional `lastHiddenCellRollbackWeek` for idempotency |
+| Week-close | `advanceWeek` after SPE-2704 funding theft |
+| Week-close notes | `hiddenCellInterferenceWeeklyReportNotes` — `agency.hidden_cell_interference` with `kind: research_rollback` |
+| Agency / UI | `buildAgencySummary`, `reportView` summary line |
+| Docs | `systems/hub-simulation.md`, `docs/research-system-audit.md` |
+| Tests | `src/test/hiddenCellStrategicInterference.test.ts` |
+
+Cell pressure active when rival-pressure band is `competitive` or `severe`. Target = lex-min active project id with `progressTime > 0`. Rollback amount scales from pressure score (1–2 weeks). Inactive bands or no eligible progress → no effect.
+
+## Out of scope
+
+- SPE-2699–2705 pressure / forgiveness / exposure / coordination / funding-theft / fallout-scale formula changes
+- Panic amplification, covert cell growth, infrastructure compromise
+- Cell detection / intel scans / open confrontation ops
+- Un-completing finished research
+- SPE-542 / SPE-430 rival sims
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Panic amplification / infrastructure compromise | SPE-39 child | Separate interference surfaces |
+| Covert cell growth + detection scans | SPE-39 child | Detection layer larger than research hook |
+| Optional SPE-2702 resolved×open jurisdiction sharpening | SPE-39 child | Post-merge Bugbot follow-up; not blocking |
+
+## Validation
+
+- `npm run test:run -- src/test/hiddenCellStrategicInterference.test.ts src/test/rivalPressure.test.ts src/test/research.test.ts src/test/reportNoteTypeAudit.test.ts`
+- `npm run lint`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -601,6 +601,8 @@ const REPORT_NOTE_METADATA_ALLOWLIST: Partial<Record<ReportNoteType, readonly st
   'agency.hidden_cell_interference': [
     'kind',
     'fundingStolen',
+    'progressTimeRolledBack',
+    'researchProjectId',
     'rivalPressureBand',
     'rivalPressureScore',
     'week',
@@ -6556,6 +6558,22 @@ function sanitizeResearchState(
 
   const base = fallback ?? createInitialResearchState()
 
+  const lastHiddenCellRollbackWeek =
+    typeof value.lastHiddenCellRollbackWeek === 'number' &&
+    Number.isFinite(value.lastHiddenCellRollbackWeek)
+      ? clamp(Math.round(value.lastHiddenCellRollbackWeek), 1, campaignWeek)
+      : undefined
+  const lastHiddenCellRollbackProjectId =
+    typeof value.lastHiddenCellRollbackProjectId === 'string' &&
+    value.lastHiddenCellRollbackProjectId.trim().length > 0
+      ? value.lastHiddenCellRollbackProjectId.trim()
+      : undefined
+  const lastHiddenCellRollbackAmount =
+    typeof value.lastHiddenCellRollbackAmount === 'number' &&
+    Number.isFinite(value.lastHiddenCellRollbackAmount)
+      ? clamp(Math.round(value.lastHiddenCellRollbackAmount), 0, 2)
+      : undefined
+
   const sanitized = stripUndefinedFields({
     projects: filterResearchProjectPrerequisiteIds(projects),
     activeProjectIds: [],
@@ -6592,6 +6610,11 @@ function sanitizeResearchState(
       0,
       MAX_RESEARCH_POOL
     ),
+    ...(lastHiddenCellRollbackWeek !== undefined ? { lastHiddenCellRollbackWeek } : {}),
+    ...(lastHiddenCellRollbackProjectId !== undefined
+      ? { lastHiddenCellRollbackProjectId }
+      : {}),
+    ...(lastHiddenCellRollbackAmount !== undefined ? { lastHiddenCellRollbackAmount } : {}),
   }) as ResearchState
 
   const reconciled = applyHydratedFacilityResearchScalars(

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -6573,6 +6573,12 @@ function sanitizeResearchState(
     Number.isFinite(value.lastHiddenCellRollbackAmount)
       ? clamp(Math.round(value.lastHiddenCellRollbackAmount), 0, 2)
       : undefined
+  // SPE-2706: all-or-nothing markers — incomplete triad must not lock a week without a note.
+  const hasCompleteRollbackMarkers =
+    lastHiddenCellRollbackWeek !== undefined &&
+    lastHiddenCellRollbackProjectId !== undefined &&
+    lastHiddenCellRollbackAmount !== undefined &&
+    lastHiddenCellRollbackAmount > 0
 
   const sanitized = stripUndefinedFields({
     projects: filterResearchProjectPrerequisiteIds(projects),
@@ -6610,11 +6616,13 @@ function sanitizeResearchState(
       0,
       MAX_RESEARCH_POOL
     ),
-    ...(lastHiddenCellRollbackWeek !== undefined ? { lastHiddenCellRollbackWeek } : {}),
-    ...(lastHiddenCellRollbackProjectId !== undefined
-      ? { lastHiddenCellRollbackProjectId }
+    ...(hasCompleteRollbackMarkers
+      ? {
+          lastHiddenCellRollbackWeek,
+          lastHiddenCellRollbackProjectId,
+          lastHiddenCellRollbackAmount,
+        }
       : {}),
-    ...(lastHiddenCellRollbackAmount !== undefined ? { lastHiddenCellRollbackAmount } : {}),
   }) as ResearchState
 
   const reconciled = applyHydratedFacilityResearchScalars(

--- a/src/domain/hiddenCellInterferenceWeeklyReportNotes.ts
+++ b/src/domain/hiddenCellInterferenceWeeklyReportNotes.ts
@@ -1,20 +1,35 @@
 /**
- * SPE-2704: weekly report notes for hidden-cell strategic interference (funding theft).
+ * SPE-2704 / SPE-2706: weekly report notes for hidden-cell strategic interference.
  *
- * Emits notes from applied fundingHistory theft entries — no new GameState persistence.
+ * Emits notes from applied fundingHistory theft and research-rollback markers —
+ * no parallel persistence beyond those existing surfaces.
  */
 
 import {
   findHiddenCellFundingTheftAmountForWeek,
+  findHiddenCellResearchRollbackAmountForWeek,
+  findHiddenCellResearchRollbackProjectIdForWeek,
   resolveHiddenCellFundingTheftFromPressure,
+  resolveHiddenCellResearchRollbackFromPressure,
   type HiddenCellInterferenceEffect,
+  type HiddenCellResearchRollbackEffect,
 } from './hiddenCellStrategicInterference'
-import type { FundingState, ReportNote } from './models'
+import type { FundingState, ReportNote, ResearchState } from './models'
 import { createDeterministicReportNote } from './reportNotes'
 import type { RivalPressureView } from './rivalPressure'
 
 export function formatHiddenCellInterferenceNoteContent(
   effect: Pick<HiddenCellInterferenceEffect, 'summary' | 'fundingStolen' | 'rivalPressureBand'>,
+  week: number
+): string {
+  return `Week ${week} — ${effect.summary}`
+}
+
+export function formatHiddenCellResearchRollbackNoteContent(
+  effect: Pick<
+    HiddenCellResearchRollbackEffect,
+    'summary' | 'progressTimeRolledBack' | 'rivalPressureBand' | 'targetProjectId'
+  >,
   week: number
 ): string {
   return `Week ${week} — ${effect.summary}`
@@ -56,6 +71,75 @@ export function buildWeeklyHiddenCellInterferenceReportNotes(input: {
         fundingStolen: effect.fundingStolen,
         rivalPressureBand: effect.rivalPressureBand,
         rivalPressureScore: effect.rivalPressureScore,
+        week: input.week,
+      }
+    ),
+  ]
+}
+
+/** Builds weekly report notes when hidden-cell research rollback was applied for the closed week. */
+export function buildWeeklyHiddenCellResearchRollbackReportNotes(input: {
+  researchState: ResearchState | null | undefined
+  rivalPressure: Pick<RivalPressureView, 'score' | 'band'>
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const appliedAmount = findHiddenCellResearchRollbackAmountForWeek(
+    input.researchState ?? undefined,
+    input.week
+  )
+  const projectId = findHiddenCellResearchRollbackProjectIdForWeek(
+    input.researchState ?? undefined,
+    input.week
+  )
+  if (appliedAmount <= 0 || !projectId) {
+    return []
+  }
+
+  const effect = resolveHiddenCellResearchRollbackFromPressure(
+    input.rivalPressure,
+    input.researchState ?? undefined
+  )
+
+  // After apply, progress is already reduced — rebuild summary from applied markers.
+  const noteEffect: Pick<
+    HiddenCellResearchRollbackEffect,
+    | 'summary'
+    | 'progressTimeRolledBack'
+    | 'rivalPressureBand'
+    | 'targetProjectId'
+    | 'kind'
+    | 'rivalPressureScore'
+    | 'active'
+    | 'baseRollbackAmount'
+  > = {
+    active: true,
+    kind: 'research_rollback',
+    rivalPressureScore: input.rivalPressure.score,
+    rivalPressureBand: input.rivalPressure.band,
+    baseRollbackAmount: effect.baseRollbackAmount,
+    progressTimeRolledBack: appliedAmount,
+    targetProjectId: projectId,
+    summary:
+      `Hidden-cell interference rolled back ${appliedAmount} week` +
+      `${appliedAmount === 1 ? '' : 's'} of research on ${projectId} ` +
+      `(${input.rivalPressure.band} cell pressure; strategic sabotage before open confrontation).`,
+  }
+
+  return [
+    createDeterministicReportNote(
+      formatHiddenCellResearchRollbackNoteContent(noteEffect, input.week),
+      input.week,
+      input.sequenceStart,
+      input.baseTimestamp,
+      'agency.hidden_cell_interference',
+      {
+        kind: 'research_rollback',
+        progressTimeRolledBack: appliedAmount,
+        researchProjectId: projectId,
+        rivalPressureBand: input.rivalPressure.band,
+        rivalPressureScore: input.rivalPressure.score,
         week: input.week,
       }
     ),

--- a/src/domain/hiddenCellStrategicInterference.ts
+++ b/src/domain/hiddenCellStrategicInterference.ts
@@ -330,11 +330,17 @@ export function hasHiddenCellResearchRollbackForWeek(
   researchState: ResearchState | undefined,
   closedWeek: number
 ): boolean {
-  if (!researchState || researchState.lastHiddenCellRollbackWeek === undefined) {
+  if (!researchState) {
     return false
   }
 
-  return researchState.lastHiddenCellRollbackWeek === Math.max(1, Math.trunc(closedWeek))
+  const week = Math.max(1, Math.trunc(closedWeek))
+  return (
+    researchState.lastHiddenCellRollbackWeek === week &&
+    typeof researchState.lastHiddenCellRollbackProjectId === 'string' &&
+    researchState.lastHiddenCellRollbackProjectId.length > 0 &&
+    Math.max(0, Math.trunc(researchState.lastHiddenCellRollbackAmount ?? 0)) > 0
+  )
 }
 
 /**

--- a/src/domain/hiddenCellStrategicInterference.ts
+++ b/src/domain/hiddenCellStrategicInterference.ts
@@ -1,14 +1,16 @@
 /**
- * SPE-2704 / SPE-39: bounded hidden-cell strategic interference (funding theft).
+ * SPE-2704 / SPE-2706 / SPE-39: bounded hidden-cell strategic interference.
  *
- * Derives cell-pressure activity from rival-pressure band and applies one
- * deterministic funding-theft expense through existing FundingState history.
+ * Derives cell-pressure activity from rival-pressure band and applies:
+ * - funding theft (SPE-2704) through existing FundingState history
+ * - research rollback (SPE-2706) against active ResearchState progress
+ *
  * No per-cell entities; no detection layer.
  */
 
 import { applyFundingExpense, recomputeBudgetPressure } from './funding'
 import { clamp } from './math'
-import type { FundingState, GameState } from './models'
+import type { FundingState, GameState, ResearchState } from './models'
 import {
   buildRivalPressure,
   buildRivalPressureFromRankingScore,
@@ -19,7 +21,7 @@ import {
 export const HIDDEN_CELL_FUNDING_THEFT_REASON = 'hidden_cell_funding_theft'
 export const HIDDEN_CELL_FUNDING_THEFT_SOURCE_ID = 'hidden-cell-funding-theft'
 
-export type HiddenCellInterferenceKind = 'funding_theft' | 'none'
+export type HiddenCellInterferenceKind = 'funding_theft' | 'research_rollback' | 'none'
 
 export interface HiddenCellInterferenceEffect {
   readonly active: boolean
@@ -33,10 +35,25 @@ export interface HiddenCellInterferenceEffect {
   readonly summary: string
 }
 
+export interface HiddenCellResearchRollbackEffect {
+  readonly active: boolean
+  readonly kind: HiddenCellInterferenceKind
+  readonly rivalPressureScore: number
+  readonly rivalPressureBand: RivalPressureBand
+  /** Base rollback weeks before progress clamp (0 when inactive). */
+  readonly baseRollbackAmount: number
+  /** Applied progressTime reduction (0 when inactive or no eligible progress). */
+  readonly progressTimeRolledBack: number
+  readonly targetProjectId: string | null
+  readonly summary: string
+}
+
 export interface HiddenCellInterferenceSummary {
   readonly active: boolean
   readonly kind: HiddenCellInterferenceKind
   readonly fundingStolen: number
+  readonly progressTimeRolledBack: number
+  readonly researchProjectId: string | null
   readonly rivalPressureBand: RivalPressureBand
   readonly summary: string
 }
@@ -61,7 +78,22 @@ export function computeHiddenCellFundingTheftBaseAmount(
   return clamp(Math.round((clamp(Math.round(score), 0, 100) - 50) * 1.5), 1, 120)
 }
 
-function buildInterferenceSummary(input: {
+/**
+ * Base research-rollback weeks from rival pressure score alone (progress clamp applied separately).
+ * Inactive bands → 0. Active: 1–2 weeks above peer-balanced pressure floor.
+ */
+export function computeHiddenCellResearchRollbackBaseAmount(
+  score: number,
+  band: RivalPressureBand
+): number {
+  if (!isHiddenCellPressureActive(band)) {
+    return 0
+  }
+
+  return clamp(Math.round((clamp(Math.round(score), 0, 100) - 50) / 25), 1, 2)
+}
+
+function buildFundingInterferenceSummary(input: {
   active: boolean
   band: RivalPressureBand
   fundingStolen: number
@@ -81,6 +113,62 @@ function buildInterferenceSummary(input: {
   return (
     `Hidden-cell interference diverted ${input.fundingStolen} funding ` +
     `(${input.band} cell pressure; strategic theft before open confrontation).`
+  )
+}
+
+function buildResearchRollbackSummary(input: {
+  active: boolean
+  band: RivalPressureBand
+  progressTimeRolledBack: number
+  baseRollbackAmount: number
+  targetProjectId: string | null
+}): string {
+  if (!input.active) {
+    return `Hidden-cell research interference inactive (${input.band}): no research rollback this week.`
+  }
+
+  if (input.progressTimeRolledBack <= 0 || !input.targetProjectId) {
+    return (
+      `Hidden-cell research interference active (${input.band}): research rollback blocked ` +
+      `(no eligible active progress; base claim ${input.baseRollbackAmount} week` +
+      `${input.baseRollbackAmount === 1 ? '' : 's'}).`
+    )
+  }
+
+  return (
+    `Hidden-cell interference rolled back ${input.progressTimeRolledBack} week` +
+    `${input.progressTimeRolledBack === 1 ? '' : 's'} of research on ${input.targetProjectId} ` +
+    `(${input.band} cell pressure; strategic sabotage before open confrontation).`
+  )
+}
+
+function composeInterferenceSummary(input: {
+  active: boolean
+  band: RivalPressureBand
+  fundingStolen: number
+  progressTimeRolledBack: number
+  researchProjectId: string | null
+  fundingSummary: string
+  researchSummary: string
+}): string {
+  if (!input.active) {
+    return `Hidden-cell interference inactive (${input.band}): no strategic diversion this week.`
+  }
+
+  const parts: string[] = []
+  if (input.fundingStolen > 0) {
+    parts.push(input.fundingSummary)
+  }
+  if (input.progressTimeRolledBack > 0 && input.researchProjectId) {
+    parts.push(input.researchSummary)
+  }
+
+  if (parts.length > 0) {
+    return parts.join(' ')
+  }
+
+  return (
+    `Hidden-cell interference active (${input.band}): no funding or research diversion applied this week.`
   )
 }
 
@@ -108,7 +196,7 @@ export function resolveHiddenCellFundingTheft(input: {
     rivalPressureBand,
     baseTheftAmount,
     fundingStolen,
-    summary: buildInterferenceSummary({
+    summary: buildFundingInterferenceSummary({
       active,
       band: rivalPressureBand,
       fundingStolen,
@@ -136,6 +224,91 @@ export function resolveHiddenCellFundingTheftFromRankingScore(
   return resolveHiddenCellFundingTheftFromPressure(pressure, funding)
 }
 
+/**
+ * Lex-min active project id with progressTime > 0 (deterministic target selection).
+ * Completed projects are never selected.
+ */
+export function selectHiddenCellResearchRollbackTarget(
+  researchState: ResearchState | undefined
+): string | null {
+  if (!researchState) {
+    return null
+  }
+
+  const eligible = researchState.activeProjectIds
+    .filter((projectId) => {
+      const project = researchState.projects[projectId]
+      return (
+        Boolean(project) &&
+        project.status === 'active' &&
+        Math.max(0, Math.trunc(project.progressTime ?? 0)) > 0
+      )
+    })
+    .sort((left, right) => left.localeCompare(right))
+
+  return eligible[0] ?? null
+}
+
+/** Pure resolve: identical pressure + research inputs → identical rollback effect. */
+export function resolveHiddenCellResearchRollback(input: {
+  rivalPressureScore: number
+  rivalPressureBand: RivalPressureBand
+  researchState: ResearchState | undefined
+}): HiddenCellResearchRollbackEffect {
+  const rivalPressureScore = clamp(Math.round(input.rivalPressureScore), 0, 100)
+  const rivalPressureBand = input.rivalPressureBand
+  const active = isHiddenCellPressureActive(rivalPressureBand)
+  const baseRollbackAmount = computeHiddenCellResearchRollbackBaseAmount(
+    rivalPressureScore,
+    rivalPressureBand
+  )
+  const targetProjectId = active ? selectHiddenCellResearchRollbackTarget(input.researchState) : null
+  const availableProgress =
+    targetProjectId && input.researchState
+      ? Math.max(0, Math.trunc(input.researchState.projects[targetProjectId]?.progressTime ?? 0))
+      : 0
+  const progressTimeRolledBack =
+    active && targetProjectId ? Math.min(availableProgress, baseRollbackAmount) : 0
+  const kind: HiddenCellInterferenceKind =
+    progressTimeRolledBack > 0 ? 'research_rollback' : 'none'
+
+  return {
+    active,
+    kind,
+    rivalPressureScore,
+    rivalPressureBand,
+    baseRollbackAmount,
+    progressTimeRolledBack,
+    targetProjectId: progressTimeRolledBack > 0 ? targetProjectId : null,
+    summary: buildResearchRollbackSummary({
+      active,
+      band: rivalPressureBand,
+      progressTimeRolledBack,
+      baseRollbackAmount,
+      targetProjectId: progressTimeRolledBack > 0 ? targetProjectId : null,
+    }),
+  }
+}
+
+export function resolveHiddenCellResearchRollbackFromPressure(
+  pressure: Pick<RivalPressureView, 'score' | 'band'>,
+  researchState: ResearchState | undefined
+): HiddenCellResearchRollbackEffect {
+  return resolveHiddenCellResearchRollback({
+    rivalPressureScore: pressure.score,
+    rivalPressureBand: pressure.band,
+    researchState,
+  })
+}
+
+export function resolveHiddenCellResearchRollbackFromRankingScore(
+  rankingScore: number,
+  researchState: ResearchState | undefined
+): HiddenCellResearchRollbackEffect {
+  const pressure = buildRivalPressureFromRankingScore(rankingScore)
+  return resolveHiddenCellResearchRollbackFromPressure(pressure, researchState)
+}
+
 export function hasHiddenCellFundingTheftForWeek(
   fundingState: FundingState | undefined,
   closedWeek: number
@@ -151,6 +324,17 @@ export function hasHiddenCellFundingTheftForWeek(
       entry.reason === HIDDEN_CELL_FUNDING_THEFT_REASON &&
       entry.sourceId === HIDDEN_CELL_FUNDING_THEFT_SOURCE_ID
   )
+}
+
+export function hasHiddenCellResearchRollbackForWeek(
+  researchState: ResearchState | undefined,
+  closedWeek: number
+): boolean {
+  if (!researchState || researchState.lastHiddenCellRollbackWeek === undefined) {
+    return false
+  }
+
+  return researchState.lastHiddenCellRollbackWeek === Math.max(1, Math.trunc(closedWeek))
 }
 
 /**
@@ -184,20 +368,95 @@ export function applyHiddenCellFundingTheftToFundingState(
   }
 }
 
-/** Read-time summary for agency/report surfaces from current ranking pressure + funding. */
+/**
+ * Apply research rollback to ResearchState once per closed week.
+ * Progress-only: never un-completes projects; clamps to available progressTime.
+ */
+export function applyHiddenCellResearchRollbackToResearchState(
+  state: ResearchState,
+  effect: HiddenCellResearchRollbackEffect,
+  closedWeek: number
+): {
+  state: ResearchState
+  appliedAmount: number
+  effect: HiddenCellResearchRollbackEffect
+} {
+  const week = Math.max(1, Math.trunc(closedWeek))
+
+  if (
+    effect.progressTimeRolledBack <= 0 ||
+    !effect.targetProjectId ||
+    hasHiddenCellResearchRollbackForWeek(state, week)
+  ) {
+    return { state, appliedAmount: 0, effect }
+  }
+
+  const project = state.projects[effect.targetProjectId]
+  if (!project || project.status !== 'active') {
+    return { state, appliedAmount: 0, effect }
+  }
+
+  const currentProgress = Math.max(0, Math.trunc(project.progressTime ?? 0))
+  const appliedAmount = Math.min(currentProgress, Math.max(0, Math.trunc(effect.progressTimeRolledBack)))
+  if (appliedAmount <= 0) {
+    return { state, appliedAmount: 0, effect }
+  }
+
+  return {
+    state: {
+      ...state,
+      lastHiddenCellRollbackWeek: week,
+      lastHiddenCellRollbackProjectId: effect.targetProjectId,
+      lastHiddenCellRollbackAmount: appliedAmount,
+      projects: {
+        ...state.projects,
+        [effect.targetProjectId]: {
+          ...project,
+          progressTime: currentProgress - appliedAmount,
+          lastUpdatedWeek: week,
+        },
+      },
+    },
+    appliedAmount,
+    effect,
+  }
+}
+
+/** Read-time summary for agency/report surfaces from current ranking pressure + funding + research. */
 export function buildHiddenCellInterferenceSummary(
-  game: Pick<GameState, 'reports' | 'events' | 'funding' | 'agency'>
+  game: Pick<GameState, 'reports' | 'events' | 'funding' | 'agency' | 'researchState'>
 ): HiddenCellInterferenceSummary {
   const pressure = buildRivalPressure(game)
   const funding = game.agency?.funding ?? game.funding
-  const effect = resolveHiddenCellFundingTheftFromPressure(pressure, funding)
+  const fundingEffect = resolveHiddenCellFundingTheftFromPressure(pressure, funding)
+  const researchEffect = resolveHiddenCellResearchRollbackFromPressure(pressure, game.researchState)
+  const active = fundingEffect.active
+  const fundingStolen = fundingEffect.fundingStolen
+  const progressTimeRolledBack = researchEffect.progressTimeRolledBack
+  const researchProjectId = researchEffect.targetProjectId
+  const kind: HiddenCellInterferenceKind =
+    fundingStolen > 0
+      ? 'funding_theft'
+      : progressTimeRolledBack > 0
+        ? 'research_rollback'
+        : 'none'
 
   return {
-    active: effect.active,
-    kind: effect.kind,
-    fundingStolen: effect.fundingStolen,
-    rivalPressureBand: effect.rivalPressureBand,
-    summary: effect.summary,
+    active,
+    kind,
+    fundingStolen,
+    progressTimeRolledBack,
+    researchProjectId,
+    rivalPressureBand: pressure.band,
+    summary: composeInterferenceSummary({
+      active,
+      band: pressure.band,
+      fundingStolen,
+      progressTimeRolledBack,
+      researchProjectId,
+      fundingSummary: fundingEffect.summary,
+      researchSummary: researchEffect.summary,
+    }),
   }
 }
 
@@ -223,4 +482,28 @@ export function findHiddenCellFundingTheftAmountForWeek(
   }
 
   return Math.abs(entry.delta)
+}
+
+/** Locate applied research rollback amount for a closed week (note surfacing / tests). */
+export function findHiddenCellResearchRollbackAmountForWeek(
+  researchState: ResearchState | undefined,
+  closedWeek: number
+): number {
+  if (!hasHiddenCellResearchRollbackForWeek(researchState, closedWeek)) {
+    return 0
+  }
+
+  return Math.max(0, Math.trunc(researchState?.lastHiddenCellRollbackAmount ?? 0))
+}
+
+export function findHiddenCellResearchRollbackProjectIdForWeek(
+  researchState: ResearchState | undefined,
+  closedWeek: number
+): string | null {
+  if (!hasHiddenCellResearchRollbackForWeek(researchState, closedWeek)) {
+    return null
+  }
+
+  const projectId = researchState?.lastHiddenCellRollbackProjectId
+  return typeof projectId === 'string' && projectId.length > 0 ? projectId : null
 }

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -2120,6 +2120,12 @@ export interface ResearchState {
   researchSpeedMultiplier: number
   researchDataPool: number
   researchMaterialsPool: number
+  /** SPE-2706: closed week of last applied hidden-cell research rollback (idempotency). */
+  lastHiddenCellRollbackWeek?: number
+  /** SPE-2706: project targeted by last applied research rollback. */
+  lastHiddenCellRollbackProjectId?: string
+  /** SPE-2706: progressTime weeks removed by last applied research rollback. */
+  lastHiddenCellRollbackAmount?: number
 }
 
 export type AgentAttritionStatus = 'active' | 'at_risk' | 'temporarily_unavailable' | 'lost'

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -326,11 +326,16 @@ import { applyWeeklyPublicDisclosureProgressionTick } from '../publicDisclosureW
 import { buildWeeklyPublicDisclosureTrustOutcomeReportNotes } from '../publicDisclosureTrustOutcomeWeeklyReportNotes'
 import { buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes } from '../publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes'
 import { buildWeeklyCrossJurisdictionCoordinationReportNotes } from '../crossJurisdictionCoordinationWeeklyReportNotes'
-import { buildWeeklyHiddenCellInterferenceReportNotes } from '../hiddenCellInterferenceWeeklyReportNotes'
+import {
+  buildWeeklyHiddenCellInterferenceReportNotes,
+  buildWeeklyHiddenCellResearchRollbackReportNotes,
+} from '../hiddenCellInterferenceWeeklyReportNotes'
 import {
   applyHiddenCellFundingTheftToFundingState,
+  applyHiddenCellResearchRollbackToResearchState,
   findHiddenCellFundingTheftAmountForWeek,
   resolveHiddenCellFundingTheftFromPressure,
+  resolveHiddenCellResearchRollbackFromPressure,
 } from '../hiddenCellStrategicInterference'
 import { buildRivalPressure } from '../rivalPressure'
 import { applyWeeklySelfCensoringInformationTick } from '../selfCensoringInformationWeeklyRetention'
@@ -4383,6 +4388,20 @@ function updateAgencyMetrics(
     )
   const fundingAfterHiddenCellTheft = Math.max(0, fundingStateAfterHiddenCellTheft.funding)
 
+  // SPE-2706 / SPE-39: hidden-cell research rollback (independent of funding theft).
+  const researchStateBeforeRollback = context.nextState.researchState
+  const hiddenCellResearchRollback = resolveHiddenCellResearchRollbackFromPressure(
+    rivalPressureForInterference,
+    researchStateBeforeRollback
+  )
+  const researchStateAfterHiddenCellRollback = researchStateBeforeRollback
+    ? applyHiddenCellResearchRollbackToResearchState(
+        researchStateBeforeRollback,
+        hiddenCellResearchRollback,
+        closedWeek
+      ).state
+    : researchStateBeforeRollback
+
   if (
     fundingAfterHiddenCellTheft !== context.nextState.funding ||
     nextContainmentRating !== context.nextState.containmentRating ||
@@ -4433,6 +4452,7 @@ function updateAgencyMetrics(
       containmentRating: nextContainmentRating,
       clearanceLevel: nextClearanceLevel,
       agency: nextAgency,
+      researchState: researchStateAfterHiddenCellRollback,
       reports: [...context.sourceState.reports, report],
     },
   }
@@ -5338,8 +5358,8 @@ export function advanceWeek(
     }
   }
 
-  // SPE-2704 / SPE-39: hidden-cell funding theft → weekly interference note.
-  // Funding history + report notes key off the closed week (sourceState.week), not result.week.
+  // SPE-2704 / SPE-2706 / SPE-39: hidden-cell interference → weekly notes.
+  // Funding history + research rollback markers key off the closed week (sourceState.week).
   if (result.reports.length > 0) {
     const lastWeeklyReport = result.reports[result.reports.length - 1]
     const closedWeekForInterference = sourceState.week
@@ -5350,7 +5370,7 @@ export function advanceWeek(
       closedWeekForInterference
     )
     const fundingBeforeTheft = result.funding + appliedTheft
-    const hiddenCellNotes = buildWeeklyHiddenCellInterferenceReportNotes({
+    const hiddenCellFundingNotes = buildWeeklyHiddenCellInterferenceReportNotes({
       fundingState: result.agency?.fundingState,
       rivalPressure: rivalPressureForNotes,
       fundingBeforeTheft,
@@ -5358,6 +5378,14 @@ export function advanceWeek(
       sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + 1,
       baseTimestamp: noteBaseTimestamp,
     })
+    const hiddenCellResearchNotes = buildWeeklyHiddenCellResearchRollbackReportNotes({
+      researchState: result.researchState,
+      rivalPressure: rivalPressureForNotes,
+      week: closedWeekForInterference,
+      sequenceStart: (lastWeeklyReport?.notes?.length ?? 0) + hiddenCellFundingNotes.length + 1,
+      baseTimestamp: noteBaseTimestamp,
+    })
+    const hiddenCellNotes = [...hiddenCellFundingNotes, ...hiddenCellResearchNotes]
 
     if (hiddenCellNotes.length > 0) {
       const reports = [...result.reports]

--- a/src/features/report/reportView.ts
+++ b/src/features/report/reportView.ts
@@ -43,9 +43,25 @@ export function getReportPageView(game: GameState): ReportPageView {
     `cross-jurisdiction packets ${agencySummary.crossJurisdictionCoordination.packetCount}, ` +
     `hidden-cell interference ${
       agencySummary.hiddenCellInterference.active
-        ? agencySummary.hiddenCellInterference.fundingStolen > 0
-          ? `${agencySummary.hiddenCellInterference.rivalPressureBand} theft ${agencySummary.hiddenCellInterference.fundingStolen}`
-          : `${agencySummary.hiddenCellInterference.rivalPressureBand} (no available funds)`
+        ? (() => {
+            const parts: string[] = []
+            if (agencySummary.hiddenCellInterference.fundingStolen > 0) {
+              parts.push(`theft ${agencySummary.hiddenCellInterference.fundingStolen}`)
+            }
+            if (
+              agencySummary.hiddenCellInterference.progressTimeRolledBack > 0 &&
+              agencySummary.hiddenCellInterference.researchProjectId
+            ) {
+              parts.push(
+                `research -${agencySummary.hiddenCellInterference.progressTimeRolledBack}wk ` +
+                  `(${agencySummary.hiddenCellInterference.researchProjectId})`
+              )
+            }
+            if (parts.length === 0) {
+              return `${agencySummary.hiddenCellInterference.rivalPressureBand} (no diversion)`
+            }
+            return `${agencySummary.hiddenCellInterference.rivalPressureBand} ${parts.join('; ')}`
+          })()
         : 'inactive'
     }, ` +
     `stability ${agencySummary.stability.score} (${agencySummary.stability.level}), ` +

--- a/src/test/hiddenCellStrategicInterference.test.ts
+++ b/src/test/hiddenCellStrategicInterference.test.ts
@@ -10,24 +10,36 @@ import {
 } from '../domain/funding'
 import {
   applyHiddenCellFundingTheftToFundingState,
+  applyHiddenCellResearchRollbackToResearchState,
   computeHiddenCellFundingTheftBaseAmount,
+  computeHiddenCellResearchRollbackBaseAmount,
   findHiddenCellFundingTheftAmountForWeek,
+  findHiddenCellResearchRollbackAmountForWeek,
+  findHiddenCellResearchRollbackProjectIdForWeek,
   hasHiddenCellFundingTheftForWeek,
+  hasHiddenCellResearchRollbackForWeek,
   HIDDEN_CELL_FUNDING_THEFT_REASON,
   HIDDEN_CELL_FUNDING_THEFT_SOURCE_ID,
   isHiddenCellPressureActive,
   resolveHiddenCellFundingTheft,
   resolveHiddenCellFundingTheftFromPressure,
   resolveHiddenCellFundingTheftFromRankingScore,
+  resolveHiddenCellResearchRollbackFromPressure,
+  resolveHiddenCellResearchRollbackFromRankingScore,
+  selectHiddenCellResearchRollbackTarget,
 } from '../domain/hiddenCellStrategicInterference'
-import { buildWeeklyHiddenCellInterferenceReportNotes } from '../domain/hiddenCellInterferenceWeeklyReportNotes'
+import {
+  buildWeeklyHiddenCellInterferenceReportNotes,
+  buildWeeklyHiddenCellResearchRollbackReportNotes,
+} from '../domain/hiddenCellInterferenceWeeklyReportNotes'
+import { createInitialResearchState } from '../domain/research'
 import {
   buildRivalPressureFromRankingScore,
   type RivalPressureBand,
 } from '../domain/rivalPressure'
 import { advanceWeek } from '../domain/sim/advanceWeek'
 import { getReportPageView } from '../features/report/reportView'
-import type { WeeklyReport } from '../domain/models'
+import type { ResearchState, WeeklyReport } from '../domain/models'
 
 function reportWithFailures(week: number, failures: number, unresolved: number): WeeklyReport {
   return {
@@ -53,7 +65,33 @@ function freezeCasesForQuietWeek(state: ReturnType<typeof createStartingState>) 
   }
 }
 
-describe('hidden-cell strategic interference (SPE-2704)', () => {
+function researchStateWithActiveProgress(input?: {
+  projectIds?: string[]
+  progressTime?: number
+}): ResearchState {
+  const projectIds = input?.projectIds ?? ['proj-b', 'proj-a']
+  const progressTime = input?.progressTime ?? 3
+  const projects: ResearchState['projects'] = {}
+  for (const projectId of projectIds) {
+    projects[projectId] = {
+      projectId,
+      status: 'active',
+      costTime: 6,
+      costData: 0,
+      costMaterials: 0,
+      progressTime,
+      unlocks: [],
+      startedWeek: 1,
+    }
+  }
+  return {
+    ...createInitialResearchState(),
+    projects,
+    activeProjectIds: [...projectIds],
+  }
+}
+
+describe('hidden-cell strategic interference (SPE-2704 / SPE-2706)', () => {
   it('gates cell pressure on competitive/severe rival bands only', () => {
     const bands: RivalPressureBand[] = ['suppressed', 'balanced', 'competitive', 'severe']
     expect(bands.map(isHiddenCellPressureActive)).toEqual([false, false, true, true])
@@ -282,6 +320,7 @@ describe('hidden-cell strategic interference (SPE-2704)', () => {
     if (state.agency) {
       state.agency.funding = 2000
     }
+    state.researchState = researchStateWithActiveProgress()
 
     const pressure = buildRivalPressureFromRankingScore(buildAgencySummary(state).ranking.score)
     expect(isHiddenCellPressureActive(pressure.band)).toBe(false)
@@ -290,10 +329,180 @@ describe('hidden-cell strategic interference (SPE-2704)', () => {
     expect(findHiddenCellFundingTheftAmountForWeek(nextState.agency?.fundingState, state.week)).toBe(
       0
     )
+    expect(
+      findHiddenCellResearchRollbackAmountForWeek(nextState.researchState, state.week)
+    ).toBe(0)
 
     const lastReport = nextState.reports[nextState.reports.length - 1]
     const interferenceNotes =
       lastReport?.notes?.filter((note) => note.type === 'agency.hidden_cell_interference') ?? []
     expect(interferenceNotes).toHaveLength(0)
+  })
+
+  it('selects lex-min active project with progress for research rollback', () => {
+    expect(selectHiddenCellResearchRollbackTarget(researchStateWithActiveProgress())).toBe('proj-a')
+    expect(
+      selectHiddenCellResearchRollbackTarget(
+        researchStateWithActiveProgress({ projectIds: ['proj-z'], progressTime: 0 })
+      )
+    ).toBeNull()
+  })
+
+  it('derives identical research-rollback outcomes for identical inputs', () => {
+    const research = researchStateWithActiveProgress({ progressTime: 4 })
+    const left = resolveHiddenCellResearchRollbackFromRankingScore(20, research)
+    const right = resolveHiddenCellResearchRollbackFromRankingScore(20, research)
+
+    expect(left).toEqual(right)
+    expect(left.active).toBe(true)
+    expect(left.kind).toBe('research_rollback')
+    expect(left.targetProjectId).toBe('proj-a')
+    expect(left.progressTimeRolledBack).toBeGreaterThan(0)
+    expect(left.summary).toMatch(/rolled back/)
+    expect(left.summary).toMatch(/proj-a/)
+  })
+
+  it('applies no research rollback when cell pressure is inactive', () => {
+    const research = researchStateWithActiveProgress()
+    const balanced = resolveHiddenCellResearchRollbackFromRankingScore(50, research)
+    const suppressed = resolveHiddenCellResearchRollbackFromRankingScore(80, research)
+
+    expect(balanced.active).toBe(false)
+    expect(balanced.progressTimeRolledBack).toBe(0)
+    expect(balanced.kind).toBe('none')
+    expect(suppressed.active).toBe(false)
+    expect(suppressed.progressTimeRolledBack).toBe(0)
+  })
+
+  it('clamps research rollback to available progressTime and never un-completes', () => {
+    const research = researchStateWithActiveProgress({
+      projectIds: ['proj-a'],
+      progressTime: 1,
+    })
+    const effect = resolveHiddenCellResearchRollbackFromRankingScore(10, research)
+    expect(effect.baseRollbackAmount).toBeGreaterThanOrEqual(1)
+    expect(effect.progressTimeRolledBack).toBe(1)
+
+    const applied = applyHiddenCellResearchRollbackToResearchState(research, effect, 5)
+    expect(applied.appliedAmount).toBe(1)
+    expect(applied.state.projects['proj-a']?.progressTime).toBe(0)
+    expect(applied.state.projects['proj-a']?.status).toBe('active')
+    expect(applied.state.completedProjectIds).not.toContain('proj-a')
+  })
+
+  it('applies research rollback idempotently once per closed week', () => {
+    const research = researchStateWithActiveProgress({ progressTime: 4 })
+    const effect = resolveHiddenCellResearchRollbackFromRankingScore(15, research)
+
+    const first = applyHiddenCellResearchRollbackToResearchState(research, effect, 3)
+    expect(first.appliedAmount).toBe(effect.progressTimeRolledBack)
+    expect(first.state.projects['proj-a']?.progressTime).toBe(4 - effect.progressTimeRolledBack)
+    expect(hasHiddenCellResearchRollbackForWeek(first.state, 3)).toBe(true)
+    expect(findHiddenCellResearchRollbackAmountForWeek(first.state, 3)).toBe(effect.progressTimeRolledBack)
+    expect(findHiddenCellResearchRollbackProjectIdForWeek(first.state, 3)).toBe('proj-a')
+
+    const second = applyHiddenCellResearchRollbackToResearchState(first.state, effect, 3)
+    expect(second.appliedAmount).toBe(0)
+    expect(second.state.projects['proj-a']?.progressTime).toBe(
+      first.state.projects['proj-a']?.progressTime
+    )
+  })
+
+  it('keeps SPE-2704 funding-theft outcomes unchanged for the same pressure + funding inputs', () => {
+    const pressure = buildRivalPressureFromRankingScore(20)
+    const fundingEffect = resolveHiddenCellFundingTheftFromPressure(pressure, 900)
+    const research = researchStateWithActiveProgress()
+    const researchEffect = resolveHiddenCellResearchRollbackFromPressure(pressure, research)
+
+    // Research path must not alter funding-theft resolve.
+    expect(fundingEffect.fundingStolen).toBe(
+      resolveHiddenCellFundingTheftFromPressure(pressure, 900).fundingStolen
+    )
+    expect(fundingEffect.kind).toBe('funding_theft')
+    expect(researchEffect.kind).toBe('research_rollback')
+    expect(computeHiddenCellResearchRollbackBaseAmount(pressure.score, pressure.band)).toBe(
+      researchEffect.baseRollbackAmount
+    )
+  })
+
+  it('builds weekly research-rollback notes only when rollback was applied', () => {
+    const pressure = buildRivalPressureFromRankingScore(20)
+    const research = researchStateWithActiveProgress({ progressTime: 4 })
+    const effect = resolveHiddenCellResearchRollbackFromPressure(pressure, research)
+    const applied = applyHiddenCellResearchRollbackToResearchState(research, effect, 2)
+
+    const notes = buildWeeklyHiddenCellResearchRollbackReportNotes({
+      researchState: applied.state,
+      rivalPressure: pressure,
+      week: 2,
+      sequenceStart: 1,
+      baseTimestamp: 1_700_000_000_000,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.type).toBe('agency.hidden_cell_interference')
+    expect(notes[0]?.content).toMatch(/rolled back/)
+    expect(notes[0]?.metadata).toMatchObject({
+      kind: 'research_rollback',
+      progressTimeRolledBack: effect.progressTimeRolledBack,
+      researchProjectId: 'proj-a',
+      rivalPressureBand: pressure.band,
+      week: 2,
+    })
+
+    const inactiveNotes = buildWeeklyHiddenCellResearchRollbackReportNotes({
+      researchState: researchStateWithActiveProgress(),
+      rivalPressure: buildRivalPressureFromRankingScore(50),
+      week: 2,
+      sequenceStart: 1,
+    })
+    expect(inactiveNotes).toHaveLength(0)
+  })
+
+  it('advanceWeek rolls back research and emits interference note under severe cell pressure', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.reports = [
+      reportWithFailures(1, 5, 4),
+      reportWithFailures(2, 5, 4),
+      reportWithFailures(3, 5, 4),
+    ]
+    state.funding = 2000
+    if (state.agency) {
+      state.agency.funding = 2000
+      state.agency.fundingState = createInitialFundingState(
+        state.config.fundingBasePerWeek,
+        state.config.fundingPerResolution,
+        state.config.fundingPenaltyPerFail,
+        state.config.fundingPenaltyPerUnresolved,
+        2000
+      )
+    }
+    state.researchState = researchStateWithActiveProgress({ progressTime: 4 })
+
+    const pressureBefore = buildRivalPressureFromRankingScore(buildAgencySummary(state).ranking.score)
+    expect(isHiddenCellPressureActive(pressureBefore.band)).toBe(true)
+    const expectedRollback = resolveHiddenCellResearchRollbackFromPressure(
+      pressureBefore,
+      state.researchState
+    ).progressTimeRolledBack
+    expect(expectedRollback).toBeGreaterThan(0)
+
+    const closedWeek = state.week
+    const nextState = advanceWeek(state)
+    expect(findHiddenCellResearchRollbackAmountForWeek(nextState.researchState, closedWeek)).toBe(
+      expectedRollback
+    )
+    expect(nextState.researchState?.projects['proj-a']?.progressTime).toBe(4 - expectedRollback)
+
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const researchNotes =
+      lastReport?.notes?.filter(
+        (note) =>
+          note.type === 'agency.hidden_cell_interference' &&
+          note.metadata?.kind === 'research_rollback'
+      ) ?? []
+    expect(researchNotes.length).toBeGreaterThanOrEqual(1)
+    expect(researchNotes[0]?.content).toMatch(/rolled back/)
   })
 })

--- a/systems/hub-simulation.md
+++ b/systems/hub-simulation.md
@@ -179,13 +179,15 @@ jurisdictions (distant reappearance), week-close emits a bounded liaison/shared-
 (`agency.cross_jurisdiction_coordination`) and agency/report summaries surface the packet count.
 Weak signature matches and same-jurisdiction reappearance do not emit a packet.
 
-Hidden-cell strategic interference is a bounded week-close funding hook
+Hidden-cell strategic interference is a bounded week-close hook
 (`src/domain/hiddenCellStrategicInterference.ts`): when rival-pressure band is competitive or
-severe, abstract cell pressure diverts a deterministic funding amount through existing
-`FundingState` history (`hidden_cell_funding_theft`). Suppressed/balanced pressure is inactive.
-Week-close emits `agency.hidden_cell_interference` when theft applies; agency/report summaries
-expose the active/inactive signal. This is not a full adversary-org sim and does not include cell
-detection.
+severe, abstract cell pressure may (1) divert a deterministic funding amount through existing
+`FundingState` history (`hidden_cell_funding_theft`) and/or (2) roll back bounded active-research
+`progressTime` on a lex-min eligible project (SPE-2706; idempotent via
+`ResearchState.lastHiddenCellRollbackWeek`). Suppressed/balanced pressure is inactive.
+Week-close emits `agency.hidden_cell_interference` when funding theft and/or research rollback
+applies; agency/report summaries expose the active/inactive signal. This is not a full
+adversary-org sim and does not include cell detection.
 
 ### Stage B — Build hub opportunity pools
 


### PR DESCRIPTION
﻿## Linear

- **Slice issue:** SPE-2706 — https://linear.app/spectranoir/issue/SPE-2706/spe-39-hidden-cell-strategic-interference-research-rollback
- **Parent issue (if any):** SPE-39 — https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Deterministic hidden-cell research rollback when rival pressure is competitive/severe
- Week-close ResearchState progressTime reduction (idempotent via lastHiddenCellRollbackWeek markers)
- agency.hidden_cell_interference note with kind research_rollback + agency/report summary
- SPE-2704 funding-theft path left unchanged for same inputs

## Docs updated

- systems/hub-simulation.md
- docs/research-system-audit.md
- SCHEMA_REGISTRY.md (ResearchState rollback markers)
- planning/spe-2706-hidden-cell-research-rollback-slice.md

## Parent status

- SPE-39 remains Backlog/open (other interference surfaces + optional SPE-2702 sharpening)

## Scope boundary

- One research-rollback interference path only; no detection/scans UX; no SPE-2699–2705 math reopen

## Validation

- [x] Targeted tests: hiddenCellStrategicInterference / rivalPressure / research / reportNoteTypeAudit
- [x] Lint / verify: npm run lint

## Follow-ups

- Panic amplification, infrastructure compromise, covert cell growth + detection
- Optional SPE-2702 resolved×open jurisdiction sharpening

## Linear updated

- [x] Slice issue linked in PR body
- [ ] PR URL on slice issue
- [ ] Post-merge comment on slice issue (what shipped + validation)
