### PR TITLE
SPE-2716: Require resolved×open distant pair for coordination packets

### DIFF
--- a/planning/spe-2702-cross-jurisdiction-coordination-packet-slice.md
+++ b/planning/spe-2702-cross-jurisdiction-coordination-packet-slice.md
@@ -30,7 +30,7 @@ One deterministic bounded cross-jurisdiction liaison/coordination packet (shared
 | Docs | `systems/hub-simulation.md` |
 | Tests | `src/test/crossJurisdictionCoordinationPacket.test.ts` |
 
-Compose rule: `archive_signature` intake with tentative/strong match band + linked cases (topic keys) with **two distinct** `regionTag` values → packet (lex-min prior, next current). Weak/none match or single jurisdiction → no packet.
+Compose rule: `archive_signature` intake with tentative/strong match band + linked cases (topic keys) with a **resolved × open** distant `regionTag` pair → packet. Weak/none match, same jurisdiction, or open×open / resolved×resolved multi-region without a resolved→open pair → no packet. (SPE-2716 dropped the former lex-min unique-regions fallback.)
 
 ## Out of scope
 
@@ -44,8 +44,9 @@ Compose rule: `archive_signature` intake with tentative/strong match band + link
 
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
-| Hidden-cell strategic interference | SPE-39 child | Larger adversary layer |
-| Legitimacy fallout tick standing scale | SPE-39 / procurement follow-up | Alternate fallout surface |
+| Hidden-cell strategic interference | SPE-39 children (SPE-2704+) | Larger adversary layer — owned elsewhere |
+| Legitimacy fallout tick standing scale | SPE-2705 | Alternate fallout surface — shipped |
+| Resolved×open jurisdiction sharpening (drop lex-min fallback) | SPE-2716 | Post-merge Bugbot residual — owned by child |
 | Richer jurisdiction distance graph (route hops) | SPE-49 / SPE-558 follow-up | RegionTag inequality is enough for parent AC |
 
 ## Validation

--- a/planning/spe-2714-hidden-cell-covert-growth-detection-slice.md
+++ b/planning/spe-2714-hidden-cell-covert-growth-detection-slice.md
@@ -45,7 +45,7 @@ Cell pressure active when rival-pressure band is `competitive` or `severe`. Grow
 
 | Item | Suggested owner | Why deferred |
 | --- | --- | --- |
-| Optional SPE-2702 resolved×open jurisdiction sharpening | SPE-39 child | Post-merge Bugbot follow-up; not blocking |
+| Optional SPE-2702 resolved×open jurisdiction sharpening | SPE-2716 | Post-merge Bugbot follow-up — owned by SPE-2716 |
 | Open confrontation / cell raid ops after imminent narrowing | SPE-39 / ops follow-up | Larger mission surface than growth/narrowing signal |
 | Player-initiated intel scan actions | intel follow-up | Avoid scans UX sprawl in this slice |
 

--- a/planning/spe-2716-resolved-open-jurisdiction-sharpening-slice.md
+++ b/planning/spe-2716-resolved-open-jurisdiction-sharpening-slice.md
@@ -1,0 +1,49 @@
+# SPE-2716 — SPE-2702 residual: require resolved×open distant pair
+
+**Linear:** [SPE-2716](https://linear.app/spectranoir/issue/SPE-2716/spe-2702-residual-require-resolvedopen-distant-pair-drop-lex-min-multi)  
+**Parent:** [SPE-39](https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer) (stays **Backlog**/open after merge)  
+**Related:** [SPE-2702](https://linear.app/spectranoir/issue/SPE-2702/spe-39-cross-jurisdiction-coordination-packet-on-distant-reappearance) (Done; this child owns Bugbot residual), [SPE-854](https://linear.app/spectranoir/issue/SPE-854/information-intake-and-verification-engine)  
+**Branch:** `jamesdyedbq/spe-2716-spe-2702-resolved-open-jurisdiction-sharpening`  
+**Base:** `main` @ `f4b403f042ddff75afaa3b6131c9d8658ec834d6`
+
+## Goal
+
+Drop the lex-min multi-region `regionTag` fallback in `pickJurisdictionPair` so coordination packets emit only for a true prior-resolved → current-open distant reappearance.
+
+## Acceptance (this slice)
+
+- [x] Resolved × open distant `regionTag` + tentative/strong `archive_signature` → packet
+- [x] Open × open distant multi-region → no packet
+- [x] Resolved × resolved distant multi-region → no packet
+- [x] Same-jurisdiction / weak / non-signature intake still → no packet
+- [x] Prior SPE-2702 resolved×open emit + weekly note / agency summary cases unchanged
+- [x] Docs updated; SCHEMA_REGISTRY untouched; SPE-854 / SPE-2699–2714 math untouched
+
+## Implementation notes
+
+| Area | Anchor |
+| --- | --- |
+| Domain | `src/domain/crossJurisdictionCoordinationPacket.ts` — `pickJurisdictionPair` returns null without resolved×open distant pair |
+| Docs | `systems/hub-simulation.md` coordination-packet paragraph |
+| Tests | `src/test/crossJurisdictionCoordinationPacket.test.ts` |
+| Parent slice | `planning/spe-2702-cross-jurisdiction-coordination-packet-slice.md` deferred row → this child |
+
+Compose rule (post-SPE-2716): `archive_signature` with tentative/strong band + linked cases with at least one **resolved** case and one **open** case on distinct `regionTag`s → packet. No lex-min fallback for status-homogeneous multi-region sets.
+
+## Out of scope
+
+- SPE-854 verification core
+- SPE-2699–2714 standing/rival/interference math
+- SPE-558 region-packet expansion / richer distance graph
+- Concurrent multi-region alert rename without resolved×open
+
+## Deferred
+
+| Item | Suggested owner | Why deferred |
+| --- | --- | --- |
+| Richer jurisdiction distance graph (route hops) | SPE-49 / SPE-558 | RegionTag inequality remains enough for parent AC |
+
+## Validation
+
+- `npm run test:run -- src/test/crossJurisdictionCoordinationPacket.test.ts`
+- `npm run lint`

--- a/src/domain/crossJurisdictionCoordinationPacket.ts
+++ b/src/domain/crossJurisdictionCoordinationPacket.ts
@@ -1,5 +1,6 @@
 /**
- * SPE-2702 / SPE-39: bounded cross-jurisdiction coordination packets on distant reappearance.
+ * SPE-2702 / SPE-2716 / SPE-39: bounded cross-jurisdiction coordination packets on distant
+ * reappearance (resolved × open jurisdiction pair only).
  *
  * Read-time projection from SPE-854 archive-signature intake + case regionTags —
  * no new GameState persistence.
@@ -187,6 +188,11 @@ function listCasesLinkedToTopic(
   return linked.sort((left, right) => left.id.localeCompare(right.id))
 }
 
+/**
+ * Prefer a prior-resolved → current-open distant regionTag pair.
+ * Returns null when no such pair exists (including open×open or resolved×resolved
+ * multi-region sets — SPE-2716 drops the former lex-min regionTag fallback).
+ */
 function pickJurisdictionPair(
   linkedCases: readonly CaseRegionSlice[]
 ): {
@@ -219,33 +225,7 @@ function pickJurisdictionPair(
     }
   }
 
-  const uniqueRegions = [
-    ...new Set(
-      linkedCases
-        .map((currentCase) => normalizeToken(currentCase.regionTag ?? ''))
-        .filter((region) => region.length > 0)
-    ),
-  ].sort((left, right) => left.localeCompare(right))
-
-  if (uniqueRegions.length < 2) {
-    return null
-  }
-
-  const priorJurisdictionRef = uniqueRegions[0]
-  const currentJurisdictionRef = uniqueRegions[1]
-  const priorCase = linkedCases.find(
-    (currentCase) => normalizeToken(currentCase.regionTag ?? '') === priorJurisdictionRef
-  )
-  const currentCase = linkedCases.find(
-    (currentCase) => normalizeToken(currentCase.regionTag ?? '') === currentJurisdictionRef
-  )
-
-  return {
-    priorJurisdictionRef,
-    currentJurisdictionRef,
-    priorSiteLabel: priorCase?.title,
-    currentSiteLabel: currentCase?.title,
-  }
+  return null
 }
 
 /** Compose distant-reappearance signals from intake archive signatures + case region tags. */

--- a/src/test/crossJurisdictionCoordinationPacket.test.ts
+++ b/src/test/crossJurisdictionCoordinationPacket.test.ts
@@ -47,7 +47,7 @@ function weakArchiveSignature(): InformationIntakeReportRecord {
   }
 }
 
-describe('crossJurisdictionCoordinationPacket (SPE-2702)', () => {
+describe('crossJurisdictionCoordinationPacket (SPE-2702 / SPE-2716)', () => {
   it('resolves archive_signature match bands', () => {
     expect(resolveSignatureMatchBand(IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE)).toBe('tentative')
     expect(resolveSignatureMatchBand(weakArchiveSignature())).toBe('weak')
@@ -188,6 +188,54 @@ describe('crossJurisdictionCoordinationPacket (SPE-2702)', () => {
       projectCrossJurisdictionCoordinationPackets({
         reports: { [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE },
         cases: { [prior.id]: prior, [current.id]: current },
+      })
+    ).toEqual([])
+  })
+
+  it('emits no packet for open×open distant multi-region (no resolved prior)', () => {
+    const openWest = makeCase({
+      id: 'case-open-west',
+      title: 'Open canal site',
+      status: 'open',
+      tags: ['topic:canal-bridge-incident'],
+      regionTag: 'region:canal-west',
+    })
+    const openEast = makeCase({
+      id: 'case-open-east',
+      title: 'Open harbor site',
+      status: 'open',
+      tags: ['topic:canal-bridge-incident'],
+      regionTag: 'region:harbor-east',
+    })
+
+    expect(
+      projectCrossJurisdictionCoordinationPackets({
+        reports: { [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE },
+        cases: { [openWest.id]: openWest, [openEast.id]: openEast },
+      })
+    ).toEqual([])
+  })
+
+  it('emits no packet for resolved×resolved distant multi-region (no open current)', () => {
+    const resolvedWest = makeCase({
+      id: 'case-resolved-west',
+      title: 'Closed canal site',
+      status: 'resolved',
+      tags: ['topic:canal-bridge-incident'],
+      regionTag: 'region:canal-west',
+    })
+    const resolvedEast = makeCase({
+      id: 'case-resolved-east',
+      title: 'Closed harbor site',
+      status: 'resolved',
+      tags: ['topic:canal-bridge-incident'],
+      regionTag: 'region:harbor-east',
+    })
+
+    expect(
+      projectCrossJurisdictionCoordinationPackets({
+        reports: { [IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE.id]: IMPOSSIBLE_ARCHIVED_SIGNATURE_FIXTURE },
+        cases: { [resolvedWest.id]: resolvedWest, [resolvedEast.id]: resolvedEast },
       })
     ).toEqual([])
   })

--- a/systems/hub-simulation.md
+++ b/systems/hub-simulation.md
@@ -174,10 +174,12 @@ posture for legibility.
 
 Cross-jurisdiction coordination packets are a separate **read-time** projection
 (`src/domain/crossJurisdictionCoordinationPacket.ts`): when SPE-854 `archive_signature` intake
-reaches a tentative or strong match band and linked cases show two distinct `regionTag`
-jurisdictions (distant reappearance), week-close emits a bounded liaison/shared-signature alert note
-(`agency.cross_jurisdiction_coordination`) and agency/report summaries surface the packet count.
-Weak signature matches and same-jurisdiction reappearance do not emit a packet.
+reaches a tentative or strong match band and linked cases include a **resolved × open** distant
+`regionTag` pair (prior resolved site → current open reappearance), week-close emits a bounded
+liaison/shared-signature alert note (`agency.cross_jurisdiction_coordination`) and agency/report
+summaries surface the packet count. Weak signature matches, same-jurisdiction pairs, and
+concurrent open×open or resolved×resolved multi-region sets (no resolved→open pair) do not emit
+a packet.
 
 Hidden-cell strategic interference is a bounded week-close hook
 (`src/domain/hiddenCellStrategicInterference.ts`): when rival-pressure band is competitive or


### PR DESCRIPTION
## Linear

- **Slice issue:** SPE-2716 — https://linear.app/spectranoir/issue/SPE-2716/spe-2702-residual-require-resolvedopen-distant-pair-drop-lex-min-multi
- **Parent issue (if any):** SPE-39 — https://linear.app/spectranoir/issue/SPE-39/agency-standing-rankings-and-rival-pressure-layer
- **Child issues covered:** slice only (SPE-2702 Done residual owned by this child)

## Summary

@coderabbitai summary

## What shipped

- `pickJurisdictionPair` now returns null unless a resolved × open distant `regionTag` pair exists (lex-min multi-region fallback removed)
- Open×open and resolved×resolved distant multi-region sets no longer emit a coordination packet; true prior-resolved → current-open distant reappearance still emits
- Targeted Vitest coverage for the no-emit status-homogeneous cases; prior SPE-2702 resolved×open emit/summary cases preserved

## Docs updated

- `systems/hub-simulation.md` (coordination packet paragraph)
- `planning/spe-2716-resolved-open-jurisdiction-sharpening-slice.md` (new)
- `planning/spe-2702-cross-jurisdiction-coordination-packet-slice.md` (compose rule + deferred → SPE-2716)
- `planning/spe-2714-hidden-cell-covert-growth-detection-slice.md` (deferred pointer → SPE-2716)

## Parent status

- SPE-39 remains open/Backlog — residual sharpening child only; SPE-2702 stays Done

## Scope boundary

- No SPE-854 verification-core changes
- No SPE-2699–2714 standing/rival/interference math
- No SCHEMA_REGISTRY / persistence changes
- No SPE-558 region-packet expansion

## Validation

- [x] Targeted tests: `npm run test:run -- src/test/crossJurisdictionCoordinationPacket.test.ts src/test/advanceWeek.crossJurisdictionCoordination.integration.test.ts` (13 passed)
- [x] Lint / verify: `npm run lint`

## Follow-ups

- Richer jurisdiction distance graph remains SPE-49 / SPE-558

## Linear updated

- [x] Slice issue linked in this PR body (not parent only)
- [ ] PR URL commented on slice issue
- [ ] Accurate status through merge (Done only when full child boundary ships)
- [ ] Post-merge comment on slice issue (PR URL + what shipped + validation)

Made with [Cursor](https://cursor.com)