### PR TITLE
SPE-2714: Hidden-cell strategic interference (covert cell growth + detection narrowing)

### DIFF
--- a/SCHEMA_REGISTRY.md
+++ b/SCHEMA_REGISTRY.md
@@ -90,6 +90,7 @@ Documents the versioned serialization format for the full game store state.
 - Optional `ResearchState.lastHiddenCellRollbackWeek` / `lastHiddenCellRollbackProjectId` / `lastHiddenCellRollbackAmount` (SPE-2706) are sanitized in `sanitizeResearchState`; missing markers stay legacy-compatible (no rollback applied for that load)
 - Optional `GameState.lastHiddenCellPanicAmplificationWeek` / `lastHiddenCellPanicAmplificationAmount` (SPE-2707) are sanitized with global pressure scalars; incomplete pairs are dropped so a week cannot lock without a matching applied amount
 - Optional `AgencyState.lastHiddenCellInfrastructureCompromiseWeek` / `lastHiddenCellInfrastructureCompromiseAmount` (SPE-2710) are sanitized in `sanitizeAgencyState`; incomplete pairs are dropped so a week cannot lock without a matching applied amount
+- Optional `AgencyState.hiddenCellCovertGrowthLevel` / `hiddenCellDetectionNarrowing` / `lastHiddenCellCovertGrowthWeek` / `lastHiddenCellCovertGrowthAmount` / `lastHiddenCellDetectionNarrowingAmount` (SPE-2714) are sanitized in `sanitizeAgencyState`; week markers require at least one positive applied amount so a week cannot lock without a matching note
 
 ---
 

--- a/planning/spe-2706-hidden-cell-research-rollback-slice.md
+++ b/planning/spe-2706-hidden-cell-research-rollback-slice.md
@@ -47,7 +47,7 @@ Cell pressure active when rival-pressure band is `competitive` or `severe`. Targ
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
 | Panic amplification / infrastructure compromise | SPE-39 child | Separate interference surfaces |
-| Covert cell growth + detection scans | SPE-39 child | Detection layer larger than research hook |
+| Covert cell growth + detection scans | SPE-2714 | Detection layer larger than research hook |
 | Optional SPE-2702 resolved×open jurisdiction sharpening | SPE-39 child | Post-merge Bugbot follow-up; not blocking |
 
 ## Validation

--- a/planning/spe-2707-hidden-cell-panic-amplification-slice.md
+++ b/planning/spe-2707-hidden-cell-panic-amplification-slice.md
@@ -47,7 +47,7 @@ Cell pressure active when rival-pressure band is `competitive` or `severe`. Ampl
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
 | Infrastructure compromise | SPE-2710 | Separate interference surface (opened) |
-| Covert cell growth + detection scans | SPE-39 child | Detection layer larger than pressure hook |
+| Covert cell growth + detection scans | SPE-2714 | Detection layer larger than pressure hook |
 | Optional SPE-2702 resolved×open jurisdiction sharpening | SPE-39 child | Post-merge Bugbot follow-up; not blocking |
 
 ## Validation

--- a/planning/spe-2710-hidden-cell-infrastructure-compromise-slice.md
+++ b/planning/spe-2710-hidden-cell-infrastructure-compromise-slice.md
@@ -45,7 +45,7 @@ Cell pressure active when rival-pressure band is `competitive` or `severe`. Comp
 
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
-| Covert cell growth + detection scans | SPE-39 child | Detection layer larger than pressure hook |
+| Covert cell growth + detection scans | SPE-2714 | Detection layer larger than pressure hook |
 | Optional SPE-2702 resolved×open jurisdiction sharpening | SPE-39 child | Post-merge Bugbot follow-up; not blocking |
 | Hire/restore path for maintenance specialists | SPE-94 / ops follow-up | Existing pool has no mid-run restore; out of interference boundary |
 

--- a/planning/spe-2714-hidden-cell-covert-growth-detection-slice.md
+++ b/planning/spe-2714-hidden-cell-covert-growth-detection-slice.md
@@ -1,0 +1,55 @@
+# SPE-2714 — Hidden-cell strategic interference (covert cell growth + detection narrowing)
+
+**Linear:** [SPE-2714](https://linear.app/spectranoir/issue/SPE-2714/spe-39-hidden-cell-strategic-interference-covert-cell-growth-detection)  
+**Parent:** [SPE-39](https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer) (stays **Backlog**/open after merge)  
+**Branch:** `jamesdyedbq/spe-2714-spe-39-hidden-cell-strategic-interference-covert-growth`  
+**Base:** `main` @ `b2b99603bac827ecdfff30ab99cacc3b8de2097c`
+
+## Goal
+
+One deterministic bounded hidden-cell interference path from abstract rival/hidden-cell pressure into **covert cell growth** plus a minimal **intelligence-driven detection-narrowing** signal (vague → regional → sector → imminent) before open confrontation — closes parent SPE-39 residual for XCOM-style covert growth/detection without a full adversary org sim, SPE-854 verification-core changes, or scan UX sprawl.
+
+## Acceptance (this slice)
+
+- [x] Identical ranking/pressure + prior growth/narrowing inputs → identical growth/detection outcome
+- [x] No covert growth or detection narrowing when cell pressure inactive (rival band suppressed/balanced)
+- [x] Active path increases bounded cumulative covert-growth level and advances detection-narrowing band; idempotent per closed week
+- [x] Weekly report note + agency/report summary expose a legible interference signal (narrowing band without full location truth)
+- [x] SPE-2704/2706/2707/2710 paths unchanged for the same inputs
+- [x] SPE-2699–2710 rival-pressure formula outputs unchanged for same ranking inputs
+- [x] No SPE-854 verification-core changes; no case-scouting DetectionScanResult UX
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Domain | `src/domain/hiddenCellStrategicInterference.ts` — reuse cell-pressure gate; covert growth + narrowing resolve + apply |
+| Agency state | `hiddenCellCovertGrowthLevel`, `hiddenCellDetectionNarrowing`; idempotency via `lastHiddenCellCovertGrowthWeek` / `Amount` |
+| Week-close | `advanceWeek` after SPE-2710 infrastructure compromise |
+| Week-close notes | `hiddenCellInterferenceWeeklyReportNotes` — `agency.hidden_cell_interference` with `kind: covert_cell_growth` |
+| Agency / UI | `buildAgencySummary`, `reportView` summary line |
+| Docs | `systems/hub-simulation.md`, `SCHEMA_REGISTRY.md` |
+| Tests | `src/test/hiddenCellStrategicInterference.test.ts` |
+
+Cell pressure active when rival-pressure band is `competitive` or `severe`. Growth amount scales from pressure score (1–3), clamped so cumulative level stays within max. Detection narrowing advances from the same growth tick (deterministic delta), mapped to player-facing bands without revealing coordinates. Inactive bands → no effect.
+
+## Out of scope
+
+- SPE-2699–2710 pressure / forgiveness / exposure / coordination / funding / research / panic / infra formula changes
+- Open confrontation ops / cell raid missions
+- SPE-854 verification core; case-scouting DetectionScanResult UX
+- FacilityInstance status offline / FacilityState upgrade wiring
+- SPE-542 / SPE-430 rival sims
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Optional SPE-2702 resolved×open jurisdiction sharpening | SPE-39 child | Post-merge Bugbot follow-up; not blocking |
+| Open confrontation / cell raid ops after imminent narrowing | SPE-39 / ops follow-up | Larger mission surface than growth/narrowing signal |
+| Player-initiated intel scan actions | intel follow-up | Avoid scans UX sprawl in this slice |
+
+## Validation
+
+- `npm run test:run -- src/test/hiddenCellStrategicInterference.test.ts src/test/rivalPressure.test.ts src/test/reportNoteTypeAudit.test.ts`
+- `npm run lint`

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -48,7 +48,12 @@ import {
   sanitizeSupportStaffSummary,
 } from '../../domain/funding'
 import { sanitizeProgressionUnlockIds } from '../../domain/agencyProgression'
-import { HIDDEN_CELL_INFRASTRUCTURE_COMPROMISE_MAX } from '../../domain/hiddenCellStrategicInterference'
+import {
+  HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX,
+  HIDDEN_CELL_COVERT_GROWTH_MAX,
+  HIDDEN_CELL_DETECTION_NARROWING_MAX,
+  HIDDEN_CELL_INFRASTRUCTURE_COMPROMISE_MAX,
+} from '../../domain/hiddenCellStrategicInterference'
 import { normalizeRuntimeState, reconcileRuntimeUiSelections } from '../../domain/gameStateManager'
 import { normalizeCaseInstance } from '../../domain/case/normalizeCase'
 import { sanitizeDistrictScheduleState } from '../../domain/districtSchedule'
@@ -606,6 +611,9 @@ const REPORT_NOTE_METADATA_ALLOWLIST: Partial<Record<ReportNoteType, readonly st
     'researchProjectId',
     'pressureAmplified',
     'maintenanceCompromised',
+    'covertGrowthApplied',
+    'detectionNarrowingApplied',
+    'detectionNarrowingBand',
     'rivalPressureBand',
     'rivalPressureScore',
     'week',
@@ -6225,6 +6233,53 @@ function sanitizeAgencyState(
     lastHiddenCellInfrastructureCompromiseWeek !== undefined &&
     lastHiddenCellInfrastructureCompromiseAmount !== undefined &&
     lastHiddenCellInfrastructureCompromiseAmount > 0
+
+  const hiddenCellCovertGrowthLevel =
+    typeof raw.hiddenCellCovertGrowthLevel === 'number' &&
+    Number.isFinite(raw.hiddenCellCovertGrowthLevel)
+      ? Math.max(
+          0,
+          Math.min(HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX, Math.round(raw.hiddenCellCovertGrowthLevel))
+        )
+      : undefined
+  const hiddenCellDetectionNarrowing =
+    typeof raw.hiddenCellDetectionNarrowing === 'number' &&
+    Number.isFinite(raw.hiddenCellDetectionNarrowing)
+      ? Math.max(
+          0,
+          Math.min(HIDDEN_CELL_DETECTION_NARROWING_MAX, Math.round(raw.hiddenCellDetectionNarrowing))
+        )
+      : undefined
+  const lastHiddenCellCovertGrowthWeek =
+    typeof raw.lastHiddenCellCovertGrowthWeek === 'number' &&
+    Number.isFinite(raw.lastHiddenCellCovertGrowthWeek)
+      ? Math.max(1, Math.min(campaignWeek, Math.round(raw.lastHiddenCellCovertGrowthWeek)))
+      : undefined
+  const lastHiddenCellCovertGrowthAmount =
+    typeof raw.lastHiddenCellCovertGrowthAmount === 'number' &&
+    Number.isFinite(raw.lastHiddenCellCovertGrowthAmount)
+      ? Math.max(
+          0,
+          Math.min(HIDDEN_CELL_COVERT_GROWTH_MAX, Math.round(raw.lastHiddenCellCovertGrowthAmount))
+        )
+      : undefined
+  const lastHiddenCellDetectionNarrowingAmount =
+    typeof raw.lastHiddenCellDetectionNarrowingAmount === 'number' &&
+    Number.isFinite(raw.lastHiddenCellDetectionNarrowingAmount)
+      ? Math.max(
+          0,
+          Math.min(
+            HIDDEN_CELL_DETECTION_NARROWING_MAX,
+            Math.round(raw.lastHiddenCellDetectionNarrowingAmount)
+          )
+        )
+      : undefined
+  // SPE-2714: week marker requires at least one positive applied amount.
+  const hasCompleteCovertGrowthMarkers =
+    lastHiddenCellCovertGrowthWeek !== undefined &&
+    ((lastHiddenCellCovertGrowthAmount !== undefined && lastHiddenCellCovertGrowthAmount > 0) ||
+      (lastHiddenCellDetectionNarrowingAmount !== undefined &&
+        lastHiddenCellDetectionNarrowingAmount > 0))
   const courierShellFront = sanitizeCourierShellFrontState(raw.courierShellFront, campaignWeek)
   const progressionUnlockIds = sanitizeProgressionUnlockIds(raw.progressionUnlockIds)
 
@@ -6262,6 +6317,15 @@ function sanitizeAgencyState(
       ? {
           lastHiddenCellInfrastructureCompromiseWeek,
           lastHiddenCellInfrastructureCompromiseAmount,
+        }
+      : {}),
+    ...(hiddenCellCovertGrowthLevel !== undefined ? { hiddenCellCovertGrowthLevel } : {}),
+    ...(hiddenCellDetectionNarrowing !== undefined ? { hiddenCellDetectionNarrowing } : {}),
+    ...(hasCompleteCovertGrowthMarkers
+      ? {
+          lastHiddenCellCovertGrowthWeek,
+          lastHiddenCellCovertGrowthAmount: lastHiddenCellCovertGrowthAmount ?? 0,
+          lastHiddenCellDetectionNarrowingAmount: lastHiddenCellDetectionNarrowingAmount ?? 0,
         }
       : {}),
     ...(typeof mirrors.coordinationFrictionActive === 'boolean'

--- a/src/app/store/runTransfer.ts
+++ b/src/app/store/runTransfer.ts
@@ -52,6 +52,7 @@ import {
   HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX,
   HIDDEN_CELL_COVERT_GROWTH_MAX,
   HIDDEN_CELL_DETECTION_NARROWING_MAX,
+  HIDDEN_CELL_DETECTION_NARROWING_TICK_MAX,
   HIDDEN_CELL_INFRASTRUCTURE_COMPROMISE_MAX,
 } from '../../domain/hiddenCellStrategicInterference'
 import { normalizeRuntimeState, reconcileRuntimeUiSelections } from '../../domain/gameStateManager'
@@ -6269,7 +6270,7 @@ function sanitizeAgencyState(
       ? Math.max(
           0,
           Math.min(
-            HIDDEN_CELL_DETECTION_NARROWING_MAX,
+            HIDDEN_CELL_DETECTION_NARROWING_TICK_MAX,
             Math.round(raw.lastHiddenCellDetectionNarrowingAmount)
           )
         )

--- a/src/domain/hiddenCellInterferenceWeeklyReportNotes.ts
+++ b/src/domain/hiddenCellInterferenceWeeklyReportNotes.ts
@@ -1,21 +1,27 @@
 /**
- * SPE-2704 / SPE-2706 / SPE-2707 / SPE-2710: weekly report notes for hidden-cell strategic interference.
+ * SPE-2704 / SPE-2706 / SPE-2707 / SPE-2710 / SPE-2714: weekly report notes for hidden-cell strategic interference.
  *
  * Emits notes from applied fundingHistory theft, research-rollback markers,
- * panic-amplification markers, and infrastructure-compromise markers —
- * no parallel sabotage sim beyond SPE-94 maintenance capacity.
+ * panic-amplification markers, infrastructure-compromise markers, and
+ * covert-growth / detection-narrowing markers — no parallel sabotage sim
+ * beyond SPE-94 maintenance capacity and abstract agency counters.
  */
 
 import {
+  detectionNarrowingBandFromProgress,
+  findHiddenCellCovertGrowthAmountForWeek,
+  findHiddenCellDetectionNarrowingAmountForWeek,
   findHiddenCellFundingTheftAmountForWeek,
   findHiddenCellInfrastructureCompromiseAmountForWeek,
   findHiddenCellPanicAmplificationAmountForWeek,
   findHiddenCellResearchRollbackAmountForWeek,
   findHiddenCellResearchRollbackProjectIdForWeek,
+  resolveHiddenCellCovertGrowthFromPressure,
   resolveHiddenCellFundingTheftFromPressure,
   resolveHiddenCellInfrastructureCompromiseFromPressure,
   resolveHiddenCellPanicAmplificationFromPressure,
   resolveHiddenCellResearchRollbackFromPressure,
+  type HiddenCellCovertGrowthEffect,
   type HiddenCellInfrastructureCompromiseEffect,
   type HiddenCellInterferenceEffect,
   type HiddenCellPanicAmplificationEffect,
@@ -56,6 +62,16 @@ export function formatHiddenCellInfrastructureCompromiseNoteContent(
   effect: Pick<
     HiddenCellInfrastructureCompromiseEffect,
     'summary' | 'maintenanceCompromised' | 'rivalPressureBand'
+  >,
+  week: number
+): string {
+  return `Week ${week} — ${effect.summary}`
+}
+
+export function formatHiddenCellCovertGrowthNoteContent(
+  effect: Pick<
+    HiddenCellCovertGrowthEffect,
+    'summary' | 'growthApplied' | 'narrowingApplied' | 'detectionNarrowingBand' | 'rivalPressureBand'
   >,
   week: number
 ): string {
@@ -288,6 +304,94 @@ export function buildWeeklyHiddenCellInfrastructureCompromiseReportNotes(input: 
       {
         kind: 'infrastructure_compromise',
         maintenanceCompromised: appliedAmount,
+        rivalPressureBand: input.rivalPressure.band,
+        rivalPressureScore: input.rivalPressure.score,
+        week: input.week,
+      }
+    ),
+  ]
+}
+
+/** Builds weekly report notes when hidden-cell covert growth / detection narrowing was applied. */
+export function buildWeeklyHiddenCellCovertGrowthReportNotes(input: {
+  agency: Pick<
+    AgencyState,
+    | 'lastHiddenCellCovertGrowthWeek'
+    | 'lastHiddenCellCovertGrowthAmount'
+    | 'lastHiddenCellDetectionNarrowingAmount'
+    | 'hiddenCellCovertGrowthLevel'
+    | 'hiddenCellDetectionNarrowing'
+  > | null | undefined
+  rivalPressure: Pick<RivalPressureView, 'score' | 'band'>
+  /** Pre-apply growth/narrowing used to rebuild the effect summary deterministically. */
+  covertGrowthLevelBefore: number
+  detectionNarrowingBefore: number
+  week: number
+  sequenceStart: number
+  baseTimestamp?: number
+}): ReportNote[] {
+  const appliedGrowth = findHiddenCellCovertGrowthAmountForWeek(
+    input.agency ?? undefined,
+    input.week
+  )
+  const appliedNarrowing = findHiddenCellDetectionNarrowingAmountForWeek(
+    input.agency ?? undefined,
+    input.week
+  )
+  if (appliedGrowth <= 0 && appliedNarrowing <= 0) {
+    return []
+  }
+
+  const effect = resolveHiddenCellCovertGrowthFromPressure(
+    input.rivalPressure,
+    input.covertGrowthLevelBefore,
+    input.detectionNarrowingBefore
+  )
+  const detectionNarrowingBand = detectionNarrowingBandFromProgress(
+    Math.max(0, Math.trunc(input.detectionNarrowingBefore)) + appliedNarrowing
+  )
+  const noteEffect: Pick<
+    HiddenCellCovertGrowthEffect,
+    | 'summary'
+    | 'growthApplied'
+    | 'narrowingApplied'
+    | 'detectionNarrowingBand'
+    | 'rivalPressureBand'
+    | 'kind'
+    | 'rivalPressureScore'
+    | 'active'
+    | 'baseGrowthAmount'
+    | 'baseNarrowingAmount'
+  > = {
+    active: true,
+    kind: 'covert_cell_growth',
+    rivalPressureScore: input.rivalPressure.score,
+    rivalPressureBand: input.rivalPressure.band,
+    baseGrowthAmount: effect.baseGrowthAmount,
+    growthApplied: appliedGrowth,
+    baseNarrowingAmount: effect.baseNarrowingAmount,
+    narrowingApplied: appliedNarrowing,
+    detectionNarrowingBand,
+    summary:
+      appliedGrowth > 0
+        ? `Hidden-cell interference expanded covert network pressure by ${appliedGrowth} ` +
+          `(${input.rivalPressure.band} cell pressure; intel narrowing advanced to ${detectionNarrowingBand} before open confrontation).`
+        : `Hidden-cell interference held covert network pressure at cap ` +
+          `(${input.rivalPressure.band} cell pressure; intel narrowing advanced to ${detectionNarrowingBand} before open confrontation).`,
+  }
+
+  return [
+    createDeterministicReportNote(
+      formatHiddenCellCovertGrowthNoteContent(noteEffect, input.week),
+      input.week,
+      input.sequenceStart,
+      input.baseTimestamp,
+      'agency.hidden_cell_interference',
+      {
+        kind: 'covert_cell_growth',
+        covertGrowthApplied: appliedGrowth,
+        detectionNarrowingApplied: appliedNarrowing,
+        detectionNarrowingBand,
         rivalPressureBand: input.rivalPressure.band,
         rivalPressureScore: input.rivalPressure.score,
         week: input.week,

--- a/src/domain/hiddenCellStrategicInterference.ts
+++ b/src/domain/hiddenCellStrategicInterference.ts
@@ -1,13 +1,14 @@
 /**
- * SPE-2704 / SPE-2706 / SPE-2707 / SPE-2710 / SPE-39: bounded hidden-cell strategic interference.
+ * SPE-2704 / SPE-2706 / SPE-2707 / SPE-2710 / SPE-2714 / SPE-39: bounded hidden-cell strategic interference.
  *
  * Derives cell-pressure activity from rival-pressure band and applies:
  * - funding theft (SPE-2704) through existing FundingState history
  * - research rollback (SPE-2706) against active ResearchState progress
  * - panic amplification (SPE-2707) into ambient GameState.globalPressure
  * - infrastructure compromise (SPE-2710) against maintenance specialist capacity
+ * - covert cell growth + detection narrowing (SPE-2714) on agency abstract counters
  *
- * No per-cell entities; no detection layer.
+ * No per-cell entities; detection is abstract narrowing bands only (no SPE-854 / scan UX).
  */
 
 import { applyFundingExpense, recomputeBudgetPressure } from './funding'
@@ -29,12 +30,33 @@ export const HIDDEN_CELL_PANIC_AMPLIFICATION_MAX = 4
 /** Max maintenance specialists one infrastructure-compromise tick may drain. */
 export const HIDDEN_CELL_INFRASTRUCTURE_COMPROMISE_MAX = 2
 
+/** Max covert-growth points one tick may add. */
+export const HIDDEN_CELL_COVERT_GROWTH_MAX = 3
+
+/** Cap on cumulative abstract covert-growth level. */
+export const HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX = 20
+
+/** Cap on cumulative detection-narrowing progress (0–100). */
+export const HIDDEN_CELL_DETECTION_NARROWING_MAX = 100
+
+/** Narrowing progress points per unit of applied covert growth. */
+export const HIDDEN_CELL_DETECTION_NARROWING_PER_GROWTH = 8
+
 export type HiddenCellInterferenceKind =
   | 'funding_theft'
   | 'research_rollback'
   | 'panic_amplification'
   | 'infrastructure_compromise'
+  | 'covert_cell_growth'
   | 'none'
+
+/** Player-facing detection-narrowing band — no coordinates / full cell truth. */
+export type HiddenCellDetectionNarrowingBand =
+  | 'none'
+  | 'vague'
+  | 'regional'
+  | 'sector'
+  | 'imminent'
 
 export interface HiddenCellInterferenceEffect {
   readonly active: boolean
@@ -85,6 +107,24 @@ export interface HiddenCellInfrastructureCompromiseEffect {
   readonly summary: string
 }
 
+export interface HiddenCellCovertGrowthEffect {
+  readonly active: boolean
+  readonly kind: HiddenCellInterferenceKind
+  readonly rivalPressureScore: number
+  readonly rivalPressureBand: RivalPressureBand
+  /** Base growth before cumulative-level clamp (0 when inactive). */
+  readonly baseGrowthAmount: number
+  /** Applied growth after clamp to remaining room (0 when inactive or at cap). */
+  readonly growthApplied: number
+  /** Base narrowing before progress clamp (0 when inactive). */
+  readonly baseNarrowingAmount: number
+  /** Applied narrowing after clamp (0 when inactive or at cap). */
+  readonly narrowingApplied: number
+  /** Detection band after applying this tick's narrowing to current progress. */
+  readonly detectionNarrowingBand: HiddenCellDetectionNarrowingBand
+  readonly summary: string
+}
+
 export interface HiddenCellInterferenceSummary {
   readonly active: boolean
   readonly kind: HiddenCellInterferenceKind
@@ -93,6 +133,11 @@ export interface HiddenCellInterferenceSummary {
   readonly researchProjectId: string | null
   readonly pressureAmplified: number
   readonly maintenanceCompromised: number
+  readonly covertGrowthApplied: number
+  readonly detectionNarrowingApplied: number
+  readonly detectionNarrowingBand: HiddenCellDetectionNarrowingBand
+  readonly covertGrowthLevel: number
+  readonly detectionNarrowing: number
   readonly rivalPressureBand: RivalPressureBand
   readonly summary: string
 }
@@ -168,6 +213,65 @@ export function computeHiddenCellInfrastructureCompromiseBaseAmount(
     1,
     HIDDEN_CELL_INFRASTRUCTURE_COMPROMISE_MAX
   )
+}
+
+/**
+ * Base covert-growth points from rival pressure score alone (cumulative clamp applied separately).
+ * Inactive bands → 0. Active: 1–3 growth points above peer-balanced floor.
+ */
+export function computeHiddenCellCovertGrowthBaseAmount(
+  score: number,
+  band: RivalPressureBand
+): number {
+  if (!isHiddenCellPressureActive(band)) {
+    return 0
+  }
+
+  return clamp(
+    Math.round((clamp(Math.round(score), 0, 100) - 50) / 16.5),
+    1,
+    HIDDEN_CELL_COVERT_GROWTH_MAX
+  )
+}
+
+/**
+ * Base detection-narrowing progress from applied (or prospective) growth amount.
+ * Inactive / zero growth → 0. Active: growth × HIDDEN_CELL_DETECTION_NARROWING_PER_GROWTH.
+ */
+export function computeHiddenCellDetectionNarrowingBaseAmount(
+  growthAmount: number,
+  band: RivalPressureBand
+): number {
+  if (!isHiddenCellPressureActive(band)) {
+    return 0
+  }
+
+  const growth = Math.max(0, Math.trunc(growthAmount))
+  if (growth <= 0) {
+    return 0
+  }
+
+  return clamp(growth * HIDDEN_CELL_DETECTION_NARROWING_PER_GROWTH, 1, HIDDEN_CELL_DETECTION_NARROWING_MAX)
+}
+
+/** Map cumulative narrowing progress to a player-facing band (no location truth). */
+export function detectionNarrowingBandFromProgress(
+  narrowing: number
+): HiddenCellDetectionNarrowingBand {
+  const progress = clamp(Math.trunc(narrowing), 0, HIDDEN_CELL_DETECTION_NARROWING_MAX)
+  if (progress <= 0) {
+    return 'none'
+  }
+  if (progress < 25) {
+    return 'vague'
+  }
+  if (progress < 50) {
+    return 'regional'
+  }
+  if (progress < 75) {
+    return 'sector'
+  }
+  return 'imminent'
 }
 
 function buildFundingInterferenceSummary(input: {
@@ -269,6 +373,43 @@ function buildInfrastructureCompromiseSummary(input: {
   )
 }
 
+function buildCovertGrowthSummary(input: {
+  active: boolean
+  band: RivalPressureBand
+  growthApplied: number
+  baseGrowthAmount: number
+  narrowingApplied: number
+  detectionNarrowingBand: HiddenCellDetectionNarrowingBand
+}): string {
+  if (!input.active) {
+    return (
+      `Hidden-cell covert growth inactive (${input.band}): ` +
+      `no covert network expansion or detection narrowing this week.`
+    )
+  }
+
+  if (input.growthApplied <= 0 && input.narrowingApplied <= 0) {
+    return (
+      `Hidden-cell covert growth active (${input.band}): covert expansion blocked ` +
+      `(growth/narrowing at cap; base claim ${input.baseGrowthAmount}).`
+    )
+  }
+
+  const growthPart =
+    input.growthApplied > 0
+      ? `expanded covert network pressure by ${input.growthApplied}`
+      : 'held covert network pressure at cap'
+  const narrowingPart =
+    input.narrowingApplied > 0
+      ? `intel narrowing advanced to ${input.detectionNarrowingBand}`
+      : `intel narrowing held at ${input.detectionNarrowingBand}`
+
+  return (
+    `Hidden-cell interference ${growthPart} ` +
+    `(${input.band} cell pressure; ${narrowingPart} before open confrontation).`
+  )
+}
+
 function composeInterferenceSummary(input: {
   active: boolean
   band: RivalPressureBand
@@ -277,10 +418,13 @@ function composeInterferenceSummary(input: {
   researchProjectId: string | null
   pressureAmplified: number
   maintenanceCompromised: number
+  growthApplied: number
+  narrowingApplied: number
   fundingSummary: string
   researchSummary: string
   panicSummary: string
   infrastructureSummary: string
+  covertGrowthSummary: string
 }): string {
   if (!input.active) {
     return `Hidden-cell interference inactive (${input.band}): no strategic diversion this week.`
@@ -299,13 +443,16 @@ function composeInterferenceSummary(input: {
   if (input.maintenanceCompromised > 0) {
     parts.push(input.infrastructureSummary)
   }
+  if (input.growthApplied > 0 || input.narrowingApplied > 0) {
+    parts.push(input.covertGrowthSummary)
+  }
 
   if (parts.length > 0) {
     return parts.join(' ')
   }
 
   return (
-    `Hidden-cell interference active (${input.band}): no funding, research, panic, or infrastructure diversion applied this week.`
+    `Hidden-cell interference active (${input.band}): no funding, research, panic, infrastructure, or covert diversion applied this week.`
   )
 }
 
@@ -550,6 +697,104 @@ export function resolveHiddenCellInfrastructureCompromiseFromRankingScore(
   )
 }
 
+/**
+ * Pure resolve: identical pressure + prior growth/narrowing → identical covert-growth effect.
+ * Detection narrowing is derived from the prospective growth tick (not a separate scan UX).
+ */
+export function resolveHiddenCellCovertGrowth(input: {
+  rivalPressureScore: number
+  rivalPressureBand: RivalPressureBand
+  covertGrowthLevel: number
+  detectionNarrowing: number
+}): HiddenCellCovertGrowthEffect {
+  const rivalPressureScore = clamp(Math.round(input.rivalPressureScore), 0, 100)
+  const rivalPressureBand = input.rivalPressureBand
+  const active = isHiddenCellPressureActive(rivalPressureBand)
+  const baseGrowthAmount = computeHiddenCellCovertGrowthBaseAmount(
+    rivalPressureScore,
+    rivalPressureBand
+  )
+  const currentLevel = clamp(
+    Math.trunc(input.covertGrowthLevel),
+    0,
+    HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX
+  )
+  const growthRoom = HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX - currentLevel
+  const growthApplied = active ? Math.min(growthRoom, baseGrowthAmount) : 0
+
+  // When growth is at cap but pressure is still active, allow a residual narrowing tick
+  // so intel can still advance without inventing a second pressure formula.
+  const prospectiveGrowthForNarrowing = active
+    ? growthApplied > 0
+      ? growthApplied
+      : baseGrowthAmount > 0
+        ? 1
+        : 0
+    : 0
+  const baseNarrowingAmount = computeHiddenCellDetectionNarrowingBaseAmount(
+    prospectiveGrowthForNarrowing,
+    rivalPressureBand
+  )
+  const currentNarrowing = clamp(
+    Math.trunc(input.detectionNarrowing),
+    0,
+    HIDDEN_CELL_DETECTION_NARROWING_MAX
+  )
+  const narrowingRoom = HIDDEN_CELL_DETECTION_NARROWING_MAX - currentNarrowing
+  const narrowingApplied = active ? Math.min(narrowingRoom, baseNarrowingAmount) : 0
+  const detectionNarrowingBand = detectionNarrowingBandFromProgress(
+    currentNarrowing + narrowingApplied
+  )
+  const kind: HiddenCellInterferenceKind =
+    growthApplied > 0 || narrowingApplied > 0 ? 'covert_cell_growth' : 'none'
+
+  return {
+    active,
+    kind,
+    rivalPressureScore,
+    rivalPressureBand,
+    baseGrowthAmount,
+    growthApplied,
+    baseNarrowingAmount,
+    narrowingApplied,
+    detectionNarrowingBand,
+    summary: buildCovertGrowthSummary({
+      active,
+      band: rivalPressureBand,
+      growthApplied,
+      baseGrowthAmount,
+      narrowingApplied,
+      detectionNarrowingBand,
+    }),
+  }
+}
+
+export function resolveHiddenCellCovertGrowthFromPressure(
+  pressure: Pick<RivalPressureView, 'score' | 'band'>,
+  covertGrowthLevel: number,
+  detectionNarrowing: number
+): HiddenCellCovertGrowthEffect {
+  return resolveHiddenCellCovertGrowth({
+    rivalPressureScore: pressure.score,
+    rivalPressureBand: pressure.band,
+    covertGrowthLevel,
+    detectionNarrowing,
+  })
+}
+
+export function resolveHiddenCellCovertGrowthFromRankingScore(
+  rankingScore: number,
+  covertGrowthLevel: number,
+  detectionNarrowing: number
+): HiddenCellCovertGrowthEffect {
+  const pressure = buildRivalPressureFromRankingScore(rankingScore)
+  return resolveHiddenCellCovertGrowthFromPressure(
+    pressure,
+    covertGrowthLevel,
+    detectionNarrowing
+  )
+}
+
 export function hasHiddenCellFundingTheftForWeek(
   fundingState: FundingState | undefined,
   closedWeek: number
@@ -614,6 +859,30 @@ export function hasHiddenCellInfrastructureCompromiseForWeek(
   return (
     agency.lastHiddenCellInfrastructureCompromiseWeek === week &&
     Math.max(0, Math.trunc(agency.lastHiddenCellInfrastructureCompromiseAmount ?? 0)) > 0
+  )
+}
+
+export function hasHiddenCellCovertGrowthForWeek(
+  agency: Pick<
+    AgencyState,
+    | 'lastHiddenCellCovertGrowthWeek'
+    | 'lastHiddenCellCovertGrowthAmount'
+    | 'lastHiddenCellDetectionNarrowingAmount'
+  > | undefined,
+  closedWeek: number
+): boolean {
+  if (!agency) {
+    return false
+  }
+
+  const week = Math.max(1, Math.trunc(closedWeek))
+  if (agency.lastHiddenCellCovertGrowthWeek !== week) {
+    return false
+  }
+
+  return (
+    Math.max(0, Math.trunc(agency.lastHiddenCellCovertGrowthAmount ?? 0)) > 0 ||
+    Math.max(0, Math.trunc(agency.lastHiddenCellDetectionNarrowingAmount ?? 0)) > 0
   )
 }
 
@@ -786,7 +1055,84 @@ export function applyHiddenCellInfrastructureCompromiseToAgencyState(
   }
 }
 
-/** Read-time summary for agency/report surfaces from current ranking pressure + funding + research + panic + infra. */
+/**
+ * Apply covert growth + detection narrowing once per closed week.
+ * Abstract counters only — no per-cell entities or SPE-854 scan UX.
+ */
+export function applyHiddenCellCovertGrowthToAgencyState(
+  agency: Pick<
+    AgencyState,
+    | 'hiddenCellCovertGrowthLevel'
+    | 'hiddenCellDetectionNarrowing'
+    | 'lastHiddenCellCovertGrowthWeek'
+    | 'lastHiddenCellCovertGrowthAmount'
+    | 'lastHiddenCellDetectionNarrowingAmount'
+  >,
+  effect: HiddenCellCovertGrowthEffect,
+  closedWeek: number
+): {
+  state: Pick<
+    AgencyState,
+    | 'hiddenCellCovertGrowthLevel'
+    | 'hiddenCellDetectionNarrowing'
+    | 'lastHiddenCellCovertGrowthWeek'
+    | 'lastHiddenCellCovertGrowthAmount'
+    | 'lastHiddenCellDetectionNarrowingAmount'
+  >
+  appliedGrowth: number
+  appliedNarrowing: number
+  effect: HiddenCellCovertGrowthEffect
+} {
+  const week = Math.max(1, Math.trunc(closedWeek))
+  const currentLevel = clamp(
+    Math.trunc(agency.hiddenCellCovertGrowthLevel ?? 0),
+    0,
+    HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX
+  )
+  const currentNarrowing = clamp(
+    Math.trunc(agency.hiddenCellDetectionNarrowing ?? 0),
+    0,
+    HIDDEN_CELL_DETECTION_NARROWING_MAX
+  )
+  const appliedGrowth = Math.max(
+    0,
+    Math.min(HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX - currentLevel, Math.trunc(effect.growthApplied))
+  )
+  const appliedNarrowing = Math.max(
+    0,
+    Math.min(
+      HIDDEN_CELL_DETECTION_NARROWING_MAX - currentNarrowing,
+      Math.trunc(effect.narrowingApplied)
+    )
+  )
+
+  if (
+    (appliedGrowth <= 0 && appliedNarrowing <= 0) ||
+    hasHiddenCellCovertGrowthForWeek(agency, week)
+  ) {
+    return {
+      state: agency,
+      appliedGrowth: 0,
+      appliedNarrowing: 0,
+      effect,
+    }
+  }
+
+  return {
+    state: {
+      hiddenCellCovertGrowthLevel: currentLevel + appliedGrowth,
+      hiddenCellDetectionNarrowing: currentNarrowing + appliedNarrowing,
+      lastHiddenCellCovertGrowthWeek: week,
+      lastHiddenCellCovertGrowthAmount: appliedGrowth,
+      lastHiddenCellDetectionNarrowingAmount: appliedNarrowing,
+    },
+    appliedGrowth,
+    appliedNarrowing,
+    effect,
+  }
+}
+
+/** Read-time summary for agency/report surfaces from current ranking pressure + funding + research + panic + infra + covert. */
 export function buildHiddenCellInterferenceSummary(
   game: Pick<GameState, 'reports' | 'events' | 'funding' | 'agency' | 'researchState'>
 ): HiddenCellInterferenceSummary {
@@ -800,12 +1146,21 @@ export function buildHiddenCellInterferenceSummary(
     pressure,
     maintenanceAvailable
   )
+  const covertGrowthLevel = game.agency?.hiddenCellCovertGrowthLevel ?? 0
+  const detectionNarrowing = game.agency?.hiddenCellDetectionNarrowing ?? 0
+  const covertGrowthEffect = resolveHiddenCellCovertGrowthFromPressure(
+    pressure,
+    covertGrowthLevel,
+    detectionNarrowing
+  )
   const active = fundingEffect.active
   const fundingStolen = fundingEffect.fundingStolen
   const progressTimeRolledBack = researchEffect.progressTimeRolledBack
   const researchProjectId = researchEffect.targetProjectId
   const pressureAmplified = panicEffect.pressureAmplified
   const maintenanceCompromised = infrastructureEffect.maintenanceCompromised
+  const covertGrowthApplied = covertGrowthEffect.growthApplied
+  const detectionNarrowingApplied = covertGrowthEffect.narrowingApplied
   const kind: HiddenCellInterferenceKind =
     fundingStolen > 0
       ? 'funding_theft'
@@ -815,7 +1170,9 @@ export function buildHiddenCellInterferenceSummary(
           ? 'panic_amplification'
           : maintenanceCompromised > 0
             ? 'infrastructure_compromise'
-            : 'none'
+            : covertGrowthApplied > 0 || detectionNarrowingApplied > 0
+              ? 'covert_cell_growth'
+              : 'none'
 
   return {
     active,
@@ -825,6 +1182,11 @@ export function buildHiddenCellInterferenceSummary(
     researchProjectId,
     pressureAmplified,
     maintenanceCompromised,
+    covertGrowthApplied,
+    detectionNarrowingApplied,
+    detectionNarrowingBand: covertGrowthEffect.detectionNarrowingBand,
+    covertGrowthLevel,
+    detectionNarrowing,
     rivalPressureBand: pressure.band,
     summary: composeInterferenceSummary({
       active,
@@ -834,10 +1196,13 @@ export function buildHiddenCellInterferenceSummary(
       researchProjectId,
       pressureAmplified,
       maintenanceCompromised,
+      growthApplied: covertGrowthApplied,
+      narrowingApplied: detectionNarrowingApplied,
       fundingSummary: fundingEffect.summary,
       researchSummary: researchEffect.summary,
       panicSummary: panicEffect.summary,
       infrastructureSummary: infrastructureEffect.summary,
+      covertGrowthSummary: covertGrowthEffect.summary,
     }),
   }
 }
@@ -919,4 +1284,38 @@ export function findHiddenCellInfrastructureCompromiseAmountForWeek(
   }
 
   return Math.max(0, Math.trunc(agency?.lastHiddenCellInfrastructureCompromiseAmount ?? 0))
+}
+
+/** Locate applied covert-growth amount for a closed week (note surfacing / tests). */
+export function findHiddenCellCovertGrowthAmountForWeek(
+  agency: Pick<
+    AgencyState,
+    | 'lastHiddenCellCovertGrowthWeek'
+    | 'lastHiddenCellCovertGrowthAmount'
+    | 'lastHiddenCellDetectionNarrowingAmount'
+  > | undefined,
+  closedWeek: number
+): number {
+  if (!hasHiddenCellCovertGrowthForWeek(agency, closedWeek)) {
+    return 0
+  }
+
+  return Math.max(0, Math.trunc(agency?.lastHiddenCellCovertGrowthAmount ?? 0))
+}
+
+/** Locate applied detection-narrowing amount for a closed week (note surfacing / tests). */
+export function findHiddenCellDetectionNarrowingAmountForWeek(
+  agency: Pick<
+    AgencyState,
+    | 'lastHiddenCellCovertGrowthWeek'
+    | 'lastHiddenCellCovertGrowthAmount'
+    | 'lastHiddenCellDetectionNarrowingAmount'
+  > | undefined,
+  closedWeek: number
+): number {
+  if (!hasHiddenCellCovertGrowthForWeek(agency, closedWeek)) {
+    return 0
+  }
+
+  return Math.max(0, Math.trunc(agency?.lastHiddenCellDetectionNarrowingAmount ?? 0))
 }

--- a/src/domain/hiddenCellStrategicInterference.ts
+++ b/src/domain/hiddenCellStrategicInterference.ts
@@ -42,6 +42,10 @@ export const HIDDEN_CELL_DETECTION_NARROWING_MAX = 100
 /** Narrowing progress points per unit of applied covert growth. */
 export const HIDDEN_CELL_DETECTION_NARROWING_PER_GROWTH = 8
 
+/** Max narrowing points one closed-week tick may apply. */
+export const HIDDEN_CELL_DETECTION_NARROWING_TICK_MAX =
+  HIDDEN_CELL_COVERT_GROWTH_MAX * HIDDEN_CELL_DETECTION_NARROWING_PER_GROWTH
+
 export type HiddenCellInterferenceKind =
   | 'funding_theft'
   | 'research_rollback'

--- a/src/domain/models.ts
+++ b/src/domain/models.ts
@@ -2375,6 +2375,25 @@ export interface AgencyState {
   lastHiddenCellInfrastructureCompromiseWeek?: number
   /** SPE-2710: specialists drained on lastHiddenCellInfrastructureCompromiseWeek. */
   lastHiddenCellInfrastructureCompromiseAmount?: number
+  /**
+   * SPE-2714: cumulative abstract covert-cell growth level (0–20).
+   * Not a per-cell entity count — pressure intensity only.
+   */
+  hiddenCellCovertGrowthLevel?: number
+  /**
+   * SPE-2714: cumulative intelligence-driven detection-narrowing progress (0–100).
+   * Maps to vague/regional/sector/imminent bands; no location truth.
+   */
+  hiddenCellDetectionNarrowing?: number
+  /**
+   * SPE-2714: closed week when covert growth / detection narrowing last applied.
+   * Paired with lastHiddenCellCovertGrowthAmount / lastHiddenCellDetectionNarrowingAmount.
+   */
+  lastHiddenCellCovertGrowthWeek?: number
+  /** SPE-2714: growth points applied on lastHiddenCellCovertGrowthWeek. */
+  lastHiddenCellCovertGrowthAmount?: number
+  /** SPE-2714: narrowing points applied on lastHiddenCellCovertGrowthWeek. */
+  lastHiddenCellDetectionNarrowingAmount?: number
   protocolSelectionLimit?: number
   activeProtocolIds?: string[]
   /**

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -344,7 +344,9 @@ import {
   findHiddenCellFundingTheftAmountForWeek,
   findHiddenCellInfrastructureCompromiseAmountForWeek,
   HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX,
+  HIDDEN_CELL_COVERT_GROWTH_MAX,
   HIDDEN_CELL_DETECTION_NARROWING_MAX,
+  HIDDEN_CELL_DETECTION_NARROWING_TICK_MAX,
   resolveHiddenCellCovertGrowthFromPressure,
   resolveHiddenCellFundingTheftFromPressure,
   resolveHiddenCellInfrastructureCompromiseFromPressure,
@@ -737,12 +739,21 @@ function canonicalizeAgencyState(base: Partial<AgencyState> | null | undefined):
   const lastHiddenCellCovertGrowthAmount =
     typeof base?.lastHiddenCellCovertGrowthAmount === 'number' &&
     Number.isFinite(base.lastHiddenCellCovertGrowthAmount)
-      ? Math.max(0, Math.trunc(base.lastHiddenCellCovertGrowthAmount))
+      ? Math.max(
+          0,
+          Math.min(HIDDEN_CELL_COVERT_GROWTH_MAX, Math.trunc(base.lastHiddenCellCovertGrowthAmount))
+        )
       : undefined
   const lastHiddenCellDetectionNarrowingAmount =
     typeof base?.lastHiddenCellDetectionNarrowingAmount === 'number' &&
     Number.isFinite(base.lastHiddenCellDetectionNarrowingAmount)
-      ? Math.max(0, Math.trunc(base.lastHiddenCellDetectionNarrowingAmount))
+      ? Math.max(
+          0,
+          Math.min(
+            HIDDEN_CELL_DETECTION_NARROWING_TICK_MAX,
+            Math.trunc(base.lastHiddenCellDetectionNarrowingAmount)
+          )
+        )
       : undefined
   // SPE-2714: week marker requires at least one applied amount so a week cannot lock without a note.
   const hasCompleteCovertGrowthMarkers =

--- a/src/domain/sim/advanceWeek.ts
+++ b/src/domain/sim/advanceWeek.ts
@@ -327,18 +327,25 @@ import { buildWeeklyPublicDisclosureTrustOutcomeReportNotes } from '../publicDis
 import { buildWeeklyPublicDisclosureSegmentedTrustOutcomeReportNotes } from '../publicDisclosureSegmentedTrustOutcomeWeeklyReportNotes'
 import { buildWeeklyCrossJurisdictionCoordinationReportNotes } from '../crossJurisdictionCoordinationWeeklyReportNotes'
 import {
+  buildWeeklyHiddenCellCovertGrowthReportNotes,
   buildWeeklyHiddenCellInfrastructureCompromiseReportNotes,
   buildWeeklyHiddenCellInterferenceReportNotes,
   buildWeeklyHiddenCellPanicAmplificationReportNotes,
   buildWeeklyHiddenCellResearchRollbackReportNotes,
 } from '../hiddenCellInterferenceWeeklyReportNotes'
 import {
+  applyHiddenCellCovertGrowthToAgencyState,
   applyHiddenCellFundingTheftToFundingState,
   applyHiddenCellInfrastructureCompromiseToAgencyState,
   applyHiddenCellPanicAmplificationToGameState,
   applyHiddenCellResearchRollbackToResearchState,
+  findHiddenCellCovertGrowthAmountForWeek,
+  findHiddenCellDetectionNarrowingAmountForWeek,
   findHiddenCellFundingTheftAmountForWeek,
   findHiddenCellInfrastructureCompromiseAmountForWeek,
+  HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX,
+  HIDDEN_CELL_DETECTION_NARROWING_MAX,
+  resolveHiddenCellCovertGrowthFromPressure,
   resolveHiddenCellFundingTheftFromPressure,
   resolveHiddenCellInfrastructureCompromiseFromPressure,
   resolveHiddenCellPanicAmplificationFromPressure,
@@ -703,6 +710,47 @@ function canonicalizeAgencyState(base: Partial<AgencyState> | null | undefined):
     lastHiddenCellInfrastructureCompromiseAmount !== undefined &&
     lastHiddenCellInfrastructureCompromiseAmount > 0
 
+  const hiddenCellCovertGrowthLevel =
+    typeof base?.hiddenCellCovertGrowthLevel === 'number' &&
+    Number.isFinite(base.hiddenCellCovertGrowthLevel)
+      ? Math.max(
+          0,
+          Math.min(HIDDEN_CELL_COVERT_GROWTH_LEVEL_MAX, Math.trunc(base.hiddenCellCovertGrowthLevel))
+        )
+      : undefined
+  const hiddenCellDetectionNarrowing =
+    typeof base?.hiddenCellDetectionNarrowing === 'number' &&
+    Number.isFinite(base.hiddenCellDetectionNarrowing)
+      ? Math.max(
+          0,
+          Math.min(
+            HIDDEN_CELL_DETECTION_NARROWING_MAX,
+            Math.trunc(base.hiddenCellDetectionNarrowing)
+          )
+        )
+      : undefined
+  const lastHiddenCellCovertGrowthWeek =
+    typeof base?.lastHiddenCellCovertGrowthWeek === 'number' &&
+    Number.isFinite(base.lastHiddenCellCovertGrowthWeek)
+      ? Math.max(1, Math.trunc(base.lastHiddenCellCovertGrowthWeek))
+      : undefined
+  const lastHiddenCellCovertGrowthAmount =
+    typeof base?.lastHiddenCellCovertGrowthAmount === 'number' &&
+    Number.isFinite(base.lastHiddenCellCovertGrowthAmount)
+      ? Math.max(0, Math.trunc(base.lastHiddenCellCovertGrowthAmount))
+      : undefined
+  const lastHiddenCellDetectionNarrowingAmount =
+    typeof base?.lastHiddenCellDetectionNarrowingAmount === 'number' &&
+    Number.isFinite(base.lastHiddenCellDetectionNarrowingAmount)
+      ? Math.max(0, Math.trunc(base.lastHiddenCellDetectionNarrowingAmount))
+      : undefined
+  // SPE-2714: week marker requires at least one applied amount so a week cannot lock without a note.
+  const hasCompleteCovertGrowthMarkers =
+    lastHiddenCellCovertGrowthWeek !== undefined &&
+    ((lastHiddenCellCovertGrowthAmount !== undefined && lastHiddenCellCovertGrowthAmount > 0) ||
+      (lastHiddenCellDetectionNarrowingAmount !== undefined &&
+        lastHiddenCellDetectionNarrowingAmount > 0))
+
   return {
     containmentRating: safeNumber(base?.containmentRating, 0),
     clearanceLevel: safeNumber(base?.clearanceLevel, 1),
@@ -715,6 +763,19 @@ function canonicalizeAgencyState(base: Partial<AgencyState> | null | undefined):
       ? {
           lastHiddenCellInfrastructureCompromiseWeek,
           lastHiddenCellInfrastructureCompromiseAmount,
+        }
+      : {}),
+    ...(hiddenCellCovertGrowthLevel !== undefined
+      ? { hiddenCellCovertGrowthLevel }
+      : {}),
+    ...(hiddenCellDetectionNarrowing !== undefined
+      ? { hiddenCellDetectionNarrowing }
+      : {}),
+    ...(hasCompleteCovertGrowthMarkers
+      ? {
+          lastHiddenCellCovertGrowthWeek,
+          lastHiddenCellCovertGrowthAmount: lastHiddenCellCovertGrowthAmount ?? 0,
+          lastHiddenCellDetectionNarrowingAmount: lastHiddenCellDetectionNarrowingAmount ?? 0,
         }
       : {}),
     ...(typeof base?.protocolSelectionLimit === 'number'
@@ -4469,6 +4530,32 @@ function updateAgencyMetrics(
     closedWeek
   )
 
+  // SPE-2714 / SPE-39: covert cell growth + detection narrowing (abstract agency counters).
+  const covertGrowthLevelBefore = Math.max(
+    0,
+    Math.trunc(prevAgency.hiddenCellCovertGrowthLevel ?? 0)
+  )
+  const detectionNarrowingBefore = Math.max(
+    0,
+    Math.trunc(prevAgency.hiddenCellDetectionNarrowing ?? 0)
+  )
+  const hiddenCellCovertGrowth = resolveHiddenCellCovertGrowthFromPressure(
+    rivalPressureForInterference,
+    covertGrowthLevelBefore,
+    detectionNarrowingBefore
+  )
+  const covertGrowthApplied = applyHiddenCellCovertGrowthToAgencyState(
+    {
+      hiddenCellCovertGrowthLevel: prevAgency.hiddenCellCovertGrowthLevel,
+      hiddenCellDetectionNarrowing: prevAgency.hiddenCellDetectionNarrowing,
+      lastHiddenCellCovertGrowthWeek: prevAgency.lastHiddenCellCovertGrowthWeek,
+      lastHiddenCellCovertGrowthAmount: prevAgency.lastHiddenCellCovertGrowthAmount,
+      lastHiddenCellDetectionNarrowingAmount: prevAgency.lastHiddenCellDetectionNarrowingAmount,
+    },
+    hiddenCellCovertGrowth,
+    closedWeek
+  )
+
   if (
     fundingAfterHiddenCellTheft !== context.nextState.funding ||
     nextContainmentRating !== context.nextState.containmentRating ||
@@ -4505,6 +4592,17 @@ function updateAgencyMetrics(
             infrastructureCompromiseApplied.state.lastHiddenCellInfrastructureCompromiseWeek,
           lastHiddenCellInfrastructureCompromiseAmount:
             infrastructureCompromiseApplied.state.lastHiddenCellInfrastructureCompromiseAmount,
+        }
+      : {}),
+    ...(covertGrowthApplied.appliedGrowth > 0 || covertGrowthApplied.appliedNarrowing > 0
+      ? {
+          hiddenCellCovertGrowthLevel: covertGrowthApplied.state.hiddenCellCovertGrowthLevel,
+          hiddenCellDetectionNarrowing: covertGrowthApplied.state.hiddenCellDetectionNarrowing,
+          lastHiddenCellCovertGrowthWeek: covertGrowthApplied.state.lastHiddenCellCovertGrowthWeek,
+          lastHiddenCellCovertGrowthAmount:
+            covertGrowthApplied.state.lastHiddenCellCovertGrowthAmount,
+          lastHiddenCellDetectionNarrowingAmount:
+            covertGrowthApplied.state.lastHiddenCellDetectionNarrowingAmount,
         }
       : {}),
   }
@@ -5498,11 +5596,40 @@ export function advanceWeek(
         baseTimestamp: noteBaseTimestamp,
       }
     )
+    const appliedCovertGrowth = findHiddenCellCovertGrowthAmountForWeek(
+      result.agency,
+      closedWeekForInterference
+    )
+    const appliedDetectionNarrowing = findHiddenCellDetectionNarrowingAmountForWeek(
+      result.agency,
+      closedWeekForInterference
+    )
+    const covertGrowthLevelBefore =
+      Math.max(0, Math.trunc(result.agency?.hiddenCellCovertGrowthLevel ?? 0)) - appliedCovertGrowth
+    const detectionNarrowingBefore =
+      Math.max(0, Math.trunc(result.agency?.hiddenCellDetectionNarrowing ?? 0)) -
+      appliedDetectionNarrowing
+    const hiddenCellCovertGrowthNotes = buildWeeklyHiddenCellCovertGrowthReportNotes({
+      agency: result.agency,
+      rivalPressure: rivalPressureForNotes,
+      covertGrowthLevelBefore: Math.max(0, covertGrowthLevelBefore),
+      detectionNarrowingBefore: Math.max(0, detectionNarrowingBefore),
+      week: closedWeekForInterference,
+      sequenceStart:
+        noteSequenceBase +
+        hiddenCellFundingNotes.length +
+        hiddenCellResearchNotes.length +
+        hiddenCellPanicNotes.length +
+        hiddenCellInfrastructureNotes.length +
+        1,
+      baseTimestamp: noteBaseTimestamp,
+    })
     const hiddenCellNotes = [
       ...hiddenCellFundingNotes,
       ...hiddenCellResearchNotes,
       ...hiddenCellPanicNotes,
       ...hiddenCellInfrastructureNotes,
+      ...hiddenCellCovertGrowthNotes,
     ]
 
     if (hiddenCellNotes.length > 0) {

--- a/src/features/report/reportView.ts
+++ b/src/features/report/reportView.ts
@@ -65,6 +65,15 @@ export function getReportPageView(game: GameState): ReportPageView {
                 `infra -${agencySummary.hiddenCellInterference.maintenanceCompromised} maint`
               )
             }
+            if (
+              agencySummary.hiddenCellInterference.covertGrowthApplied > 0 ||
+              agencySummary.hiddenCellInterference.detectionNarrowingApplied > 0
+            ) {
+              parts.push(
+                `covert +${agencySummary.hiddenCellInterference.covertGrowthApplied}` +
+                  ` (${agencySummary.hiddenCellInterference.detectionNarrowingBand})`
+              )
+            }
             if (parts.length === 0) {
               return `${agencySummary.hiddenCellInterference.rivalPressureBand} (no diversion)`
             }

--- a/src/test/hiddenCellStrategicInterference.test.ts
+++ b/src/test/hiddenCellStrategicInterference.test.ts
@@ -10,28 +10,38 @@ import {
   hasWeeklyOperatingCostForWeek,
 } from '../domain/funding'
 import {
+  applyHiddenCellCovertGrowthToAgencyState,
   applyHiddenCellFundingTheftToFundingState,
   applyHiddenCellInfrastructureCompromiseToAgencyState,
   applyHiddenCellPanicAmplificationToGameState,
   applyHiddenCellResearchRollbackToResearchState,
+  computeHiddenCellCovertGrowthBaseAmount,
   computeHiddenCellFundingTheftBaseAmount,
   computeHiddenCellInfrastructureCompromiseBaseAmount,
   computeHiddenCellPanicAmplificationBaseAmount,
   computeHiddenCellResearchRollbackBaseAmount,
+  detectionNarrowingBandFromProgress,
+  findHiddenCellCovertGrowthAmountForWeek,
+  findHiddenCellDetectionNarrowingAmountForWeek,
   findHiddenCellFundingTheftAmountForWeek,
   findHiddenCellInfrastructureCompromiseAmountForWeek,
   findHiddenCellPanicAmplificationAmountForWeek,
   findHiddenCellResearchRollbackAmountForWeek,
   findHiddenCellResearchRollbackProjectIdForWeek,
+  hasHiddenCellCovertGrowthForWeek,
   hasHiddenCellFundingTheftForWeek,
   hasHiddenCellInfrastructureCompromiseForWeek,
   hasHiddenCellPanicAmplificationForWeek,
   hasHiddenCellResearchRollbackForWeek,
+  HIDDEN_CELL_COVERT_GROWTH_MAX,
+  HIDDEN_CELL_DETECTION_NARROWING_MAX,
   HIDDEN_CELL_FUNDING_THEFT_REASON,
   HIDDEN_CELL_FUNDING_THEFT_SOURCE_ID,
   HIDDEN_CELL_INFRASTRUCTURE_COMPROMISE_MAX,
   HIDDEN_CELL_PANIC_AMPLIFICATION_MAX,
   isHiddenCellPressureActive,
+  resolveHiddenCellCovertGrowthFromPressure,
+  resolveHiddenCellCovertGrowthFromRankingScore,
   resolveHiddenCellFundingTheft,
   resolveHiddenCellFundingTheftFromPressure,
   resolveHiddenCellFundingTheftFromRankingScore,
@@ -44,6 +54,7 @@ import {
   selectHiddenCellResearchRollbackTarget,
 } from '../domain/hiddenCellStrategicInterference'
 import {
+  buildWeeklyHiddenCellCovertGrowthReportNotes,
   buildWeeklyHiddenCellInfrastructureCompromiseReportNotes,
   buildWeeklyHiddenCellInterferenceReportNotes,
   buildWeeklyHiddenCellPanicAmplificationReportNotes,
@@ -108,7 +119,7 @@ function researchStateWithActiveProgress(input?: {
   }
 }
 
-describe('hidden-cell strategic interference (SPE-2704 / SPE-2706 / SPE-2707 / SPE-2710)', () => {
+describe('hidden-cell strategic interference (SPE-2704 / SPE-2706 / SPE-2707 / SPE-2710 / SPE-2714)', () => {
   it('gates cell pressure on competitive/severe rival bands only', () => {
     const bands: RivalPressureBand[] = ['suppressed', 'balanced', 'competitive', 'severe']
     expect(bands.map(isHiddenCellPressureActive)).toEqual([false, false, true, true])
@@ -1024,6 +1035,324 @@ describe('hidden-cell strategic interference (SPE-2704 / SPE-2706 / SPE-2707 / S
     expect(afterSecond.agency?.lastHiddenCellInfrastructureCompromiseAmount).toBe(applied)
     expect(afterSecond.agency?.maintenanceSpecialistsAvailable).toBe(
       afterFirst.agency?.maintenanceSpecialistsAvailable
+    )
+  })
+
+  it('derives identical covert-growth / detection-narrowing outcomes for identical inputs', () => {
+    const left = resolveHiddenCellCovertGrowthFromRankingScore(20, 0, 0)
+    const right = resolveHiddenCellCovertGrowthFromRankingScore(20, 0, 0)
+
+    expect(left).toEqual(right)
+    expect(left.active).toBe(true)
+    expect(left.kind).toBe('covert_cell_growth')
+    expect(left.growthApplied).toBeGreaterThan(0)
+    expect(left.growthApplied).toBeLessThanOrEqual(HIDDEN_CELL_COVERT_GROWTH_MAX)
+    expect(left.narrowingApplied).toBeGreaterThan(0)
+    expect(left.detectionNarrowingBand).not.toBe('none')
+    expect(left.summary).toMatch(/expanded covert network pressure/)
+    expect(left.summary).toMatch(/intel narrowing advanced/)
+  })
+
+  it('applies no covert growth when cell pressure is inactive', () => {
+    const balanced = resolveHiddenCellCovertGrowthFromRankingScore(50, 0, 0)
+    const suppressed = resolveHiddenCellCovertGrowthFromRankingScore(80, 0, 0)
+
+    expect(balanced.active).toBe(false)
+    expect(balanced.growthApplied).toBe(0)
+    expect(balanced.narrowingApplied).toBe(0)
+    expect(balanced.kind).toBe('none')
+    expect(suppressed.active).toBe(false)
+    expect(suppressed.growthApplied).toBe(0)
+  })
+
+  it('maps detection-narrowing progress to player-facing bands without location truth', () => {
+    expect(detectionNarrowingBandFromProgress(0)).toBe('none')
+    expect(detectionNarrowingBandFromProgress(10)).toBe('vague')
+    expect(detectionNarrowingBandFromProgress(30)).toBe('regional')
+    expect(detectionNarrowingBandFromProgress(60)).toBe('sector')
+    expect(detectionNarrowingBandFromProgress(90)).toBe('imminent')
+    expect(detectionNarrowingBandFromProgress(HIDDEN_CELL_DETECTION_NARROWING_MAX)).toBe(
+      'imminent'
+    )
+  })
+
+  it('applies covert growth idempotently once per closed week', () => {
+    const effect = resolveHiddenCellCovertGrowthFromRankingScore(15, 2, 8)
+    expect(effect.growthApplied).toBeGreaterThan(0)
+
+    const first = applyHiddenCellCovertGrowthToAgencyState(
+      { hiddenCellCovertGrowthLevel: 2, hiddenCellDetectionNarrowing: 8 },
+      effect,
+      3
+    )
+    expect(first.appliedGrowth).toBe(effect.growthApplied)
+    expect(first.appliedNarrowing).toBe(effect.narrowingApplied)
+    expect(first.state.hiddenCellCovertGrowthLevel).toBe(2 + effect.growthApplied)
+    expect(first.state.hiddenCellDetectionNarrowing).toBe(8 + effect.narrowingApplied)
+    expect(hasHiddenCellCovertGrowthForWeek(first.state, 3)).toBe(true)
+    expect(findHiddenCellCovertGrowthAmountForWeek(first.state, 3)).toBe(effect.growthApplied)
+    expect(findHiddenCellDetectionNarrowingAmountForWeek(first.state, 3)).toBe(
+      effect.narrowingApplied
+    )
+
+    const second = applyHiddenCellCovertGrowthToAgencyState(first.state, effect, 3)
+    expect(second.appliedGrowth).toBe(0)
+    expect(second.appliedNarrowing).toBe(0)
+    expect(second.state.hiddenCellCovertGrowthLevel).toBe(first.state.hiddenCellCovertGrowthLevel)
+  })
+
+  it('does not alter SPE-2704/2706/2707/2710 resolve outputs when resolving covert growth', () => {
+    const pressure = buildRivalPressureFromRankingScore(20)
+    const research = researchStateWithActiveProgress()
+    const fundingBefore = resolveHiddenCellFundingTheftFromPressure(pressure, 900).fundingStolen
+    const researchBefore = resolveHiddenCellResearchRollbackFromPressure(
+      pressure,
+      research
+    ).progressTimeRolledBack
+    const panicBefore = resolveHiddenCellPanicAmplificationFromPressure(pressure).pressureAmplified
+    const infraBefore = resolveHiddenCellInfrastructureCompromiseFromPressure(
+      pressure,
+      4
+    ).maintenanceCompromised
+
+    const covertEffect = resolveHiddenCellCovertGrowthFromPressure(pressure, 0, 0)
+    expect(covertEffect.kind).toBe('covert_cell_growth')
+    expect(computeHiddenCellCovertGrowthBaseAmount(pressure.score, pressure.band)).toBe(
+      covertEffect.baseGrowthAmount
+    )
+
+    expect(resolveHiddenCellFundingTheftFromPressure(pressure, 900).fundingStolen).toBe(
+      fundingBefore
+    )
+    expect(
+      resolveHiddenCellResearchRollbackFromPressure(pressure, research).progressTimeRolledBack
+    ).toBe(researchBefore)
+    expect(resolveHiddenCellPanicAmplificationFromPressure(pressure).pressureAmplified).toBe(
+      panicBefore
+    )
+    expect(
+      resolveHiddenCellInfrastructureCompromiseFromPressure(pressure, 4).maintenanceCompromised
+    ).toBe(infraBefore)
+  })
+
+  it('builds weekly covert-growth notes only when growth or narrowing was applied', () => {
+    const pressure = buildRivalPressureFromRankingScore(20)
+    const effect = resolveHiddenCellCovertGrowthFromPressure(pressure, 0, 0)
+    const applied = applyHiddenCellCovertGrowthToAgencyState(
+      { hiddenCellCovertGrowthLevel: 0, hiddenCellDetectionNarrowing: 0 },
+      effect,
+      2
+    )
+
+    const notes = buildWeeklyHiddenCellCovertGrowthReportNotes({
+      agency: applied.state,
+      rivalPressure: pressure,
+      covertGrowthLevelBefore: 0,
+      detectionNarrowingBefore: 0,
+      week: 2,
+      sequenceStart: 1,
+      baseTimestamp: 1_700_000_000_000,
+    })
+
+    expect(notes).toHaveLength(1)
+    expect(notes[0]?.type).toBe('agency.hidden_cell_interference')
+    expect(notes[0]?.content).toMatch(/expanded covert network pressure/)
+    expect(notes[0]?.metadata).toMatchObject({
+      kind: 'covert_cell_growth',
+      covertGrowthApplied: effect.growthApplied,
+      detectionNarrowingApplied: effect.narrowingApplied,
+      rivalPressureBand: pressure.band,
+      week: 2,
+    })
+
+    const inactiveNotes = buildWeeklyHiddenCellCovertGrowthReportNotes({
+      agency: { hiddenCellCovertGrowthLevel: 0, hiddenCellDetectionNarrowing: 0 },
+      rivalPressure: buildRivalPressureFromRankingScore(50),
+      covertGrowthLevelBefore: 0,
+      detectionNarrowingBefore: 0,
+      week: 2,
+      sequenceStart: 1,
+    })
+    expect(inactiveNotes).toHaveLength(0)
+  })
+
+  it('retains covert-growth note metadata and markers through hydrateGame', () => {
+    const pressure = buildRivalPressureFromRankingScore(20)
+    const effect = resolveHiddenCellCovertGrowthFromPressure(pressure, 0, 0)
+    const applied = applyHiddenCellCovertGrowthToAgencyState(
+      { hiddenCellCovertGrowthLevel: 0, hiddenCellDetectionNarrowing: 0 },
+      effect,
+      4
+    )
+    const notes = buildWeeklyHiddenCellCovertGrowthReportNotes({
+      agency: applied.state,
+      rivalPressure: pressure,
+      covertGrowthLevelBefore: 0,
+      detectionNarrowingBefore: 0,
+      week: 4,
+      sequenceStart: 1,
+      baseTimestamp: 1_700_000_000_000,
+    })
+
+    const state = createStartingState()
+    state.week = 5
+    if (state.agency) {
+      state.agency.hiddenCellCovertGrowthLevel = applied.state.hiddenCellCovertGrowthLevel
+      state.agency.hiddenCellDetectionNarrowing = applied.state.hiddenCellDetectionNarrowing
+      state.agency.lastHiddenCellCovertGrowthWeek = applied.state.lastHiddenCellCovertGrowthWeek
+      state.agency.lastHiddenCellCovertGrowthAmount = applied.state.lastHiddenCellCovertGrowthAmount
+      state.agency.lastHiddenCellDetectionNarrowingAmount =
+        applied.state.lastHiddenCellDetectionNarrowingAmount
+    }
+    state.reports = [
+      {
+        week: 4,
+        resolvedCases: [],
+        partialCases: [],
+        failedCases: [],
+        unresolvedTriggers: [],
+        notes,
+      } as unknown as WeeklyReport,
+    ]
+
+    const hydrated = hydrateGame(JSON.parse(JSON.stringify(state)), createStartingState())
+    expect(hydrated.agency?.lastHiddenCellCovertGrowthWeek).toBe(4)
+    expect(hydrated.agency?.lastHiddenCellCovertGrowthAmount).toBe(effect.growthApplied)
+    expect(hydrated.agency?.lastHiddenCellDetectionNarrowingAmount).toBe(effect.narrowingApplied)
+    expect(hydrated.agency?.hiddenCellCovertGrowthLevel).toBe(
+      applied.state.hiddenCellCovertGrowthLevel
+    )
+    expect(hydrated.reports[0]?.notes?.[0]?.metadata).toMatchObject({
+      kind: 'covert_cell_growth',
+      covertGrowthApplied: effect.growthApplied,
+      detectionNarrowingApplied: effect.narrowingApplied,
+      rivalPressureBand: pressure.band,
+      week: 4,
+    })
+  })
+
+  it('advanceWeek grows covert pressure and emits note under severe cell pressure', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.reports = [
+      reportWithFailures(1, 5, 4),
+      reportWithFailures(2, 5, 4),
+      reportWithFailures(3, 5, 4),
+    ]
+    state.funding = 2000
+    if (state.agency) {
+      state.agency.funding = 2000
+      state.agency.fundingState = createInitialFundingState(
+        state.config.fundingBasePerWeek,
+        state.config.fundingPerResolution,
+        state.config.fundingPenaltyPerFail,
+        state.config.fundingPenaltyPerUnresolved,
+        2000
+      )
+      state.agency.hiddenCellCovertGrowthLevel = 0
+      state.agency.hiddenCellDetectionNarrowing = 0
+    }
+
+    const pressureBefore = buildRivalPressureFromRankingScore(buildAgencySummary(state).ranking.score)
+    expect(isHiddenCellPressureActive(pressureBefore.band)).toBe(true)
+    const expected = resolveHiddenCellCovertGrowthFromPressure(pressureBefore, 0, 0)
+    expect(expected.growthApplied).toBeGreaterThan(0)
+
+    const closedWeek = state.week
+    const nextState = advanceWeek(state)
+    expect(findHiddenCellCovertGrowthAmountForWeek(nextState.agency, closedWeek)).toBe(
+      expected.growthApplied
+    )
+    expect(findHiddenCellDetectionNarrowingAmountForWeek(nextState.agency, closedWeek)).toBe(
+      expected.narrowingApplied
+    )
+    expect(nextState.agency?.hiddenCellCovertGrowthLevel).toBe(expected.growthApplied)
+    expect(nextState.agency?.hiddenCellDetectionNarrowing).toBe(expected.narrowingApplied)
+
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const covertNotes =
+      lastReport?.notes?.filter(
+        (note) =>
+          note.type === 'agency.hidden_cell_interference' &&
+          note.metadata?.kind === 'covert_cell_growth'
+      ) ?? []
+    expect(covertNotes.length).toBeGreaterThanOrEqual(1)
+    expect(covertNotes[0]?.content).toMatch(/expanded covert network pressure/)
+  })
+
+  it('advanceWeek emits no covert-growth note when cell pressure is inactive', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.reports = []
+    state.funding = 2000
+    if (state.agency) {
+      state.agency.funding = 2000
+      state.agency.hiddenCellCovertGrowthLevel = 0
+      state.agency.hiddenCellDetectionNarrowing = 0
+    }
+
+    const pressure = buildRivalPressureFromRankingScore(buildAgencySummary(state).ranking.score)
+    expect(isHiddenCellPressureActive(pressure.band)).toBe(false)
+
+    const nextState = advanceWeek(state)
+    expect(findHiddenCellCovertGrowthAmountForWeek(nextState.agency, state.week)).toBe(0)
+    expect(nextState.agency?.hiddenCellCovertGrowthLevel ?? 0).toBe(0)
+
+    const lastReport = nextState.reports[nextState.reports.length - 1]
+    const covertNotes =
+      lastReport?.notes?.filter(
+        (note) =>
+          note.type === 'agency.hidden_cell_interference' &&
+          note.metadata?.kind === 'covert_cell_growth'
+      ) ?? []
+    expect(covertNotes).toHaveLength(0)
+  })
+
+  it('preserves covert-growth markers through a second advanceWeek canonicalize', () => {
+    const state = createStartingState()
+    freezeCasesForQuietWeek(state)
+    state.reports = [
+      reportWithFailures(1, 5, 4),
+      reportWithFailures(2, 5, 4),
+      reportWithFailures(3, 5, 4),
+    ]
+    state.funding = 2000
+    if (state.agency) {
+      state.agency.funding = 2000
+      state.agency.fundingState = createInitialFundingState(
+        state.config.fundingBasePerWeek,
+        state.config.fundingPerResolution,
+        state.config.fundingPenaltyPerFail,
+        state.config.fundingPenaltyPerUnresolved,
+        2000
+      )
+    }
+
+    const closedWeek = state.week
+    const afterFirst = advanceWeek(state)
+    const appliedGrowth = findHiddenCellCovertGrowthAmountForWeek(afterFirst.agency, closedWeek)
+    const appliedNarrowing = findHiddenCellDetectionNarrowingAmountForWeek(
+      afterFirst.agency,
+      closedWeek
+    )
+    expect(appliedGrowth).toBeGreaterThan(0)
+    expect(afterFirst.agency?.lastHiddenCellCovertGrowthWeek).toBe(closedWeek)
+    expect(afterFirst.agency?.lastHiddenCellCovertGrowthAmount).toBe(appliedGrowth)
+    expect(afterFirst.agency?.lastHiddenCellDetectionNarrowingAmount).toBe(appliedNarrowing)
+
+    freezeCasesForQuietWeek(afterFirst)
+    afterFirst.reports = []
+    const afterSecond = advanceWeek(afterFirst)
+    expect(isHiddenCellPressureActive(
+      buildRivalPressureFromRankingScore(buildAgencySummary(afterFirst).ranking.score).band
+    )).toBe(false)
+    expect(afterSecond.agency?.lastHiddenCellCovertGrowthWeek).toBe(closedWeek)
+    expect(afterSecond.agency?.lastHiddenCellCovertGrowthAmount).toBe(appliedGrowth)
+    expect(afterSecond.agency?.hiddenCellCovertGrowthLevel).toBe(
+      afterFirst.agency?.hiddenCellCovertGrowthLevel
+    )
+    expect(afterSecond.agency?.hiddenCellDetectionNarrowing).toBe(
+      afterFirst.agency?.hiddenCellDetectionNarrowing
     )
   })
 })

--- a/systems/hub-simulation.md
+++ b/systems/hub-simulation.md
@@ -187,15 +187,20 @@ severe, abstract cell pressure may (1) divert a deterministic funding amount thr
 `ResearchState.lastHiddenCellRollbackWeek`), (3) amplify ambient panic/unrest by adding
 bounded points to `GameState.globalPressure` (SPE-2707; idempotent via
 `lastHiddenCellPanicAmplificationWeek` / `Amount`; applied after the pressure pipeline so the
-bump carries into later weeks rather than spawning same-tick major incidents), and/or
+bump carries into later weeks rather than spawning same-tick major incidents),
 (4) compromise facility/ops infrastructure by draining SPE-94
 `AgencyState.maintenanceSpecialistsAvailable` (SPE-2710; idempotent via
 `lastHiddenCellInfrastructureCompromiseWeek` / `Amount`; drain carries into the next week's
-equipment-recovery bottleneck).
+equipment-recovery bottleneck), and/or (5) expand abstract covert-network pressure while
+advancing an intelligence-driven detection-narrowing band
+(`vague` → `regional` → `sector` → `imminent`) on
+`AgencyState.hiddenCellCovertGrowthLevel` / `hiddenCellDetectionNarrowing` (SPE-2714;
+idempotent via `lastHiddenCellCovertGrowthWeek` + applied amounts; no per-cell entities,
+no SPE-854 verification-core changes, no scan UX).
 Suppressed/balanced pressure is inactive. Week-close emits `agency.hidden_cell_interference`
-when funding theft, research rollback, panic amplification, and/or infrastructure compromise
-applies; agency/report summaries expose the active/inactive signal. This is not a full
-adversary-org sim and does not include cell detection.
+when funding theft, research rollback, panic amplification, infrastructure compromise, and/or
+covert growth/detection narrowing applies; agency/report summaries expose the active/inactive
+signal. This is not a full adversary-org sim and does not open confrontation ops.
 
 ### Stage B — Build hub opportunity pools
 


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2714 — https://linear.app/spectranoir/issue/SPE-2714/spe-39-hidden-cell-strategic-interference-covert-cell-growth-detection
- **Parent issue (if any):** SPE-39 — https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer
- **Child issues covered:** slice only

## Summary

@coderabbitai summary

## What shipped

- Deterministic covert-cell growth + intelligence-driven detection-narrowing (vague → regional → sector → imminent) under competitive/severe rival pressure
- Week-close `agency.hidden_cell_interference` note (`kind: covert_cell_growth`) + agency/report summary; idempotent agency markers hydrated via `sanitizeAgencyState`
- SPE-2704/2706/2707/2710 interference paths unchanged for the same inputs

## Docs updated

- `systems/hub-simulation.md`
- `SCHEMA_REGISTRY.md`
- `planning/spe-2714-hidden-cell-covert-growth-detection-slice.md`
- Deferred owner pointers on SPE-2706/2707/2710 slice docs

## Parent status

- Parent SPE-39 remains **Backlog**/open — child slice only (residual: optional SPE-2702 resolved×open sharpening)

## Scope boundary

- No SPE-854 verification-core changes; no case-scouting DetectionScanResult UX / scan sprawl
- No reopen of SPE-2699–2710 formulas/amounts
- No open confrontation / cell raid ops; no FacilityInstance offline wiring; no SPE-542/SPE-430 rival sims

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/hiddenCellStrategicInterference.test.ts src/test/rivalPressure.test.ts src/test/reportNoteTypeAudit.test.ts`
- [x] Lint / verify: `npm run lint`

## Follow-ups

- Optional SPE-2702 resolved×open jurisdiction sharpening (SPE-39 child)
- Open confrontation / cell raid ops after imminent narrowing (ops follow-up)
- Player-initiated intel scan actions (intel follow-up; avoid scans UX sprawl)

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)

Made with [Cursor](https://cursor.com)